### PR TITLE
Old school bits and bytes...

### DIFF
--- a/src/Microsoft.Data.Entity/ChangeTracking/EntityEntry.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/EntityEntry.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
 
         public virtual EntityState State
         {
-            get { return _entry.GetEntityState(); }
+            get { return _entry.EntityState; }
             set
             {
                 Check.IsDefined(value, "value");

--- a/src/Microsoft.Data.Entity/EntityState.cs
+++ b/src/Microsoft.Data.Entity/EntityState.cs
@@ -4,10 +4,10 @@ namespace Microsoft.Data.Entity
 {
     public enum EntityState
     {
-        Unknown = 1,
-        Unchanged = 2,
-        Added = 3,
-        Deleted = 4,
-        Modified = 5
+        Unknown = 0,
+        Unchanged = 1,
+        Added = 2,
+        Deleted = 3,
+        Modified = 4
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/Compiled/CompiledEntityType.cs
+++ b/src/Microsoft.Data.Entity/Metadata/Compiled/CompiledEntityType.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
     {
         private IProperty[] _keys;
         private IProperty[] _properties;
+        private IDictionary<string, int> _propertyIndexes;
 
         public IProperty Property([NotNull] string name)
         {
@@ -51,6 +52,26 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
         private IProperty[] EnsurePropertiesInitialized()
         {
             return LazyInitializer.EnsureInitialized(ref _properties, LoadProperties);
+        }
+
+        public int PropertyIndex([NotNull] string name)
+        {
+            var indexes = LazyInitializer.EnsureInitialized(ref _propertyIndexes, BuildIndexes);
+            int index;
+            return indexes.TryGetValue(name, out index) ? index : -1;
+        }
+
+        private IDictionary<string, int> BuildIndexes()
+        {
+            var properties = EnsurePropertiesInitialized();
+
+            _propertyIndexes = new Dictionary<string, int>(properties.Length, StringComparer.Ordinal);
+            for (var i = 0; i < _properties.Length; i++)
+            {
+                _propertyIndexes[_properties[i].Name] = i;
+            }
+
+            return _propertyIndexes;
         }
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/IEntityType.cs
+++ b/src/Microsoft.Data.Entity/Metadata/IEntityType.cs
@@ -15,5 +15,6 @@ namespace Microsoft.Data.Entity.Metadata
         IProperty Property([NotNull] string name);
         IEnumerable<IProperty> Properties { get; }
         IEnumerable<IForeignKey> ForeignKeys { get; }
+        int PropertyIndex([NotNull] string name);
     }
 }

--- a/test/Microsoft.Data.Entity.FunctionalTest/Metadata/CompiledModelTest.cs
+++ b/test/Microsoft.Data.Entity.FunctionalTest/Metadata/CompiledModelTest.cs
@@ -95,14 +95,14 @@ namespace Microsoft.Data.Entity.Metadata
             // Numbers are not 100% consistent due to other threads running and GC.GetTotalMemory not 
             // necessarily returning an accurate number. At the time of check in the numbers are:
             //
-            //  Compiled: 2168 (50)  Built: 4546216 (50) Ratio: 0.000476880113043463
-            //  Compiled: 8360 (100)  Built: 4547384 (100) Ratio: 0.00183841962763646
-            //  Compiled: 130224 (2500)  Built: 4549088 (2500) Ratio: 0.0286263972031317
-            //  Compiled: 139768 (150)  Built: 4550104 (150) Ratio: 0.0307175396430499
-            //  Compiled: 553888 (2500)  Built: 4552000 (2500) Ratio: 0.12168014059754
-            //  Compiled: 554280 (7500)  Built: 4553888 (7500) Ratio: 0.121715773422623
-            //  Compiled: 834848 (5000)  Built: 4555768 (5000) Ratio: 0.183250771329883
-            //  Compiled: 1395816 (10000)  Built: 4558256 (10000) Ratio: 0.306217114615765
+            //  Compiled: 2168 (50)  Built: 4091744 (50) Ratio: 0.000529847419584412
+            //  Compiled: 8360 (100)  Built: 4092824 (100) Ratio: 0.00204259943745443
+            //  Compiled: 182928 (2500)  Built: 4126088 (2500) Ratio: 0.0443344882610356
+            //  Compiled: 192488 (150)  Built: 4126392 (150) Ratio: 0.0466480159907251
+            //  Compiled: 606384 (2500)  Built: 4126632 (2500) Ratio: 0.146944045410398
+            //  Compiled: 672120 (7500)  Built: 4192272 (7500) Ratio: 0.160323566791468
+            //  Compiled: 952560 (5000)  Built: 4192912 (5000) Ratio: 0.227183399031508
+            //  Compiled: 1513272 (10000)  Built: 4193584 (10000) Ratio: 0.36085410474668
             //
             // Uncomment to get new numbers:
             //for (var i = 1; i < compiledMemory.Count; i++)

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/PropertyEntryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/PropertyEntryTest.cs
@@ -132,6 +132,79 @@ namespace Microsoft.Data.Entity.ChangeTracking
             Assert.Equal(EntityState.Unchanged, entityEntry.State);
         }
 
+        [Fact]
+        public void Different_numbers_of_properties_are_packed_and_manipulated_correctly()
+        {
+            PropertyManipulation(0);
+            PropertyManipulation(1);
+            PropertyManipulation(28);
+            PropertyManipulation(29);
+            PropertyManipulation(30);
+            PropertyManipulation(32);
+            PropertyManipulation(33);
+            PropertyManipulation(60);
+            PropertyManipulation(61);
+            PropertyManipulation(62);
+            PropertyManipulation(64);
+            PropertyManipulation(65);
+        }
+
+        public void PropertyManipulation(int propertyCount)
+        {
+            var model = new Model();
+            var entityType = new EntityType(typeof(Pickle));
+            model.AddEntityType(entityType);
+
+            var propertyNames = new string[propertyCount];
+            for (var i = 0; i < propertyCount; i++)
+            {
+                propertyNames[i] = "Prop" + i;
+                entityType.AddProperty(new Property(typeof(Pickle).GetProperty(propertyNames[i])));
+            }
+
+            var entityEntry = new EntityEntry<Pickle>(
+                new ChangeTracker(model, new Mock<ActiveIdentityGenerators>().Object),
+                new Pickle()) { State = EntityState.Unchanged };
+
+            for (var i = 0; i < propertyCount; i++)
+            {
+                entityEntry.Property(propertyNames[i]).IsModified = true;
+
+                for (var j = 0; j < propertyCount; j++)
+                {
+                    Assert.Equal(j <= i, entityEntry.Property(propertyNames[j]).IsModified);
+                }
+
+                Assert.Equal(EntityState.Modified, entityEntry.State);
+            }
+
+            for (var i = 0; i < propertyCount; i++)
+            {
+                entityEntry.Property(propertyNames[i]).IsModified = false;
+
+                for (var j = 0; j < propertyCount; j++)
+                {
+                    Assert.Equal(j > i, entityEntry.Property(propertyNames[j]).IsModified);
+                }
+
+                Assert.Equal(i == propertyCount - 1 ? EntityState.Unchanged : EntityState.Modified, entityEntry.State);
+            }
+
+            entityEntry.State = EntityState.Modified;
+
+            for (var i = 0; i < propertyCount; i++)
+            {
+                Assert.True(entityEntry.Property(propertyNames[i]).IsModified);
+            }
+
+            entityEntry.State = EntityState.Unchanged;
+
+            for (var i = 0; i < propertyCount; i++)
+            {
+                Assert.False(entityEntry.Property(propertyNames[i]).IsModified);
+            }
+        }
+
         #region Fixture
 
         public class Cheese
@@ -139,6 +212,75 @@ namespace Microsoft.Data.Entity.ChangeTracking
             public int Id { get; set; }
             public string Name { get; set; }
             public string Maturity { get; set; }
+        }
+
+        public class Pickle
+        {
+            public string Prop0 { get; set; }
+            public string Prop1 { get; set; }
+            public string Prop2 { get; set; }
+            public string Prop3 { get; set; }
+            public string Prop4 { get; set; }
+            public string Prop5 { get; set; }
+            public string Prop6 { get; set; }
+            public string Prop7 { get; set; }
+            public string Prop8 { get; set; }
+            public string Prop9 { get; set; }
+            public string Prop10 { get; set; }
+            public string Prop11 { get; set; }
+            public string Prop12 { get; set; }
+            public string Prop13 { get; set; }
+            public string Prop14 { get; set; }
+            public string Prop15 { get; set; }
+            public string Prop16 { get; set; }
+            public string Prop17 { get; set; }
+            public string Prop18 { get; set; }
+            public string Prop19 { get; set; }
+            public string Prop20 { get; set; }
+            public string Prop21 { get; set; }
+            public string Prop22 { get; set; }
+            public string Prop23 { get; set; }
+            public string Prop24 { get; set; }
+            public string Prop25 { get; set; }
+            public string Prop26 { get; set; }
+            public string Prop27 { get; set; }
+            public string Prop28 { get; set; }
+            public string Prop29 { get; set; }
+            public string Prop30 { get; set; }
+            public string Prop31 { get; set; }
+            public string Prop32 { get; set; }
+            public string Prop33 { get; set; }
+            public string Prop34 { get; set; }
+            public string Prop35 { get; set; }
+            public string Prop36 { get; set; }
+            public string Prop37 { get; set; }
+            public string Prop38 { get; set; }
+            public string Prop39 { get; set; }
+            public string Prop40 { get; set; }
+            public string Prop41 { get; set; }
+            public string Prop42 { get; set; }
+            public string Prop43 { get; set; }
+            public string Prop44 { get; set; }
+            public string Prop45 { get; set; }
+            public string Prop46 { get; set; }
+            public string Prop47 { get; set; }
+            public string Prop48 { get; set; }
+            public string Prop49 { get; set; }
+            public string Prop50 { get; set; }
+            public string Prop51 { get; set; }
+            public string Prop52 { get; set; }
+            public string Prop53 { get; set; }
+            public string Prop54 { get; set; }
+            public string Prop55 { get; set; }
+            public string Prop56 { get; set; }
+            public string Prop57 { get; set; }
+            public string Prop58 { get; set; }
+            public string Prop59 { get; set; }
+            public string Prop60 { get; set; }
+            public string Prop61 { get; set; }
+            public string Prop62 { get; set; }
+            public string Prop63 { get; set; }
+            public string Prop64 { get; set; }
         }
 
         private static IModel BuildModel()

--- a/test/Microsoft.Data.Entity.Tests/EntityContextTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/EntityContextTest.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Data.Entity
 
         public class ContextWithSets : EntityContext
         {
-            private readonly EntitySet<Random> _noSetter;
+            private readonly EntitySet<Random> _noSetter = null;
 
             public ContextWithSets()
                 : base(new EntityConfiguration())


### PR DESCRIPTION
Old school bits and bytes... (Changes to property access in metadata/change tracker)

These changes cover two things:
1. Adding property indexes to the metadata API so that manipulation based on indexes such as in the change tracker is efficient.  I also did the bit-packing optimization for space in the change tracker.
1. Changing the data structures used in EntityType so that
2. There is no pretense at thread-safety. (The code was not thread safe as it was although looked so at a superficial level. For example, if two threads both try to add different properties it could happen that only one of the properties got added.)
3. Allow for sorting on property insert rather than removal
4. Make Properties.Count fast because LINQ will use the IList optimization
5. Provide a basis for the property indexes needed above
