### PR TITLE
Avoid deleting unchanged entities

### DIFF
--- a/src/Microsoft.Data.Entity/EntityContext.cs
+++ b/src/Microsoft.Data.Entity/EntityContext.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -63,8 +64,12 @@ namespace Microsoft.Data.Entity
 
         public virtual Task<int> SaveChangesAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            return _configuration.DataStore.SaveChangesAsync(
-                _configuration.StateManager.StateEntries, Model, cancellationToken);
+            var entriesToSave = _configuration.StateManager.StateEntries.Where(e => e.EntityState.IsDirty());
+
+            return entriesToSave.Any()
+                ?_configuration.DataStore.SaveChangesAsync(
+                    entriesToSave, Model, cancellationToken)
+                : Task.FromResult(0);
         }
 
         public void Dispose()

--- a/src/Microsoft.Data.Entity/EntityStateExtensions.cs
+++ b/src/Microsoft.Data.Entity/EntityStateExtensions.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity
+{
+    public static class EntityStateExtensions
+    {
+        public static bool IsDirty(this EntityState state)
+        {
+            return state == EntityState.Added || state == EntityState.Modified || state == EntityState.Deleted;
+        }
+    }
+}

--- a/src/Microsoft.Data.Relational/Properties/Strings.Designer.cs
+++ b/src/Microsoft.Data.Relational/Properties/Strings.Designer.cs
@@ -59,6 +59,22 @@ namespace Microsoft.Data.Relational
         }
 
         /// <summary>
+        /// Can not create a ModificationFunction for an entity in state '{entityState}'.
+        /// </summary>
+        internal static string ModificationFunctionInvalidEntityState
+        {
+            get { return GetString("ModificationFunctionInvalidEntityState"); }
+        }
+
+        /// <summary>
+        /// Can not create a ModificationFunction for an entity in state '{entityState}'.
+        /// </summary>
+        internal static string FormatModificationFunctionInvalidEntityState(object entityState)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ModificationFunctionInvalidEntityState", "entityState"), entityState);
+        }
+
+        /// <summary>
         /// Update failed. Expected rows affected '{expectedRowsAffected}'. Actual rows affected '{actualRowsAffected}'.
         /// </summary>
         internal static string UpdateConcurrencyException

--- a/src/Microsoft.Data.Relational/Properties/Strings.resx
+++ b/src/Microsoft.Data.Relational/Properties/Strings.resx
@@ -126,6 +126,9 @@
   <data name="InvalidSchemaQualifiedName" xml:space="preserve">
     <value>The schema qualified name '{name}' is invalid. Schema qualified names must be of the form [&lt;schema_name&gt;.]&lt;object_name&gt;.</value>
   </data>
+  <data name="ModificationFunctionInvalidEntityState" xml:space="preserve">
+    <value>Can not create a ModificationFunction for an entity in state '{entityState}'.</value>
+  </data>
   <data name="UpdateConcurrencyException" xml:space="preserve">
     <value>Update failed. Expected rows affected '{expectedRowsAffected}'. Actual rows affected '{actualRowsAffected}'.</value>
   </data>

--- a/src/Microsoft.Data.Relational/Update/ModificationCommand.cs
+++ b/src/Microsoft.Data.Relational/Update/ModificationCommand.cs
@@ -8,10 +8,11 @@ using JetBrains.Annotations;
 using Microsoft.Data.Entity;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Relational.Utilities;
 
 namespace Microsoft.Data.Relational.Update
 {
-    internal class ModificationCommand
+    public class ModificationCommand
     {
         private readonly StateEntry _stateEntry;
         private readonly KeyValuePair<string, object>[] _columnValues;
@@ -29,9 +30,12 @@ namespace Microsoft.Data.Relational.Update
 
         public ModificationCommand([NotNull] StateEntry stateEntry)
         {
-            Contract.Assert(
-                stateEntry.EntityState == EntityState.Added || stateEntry.EntityState == EntityState.Modified ||
-                stateEntry.EntityState == EntityState.Deleted, "Unexpected entity state");
+            Check.NotNull(stateEntry, "stateEntry");
+            
+            if(!(stateEntry.EntityState.IsDirty()))
+            {
+                throw new NotSupportedException(Strings.FormatModificationFunctionInvalidEntityState(stateEntry.EntityState));
+            }
 
             _stateEntry = stateEntry;
             _operation =

--- a/src/Microsoft.Data.Relational/Update/ModificationCommandBatch.cs
+++ b/src/Microsoft.Data.Relational/Update/ModificationCommandBatch.cs
@@ -4,27 +4,33 @@ using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Text;
+using JetBrains.Annotations;
+using Microsoft.Data.Relational.Utilities;
 
 namespace Microsoft.Data.Relational.Update
 {
-    internal class ModificationCommandBatch
+    public class ModificationCommandBatch
     {
         private readonly ModificationCommand[] _batchCommands;
 
-        public ModificationCommandBatch(ModificationCommand[] batchCommands)
+        public ModificationCommandBatch([NotNull] ModificationCommand[] batchCommands)
         {
+            Check.NotNull(batchCommands, "batchCommands");
+
             Contract.Assert(batchCommands.Any(), "batchCommands array is empty");
 
             _batchCommands = batchCommands;
         }
 
-        public IEnumerable<ModificationCommand> BatchCommands
+        public virtual IEnumerable<ModificationCommand> BatchCommands
         {
             get { return _batchCommands; }
         }
 
-        public string CompileBatch(SqlGenerator sqlGenerator, out List<KeyValuePair<string, object>> parameters)
+        public virtual string CompileBatch([NotNull] SqlGenerator sqlGenerator, [NotNull] out List<KeyValuePair<string, object>> parameters)
         {
+            Check.NotNull(sqlGenerator, "sqlGenerator");
+
             var stringBuilder = new StringBuilder();
             parameters = new List<KeyValuePair<string, object>>();
 

--- a/src/Microsoft.Data.Relational/Update/ModificationOperation.cs
+++ b/src/Microsoft.Data.Relational/Update/ModificationOperation.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.Data.Relational.Update
 {
-    internal enum ModificationOperation : byte
+    public enum ModificationOperation : byte
     {
         Insert,
         Update,

--- a/test/Microsoft.Data.Relational.Tests/Update/ModificationCommandTest.cs
+++ b/test/Microsoft.Data.Relational.Tests/Update/ModificationCommandTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Data.Entity;
@@ -81,6 +82,22 @@ namespace Microsoft.Data.Relational.Tests.Update
             Assert.Equal(ModificationOperation.Delete, modificationCommand.Operation);
             Assert.Null(modificationCommand.ColumnValues);
             Assert.Equal(properties.Where(p => p.Key == "Col1"), modificationCommand.WhereClauses);
+        }
+
+        [Fact]
+        public void ModificationCommand_throws_for_unchanged_entities()
+        {
+            var stateEntry = CreateMockStateEntry("T1", EntityState.Unchanged, new Dictionary<string, object>(), new string[0]);
+
+            Assert.Throws<NotSupportedException>(() => new ModificationCommand(stateEntry));
+        }
+
+        [Fact]
+        public void ModificationCommand_throws_for_unknown_entities()
+        {
+            var stateEntry = CreateMockStateEntry("T1", EntityState.Unknown, new Dictionary<string, object>(), new string[0]);
+
+            Assert.Throws<NotSupportedException>(() => new ModificationCommand(stateEntry));
         }
 
         private static StateEntry CreateMockStateEntry(string tableName, EntityState entityState,


### PR DESCRIPTION
RelationalDataStore didn't filter out unchanged entries and the default
operation for ModificationOperation was DELETE. This meant we would
delete any unchanged data from the database.

Made BatchExecutor an explicit dependency of RelationalDataStore so that
it could be mocked for unit testing. Had to make a few classes public to
do this, but discussed with Pawel and the plan was that these would be
public in the end anyway.
