### PR TITLE
Adds further examples of API extensibility pattern.

### DIFF
--- a/src/Microsoft.Data.Entity/ChangeTracking/ChangeTracker.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/ChangeTracker.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             // TODO: Error checking for type that is not in the model
             // TODO: Error checking for different entity instance with same key
 
-            var key = _model.Entity(entity).CreateKey(entity);
+            var key = _model.Entity(entity).CreateEntityKey(entity);
 
             ChangeTrackerEntry entry;
             return _identityMap.TryGetValue(key, out entry) ? entry : null;

--- a/src/Microsoft.Data.Entity/ChangeTracking/ChangeTrackerEntry.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/ChangeTrackerEntry.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
 
         public virtual EntityKey Key
         {
-            get { return _changeTracker.Model.Entity(_entity).CreateKey(_entity); }
+            get { return _changeTracker.Model.Entity(_entity).CreateEntityKey(_entity); }
         }
 
         public virtual EntityState EntityState

--- a/src/Microsoft.Data.Entity/Metadata/EntityType.cs
+++ b/src/Microsoft.Data.Entity/Metadata/EntityType.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return Properties; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             Check.NotNull(entity, "entity");
 

--- a/src/Microsoft.Data.Entity/Metadata/IEntityType.cs
+++ b/src/Microsoft.Data.Entity/Metadata/IEntityType.cs
@@ -15,6 +15,6 @@ namespace Microsoft.Data.Entity.Metadata
         IEnumerable<IProperty> Key { get; }
         IProperty Property([NotNull] string name);
         IEnumerable<IProperty> Properties { get; }
-        EntityKey CreateKey([NotNull] object entity);
+        EntityKey CreateEntityKey([NotNull] object entity);
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/MetadataBase.cs
+++ b/src/Microsoft.Data.Entity/Metadata/MetadataBase.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Data.Entity.Metadata
         {
             Check.NotNull(annotation, "annotation");
 
-            _annotations.ExchangeValue(l => l.Remove(annotation.Name));
+            _annotations.ExchangeValue(d => d.Remove(annotation.Name));
         }
 
 // ReSharper disable once AnnotationRedundanceInHierarchy
@@ -46,9 +46,8 @@ namespace Microsoft.Data.Entity.Metadata
                 Check.NotEmpty(annotationName, "annotationName");
                 Check.NotEmpty(value, "value");
 
-                _annotations.ExchangeValue(l => l.Remove(annotationName));
-
-                AddAnnotation(new Annotation(annotationName, value));
+                _annotations.ExchangeValue(
+                    d => d.SetItem(annotationName, new Annotation(annotationName, value)));
             }
         }
 

--- a/src/Microsoft.Data.Entity/Metadata/ModelBuilder.cs
+++ b/src/Microsoft.Data.Entity/Metadata/ModelBuilder.cs
@@ -98,6 +98,13 @@ namespace Microsoft.Data.Entity.Metadata
                 return this;
             }
 
+            public EntityBuilder<TEntity> StorageName([NotNull] string storageName)
+            {
+                Metadata.StorageName = storageName;
+
+                return this;
+            }
+
             public class PropertiesBuilder
             {
                 private readonly EntityType _entityType;
@@ -126,6 +133,13 @@ namespace Microsoft.Data.Entity.Metadata
                     internal PropertyBuilder(Property property)
                         : base(property)
                     {
+                    }
+
+                    public PropertyBuilder StorageName([NotNull] string storageName)
+                    {
+                        Metadata.StorageName = storageName;
+
+                        return this;
                     }
                 }
             }

--- a/src/Microsoft.Data.Relational/ApiExtensions.cs
+++ b/src/Microsoft.Data.Relational/ApiExtensions.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Relational.Utilities;
+
+namespace Microsoft.Data.Relational
+{
+    public static class ApiExtensions
+    {
+        public static class Annotations
+        {
+            public const string StorageTypeName = "StorageTypeName";
+        }
+
+        public static ModelBuilder.EntityBuilder<TEntity> ToTable<TEntity>(
+            [NotNull] this ModelBuilder.EntityBuilder<TEntity> entityBuilder,
+            SchemaQualifiedName tableName)
+            where TEntity : class
+        {
+            Check.NotNull(entityBuilder, "entityBuilder");
+
+            entityBuilder.StorageName(tableName);
+
+            return entityBuilder;
+        }
+
+        public static ModelBuilder.EntityBuilder<TEntity>.PropertiesBuilder.PropertyBuilder ColumnName<TEntity>(
+            [NotNull] this ModelBuilder.EntityBuilder<TEntity>.PropertiesBuilder.PropertyBuilder propertyBuilder,
+            [NotNull] string columnName)
+            where TEntity : class
+        {
+            Check.NotNull(propertyBuilder, "propertyBuilder");
+
+            propertyBuilder.StorageName(columnName);
+
+            return propertyBuilder;
+        }
+
+        public static ModelBuilder.EntityBuilder<TEntity>.PropertiesBuilder.PropertyBuilder ColumnType<TEntity>(
+            [NotNull] this ModelBuilder.EntityBuilder<TEntity>.PropertiesBuilder.PropertyBuilder propertyBuilder,
+            [NotNull] string typeName)
+            where TEntity : class
+        {
+            Check.NotNull(propertyBuilder, "propertyBuilder");
+
+            propertyBuilder.Annotation(Annotations.StorageTypeName, typeName);
+
+            return propertyBuilder;
+        }
+    }
+}

--- a/src/Microsoft.Data.Relational/Model/Column.cs
+++ b/src/Microsoft.Data.Relational/Model/Column.cs
@@ -7,18 +7,19 @@ namespace Microsoft.Data.Relational.Model
 {
     public class Column
     {
-        private readonly SchemaQualifiedName _name;
+        private readonly string _name;
         private string _dataType;
 
-        public Column(SchemaQualifiedName name, [NotNull] string dataType)
+        public Column([NotNull] string name, [NotNull] string dataType)
         {
+            Check.NotEmpty(name, "name");
             Check.NotEmpty(dataType, "dataType");
 
             _name = name;
             _dataType = dataType;
         }
 
-        public virtual SchemaQualifiedName Name
+        public virtual string Name
         {
             get { return _name; }
             [param: NotNull]

--- a/test/Microsoft.Data.Entity.FunctionalTest/Metadata/KoolModel.cs
+++ b/test/Microsoft.Data.Entity.FunctionalTest/Metadata/KoolModel.cs
@@ -301,7 +301,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity1Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity1, int>(((KoolEntity1)entity).Id);
         }
@@ -320,7 +320,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity2Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity2, int>(((KoolEntity2)entity).Id);
         }
@@ -339,7 +339,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity3Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity3, int>(((KoolEntity3)entity).Id);
         }
@@ -358,7 +358,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity4Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity4, int>(((KoolEntity4)entity).Id);
         }
@@ -377,7 +377,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity5Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity5, int>(((KoolEntity5)entity).Id);
         }
@@ -396,7 +396,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity6Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity6, int>(((KoolEntity6)entity).Id);
         }
@@ -415,7 +415,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity7Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity7, int>(((KoolEntity7)entity).Id);
         }
@@ -434,7 +434,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity8Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity8, int>(((KoolEntity8)entity).Id);
         }
@@ -453,7 +453,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity9Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity9, int>(((KoolEntity9)entity).Id);
         }
@@ -472,7 +472,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity10Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity10, int>(((KoolEntity10)entity).Id);
         }
@@ -491,7 +491,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity11Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity11, int>(((KoolEntity11)entity).Id);
         }
@@ -510,7 +510,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity12Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity12, int>(((KoolEntity12)entity).Id);
         }
@@ -529,7 +529,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity13Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity13, int>(((KoolEntity13)entity).Id);
         }
@@ -548,7 +548,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity14Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity14, int>(((KoolEntity14)entity).Id);
         }
@@ -567,7 +567,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity15Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity15, int>(((KoolEntity15)entity).Id);
         }
@@ -586,7 +586,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity16Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity16, int>(((KoolEntity16)entity).Id);
         }
@@ -605,7 +605,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity17Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity17, int>(((KoolEntity17)entity).Id);
         }
@@ -624,7 +624,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity18Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity18, int>(((KoolEntity18)entity).Id);
         }
@@ -643,7 +643,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity19Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity19, int>(((KoolEntity19)entity).Id);
         }
@@ -662,7 +662,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity20Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity20, int>(((KoolEntity20)entity).Id);
         }
@@ -681,7 +681,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity21Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity21, int>(((KoolEntity21)entity).Id);
         }
@@ -700,7 +700,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity22Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity22, int>(((KoolEntity22)entity).Id);
         }
@@ -719,7 +719,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity23Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity23, int>(((KoolEntity23)entity).Id);
         }
@@ -738,7 +738,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity24Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity24, int>(((KoolEntity24)entity).Id);
         }
@@ -757,7 +757,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity25Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity25, int>(((KoolEntity25)entity).Id);
         }
@@ -776,7 +776,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity26Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity26, int>(((KoolEntity26)entity).Id);
         }
@@ -795,7 +795,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity27Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity27, int>(((KoolEntity27)entity).Id);
         }
@@ -814,7 +814,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity28Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity28, int>(((KoolEntity28)entity).Id);
         }
@@ -833,7 +833,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity29Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity29, int>(((KoolEntity29)entity).Id);
         }
@@ -852,7 +852,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity30Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity30, int>(((KoolEntity30)entity).Id);
         }
@@ -871,7 +871,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity31Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity31, int>(((KoolEntity31)entity).Id);
         }
@@ -890,7 +890,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity32Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity32, int>(((KoolEntity32)entity).Id);
         }
@@ -909,7 +909,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity33Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity33, int>(((KoolEntity33)entity).Id);
         }
@@ -928,7 +928,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity34Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity34, int>(((KoolEntity34)entity).Id);
         }
@@ -947,7 +947,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity35Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity35, int>(((KoolEntity35)entity).Id);
         }
@@ -966,7 +966,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity36Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity36, int>(((KoolEntity36)entity).Id);
         }
@@ -985,7 +985,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity37Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity37, int>(((KoolEntity37)entity).Id);
         }
@@ -1004,7 +1004,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity38Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity38, int>(((KoolEntity38)entity).Id);
         }
@@ -1023,7 +1023,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity39Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity39, int>(((KoolEntity39)entity).Id);
         }
@@ -1042,7 +1042,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity40Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity40, int>(((KoolEntity40)entity).Id);
         }
@@ -1061,7 +1061,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity41Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity41, int>(((KoolEntity41)entity).Id);
         }
@@ -1080,7 +1080,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity42Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity42, int>(((KoolEntity42)entity).Id);
         }
@@ -1099,7 +1099,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity43Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity43, int>(((KoolEntity43)entity).Id);
         }
@@ -1118,7 +1118,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity44Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity44, int>(((KoolEntity44)entity).Id);
         }
@@ -1137,7 +1137,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity45Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity45, int>(((KoolEntity45)entity).Id);
         }
@@ -1156,7 +1156,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity46Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity46, int>(((KoolEntity46)entity).Id);
         }
@@ -1175,7 +1175,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity47Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity47, int>(((KoolEntity47)entity).Id);
         }
@@ -1194,7 +1194,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity48Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity48, int>(((KoolEntity48)entity).Id);
         }
@@ -1213,7 +1213,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity49Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity49, int>(((KoolEntity49)entity).Id);
         }
@@ -1232,7 +1232,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return "KoolEntity50Table"; }
         }
 
-        public EntityKey CreateKey(object entity)
+        public EntityKey CreateEntityKey(object entity)
         {
             return new SimpleEntityKey<KoolEntity50, int>(((KoolEntity50)entity).Id);
         }

--- a/test/Microsoft.Data.Entity.Tests/Metadata/EntityTypeTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Metadata/EntityTypeTest.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Data.Entity.Metadata
             Assert.Equal(
                 "entity",
                 // ReSharper disable once AssignNullToNotNullAttribute
-                Assert.Throws<ArgumentNullException>(() => entityType.CreateKey(null)).ParamName);
+                Assert.Throws<ArgumentNullException>(() => entityType.CreateEntityKey(null)).ParamName);
         }
 
         [Fact]
@@ -185,7 +185,7 @@ namespace Microsoft.Data.Entity.Metadata
         {
             var entityType = new EntityType(typeof(Customer)) { Key = new[] { new Property(Customer.IdProperty) } };
 
-            var key = entityType.CreateKey(new Customer { Id = 77 });
+            var key = entityType.CreateEntityKey(new Customer { Id = 77 });
 
             Assert.IsType<SimpleEntityKey<Customer, int>>(key);
             Assert.Equal(77, key.Value);

--- a/test/Microsoft.Data.Entity.Tests/Metadata/MetadataBaseTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Metadata/MetadataBaseTest.cs
@@ -55,6 +55,16 @@ namespace Microsoft.Data.Entity.Metadata
         }
 
         [Fact]
+        public void Add_duplicate_annotation_throws()
+        {
+            var metadataBase = new ConcreteMetadata();
+
+            metadataBase.AddAnnotation(new Annotation("Foo", "Bar"));
+
+            Assert.Throws<ArgumentException>(() => metadataBase.AddAnnotation(new Annotation("Foo", "Bar")));
+        }
+
+        [Fact]
         public void Can_remove_annotation()
         {
             var metadataBase = new ConcreteMetadata();
@@ -67,6 +77,8 @@ namespace Microsoft.Data.Entity.Metadata
             metadataBase.RemoveAnnotation(annotation);
 
             Assert.Null(metadataBase["Foo"]);
+
+            metadataBase.RemoveAnnotation(annotation); // no throw
         }
 
         [Fact]

--- a/test/Microsoft.Data.Entity.Tests/Metadata/ModelBuilderTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Metadata/ModelBuilderTest.cs
@@ -78,6 +78,19 @@ namespace Microsoft.Data.Entity.Metadata
         }
 
         [Fact]
+        public void Can_set_entity_storage_name()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+
+            modelBuilder
+                .Entity<Customer>()
+                .StorageName("foo");
+
+            Assert.Equal("foo", model.Entity(typeof(Customer)).StorageName);
+        }
+
+        [Fact]
         public void Can_set_property_annotation()
         {
             var model = new Model();
@@ -90,6 +103,21 @@ namespace Microsoft.Data.Entity.Metadata
             Assert.Equal(
                 "bar",
                 model.Entity(typeof(Customer)).Property("Name")["foo"]);
+        }
+
+        [Fact]
+        public void Can_set_property_storage_name()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+
+            modelBuilder
+                .Entity<Customer>()
+                .Properties(ps => ps.Property(c => c.Name).StorageName("foo"));
+
+            Assert.Equal(
+                "foo",
+                model.Entity(typeof(Customer)).Property("Name").StorageName);
         }
 
         [Fact]

--- a/test/Microsoft.Data.Relational.Tests/ApiExtensionsTest.cs
+++ b/test/Microsoft.Data.Relational.Tests/ApiExtensionsTest.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.Data.Entity.Metadata;
+using Xunit;
+
+namespace Microsoft.Data.Relational
+{
+    public class ApiExtensionsTest
+    {
+        #region Fixture
+
+        public class Customer
+        {
+            public int Id { get; set; }
+        }
+
+        #endregion
+
+        [Fact]
+        public void ToTable_sets_storage_name_on_entity()
+        {
+            var model = new Entity.Metadata.Model();
+            var modelBuilder = new ModelBuilder(model);
+
+            modelBuilder.Entity<Customer>().ToTable("customers");
+
+            Assert.Equal("customers", model.Entities.Single().StorageName);
+        }
+
+        [Fact]
+        public void ColumnName_sets_storage_name_on_entity_property()
+        {
+            var model = new Entity.Metadata.Model();
+            var modelBuilder = new ModelBuilder(model);
+
+            modelBuilder.Entity<Customer>().Properties(ps => ps.Property(c => c.Id).ColumnName("id"));
+
+            Assert.Equal("id", model.Entities.Single().Properties.Single().StorageName);
+        }
+
+        [Fact]
+        public void ColumnType_sets_annotation_on_entity_property()
+        {
+            var model = new Entity.Metadata.Model();
+            var modelBuilder = new ModelBuilder(model);
+
+            modelBuilder.Entity<Customer>().Properties(ps => ps.Property(c => c.Id).ColumnType("bigint"));
+
+            Assert.Equal("bigint", model.Entities.Single().Properties.Single()[ApiExtensions.Annotations.StorageTypeName]);
+        }
+    }
+}

--- a/test/Microsoft.Data.Relational.Tests/Microsoft.Data.Relational.Tests.net45.csproj
+++ b/test/Microsoft.Data.Relational.Tests/Microsoft.Data.Relational.Tests.net45.csproj
@@ -45,6 +45,10 @@
     <None Include="_project.json" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Data.Entity\Microsoft.Data.Entity.net45.csproj">
+      <Project>{71415CEC-8111-4C73-8751-512D22F10602}</Project>
+      <Name>Microsoft.Data.Entity.net45</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\Microsoft.Data.Relational\Microsoft.Data.Relational.net45.csproj">
       <Project>{75c5a774-a3f3-43eb-97d3-dbe0cf2825d8}</Project>
       <Name>Microsoft.Data.Relational.net45</Name>
@@ -55,6 +59,7 @@
       <Link>ApiConsistencyTestBase.cs</Link>
     </Compile>
     <Compile Include="ApiConsistencyTest.cs" />
+    <Compile Include="ApiExtensionsTest.cs" />
     <Compile Include="SchemaQualifiedNameTest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Also renames IEntityKey.CreateKey to CreateEntityKey to differentiate from IEntityType.Key.
Fixes a bug in the relational Column type.
