### PR TITLE
Are you the Keymaster?

### DIFF
--- a/src/Microsoft.Data.Entity/ChangeTracking/ChangeTrackerFactory.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/ChangeTrackerFactory.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Identity;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.ChangeTracking
+{
+    public class ChangeTrackerFactory
+    {
+        private readonly ActiveIdentityGenerators _identityGenerators;
+
+        // Intended only for creation of test doubles
+        internal ChangeTrackerFactory()
+        {
+        }
+
+        public ChangeTrackerFactory([NotNull] ActiveIdentityGenerators identityGenerators)
+        {
+            Check.NotNull(identityGenerators, "identityGenerators");
+
+            _identityGenerators = identityGenerators;
+        }
+
+        public virtual ChangeTracker Create([NotNull] IModel model)
+        {
+            Check.NotNull(model, "model");
+
+            return new ChangeTracker(model, _identityGenerators);
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/ChangeTracking/EntityEntry.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/EntityEntry.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System.Threading;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 
@@ -34,12 +35,12 @@ namespace Microsoft.Data.Entity.ChangeTracking
 
         public virtual EntityState State
         {
-            get { return _entry.EntityState; }
+            get { return _entry.GetEntityState(); }
             set
             {
                 Check.IsDefined(value, "value");
 
-                _entry.EntityState = value;
+                _entry.SetEntityStateAsync(value, CancellationToken.None).Wait();
             }
         }
 

--- a/src/Microsoft.Data.Entity/EntityContext.cs
+++ b/src/Microsoft.Data.Entity/EntityContext.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Data.Entity
     public class EntityContext : IDisposable
     {
         private readonly EntityConfiguration _entityConfiguration;
+        private ChangeTracker _changeTracker;
+        private IModel _model;
 
         public EntityContext([NotNull] EntityConfiguration entityConfiguration)
         {
@@ -47,10 +49,7 @@ namespace Microsoft.Data.Entity
         {
             Check.NotNull(entity, "entity");
 
-            // TODO: Somewhere down this call path needs to do key generation
-            ChangeTracker.Entry(entity).State = EntityState.Added;
-
-            return entity;
+            return AddAsync(entity, CancellationToken.None).Result;
         }
 
         public virtual Task<TEntity> AddAsync<TEntity>([NotNull] TEntity entity)
@@ -60,12 +59,13 @@ namespace Microsoft.Data.Entity
             return AddAsync(entity, CancellationToken.None);
         }
 
-        public virtual Task<TEntity> AddAsync<TEntity>([NotNull] TEntity entity, CancellationToken cancellationToken)
+        public virtual async Task<TEntity> AddAsync<TEntity>([NotNull] TEntity entity, CancellationToken cancellationToken)
         {
             Check.NotNull(entity, "entity");
 
-            // TODO: When key gen exists this will need to be really async
-            return Task.FromResult(Add(entity));
+            await ChangeTracker.Entry(entity).Entry.SetEntityStateAsync(EntityState.Added, cancellationToken);
+
+            return entity;
         }
 
         public virtual TEntity Update<TEntity>([NotNull] TEntity entity)
@@ -98,12 +98,21 @@ namespace Microsoft.Data.Entity
 
         public virtual ChangeTracker ChangeTracker
         {
-            get { return _entityConfiguration.ChangeTracker; }
+            get { return _changeTracker; }
         }
 
+        // TODO: Model discovery/configuration needed
         public virtual IModel Model
         {
-            get { return _entityConfiguration.Model; }
+            get { return _model; }
+            [param: NotNull]
+            set
+            {
+                Check.NotNull(value, "value");
+
+                _model = value;
+                _changeTracker = _entityConfiguration.ChangeTrackerFactory.Create(value);
+            }
         }
     }
 }

--- a/src/Microsoft.Data.Entity/EntityServices.cs
+++ b/src/Microsoft.Data.Entity/EntityServices.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using Microsoft.AspNet.DependencyInjection;
 using Microsoft.AspNet.Logging;
+using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Identity;
 using Microsoft.Data.Entity.Services;
 
@@ -14,7 +14,9 @@ namespace Microsoft.Data.Entity
         public static IEnumerable<IServiceDescriptor> GetDefaultServices()
         {
             yield return ServiceDescriptor.Singleton<ILoggerFactory, ConsoleLoggerFactory>();
-            yield return ServiceDescriptor.Singleton<IIdentityGenerator<Guid>, GuidIdentityGenerator>();
+            yield return ServiceDescriptor.Singleton<IdentityGeneratorFactory, DefaultIdentityGeneratorFactory>();
+            yield return ServiceDescriptor.Singleton<ActiveIdentityGenerators, ActiveIdentityGenerators>();
+            yield return ServiceDescriptor.Scoped<ChangeTrackerFactory, ChangeTrackerFactory>();
         }
     }
 }

--- a/src/Microsoft.Data.Entity/Identity/ActiveIdentityGenerators.cs
+++ b/src/Microsoft.Data.Entity/Identity/ActiveIdentityGenerators.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Identity
+{
+    public class ActiveIdentityGenerators
+    {
+        private readonly IdentityGeneratorFactory _factory;
+
+        private readonly LazyRef<ImmutableDictionary<IProperty, IIdentityGenerator>> _identityGenerators
+            = new LazyRef<ImmutableDictionary<IProperty, IIdentityGenerator>>(
+                () => ImmutableDictionary<IProperty, IIdentityGenerator>.Empty);
+
+        // Intended only for creation of test doubles
+        internal ActiveIdentityGenerators()
+        {
+        }
+
+        public ActiveIdentityGenerators([NotNull] IdentityGeneratorFactory factory)
+        {
+            Check.NotNull(factory, "factory");
+
+            _factory = factory;
+        }
+
+        public virtual IIdentityGenerator GetOrAdd([NotNull] IProperty property)
+        {
+            Check.NotNull(property, "property");
+
+            IIdentityGenerator generator;
+            if (_identityGenerators.Value.TryGetValue(property, out generator))
+            {
+                return generator;
+            }
+
+            _identityGenerators.ExchangeValue(
+                d => !d.ContainsKey(property) ? d.Add(property, _factory.Create(property)) : d);
+
+            return _identityGenerators.Value[property];
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/Identity/DefaultIdentityGeneratorFactory.cs
+++ b/src/Microsoft.Data.Entity/Identity/DefaultIdentityGeneratorFactory.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.Identity
+{
+    public class DefaultIdentityGeneratorFactory : IdentityGeneratorFactory
+    {
+        public override IIdentityGenerator Create(IProperty property)
+        {
+            switch (property.ValueGenerationStrategy)
+            {
+                case ValueGenerationStrategy.None:
+                    return null;
+                case ValueGenerationStrategy.Client:
+                    if (property.PropertyType == typeof(Guid))
+                    {
+                        return new GuidIdentityGenerator();
+                    }
+                    goto default;
+                default:
+                    // TODO: Proper handling of error case.
+                    throw new NotSupportedException("No identity generator has been registered for type x and strategy y.");
+            }
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/Identity/GuidIdentityGenerator.cs
+++ b/src/Microsoft.Data.Entity/Identity/GuidIdentityGenerator.cs
@@ -1,20 +1,21 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Data.Entity.Identity
 {
     public class GuidIdentityGenerator : IIdentityGenerator<Guid>
     {
-        public virtual Task<Guid> NextAsync()
+        public virtual Task<Guid> NextAsync(CancellationToken cancellationToken)
         {
             return Task.FromResult(Guid.NewGuid());
         }
 
-        async Task<object> IIdentityGenerator.NextAsync()
+        async Task<object> IIdentityGenerator.NextAsync(CancellationToken cancellationToken)
         {
-            return await NextAsync();
+            return await NextAsync(cancellationToken);
         }
     }
 }

--- a/src/Microsoft.Data.Entity/Identity/IIdentityGenerator.cs
+++ b/src/Microsoft.Data.Entity/Identity/IIdentityGenerator.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Data.Entity.Identity
 {
     public interface IIdentityGenerator
     {
-        Task<object> NextAsync();
+        Task<object> NextAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Data.Entity/Identity/IIdentityGenerator`.cs
+++ b/src/Microsoft.Data.Entity/Identity/IIdentityGenerator`.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Data.Entity.Identity
 {
     public interface IIdentityGenerator<T> : IIdentityGenerator
     {
-        new Task<T> NextAsync();
+        new Task<T> NextAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Microsoft.Data.Entity/Identity/IdentityGeneratorFactory.cs
+++ b/src/Microsoft.Data.Entity/Identity/IdentityGeneratorFactory.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.Identity
+{
+    public abstract class IdentityGeneratorFactory
+    {
+        public abstract IIdentityGenerator Create([NotNull] IProperty property);
+    }
+}

--- a/src/Microsoft.Data.Entity/Identity/OverridingIdentityGeneratorFactory.cs
+++ b/src/Microsoft.Data.Entity/Identity/OverridingIdentityGeneratorFactory.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Identity
+{
+    public class OverridingIdentityGeneratorFactory : IdentityGeneratorFactory
+    {
+        private readonly IdentityGeneratorFactory _overridingFactory;
+        private readonly IdentityGeneratorFactory _defaultFactory;
+
+        public OverridingIdentityGeneratorFactory(
+            [NotNull] IdentityGeneratorFactory overridingFactory, [NotNull] IdentityGeneratorFactory defaultFactory)
+        {
+            Check.NotNull(overridingFactory, "overridingFactory");
+            Check.NotNull(defaultFactory, "defaultFactory");
+
+            _overridingFactory = overridingFactory;
+            _defaultFactory = defaultFactory;
+        }
+
+        public override IIdentityGenerator Create(IProperty property)
+        {
+            return _overridingFactory.Create(property) ?? _defaultFactory.Create(property);
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/Metadata/Compiled/CompiledPropertyBase`.cs
+++ b/src/Microsoft.Data.Entity/Metadata/Compiled/CompiledPropertyBase`.cs
@@ -34,5 +34,10 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
         {
             get { return typeof(TEntity); }
         }
+
+        public ValueGenerationStrategy ValueGenerationStrategy
+        {
+            get { return ValueGenerationStrategy.None; }
+        }
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/IProperty.cs
+++ b/src/Microsoft.Data.Entity/Metadata/IProperty.cs
@@ -13,5 +13,6 @@ namespace Microsoft.Data.Entity.Metadata
         Type DeclaringType { get; }
         void SetValue([NotNull] object instance, [CanBeNull] object value);
         object GetValue([NotNull] object instance);
+        ValueGenerationStrategy ValueGenerationStrategy { get; }
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/Property.cs
+++ b/src/Microsoft.Data.Entity/Metadata/Property.cs
@@ -69,6 +69,8 @@ namespace Microsoft.Data.Entity.Metadata
             get { return _declaringType; }
         }
 
+        public virtual ValueGenerationStrategy ValueGenerationStrategy { get; [param: NotNull] set; }
+
         public virtual void SetValue(object instance, object value)
         {
             Check.NotNull(instance, "instance");

--- a/src/Microsoft.Data.Entity/Metadata/ValueGenerationStrategy.cs
+++ b/src/Microsoft.Data.Entity/Metadata/ValueGenerationStrategy.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.Metadata
+{
+    public enum ValueGenerationStrategy
+    {
+        None,
+        Client,
+        StoreSequence,
+        StoreIdentity,
+        StoreComputed
+    }
+}

--- a/src/Microsoft.Data.Entity/Properties/InternalsVisibleTo.cs
+++ b/src/Microsoft.Data.Entity/Properties/InternalsVisibleTo.cs
@@ -9,9 +9,6 @@ using System.Runtime.CompilerServices;
 
 // for Moq
 
-[assembly:
-    InternalsVisibleTo(
-        "DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7"
-        )]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 
 #endif

--- a/src/Microsoft.Data.Entity/Properties/Strings.Designer.cs
+++ b/src/Microsoft.Data.Entity/Properties/Strings.Designer.cs
@@ -50,6 +50,22 @@ namespace Microsoft.Data.Entity
             return string.Format(CultureInfo.CurrentCulture, GetString("MissingConfigurationItem", "serviceType"), serviceType);
         }
 
+        /// <summary>
+        /// The entity of type '{entityType}' cannot be tracked because type '{entityType}' has not been included in the model. To include this type in the model create an EntitySet&lt;{entityType}&gt; property on your EntityContext class, or use the ModelBuilder.Entity&lt;{entityType}&gt; method.
+        /// </summary>
+        internal static string TypeNotInModel(object entityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("TypeNotInModel", "entityType"), entityType);
+        }
+
+        /// <summary>
+        /// The instance of entity type '{entityType}' cannot be tracked because another instance of this type with the same key is already being tracked. For new entities consider using an IIdentityGenerator to generate unique key values.
+        /// </summary>
+        internal static string IdentityConflict(object entityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("IdentityConflict", "entityType"), entityType);
+        }
+
         private static string GetString(string name, params string[] argumentNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.Data.Entity/Properties/Strings.resx
+++ b/src/Microsoft.Data.Entity/Properties/Strings.resx
@@ -132,4 +132,10 @@
   <data name="MissingConfigurationItem" xml:space="preserve">
     <value>A service of type '{serviceType}' has not been configured. Either configure the service explicitly, or ensure one is available from the current IServiceProvider.</value>
   </data>
+  <data name="TypeNotInModel" xml:space="preserve">
+    <value>The entity of type '{entityType}' cannot be tracked because type '{entityType}' has not been included in the model. To include this type in the model create an EntitySet&lt;{entityType}&gt; property on your EntityContext class, or use the ModelBuilder.Entity&lt;{entityType}&gt; method.</value>
+  </data>
+  <data name="IdentityConflict" xml:space="preserve">
+    <value>The instance of entity type '{entityType}' cannot be tracked because another instance of this type with the same key is already being tracked. For new entities consider using an IIdentityGenerator to generate unique key values.</value>
+  </data>
 </root>

--- a/src/Microsoft.Data.InMemory/InMemoryIdentityGenerator.cs
+++ b/src/Microsoft.Data.InMemory/InMemoryIdentityGenerator.cs
@@ -10,14 +10,14 @@ namespace Microsoft.Data.InMemory
     {
         private static long _current;
 
-        public Task<long> NextAsync()
+        public Task<long> NextAsync(CancellationToken cancellationToken)
         {
             return Task.FromResult(Interlocked.Increment(ref _current));
         }
 
-        async Task<object> IIdentityGenerator.NextAsync()
+        async Task<object> IIdentityGenerator.NextAsync(CancellationToken cancellationToken)
         {
-            return await NextAsync();
+            return await NextAsync(cancellationToken);
         }
     }
 }

--- a/src/Microsoft.Data.InMemory/InMemoryIdentityGeneratorFactory.cs
+++ b/src/Microsoft.Data.InMemory/InMemoryIdentityGeneratorFactory.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Identity;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.InMemory
+{
+    public class InMemoryIdentityGeneratorFactory : DefaultIdentityGeneratorFactory
+    {
+        public override IIdentityGenerator Create(IProperty property)
+        {
+            switch (property.ValueGenerationStrategy)
+            {
+                case ValueGenerationStrategy.Client:
+                    if (property.PropertyType == typeof(long))
+                    {
+                        return new InMemoryIdentityGenerator();
+                    }
+                    goto default;
+                default:
+                    return base.Create(property);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Data.InMemory/InMemoryServices.cs
+++ b/src/Microsoft.Data.InMemory/InMemoryServices.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Data.InMemory
     {
         public static IEnumerable<IServiceDescriptor> GetDefaultServices()
         {
-            yield return ServiceDescriptor.Singleton<IIdentityGenerator<long>, InMemoryIdentityGenerator>();
+            yield return ServiceDescriptor.Singleton<IdentityGeneratorFactory, InMemoryIdentityGeneratorFactory>();
         }
     }
 }

--- a/src/Microsoft.Data.Migrations/Properties/InternalsVisibleTo.cs
+++ b/src/Microsoft.Data.Migrations/Properties/InternalsVisibleTo.cs
@@ -8,9 +8,6 @@ using System.Runtime.CompilerServices;
 
 // for Moq
 
-[assembly:
-    InternalsVisibleTo(
-        "DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7"
-        )]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 
 #endif

--- a/src/Microsoft.Data.Relational/IDbCommandExecutor.cs
+++ b/src/Microsoft.Data.Relational/IDbCommandExecutor.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 
@@ -7,6 +8,7 @@ namespace Microsoft.Data.Relational
 {
     public interface IDbCommandExecutor
     {
-        Task<T> ExecuteScalarAsync<T>([NotNull] string commandText, [NotNull] params object[] parameters);
+        Task<T> ExecuteScalarAsync<T>(
+            [NotNull] string commandText, CancellationToken cancellationToken, [NotNull] params object[] parameters);
     }
 }

--- a/src/Microsoft.Data.Relational/Properties/InternalsVisibleTo.cs
+++ b/src/Microsoft.Data.Relational/Properties/InternalsVisibleTo.cs
@@ -8,9 +8,6 @@ using System.Runtime.CompilerServices;
 
 // for Moq
 
-[assembly:
-    InternalsVisibleTo(
-        "DynamicProxyGenAssembly2, PublicKey=0024000004800000940000000602000000240000525341310004000001000100c547cac37abd99c8db225ef2f6c8a3602f3b3606cc9891605d02baa56104f4cfc0734aa39b93bf7852f7d9266654753cc297e7d2edfe0bac1cdcf9f717241550e0a7b191195b7667bb4f64bcb8e2121380fd1d9d46ad2d92d2d15605093924cceaf74c4861eff62abf69b9291ed0a340e113be11e6a7d3113e92484cf7045cc7"
-        )]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]
 
 #endif

--- a/src/Microsoft.Data.SqlServer/SequenceIdentityGenerator.cs
+++ b/src/Microsoft.Data.SqlServer/SequenceIdentityGenerator.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System.Threading;
 #if NET45
 using Microsoft.Data.Migrations.Model;
 using Microsoft.Data.Relational;
@@ -53,20 +54,20 @@ namespace Microsoft.Data.SqlServer
                     new SqlServerMigrationOperationSqlGenerator().DelimitIdentifier(_sequenceName));
         }
 
-        public virtual async Task<long> NextAsync()
+        public virtual async Task<long> NextAsync(CancellationToken cancellationToken)
         {
             if (_current == _max)
             {
-                _current = await _commandExecutor.ExecuteScalarAsync<long>(_selectNextValueSql);
+                _current = await _commandExecutor.ExecuteScalarAsync<long>(_selectNextValueSql, cancellationToken);
                 _max = _current + _increment;
             }
 
             return ++_current;
         }
 
-        async Task<object> IIdentityGenerator.NextAsync()
+        async Task<object> IIdentityGenerator.NextAsync(CancellationToken cancellationToken)
         {
-            return await NextAsync();
+            return await NextAsync(cancellationToken);
         }
 
         public virtual CreateSequenceOperation CreateMigrationOperation()

--- a/src/Microsoft.Data.SqlServer/SequentialGuidIdentityGenerator.cs
+++ b/src/Microsoft.Data.SqlServer/SequentialGuidIdentityGenerator.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.SqlServer
             _counter = DateTime.UtcNow.Ticks;
         }
 
-        public Task<Guid> NextAsync()
+        public Task<Guid> NextAsync(CancellationToken cancellationToken)
         {
             var guidBytes = Guid.NewGuid().ToByteArray();
             var counterBytes = BitConverter.GetBytes(Interlocked.Increment(ref _counter));
@@ -38,9 +38,9 @@ namespace Microsoft.Data.SqlServer
             return Task.FromResult(new Guid(guidBytes));
         }
 
-        async Task<object> IIdentityGenerator.NextAsync()
+        async Task<object> IIdentityGenerator.NextAsync(CancellationToken cancellationToken)
         {
-            return await NextAsync();
+            return await NextAsync(cancellationToken);
         }
     }
 }

--- a/src/Microsoft.Data.SqlServer/SqlServerIdentityGeneratorFactory.cs
+++ b/src/Microsoft.Data.SqlServer/SqlServerIdentityGeneratorFactory.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.Identity;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.SqlServer
+{
+    public class SqlServerIdentityGeneratorFactory : DefaultIdentityGeneratorFactory
+    {
+        public override IIdentityGenerator Create(IProperty property)
+        {
+            switch (property.ValueGenerationStrategy)
+            {
+                case ValueGenerationStrategy.Client:
+                    if (property.PropertyType == typeof(Guid))
+                    {
+                        return new SequentialGuidIdentityGenerator();
+                    }
+                    goto default;
+
+                case ValueGenerationStrategy.StoreSequence:
+#if NET45
+                    if (property.PropertyType == typeof(long))
+                    {
+                        return new SequenceIdentityGenerator(new SqlServerSimpleCommandExecutor("TODO: Connection string"));
+                    }
+#endif
+                    goto default;
+
+                default:
+                    return base.Create(property);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlServer/SqlServerServices.cs
+++ b/src/Microsoft.Data.SqlServer/SqlServerServices.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using Microsoft.AspNet.DependencyInjection;
 using Microsoft.Data.Entity.Identity;
@@ -12,11 +11,7 @@ namespace Microsoft.Data.SqlServer
     {
         public static IEnumerable<IServiceDescriptor> GetDefaultServices()
         {
-            yield return ServiceDescriptor.Singleton<IIdentityGenerator<Guid>, SequentialGuidIdentityGenerator>();
-#if NET45
-            yield return ServiceDescriptor.Transient<IIdentityGenerator<long>>(
-                new SequenceIdentityGenerator(new SqlServerSimpleCommandExecutor("TODO: Connection string")));
-#endif
+            yield return ServiceDescriptor.Singleton<IdentityGeneratorFactory, SqlServerIdentityGeneratorFactory>();
         }
     }
 }

--- a/src/Microsoft.Data.SqlServer/SqlServerSimpleCommandExecutor.cs
+++ b/src/Microsoft.Data.SqlServer/SqlServerSimpleCommandExecutor.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System.Threading;
 #if NET45
 using System.Data.SqlClient;
 using System.Threading.Tasks;
@@ -29,21 +30,21 @@ namespace Microsoft.Data.SqlServer
             _commandTimeout = commandTimeout;
         }
 
-        public async Task<T> ExecuteScalarAsync<T>(string commandText, params object[] parameters)
+        public async Task<T> ExecuteScalarAsync<T>(string commandText, CancellationToken cancellationToken, params object[] parameters)
         {
             Check.NotEmpty(commandText, "commandText");
             Check.NotNull(parameters, "parameters");
 
             using (var connection = new SqlConnection(_connectionString))
             {
-                await connection.OpenAsync();
+                await connection.OpenAsync(cancellationToken);
 
                 using (var command = connection.CreateCommand())
                 {
                     command.CommandText = commandText;
                     command.CommandTimeout = _commandTimeout;
 
-                    return (T)await command.ExecuteScalarAsync();
+                    return (T)await command.ExecuteScalarAsync(cancellationToken);
                 }
             }
         }

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -2,7 +2,9 @@
 
 using System;
 using System.Linq;
+using Microsoft.Data.Entity.Identity;
 using Microsoft.Data.Entity.Metadata;
+using Moq;
 using Xunit;
 
 namespace Microsoft.Data.Entity.ChangeTracking
@@ -15,9 +17,15 @@ namespace Microsoft.Data.Entity.ChangeTracking
             Assert.Equal(
                 "model",
                 // ReSharper disable once AssignNullToNotNullAttribute
-                Assert.Throws<ArgumentNullException>(() => new ChangeTracker(null)).ParamName);
+                Assert.Throws<ArgumentNullException>(
+                    () => new ChangeTracker(null, new Mock<ActiveIdentityGenerators>().Object)).ParamName);
 
-            var changeTracker = new ChangeTracker(new Model());
+            Assert.Equal(
+                "identityGenerators",
+                // ReSharper disable once AssignNullToNotNullAttribute
+                Assert.Throws<ArgumentNullException>(() => new ChangeTracker(new Model(), null)).ParamName);
+
+            var changeTracker = new ChangeTracker(BuildModel(), new Mock<ActiveIdentityGenerators>().Object);
 
             Assert.Equal(
                 "entity",
@@ -32,7 +40,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
         [Fact]
         public void Entry_returns_tracking_entry_if_entity_is_already_tracked_otherwise_new_entry()
         {
-            var tracker = new ChangeTracker(BuildModel());
+            var tracker = new ChangeTracker(BuildModel(), new Mock<ActiveIdentityGenerators>().Object);
 
             var category = new Category();
             var entry = tracker.Entry(category);
@@ -52,7 +60,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
         [Fact]
         public void Non_generic_Entry_returns_tracking_entry_if_entity_is_already_tracked_otherwise_new_entry()
         {
-            var tracker = new ChangeTracker(BuildModel());
+            var tracker = new ChangeTracker(BuildModel(), new Mock<ActiveIdentityGenerators>().Object);
 
             var category = new Category();
             var entry = tracker.Entry((object)category);
@@ -70,9 +78,37 @@ namespace Microsoft.Data.Entity.ChangeTracking
         }
 
         [Fact]
+        public void Entry_returns_new_entry_if_another_entity_with_the_same_key_is_already_tracked()
+        {
+            var tracker = new ChangeTracker(BuildModel(), new Mock<ActiveIdentityGenerators>().Object);
+
+            Assert.NotSame(
+                tracker.Entry(new Category { Id = 77 }).Entry,
+                tracker.Entry(new Category { Id = 77 }).Entry);
+
+            Assert.NotSame(
+                tracker.Entry((object)new Category { Id = 77 }).Entry,
+                tracker.Entry((object)new Category { Id = 77 }).Entry);
+        }
+
+        [Fact]
+        public void Entry_throws_for_entity_not_in_the_model()
+        {
+            var tracker = new ChangeTracker(BuildModel(), new Mock<ActiveIdentityGenerators>().Object);
+
+            Assert.Equal(
+                Strings.TypeNotInModel("Random"),
+                Assert.Throws<InvalidOperationException>(() => tracker.Entry(new Random())).Message);
+
+            Assert.Equal(
+                Strings.TypeNotInModel("Random"),
+                Assert.Throws<InvalidOperationException>(() => tracker.Entry((object)new Random())).Message);
+        }
+
+        [Fact]
         public void Can_get_all_entities()
         {
-            var tracker = new ChangeTracker(BuildModel());
+            var tracker = new ChangeTracker(BuildModel(), new Mock<ActiveIdentityGenerators>().Object);
 
             new EntityEntry(tracker, new Category { Id = 77 }) { State = EntityState.Added };
             new EntityEntry(tracker, new Category { Id = 78 }) { State = EntityState.Added };
@@ -103,7 +139,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
         [Fact]
         public void Can_get_all_entities_of_a_given_type()
         {
-            var tracker = new ChangeTracker(BuildModel());
+            var tracker = new ChangeTracker(BuildModel(), new Mock<ActiveIdentityGenerators>().Object);
 
             new EntityEntry(tracker, new Category { Id = 77 }) { State = EntityState.Added };
             new EntityEntry(tracker, new Category { Id = 78 }) { State = EntityState.Added };
@@ -133,7 +169,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
         public void Can_get_model()
         {
             var model = BuildModel();
-            Assert.Same(model, new ChangeTracker(model).Model);
+            Assert.Same(model, new ChangeTracker(model, new Mock<ActiveIdentityGenerators>().Object).Model);
         }
 
         #region Fixture

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/PropertyEntryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/PropertyEntryTest.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Data.Entity.Identity;
 using Microsoft.Data.Entity.Metadata;
+using Moq;
 using Xunit;
 
 namespace Microsoft.Data.Entity.ChangeTracking
@@ -11,7 +13,9 @@ namespace Microsoft.Data.Entity.ChangeTracking
         [Fact]
         public void Members_check_arguments()
         {
-            var entityEntry = new EntityEntry<Cheese>(new ChangeTracker(BuildModel()), new Cheese());
+            var entityEntry = new EntityEntry<Cheese>(
+                new ChangeTracker(BuildModel(), new Mock<ActiveIdentityGenerators>().Object),
+                new Cheese());
 
             Assert.Equal(
                 Strings.ArgumentIsEmpty("name"),
@@ -33,8 +37,9 @@ namespace Microsoft.Data.Entity.ChangeTracking
         [Fact]
         public void Can_get_name()
         {
-            var entity = new Cheese();
-            var entityEntry = new EntityEntry<Cheese>(new ChangeTracker(BuildModel()), entity) { State = EntityState.Unchanged };
+            var entityEntry = new EntityEntry<Cheese>(
+                new ChangeTracker(BuildModel(), new Mock<ActiveIdentityGenerators>().Object),
+                new Cheese());
 
             Assert.Equal("Maturity", new PropertyEntry(entityEntry, "Maturity").Name);
             Assert.Equal("Maturity", new PropertyEntry<Cheese, string>(entityEntry, "Maturity").Name);
@@ -43,8 +48,9 @@ namespace Microsoft.Data.Entity.ChangeTracking
         [Fact]
         public void Can_set_unchanged_properties_to_modified_and_back_to_unchanged()
         {
-            var entity = new Cheese();
-            var entityEntry = new EntityEntry<Cheese>(new ChangeTracker(BuildModel()), entity) { State = EntityState.Unchanged };
+            var entityEntry = new EntityEntry<Cheese>(
+                new ChangeTracker(BuildModel(), new Mock<ActiveIdentityGenerators>().Object),
+                new Cheese()) { State = EntityState.Unchanged };
 
             var nameEntry = new PropertyEntry<Cheese, string>(entityEntry, "Name");
             var maturityEntry = new PropertyEntry<Cheese, string>(entityEntry, "Maturity");
@@ -66,8 +72,9 @@ namespace Microsoft.Data.Entity.ChangeTracking
         [Fact]
         public void Changing_property_states_for_Added_Deleted_and_Unknown_properties_has_no_effect()
         {
-            var entity = new Cheese();
-            var entityEntry = new EntityEntry<Cheese>(new ChangeTracker(BuildModel()), entity) { State = EntityState.Added };
+            var entityEntry = new EntityEntry<Cheese>(
+                new ChangeTracker(BuildModel(), new Mock<ActiveIdentityGenerators>().Object),
+                new Cheese()) { State = EntityState.Added };
 
             var nameEntry = new PropertyEntry<Cheese, string>(entityEntry, "Name");
             var maturityEntry = new PropertyEntry<Cheese, string>(entityEntry, "Maturity");
@@ -78,11 +85,13 @@ namespace Microsoft.Data.Entity.ChangeTracking
             Assert.False(maturityEntry.IsModified);
 
             entityEntry.State = EntityState.Deleted;
+            maturityEntry.IsModified = true;
 
             Assert.False(nameEntry.IsModified);
             Assert.False(maturityEntry.IsModified);
 
             entityEntry.State = EntityState.Unknown;
+            maturityEntry.IsModified = true;
 
             Assert.False(nameEntry.IsModified);
             Assert.False(maturityEntry.IsModified);
@@ -91,8 +100,9 @@ namespace Microsoft.Data.Entity.ChangeTracking
         [Fact]
         public void Changing_property_state_to_modified_marks_entity_as_Modified()
         {
-            var entity = new Cheese();
-            var entityEntry = new EntityEntry<Cheese>(new ChangeTracker(BuildModel()), entity) { State = EntityState.Unchanged };
+            var entityEntry = new EntityEntry<Cheese>(
+                new ChangeTracker(BuildModel(), new Mock<ActiveIdentityGenerators>().Object),
+                new Cheese()) { State = EntityState.Unchanged };
 
             new PropertyEntry<Cheese, string>(entityEntry, "Maturity") { IsModified = true };
 
@@ -102,8 +112,9 @@ namespace Microsoft.Data.Entity.ChangeTracking
         [Fact]
         public void Changing_all_property_states_to_unchanged_marks_entity_as_Unchanged()
         {
-            var entity = new Cheese();
-            var entityEntry = new EntityEntry<Cheese>(new ChangeTracker(BuildModel()), entity) { State = EntityState.Modified };
+            var entityEntry = new EntityEntry<Cheese>(
+                new ChangeTracker(BuildModel(), new Mock<ActiveIdentityGenerators>().Object),
+                new Cheese()) { State = EntityState.Modified };
 
             var idEntry = new PropertyEntry<Cheese, int>(entityEntry, "Id");
             var nameEntry = new PropertyEntry<Cheese, string>(entityEntry, "Name");

--- a/test/Microsoft.Data.Entity.Tests/Microsoft.Data.Entity.Tests.net45.csproj
+++ b/test/Microsoft.Data.Entity.Tests/Microsoft.Data.Entity.Tests.net45.csproj
@@ -37,6 +37,9 @@
     <Reference Include="Microsoft.AspNet.Logging">
       <HintPath>..\..\packages\Microsoft.AspNet.Logging.0.1-alpha-022\lib\net45\Microsoft.AspNet.Logging.dll</HintPath>
     </Reference>
+    <Reference Include="Moq">
+      <HintPath>..\..\packages\Moq.4.2.1312.1622\lib\net40\Moq.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="xunit, Version=1.9.2.1705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">

--- a/test/Microsoft.Data.Entity.Tests/packages.config
+++ b/test/Microsoft.Data.Entity.Tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
 <packages>
+  <package id="Moq" version="4.2.1312.1622" targetFramework="net451" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.Logging" version="0.1-alpha-022" targetFramework="net45" />
   <package id="Microsoft.AspNet.DependencyInjection" version="0.1-alpha-028" targetFramework="net45" />

--- a/test/Microsoft.Data.SqlServer.FunctionalTest/SequenceIdentityGeneratorTest.cs
+++ b/test/Microsoft.Data.SqlServer.FunctionalTest/SequenceIdentityGeneratorTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -18,11 +19,11 @@ namespace Microsoft.Data.SqlServer
                 await testDatabase.ExecuteNonQueryAsync(
                     SqlServerMigrationOperationSqlGenerator.Generate(sequenceIdentityGenerator.CreateMigrationOperation()));
 
-                var next = sequenceIdentityGenerator.NextAsync().Result;
+                var next = sequenceIdentityGenerator.NextAsync(CancellationToken.None).Result;
 
                 for (var i = 1; i <= 100; i++)
                 {
-                    Assert.Equal(next + i, await sequenceIdentityGenerator.NextAsync());
+                    Assert.Equal(next + i, await sequenceIdentityGenerator.NextAsync(CancellationToken.None));
                 }
             }
         }

--- a/test/Microsoft.Data.SqlServer.FunctionalTest/SequentialGuidIdentityGeneratorTest.cs
+++ b/test/Microsoft.Data.SqlServer.FunctionalTest/SequentialGuidIdentityGeneratorTest.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -17,7 +18,7 @@ namespace Microsoft.Data.SqlServer
 
             for (var _ = 0; _ < 100; _++)
             {
-                values.Add(await sequentialGuidIdentityGenerator.NextAsync());
+                values.Add(await sequentialGuidIdentityGenerator.NextAsync(CancellationToken.None));
             }
 
             using (var testDatabase = await TestDatabase.Create())

--- a/test/Microsoft.Data.SqlServer.FunctionalTest/SqlServerSimpleCommandExecutorTest.cs
+++ b/test/Microsoft.Data.SqlServer.FunctionalTest/SqlServerSimpleCommandExecutorTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -14,7 +15,7 @@ namespace Microsoft.Data.SqlServer
             {
                 var commandExecutor = new SqlServerSimpleCommandExecutor(testDatabase.Connection.ConnectionString);
 
-                var scalar = await commandExecutor.ExecuteScalarAsync<int>("select 42");
+                var scalar = await commandExecutor.ExecuteScalarAsync<int>("select 42", CancellationToken.None);
 
                 Assert.Equal(42, scalar);
             }

--- a/test/Microsoft.Data.SqlServer.FunctionalTest/TestDatabase.cs
+++ b/test/Microsoft.Data.SqlServer.FunctionalTest/TestDatabase.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Data.Common;
 using System.Data.SqlClient;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Relational;
 
@@ -61,11 +62,11 @@ namespace Microsoft.Data.SqlServer
             get { return _connection; }
         }
 
-        public async Task<T> ExecuteScalarAsync<T>(string sql, params object[] parameters)
+        public async Task<T> ExecuteScalarAsync<T>(string sql, CancellationToken cancellationToken, params object[] parameters)
         {
             using (var command = CreateCommand(sql, parameters))
             {
-                return (T)await command.ExecuteScalarAsync();
+                return (T)await command.ExecuteScalarAsync(cancellationToken);
             }
         }
 

--- a/test/Microsoft.Data.SqlServer.Tests/SqlServerServicesTest.cs
+++ b/test/Microsoft.Data.SqlServer.Tests/SqlServerServicesTest.cs
@@ -15,8 +15,7 @@ namespace Microsoft.Data.SqlServer
         {
             var services = SqlServerServices.GetDefaultServices().ToList();
 
-            Assert.True(services.Any(sd => sd.ServiceType == typeof(IIdentityGenerator<Guid>)));
-            Assert.True(services.Any(sd => sd.ServiceType == typeof(IIdentityGenerator<long>)));
+            Assert.True(services.Any(sd => sd.ServiceType == typeof(IdentityGeneratorFactory)));
         }
 
         [Fact]
@@ -24,8 +23,7 @@ namespace Microsoft.Data.SqlServer
         {
             var serviceProvider = new ServiceProvider().Add(SqlServerServices.GetDefaultServices());
 
-            Assert.NotNull(serviceProvider.GetService<IIdentityGenerator<long>>());
-            Assert.NotNull(serviceProvider.GetService<IIdentityGenerator<Guid>>());
+            Assert.NotNull(serviceProvider.GetService<IdentityGeneratorFactory>());
         }
     }
 }


### PR DESCRIPTION
Are you the Keymaster? (First attempt at wiring up change tracker to identity generation)

The idea here is to allow the change tracker to generate a key for new entities when added. Whether or not a key should be generated is determined by metadata on the property in the model. If it is known that key generation is required then the provider must be involved in selecting the appropriate key generator for the type of the property. Providers register an IdentityGeneratorFactory to handle this. However, the user can also register an IdentityGeneratorFactory to override the behavior for some or all properties of a given type.

We could also allow for an identity generator to be registered directly in the model, but this has implications for serialization of the model which is needed for both Migrations and compiled model state. It may be that there is some hook that allows runtime annotation of the model even if it has been compiled.

The configuration keeps the collection of active identity generators so that they can be shared by multiple context instances. This can also be changed in the configuration to allow for different levels of sharing.

Some additional testing still required.
