### PR TITLE
GoingCivilised - replacing KeyValuePairs describing database columns in ...

### DIFF
--- a/src/Microsoft.Data.Relational/DatabaseBuilder.cs
+++ b/src/Microsoft.Data.Relational/DatabaseBuilder.cs
@@ -98,8 +98,22 @@ namespace Microsoft.Data.Relational
                 {
                     IsNullable = property.IsNullable,
                     DefaultValue = property.ColumnDefaultValue(),
-                    DefaultSql = property.ColumnDefaultSql()
+                    DefaultSql = property.ColumnDefaultSql(),
+                    GenerationStrategy = TranslateValueGenerationStrategy(property.ValueGenerationStrategy)
                 });
+        }
+
+        private static StoreValueGenerationStrategy TranslateValueGenerationStrategy(ValueGenerationStrategy generationStrategy)
+        {
+            switch (generationStrategy)
+            {
+                case ValueGenerationStrategy.StoreComputed:
+                    return StoreValueGenerationStrategy.Computed;
+                case ValueGenerationStrategy.StoreIdentity:
+                    return StoreValueGenerationStrategy.Identity;
+                default:
+                    return StoreValueGenerationStrategy.None;
+            }
         }
 
         private void BuildPrimaryKey(Database database, IKey primaryKey)

--- a/src/Microsoft.Data.Relational/Model/Column.cs
+++ b/src/Microsoft.Data.Relational/Model/Column.cs
@@ -63,5 +63,7 @@ namespace Microsoft.Data.Relational.Model
         public virtual object DefaultValue { get; [param: CanBeNull] set; }
 
         public virtual string DefaultSql { get; [param: CanBeNull] set; }
+
+        public virtual StoreValueGenerationStrategy GenerationStrategy { get; set; }
     }
 }

--- a/src/Microsoft.Data.Relational/Model/StoreValueGenerationStrategy.cs
+++ b/src/Microsoft.Data.Relational/Model/StoreValueGenerationStrategy.cs
@@ -1,0 +1,9 @@
+﻿namespace Microsoft.Data.Relational.Model
+{
+    public enum StoreValueGenerationStrategy
+    {
+        None,
+        Identity, 
+        Computed
+    }
+}

--- a/src/Microsoft.Data.Relational/RelationalDataStore.cs
+++ b/src/Microsoft.Data.Relational/RelationalDataStore.cs
@@ -48,7 +48,10 @@ namespace Microsoft.Data.Relational
             Check.NotNull(stateEntries, "stateEntries");
             Check.NotNull(model, "model");
 
-            var commands = new CommandBatchPreparer().BatchCommands(stateEntries);
+            //TODO: this should be cached
+            var database = new DatabaseBuilder().Build(model);
+
+            var commands = new CommandBatchPreparer().BatchCommands(stateEntries, database);
 
             using (var connection = CreateConnection(_connectionString))
             {

--- a/src/Microsoft.Data.Relational/Update/CommandBatchPreparer.cs
+++ b/src/Microsoft.Data.Relational/Update/CommandBatchPreparer.cs
@@ -2,17 +2,22 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Relational.Model;
 
 namespace Microsoft.Data.Relational.Update
 {
     internal class CommandBatchPreparer
     {
-        public IEnumerable<ModificationCommandBatch> BatchCommands(IEnumerable<StateEntry> stateEntries)
+        public IEnumerable<ModificationCommandBatch> BatchCommands([NotNull] IEnumerable<StateEntry> stateEntries, [NotNull] Database database)
         {
             return
                 stateEntries.Select(
-                    e => new ModificationCommandBatch(new[] { new ModificationCommand(e) }));
+                    e => new ModificationCommandBatch(new[]
+                        {
+                            new ModificationCommand(e, database.GetTable(e.EntityType.StorageName))
+                        }));
         }
     }
 }

--- a/src/Microsoft.Data.Relational/Update/ModificationCommandBatch.cs
+++ b/src/Microsoft.Data.Relational/Update/ModificationCommandBatch.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
 using Microsoft.Data.Relational.Utilities;
+using Microsoft.Data.Relational.Model;
 
 namespace Microsoft.Data.Relational.Update
 {
@@ -68,12 +69,12 @@ namespace Microsoft.Data.Relational.Update
         {
             var commandParameters = CreateParameters(modificationCommand.ColumnValues, parameters);
 
-            sqlGenerator.AppendInsertCommand(
+            sqlGenerator.AppendInsertOperation(
                 stringBuilder,
-                modificationCommand.TableName,
+                modificationCommand.Table,
                 modificationCommand.ColumnValues.Zip(
                     commandParameters,
-                    (c, p) => new KeyValuePair<string, string>(c.Key, p.Key)));
+                    (c, p) => new KeyValuePair<Column, string>(c.Key, p.Key)).ToArray());
         }
 
         private void AppendUpdateCommand(ModificationCommand modificationCommand, SqlGenerator sqlGenerator,
@@ -82,13 +83,11 @@ namespace Microsoft.Data.Relational.Update
             var updateParameters = CreateParameters(modificationCommand.ColumnValues, parameters);
             var whereClauseParameters = CreateParameters(modificationCommand.WhereClauses, parameters);
 
-            sqlGenerator.AppendUpdateCommand(
-                stringBuilder,
-                modificationCommand.TableName,
+            sqlGenerator.AppendUpdateOperation(stringBuilder, modificationCommand.Table,
                 modificationCommand.ColumnValues.Zip(
-                    updateParameters, (c, p) => new KeyValuePair<string, string>(c.Key, p.Key)),
+                    updateParameters, (c, p) => new KeyValuePair<Column, string>(c.Key, p.Key)).ToArray(),
                 modificationCommand.WhereClauses.Zip(
-                    whereClauseParameters, (c, p) => new KeyValuePair<string, string>(c.Key, p.Key)));
+                    whereClauseParameters, (c, p) => new KeyValuePair<Column, string>(c.Key, p.Key)).ToArray());
         }
 
         private void AppendDeleteCommand(ModificationCommand modificationCommand, SqlGenerator sqlGenerator,
@@ -98,12 +97,12 @@ namespace Microsoft.Data.Relational.Update
 
             sqlGenerator.AppendDeleteCommand(
                 stringBuilder,
-                modificationCommand.TableName,
+                modificationCommand.Table,
                 modificationCommand.WhereClauses.Zip(
-                    whereClauseParameters, (c, p) => new KeyValuePair<string, string>(c.Key, p.Key)));
+                    whereClauseParameters, (c, p) => new KeyValuePair<Column, string>(c.Key, p.Key)));
         }
 
-        private List<KeyValuePair<string, object>> CreateParameters(IEnumerable<KeyValuePair<string, object>> values,
+        private static List<KeyValuePair<string, object>> CreateParameters(IEnumerable<KeyValuePair<Column, object>> values,
             List<KeyValuePair<string, object>> parameters)
         {
             var newParameters = new List<KeyValuePair<string, object>>();

--- a/test/Microsoft.Data.Relational.Tests/DatabaseBuilderTest.cs
+++ b/test/Microsoft.Data.Relational.Tests/DatabaseBuilderTest.cs
@@ -6,6 +6,7 @@ using Microsoft.Data.Entity.Metadata;
 using Moq;
 using Xunit;
 using Microsoft.Data.Relational.Model;
+using Metadata = Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Relational.Tests
 {
@@ -26,6 +27,7 @@ namespace Microsoft.Data.Relational.Tests
             Assert.Equal(1, table0.Columns.Count);
             Assert.Equal("Id", table0.Columns[0].Name);
             Assert.Equal("int", table0.Columns[0].DataType);
+            Assert.Equal(StoreValueGenerationStrategy.None, table0.Columns[0].GenerationStrategy);
             Assert.NotNull(table1.PrimaryKey.Name);
             Assert.Equal("MyPK0", table0.PrimaryKey.Name);
             Assert.Same(table0.Columns[0], table0.PrimaryKey.Columns[0]);
@@ -35,6 +37,7 @@ namespace Microsoft.Data.Relational.Tests
             Assert.Equal(1, table1.Columns.Count);
             Assert.Equal("Id", table1.Columns[0].Name);
             Assert.Equal("int", table1.Columns[0].DataType);
+            Assert.Equal(StoreValueGenerationStrategy.Identity, table1.Columns[0].GenerationStrategy);
             Assert.NotNull(table1.PrimaryKey.Name);
             Assert.Equal("MyPK1", table1.PrimaryKey.Name);
             Assert.Same(table1.Columns[0], table1.PrimaryKey.Columns[0]);
@@ -168,12 +171,13 @@ namespace Microsoft.Data.Relational.Tests
 
         private static IModel CreateModel()
         {
-            var model = new Entity.Metadata.Model() { StorageName = "MyDatabase" };
+            var model = new Metadata.Model { StorageName = "MyDatabase" };
 
             var dependentEntityType = new EntityType("Dependent") { StorageName = "dbo.MyTable0" };
             var principalEntityType = new EntityType("Principal") { StorageName = "dbo.MyTable1" };
             var dependentProperty = dependentEntityType.AddProperty("Id", typeof(int), shadowProperty: false);
             var principalProperty = principalEntityType.AddProperty("Id", typeof(int), shadowProperty: false);
+            principalProperty.ValueGenerationStrategy = Metadata.ValueGenerationStrategy.StoreIdentity;
 
             model.AddEntityType(principalEntityType);
             model.AddEntityType(dependentEntityType);

--- a/test/Microsoft.Data.Relational.Tests/Update/BatchExecutorTest.cs
+++ b/test/Microsoft.Data.Relational.Tests/Update/BatchExecutorTest.cs
@@ -9,6 +9,7 @@ using Microsoft.Data.Relational.Update;
 using Moq;
 using Moq.Protected;
 using Xunit;
+using Microsoft.Data.Relational.Model;
 
 namespace Microsoft.Data.Relational.Tests.Update
 {
@@ -18,9 +19,10 @@ namespace Microsoft.Data.Relational.Tests.Update
         public async void ExecuteAsync_executes_batch_commands_and_consumes_reader()
         {
             var mockModificationCommand = new Mock<ModificationCommand>();
-            mockModificationCommand.Setup(c => c.TableName).Returns("table");
-            mockModificationCommand.Setup(c => c.ColumnValues).Returns(new[] { new KeyValuePair<string, object>("Id", 1) });
-            mockModificationCommand.Setup(c => c.WhereClauses).Returns(new KeyValuePair<string, object>[0]);
+            mockModificationCommand.Setup(c => c.Table).Returns(new Table("table"));
+            mockModificationCommand.Setup(c => c.ColumnValues)
+                .Returns(new[] { new KeyValuePair<Column, object>(new Column("Id", "_"), 1) });
+            mockModificationCommand.Setup(c => c.WhereClauses).Returns(new KeyValuePair<Column, object>[0]);
 
             var batch = new ModificationCommandBatch(new[] { mockModificationCommand.Object });
 
@@ -43,9 +45,10 @@ namespace Microsoft.Data.Relational.Tests.Update
         public async void ExecuteAsync_throws_if_records_affected_and_command_count_dont_match()
         {
             var mockModificationCommand = new Mock<ModificationCommand>();
-            mockModificationCommand.Setup(c => c.TableName).Returns("table");
-            mockModificationCommand.Setup(c => c.ColumnValues).Returns(new[] { new KeyValuePair<string, object>("Id", 1) });
-            mockModificationCommand.Setup(c => c.WhereClauses).Returns(new KeyValuePair<string, object>[0]);
+            mockModificationCommand.Setup(c => c.Table).Returns(new Table("table"));
+            mockModificationCommand.Setup(c => c.ColumnValues)
+                .Returns(new[] { new KeyValuePair<Column, object>(new Column("Id", "_"), 1) });
+            mockModificationCommand.Setup(c => c.WhereClauses).Returns(new KeyValuePair<Column, object>[0]);
 
             var batch = new ModificationCommandBatch(new[] { mockModificationCommand.Object });
 

--- a/test/Microsoft.Data.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/Microsoft.Data.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -2,13 +2,14 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Relational.Update;
+using Microsoft.Data.Relational.Model;
 using Xunit;
+using Database = Microsoft.Data.Relational.Model.Database;
 
 namespace Microsoft.Data.Relational.Tests.Update
 {
@@ -17,15 +18,16 @@ namespace Microsoft.Data.Relational.Tests.Update
         [Fact]
         public async Task BatchCommands_creates_valid_batch_for_added_entities()
         {
+            var database = CreateDatabase();
             var model = CreateModel();
 
             var stateEntry = new MixedStateEntry(
                 CreateConfiguration(),
                 model.GetEntityType(typeof(FakeEntity)), new FakeEntity { Id = 42, Value = "Test" });
 
-            await stateEntry.SetEntityStateAsync(EntityState.Added, new CancellationToken());
+            await stateEntry.SetEntityStateAsync(EntityState.Added);
 
-            var commandBatches = new CommandBatchPreparer().BatchCommands(new[] { stateEntry }).ToArray();
+            var commandBatches = new CommandBatchPreparer().BatchCommands(new[] { stateEntry }, database).ToArray();
             Assert.Equal(1, commandBatches.Count());
             Assert.Equal(1, commandBatches.First().BatchCommands.Count());
 
@@ -37,21 +39,22 @@ namespace Microsoft.Data.Relational.Tests.Update
                         new KeyValuePair<string, object>("Id", 42),
                         new KeyValuePair<string, object>("Value", "Test"),
                     },
-                command.ColumnValues);
+                command.ColumnValues.Select(v => new KeyValuePair<string, object>(v.Key.Name, v.Value)));
         }
 
         [Fact]
         public async Task BatchCommands_creates_valid_batch_for_updated_entities()
         {
+            var database = CreateDatabase();
             var model = CreateModel();
 
             var stateEntry = new MixedStateEntry(
                 CreateConfiguration(),
                 model.GetEntityType(typeof(FakeEntity)), new FakeEntity { Id = 42, Value = "Test" });
 
-            await stateEntry.SetEntityStateAsync(EntityState.Modified, new CancellationToken());
+            await stateEntry.SetEntityStateAsync(EntityState.Modified);
 
-            var commandBatches = new CommandBatchPreparer().BatchCommands(new[] { stateEntry }).ToArray();
+            var commandBatches = new CommandBatchPreparer().BatchCommands(new[] { stateEntry }, database).ToArray();
             Assert.Equal(1, commandBatches.Count());
             Assert.Equal(1, commandBatches.First().BatchCommands.Count());
 
@@ -63,28 +66,29 @@ namespace Microsoft.Data.Relational.Tests.Update
                     {
                         new KeyValuePair<string, object>("Value", "Test"),
                     },
-                command.ColumnValues);
+                command.ColumnValues.Select(v => new KeyValuePair<string, object>(v.Key.Name, v.Value)));
 
             Assert.Equal(
                 new[]
                     {
                         new KeyValuePair<string, object>("Id", 42),
                     },
-                command.WhereClauses);
+                command.WhereClauses.Select(v => new KeyValuePair<string, object>(v.Key.Name, v.Value)));
         }
 
         [Fact]
         public async Task BatchCommands_creates_valid_batch_for_deleted_entities()
         {
+            var database = CreateDatabase();
             var model = CreateModel();
 
             var stateEntry = new MixedStateEntry(
                 CreateConfiguration(),
                 model.GetEntityType(typeof(FakeEntity)), new FakeEntity { Id = 42, Value = "Test" });
 
-            await stateEntry.SetEntityStateAsync(EntityState.Deleted, new CancellationToken());
+            await stateEntry.SetEntityStateAsync(EntityState.Deleted);
 
-            var commandBatches = new CommandBatchPreparer().BatchCommands(new[] { stateEntry }).ToArray();
+            var commandBatches = new CommandBatchPreparer().BatchCommands(new[] { stateEntry }, database).ToArray();
             Assert.Equal(1, commandBatches.Count());
             Assert.Equal(1, commandBatches.First().BatchCommands.Count());
 
@@ -98,12 +102,21 @@ namespace Microsoft.Data.Relational.Tests.Update
                     {
                         new KeyValuePair<string, object>("Id", 42),
                     },
-                command.WhereClauses);
+                command.WhereClauses.Select(v => new KeyValuePair<string, object>(v.Key.Name, v.Value)));
         }
 
         private static ContextConfiguration CreateConfiguration()
         {
             return new EntityContext(new EntityConfigurationBuilder().BuildConfiguration()).Configuration;
+        }
+
+        private static Database CreateDatabase()
+        {
+            var table = new Table("FakeEntity", new[] { new Column("Id", "_"), new Column("Value", "_") });
+            table.PrimaryKey = new PrimaryKey("PK", table.Columns.Where(c => c.Name == "Id").ToArray());
+            var database = new Database();
+            database.AddTable(table);
+            return database;
         }
 
         private static IModel CreateModel()

--- a/test/Microsoft.Data.SqlServer.FunctionalTests/TestDatabase.cs
+++ b/test/Microsoft.Data.SqlServer.FunctionalTests/TestDatabase.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.SqlServer.FunctionalTests
 {
     public class TestDatabase : IDisposable, IDbCommandExecutor
     {
-        public const int CommandTimeout = 1;
+        public const int CommandTimeout = 5;
         private const string DefaultDatabaseName = "Microsoft.Data.SqlServer.FunctionalTest";
         private const string NorthwindDatabaseName = "Northwind";
 


### PR DESCRIPTION
GoingCivilised - replacing KeyValuePairs describing database columns in Update with types describing the database. Wiring Insert and Update operations to enable result propagation.
