### PR TITLE
Tasty delegates...

### DIFF
--- a/src/Microsoft.Data.Entity/ChangeTracking/ClrStateEntry.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/ClrStateEntry.cs
@@ -38,14 +38,14 @@ namespace Microsoft.Data.Entity.ChangeTracking
         {
             Check.NotNull(property, "property");
 
-            return property.GetValue(_entity);
+            return StateManager.GetClrPropertyGetter(property).GetClrValue(_entity);
         }
 
         public override void SetPropertyValue(IProperty property, object value)
         {
             Check.NotNull(property, "property");
 
-            property.SetValue(_entity, value);
+            StateManager.GetClrPropertySetter(property).SetClrValue(_entity, value);
         }
     }
 }

--- a/src/Microsoft.Data.Entity/ChangeTracking/MixedStateEntry.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/MixedStateEntry.cs
@@ -40,7 +40,9 @@ namespace Microsoft.Data.Entity.ChangeTracking
         {
             Check.NotNull(property, "property");
 
-            return property.HasClrProperty ? property.GetValue(_entity) : _propertyValues[property.ShadowIndex];
+            return property.HasClrProperty 
+                ? StateManager.GetClrPropertyGetter(property).GetClrValue(_entity) 
+                : _propertyValues[property.ShadowIndex];
         }
 
         public override void SetPropertyValue(IProperty property, object value)
@@ -49,7 +51,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
 
             if (property.HasClrProperty)
             {
-                property.SetValue(_entity, value);
+                StateManager.GetClrPropertySetter(property).SetClrValue(_entity, value);
             }
             else
             {

--- a/src/Microsoft.Data.Entity/ChangeTracking/StateManager.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/StateManager.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Data.Entity.ChangeTracking
         private readonly IEntityStateListener[] _entityStateListeners;
         private readonly EntityKeyFactorySource _keyFactorySource;
         private readonly StateEntryFactory _stateEntryFactory;
+        private readonly ClrPropertyGetterSource _getterSource;
+        private readonly ClrPropertySetterSource _setterSource;
 
         /// <summary>
         ///     This constructor is intended only for use when creating test doubles that will override members
@@ -38,18 +40,24 @@ namespace Microsoft.Data.Entity.ChangeTracking
             [NotNull] ActiveIdentityGenerators identityGenerators,
             [NotNull] IEnumerable<IEntityStateListener> entityStateListeners,
             [NotNull] EntityKeyFactorySource entityKeyFactorySource,
-            [NotNull] StateEntryFactory stateEntryFactory)
+            [NotNull] StateEntryFactory stateEntryFactory,
+            [NotNull] ClrPropertyGetterSource getterSource,
+            [NotNull] ClrPropertySetterSource setterSource)
         {
             Check.NotNull(model, "model");
             Check.NotNull(identityGenerators, "identityGenerators");
             Check.NotNull(entityStateListeners, "entityStateListeners");
             Check.NotNull(entityKeyFactorySource, "entityKeyFactorySource");
             Check.NotNull(stateEntryFactory, "stateEntryFactory");
+            Check.NotNull(getterSource, "getterSource");
+            Check.NotNull(setterSource, "setterSource");
 
             _model = model;
             _identityGenerators = identityGenerators;
             _keyFactorySource = entityKeyFactorySource;
             _stateEntryFactory = stateEntryFactory;
+            _getterSource = getterSource;
+            _setterSource = setterSource;
 
             var stateListeners = entityStateListeners.ToArray();
             _entityStateListeners = stateListeners.Length == 0 ? null : stateListeners;
@@ -224,5 +232,16 @@ namespace Microsoft.Data.Entity.ChangeTracking
                 e => e.EntityType == foreignKey.DependentType
                      && principalKeyValue.Equals(e.GetDependentKeyValue(foreignKey)));
         }
+
+        internal virtual IClrPropertyGetter GetClrPropertyGetter(IProperty property)
+        {
+            return _getterSource.GetAccessor(property);
+        }
+
+        internal virtual IClrPropertySetter GetClrPropertySetter(IProperty property)
+        {
+            return _setterSource.GetAccessor(property);
+        }
+
     }
 }

--- a/src/Microsoft.Data.Entity/ChangeTracking/StateManagerFactory.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/StateManagerFactory.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Data.Entity.ChangeTracking
         private readonly IEnumerable<IEntityStateListener> _entityStateListeners;
         private readonly EntityKeyFactorySource _keyFactorySource;
         private readonly StateEntryFactory _stateEntryFactory;
+        private readonly ClrPropertyGetterSource _getterSource;
+        private readonly ClrPropertySetterSource _setterSource;
 
         /// <summary>
         ///     This constructor is intended only for use when creating test doubles that will override members
@@ -29,25 +31,31 @@ namespace Microsoft.Data.Entity.ChangeTracking
             [NotNull] ActiveIdentityGenerators identityGenerators,
             [NotNull] IEnumerable<IEntityStateListener> entityStateListeners,
             [NotNull] EntityKeyFactorySource entityKeyFactorySource,
-            [NotNull] StateEntryFactory stateEntryFactory)
+            [NotNull] StateEntryFactory stateEntryFactory,
+            [NotNull] ClrPropertyGetterSource getterSource,
+            [NotNull] ClrPropertySetterSource setterSource)
 
         {
             Check.NotNull(identityGenerators, "identityGenerators");
             Check.NotNull(entityStateListeners, "entityStateListeners");
             Check.NotNull(entityKeyFactorySource, "entityKeyFactorySource");
             Check.NotNull(stateEntryFactory, "stateEntryFactory");
+            Check.NotNull(getterSource, "getterSource");
+            Check.NotNull(setterSource, "setterSource");
 
             _identityGenerators = identityGenerators;
             _entityStateListeners = entityStateListeners;
             _keyFactorySource = entityKeyFactorySource;
             _stateEntryFactory = stateEntryFactory;
+            _getterSource = getterSource;
+            _setterSource = setterSource;
         }
 
         public virtual StateManager Create([NotNull] RuntimeModel model)
         {
             Check.NotNull(model, "model");
 
-            return new StateManager(model, _identityGenerators, _entityStateListeners, _keyFactorySource, _stateEntryFactory);
+            return new StateManager(model, _identityGenerators, _entityStateListeners, _keyFactorySource, _stateEntryFactory, _getterSource, _setterSource);
         }
     }
 }

--- a/src/Microsoft.Data.Entity/EntityServices.cs
+++ b/src/Microsoft.Data.Entity/EntityServices.cs
@@ -24,7 +24,9 @@ namespace Microsoft.Data.Entity
                 .AddSingleton<IEntityStateListener, NavigationFixer>()
                 .AddSingleton<EntityKeyFactorySource, EntityKeyFactorySource>()
                 .AddSingleton<StateEntryFactory, StateEntryFactory>()
-                .AddSingleton<RuntimeModelFactory, RuntimeModelFactory>();
+                .AddSingleton<RuntimeModelFactory, RuntimeModelFactory>()
+                .AddSingleton<ClrPropertyGetterSource, ClrPropertyGetterSource>()
+                .AddSingleton<ClrPropertySetterSource, ClrPropertySetterSource>();
         }
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/ClrAccessorSource.cs
+++ b/src/Microsoft.Data.Entity/Metadata/ClrAccessorSource.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Metadata
+{
+    public abstract class ClrAccessorSource<TAccessor>
+        where TAccessor : class
+    {
+        private static readonly MethodInfo _genericCreate
+            = typeof(ClrAccessorSource<TAccessor>).GetTypeInfo().GetDeclaredMethods("CreateGeneric").Single();
+
+        private readonly ThreadSafeLazyRef<ImmutableDictionary<Tuple<Type, string>, TAccessor>> _setters
+            = new ThreadSafeLazyRef<ImmutableDictionary<Tuple<Type, string>, TAccessor>>(() => ImmutableDictionary<Tuple<Type, string>, TAccessor>.Empty);
+
+        public virtual TAccessor GetAccessor([NotNull] IProperty property)
+        {
+            Check.NotNull(property, "property");
+
+            var clrPropertySetter = property as TAccessor;
+
+            if (clrPropertySetter != null)
+            {
+                return clrPropertySetter;
+            }
+
+            return GetAccessor(property.EntityType.Type, property.Name);
+        }
+
+        public virtual TAccessor GetAccessor([NotNull] Type propertyType, [NotNull] string propertyName)
+        {
+            Check.NotNull(propertyType, "propertyType");
+            Check.NotEmpty(propertyName, "propertyName");
+
+            var key = Tuple.Create(propertyType, propertyName);
+
+            TAccessor clrPropertySetter;
+            if (!_setters.Value.TryGetValue(key, out clrPropertySetter))
+            {
+                var accessor = Create(propertyType.GetAnyProperty(propertyName));
+                _setters.ExchangeValue(d => d.ContainsKey(key) ? d : d.Add(key, accessor));
+                clrPropertySetter = _setters.Value[key];
+            }
+
+            return clrPropertySetter;
+        }
+
+        private TAccessor Create(PropertyInfo property)
+        {
+            var boundMethod = _genericCreate.MakeGenericMethod(property.DeclaringType, property.PropertyType);
+
+            return (TAccessor)boundMethod.Invoke(this, new object[] { property });
+        }
+
+        protected abstract TAccessor CreateGeneric<TEntity, TValue>([NotNull] PropertyInfo property);
+    }
+}

--- a/src/Microsoft.Data.Entity/Metadata/ClrPropertyGetter.cs
+++ b/src/Microsoft.Data.Entity/Metadata/ClrPropertyGetter.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Metadata
+{
+    public class ClrPropertyGetter<TEntity, TValue> : IClrPropertyGetter
+    {
+        private readonly Func<TEntity, TValue> _getter;
+
+        public ClrPropertyGetter([NotNull] Func<TEntity, TValue> getter)
+        {
+            Check.NotNull(getter, "getter");
+
+            _getter = getter;
+        }
+
+        public object GetClrValue(object instance)
+        {
+            Check.NotNull(instance, "instance");
+
+            return _getter((TEntity)instance);
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/Metadata/ClrPropertyGetterSource.cs
+++ b/src/Microsoft.Data.Entity/Metadata/ClrPropertyGetterSource.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Metadata
+{
+    public class ClrPropertyGetterSource : ClrAccessorSource<IClrPropertyGetter>
+    {
+        protected override IClrPropertyGetter CreateGeneric<TEntity, TValue>(PropertyInfo property)
+        {
+            Check.NotNull(property, "property");
+
+            // TODO: Handle case where there is not setter or setter is private on a base type
+            var getterDelegate = (Func<TEntity, TValue>)property.GetMethod.CreateDelegate(typeof(Func<TEntity, TValue>));
+
+            return new ClrPropertyGetter<TEntity, TValue>(getterDelegate);
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/Metadata/ClrPropertySetter.cs
+++ b/src/Microsoft.Data.Entity/Metadata/ClrPropertySetter.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Metadata
+{
+    public class ClrPropertySetter<TEntity, TValue> : IClrPropertySetter
+    {
+        private readonly Action<TEntity, TValue> _setter;
+
+        public ClrPropertySetter([NotNull] Action<TEntity, TValue> setter)
+        {
+            Check.NotNull(setter, "setter");
+
+            _setter = setter;
+        }
+
+        public void SetClrValue(object instance, object value)
+        {
+            Check.NotNull(instance, "instance");
+
+            _setter((TEntity)instance, (TValue)value);
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/Metadata/ClrPropertySetterSource.cs
+++ b/src/Microsoft.Data.Entity/Metadata/ClrPropertySetterSource.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Metadata
+{
+    public class ClrPropertySetterSource : ClrAccessorSource<IClrPropertySetter>
+    {
+        protected override IClrPropertySetter CreateGeneric<TEntity, TValue>(PropertyInfo property)
+        {
+            Check.NotNull(property, "property");
+
+            // TODO: Handle case where there is not setter or setter is private on a base type
+            var setterDelegate = (Action<TEntity, TValue>)property.SetMethod.CreateDelegate(typeof(Action<TEntity, TValue>));
+
+            return new ClrPropertySetter<TEntity, TValue>(setterDelegate);
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/Metadata/IClrPropertyGetter.cs
+++ b/src/Microsoft.Data.Entity/Metadata/IClrPropertyGetter.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace Microsoft.Data.Entity.Metadata
+{
+    public interface IClrPropertyGetter
+    {
+        object GetClrValue([NotNull] object instance);
+    }
+}

--- a/src/Microsoft.Data.Entity/Metadata/IClrPropertySetter.cs
+++ b/src/Microsoft.Data.Entity/Metadata/IClrPropertySetter.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace Microsoft.Data.Entity.Metadata
+{
+    public interface IClrPropertySetter
+    {
+        void SetClrValue([NotNull] object instance, [CanBeNull] object value);
+    }
+}

--- a/src/Microsoft.Data.Entity/Metadata/IProperty.cs
+++ b/src/Microsoft.Data.Entity/Metadata/IProperty.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
 using System;
-using JetBrains.Annotations;
 
 namespace Microsoft.Data.Entity.Metadata
 {
@@ -11,8 +10,6 @@ namespace Microsoft.Data.Entity.Metadata
         Type PropertyType { get; }
         IEntityType EntityType { get; }
         bool IsNullable { get; }
-        void SetValue([NotNull] object instance, [CanBeNull] object value);
-        object GetValue([NotNull] object instance);
         ValueGenerationStrategy ValueGenerationStrategy { get; }
         int Index { get; }
         int ShadowIndex { get; }

--- a/src/Microsoft.Data.Entity/Metadata/Property.cs
+++ b/src/Microsoft.Data.Entity/Metadata/Property.cs
@@ -92,22 +92,6 @@ namespace Microsoft.Data.Entity.Metadata
             }
         }
 
-        // TODO: Move these off IProperty
-        public virtual void SetValue(object instance, object value)
-        {
-            Check.NotNull(instance, "instance");
-
-            EntityType.Type.GetAnyProperty(Name).SetValue(instance, value);
-        }
-
-        // TODO: Move these off IProperty
-        public virtual object GetValue(object instance)
-        {
-            Check.NotNull(instance, "instance");
-
-            return EntityType.Type.GetAnyProperty(Name).GetValue(instance);
-        }
-
         IEntityType IProperty.EntityType
         {
             get { return EntityType; }

--- a/src/Microsoft.Data.Relational/Update/CommandBatchPreparer.cs
+++ b/src/Microsoft.Data.Relational/Update/CommandBatchPreparer.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Data.Relational.Update
                     p.ValueGenerationStrategy != ValueGenerationStrategy.StoreComputed &&
                     p.ValueGenerationStrategy != ValueGenerationStrategy.StoreIdentity &&
                     (includeKeys || !entityType.GetKey().Properties.Contains(p)))
-                .Select(p => new KeyValuePair<string, object>(p.StorageName, p.GetValue(stateEntry.Entity)));
+                .Select(p => new KeyValuePair<string, object>(p.StorageName, stateEntry.GetPropertyValue(p)));
         }
 
         private static IEnumerable<KeyValuePair<string, object>> GetWhereClauses(StateEntry stateEntry)
@@ -53,7 +53,7 @@ namespace Microsoft.Data.Relational.Update
             return
                 stateEntry
                     .EntityType.GetKey().Properties
-                        .Select(k => new KeyValuePair<string, object>(k.Name, k.GetValue(stateEntry.Entity)));
+                        .Select(k => new KeyValuePair<string, object>(k.Name, stateEntry.GetPropertyValue(k)));
         }
     }
 }

--- a/test/Microsoft.Data.Entity.FunctionalTests/Metadata/CompiledModelTest.cs
+++ b/test/Microsoft.Data.Entity.FunctionalTests/Metadata/CompiledModelTest.cs
@@ -65,12 +65,26 @@ namespace Microsoft.Data.Entity.FunctionalTests.Metadata
         [Fact]
         public void Property_values_can_be_read_and_set_using_compiled_metadata_without_reflection()
         {
-            var entity = new KoolEntity15();
-            var property = new _OneTwoThreeContextModel().GetEntityType(entity.GetType()).TryGetProperty("Id");
+            var configuration = new EntityConfiguration { Model = new _OneTwoThreeContextModel() };
 
-            Assert.Equal(0, property.GetValue(entity));
-            property.SetValue(entity, 777);
-            Assert.Equal(777, property.GetValue(entity));
+            using (var context = new EntityContext(configuration))
+            {
+                var entity = new KoolEntity15();
+                var property = (_KoolEntity15IdProperty)context.Model.GetEntityType(entity.GetType()).TryGetProperty("Id");
+
+                var stateEntry = context.ChangeTracker.Entry(entity).StateEntry;
+
+                Assert.False(property.GetterCalled);
+                Assert.False(property.SetterCalled);
+
+                Assert.Equal(0, stateEntry.GetPropertyValue(property));
+                Assert.True(property.GetterCalled);
+
+                stateEntry.SetPropertyValue(property, 777);
+
+                Assert.True(property.SetterCalled);
+                Assert.Equal(777, stateEntry.GetPropertyValue(property));
+            }
         }
 
         [Fact]

--- a/test/Microsoft.Data.Entity.FunctionalTests/Metadata/KoolModel.cs
+++ b/test/Microsoft.Data.Entity.FunctionalTests/Metadata/KoolModel.cs
@@ -3169,7 +3169,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.Metadata
         }
     }
 
-    public class _KoolEntity15IdProperty : CompiledPropertyNoAnnotations<int>, IProperty
+    public class _KoolEntity15IdProperty : CompiledPropertyNoAnnotations<int>, IProperty, IClrPropertyGetter, IClrPropertySetter
     {
         public _KoolEntity15IdProperty(IEntityType entityType)
             : base(entityType)
@@ -3204,6 +3204,21 @@ namespace Microsoft.Data.Entity.FunctionalTests.Metadata
         public int ShadowIndex
         {
             get { return -2; }
+        }
+
+        public bool GetterCalled { get; set; }
+        public bool SetterCalled { get; set; }
+
+        public object GetClrValue(object instance)
+        {
+            GetterCalled = true;
+            return ((KoolEntity15)instance).Id;
+        }
+
+        public void SetClrValue(object instance, object value)
+        {
+            SetterCalled = true;
+            ((KoolEntity15)instance).Id = (int)value;
         }
     }
 

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/NavigationFixerTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/NavigationFixerTest.cs
@@ -87,7 +87,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
                 new Mock<ActiveIdentityGenerators>().Object,
                 Enumerable.Empty<IEntityStateListener>(),
                 new EntityKeyFactorySource(),
-                new StateEntryFactory());
+                new StateEntryFactory(),
+                new ClrPropertyGetterSource(), 
+                new ClrPropertySetterSource());
         }
 
         #region Fixture

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateEntryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateEntryTest.cs
@@ -95,13 +95,16 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             managerMock.Setup(m => m.GetIdentityGenerator(keyMock.Object)).Returns(generatorMock.Object);
 
+            var setterMock = new Mock<IClrPropertySetter>();
+            managerMock.Setup(m => m.GetClrPropertySetter(keyMock.Object)).Returns(setterMock.Object);
+
             var entity = new Random();
             var entry = CreateStateEntry(managerMock.Object, entityTypeMock.Object, entity);
             entry.SetEntityStateAsync(EntityState.Added, CancellationToken.None).Wait();
 
             if (keyMock.Object.HasClrProperty)
             {
-                keyMock.Verify(m => m.SetValue(entity, keyValue));
+                setterMock.Verify(m => m.SetClrValue(entity, keyValue));
             }
             else
             {
@@ -113,7 +116,6 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         public void Can_create_primary_key()
         {
             var propertyMock1 = new Mock<IProperty>();
-            propertyMock1.Setup(m => m.GetValue(It.IsAny<object>())).Returns("Atmosphere");
 
             var entityTypeMock = CreateEntityTypeMock(propertyMock1);
 
@@ -122,6 +124,13 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var managerMock = new Mock<StateManager>();
             managerMock.Setup(m => m.Model).Returns(modelMock.Object);
+
+            var getterMock = new Mock<IClrPropertyGetter>();
+            getterMock.Setup(m => m.GetClrValue(It.IsAny<object>())).Returns("Atmosphere");
+            managerMock.Setup(m => m.GetClrPropertyGetter(propertyMock1.Object)).Returns(getterMock.Object);
+
+            var setterMock = new Mock<IClrPropertySetter>();
+            managerMock.Setup(m => m.GetClrPropertySetter(propertyMock1.Object)).Returns(setterMock.Object);
 
             var entry = CreateStateEntry(managerMock.Object, entityTypeMock.Object, new Random());
             entry.SetPropertyValue(propertyMock1.Object, "Atmosphere");
@@ -135,10 +144,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         public void Can_create_foreign_key_value_based_on_dependent_values()
         {
             var principalProp = new Mock<IProperty>();
-            principalProp.Setup(m => m.GetValue(It.IsAny<object>())).Returns("Wax");
-
             var dependentProp = new Mock<IProperty>();
-            dependentProp.Setup(m => m.GetValue(It.IsAny<object>())).Returns("On");
 
             var principalProps = new[] { principalProp.Object };
             var dependentProps = new[] { dependentProp.Object };
@@ -151,6 +157,19 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var managerMock = new Mock<StateManager>();
             managerMock.Setup(m => m.Model).Returns(modelMock.Object);
+
+            var getterMock1 = new Mock<IClrPropertyGetter>();
+            getterMock1.Setup(m => m.GetClrValue(It.IsAny<object>())).Returns("Wax");
+
+            var getterMock2 = new Mock<IClrPropertyGetter>();
+            getterMock2.Setup(m => m.GetClrValue(It.IsAny<object>())).Returns("On");
+
+            managerMock.Setup(m => m.GetClrPropertyGetter(principalProp.Object)).Returns(getterMock1.Object);
+            managerMock.Setup(m => m.GetClrPropertyGetter(dependentProp.Object)).Returns(getterMock2.Object);
+
+            var setterMock = new Mock<IClrPropertySetter>();
+            managerMock.Setup(m => m.GetClrPropertySetter(principalProp.Object)).Returns(setterMock.Object);
+            managerMock.Setup(m => m.GetClrPropertySetter(dependentProp.Object)).Returns(setterMock.Object);
 
             var foreignKeyMock = new Mock<IForeignKey>();
             foreignKeyMock.Setup(m => m.PrincipalType).Returns(principalTypeMock.Object);
@@ -170,10 +189,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         public void Can_create_foreign_key_value_based_on_principal_end_values()
         {
             var principalProp = new Mock<IProperty>();
-            principalProp.Setup(m => m.GetValue(It.IsAny<object>())).Returns("Wax");
-
             var dependentProp = new Mock<IProperty>();
-            dependentProp.Setup(m => m.GetValue(It.IsAny<object>())).Returns("Off");
 
             var principalProps = new[] { principalProp.Object };
             var dependentProps = new[] { dependentProp.Object };
@@ -186,6 +202,19 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var managerMock = new Mock<StateManager>();
             managerMock.Setup(m => m.Model).Returns(modelMock.Object);
+
+            var getterMock1 = new Mock<IClrPropertyGetter>();
+            getterMock1.Setup(m => m.GetClrValue(It.IsAny<object>())).Returns("Wax");
+
+            var getterMock2 = new Mock<IClrPropertyGetter>();
+            getterMock2.Setup(m => m.GetClrValue(It.IsAny<object>())).Returns("Off");
+
+            managerMock.Setup(m => m.GetClrPropertyGetter(principalProp.Object)).Returns(getterMock1.Object);
+            managerMock.Setup(m => m.GetClrPropertyGetter(dependentProp.Object)).Returns(getterMock2.Object);
+
+            var setterMock = new Mock<IClrPropertySetter>();
+            managerMock.Setup(m => m.GetClrPropertySetter(principalProp.Object)).Returns(setterMock.Object);
+            managerMock.Setup(m => m.GetClrPropertySetter(dependentProp.Object)).Returns(setterMock.Object);
 
             var foreignKeyMock = new Mock<IForeignKey>();
             foreignKeyMock.Setup(m => m.PrincipalType).Returns(principalTypeMock.Object);

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateManagerTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateManagerTest.cs
@@ -21,36 +21,41 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
                 // ReSharper disable once AssignNullToNotNullAttribute
                 Assert.Throws<ArgumentNullException>(
                     () => new StateManager(
-                        null, new Mock<ActiveIdentityGenerators>().Object, Enumerable.Empty<IEntityStateListener>(),
-                        new Mock<EntityKeyFactorySource>().Object, new Mock<StateEntryFactory>().Object)).ParamName);
+                        null, Mock.Of<ActiveIdentityGenerators>(), Enumerable.Empty<IEntityStateListener>(),
+                        Mock.Of<EntityKeyFactorySource>(), Mock.Of<StateEntryFactory>(),
+                        Mock.Of<ClrPropertyGetterSource>(), Mock.Of<ClrPropertySetterSource>())).ParamName);
 
             Assert.Equal(
                 "identityGenerators",
                 // ReSharper disable once AssignNullToNotNullAttribute
                 Assert.Throws<ArgumentNullException>(
                     () => new StateManager(Mock.Of<RuntimeModel>(), null, Enumerable.Empty<IEntityStateListener>(),
-                        new Mock<EntityKeyFactorySource>().Object, new Mock<StateEntryFactory>().Object)).ParamName);
+                        Mock.Of<EntityKeyFactorySource>(), Mock.Of<StateEntryFactory>(),
+                        Mock.Of<ClrPropertyGetterSource>(), Mock.Of<ClrPropertySetterSource>())).ParamName);
 
             Assert.Equal(
                 "entityStateListeners",
                 // ReSharper disable once AssignNullToNotNullAttribute
                 Assert.Throws<ArgumentNullException>(
-                    () => new StateManager(Mock.Of<RuntimeModel>(), new Mock<ActiveIdentityGenerators>().Object, null,
-                        new Mock<EntityKeyFactorySource>().Object, new Mock<StateEntryFactory>().Object)).ParamName);
+                    () => new StateManager(Mock.Of<RuntimeModel>(), Mock.Of<ActiveIdentityGenerators>(), null,
+                        Mock.Of<EntityKeyFactorySource>(), Mock.Of<StateEntryFactory>(),
+                        Mock.Of<ClrPropertyGetterSource>(), Mock.Of<ClrPropertySetterSource>())).ParamName);
 
             Assert.Equal(
                 "entityKeyFactorySource",
                 // ReSharper disable once AssignNullToNotNullAttribute
                 Assert.Throws<ArgumentNullException>(
-                    () => new StateManager(Mock.Of<RuntimeModel>(), new Mock<ActiveIdentityGenerators>().Object, Enumerable.Empty<IEntityStateListener>(),
-                        null, new Mock<StateEntryFactory>().Object)).ParamName);
+                    () => new StateManager(Mock.Of<RuntimeModel>(), Mock.Of<ActiveIdentityGenerators>(),
+                        Enumerable.Empty<IEntityStateListener>(), null, Mock.Of<StateEntryFactory>(),
+                        Mock.Of<ClrPropertyGetterSource>(), Mock.Of<ClrPropertySetterSource>())).ParamName);
 
             Assert.Equal(
                 "stateEntryFactory",
                 // ReSharper disable once AssignNullToNotNullAttribute
                 Assert.Throws<ArgumentNullException>(
-                    () => new StateManager(Mock.Of<RuntimeModel>(), new Mock<ActiveIdentityGenerators>().Object, Enumerable.Empty<IEntityStateListener>(),
-                        new Mock<EntityKeyFactorySource>().Object, null)).ParamName);
+                    () => new StateManager(Mock.Of<RuntimeModel>(), Mock.Of<ActiveIdentityGenerators>(),
+                        Enumerable.Empty<IEntityStateListener>(), Mock.Of<EntityKeyFactorySource>(), null,
+                        Mock.Of<ClrPropertyGetterSource>(), Mock.Of<ClrPropertySetterSource>())).ParamName);
 
             var stateManager = CreateStateManager(Mock.Of<RuntimeModel>());
 
@@ -79,10 +84,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             return new StateManager(
                 model,
-                new Mock<ActiveIdentityGenerators>().Object,
+                Mock.Of<ActiveIdentityGenerators>(),
                 Enumerable.Empty<IEntityStateListener>(),
                 new EntityKeyFactorySource(),
-                new StateEntryFactory());
+                new StateEntryFactory(),
+                new ClrPropertyGetterSource(), 
+                new ClrPropertySetterSource());
         }
 
         [Fact]
@@ -272,10 +279,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var stateManager = new StateManager(
                 BuildModel(),
-                new Mock<ActiveIdentityGenerators>().Object,
+                Mock.Of<ActiveIdentityGenerators>(),
                 listeners.Select(m => m.Object),
                 new EntityKeyFactorySource(),
-                new StateEntryFactory());
+                new StateEntryFactory(),
+                new ClrPropertyGetterSource(), 
+                new ClrPropertySetterSource());
 
             var entry = stateManager.GetOrCreateEntry(new Category { Id = 77 });
             entry.SetEntityStateAsync(EntityState.Added, CancellationToken.None).Wait();

--- a/test/Microsoft.Data.Entity.Tests/EntitySetInitializerTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/EntitySetInitializerTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 using Moq;
 using Xunit;
@@ -15,9 +16,9 @@ namespace Microsoft.Data.Entity.Tests
             Assert.Equal(
                 "setFinder",
                 // ReSharper disable once AssignNullToNotNullAttribute
-                Assert.Throws<ArgumentNullException>(() => new EntitySetInitializer(null)).ParamName);
+                Assert.Throws<ArgumentNullException>(() => new EntitySetInitializer(null, new ClrPropertySetterSource())).ParamName);
 
-            var initializer = new EntitySetInitializer(new Mock<EntitySetFinder>().Object);
+            var initializer = new EntitySetInitializer(new Mock<EntitySetFinder>().Object, new ClrPropertySetterSource());
 
             Assert.Equal(
                 "context",
@@ -40,7 +41,7 @@ namespace Microsoft.Data.Entity.Tests
 
             using (var context = new JustAContext())
             {
-                new EntitySetInitializer(setFinderMock.Object).InitializeSets(context);
+                new EntitySetInitializer(setFinderMock.Object, new ClrPropertySetterSource()).InitializeSets(context);
 
                 Assert.NotNull(context.One);
                 Assert.NotNull(context.GetTwo());

--- a/test/Microsoft.Data.Entity.Tests/Metadata/ClrPropertyGetterSourceTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Metadata/ClrPropertyGetterSourceTest.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Metadata;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.Metadata
+{
+    public class ClrPropertyGetterSourceTest
+    {
+        [Fact]
+        public void Property_is_returned_if_it_implements_IClrPropertyGetter()
+        {
+            var getterMock = new Mock<IClrPropertyGetter>();
+            var propertyMock = getterMock.As<IProperty>();
+
+            var source = new ClrPropertyGetterSource();
+
+            Assert.Same(getterMock.Object, source.GetAccessor(propertyMock.Object));
+        }
+
+        [Fact]
+        public void Delegate_getter_is_returned_for_IProperty_property()
+        {
+            var entityType = new EntityType(typeof(Customer));
+            var idProperty = entityType.AddProperty(new Property("Id", typeof(int), hasClrProperty: true));
+
+            Assert.Equal(7, new ClrPropertyGetterSource().GetAccessor(idProperty).GetClrValue(new Customer { Id = 7 }));
+        }
+
+        [Fact]
+        public void Delegate_getter_is_returned_for_property_type_and_name()
+        {
+            Assert.Equal(7, new ClrPropertyGetterSource().GetAccessor(typeof(Customer), "Id").GetClrValue(new Customer { Id = 7 }));
+        }
+
+        [Fact]
+        public void Delegate_getter_is_cached_by_type_and_property_name()
+        {
+            var entityType = new EntityType(typeof(Customer));
+            var idProperty = entityType.AddProperty(new Property("Id", typeof(int), hasClrProperty: true));
+
+            var source = new ClrPropertyGetterSource();
+
+            var accessor = source.GetAccessor(typeof(Customer), "Id");
+            Assert.Same(accessor, source.GetAccessor(typeof(Customer), "Id"));
+            Assert.Same(accessor, source.GetAccessor(idProperty));
+        }
+
+        #region Fixture
+
+        private class Customer
+        {
+            internal int Id { get; set; }
+        }
+
+        #endregion
+    }
+}

--- a/test/Microsoft.Data.Entity.Tests/Metadata/ClrPropertySetterSourceTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Metadata/ClrPropertySetterSourceTest.cs
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Metadata;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.Metadata
+{
+    public class ClrPropertySetterSourceTest
+    {
+        [Fact]
+        public void Property_is_returned_if_it_implements_IClrPropertySetter()
+        {
+            var setterMock = new Mock<IClrPropertySetter>();
+            var propertyMock = setterMock.As<IProperty>();
+
+            var source = new ClrPropertySetterSource();
+
+            Assert.Same(setterMock.Object, source.GetAccessor(propertyMock.Object));
+        }
+
+        [Fact]
+        public void Delegate_setter_is_returned_for_IProperty_property()
+        {
+            var entityType = new EntityType(typeof(Customer));
+            var idProperty = entityType.AddProperty(new Property("Id", typeof(int), hasClrProperty: true));
+
+            var customer = new Customer { Id = 7 };
+
+            new ClrPropertySetterSource().GetAccessor(idProperty).SetClrValue(customer, 77);
+
+            Assert.Equal(77, customer.Id);
+        }
+
+        [Fact]
+        public void Delegate_setter_is_returned_for_property_type_and_name()
+        {
+            var customer = new Customer { Id = 7 };
+
+            new ClrPropertySetterSource().GetAccessor(typeof(Customer), "Id").SetClrValue(customer, 77);
+
+            Assert.Equal(77, customer.Id);
+        }
+
+        [Fact]
+        public void Delegate_setter_is_cached_by_type_and_property_name()
+        {
+            var entityType = new EntityType(typeof(Customer));
+            var idProperty = entityType.AddProperty(new Property("Id", typeof(int), hasClrProperty: true));
+
+            var source = new ClrPropertySetterSource();
+
+            var accessor = source.GetAccessor(typeof(Customer), "Id");
+            Assert.Same(accessor, source.GetAccessor(typeof(Customer), "Id"));
+            Assert.Same(accessor, source.GetAccessor(idProperty));
+        }
+
+        #region Fixture
+
+        private class Customer
+        {
+            internal int Id { get; set; }
+        }
+
+        #endregion
+    }
+}

--- a/test/Microsoft.Data.Entity.Tests/Metadata/PropertyTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Metadata/PropertyTest.cs
@@ -33,18 +33,6 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 "propertyInfo",
                 // ReSharper disable once AssignNullToNotNullAttribute
                 Assert.Throws<ArgumentNullException>(() => new Property(null)).ParamName);
-
-            var property = new Property(Customer.NameProperty);
-
-            Assert.Equal(
-                "instance",
-                // ReSharper disable once AssignNullToNotNullAttribute
-                Assert.Throws<ArgumentNullException>(() => property.GetValue(null)).ParamName);
-
-            Assert.Equal(
-                "instance",
-                // ReSharper disable once AssignNullToNotNullAttribute
-                Assert.Throws<ArgumentNullException>(() => property.SetValue(null, "Kake")).ParamName);
         }
 
         [Fact]
@@ -71,19 +59,6 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal("Name", property.Name);
             Assert.Same(typeof(string), property.PropertyType);
             Assert.True(property.IsNullable);
-        }
-
-        [Fact]
-        public void Can_get_and_set_property_value()
-        {
-            var entityType = new EntityType(typeof(Customer));
-            var property = new Property(Customer.NameProperty);
-            entityType.AddProperty(property);
-            var entity = new Customer();
-
-            Assert.Null(property.GetValue(entity));
-            property.SetValue(entity, "There is no kake");
-            Assert.Equal("There is no kake", property.GetValue(entity));
         }
 
         [Fact]

--- a/test/Microsoft.Data.InMemory.Tests/InMemoryDataStoreTest.cs
+++ b/test/Microsoft.Data.InMemory.Tests/InMemoryDataStoreTest.cs
@@ -129,7 +129,9 @@ namespace Microsoft.Data.InMemory.Tests
                 new Mock<ActiveIdentityGenerators>().Object,
                 Enumerable.Empty<IEntityStateListener>(),
                 new EntityKeyFactorySource(),
-                new StateEntryFactory());
+                new StateEntryFactory(),
+                new ClrPropertyGetterSource(), 
+                new ClrPropertySetterSource());
         }
     }
 }

--- a/test/Microsoft.Data.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/Microsoft.Data.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -20,7 +20,11 @@ namespace Microsoft.Data.Relational.Update
         {
             var model = CreateModel();
             var stateManager =
-                new StateManager(model, Mock.Of<ActiveIdentityGenerators>(), new IEntityStateListener[0], new EntityKeyFactorySource(), new StateEntryFactory());
+                new StateManager(
+                    model, Mock.Of<ActiveIdentityGenerators>(),
+                    new IEntityStateListener[0], new EntityKeyFactorySource(),
+                    new StateEntryFactory(), new ClrPropertyGetterSource(), new ClrPropertySetterSource());
+
             var stateEntry = new MixedStateEntry(stateManager, model.GetEntityType(typeof(FakeEntity)), new FakeEntity { Id = 42, Value = "Test" });
             await stateEntry.SetEntityStateAsync(EntityState.Added, new CancellationToken());
 
@@ -44,7 +48,11 @@ namespace Microsoft.Data.Relational.Update
         {
             var model = CreateModel();
             var stateManager =
-                new StateManager(model, Mock.Of<ActiveIdentityGenerators>(), new IEntityStateListener[0], new EntityKeyFactorySource(), new StateEntryFactory());
+                new StateManager(
+                    model, Mock.Of<ActiveIdentityGenerators>(),
+                    new IEntityStateListener[0], new EntityKeyFactorySource(),
+                    new StateEntryFactory(), new ClrPropertyGetterSource(), new ClrPropertySetterSource());
+
             var stateEntry = new MixedStateEntry(stateManager, model.GetEntityType(typeof(FakeEntity)), new FakeEntity { Id = 42, Value = "Test" });
             await stateEntry.SetEntityStateAsync(EntityState.Modified, new CancellationToken());
 
@@ -75,7 +83,11 @@ namespace Microsoft.Data.Relational.Update
         {
             var model = CreateModel();
             var stateManager =
-                new StateManager(model, Mock.Of<ActiveIdentityGenerators>(), new IEntityStateListener[0], new EntityKeyFactorySource(), new StateEntryFactory());
+                new StateManager(
+                    model, Mock.Of<ActiveIdentityGenerators>(),
+                    new IEntityStateListener[0], new EntityKeyFactorySource(),
+                    new StateEntryFactory(), new ClrPropertyGetterSource(), new ClrPropertySetterSource());
+
             var stateEntry = new MixedStateEntry(stateManager, model.GetEntityType(typeof(FakeEntity)), new FakeEntity { Id = 42, Value = "Test" });
             await stateEntry.SetEntityStateAsync(EntityState.Deleted, new CancellationToken());
 
@@ -96,7 +108,7 @@ namespace Microsoft.Data.Relational.Update
                 command.WhereClauses);
         }
 
-        private static Entity.Metadata.RuntimeModel CreateModel()
+        private static RuntimeModel CreateModel()
         {
             var model = new Entity.Metadata.Model();
             var modelBuilder = new ModelBuilder(model);


### PR DESCRIPTION
Tasty delegates... (Reduce coupling of CLR property access and metadata)

This change decouples CLR property access from the core metadata APIs. It allows for getting and setting properties using cached delegates without dynamic code generation. In my initial testing this is pretty fast--two orders of magnitude faster than just Invoke. It also allows the compiled model to include pre-generated property accessors such that creation/caching/use of delegates is not required.

More tests required.
