### PR TITLE
Talking back to the principal...

### DIFF
--- a/src/Microsoft.Data.Entity/ChangeTracking/CompositeEntityKeyFactory.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/CompositeEntityKeyFactory.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using System.Linq;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.ChangeTracking
@@ -14,12 +16,13 @@ namespace Microsoft.Data.Entity.ChangeTracking
             get { return _instance; }
         }
 
-        public override EntityKey Create(StateEntry entry)
+        public override EntityKey Create(IEntityType entityType, IReadOnlyList<IProperty> properties, StateEntry entry)
         {
+            Check.NotNull(entityType, "entityType");
+            Check.NotNull(properties, "properties");
             Check.NotNull(entry, "entry");
 
-            var entityType = entry.EntityType;
-            return new CompositeEntityKey(entityType, entityType.Key.Select(entry.GetPropertyValue).ToArray());
+            return new CompositeEntityKey(entityType, properties.Select(entry.GetPropertyValue).ToArray());
         }
     }
 }

--- a/src/Microsoft.Data.Entity/ChangeTracking/EntityKeyFactory.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/EntityKeyFactory.cs
@@ -1,11 +1,14 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.ChangeTracking
 {
     public abstract class EntityKeyFactory
     {
-        public abstract EntityKey Create([NotNull] StateEntry entry);
+        public abstract EntityKey Create(
+            [NotNull] IEntityType entityType, [NotNull] IReadOnlyList<IProperty> properties, [NotNull] StateEntry entry);
     }
 }

--- a/src/Microsoft.Data.Entity/ChangeTracking/EntityKeyFactorySource.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/EntityKeyFactorySource.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
@@ -13,15 +14,13 @@ namespace Microsoft.Data.Entity.ChangeTracking
         private readonly ThreadSafeLazyRef<ImmutableDictionary<Type, EntityKeyFactory>> _keyFactories
             = new ThreadSafeLazyRef<ImmutableDictionary<Type, EntityKeyFactory>>(() => ImmutableDictionary<Type, EntityKeyFactory>.Empty);
 
-        public virtual EntityKeyFactory GetKeyFactory([NotNull] IEntityType entityType)
+        public virtual EntityKeyFactory GetKeyFactory([NotNull] IReadOnlyList<IProperty> keyProperties)
         {
-            Check.NotNull(entityType, "entityType");
+            Check.NotNull(keyProperties, "keyProperties");
 
-            var keyDefinition = entityType.Key;
-
-            if (keyDefinition.Count == 1)
+            if (keyProperties.Count == 1)
             {
-                var propertyType = keyDefinition[0].PropertyType;
+                var propertyType = keyProperties[0].PropertyType;
                 if (!_keyFactories.Value.ContainsKey(propertyType))
                 {
                     _keyFactories.ExchangeValue(

--- a/src/Microsoft.Data.Entity/ChangeTracking/NavigationFixer.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/NavigationFixer.cs
@@ -32,14 +32,12 @@ namespace Microsoft.Data.Entity.ChangeTracking
             }
 
             // Handle case where the new entity is the principal
-            foreach (var entityType in stateManager.Model.EntityTypes)
+            foreach (var foreignKey in stateManager.Model.EntityTypes.SelectMany(
+                e => e.ForeignKeys.Where(f => f.PrincipalType == entry.EntityType)))
             {
-                foreach (var foreignKey in entityType.ForeignKeys.Where(f => f.PrincipalType == entry.EntityType))
-                {
-                    var dependents = stateManager.GetDependents(entry, entityType, foreignKey).ToArray();
+                var dependents = stateManager.GetDependents(entry, foreignKey).ToArray();
 
-                    DoFixup(stateManager, foreignKey, entry, dependents);
-                }
+                DoFixup(stateManager, foreignKey, entry, dependents);
             }
         }
 

--- a/src/Microsoft.Data.Entity/ChangeTracking/SimpleEntityKeyFactory.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/SimpleEntityKeyFactory.cs
@@ -1,17 +1,20 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.ChangeTracking
 {
     public class SimpleEntityKeyFactory<TKey> : EntityKeyFactory
     {
-        public override EntityKey Create(StateEntry entry)
+        public override EntityKey Create(IEntityType entityType, IReadOnlyList<IProperty> properties, StateEntry entry)
         {
+            Check.NotNull(entityType, "entityType");
+            Check.NotNull(properties, "properties");
             Check.NotNull(entry, "entry");
 
-            var entityType = entry.EntityType;
-            return new SimpleEntityKey<TKey>(entityType, (TKey)entry.GetPropertyValue(entityType.Key[0]));
+            return new SimpleEntityKey<TKey>(entityType, (TKey)entry.GetPropertyValue(properties[0]));
         }
     }
 }

--- a/src/Microsoft.Data.Entity/ChangeTracking/StateEntry.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/StateEntry.cs
@@ -139,11 +139,25 @@ namespace Microsoft.Data.Entity.ChangeTracking
 
         public abstract void SetPropertyValue([NotNull] IProperty property, [CanBeNull] object value);
 
-        public virtual EntityKey CreateKey()
+        public virtual EntityKey GetPrimaryKeyValue()
         {
-            return _stateManager.GetKeyFactory(_entityType).Create(this);
+            return _stateManager.Model.GetKeyFactory(_entityType.Key).Create(_entityType, _entityType.Key, this);
         }
 
+        public virtual EntityKey GetDependentKeyValue([NotNull] IForeignKey foreignKey)
+        {
+            return _stateManager.Model
+                .GetKeyFactory(foreignKey.DependentProperties)
+                .Create(foreignKey.PrincipalType, foreignKey.DependentProperties, this);
+        }
+
+        public virtual EntityKey GetPrincipalKeyValue([NotNull] IForeignKey foreignKey)
+        {
+            return _stateManager.Model
+                .GetKeyFactory(foreignKey.PrincipalProperties)
+                .Create(foreignKey.PrincipalType, foreignKey.PrincipalProperties, this);
+        }
+        
         public virtual object[] GetValueBuffer()
         {
             return _entityType.Properties.Select(GetPropertyValue).ToArray();

--- a/src/Microsoft.Data.Entity/ChangeTracking/StateManagerFactory.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/StateManagerFactory.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             _stateEntryFactory = stateEntryFactory;
         }
 
-        public virtual StateManager Create([NotNull] IModel model)
+        public virtual StateManager Create([NotNull] RuntimeModel model)
         {
             Check.NotNull(model, "model");
 

--- a/src/Microsoft.Data.Entity/EntityConfiguration.cs
+++ b/src/Microsoft.Data.Entity/EntityConfiguration.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Data.Entity
         private ActiveIdentityGenerators _activeIdentityGenerators;
         private IModel _model;
         private IModelSource _modelSource;
+        private RuntimeModelFactory _runtimeModelFactory;
 
         public EntityConfiguration()
             : this(new ServiceProvider().Add(EntityServices.GetDefaultServices()))
@@ -57,6 +58,18 @@ namespace Microsoft.Data.Entity
                 Check.NotNull(value, "value");
 
                 _modelSource = value;
+            }
+        }
+
+        public virtual RuntimeModelFactory RuntimeModelFactory
+        {
+            get { return _runtimeModelFactory ?? GetRequiredService<RuntimeModelFactory>(); }
+            [param: NotNull]
+            set
+            {
+                Check.NotNull(value, "value");
+
+                _runtimeModelFactory = value;
             }
         }
 

--- a/src/Microsoft.Data.Entity/EntityContext.cs
+++ b/src/Microsoft.Data.Entity/EntityContext.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Data.Entity
     public class EntityContext : IDisposable
     {
         private readonly EntityConfiguration _configuration;
-        private readonly LazyRef<IModel> _model;
+        private readonly LazyRef<RuntimeModel> _model;
         private readonly LazyRef<StateManager> _stateManager;
 
         /// <summary>
@@ -30,7 +30,7 @@ namespace Microsoft.Data.Entity
             Check.NotNull(configuration, "configuration");
 
             _configuration = configuration;
-            _model = new LazyRef<IModel>(() => _configuration.Model ?? _configuration.ModelSource.GetModel(this));
+            _model = new LazyRef<RuntimeModel>(() => _configuration.RuntimeModelFactory.Create(_configuration.Model ?? _configuration.ModelSource.GetModel(this)));
             _stateManager = new LazyRef<StateManager>(() => _configuration.StateManagerFactory.Create(_model.Value));
 
             _configuration.EntitySetInitializer.InitializeSets(this);
@@ -122,7 +122,7 @@ namespace Microsoft.Data.Entity
             get { return new ChangeTracker(_stateManager.Value); }
         }
 
-        public virtual IModel Model
+        public virtual RuntimeModel Model
         {
             get { return _model.Value; }
         }

--- a/src/Microsoft.Data.Entity/EntityServices.cs
+++ b/src/Microsoft.Data.Entity/EntityServices.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNet.DependencyInjection;
 using Microsoft.AspNet.Logging;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Identity;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Services;
 
 namespace Microsoft.Data.Entity
@@ -23,6 +24,7 @@ namespace Microsoft.Data.Entity
             yield return Service.Singleton<IEntityStateListener, NavigationFixer>();
             yield return Service.Singleton<EntityKeyFactorySource, EntityKeyFactorySource>();
             yield return Service.Singleton<StateEntryFactory, StateEntryFactory>();
+            yield return Service.Singleton<RuntimeModelFactory, RuntimeModelFactory>();
         }
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/RuntimeModel.cs
+++ b/src/Microsoft.Data.Entity/Metadata/RuntimeModel.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Metadata
+{
+    public class RuntimeModel : IModel
+    {
+        private readonly EntityKeyFactorySource _keyFactorySource;
+        private readonly IModel _model;
+
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected RuntimeModel()
+        {
+        }
+
+        public RuntimeModel([NotNull] IModel model, [NotNull] EntityKeyFactorySource keyFactorySource)
+        {
+            Check.NotNull(model, "model");
+            Check.NotNull(keyFactorySource, "keyFactorySource");
+
+            _model = model;
+            _keyFactorySource = keyFactorySource;
+        }
+
+        public virtual EntityKeyFactory GetKeyFactory([NotNull] IReadOnlyList<IProperty> keyProperties)
+        {
+            Check.NotNull(keyProperties, "keyProperties");
+
+            return _keyFactorySource.GetKeyFactory(keyProperties);
+        }
+
+        public virtual string this[string annotationName]
+        {
+            get { return _model[annotationName]; }
+        }
+
+        public virtual IReadOnlyList<IAnnotation> Annotations
+        {
+            get { return _model.Annotations; }
+        }
+
+        public virtual IEntityType TryGetEntityType(Type type)
+        {
+            return _model.TryGetEntityType(type);
+        }
+
+        public virtual IEntityType GetEntityType(Type type)
+        {
+            return _model.GetEntityType(type);
+        }
+
+        public virtual IReadOnlyList<IEntityType> EntityTypes
+        {
+            get { return _model.EntityTypes; }
+        }
+
+        public virtual IEntityType TryGetEntityType(string name)
+        {
+            return _model.TryGetEntityType(name);
+        }
+
+        public virtual IEntityType GetEntityType(string name)
+        {
+            return _model.GetEntityType(name);
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/Metadata/RuntimeModelFactory.cs
+++ b/src/Microsoft.Data.Entity/Metadata/RuntimeModelFactory.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Metadata
+{
+    public class RuntimeModelFactory
+    {
+        private readonly EntityKeyFactorySource _keyFactorySource;
+
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected RuntimeModelFactory()
+        {
+        }
+
+        public RuntimeModelFactory([NotNull] EntityKeyFactorySource keyFactorySource)
+        {
+            Check.NotNull(keyFactorySource, "keyFactorySource");
+
+            _keyFactorySource = keyFactorySource;
+        }
+
+        public virtual RuntimeModel Create([NotNull] IModel model)
+        {
+            Check.NotNull(model, "model");
+
+            return new RuntimeModel(model, _keyFactorySource);
+        }
+    }
+}

--- a/src/Microsoft.Data.InMemory/InMemoryDataStore.cs
+++ b/src/Microsoft.Data.InMemory/InMemoryDataStore.cs
@@ -72,9 +72,9 @@ namespace Microsoft.Data.InMemory
             }
 
             _objectData.ExchangeValue(
-                db => db.AddRange(added.Select(se => new KeyValuePair<EntityKey, object[]>(se.CreateKey(), se.GetValueBuffer())))
-                    .SetItems(modified.Select(se => new KeyValuePair<EntityKey, object[]>(se.CreateKey(), se.GetValueBuffer())))
-                    .RemoveRange(deleted.Select(se => se.CreateKey())));
+                db => db.AddRange(added.Select(se => new KeyValuePair<EntityKey, object[]>(se.GetPrimaryKeyValue(), se.GetValueBuffer())))
+                    .SetItems(modified.Select(se => new KeyValuePair<EntityKey, object[]>(se.GetPrimaryKeyValue(), se.GetValueBuffer())))
+                    .RemoveRange(deleted.Select(se => se.GetPrimaryKeyValue())));
 
             if (_logger.IsEnabled(TraceType.Information))
             {

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/CompositeEntityKeyFactoryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/CompositeEntityKeyFactoryTest.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
     public class CompositeEntityKeyFactoryTest
     {
         [Fact]
-        public void Creates_a_new_key_for_key_values_in_the_given_entry()
+        public void Creates_a_new_primary_key_for_key_values_in_the_given_entry()
         {
             var keyPart1 = new Mock<IProperty>().Object;
             var keyPart2 = new Mock<IProperty>().Object;
@@ -27,9 +27,33 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entryMock.Setup(m => m.GetPropertyValue(keyPart3)).Returns(random);
             entryMock.Setup(m => m.EntityType).Returns(typeMock.Object);
 
-            var key = (CompositeEntityKey)new CompositeEntityKeyFactory().Create(entryMock.Object);
+            var key = (CompositeEntityKey)new CompositeEntityKeyFactory().Create(
+                typeMock.Object, typeMock.Object.Key, entryMock.Object);
 
             Assert.Equal(new Object[] { 7, "Ate", random }, key.Value);
+        }
+
+        [Fact]
+        public void Creates_a_new_key_for_non_primary_key_values_in_the_given_entry()
+        {
+            var keyProp = new Mock<IProperty>().Object;
+            var nonKeyPart1 = new Mock<IProperty>().Object;
+            var nonKeyPart2 = new Mock<IProperty>().Object;
+
+            var typeMock = new Mock<IEntityType>();
+            typeMock.Setup(m => m.Key).Returns(new[] { keyProp });
+
+            var random = new Random();
+            var entryMock = new Mock<StateEntry>();
+            entryMock.Setup(m => m.GetPropertyValue(keyProp)).Returns(7);
+            entryMock.Setup(m => m.GetPropertyValue(nonKeyPart1)).Returns("Ate");
+            entryMock.Setup(m => m.GetPropertyValue(nonKeyPart2)).Returns(random);
+            entryMock.Setup(m => m.EntityType).Returns(typeMock.Object);
+
+            var key = (CompositeEntityKey)new CompositeEntityKeyFactory().Create(
+                typeMock.Object, new[] { nonKeyPart2, nonKeyPart1 }, entryMock.Object);
+
+            Assert.Equal(new Object[] { random, "Ate" }, key.Value);
         }
     }
 }

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/EntityKeyFactorySourceTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/EntityKeyFactorySourceTest.cs
@@ -11,15 +11,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
     public class EntityKeyFactorySourceTest
     {
         [Fact]
-        public void Returns_a_simple_entity_key_factory_for_single_property_key()
+        public void Returns_a_simple_entity_key_factory_for_single_property()
         {
             var keyMock = new Mock<IProperty>();
             keyMock.Setup(m => m.PropertyType).Returns(typeof(int));
 
-            var typeMock = new Mock<IEntityType>();
-            typeMock.Setup(m => m.Key).Returns(new[] { keyMock.Object });
-
-            Assert.IsType<SimpleEntityKeyFactory<int>>(new EntityKeyFactorySource().GetKeyFactory(typeMock.Object));
+            Assert.IsType<SimpleEntityKeyFactory<int>>(new EntityKeyFactorySource().GetKeyFactory(new[] { keyMock.Object }));
         }
 
         [Fact]
@@ -28,26 +25,18 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var keyMock1 = new Mock<IProperty>();
             keyMock1.Setup(m => m.PropertyType).Returns(typeof(Guid));
 
-            var typeMock1 = new Mock<IEntityType>();
-            typeMock1.Setup(m => m.Key).Returns(new[] { keyMock1.Object });
-
             var keyMock2 = new Mock<IProperty>();
             keyMock2.Setup(m => m.PropertyType).Returns(typeof(Guid));
 
-            var typeMock2 = new Mock<IEntityType>();
-            typeMock2.Setup(m => m.Key).Returns(new[] { keyMock2.Object });
-
             var factorySource = new EntityKeyFactorySource();
-            Assert.Same(factorySource.GetKeyFactory(typeMock1.Object), factorySource.GetKeyFactory(typeMock2.Object));
+            Assert.Same(factorySource.GetKeyFactory(new[] { keyMock1.Object }), factorySource.GetKeyFactory(new[] { keyMock2.Object }));
         }
 
         [Fact]
         public void Returns_a_composite_entity_key_factory_for_composite_property_key()
         {
-            var typeMock = new Mock<IEntityType>();
-            typeMock.Setup(m => m.Key).Returns(new[] { new Mock<IProperty>().Object, new Mock<IProperty>().Object });
-
-            Assert.IsType<CompositeEntityKeyFactory>(new EntityKeyFactorySource().GetKeyFactory(typeMock.Object));
+            Assert.IsType<CompositeEntityKeyFactory>(
+                new EntityKeyFactorySource().GetKeyFactory(new[] { new Mock<IProperty>().Object, new Mock<IProperty>().Object }));
         }
     }
 }

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/NavigationFixerTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/NavigationFixerTest.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             public Category Category { get; set; }
         }
 
-        private static IModel BuildModel()
+        private static RuntimeModel BuildModel()
         {
             var model = new Model();
             var builder = new ModelBuilder(model);
@@ -134,7 +134,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             categoryType.AddNavigation(new CollectionNavigation(categoryIdFk, "Products"));
             productType.AddNavigation(new Navigation(categoryIdFk, "Category"));
 
-            return model;
+            return new RuntimeModel(model, new EntityKeyFactorySource());
         }
 
         #endregion

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateManagerTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateManagerTest.cs
@@ -28,31 +28,31 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
                 "identityGenerators",
                 // ReSharper disable once AssignNullToNotNullAttribute
                 Assert.Throws<ArgumentNullException>(
-                    () => new StateManager(new Model(), null, Enumerable.Empty<IEntityStateListener>(),
+                    () => new StateManager(Mock.Of<RuntimeModel>(), null, Enumerable.Empty<IEntityStateListener>(),
                         new Mock<EntityKeyFactorySource>().Object, new Mock<StateEntryFactory>().Object)).ParamName);
 
             Assert.Equal(
                 "entityStateListeners",
                 // ReSharper disable once AssignNullToNotNullAttribute
                 Assert.Throws<ArgumentNullException>(
-                    () => new StateManager(new Model(), new Mock<ActiveIdentityGenerators>().Object, null,
+                    () => new StateManager(Mock.Of<RuntimeModel>(), new Mock<ActiveIdentityGenerators>().Object, null,
                         new Mock<EntityKeyFactorySource>().Object, new Mock<StateEntryFactory>().Object)).ParamName);
 
             Assert.Equal(
                 "entityKeyFactorySource",
                 // ReSharper disable once AssignNullToNotNullAttribute
                 Assert.Throws<ArgumentNullException>(
-                    () => new StateManager(new Model(), new Mock<ActiveIdentityGenerators>().Object, Enumerable.Empty<IEntityStateListener>(),
+                    () => new StateManager(Mock.Of<RuntimeModel>(), new Mock<ActiveIdentityGenerators>().Object, Enumerable.Empty<IEntityStateListener>(),
                         null, new Mock<StateEntryFactory>().Object)).ParamName);
 
             Assert.Equal(
                 "stateEntryFactory",
                 // ReSharper disable once AssignNullToNotNullAttribute
                 Assert.Throws<ArgumentNullException>(
-                    () => new StateManager(new Model(), new Mock<ActiveIdentityGenerators>().Object, Enumerable.Empty<IEntityStateListener>(),
+                    () => new StateManager(Mock.Of<RuntimeModel>(), new Mock<ActiveIdentityGenerators>().Object, Enumerable.Empty<IEntityStateListener>(),
                         new Mock<EntityKeyFactorySource>().Object, null)).ParamName);
 
-            var stateManager = CreateStateManager(new Model());
+            var stateManager = CreateStateManager(Mock.Of<RuntimeModel>());
 
             Assert.Equal(
                 "entity",
@@ -75,7 +75,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
                 Assert.Throws<ArgumentNullException>(() => stateManager.GetIdentityGenerator(null)).ParamName);
         }
 
-        private static StateManager CreateStateManager(IModel model)
+        private static StateManager CreateStateManager(RuntimeModel model)
         {
             return new StateManager(
                 model,
@@ -300,16 +300,6 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             }
         }
 
-        [Fact]
-        public void Can_get_key_factory()
-        {
-            var model = BuildModel();
-            var stateManager = CreateStateManager(model);
-
-            Assert.IsType<SimpleEntityKeyFactory<int>>(stateManager.GetKeyFactory(model.GetEntityType(typeof(Category))));
-            Assert.IsType<SimpleEntityKeyFactory<Guid>>(stateManager.GetKeyFactory(model.GetEntityType(typeof(Product))));
-        }
-
         #region Fixture
 
         private class Category
@@ -325,7 +315,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             public decimal Price { get; set; }
         }
 
-        private static IModel BuildModel()
+        private static RuntimeModel BuildModel()
         {
             var model = new Model();
             var builder = new ModelBuilder(model);
@@ -340,7 +330,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             locationType.AddProperty(new Property("Planet", typeof(string), hasClrProperty: false));
             model.AddEntityType(locationType);
 
-            return model;
+            return new RuntimeModel(model, new EntityKeyFactorySource());
         }
 
         #endregion

--- a/test/Microsoft.Data.Entity.Tests/Metadata/RuntimeModelTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Metadata/RuntimeModelTest.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Metadata;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.Metadata
+{
+    public class RuntimeModelTest
+    {
+        [Fact]
+        public void Can_get_key_factory()
+        {
+            var factory = Mock.Of<EntityKeyFactory>();
+            var factoryMock = new Mock<EntityKeyFactorySource>();
+            var keyProperties = new[] { Mock.Of<IProperty>() };
+            factoryMock.Setup(m => m.GetKeyFactory(keyProperties)).Returns(factory);
+
+            var model = new RuntimeModel(Mock.Of<IModel>(), factoryMock.Object);
+
+            Assert.Same(factory, model.GetKeyFactory(keyProperties));
+        }
+    }
+}

--- a/test/Microsoft.Data.InMemory.Tests/InMemoryDataStoreTest.cs
+++ b/test/Microsoft.Data.InMemory.Tests/InMemoryDataStoreTest.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Data.InMemory.Tests
                 l => l.WriteCore(TraceType.Information, 0, null, null, It.IsAny<Func<object, Exception, string>>()), Times.Once);
         }
 
-        private static Model CreateModel()
+        private static RuntimeModel CreateModel()
         {
             var model = new Model();
             var modelBuilder = new ModelBuilder(model);
@@ -119,10 +119,10 @@ namespace Microsoft.Data.InMemory.Tests
                 .Key(c => c.Id)
                 .Properties(ps => ps.Property(c => c.Name));
 
-            return model;
+            return new RuntimeModel(model, new EntityKeyFactorySource());
         }
 
-        private static StateManager CreateStateManager(IModel model)
+        private static StateManager CreateStateManager(RuntimeModel model)
         {
             return new StateManager(
                 model,

--- a/test/Microsoft.Data.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/Microsoft.Data.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Data.Relational.Update
                 command.WhereClauses);
         }
 
-        private static Entity.Metadata.Model CreateModel()
+        private static Entity.Metadata.RuntimeModel CreateModel()
         {
             var model = new Entity.Metadata.Model();
             var modelBuilder = new ModelBuilder(model);
@@ -106,7 +106,7 @@ namespace Microsoft.Data.Relational.Update
                 .Key(c => c.Id)
                 .Properties(ps => ps.Property(c => c.Value));
 
-            return model;
+            return new RuntimeModel(model, new EntityKeyFactorySource());
         }
 
         public class FakeEntity


### PR DESCRIPTION
Talking back to the principal... (Update fixup-related code to use previous changes)

Previous checkins included back-pointers on FKs and key types. This change cleans up the code for finding principals and dependents and using them in fixup such that it makes use of these facilities.

Also included here is the concept of RuntimeModel which implements IModel but adds additional services that require state but which are not part of the model definition itself.
