### PR TITLE
Expressive fielding...

### DIFF
--- a/src/Microsoft.Data.Entity/ChangeTracking/CompositeEntityKeyFactory.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/CompositeEntityKeyFactory.cs
@@ -25,5 +25,15 @@ namespace Microsoft.Data.Entity.ChangeTracking
             // TODO: What happens if we get a null property value?
             return new CompositeEntityKey(entityType, properties.Select(entry.GetPropertyValue).ToArray());
         }
+
+        public override EntityKey Create(IEntityType entityType, IReadOnlyList<IProperty> properties, object[] valueBuffer)
+        {
+            Check.NotNull(entityType, "entityType");
+            Check.NotNull(properties, "properties");
+            Check.NotNull(valueBuffer, "valueBuffer");
+
+            // TODO: What happens if we get a null property value?
+            return new CompositeEntityKey(entityType, properties.Select(p => valueBuffer[p.Index]).ToArray());
+        }
     }
 }

--- a/src/Microsoft.Data.Entity/ChangeTracking/EntityKeyFactory.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/EntityKeyFactory.cs
@@ -10,5 +10,8 @@ namespace Microsoft.Data.Entity.ChangeTracking
     {
         public abstract EntityKey Create(
             [NotNull] IEntityType entityType, [NotNull] IReadOnlyList<IProperty> properties, [NotNull] StateEntry entry);
+
+        public abstract EntityKey Create(
+            [NotNull] IEntityType entityType, [NotNull] IReadOnlyList<IProperty> properties, [NotNull] object[] valueBuffer);
     }
 }

--- a/src/Microsoft.Data.Entity/ChangeTracking/ShadowStateEntry.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/ShadowStateEntry.cs
@@ -35,6 +35,14 @@ namespace Microsoft.Data.Entity.ChangeTracking
             _propertyValues = new object[entityType.ShadowPropertyCount];
         }
 
+        public ShadowStateEntry([NotNull] StateManager stateManager, [NotNull] IEntityType entityType, [NotNull] object[] valueBuffer)
+            : base(stateManager, entityType)
+        {
+            Check.NotNull(valueBuffer, "valueBuffer");
+
+            _propertyValues = valueBuffer;
+        }
+
         public override object GetPropertyValue(IProperty property)
         {
             Check.NotNull(property, "property");

--- a/src/Microsoft.Data.Entity/ChangeTracking/SimpleEntityKeyFactory.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/SimpleEntityKeyFactory.cs
@@ -17,5 +17,15 @@ namespace Microsoft.Data.Entity.ChangeTracking
             // TODO: What happens if we get a null property value?
             return new SimpleEntityKey<TKey>(entityType, (TKey)entry.GetPropertyValue(properties[0]));
         }
+
+        public override EntityKey Create(IEntityType entityType, IReadOnlyList<IProperty> properties, object[] valueBuffer)
+        {
+            Check.NotNull(entityType, "entityType");
+            Check.NotNull(properties, "properties");
+            Check.NotNull(valueBuffer, "valueBuffer");
+
+            // TODO: What happens if we get a null property value?
+            return new SimpleEntityKey<TKey>(entityType, (TKey)valueBuffer[properties[0].Index]);
+        }
     }
 }

--- a/src/Microsoft.Data.Entity/ChangeTracking/StateEntry.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/StateEntry.cs
@@ -132,6 +132,13 @@ namespace Microsoft.Data.Entity.ChangeTracking
             }
         }
 
+        internal virtual void SetAttached()
+        {
+            _stateManager.StateChanging(this, EntityState.Unchanged);
+            _stateData.EntityState = EntityState.Unchanged;
+            _stateManager.StateChanged(this, EntityState.Unknown);
+        }
+
         public abstract object GetPropertyValue([NotNull] IProperty property);
 
         public abstract void SetPropertyValue([NotNull] IProperty property, [CanBeNull] object value);

--- a/src/Microsoft.Data.Entity/ChangeTracking/StateEntryFactory.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/StateEntryFactory.cs
@@ -25,5 +25,22 @@ namespace Microsoft.Data.Entity.ChangeTracking
                 ? (StateEntry)new MixedStateEntry(stateManager, entityType, entity)
                 : new ClrStateEntry(stateManager, entityType, entity);
         }
+
+        public virtual StateEntry Create(
+            [NotNull] StateManager stateManager, [NotNull] IEntityType entityType, [NotNull] object[] valueBuffer)
+        {
+            Check.NotNull(stateManager, "stateManager");
+            Check.NotNull(entityType, "entityType");
+            Check.NotNull(valueBuffer, "valueBuffer");
+
+            if (!entityType.HasClrType)
+            {
+                return new ShadowStateEntry(stateManager, entityType, valueBuffer);
+            }
+
+            return entityType.ShadowPropertyCount > 0
+                ? (StateEntry)new MixedStateEntry(stateManager, entityType, valueBuffer)
+                : new ClrStateEntry(stateManager, entityType, valueBuffer);
+        }
     }
 }

--- a/src/Microsoft.Data.Entity/ChangeTracking/StateManagerFactory.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/StateManagerFactory.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
         private readonly StateEntryFactory _stateEntryFactory;
         private readonly ClrPropertyGetterSource _getterSource;
         private readonly ClrPropertySetterSource _setterSource;
+        private readonly EntityMaterializerSource _materializerSource;
 
         /// <summary>
         ///     This constructor is intended only for use when creating test doubles that will override members
@@ -33,8 +34,8 @@ namespace Microsoft.Data.Entity.ChangeTracking
             [NotNull] EntityKeyFactorySource entityKeyFactorySource,
             [NotNull] StateEntryFactory stateEntryFactory,
             [NotNull] ClrPropertyGetterSource getterSource,
-            [NotNull] ClrPropertySetterSource setterSource)
-
+            [NotNull] ClrPropertySetterSource setterSource,
+            [NotNull] EntityMaterializerSource materializerSource)
         {
             Check.NotNull(identityGenerators, "identityGenerators");
             Check.NotNull(entityStateListeners, "entityStateListeners");
@@ -42,6 +43,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             Check.NotNull(stateEntryFactory, "stateEntryFactory");
             Check.NotNull(getterSource, "getterSource");
             Check.NotNull(setterSource, "setterSource");
+            Check.NotNull(materializerSource, "materializerSource");
 
             _identityGenerators = identityGenerators;
             _entityStateListeners = entityStateListeners;
@@ -49,13 +51,16 @@ namespace Microsoft.Data.Entity.ChangeTracking
             _stateEntryFactory = stateEntryFactory;
             _getterSource = getterSource;
             _setterSource = setterSource;
+            _materializerSource = materializerSource;
         }
 
         public virtual StateManager Create([NotNull] IModel model)
         {
             Check.NotNull(model, "model");
 
-            return new StateManager(model, _identityGenerators, _entityStateListeners, _keyFactorySource, _stateEntryFactory, _getterSource, _setterSource);
+            return new StateManager(
+                model,  _identityGenerators,  _entityStateListeners, 
+                _keyFactorySource, _stateEntryFactory, _getterSource, _setterSource, _materializerSource);
         }
     }
 }

--- a/src/Microsoft.Data.Entity/EntityServices.cs
+++ b/src/Microsoft.Data.Entity/EntityServices.cs
@@ -26,7 +26,8 @@ namespace Microsoft.Data.Entity
                 .AddSingleton<StateEntryFactory, StateEntryFactory>()
                 .AddSingleton<ClrPropertyGetterSource, ClrPropertyGetterSource>()
                 .AddSingleton<ClrPropertySetterSource, ClrPropertySetterSource>()
-                .AddSingleton<EntitySetSource, EntitySetSource>();
+                .AddSingleton<EntitySetSource, EntitySetSource>()
+                .AddSingleton<EntityMaterializerSource, EntityMaterializerSource>();
         }
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/Compiled/CompiledEntityType.cs
+++ b/src/Microsoft.Data.Entity/Metadata/Compiled/CompiledEntityType.cs
@@ -90,11 +90,6 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
             get { return true; }
         }
 
-        public object CreateInstance([NotNull] object[] values)
-        {
-            return null;
-        }
-
         public IModel Model
         {
             get { return _model; }

--- a/src/Microsoft.Data.Entity/Metadata/EntityMaterializerSource.cs
+++ b/src/Microsoft.Data.Entity/Metadata/EntityMaterializerSource.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Metadata
+{
+    public class EntityMaterializerSource
+    {
+        private readonly ThreadSafeDictionaryCache<Type, Func<object[], object>> _cache
+            = new ThreadSafeDictionaryCache<Type, Func<object[], object>>();
+
+        public virtual Func<object[], object> GetMaterializer([NotNull] IEntityType entityType)
+        {
+            Check.NotNull(entityType, "entityType");
+
+            var materializer = entityType as IEntityMaterializer;
+            if (materializer != null)
+            {
+                return materializer.CreatEntity;
+            }
+
+            return _cache.GetOrAdd(entityType.Type, k => BuildDelegate(entityType));
+        }
+
+        private static Func<object[], object> BuildDelegate(IEntityType entityType)
+        {
+            // TODO: assumes no inheritance hierarchy for entity
+
+            var fields = FindFields(entityType);
+            var clrType = entityType.Type;
+
+            var bufferParameter = Expression.Parameter(typeof(object[]), "valueBuffer");
+            var instanceVariable = Expression.Variable(clrType, "instance");
+
+            var blockExpressions = new List<Expression>();
+            blockExpressions.Add(Expression.Assign(instanceVariable, Expression.New(clrType.GetDeclaredConstructor(null))));
+
+            foreach (var field in fields)
+            {
+                blockExpressions.Add(
+                    Expression.Assign(Expression.Field(instanceVariable, field.Item2),
+                        Expression.Convert(Expression.ArrayAccess(bufferParameter, Expression.Constant(field.Item1.Index)), field.Item2.FieldType)));
+            }
+
+            blockExpressions.Add(instanceVariable);
+
+            return Expression.Lambda<Func<object[], object>>(Expression.Block(new[] { instanceVariable }, blockExpressions), bufferParameter).Compile();
+        }
+
+        private static IEnumerable<Tuple<IProperty, FieldInfo>> FindFields(IEntityType entityType)
+        {
+            // TODO: This currently assumes auto-properties with current compiler naming
+            // TODO: Need better way to find field name and/or annotation in model for field name
+            // TODO: Also assumes no inheritance hierarchy for entity
+
+            var allFields = entityType.Type.GetRuntimeFields().ToArray();
+            return entityType.Properties
+                .Where(p => p.IsClrProperty)
+                .Select(p => Tuple.Create(p, allFields.Single(f => f.Name == "<" + p.Name + ">k__BackingField")));
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/Metadata/EntityType.cs
+++ b/src/Microsoft.Data.Entity/Metadata/EntityType.cs
@@ -58,26 +58,6 @@ namespace Microsoft.Data.Entity.Metadata
             get { return _type; }
         }
 
-        public object CreateInstance(object[] values)
-        {
-            Check.NotNull(values, "values");
-
-            if (_activator == null)
-            {
-                var ctor = Type.GetDeclaredConstructor(new[] { typeof(object[]) });
-
-                if (ctor == null)
-                {
-                    // TODO: Fallback to slow path
-                    throw new InvalidOperationException();
-                }
-
-                _activator = vs => ctor.Invoke(new object[] { vs });
-            }
-
-            return _activator(values);
-        }
-
         public virtual Key GetKey()
         {
             if (_key == null)

--- a/src/Microsoft.Data.Entity/Metadata/IEntityMaterializer.cs
+++ b/src/Microsoft.Data.Entity/Metadata/IEntityMaterializer.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace Microsoft.Data.Entity.Metadata
+{
+    public interface IEntityMaterializer
+    {
+        object CreatEntity([NotNull] object[] valueBuffer);
+    }
+}

--- a/src/Microsoft.Data.Entity/Metadata/IEntityType.cs
+++ b/src/Microsoft.Data.Entity/Metadata/IEntityType.cs
@@ -24,7 +24,6 @@ namespace Microsoft.Data.Entity.Metadata
         IReadOnlyList<IProperty> Properties { get; }
         IReadOnlyList<IForeignKey> ForeignKeys { get; }
         IReadOnlyList<INavigation> Navigations { get; }
-        object CreateInstance([NotNull] object[] values);
         int ShadowPropertyCount { get; }
         bool HasClrType { get; }
     }

--- a/src/Microsoft.Data.Entity/SimpleTemporaryConvention.cs
+++ b/src/Microsoft.Data.Entity/SimpleTemporaryConvention.cs
@@ -19,7 +19,10 @@ namespace Microsoft.Data.Entity
             foreach (var entityType in model.EntityTypes)
             {
                 foreach (var propertyInfo in entityType.Type.GetRuntimeProperties()
-                    .Where(p => !p.IsStatic() && !p.GetIndexParameters().Any()))
+                    .Where(p => !p.IsStatic() 
+                        && !p.GetIndexParameters().Any() 
+                        && p.PropertyType.Namespace.StartsWith("System")
+                        && !p.PropertyType.Namespace.StartsWith("System.Collections")))
                 {
                     var property = entityType.AddProperty(propertyInfo);
 

--- a/test/Microsoft.Data.Entity.FunctionalTests/FixupTest.cs
+++ b/test/Microsoft.Data.Entity.FunctionalTests/FixupTest.cs
@@ -49,6 +49,53 @@ namespace Microsoft.Data.Entity.FunctionalTests
             }
         }
 
+        [Fact]
+        public void Navigation_fixup_happens_when_entities_are_materialized()
+        {
+            var model = BuildModel();
+            var configuration = new EntityConfiguration { Model = model };
+
+            var categoryType = model.GetEntityType(typeof(Category));
+            var productType = model.GetEntityType(typeof(Product));
+            var offerType = model.GetEntityType(typeof(SpecialOffer));
+
+            using (var context = new EntityContext(configuration))
+            {
+                var stateManager = context.ChangeTracker.StateManager;
+
+                stateManager.GetOrMaterializeEntry(categoryType, new object[] { 11 });
+                stateManager.GetOrMaterializeEntry(categoryType, new object[] { 12 });
+                stateManager.GetOrMaterializeEntry(categoryType, new object[] { 13 });
+
+
+                stateManager.GetOrMaterializeEntry(productType, new object[] { 11, 21 });
+                AssertAllFixedUp(context);
+                stateManager.GetOrMaterializeEntry(productType, new object[] { 11, 22 });
+                AssertAllFixedUp(context);
+                stateManager.GetOrMaterializeEntry(productType, new object[] { 11, 23 });
+                AssertAllFixedUp(context);
+                stateManager.GetOrMaterializeEntry(productType, new object[] { 12, 24 });
+                AssertAllFixedUp(context);
+                stateManager.GetOrMaterializeEntry(productType, new object[] { 12, 25 });
+                AssertAllFixedUp(context);
+
+                stateManager.GetOrMaterializeEntry(offerType, new object[] { 31, 22});
+                AssertAllFixedUp(context);
+                stateManager.GetOrMaterializeEntry(offerType, new object[] { 32, 22 });
+                AssertAllFixedUp(context);
+                stateManager.GetOrMaterializeEntry(offerType, new object[] { 33, 24 });
+                AssertAllFixedUp(context);
+                stateManager.GetOrMaterializeEntry(offerType, new object[] { 34, 24 });
+                AssertAllFixedUp(context);
+                stateManager.GetOrMaterializeEntry(offerType, new object[] { 35, 24 });
+                AssertAllFixedUp(context);
+
+                Assert.Equal(3, context.ChangeTracker.Entries<Category>().Count());
+                Assert.Equal(5, context.ChangeTracker.Entries<Product>().Count());
+                Assert.Equal(5, context.ChangeTracker.Entries<SpecialOffer>().Count());
+            }
+        }
+
         public void AssertAllFixedUp(EntityContext context)
         {
             foreach (var entry in context.ChangeTracker.Entries<Product>())

--- a/test/Microsoft.Data.Entity.FunctionalTests/Metadata/CompiledModelTest.cs
+++ b/test/Microsoft.Data.Entity.FunctionalTests/Metadata/CompiledModelTest.cs
@@ -88,6 +88,31 @@ namespace Microsoft.Data.Entity.FunctionalTests.Metadata
         }
 
         [Fact]
+        public void Entity_can_be_materialized_using_compiled_metadata_without_reflection()
+        {
+            var configuration = new EntityConfiguration { Model = new _OneTwoThreeContextModel() };
+
+            using (var context = new EntityContext(configuration))
+            {
+                var entityType = (_KoolEntity15EntityType)context.Model.GetEntityType(typeof(KoolEntity15));
+
+                var gu = Guid.NewGuid();
+                var stateEntry = context.ChangeTracker.StateManager.GetOrMaterializeEntry(
+                    entityType, new object[] { "Foo", gu, 77 });
+
+                Assert.False(entityType.CreateEntityWasUsed);
+
+                var entity = (KoolEntity15)stateEntry.Entity;
+
+                Assert.True(entityType.CreateEntityWasUsed);
+
+                Assert.Equal(77, entity.Id);
+                Assert.Equal("Foo", entity.Foo15);
+                Assert.Equal(gu, entity.Goo15);
+            }
+        }
+
+        [Fact]
         public void Navigation_fixup_happens_with_compiled_metadata_when_new_entities_are_tracked()
         {
             FixupTest(new _OneTwoThreeContextModel());

--- a/test/Microsoft.Data.Entity.FunctionalTests/Metadata/KoolModel.cs
+++ b/test/Microsoft.Data.Entity.FunctionalTests/Metadata/KoolModel.cs
@@ -151,9 +151,38 @@ namespace Microsoft.Data.Entity.FunctionalTests.Metadata
 
     public class KoolEntity15
     {
-        public int Id { get; set; }
-        public string Foo15 { get; set; }
-        public Guid Goo15 { get; set; }
+        private int _id;
+        private string _foo15;
+        private Guid _goo15;
+
+        public int Id
+        {
+            get { return _id; }
+            set { _id = value; }
+        }
+
+        public string Foo15
+        {
+            get { return _foo15; }
+            set { _foo15 = value; }
+        }
+
+        public Guid Goo15
+        {
+            get { return _goo15; }
+            set { _goo15 = value; }
+        }
+
+        // ReSharper disable once InconsistentNaming
+        public static KoolEntity15 _EntityFramework_Create(object[] valueBuffer)
+        {
+            return new KoolEntity15
+                {
+                    _id = (int)valueBuffer[2],
+                    _foo15 = (string)valueBuffer[0],
+                    _goo15 = (Guid)valueBuffer[1]
+                };
+        }
     }
 
     public class KoolEntity16
@@ -959,7 +988,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.Metadata
         }
     }
 
-    public class _KoolEntity15EntityType : CompiledEntityType<KoolEntity15>, IEntityType
+    public class _KoolEntity15EntityType : CompiledEntityType<KoolEntity15>, IEntityType, IEntityMaterializer
     {
         public _KoolEntity15EntityType(IModel model)
             : base(model)
@@ -991,6 +1020,14 @@ namespace Microsoft.Data.Entity.FunctionalTests.Metadata
             return ZipAnnotations(
                 new[] { "Annotation1", "Annotation2" },
                 new[] { "Value1", "Value2" }).ToArray();
+        }
+
+        public bool CreateEntityWasUsed { get; set; }
+
+        public object CreatEntity(object[] valueBuffer)
+        {
+            CreateEntityWasUsed = true;
+            return KoolEntity15._EntityFramework_Create(valueBuffer);
         }
     }
 

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/ClrStateEntryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/ClrStateEntryTest.cs
@@ -19,24 +19,22 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.Equal(
                 "stateManager",
                 // ReSharper disable once AssignNullToNotNullAttribute
-                Assert.Throws<ArgumentNullException>(() => new ClrStateEntry(null, entityTypeMock.Object, new Random())).ParamName);
+                Assert.Throws<ArgumentNullException>(() => new ClrStateEntry(null, entityTypeMock.Object, new SomeEntity())).ParamName);
             Assert.Equal(
                 "entityType",
                 // ReSharper disable once AssignNullToNotNullAttribute
-                Assert.Throws<ArgumentNullException>(
-                    () => new ClrStateEntry(stateManager, null, new Random())).ParamName);
+                Assert.Throws<ArgumentNullException>(() => new ClrStateEntry(stateManager, null, new SomeEntity())).ParamName);
             Assert.Equal(
                 "entity",
                 // ReSharper disable once AssignNullToNotNullAttribute
-                Assert.Throws<ArgumentNullException>(
-                    () => new ClrStateEntry(stateManager, entityTypeMock.Object, null)).ParamName);
+                Assert.Throws<ArgumentNullException>(() => new ClrStateEntry(stateManager, entityTypeMock.Object, (object)null)).ParamName);
         }
 
         [Fact]
         public void Can_get_entity()
         {
             var entityTypeMock = CreateEntityTypeMock();
-            var entity = new Random();
+            var entity = new SomeEntity();
             var entry = new ClrStateEntry(CreateManagerMock(entityTypeMock).Object, entityTypeMock.Object, entity);
 
             Assert.Same(entity, entry.Entity);
@@ -55,7 +53,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var setterMock = new Mock<IClrPropertySetter>();
             managerMock.Setup(m => m.GetClrPropertySetter(propertyMock.Object)).Returns(setterMock.Object);
 
-            var entity = new Random();
+            var entity = new SomeEntity();
             var entry = new ClrStateEntry(managerMock.Object, entityTypeMock.Object, entity);
 
             Assert.Equal(null, entry.GetPropertyValue(propertyMock.Object));
@@ -84,7 +82,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             managerMock.Setup(m => m.GetClrPropertyGetter(propertyMock1.Object)).Returns(getterMock1.Object);
             managerMock.Setup(m => m.GetClrPropertyGetter(propertyMock2.Object)).Returns(getterMock2.Object);
 
-            var entry = new ClrStateEntry(managerMock.Object, entityTypeMock.Object, new Random());
+            var entry = new ClrStateEntry(managerMock.Object, entityTypeMock.Object, new SomeEntity());
 
             Assert.Equal(new object[] { "Magic", "Tree House" }, entry.GetValueBuffer());
         }

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/CompositeEntityKeyFactoryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/CompositeEntityKeyFactoryTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var key = (CompositeEntityKey)new CompositeEntityKeyFactory().Create(
                 typeMock.Object, typeMock.Object.GetKey().Properties, entryMock.Object);
 
-            Assert.Equal(new Object[] { 7, "Ate", random }, key.Value);
+            Assert.Equal(new object[] { 7, "Ate", random }, key.Value);
         }
 
         [Fact]
@@ -52,6 +52,48 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var key = (CompositeEntityKey)new CompositeEntityKeyFactory().Create(
                 typeMock.Object, new[] { nonKeyPart2, nonKeyPart1 }, entryMock.Object);
+
+            Assert.Equal(new object[] { random, "Ate" }, key.Value);
+        }
+
+        [Fact]
+        public void Creates_a_new_primary_key_for_key_values_in_the_given_value_buffer()
+        {
+            var keyPart1Mock = new Mock<IProperty>();
+            keyPart1Mock.Setup(m => m.Index).Returns(0);
+            var keyPart2Mock = new Mock<IProperty>();
+            keyPart2Mock.Setup(m => m.Index).Returns(1);
+            var keyPart3Mock = new Mock<IProperty>();
+            keyPart3Mock.Setup(m => m.Index).Returns(2);
+
+            var typeMock = new Mock<IEntityType>();
+            typeMock.Setup(m => m.GetKey().Properties).Returns(new[] { keyPart1Mock.Object, keyPart2Mock.Object, keyPart3Mock.Object });
+
+            var random = new Random();
+
+            var key = (CompositeEntityKey)new CompositeEntityKeyFactory().Create(
+                typeMock.Object, typeMock.Object.GetKey().Properties, new object[] { 7, "Ate", random });
+
+            Assert.Equal(new Object[] { 7, "Ate", random }, key.Value);
+        }
+
+        [Fact]
+        public void Creates_a_new_key_for_non_primary_key_values_in_the_given_value_buffer()
+        {
+            var keyPropMock = new Mock<IProperty>();
+            keyPropMock.Setup(m => m.Index).Returns(0);
+            var nonKeyPart1Mock = new Mock<IProperty>();
+            nonKeyPart1Mock.Setup(m => m.Index).Returns(1);
+            var nonKeyPart2Mock = new Mock<IProperty>();
+            nonKeyPart2Mock.Setup(m => m.Index).Returns(2);
+
+            var typeMock = new Mock<IEntityType>();
+            typeMock.Setup(m => m.GetKey().Properties).Returns(new[] { keyPropMock.Object });
+
+            var random = new Random();
+
+            var key = (CompositeEntityKey)new CompositeEntityKeyFactory().Create(
+                typeMock.Object, new[] { nonKeyPart2Mock.Object, nonKeyPart1Mock.Object }, new object[] { 7, "Ate", random });
 
             Assert.Equal(new Object[] { random, "Ate" }, key.Value);
         }

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/NavigationFixerTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/NavigationFixerTest.cs
@@ -88,8 +88,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
                 Enumerable.Empty<IEntityStateListener>(),
                 new EntityKeyFactorySource(),
                 new StateEntryFactory(),
-                new ClrPropertyGetterSource(),
-                new ClrPropertySetterSource());
+                new ClrPropertyGetterSource(), 
+                new ClrPropertySetterSource(),
+                new EntityMaterializerSource());
         }
 
         #region Fixture

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/ShadowStateEntryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/ShadowStateEntryTest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var propertyMock = new Mock<IProperty>();
             var entityTypeMock = CreateEntityTypeMock(propertyMock);
-            var entry = new MixedStateEntry(CreateManagerMock(entityTypeMock).Object, entityTypeMock.Object, new Random());
+            var entry = new MixedStateEntry(CreateManagerMock(entityTypeMock).Object, entityTypeMock.Object, new SomeEntity());
 
             Assert.Equal(null, entry.GetPropertyValue(propertyMock.Object));
 
@@ -56,7 +56,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var propertyMock1 = new Mock<IProperty>();
             var propertyMock2 = new Mock<IProperty>();
             var entityTypeMock = CreateEntityTypeMock(propertyMock1, propertyMock2);
-            var entry = new MixedStateEntry(CreateManagerMock(entityTypeMock).Object, entityTypeMock.Object, new Random());
+            var entry = new MixedStateEntry(CreateManagerMock(entityTypeMock).Object, entityTypeMock.Object, new SomeEntity());
 
             entry.SetPropertyValue(propertyMock1.Object, "Magic");
             entry.SetPropertyValue(propertyMock2.Object, "Tree House");

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/SimpleEntityKeyFactoryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/SimpleEntityKeyFactoryTest.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Metadata;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.ChangeTracking
+{
+    public class SimpleEntityKeyFactoryTest
+    {
+        [Fact]
+        public void Creates_a_new_primary_key_for_key_values_in_the_given_entry()
+        {
+            var keyProp = new Mock<IProperty>().Object;
+
+            var typeMock = new Mock<IEntityType>();
+            typeMock.Setup(m => m.GetKey().Properties).Returns(new[] { keyProp });
+
+            var entryMock = new Mock<StateEntry>();
+            entryMock.Setup(m => m.GetPropertyValue(keyProp)).Returns(7);
+            entryMock.Setup(m => m.EntityType).Returns(typeMock.Object);
+
+            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>().Create(
+                typeMock.Object, typeMock.Object.GetKey().Properties, entryMock.Object);
+
+            Assert.Equal(7, key.Value);
+        }
+
+        [Fact]
+        public void Creates_a_new_key_for_non_primary_key_values_in_the_given_entry()
+        {
+            var keyProp = new Mock<IProperty>().Object;
+            var nonKeyProp = new Mock<IProperty>().Object;
+
+            var typeMock = new Mock<IEntityType>();
+            typeMock.Setup(m => m.GetKey().Properties).Returns(new[] { keyProp });
+
+            var random = new Random();
+            var entryMock = new Mock<StateEntry>();
+            entryMock.Setup(m => m.GetPropertyValue(keyProp)).Returns(7);
+            entryMock.Setup(m => m.GetPropertyValue(nonKeyProp)).Returns("Ate");
+            entryMock.Setup(m => m.EntityType).Returns(typeMock.Object);
+
+            var key = (SimpleEntityKey<string>)new SimpleEntityKeyFactory<string>().Create(
+                typeMock.Object, new[] { nonKeyProp }, entryMock.Object);
+
+            Assert.Equal("Ate", key.Value);
+        }
+
+        [Fact]
+        public void Creates_a_new_primary_key_for_key_values_in_the_given_value_buffer()
+        {
+            var keyPropMock = new Mock<IProperty>();
+            keyPropMock.Setup(m => m.Index).Returns(0);
+
+            var typeMock = new Mock<IEntityType>();
+            typeMock.Setup(m => m.GetKey().Properties).Returns(new[] { keyPropMock.Object });
+
+            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>().Create(
+                typeMock.Object, typeMock.Object.GetKey().Properties, new object[] { 7 });
+
+            Assert.Equal(7, key.Value);
+        }
+
+        [Fact]
+        public void Creates_a_new_key_for_non_primary_key_values_in_the_given_value_buffer()
+        {
+            var keyPropMock = new Mock<IProperty>();
+            keyPropMock.Setup(m => m.Index).Returns(0);
+            var nonKeyPropMock = new Mock<IProperty>();
+            nonKeyPropMock.Setup(m => m.Index).Returns(1);
+
+            var typeMock = new Mock<IEntityType>();
+            typeMock.Setup(m => m.GetKey().Properties).Returns(new[] { keyPropMock.Object });
+
+            var key = (SimpleEntityKey<string>)new SimpleEntityKeyFactory<string>().Create(
+                typeMock.Object, new[] { nonKeyPropMock.Object }, new object[] { 7, "Ate" });
+
+            Assert.Equal("Ate", key.Value);
+        }
+    }
+}

--- a/test/Microsoft.Data.Entity.Tests/Metadata/EntityMaterializerSourceTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Metadata/EntityMaterializerSourceTest.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.Metadata;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.Metadata
+{
+    public class EntityMaterializerSourceTest
+    {
+        [Fact]
+        public void Delegate_from_entity_type_is_returned_if_it_implements_IEntityMaterializer()
+        {
+            var materializerMock = new Mock<IEntityMaterializer>();
+            var typeMock = materializerMock.As<IEntityType>();
+
+            var valueBuffer = new object[0];
+            new EntityMaterializerSource().GetMaterializer(typeMock.Object)(valueBuffer);
+
+            materializerMock.Verify(m => m.CreatEntity(valueBuffer));
+        }
+
+        [Fact]
+        public void Can_create_materializer_for_entity()
+        {
+            var entityType = new EntityType(typeof(SomeEntity));
+            entityType.AddProperty("Id", typeof(int), shadowProperty: false);
+            entityType.AddProperty("Foo", typeof(string), shadowProperty: false);
+            entityType.AddProperty("Goo", typeof(Guid), shadowProperty: false);
+
+            var factory = new EntityMaterializerSource().GetMaterializer(entityType);
+
+            var gu = Guid.NewGuid();
+            var entity = (SomeEntity)factory(new object[] { "Fu", gu, 77 });
+
+            Assert.Equal(77, entity.Id);
+            Assert.Equal("Fu", entity.Foo);
+            Assert.Equal(gu, entity.Goo);
+        }
+
+        [Fact]
+        public void Can_create_materializer_for_entity_ignoring_shadow_fields()
+        {
+            var entityType = new EntityType(typeof(SomeEntity));
+            entityType.AddProperty("Id", typeof(int), shadowProperty: false);
+            entityType.AddProperty("IdShadow", typeof(int), shadowProperty: true);
+            entityType.AddProperty("Foo", typeof(string), shadowProperty: false);
+            entityType.AddProperty("FooShadow", typeof(string), shadowProperty: true);
+            entityType.AddProperty("Goo", typeof(Guid), shadowProperty: false);
+            entityType.AddProperty("GooShadow", typeof(Guid), shadowProperty: true);
+
+            var factory = new EntityMaterializerSource().GetMaterializer(entityType);
+
+            var gu = Guid.NewGuid();
+            var entity = (SomeEntity)factory(new object[] { "Fu", "FuS", gu, Guid.NewGuid(), 77, 777 });
+
+            Assert.Equal(77, entity.Id);
+            Assert.Equal("Fu", entity.Foo);
+            Assert.Equal(gu, entity.Goo);
+        }
+
+        private class SomeEntity
+        {
+            public int Id { get; set; }
+            public string Foo { get; set; }
+            public Guid Goo { get; set; }
+        }
+    }
+}

--- a/test/Microsoft.Data.Entity.Tests/Metadata/EntityTypeTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Metadata/EntityTypeTest.cs
@@ -21,11 +21,6 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             public static PropertyInfo ManeProperty = typeof(Customer).GetProperty("Mane");
             public static PropertyInfo UniqueProperty = typeof(Customer).GetProperty("Unique");
 
-            public Customer(object[] values)
-            {
-                Id = (int)values[0];
-            }
-
             public int Id { get; set; }
             public Guid Unique { get; set; }
             public string Name { get; set; }
@@ -44,16 +39,6 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         }
 
         #endregion
-
-        [Fact]
-        public void CreateInstance_should_use_values_ctor()
-        {
-            var entityType = new EntityType(typeof(Customer));
-
-            var instance = (Customer)entityType.CreateInstance(new object[] { 42 });
-
-            Assert.Equal(42, instance.Id);
-        }
 
         [Fact]
         public void Members_check_arguments()

--- a/test/Microsoft.Data.InMemory.Tests/InMemoryDataStoreTest.cs
+++ b/test/Microsoft.Data.InMemory.Tests/InMemoryDataStoreTest.cs
@@ -131,7 +131,8 @@ namespace Microsoft.Data.InMemory.Tests
                 new EntityKeyFactorySource(),
                 new StateEntryFactory(),
                 new ClrPropertyGetterSource(),
-                new ClrPropertySetterSource());
+                new ClrPropertySetterSource(),
+                new EntityMaterializerSource());
         }
     }
 }

--- a/test/Microsoft.Data.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/Microsoft.Data.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Data.Relational.Update
                 new StateManager(
                     model, Mock.Of<ActiveIdentityGenerators>(),
                     new IEntityStateListener[0], new EntityKeyFactorySource(),
-                    new StateEntryFactory(), new ClrPropertyGetterSource(), new ClrPropertySetterSource());
+                    new StateEntryFactory(), new ClrPropertyGetterSource(), new ClrPropertySetterSource(), new EntityMaterializerSource());
 
             var stateEntry = new MixedStateEntry(stateManager, model.GetEntityType(typeof(FakeEntity)), new FakeEntity { Id = 42, Value = "Test" });
             await stateEntry.SetEntityStateAsync(EntityState.Added, new CancellationToken());
@@ -51,7 +51,7 @@ namespace Microsoft.Data.Relational.Update
                 new StateManager(
                     model, Mock.Of<ActiveIdentityGenerators>(),
                     new IEntityStateListener[0], new EntityKeyFactorySource(),
-                    new StateEntryFactory(), new ClrPropertyGetterSource(), new ClrPropertySetterSource());
+                    new StateEntryFactory(), new ClrPropertyGetterSource(), new ClrPropertySetterSource(), new EntityMaterializerSource());
 
             var stateEntry = new MixedStateEntry(stateManager, model.GetEntityType(typeof(FakeEntity)), new FakeEntity { Id = 42, Value = "Test" });
             await stateEntry.SetEntityStateAsync(EntityState.Modified, new CancellationToken());
@@ -86,7 +86,7 @@ namespace Microsoft.Data.Relational.Update
                 new StateManager(
                     model, Mock.Of<ActiveIdentityGenerators>(),
                     new IEntityStateListener[0], new EntityKeyFactorySource(),
-                    new StateEntryFactory(), new ClrPropertyGetterSource(), new ClrPropertySetterSource());
+                    new StateEntryFactory(), new ClrPropertyGetterSource(), new ClrPropertySetterSource(), new EntityMaterializerSource());
 
             var stateEntry = new MixedStateEntry(stateManager, model.GetEntityType(typeof(FakeEntity)), new FakeEntity { Id = 42, Value = "Test" });
             await stateEntry.SetEntityStateAsync(EntityState.Deleted, new CancellationToken());


### PR DESCRIPTION
Expressive fielding... (Add materialization of state entries and entities)

This change allows the StateManager to create a new entry from a value buffer which may contain some shadow properties. The state entry can then materialize an entity from the CLR values in the buffer leaving only shadow values in a new smaller buffer. Creation of the entity instance can come from the compiled model or from a delegate compiled from an expression tree and cached.
