### PR TITLE
Need for (RS)-1-phenylpropan-2-amine...

### DIFF
--- a/src/Microsoft.Data.Entity/ContextEntitySets.cs
+++ b/src/Microsoft.Data.Entity/ContextEntitySets.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity
+{
+    public class ContextEntitySets
+    {
+        private readonly EntityContext _context;
+        private readonly EntitySetSource _source;
+        private readonly Dictionary<Type, EntitySet> _sets = new Dictionary<Type, EntitySet>();
+
+        public ContextEntitySets([NotNull] EntityContext context, [NotNull] EntitySetSource source)
+        {
+            Check.NotNull(context, "context");
+            Check.NotNull(source, "source");
+
+            _context = context;
+            _source = source;
+        }
+
+        public virtual EntitySet GetEntitySet([NotNull] Type entityType)
+        {
+            Check.NotNull(entityType, "entityType");
+
+            EntitySet entitySet;
+            if (!_sets.TryGetValue(entityType, out entitySet))
+            {
+                entitySet = _source.Create(_context, entityType);
+                _sets.Add(entityType, entitySet);
+            }
+            return entitySet;
+        }
+
+        public virtual EntitySet<TEntity> GetEntitySet<TEntity>() where TEntity : class
+        {
+            EntitySet entitySet;
+            if (!_sets.TryGetValue(typeof(TEntity), out entitySet))
+            {
+                entitySet = new EntitySet<TEntity>(_context);
+                _sets.Add(typeof(TEntity), entitySet);
+            }
+            return (EntitySet<TEntity>)entitySet;
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/DefaultModelSource.cs
+++ b/src/Microsoft.Data.Entity/DefaultModelSource.cs
@@ -25,13 +25,11 @@ namespace Microsoft.Data.Entity
 
             var model = new Model();
 
-            foreach (var setProperty in _setFinder.FindSets(context))
+            foreach (var setInfo in _setFinder.FindSets(context))
             {
-                var type = setProperty.PropertyType.GetTypeInfo().GenericTypeArguments.Single();
-
-                if (model.TryGetEntityType(type) == null)
+                if (model.TryGetEntityType(setInfo.EntityType) == null)
                 {
-                    model.AddEntityType(new EntityType(type));
+                    model.AddEntityType(new EntityType(setInfo.EntityType));
                 }
             }
 

--- a/src/Microsoft.Data.Entity/EntityConfiguration.cs
+++ b/src/Microsoft.Data.Entity/EntityConfiguration.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Data.Entity
 
         private DataStore _dataStore;
         private StateManagerFactory _stateManagerFactory;
-        private EntitySetFinder _entitySetFinder;
         private EntitySetInitializer _entitySetInitializer;
+        private EntitySetSource _entitySetSource;
         private IdentityGeneratorFactory _identityGeneratorFactory;
         private ActiveIdentityGenerators _activeIdentityGenerators;
         private IModel _model;
@@ -61,27 +61,29 @@ namespace Microsoft.Data.Entity
             }
         }
 
-        public virtual EntitySetFinder EntitySetFinder
-        {
-            get { return _entitySetFinder ?? GetRequiredService<EntitySetFinder>(); }
-            [param: NotNull]
-            set
-            {
-                Check.NotNull(value, "value");
-
-                _entitySetFinder = value;
-            }
-        }
-
         public virtual EntitySetInitializer EntitySetInitializer
         {
-            get { return _entitySetInitializer ?? GetRequiredService<EntitySetInitializer>(); }
+            // TODO: Remove this once the service provider correctly returns singleton instances
+            get { return _entitySetInitializer ?? (_entitySetInitializer = GetRequiredService<EntitySetInitializer>()); }
             [param: NotNull]
             set
             {
                 Check.NotNull(value, "value");
 
                 _entitySetInitializer = value;
+            }
+        }
+
+        public virtual EntitySetSource EntitySetSource
+        {
+            // TODO: Remove this once the service provider correctly returns singleton instances
+            get { return _entitySetSource ?? (_entitySetSource = GetRequiredService<EntitySetSource>()); }
+            [param: NotNull]
+            set
+            {
+                Check.NotNull(value, "value");
+
+                _entitySetSource = value;
             }
         }
 

--- a/src/Microsoft.Data.Entity/EntityServices.cs
+++ b/src/Microsoft.Data.Entity/EntityServices.cs
@@ -25,7 +25,8 @@ namespace Microsoft.Data.Entity
                 .AddSingleton<EntityKeyFactorySource, EntityKeyFactorySource>()
                 .AddSingleton<StateEntryFactory, StateEntryFactory>()
                 .AddSingleton<ClrPropertyGetterSource, ClrPropertyGetterSource>()
-                .AddSingleton<ClrPropertySetterSource, ClrPropertySetterSource>();
+                .AddSingleton<ClrPropertySetterSource, ClrPropertySetterSource>()
+                .AddSingleton<EntitySetSource, EntitySetSource>();
         }
     }
 }

--- a/src/Microsoft.Data.Entity/EntitySet.cs
+++ b/src/Microsoft.Data.Entity/EntitySet.cs
@@ -2,18 +2,14 @@
 
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Threading;
-using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity
 {
-    public class EntitySet<TEntity> : IQueryable<TEntity>
-        where TEntity : class
+    public abstract class EntitySet : IQueryable
     {
         private readonly EntityContext _context;
 
@@ -26,114 +22,29 @@ namespace Microsoft.Data.Entity
         {
         }
 
-        public EntitySet([NotNull] EntityContext context)
+        protected EntitySet([NotNull] EntityContext context)
         {
             Check.NotNull(context, "context");
 
             _context = context;
         }
 
-        public IEnumerator<TEntity> GetEnumerator()
+        protected internal EntityContext Context
         {
-            // TODO
-            throw new NotImplementedException();
+            get { return _context; }
         }
 
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return GetEnumerator();
+            // TODO: Consider something better here
+            return ((IEnumerable)this).GetEnumerator();
         }
 
-        // TODO
-        public Type ElementType
-        {
-            get { return null; }
-        }
+        public abstract Expression Expression { get; }
+        public abstract Type ElementType { get; }
+        public abstract IQueryProvider Provider { get; }
 
-        // TODO
-        public Expression Expression
-        {
-            get { return null; }
-        }
-
-        // TODO
-        public IQueryProvider Provider
-        {
-            get { return null; }
-        }
-
-        public virtual TEntity Add([NotNull] TEntity entity)
-        {
-            Check.NotNull(entity, "entity");
-
-            return _context.Add(entity);
-        }
-
-        public virtual Task<TEntity> AddAsync([NotNull] TEntity entity)
-        {
-            Check.NotNull(entity, "entity");
-
-            return _context.AddAsync(entity, CancellationToken.None);
-        }
-
-        public virtual Task<TEntity> AddAsync([NotNull] TEntity entity, CancellationToken cancellationToken)
-        {
-            Check.NotNull(entity, "entity");
-
-            return _context.AddAsync(entity, cancellationToken);
-        }
-
-        public virtual TEntity Remove([NotNull] TEntity entity)
-        {
-            Check.NotNull(entity, "entity");
-
-            // TODO
-            return entity;
-        }
-
-        public virtual TEntity Update([NotNull] TEntity entity)
-        {
-            Check.NotNull(entity, "entity");
-
-            return _context.Update(entity);
-        }
-
-        public virtual Task<TEntity> UpdateAsync([NotNull] TEntity entity)
-        {
-            Check.NotNull(entity, "entity");
-
-            return _context.UpdateAsync(entity, CancellationToken.None);
-        }
-
-        public virtual Task<TEntity> UpdateAsync([NotNull] TEntity entity, CancellationToken cancellationToken)
-        {
-            Check.NotNull(entity, "entity");
-
-            return _context.UpdateAsync(entity, cancellationToken);
-        }
-
-        public virtual IEnumerable<TEntity> AddRange([NotNull] IEnumerable<TEntity> entities)
-        {
-            Check.NotNull(entities, "entities");
-
-            // TODO
-            return entities;
-        }
-
-        public virtual IEnumerable<TEntity> RemoveRange([NotNull] IEnumerable<TEntity> entities)
-        {
-            Check.NotNull(entities, "entities");
-
-            // TODO
-            return entities;
-        }
-
-        public virtual IEnumerable<TEntity> UpdateRange([NotNull] IEnumerable<TEntity> entities)
-        {
-            Check.NotNull(entities, "entities");
-
-            // TODO
-            return entities;
-        }
+        // TODO: Decide whether/how to implement non-generic API
+        // TODO: Consider the role of EntitySet when entity is in shadow
     }
 }

--- a/src/Microsoft.Data.Entity/EntitySetFinder.cs
+++ b/src/Microsoft.Data.Entity/EntitySetFinder.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -9,11 +11,19 @@ namespace Microsoft.Data.Entity
 {
     public class EntitySetFinder
     {
-        public virtual PropertyInfo[] FindSets([NotNull] EntityContext context)
+        private readonly ThreadSafeDictionaryCache<Type, IReadOnlyList<EntitySetProperty>> _cache
+            = new ThreadSafeDictionaryCache<Type, IReadOnlyList<EntitySetProperty>>();
+
+        public virtual IReadOnlyList<EntitySetProperty> FindSets([NotNull] EntityContext context)
         {
             Check.NotNull(context, "context");
 
-            return context.GetType().GetRuntimeProperties()
+            return _cache.GetOrAdd(context.GetType(), FindSets);
+        }
+
+        private static EntitySetProperty[] FindSets(Type contextType)
+        {
+            return contextType.GetRuntimeProperties()
                 .Where(
                     p => !p.IsStatic()
                          && !p.GetIndexParameters().Any()
@@ -21,7 +31,50 @@ namespace Microsoft.Data.Entity
                          && p.PropertyType.GetTypeInfo().IsGenericType
                          && p.PropertyType.GetGenericTypeDefinition() == typeof(EntitySet<>))
                 .OrderBy(p => p.Name)
+                .Select(p => new EntitySetProperty(
+                    p.DeclaringType, p.Name,
+                    p.PropertyType.GetTypeInfo().GenericTypeArguments.Single(), p.SetMethod != null))
                 .ToArray();
+        }
+
+        public struct EntitySetProperty
+        {
+            private readonly Type _contextType;
+            private readonly string _name;
+            private readonly Type _entityType;
+            private readonly bool _hasSetter;
+
+            public EntitySetProperty([NotNull] Type contextType, [NotNull] string name, [NotNull] Type entityType, bool hasSetter)
+            {
+                Check.NotNull(contextType, "contextType");
+                Check.NotNull(name, "name");
+                Check.NotNull(entityType, "entityType");
+
+                _contextType = contextType;
+                _name = name;
+                _entityType = entityType;
+                _hasSetter = hasSetter;
+            }
+
+            public Type ContextType
+            {
+                get { return _contextType; }
+            }
+
+            public string Name
+            {
+                get { return _name; }
+            }
+
+            public Type EntityType
+            {
+                get { return _entityType; }
+            }
+
+            public bool HasSetter
+            {
+                get { return _hasSetter; }
+            }
         }
     }
 }

--- a/src/Microsoft.Data.Entity/EntitySetInitializer.cs
+++ b/src/Microsoft.Data.Entity/EntitySetInitializer.cs
@@ -35,13 +35,11 @@ namespace Microsoft.Data.Entity
         {
             Check.NotNull(context, "context");
 
-            // TODO: Consider caching and/or compiled model support for initializing, possibly by rewriting the
-            // context EntitySet properties to include in-line initialization
-            foreach (var setProperty in _setFinder.FindSets(context).Where(s => s.SetMethod != null))
+            foreach (var setInfo in _setFinder.FindSets(context).Where(p => p.HasSetter))
             {
-                _entitySetSetters.GetAccessor(setProperty.DeclaringType, setProperty.Name)
-                    .SetClrValue(context, Activator.CreateInstance(setProperty.PropertyType, context));
-
+                _entitySetSetters
+                    .GetAccessor(setInfo.ContextType, setInfo.Name)
+                    .SetClrValue(context, context.Set(setInfo.EntityType));
             }
         }
     }

--- a/src/Microsoft.Data.Entity/EntitySetSource.cs
+++ b/src/Microsoft.Data.Entity/EntitySetSource.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity
+{
+    public class EntitySetSource
+    {
+        private static readonly MethodInfo _genericCreate
+            = typeof(EntitySetSource).GetTypeInfo().GetDeclaredMethods("CreateConstructor").Single();
+
+        private readonly ThreadSafeDictionaryCache<Type, Func<EntityContext, EntitySet>> _cache
+            = new ThreadSafeDictionaryCache<Type, Func<EntityContext, EntitySet>>();
+
+        public virtual EntitySet Create([NotNull] EntityContext context, [NotNull] Type type)
+        {
+            Check.NotNull(context, "context");
+            Check.NotNull("type", "type");
+
+            var factory = _cache.GetOrAdd(
+                type,
+                t => (Func<EntityContext, EntitySet>)_genericCreate.MakeGenericMethod(type).Invoke(null, null));
+
+            return factory(context);
+        }
+
+        private static Func<EntityContext, EntitySet> CreateConstructor<TEntity>() where TEntity : class
+        {
+            return c => new EntitySet<TEntity>(c);
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/EntitySet`.cs
+++ b/src/Microsoft.Data.Entity/EntitySet`.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity
+{
+    public class EntitySet<TEntity> : EntitySet, IQueryable<TEntity>
+        where TEntity : class
+    {
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected EntitySet()
+        {
+        }
+
+        public EntitySet([NotNull] EntityContext context)
+            : base(context)
+        {
+        }
+
+        public virtual IEnumerator<TEntity> GetEnumerator()
+        {
+            // TODO
+            throw new NotImplementedException();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        // TODO
+        public override Type ElementType
+        {
+            get { return null; }
+        }
+
+        // TODO
+        public override Expression Expression
+        {
+            get { return null; }
+        }
+
+        // TODO
+        public override IQueryProvider Provider
+        {
+            get { return null; }
+        }
+
+        public virtual TEntity Add([NotNull] TEntity entity)
+        {
+            Check.NotNull(entity, "entity");
+
+            return Context.Add(entity);
+        }
+
+        public virtual Task<TEntity> AddAsync([NotNull] TEntity entity)
+        {
+            Check.NotNull(entity, "entity");
+
+            return Context.AddAsync(entity, CancellationToken.None);
+        }
+
+        public virtual Task<TEntity> AddAsync([NotNull] TEntity entity, CancellationToken cancellationToken)
+        {
+            Check.NotNull(entity, "entity");
+
+            return Context.AddAsync(entity, cancellationToken);
+        }
+
+        public virtual TEntity Remove([NotNull] TEntity entity)
+        {
+            Check.NotNull(entity, "entity");
+
+            // TODO
+            return entity;
+        }
+
+        public virtual TEntity Update([NotNull] TEntity entity)
+        {
+            Check.NotNull(entity, "entity");
+
+            return Context.Update(entity);
+        }
+
+        public virtual Task<TEntity> UpdateAsync([NotNull] TEntity entity)
+        {
+            Check.NotNull(entity, "entity");
+
+            return Context.UpdateAsync(entity, CancellationToken.None);
+        }
+
+        public virtual Task<TEntity> UpdateAsync([NotNull] TEntity entity, CancellationToken cancellationToken)
+        {
+            Check.NotNull(entity, "entity");
+
+            return Context.UpdateAsync(entity, cancellationToken);
+        }
+
+        public virtual IEnumerable<TEntity> AddRange([NotNull] IEnumerable<TEntity> entities)
+        {
+            Check.NotNull(entities, "entities");
+
+            // TODO
+            return entities;
+        }
+
+        public virtual IEnumerable<TEntity> RemoveRange([NotNull] IEnumerable<TEntity> entities)
+        {
+            Check.NotNull(entities, "entities");
+
+            // TODO
+            return entities;
+        }
+
+        public virtual IEnumerable<TEntity> UpdateRange([NotNull] IEnumerable<TEntity> entities)
+        {
+            Check.NotNull(entities, "entities");
+
+            // TODO
+            return entities;
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/Utilities/ThreadSafeDictionaryCache.cs
+++ b/src/Microsoft.Data.Entity/Utilities/ThreadSafeDictionaryCache.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Immutable;
+using JetBrains.Annotations;
+
+namespace Microsoft.Data.Entity.Utilities
+{
+    public class ThreadSafeDictionaryCache<TKey, TValue>
+    {
+        private readonly ThreadSafeLazyRef<ImmutableDictionary<TKey, TValue>> _cache
+            = new ThreadSafeLazyRef<ImmutableDictionary<TKey, TValue>>(() => ImmutableDictionary<TKey, TValue>.Empty);
+
+        public virtual TValue GetOrAdd([NotNull] TKey key, [NotNull] Func<TKey, TValue> factory)
+        {
+            Check.NotNull(key, "key");
+            Check.NotNull("source", "factory");
+
+            TValue value;
+            if (!_cache.Value.TryGetValue(key, out value))
+            {
+                var newValue = factory(key);
+                _cache.ExchangeValue(d => d.ContainsKey(key) ? d : d.Add(key, newValue));
+                value = _cache.Value[key];
+            }
+            return value;
+        }
+    }
+}

--- a/test/Microsoft.Data.Entity.FunctionalTests/Metadata/CompiledModelTest.cs
+++ b/test/Microsoft.Data.Entity.FunctionalTests/Metadata/CompiledModelTest.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.Metadata
                     Tuple.Create(0.1, 0.3), // All keys
                     Tuple.Create(0.1, 0.3), // All properties
                     Tuple.Create(0.1, 0.3), // All entity type annotations
-                    Tuple.Create(0.2, 0.4) // All property annotations
+                    Tuple.Create(0.2, 0.42) // All property annotations
                 };
 
             for (var i = 1; i < expected.Length; i++)
@@ -264,6 +264,18 @@ namespace Microsoft.Data.Entity.FunctionalTests.Metadata
 
             var propertyAnnotations = properties.SelectMany(e => e.Annotations);
             memory.Add(Tuple.Create(propertyAnnotations.Count(), GetMemory(), "All property annotations"));
+
+            // Do something with created objects otherwise in Release build the garbage collection
+            // happens before memory numbers are collected.
+            Assert.NotNull(annotations);
+            Assert.NotNull(entities);
+            Assert.NotNull(propertiesOneEntity);
+            Assert.NotNull(fks);
+            Assert.NotNull(navigations);
+            Assert.NotNull(keys);
+            Assert.NotNull(properties);
+            Assert.NotNull(entityAnnotations);
+            Assert.NotNull(propertyAnnotations);
 
             return memory;
         }

--- a/test/Microsoft.Data.Entity.Tests/ContextEntitySetsTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ContextEntitySetsTest.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using Moq;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests
+{
+    public class ContextEntitySetsTest
+    {
+        [Fact]
+        public void Generic_method_creates_new_generic_EntitySet()
+        {
+            var context = Mock.Of<EntityContext>();
+
+            var sets = new ContextEntitySets(context, new EntitySetSource());
+
+            var set = sets.GetEntitySet<string>();
+
+            Assert.IsType<EntitySet<string>>(set);
+            Assert.Same(context, set.Context);
+        }
+
+        [Fact]
+        public void Non_generic_method_still_creates_new_generic_EntitySet()
+        {
+            var context = Mock.Of<EntityContext>();
+
+            var sets = new ContextEntitySets(context, new EntitySetSource());
+
+            var set = sets.GetEntitySet(typeof(string));
+
+            Assert.IsType<EntitySet<string>>(set);
+            Assert.Same(context, set.Context);
+        }
+
+        [Fact]
+        public void Set_created_using_generic_method_is_cached_and_returned()
+        {
+            var sets = new ContextEntitySets(Mock.Of<EntityContext>(), new EntitySetSource());
+
+            var set = sets.GetEntitySet<string>();
+
+            Assert.Same(set, sets.GetEntitySet(typeof(string)));
+        }
+
+        [Fact]
+        public void Set_created_using_non_generic_method_is_cached_and_returned()
+        {
+            var sets = new ContextEntitySets(Mock.Of<EntityContext>(), new EntitySetSource());
+
+            var set = sets.GetEntitySet(typeof(string));
+
+            Assert.Same(set, sets.GetEntitySet<string>());
+        }
+    }
+}

--- a/test/Microsoft.Data.Entity.Tests/DefaultModelSourceTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/DefaultModelSourceTest.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Linq;
-using Microsoft.Data.Entity.Utilities;
 using Moq;
 using Xunit;
 
@@ -33,10 +32,10 @@ namespace Microsoft.Data.Entity.Tests
             setFinderMock.Setup(m => m.FindSets(It.IsAny<EntityContext>())).Returns(
                 new[]
                     {
-                        typeof(JustAClass).GetAnyProperty("One"),
-                        typeof(JustAClass).GetAnyProperty("Two"),
-                        typeof(JustAClass).GetAnyProperty("Three"),
-                        typeof(JustAClass).GetAnyProperty("Four")
+                        new EntitySetFinder.EntitySetProperty(typeof(JustAClass), "One", typeof(Random), hasSetter: true),
+                        new EntitySetFinder.EntitySetProperty(typeof(JustAClass), "Two", typeof(object), hasSetter: true),
+                        new EntitySetFinder.EntitySetProperty(typeof(JustAClass), "Three", typeof(string), hasSetter: true),
+                        new EntitySetFinder.EntitySetProperty(typeof(JustAClass), "Four", typeof(string), hasSetter: true)
                     });
 
             var model = new DefaultModelSource(setFinderMock.Object).GetModel(new Mock<EntityContext>().Object);

--- a/test/Microsoft.Data.Entity.Tests/EntityConfigurationTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/EntityConfigurationTest.cs
@@ -49,10 +49,6 @@ namespace Microsoft.Data.Entity.Tests
             Assert.Equal(
                 "value",
                 Assert.Throws<ArgumentNullException>(() => configuration.EntitySetInitializer = null).ParamName);
-
-            Assert.Equal(
-                "value",
-                Assert.Throws<ArgumentNullException>(() => configuration.EntitySetFinder = null).ParamName);
         }
 
         [Fact]
@@ -316,37 +312,6 @@ namespace Microsoft.Data.Entity.Tests
             configuration.EntitySetInitializer = service;
 
             Assert.Same(service, configuration.EntitySetInitializer);
-        }
-
-        [Fact]
-        public void Throws_if_no_EntitySetFinder_registered()
-        {
-            Assert.Equal(
-                Strings.FormatMissingConfigurationItem(typeof(EntitySetFinder)),
-                Assert.Throws<InvalidOperationException>(
-                    () => new EntityConfiguration(new ServiceCollection().BuildServiceProvider()).EntitySetFinder).Message);
-        }
-
-        [Fact]
-        public void Can_provide_EntitySetFinder_from_service_provider()
-        {
-            var serviceCollection = new ServiceCollection();
-            var service = new Mock<EntitySetFinder>().Object;
-            serviceCollection.AddInstance<EntitySetFinder>(service);
-            var configuration = new EntityConfiguration(serviceCollection.BuildServiceProvider());
-            
-            Assert.Same(service, configuration.EntitySetFinder);
-        }
-
-        [Fact]
-        public void Can_set_EntitySetFinder()
-        {
-            var configuration = new EntityConfiguration();
-
-            var service = new Mock<EntitySetFinder>().Object;
-            configuration.EntitySetFinder = service;
-
-            Assert.Same(service, configuration.EntitySetFinder);
         }
     }
 }

--- a/test/Microsoft.Data.Entity.Tests/EntityContextTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/EntityContextTest.cs
@@ -233,11 +233,15 @@ namespace Microsoft.Data.Entity.Tests
         }
 
         [Fact]
-        public void Set_returns_a_new_EntitySet_for_the_given_type()
+        public void Set_and_non_generic_set_always_return_same_instance_returns_a_new_EntitySet_for_the_given_type()
         {
             using (var context = new ContextWithSets())
             {
-                Assert.NotNull(context.Set<Product>());
+                var entitySet = context.Set<Product>();
+                Assert.NotNull(entitySet);
+                Assert.Same(entitySet, context.Set<Product>());
+                Assert.Same(entitySet, context.Set(typeof(Product)));
+                Assert.Same(entitySet, context.Products);
             }
         }
 

--- a/test/Microsoft.Data.Entity.Tests/EntitySetFactorySourceTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/EntitySetFactorySourceTest.cs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests
+{
+    public class EntitySetFactorySourceTest
+    {
+        [Fact]
+        public void Can_create_new_generic_EntitySet()
+        {
+            var context = Mock.Of<EntityContext>();
+
+            var factorySource = new EntitySetSource();
+
+            var set = factorySource.Create(context, typeof(Random));
+
+            Assert.IsType<EntitySet<Random>>(set);
+            Assert.Same(context, set.Context);
+        }
+
+        [Fact]
+        public void Always_creates_a_new_EntitySet_instance()
+        {
+            var context = Mock.Of<EntityContext>();
+
+            var factorySource = new EntitySetSource();
+
+            Assert.NotSame(factorySource.Create(context, typeof(Random)), factorySource.Create(context, typeof(Random)));
+        }
+    }
+}

--- a/test/Microsoft.Data.Entity.Tests/EntitySetFinderTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/EntitySetFinderTest.cs
@@ -25,9 +25,23 @@ namespace Microsoft.Data.Entity.Tests
         {
             using (var context = new The())
             {
+                var sets = new EntitySetFinder().FindSets(context);
+
                 Assert.Equal(
                     new[] { "Betters", "Brandies", "Drinkings", "Stops", "Yous" },
-                    new EntitySetFinder().FindSets(context).Select(e => e.Name).ToArray());
+                    sets.Select(s => s.Name).ToArray());
+
+                Assert.Equal(
+                    new[] { typeof(Streets), typeof(The), typeof(The), typeof(Streets), typeof(Streets) },
+                    sets.Select(s => s.ContextType).ToArray());
+
+                Assert.Equal(
+                    new[] { typeof(Better), typeof(Brandy), typeof(Drinking), typeof(Stop), typeof(You) },
+                    sets.Select(s => s.EntityType).ToArray());
+
+                Assert.Equal(
+                    new[] { true, true, true, false, true },
+                    sets.Select(s => s.HasSetter).ToArray());
             }
         }
 
@@ -42,7 +56,7 @@ namespace Microsoft.Data.Entity.Tests
 
             public EntitySet<You> Yous { get; set; }
             protected EntitySet<Better> Betters { get; set; }
-            internal EntitySet<Stop> Stops { get; set; }
+            internal EntitySet<Stop> Stops { get { return null; } }
         }
 
         public class The : Streets

--- a/test/Microsoft.Data.Entity.Tests/Utilities/ThreadSafeDictionaryCacheTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Utilities/ThreadSafeDictionaryCacheTest.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Utilities;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.Utilities
+{
+    public class ThreadSafeDictionaryCacheTest
+    {
+        [Fact]
+        public void Creates_new_instance_or_returns_cached_instance_as_appropriate()
+        {
+            var cache = new ThreadSafeDictionaryCache<int, string>();
+
+            Assert.Equal("Cheese", cache.GetOrAdd(1, k => "Cheese"));
+            Assert.Equal("Cheese", cache.GetOrAdd(1, k => "Pickle"));
+            Assert.Equal("Pickle", cache.GetOrAdd(2, k => "Pickle"));
+        }
+    }
+}


### PR DESCRIPTION
Need for (RS)-1-phenylpropan-2-amine... (Make creation of context instances fast)

EntitySet properties on the context are automatically initialized to appropriate EntitySet instances by the EntityContext constructor. It is important that this is very fast so that the overhead of creating a context instance is small and people will feel okay about using short-lived contexts. Also, I did this work in order to have some concrete idea of the perf impact of using a new configuration per context instance. For this case it is significant--approximately 50 times faster with caching on the configuration.
