### PR TITLE
Caching not catching...

### DIFF
--- a/src/Microsoft.Data.Entity/DefaultModelSource.cs
+++ b/src/Microsoft.Data.Entity/DefaultModelSource.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
@@ -8,6 +9,8 @@ namespace Microsoft.Data.Entity
 {
     public class DefaultModelSource : IModelSource
     {
+        private readonly ThreadSafeDictionaryCache<Type, IModel> _models = new ThreadSafeDictionaryCache<Type, IModel>();
+
         private readonly EntitySetFinder _setFinder;
 
         public DefaultModelSource([NotNull] EntitySetFinder setFinder)
@@ -21,6 +24,11 @@ namespace Microsoft.Data.Entity
         {
             Check.NotNull(context, "context");
 
+            return _models.GetOrAdd(context.GetType(), k => CreateModel(context));
+        }
+
+        private IModel CreateModel(EntityContext context)
+        {
             var model = new Model();
 
             foreach (var setInfo in _setFinder.FindSets(context))

--- a/test/Microsoft.Data.Entity.Tests/DefaultModelSourceTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/DefaultModelSourceTest.cs
@@ -45,12 +45,33 @@ namespace Microsoft.Data.Entity.Tests
                 model.EntityTypes.Select(e => e.Name).ToArray());
         }
 
-        public class JustAClass
+        private class JustAClass
         {
             public EntitySet<Random> One { get; set; }
             protected EntitySet<object> Two { get; set; }
             private EntitySet<string> Three { get; set; }
             private EntitySet<string> Four { get; set; }
+        }
+
+        [Fact]
+        public void Caches_model_by_context_type()
+        {
+            var modelSource = new DefaultModelSource(new EntitySetFinder());
+
+            var model1 = modelSource.GetModel(new Context1());
+            var model2 = modelSource.GetModel(new Context2());
+
+            Assert.NotSame(model1, model2);
+            Assert.Same(model1, modelSource.GetModel(new Context1()));
+            Assert.Same(model2, modelSource.GetModel(new Context2()));
+        }
+
+        private class Context1 : EntityContext
+        {
+        }
+
+        private class Context2 : EntityContext
+        {
         }
     }
 }

--- a/test/Microsoft.Data.Entity.Tests/Metadata/EntityMaterializerSourceTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Metadata/EntityMaterializerSourceTest.cs
@@ -40,6 +40,23 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         }
 
         [Fact]
+        public void DBNulls_are_converted_to_nulls()
+        {
+            var entityType = new EntityType(typeof(SomeEntity));
+            entityType.AddProperty("Id", typeof(int), shadowProperty: false);
+            entityType.AddProperty("Foo", typeof(string), shadowProperty: false);
+            entityType.AddProperty("Goo", typeof(Guid?), shadowProperty: false);
+
+            var factory = new EntityMaterializerSource().GetMaterializer(entityType);
+
+            var entity = (SomeEntity)factory(new object[] { DBNull.Value, DBNull.Value, 77 });
+
+            Assert.Equal(77, entity.Id);
+            Assert.Null(entity.Foo);
+            Assert.Null(entity.Goo);
+        }
+
+        [Fact]
         public void Can_create_materializer_for_entity_ignoring_shadow_fields()
         {
             var entityType = new EntityType(typeof(SomeEntity));
@@ -64,7 +81,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             public int Id { get; set; }
             public string Foo { get; set; }
-            public Guid Goo { get; set; }
+            public Guid? Goo { get; set; }
         }
     }
 }

--- a/test/Microsoft.Data.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/Microsoft.Data.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -29,6 +29,11 @@ namespace Microsoft.Data.SqlServer.FunctionalTests
                     Assert.Equal("ANTON", results[1].CustomerID);
                     Assert.Equal("ANATR", results[2].CustomerID);
                     Assert.Equal("ALFKI", results[3].CustomerID);
+
+                    Assert.Equal("(171) 555-6750", results[0].Fax);
+                    Assert.Null(results[1].Fax);
+                    Assert.Equal("(5) 555-3745", results[2].Fax);
+                    Assert.Equal("030-0076545", results[3].Fax);
                 }
             }
         }
@@ -118,6 +123,7 @@ namespace Microsoft.Data.SqlServer.FunctionalTests
         {
             public string CustomerID { get; set; }
             public string CompanyName { get; set; }
+            public string Fax { get; set; }
         }
 
         private class BloggingContext : EntityContext


### PR DESCRIPTION
Caching not catching... (Convert DBNull to null and cache models)

Temporary workaround for handling DBNulls in the value buffer when materializing entities.

Have DefaultModelSource cache the built model by context type in the configuration.
