### PR TITLE
Token cancellation tokens...

### DIFF
--- a/src/Microsoft.Data.Entity/ChangeTracking/StateEntry.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/StateEntry.cs
@@ -48,7 +48,8 @@ namespace Microsoft.Data.Entity.ChangeTracking
             get { return _stateManager; }
         }
 
-        public virtual async Task SetEntityStateAsync(EntityState value, CancellationToken cancellationToken)
+        public virtual async Task SetEntityStateAsync(
+            EntityState value, CancellationToken cancellationToken = default(CancellationToken))
         {
             // The entity state can be Modified even if some properties are not modified so always
             // set all properties to modified if the entity state is explicitly set to Modified.

--- a/src/Microsoft.Data.Entity/Database.cs
+++ b/src/Microsoft.Data.Entity/Database.cs
@@ -18,25 +18,13 @@ namespace Microsoft.Data.Entity
             return false;
         }
 
-        public virtual Task CreateAsync()
+        public virtual Task CreateAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             // TODO
             return Task.FromResult(false);
         }
 
-        public virtual Task CreateAsync(CancellationToken cancellationToken)
-        {
-            // TODO
-            return Task.FromResult(false);
-        }
-
-        public virtual Task<bool> DeleteAsync()
-        {
-            // TODO
-            return Task.FromResult(false);
-        }
-
-        public virtual Task<bool> DeleteAsync(CancellationToken cancellationToken)
+        public virtual Task<bool> DeleteAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             // TODO
             return Task.FromResult(false);

--- a/src/Microsoft.Data.Entity/EntityContext.cs
+++ b/src/Microsoft.Data.Entity/EntityContext.cs
@@ -67,12 +67,7 @@ namespace Microsoft.Data.Entity
             return SaveChangesAsync().Result;
         }
 
-        public virtual Task<int> SaveChangesAsync()
-        {
-            return SaveChangesAsync(CancellationToken.None);
-        }
-
-        public virtual Task<int> SaveChangesAsync(CancellationToken cancellationToken)
+        public virtual Task<int> SaveChangesAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return _configuration.DataStore.SaveChangesAsync(_stateManager.Value.StateEntries, Model, cancellationToken);
         }
@@ -89,14 +84,8 @@ namespace Microsoft.Data.Entity
             return AddAsync(entity, CancellationToken.None).Result;
         }
 
-        public virtual Task<TEntity> AddAsync<TEntity>([NotNull] TEntity entity)
-        {
-            Check.NotNull(entity, "entity");
-
-            return AddAsync(entity, CancellationToken.None);
-        }
-
-        public virtual async Task<TEntity> AddAsync<TEntity>([NotNull] TEntity entity, CancellationToken cancellationToken)
+        public virtual async Task<TEntity> AddAsync<TEntity>(
+            [NotNull] TEntity entity, CancellationToken cancellationToken = default(CancellationToken))
         {
             Check.NotNull(entity, "entity");
 
@@ -114,14 +103,7 @@ namespace Microsoft.Data.Entity
             return entity;
         }
 
-        public virtual Task<TEntity> UpdateAsync<TEntity>([NotNull] TEntity entity)
-        {
-            Check.NotNull(entity, "entity");
-
-            return UpdateAsync(entity, CancellationToken.None);
-        }
-
-        public virtual Task<TEntity> UpdateAsync<TEntity>([NotNull] TEntity entity, CancellationToken cancellationToken)
+        public virtual Task<TEntity> UpdateAsync<TEntity>([NotNull] TEntity entity, CancellationToken cancellationToken = default(CancellationToken))
         {
             Check.NotNull(entity, "entity");
 

--- a/src/Microsoft.Data.Entity/EntitySet`.cs
+++ b/src/Microsoft.Data.Entity/EntitySet`.cs
@@ -70,14 +70,8 @@ namespace Microsoft.Data.Entity
             return Context.Add(entity);
         }
 
-        public virtual Task<TEntity> AddAsync([NotNull] TEntity entity)
-        {
-            Check.NotNull(entity, "entity");
-
-            return Context.AddAsync(entity, CancellationToken.None);
-        }
-
-        public virtual Task<TEntity> AddAsync([NotNull] TEntity entity, CancellationToken cancellationToken)
+        public virtual Task<TEntity> AddAsync(
+            [NotNull] TEntity entity, CancellationToken cancellationToken = default(CancellationToken))
         {
             Check.NotNull(entity, "entity");
 
@@ -99,14 +93,8 @@ namespace Microsoft.Data.Entity
             return Context.Update(entity);
         }
 
-        public virtual Task<TEntity> UpdateAsync([NotNull] TEntity entity)
-        {
-            Check.NotNull(entity, "entity");
-
-            return Context.UpdateAsync(entity, CancellationToken.None);
-        }
-
-        public virtual Task<TEntity> UpdateAsync([NotNull] TEntity entity, CancellationToken cancellationToken)
+        public virtual Task<TEntity> UpdateAsync(
+            [NotNull] TEntity entity, CancellationToken cancellationToken = default(CancellationToken))
         {
             Check.NotNull(entity, "entity");
 

--- a/src/Microsoft.Data.Entity/Identity/GuidIdentityGenerator.cs
+++ b/src/Microsoft.Data.Entity/Identity/GuidIdentityGenerator.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Data.Entity.Identity
 {
     public class GuidIdentityGenerator : IIdentityGenerator<Guid>
     {
-        public virtual Task<Guid> NextAsync(CancellationToken cancellationToken)
+        public virtual Task<Guid> NextAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return Task.FromResult(Guid.NewGuid());
         }

--- a/src/Microsoft.Data.Entity/Identity/IIdentityGenerator.cs
+++ b/src/Microsoft.Data.Entity/Identity/IIdentityGenerator.cs
@@ -7,6 +7,6 @@ namespace Microsoft.Data.Entity.Identity
 {
     public interface IIdentityGenerator
     {
-        Task<object> NextAsync(CancellationToken cancellationToken);
+        Task<object> NextAsync(CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Microsoft.Data.Entity/Identity/IIdentityGenerator`.cs
+++ b/src/Microsoft.Data.Entity/Identity/IIdentityGenerator`.cs
@@ -7,6 +7,6 @@ namespace Microsoft.Data.Entity.Identity
 {
     public interface IIdentityGenerator<T> : IIdentityGenerator
     {
-        new Task<T> NextAsync(CancellationToken cancellationToken);
+        new Task<T> NextAsync(CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/Microsoft.Data.Entity/Query/IAsyncEnumerableExtensions.cs
+++ b/src/Microsoft.Data.Entity/Query/IAsyncEnumerableExtensions.cs
@@ -10,15 +10,8 @@ namespace Microsoft.Data.Entity.Query
 {
     public static class IAsyncEnumerableExtensions
     {
-        public static Task<TSource> SingleAsync<TSource>([NotNull] this IAsyncEnumerable<TSource> source)
-        {
-            Check.NotNull(source, "source");
-
-            return source.SingleAsync(CancellationToken.None);
-        }
-
         public static async Task<TSource> SingleAsync<TSource>(
-            [NotNull] this IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
+            [NotNull] this IAsyncEnumerable<TSource> source, CancellationToken cancellationToken = default(CancellationToken))
         {
             Check.NotNull(source, "source");
 
@@ -44,20 +37,10 @@ namespace Microsoft.Data.Entity.Query
             throw new InvalidOperationException(Strings.MoreThanOneElement);
         }
 
-        public static Task<TSource> SingleAsync<TSource>(
-            [NotNull] this IAsyncEnumerable<TSource> source,
-            [NotNull] Func<TSource, bool> predicate)
-        {
-            Check.NotNull(source, "source");
-            Check.NotNull(predicate, "predicate");
-
-            return source.SingleAsync(predicate, CancellationToken.None);
-        }
-
         public static async Task<TSource> SingleAsync<TSource>(
             [NotNull] this IAsyncEnumerable<TSource> source,
             [NotNull] Func<TSource, bool> predicate,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             Check.NotNull(source, "source");
             Check.NotNull(predicate, "predicate");
@@ -94,15 +77,8 @@ namespace Microsoft.Data.Entity.Query
             throw new InvalidOperationException(Strings.MoreThanOneMatch);
         }
 
-        public static Task<int> CountAsync<TSource>([NotNull] this IAsyncEnumerable<TSource> source)
-        {
-            Check.NotNull(source, "source");
-
-            return source.CountAsync(CancellationToken.None);
-        }
-
         public static async Task<int> CountAsync<TSource>(
-            [NotNull] this IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
+            [NotNull] this IAsyncEnumerable<TSource> source, CancellationToken cancellationToken = default(CancellationToken))
         {
             Check.NotNull(source, "source");
 

--- a/src/Microsoft.Data.Entity/Query/IAsyncEnumerator.cs
+++ b/src/Microsoft.Data.Entity/Query/IAsyncEnumerator.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Data.Entity.Query
 {
     public interface IAsyncEnumerator : IDisposable
     {
-        Task<bool> MoveNextAsync(CancellationToken cancellationToken);
+        Task<bool> MoveNextAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         object Current { get; }
     }

--- a/src/Microsoft.Data.Entity/QueryableExtensions.cs
+++ b/src/Microsoft.Data.Entity/QueryableExtensions.cs
@@ -19,125 +19,71 @@ namespace Microsoft.Data.Entity
             return source;
         }
 
-        public static Task<bool> AnyAsync<TSource>([NotNull] this IQueryable<TSource> source)
-        {
-            // TODO
-            return source.AnyAsync(CancellationToken.None);
-        }
-
-        public static Task<bool> AnyAsync<TSource>([NotNull] this IQueryable<TSource> source, CancellationToken cancellationToken)
+        public static Task<bool> AnyAsync<TSource>(
+            [NotNull] this IQueryable<TSource> source, CancellationToken cancellationToken = default(CancellationToken))
         {
             // TODO
             return Task.FromResult(false);
-        }
-
-        public static Task<bool> AnyAsync<TSource>(
-            [NotNull] this IQueryable<TSource> source, [NotNull] Expression<Func<TSource, bool>> predicate)
-        {
-            // TODO
-            return source.AnyAsync(predicate, CancellationToken.None);
         }
 
         public static Task<bool> AnyAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
             [NotNull] Expression<Func<TSource, bool>> predicate,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             // TODO
             return Task.FromResult(false);
         }
 
-        public static Task<List<TSource>> ToListAsync<TSource>([NotNull] this IQueryable<TSource> source)
-        {
-            // TODO
-            return ToListAsync(source, CancellationToken.None);
-        }
-
         public static Task<List<TSource>> ToListAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             // TODO
             return Task.FromResult<List<TSource>>(null);
         }
 
-        public static Task<TSource> SingleAsync<TSource>([NotNull] this IQueryable<TSource> source)
-        {
-            // TODO
-            return source.SingleAsync(CancellationToken.None);
-        }
-
         public static Task<TSource> SingleAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             // TODO
             return Task.FromResult(default(TSource));
-        }
-
-        public static Task<TSource> SingleAsync<TSource>(
-            [NotNull] this IQueryable<TSource> source, [NotNull] Expression<Func<TSource, bool>> predicate)
-        {
-            // TODO
-            return source.SingleAsync(predicate, CancellationToken.None);
         }
 
         public static Task<TSource> SingleAsync<TSource>(
             [NotNull] this IQueryable<TSource> source, [NotNull] Expression<Func<TSource, bool>> predicate,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             // TODO
             return Task.FromResult(default(TSource));
-        }
-
-        public static Task<TSource> SingleOrDefaultAsync<TSource>([NotNull] this IQueryable<TSource> source)
-        {
-            // TODO
-            return source.SingleOrDefaultAsync(CancellationToken.None);
         }
 
         public static Task<TSource> SingleOrDefaultAsync<TSource>(
             [NotNull] this IQueryable<TSource> source,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             // TODO
             return Task.FromResult(default(TSource));
-        }
-
-        public static Task<TSource> SingleOrDefaultAsync<TSource>(
-            [NotNull] this IQueryable<TSource> source, [NotNull] Expression<Func<TSource, bool>> predicate)
-        {
-            // TODO
-            return source.SingleOrDefaultAsync(predicate, CancellationToken.None);
         }
 
         public static Task<TSource> SingleOrDefaultAsync<TSource>(
             [NotNull] this IQueryable<TSource> source, [NotNull] Expression<Func<TSource, bool>> predicate,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             // TODO
             return Task.FromResult(default(TSource));
         }
 
-        public static Task<decimal> SumAsync([NotNull] this IQueryable<decimal> source)
-        {
-            // TODO
-            return source.SumAsync(CancellationToken.None);
-        }
-
-        public static Task<decimal> SumAsync([NotNull] this IQueryable<decimal> source, CancellationToken cancellationToken)
+        public static Task<decimal> SumAsync(
+            [NotNull] this IQueryable<decimal> source, CancellationToken cancellationToken = default(CancellationToken))
         {
             // TODO
             return Task.FromResult(default(decimal));
         }
 
-        public static Task<int> SumAsync([NotNull] this IQueryable<int> source)
-        {
-            // TODO
-            return source.SumAsync(CancellationToken.None);
-        }
-
-        public static Task<int> SumAsync([NotNull] this IQueryable<int> source, CancellationToken cancellationToken)
+        public static Task<int> SumAsync(
+            [NotNull] this IQueryable<int> source, CancellationToken cancellationToken = default(CancellationToken))
         {
             // TODO
             return Task.FromResult(0);

--- a/src/Microsoft.Data.Entity/Storage/DataStore.cs
+++ b/src/Microsoft.Data.Entity/Storage/DataStore.cs
@@ -13,14 +13,9 @@ namespace Microsoft.Data.Entity.Storage
 {
     public abstract class DataStore
     {
-        public Task<int> SaveChangesAsync(
-            [NotNull] IEnumerable<StateEntry> stateEntries, [NotNull] IModel model)
-        {
-            return SaveChangesAsync(stateEntries, model, CancellationToken.None);
-        }
-
         public virtual Task<int> SaveChangesAsync(
-            [NotNull] IEnumerable<StateEntry> stateEntries, [NotNull] IModel model, CancellationToken cancellationToken)
+            [NotNull] IEnumerable<StateEntry> stateEntries, [NotNull] IModel model,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             throw new NotImplementedException();
         }

--- a/src/Microsoft.Data.Entity/Utilities/EnumerableExtensions.cs
+++ b/src/Microsoft.Data.Entity/Utilities/EnumerableExtensions.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.Data.Entity.Utilities
@@ -51,7 +52,8 @@ namespace Microsoft.Data.Entity.Utilities
         }
 
         public static async Task<IEnumerable<T>> SelectAsync<T>(
-            this IEnumerable<T> source, Func<T, Task<T>> selector)
+            this IEnumerable<T> source, Func<T, Task<T>> selector,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             var results = Enumerable.Empty<T>();
 
@@ -64,7 +66,8 @@ namespace Microsoft.Data.Entity.Utilities
         }
 
         public static async Task<IEnumerable<T>> SelectManyAsync<T>(
-            this IEnumerable<T> source, Func<T, Task<IEnumerable<T>>> selector)
+            this IEnumerable<T> source, Func<T, Task<IEnumerable<T>>> selector,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             var results = Enumerable.Empty<T>();
 
@@ -77,7 +80,8 @@ namespace Microsoft.Data.Entity.Utilities
         }
 
         public static async Task<IEnumerable<T>> WhereAsync<T>(
-            this IEnumerable<T> source, Func<T, Task<bool>> predicate)
+            this IEnumerable<T> source, Func<T, Task<bool>> predicate,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             var results = Enumerable.Empty<T>();
 

--- a/src/Microsoft.Data.InMemory/InMemoryDataStore.cs
+++ b/src/Microsoft.Data.InMemory/InMemoryDataStore.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Data.InMemory
         }
 
         public override Task<int> SaveChangesAsync(
-            IEnumerable<StateEntry> stateEntries, IModel model, CancellationToken cancellationToken)
+            IEnumerable<StateEntry> stateEntries, IModel model, CancellationToken cancellationToken = default(CancellationToken))
         {
             Check.NotNull(stateEntries, "stateEntries");
             Check.NotNull(model, "model");
@@ -134,7 +134,7 @@ namespace Microsoft.Data.InMemory
                 _enumerator = enumerator;
             }
 
-            public Task<bool> MoveNextAsync(CancellationToken cancellationToken)
+            public Task<bool> MoveNextAsync(CancellationToken cancellationToken = default(CancellationToken))
             {
                 return Task.FromResult(_enumerator.MoveNext());
             }

--- a/src/Microsoft.Data.InMemory/InMemoryIdentityGenerator.cs
+++ b/src/Microsoft.Data.InMemory/InMemoryIdentityGenerator.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Data.InMemory
     {
         private static long _current;
 
-        public Task<long> NextAsync(CancellationToken cancellationToken)
+        public Task<long> NextAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return Task.FromResult(Interlocked.Increment(ref _current));
         }

--- a/src/Microsoft.Data.Relational/RelationalDataStore.cs
+++ b/src/Microsoft.Data.Relational/RelationalDataStore.cs
@@ -39,7 +39,8 @@ namespace Microsoft.Data.Relational
             get { return _connectionString; }
         }
 
-        public override async Task<int> SaveChangesAsync(IEnumerable<Entity.ChangeTracking.StateEntry> stateEntries, IModel model, CancellationToken cancellationToken)
+        public override async Task<int> SaveChangesAsync(
+            IEnumerable<Entity.ChangeTracking.StateEntry> stateEntries, IModel model, CancellationToken cancellationToken = default(CancellationToken))
         {
             var commands = new CommandBatchPreparer().BatchCommands(stateEntries);
 
@@ -111,14 +112,14 @@ namespace Microsoft.Data.Relational
                 _logger = logger;
             }
 
-            public Task<bool> MoveNextAsync(CancellationToken cancellationToken)
+            public Task<bool> MoveNextAsync(CancellationToken cancellationToken = default(CancellationToken))
             {
                 return _reader == null
                     ? InitializeAndReadAsync(cancellationToken)
                     : _reader.ReadAsync(cancellationToken);
             }
 
-            private async Task<bool> InitializeAndReadAsync(CancellationToken cancellationToken)
+            private async Task<bool> InitializeAndReadAsync(CancellationToken cancellationToken = default(CancellationToken))
             {
                 _connection = _connectionFactory();
 

--- a/src/Microsoft.Data.Relational/Update/BatchExecutor.cs
+++ b/src/Microsoft.Data.Relational/Update/BatchExecutor.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Data.Relational.Update
             _sqlGenerator = sqlGenerator;
         }
 
-        public async Task ExecuteAsync(DbConnection connection, CancellationToken cancellationToken)
+        public async Task ExecuteAsync(
+            DbConnection connection, CancellationToken cancellationToken = default(CancellationToken))
         {
             foreach (var commandbatch in _commandBatches)
             {
@@ -29,7 +30,9 @@ namespace Microsoft.Data.Relational.Update
             }
         }
 
-        private async Task ExecuteBatchAsync([NotNull] DbConnection connection, [NotNull] ModificationCommandBatch commandBatch, CancellationToken cancellationToken)
+        private async Task ExecuteBatchAsync(
+            [NotNull] DbConnection connection, [NotNull] ModificationCommandBatch commandBatch,
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             using (var cmd = CreateCommand(connection, commandBatch))
             {

--- a/src/Microsoft.Data.SqlServer/SequenceIdentityGenerator.cs
+++ b/src/Microsoft.Data.SqlServer/SequenceIdentityGenerator.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Data.SqlServer
                     new SqlServerMigrationOperationSqlGenerator().DelimitIdentifier(_sequenceName));
         }
 
-        public virtual async Task<long> NextAsync(CancellationToken cancellationToken)
+        public virtual async Task<long> NextAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             if (_current == _max)
             {

--- a/src/Microsoft.Data.SqlServer/SequentialGuidIdentityGenerator.cs
+++ b/src/Microsoft.Data.SqlServer/SequentialGuidIdentityGenerator.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.SqlServer
             _counter = DateTime.UtcNow.Ticks;
         }
 
-        public Task<Guid> NextAsync(CancellationToken cancellationToken)
+        public Task<Guid> NextAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             var guidBytes = Guid.NewGuid().ToByteArray();
             var counterBytes = BitConverter.GetBytes(Interlocked.Increment(ref _counter));


### PR DESCRIPTION
Token cancellation tokens... (Update cancellation token pattern)

Use optional parameter for cancellation token as discussed. The compiler doesn't allow CancellationToken.None because this is not a compile-time constant. However, it resolves to default(CancellationToken) which is, so using that.
