### PR TITLE
Approaching Z'ha'dum...

### DIFF
--- a/src/Microsoft.Data.Entity/Identity/ActiveIdentityGenerators.cs
+++ b/src/Microsoft.Data.Entity/Identity/ActiveIdentityGenerators.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Data.Entity.Identity
     {
         private readonly IdentityGeneratorFactory _factory;
 
-        private readonly LazyRef<ImmutableDictionary<IProperty, IIdentityGenerator>> _identityGenerators
-            = new LazyRef<ImmutableDictionary<IProperty, IIdentityGenerator>>(
+        private readonly ThreadSafeLazyRef<ImmutableDictionary<IProperty, IIdentityGenerator>> _identityGenerators
+            = new ThreadSafeLazyRef<ImmutableDictionary<IProperty, IIdentityGenerator>>(
                 () => ImmutableDictionary<IProperty, IIdentityGenerator>.Empty);
 
         // Intended only for creation of test doubles

--- a/src/Microsoft.Data.Entity/Metadata/Compiled/CompiledEntityType.cs
+++ b/src/Microsoft.Data.Entity/Metadata/Compiled/CompiledEntityType.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
 using JetBrains.Annotations;
@@ -27,24 +28,24 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
         protected abstract int[] LoadKey();
         protected abstract IProperty[] LoadProperties();
 
-        public IEnumerable<IProperty> Key
+        public IReadOnlyList<IProperty> Key
         {
             get { return LazyInitializer.EnsureInitialized(ref _keys, BuildKey); }
         }
 
-        public IEnumerable<IForeignKey> ForeignKeys
+        public IReadOnlyList<IForeignKey> ForeignKeys
         {
             // TODO: Implement FKs in the compiled model
-            get { return Enumerable.Empty<IForeignKey>(); }
+            get { return ImmutableList<IForeignKey>.Empty; }
         }
 
-        public IEnumerable<INavigation> Navigations
+        public IReadOnlyList<INavigation> Navigations
         {
             // TODO: Implement navigations in the compiled model
-            get { return Enumerable.Empty<INavigation>(); }
+            get { return ImmutableList<INavigation>.Empty; }
         }
 
-        public IEnumerable<IProperty> Properties
+        public IReadOnlyList<IProperty> Properties
         {
             get { return EnsurePropertiesInitialized(); }
         }

--- a/src/Microsoft.Data.Entity/Metadata/Compiled/CompiledMetadataBase.cs
+++ b/src/Microsoft.Data.Entity/Metadata/Compiled/CompiledMetadataBase.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
     {
         private IAnnotation[] _annotations;
 
-        public IEnumerable<IAnnotation> Annotations
+        public IReadOnlyList<IAnnotation> Annotations
         {
             get { return LazyInitializer.EnsureInitialized(ref _annotations, LoadAnnotations); }
         }

--- a/src/Microsoft.Data.Entity/Metadata/Compiled/CompiledModel.cs
+++ b/src/Microsoft.Data.Entity/Metadata/Compiled/CompiledModel.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
 
         protected abstract IEntityType[] LoadEntityTypes();
 
-        public IEnumerable<IEntityType> EntityTypes
+        public IReadOnlyList<IEntityType> EntityTypes
         {
             get { return LazyInitializer.EnsureInitialized(ref _entityTypes, LoadEntityTypes); }
         }

--- a/src/Microsoft.Data.Entity/Metadata/Compiled/CompiledProperty.cs
+++ b/src/Microsoft.Data.Entity/Metadata/Compiled/CompiledProperty.cs
@@ -26,5 +26,11 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
         {
             get { return typeof(TProperty).IsNullableType(); }
         }
+
+        public IEntityType EntityType
+        {
+            // TODO
+            get { return null; }
+        }
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/Compiled/CompiledPropertyNoAnnotations.cs
+++ b/src/Microsoft.Data.Entity/Metadata/Compiled/CompiledPropertyNoAnnotations.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
@@ -10,9 +11,9 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
 {
     public class CompiledPropertyNoAnnotations<TEntity, TProperty>
     {
-        public IEnumerable<IAnnotation> Annotations
+        public IReadOnlyList<IAnnotation> Annotations
         {
-            get { return Enumerable.Empty<IAnnotation>(); }
+            get { return ImmutableList<Annotation>.Empty; }
         }
 
         public string this[[NotNull] string annotationName]
@@ -43,6 +44,12 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
         public bool IsNullable
         {
             get { return typeof(TProperty).IsNullableType(); }
+        }
+
+        public IEntityType EntityType
+        {
+            // TODO
+            get { return null; }
         }
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/ForeignKey.cs
+++ b/src/Microsoft.Data.Entity/Metadata/ForeignKey.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
@@ -11,10 +10,9 @@ namespace Microsoft.Data.Entity.Metadata
     public class ForeignKey : MetadataBase, IForeignKey
     {
         private readonly EntityType _principalType;
-        private readonly ImmutableList<Property> _dependentProperties;
+        private readonly IReadOnlyList<Property> _dependentProperties;
 
         private Property[] _principalProperties;
-
         private string _storageName;
 
         // Intended only for creation of test doubles
@@ -24,21 +22,21 @@ namespace Microsoft.Data.Entity.Metadata
 
         public ForeignKey(
             [NotNull] EntityType principalType,
-            [NotNull] IEnumerable<Property> dependentProperties)
+            [NotNull] IReadOnlyList<Property> dependentProperties)
         {
             Check.NotNull(principalType, "principalType");
             Check.NotNull(dependentProperties, "dependentProperties");
 
             _principalType = principalType;
-            _dependentProperties = ImmutableList.CreateRange(dependentProperties);
+            _dependentProperties = dependentProperties;
         }
 
-        public virtual IEnumerable<Property> DependentProperties
+        public virtual IReadOnlyList<Property> DependentProperties
         {
             get { return _dependentProperties; }
         }
 
-        public virtual IEnumerable<Property> PrincipalProperties
+        public virtual IReadOnlyList<Property> PrincipalProperties
         {
             get { return _principalProperties ?? _principalType.Key; }
             [param: NotNull]
@@ -74,12 +72,14 @@ namespace Microsoft.Data.Entity.Metadata
             }
         }
 
-        IEnumerable<IProperty> IForeignKey.DependentProperties
+        public virtual EntityType DependentType { get; [param: CanBeNull] set; }
+
+        IReadOnlyList<IProperty> IForeignKey.DependentProperties
         {
             get { return _dependentProperties; }
         }
 
-        IEnumerable<IProperty> IForeignKey.PrincipalProperties
+        IReadOnlyList<IProperty> IForeignKey.PrincipalProperties
         {
             get { return PrincipalProperties; }
         }
@@ -87,6 +87,11 @@ namespace Microsoft.Data.Entity.Metadata
         IEntityType IForeignKey.PrincipalType
         {
             get { return _principalType; }
+        }
+
+        IEntityType IForeignKey.DependentType
+        {
+            get { return DependentType; }
         }
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/IEntityType.cs
+++ b/src/Microsoft.Data.Entity/Metadata/IEntityType.cs
@@ -11,11 +11,11 @@ namespace Microsoft.Data.Entity.Metadata
         string Name { get; }
         string StorageName { get; }
         Type Type { get; }
-        IEnumerable<IProperty> Key { get; }
+        IReadOnlyList<IProperty> Key { get; }
         IProperty Property([NotNull] string name);
-        IEnumerable<IProperty> Properties { get; }
-        IEnumerable<IForeignKey> ForeignKeys { get; }
-        IEnumerable<INavigation> Navigations { get; }
+        IReadOnlyList<IProperty> Properties { get; }
+        IReadOnlyList<IForeignKey> ForeignKeys { get; }
+        IReadOnlyList<INavigation> Navigations { get; }
         int PropertyIndex([NotNull] string name);
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/IForeignKey.cs
+++ b/src/Microsoft.Data.Entity/Metadata/IForeignKey.cs
@@ -6,9 +6,10 @@ namespace Microsoft.Data.Entity.Metadata
 {
     public interface IForeignKey : IMetadata
     {
-        IEnumerable<IProperty> DependentProperties { get; }
-        IEnumerable<IProperty> PrincipalProperties { get; }
+        IReadOnlyList<IProperty> DependentProperties { get; }
+        IReadOnlyList<IProperty> PrincipalProperties { get; }
         IEntityType PrincipalType { get; }
+        IEntityType DependentType { get; }
         bool IsUnique { get; }
         bool IsRequired { get; }
         string StorageName { get; }

--- a/src/Microsoft.Data.Entity/Metadata/IMetadata.cs
+++ b/src/Microsoft.Data.Entity/Metadata/IMetadata.cs
@@ -8,6 +8,6 @@ namespace Microsoft.Data.Entity.Metadata
     public interface IMetadata
     {
         string this[[NotNull] string annotationName] { get; }
-        IEnumerable<IAnnotation> Annotations { get; }
+        IReadOnlyList<IAnnotation> Annotations { get; }
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/IModel.cs
+++ b/src/Microsoft.Data.Entity/Metadata/IModel.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Data.Entity.Metadata
         [NotNull]
         IEntityType GetEntityType([NotNull] Type type);
 
-        IEnumerable<IEntityType> EntityTypes { get; }
+        IReadOnlyList<IEntityType> EntityTypes { get; }
         IEqualityComparer<object> EntityEqualityComparer { get; }
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/IProperty.cs
+++ b/src/Microsoft.Data.Entity/Metadata/IProperty.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Data.Entity.Metadata
         string Name { get; }
         string StorageName { get; }
         Type PropertyType { get; }
-        Type DeclaringType { get; }
+        IEntityType EntityType { get; }
         bool IsNullable { get; }
         void SetValue([NotNull] object instance, [CanBeNull] object value);
         object GetValue([NotNull] object instance);

--- a/src/Microsoft.Data.Entity/Metadata/ModelBuilder.cs
+++ b/src/Microsoft.Data.Entity/Metadata/ModelBuilder.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Data.Entity.Metadata
 
                 Metadata.Key
                     = keyExpression.GetPropertyAccessList()
-                        .Select(pi => Metadata.Property(pi.Name) ?? new Property(pi));
+                        .Select(pi => Metadata.Property(pi.Name) ?? new Property(pi)).ToArray();
 
                 return this;
             }
@@ -181,7 +181,7 @@ namespace Microsoft.Data.Entity.Metadata
                     var principalType = _modelBuilder.Entity<TReferencedEntityType>().Metadata;
 
                     var dependentProperties = foreignKeyExpression.GetPropertyAccessList()
-                        .Select(pi => _entityType.Property(pi.Name) ?? new Property(pi));
+                        .Select(pi => _entityType.Property(pi.Name) ?? new Property(pi)).ToArray();
 
                     // TODO: This code currently assumes that the FK maps to a PK on the principal end
                     var foreignKey = new ForeignKey(principalType, dependentProperties);

--- a/src/Microsoft.Data.Entity/Metadata/Navigation.cs
+++ b/src/Microsoft.Data.Entity/Metadata/Navigation.cs
@@ -10,8 +10,6 @@ namespace Microsoft.Data.Entity.Metadata
         private readonly string _name;
         private readonly ForeignKey _foreignKey;
 
-        private EntityType _entityType;
-
         public Navigation([NotNull] ForeignKey foreignKey, [NotNull] string name)
         {
             Check.NotNull(foreignKey, "foreignKey");
@@ -26,17 +24,7 @@ namespace Microsoft.Data.Entity.Metadata
             get { return _name; }
         }
 
-        public virtual EntityType EntityType
-        {
-            get { return _entityType; }
-            [param: NotNull]
-            set
-            {
-                Check.NotNull(value, "value");
-
-                _entityType = value;
-            }
-        }
+        public virtual EntityType EntityType { get; [param: CanBeNull] set; }
 
         public virtual ForeignKey ForeignKey
         {

--- a/src/Microsoft.Data.Entity/Metadata/Property.cs
+++ b/src/Microsoft.Data.Entity/Metadata/Property.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Data.Entity.Metadata
     {
         private readonly string _name;
         private readonly Type _propertyType;
-        private readonly Type _declaringType;
 
         private string _storageName;
         private bool _isNullable = true;
@@ -30,7 +29,6 @@ namespace Microsoft.Data.Entity.Metadata
         public Property([NotNull] PropertyInfo propertyInfo)
             : this(Check.NotNull(propertyInfo, "propertyInfo").Name, propertyInfo.PropertyType)
         {
-            _declaringType = propertyInfo.DeclaringType;
         }
 
         /// <summary>
@@ -71,10 +69,8 @@ namespace Microsoft.Data.Entity.Metadata
             get { return _propertyType; }
         }
 
-        public virtual Type DeclaringType
-        {
-            get { return _declaringType; }
-        }
+        // TODO: Consider properties that are part of some complex/value type
+        public virtual EntityType EntityType { get; [param: CanBeNull] set; }
 
         public virtual bool IsNullable
         {
@@ -89,7 +85,7 @@ namespace Microsoft.Data.Entity.Metadata
             Check.NotNull(instance, "instance");
 
             // TODO: Handle shadow state
-            _declaringType.GetAnyProperty(Name).SetValue(instance, value);
+            EntityType.Type.GetAnyProperty(Name).SetValue(instance, value);
         }
 
         public virtual object GetValue(object instance)
@@ -97,7 +93,12 @@ namespace Microsoft.Data.Entity.Metadata
             Check.NotNull(instance, "instance");
 
             // TODO: Handle shadow state
-            return _declaringType.GetAnyProperty(Name).GetValue(instance);
+            return EntityType.Type.GetAnyProperty(Name).GetValue(instance);
+        }
+
+        IEntityType IProperty.EntityType
+        {
+            get { return EntityType; }
         }
     }
 }

--- a/src/Microsoft.Data.Entity/Utilities/ThreadSafeLazyRef.cs
+++ b/src/Microsoft.Data.Entity/Utilities/ThreadSafeLazyRef.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using JetBrains.Annotations;
+
+namespace Microsoft.Data.Entity.Utilities
+{
+    [DebuggerStepThrough]
+    public sealed class ThreadSafeLazyRef<T>
+        where T : class
+    {
+        private Func<T> _initializer;
+        private object _syncLock;
+
+        private T _value;
+
+        public ThreadSafeLazyRef([NotNull] Func<T> initializer)
+        {
+            Check.NotNull(initializer, "initializer");
+
+            _initializer = initializer;
+        }
+
+        public T Value
+        {
+            get
+            {
+                if (_value == null)
+                {
+                    var syncLock = new object();
+
+                    syncLock
+                        = Interlocked.CompareExchange(ref _syncLock, syncLock, null)
+                          ?? syncLock;
+
+                    lock (syncLock)
+                    {
+                        if (_value == null)
+                        {
+                            _value = _initializer();
+
+                            _syncLock = null;
+                            _initializer = null;
+                        }
+                    }
+                }
+
+                return _value;
+            }
+        }
+
+        public void ExchangeValue([NotNull] Func<T, T> newValueCreator)
+        {
+            Check.NotNull(newValueCreator, "newValueCreator");
+
+            T originalValue, newValue;
+
+            do
+            {
+                originalValue = Value;
+                newValue = newValueCreator(originalValue);
+
+                if (ReferenceEquals(newValue, originalValue))
+                {
+                    return;
+                }
+            }
+            while (Interlocked.CompareExchange(ref _value, newValue, originalValue) != originalValue);
+        }
+
+        public bool HasValue
+        {
+            get { return _value != null; }
+        }
+    }
+}

--- a/src/Microsoft.Data.InMemory/InMemoryDataStore.cs
+++ b/src/Microsoft.Data.InMemory/InMemoryDataStore.cs
@@ -19,8 +19,8 @@ namespace Microsoft.Data.InMemory
 {
     public class InMemoryDataStore : DataStore
     {
-        private readonly LazyRef<ImmutableDictionary<object, object[]>> _objectData
-            = new LazyRef<ImmutableDictionary<object, object[]>>(() => ImmutableDictionary<object, object[]>.Empty);
+        private readonly ThreadSafeLazyRef<ImmutableDictionary<object, object[]>> _objectData
+            = new ThreadSafeLazyRef<ImmutableDictionary<object, object[]>>(() => ImmutableDictionary<object, object[]>.Empty);
 
         private readonly ILogger _logger;
 

--- a/test/Microsoft.Data.Entity.FunctionalTests/Metadata/CompiledModelTest.cs
+++ b/test/Microsoft.Data.Entity.FunctionalTests/Metadata/CompiledModelTest.cs
@@ -46,9 +46,6 @@ namespace Microsoft.Data.Entity.FunctionalTests.Metadata
             Assert.True(
                 compiledModel.EntityTypes.First().Properties.Select(p => p.PropertyType)
                     .SequenceEqual(builtModel.EntityTypes.First().Properties.Select(p => p.PropertyType)));
-            Assert.True(
-                compiledModel.EntityTypes.First().Properties.Select(p => p.DeclaringType)
-                    .SequenceEqual(builtModel.EntityTypes.First().Properties.Select(p => p.DeclaringType)));
 
             Assert.True(
                 compiledModel.EntityTypes.SelectMany(p => p.Annotations).Select(p => p.Name)

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateEntryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateEntryTest.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             entityTypeMock = entityTypeMock ?? new Mock<IEntityType>();
             entityTypeMock.Setup(m => m.Key).Returns(keys);
-            entityTypeMock.Setup(m => m.Properties).Returns(keys.Concat(new[] { new Mock<IProperty>().Object }));
+            entityTypeMock.Setup(m => m.Properties).Returns(keys.Concat(new[] { new Mock<IProperty>().Object }).ToArray());
             entityTypeMock.Setup(m => m.PropertyIndex("Foo")).Returns(0);
             entityTypeMock.Setup(m => m.PropertyIndex("Goo")).Returns(1);
 

--- a/test/Microsoft.Data.Entity.Tests/Metadata/EntityTypeTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Metadata/EntityTypeTest.cs
@@ -122,6 +122,28 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         }
 
         [Fact]
+        public void Property_back_pointer_is_fixed_up_as_property_is_added_and_removed()
+        {
+            var entityType1 = new EntityType(typeof(Customer));
+            var entityType2 = new EntityType(typeof(Customer));
+
+            var property = new Property(Customer.IdProperty);
+            entityType1.AddProperty(property);
+
+            Assert.Same(entityType1, property.EntityType);
+
+            entityType2.AddProperty(property);
+
+            Assert.Same(entityType2, property.EntityType);
+            Assert.Empty(entityType1.Properties);
+
+            entityType2.RemoveProperty(property);
+
+            Assert.Empty(entityType2.Properties);
+            Assert.Null(property.EntityType);
+        }
+
+        [Fact]
         public void Properties_are_ordered_by_name()
         {
             var entityType = new EntityType(typeof(Customer));
@@ -235,6 +257,35 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         }
 
         [Fact]
+        public void FK_back_pointer_is_fixed_up_as_FK_is_added_and_removed()
+        {
+            var entityType1 = new EntityType(typeof(Customer));
+            var entityType2 = new EntityType(typeof(Customer));
+
+            var property = new Property(Customer.IdProperty);
+            var foreignKey = new ForeignKey(entityType1, new[] { property });
+            entityType1.AddForeignKey(foreignKey);
+
+            Assert.Same(entityType1, foreignKey.DependentType);
+            Assert.Same(entityType1, property.EntityType);
+
+            entityType2.AddForeignKey(foreignKey);
+
+            Assert.Same(entityType2, foreignKey.DependentType);
+            Assert.Same(entityType2, property.EntityType);
+            Assert.Empty(entityType1.ForeignKeys);
+            Assert.Empty(entityType1.Properties);
+
+            entityType2.RemoveForeignKey(foreignKey);
+
+            // Currently property is not removed when FK is removed
+            Assert.Empty(entityType2.ForeignKeys);
+            Assert.Same(property, entityType2.Properties.Single());
+            Assert.Null(foreignKey.DependentType);
+            Assert.Same(entityType2, property.EntityType);
+        }
+
+        [Fact]
         public void Can_add_navigations()
         {
             var entityType = new EntityType(typeof(Order));
@@ -245,6 +296,30 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             Assert.Same(navigation, entityType.Navigations.Single());
             Assert.Same(entityType, navigation.EntityType);
+        }
+
+        [Fact]
+        public void Navigation_back_pointer_is_fixed_up_as_navigation_is_added_and_removed()
+        {
+            var entityType1 = new EntityType(typeof(Customer));
+            var entityType2 = new EntityType(typeof(Customer));
+
+            var navigation = new Navigation(
+                new ForeignKey(entityType1, new[] { new Property(Customer.IdProperty) }), "Nav");
+
+            entityType1.AddNavigation(navigation);
+
+            Assert.Same(entityType1, navigation.EntityType);
+
+            entityType2.AddNavigation(navigation);
+
+            Assert.Same(entityType2, navigation.EntityType);
+            Assert.Empty(entityType1.Navigations);
+
+            entityType2.RemoveNavigation(navigation);
+
+            Assert.Empty(entityType2.Navigations);
+            Assert.Null(navigation.EntityType);
         }
 
         [Fact]

--- a/test/Microsoft.Data.Entity.Tests/Metadata/MetadataBaseTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Metadata/MetadataBaseTest.cs
@@ -56,13 +56,16 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         }
 
         [Fact]
-        public void Add_duplicate_annotation_throws()
+        public void Add_duplicate_annotation_replaces_current_annotation()
         {
             var metadataBase = new ConcreteMetadata();
 
             metadataBase.AddAnnotation(new Annotation("Foo", "Bar"));
+            
+            var newAnnotation = new Annotation("Foo", "Bar");
+            metadataBase.AddAnnotation(newAnnotation);
 
-            Assert.Throws<ArgumentException>(() => metadataBase.AddAnnotation(new Annotation("Foo", "Bar")));
+            Assert.Same(newAnnotation, metadataBase.Annotations.Single());
         }
 
         [Fact]

--- a/test/Microsoft.Data.Entity.Tests/Metadata/ModelTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Metadata/ModelTest.cs
@@ -122,8 +122,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 entityTypeA.AddForeignKey(new ForeignKey(entityTypeB, _properties));
 
                 Assert.Equal(
-                    new[] { entityTypeB, entityTypeA, entityTypeC },
-                    model.TopologicalSort());
+                    new IEntityType[] { entityTypeB, entityTypeA, entityTypeC },
+                    model.TopologicalSort().ToArray());
             }
 
             [Fact]
@@ -144,8 +144,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 entityTypeB.AddForeignKey(new ForeignKey(entityTypeC, _properties));
 
                 Assert.Equal(
-                    new[] { entityTypeC, entityTypeB, entityTypeA },
-                    model.TopologicalSort());
+                    new IEntityType[] { entityTypeC, entityTypeB, entityTypeA },
+                    model.TopologicalSort().ToArray());
             }
 
             [Fact]
@@ -167,8 +167,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 entityTypeB.AddForeignKey(new ForeignKey(entityTypeC, _properties));
 
                 Assert.Equal(
-                    new[] { entityTypeA, entityTypeC, entityTypeB },
-                    model.TopologicalSort());
+                    new IEntityType[] { entityTypeA, entityTypeC, entityTypeB },
+                    model.TopologicalSort().ToArray());
             }
 
             [Fact]
@@ -186,8 +186,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
                 // A B C
                 Assert.Equal(
-                    new[] { entityTypeA, entityTypeB, entityTypeC },
-                    model.TopologicalSort());
+                    new IEntityType[] { entityTypeA, entityTypeB, entityTypeC },
+                    model.TopologicalSort().ToArray());
             }
 
             [Fact]

--- a/test/Microsoft.Data.Entity.Tests/Metadata/NavigationTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Metadata/NavigationTest.cs
@@ -23,11 +23,6 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var navigation = new Navigation(new Mock<ForeignKey>().Object, "Handlebars");
 
             Assert.Equal(
-                "value",
-                // ReSharper disable once AssignNullToNotNullAttribute
-                Assert.Throws<ArgumentNullException>(() => navigation.EntityType = null).ParamName);
-
-            Assert.Equal(
                 "ownerEntity",
                 // ReSharper disable once AssignNullToNotNullAttribute
                 Assert.Throws<ArgumentNullException>(() => navigation.SetOrAddEntity(null, new Random())).ParamName);

--- a/test/Microsoft.Data.Entity.Tests/Metadata/PropertyTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Metadata/PropertyTest.cs
@@ -73,7 +73,6 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var property = new Property(Customer.NameProperty);
 
             Assert.Equal("Name", property.Name);
-            Assert.Same(typeof(Customer), property.DeclaringType);
             Assert.Same(typeof(string), property.PropertyType);
             Assert.True(property.IsNullable);
         }
@@ -81,8 +80,10 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         [Fact]
         public void Can_get_and_set_property_value()
         {
-            var entity = new Customer();
+            var entityType = new EntityType(typeof(Customer));
             var property = new Property(Customer.NameProperty);
+            entityType.AddProperty(property);
+            var entity = new Customer();
 
             Assert.Null(property.GetValue(entity));
             property.SetValue(entity, "There is no kake");

--- a/test/Microsoft.Data.Entity.Tests/Utilities/LazyRefTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Utilities/LazyRefTest.cs
@@ -1,7 +1,5 @@
-﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using Microsoft.Data.Entity.Utilities;
 using Xunit;
 
@@ -10,46 +8,38 @@ namespace Microsoft.Data.Entity.Tests.Utilities
     public class LazyRefTest
     {
         [Fact]
-        public async Task Can_initialize_from_multiple_threads_and_initialization_happens_only_once()
-        {
-            var counter = 0;
-            var safeLazy = new LazyRef<string>(() => counter++.ToString());
-            var tasks = new List<Task>();
-
-            for (var i = 0; i < 10; i++)
-            {
-                tasks.Add(Task.Run(() => safeLazy.Value));
-            }
-
-            await Task.WhenAll(tasks);
-
-            Assert.Equal(1, counter);
-        }
-
-        [Fact]
-        public async Task Can_exchange_value()
-        {
-            var safeLazy = new LazyRef<string>(() => "");
-            var tasks = new List<Task>();
-
-            for (var i = 0; i < 10; i++)
-            {
-                tasks.Add(Task.Run(() => safeLazy.ExchangeValue(s => s + "s")));
-            }
-
-            await Task.WhenAll(tasks);
-
-            Assert.Equal("ssssssssss", safeLazy.Value);
-        }
-
-        [Fact]
         public void Has_value_is_false_until_value_accessed()
         {
-            var safeLazy = new LazyRef<string>(() => "s");
+            var lazy = new LazyRef<string>(() => "Cherry Coke");
 
-            Assert.False(safeLazy.HasValue);
-            Assert.Equal("s", safeLazy.Value);
-            Assert.True(safeLazy.HasValue);
+            Assert.False(lazy.HasValue);
+            Assert.Equal("Cherry Coke", lazy.Value);
+            Assert.True(lazy.HasValue);
+        }
+
+        [Fact]
+        public void Value_can_be_set_explicitly()
+        {
+            var lazy = new LazyRef<string>(() => "Cherry Coke");
+
+            lazy.Value = "Fresca";
+
+            Assert.True(lazy.HasValue);
+            Assert.Equal("Fresca", lazy.Value);
+        }
+
+        [Fact]
+        public void Initialization_can_be_reset()
+        {
+            var lazy = new LazyRef<string>(() => "Cherry Coke");
+
+            Assert.Equal("Cherry Coke", lazy.Value);
+
+            lazy.Reset(() => "Fresca");
+
+            Assert.False(lazy.HasValue);
+            Assert.Equal("Fresca", lazy.Value);
+            Assert.True(lazy.HasValue);
         }
     }
 }

--- a/test/Microsoft.Data.Entity.Tests/Utilities/ThreadSafeLazyRefTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Utilities/ThreadSafeLazyRefTest.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Data.Entity.Utilities;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.Utilities
+{
+    public class ThreadSafeLazyRefTest
+    {
+        [Fact]
+        public async Task Can_initialize_from_multiple_threads_and_initialization_happens_only_once()
+        {
+            var counter = 0;
+            var safeLazy = new ThreadSafeLazyRef<string>(() => counter++.ToString());
+            var tasks = new List<Task>();
+
+            for (var i = 0; i < 10; i++)
+            {
+                tasks.Add(Task.Run(() => safeLazy.Value));
+            }
+
+            await Task.WhenAll(tasks);
+
+            Assert.Equal(1, counter);
+        }
+
+        [Fact]
+        public async Task Can_exchange_value()
+        {
+            var safeLazy = new ThreadSafeLazyRef<string>(() => "");
+            var tasks = new List<Task>();
+
+            for (var i = 0; i < 10; i++)
+            {
+                tasks.Add(Task.Run(() => safeLazy.ExchangeValue(s => s + "s")));
+            }
+
+            await Task.WhenAll(tasks);
+
+            Assert.Equal("ssssssssss", safeLazy.Value);
+        }
+
+        [Fact]
+        public void Has_value_is_false_until_value_accessed()
+        {
+            var safeLazy = new ThreadSafeLazyRef<string>(() => "s");
+
+            Assert.False(safeLazy.HasValue);
+            Assert.Equal("s", safeLazy.Value);
+            Assert.True(safeLazy.HasValue);
+        }
+    }
+}


### PR DESCRIPTION
Approaching Z'ha'dum... (Moving towards metadata/state entries that support shadow state)

This includes:
- Back pointers to parent entity type with fixup for properties, FKs, and navigations
- Some more decoupling from CLR types--for example in Property
- Splitting LazyRef into thread safe and non-thread safe versions and using where appropriate
- Change of data structures to avoid sorting when consuming
- Exposing most metadata collections as IReadOnlyList instead of IEnumerable. This better matches the abstraction we want because it provides for cheap/natural counting and indexing, and helps reduce the need for defensive copying and the risk of accidental multiple enumerations of an IEnumerable. The downside it it doesn't allow streaming, but this seems like a reasonable tradeoff for this API.
