### PR TITLE
We're watching you...

### DIFF
--- a/src/Microsoft.Data.Entity/ChangeTracking/ShadowStateEntry.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/ShadowStateEntry.cs
@@ -26,16 +26,20 @@ namespace Microsoft.Data.Entity.ChangeTracking
             get { return null; }
         }
 
-        public ShadowStateEntry([NotNull] ContextConfiguration configuration, [NotNull] IEntityType entityType)
-            : base(configuration, entityType)
+        public ShadowStateEntry(
+            [NotNull] ContextConfiguration configuration,
+            [NotNull] IEntityType entityType)
+            : base(configuration, entityType, null)
         {
-            Check.NotNull(entityType, "entityType");
-
             _propertyValues = new object[entityType.ShadowPropertyCount];
         }
 
-        public ShadowStateEntry([NotNull] ContextConfiguration configuration, [NotNull] IEntityType entityType, [NotNull] object[] valueBuffer)
-            : base(configuration, entityType)
+        public ShadowStateEntry(
+            [NotNull] ContextConfiguration configuration,
+            [NotNull] IEntityType entityType,
+            [NotNull] object[] valueBuffer)
+            // Can't use valueBuffer optimization for original values because using for current values
+            : base(configuration, entityType, null)
         {
             Check.NotNull(valueBuffer, "valueBuffer");
 
@@ -51,7 +55,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             return _propertyValues[property.ShadowIndex];
         }
 
-        public override void SetPropertyValue(IProperty property, object value)
+        protected override void WritePropertyValue(IProperty property, object value)
         {
             Check.NotNull(property, "property");
 

--- a/src/Microsoft.Data.Entity/ChangeTracking/StateEntrySubscriber.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/StateEntrySubscriber.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System.ComponentModel;
+using JetBrains.Annotations;
+
+namespace Microsoft.Data.Entity.ChangeTracking
+{
+    public class StateEntrySubscriber
+    {
+        public virtual StateEntry SnapshotAndSubscribe([NotNull] StateEntry entry)
+        {
+            if (!entry.EntityType.UseLazyOriginalValues)
+            {
+                entry.SnapshotOriginalValues();
+            }
+
+            var changing = entry.Entity as INotifyPropertyChanging;
+            if (changing != null)
+            {
+                changing.PropertyChanging += (s, e) =>
+                    {
+                        var property = entry.EntityType.TryGetProperty(e.PropertyName);
+                        if (property != null)
+                        {
+                            entry.PropertyChanging(property);
+                        }
+                    };
+            }
+
+            var changed = entry.Entity as INotifyPropertyChanged;
+            if (changed != null)
+            {
+                changed.PropertyChanged += (s, e) =>
+                    {
+                        var property = entry.EntityType.TryGetProperty(e.PropertyName);
+                        if (property != null)
+                        {
+                            entry.PropertyChanged(property);
+                        }
+                    };
+            }
+
+            return entry;
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/EntityContext.cs
+++ b/src/Microsoft.Data.Entity/EntityContext.cs
@@ -64,11 +64,16 @@ namespace Microsoft.Data.Entity
 
         public virtual Task<int> SaveChangesAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            var entriesToSave = _configuration.StateManager.StateEntries.Where(e => e.EntityState.IsDirty());
+            var stateManager = _configuration.StateManager;
+            
+            stateManager.DetectChanges();
+
+            var entriesToSave = stateManager.StateEntries
+                .Where(e => e.EntityState.IsDirty())
+                .ToList();
 
             return entriesToSave.Any()
-                ?_configuration.DataStore.SaveChangesAsync(
-                    entriesToSave, Model, cancellationToken)
+                ? _configuration.DataStore.SaveChangesAsync(entriesToSave, Model, cancellationToken)
                 : Task.FromResult(0);
         }
 

--- a/src/Microsoft.Data.Entity/EntityServices.cs
+++ b/src/Microsoft.Data.Entity/EntityServices.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Data.Entity
                 .AddSingleton<EntitySetSource, EntitySetSource>()
                 .AddSingleton<ClrCollectionAccessorSource, ClrCollectionAccessorSource>()
                 .AddSingleton<EntityMaterializerSource, EntityMaterializerSource>()
+                .AddSingleton<StateEntrySubscriber, StateEntrySubscriber>()
                 .AddScoped<StateEntryFactory, StateEntryFactory>()
                 .AddScoped<IEntityStateListener, NavigationFixer>()
                 .AddScoped<StateEntryNotifier, StateEntryNotifier>()

--- a/src/Microsoft.Data.Entity/INotifyPropertyChanging.cs
+++ b/src/Microsoft.Data.Entity/INotifyPropertyChanging.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+
+#if !NET45
+// TODO: This should be shipped in some other assembly/NuGet package with type-forwarding/unification for full .NET
+
+namespace System.ComponentModel
+{
+    public interface INotifyPropertyChanging
+    {
+        event PropertyChangingEventHandler PropertyChanging;
+    }
+
+    public delegate void PropertyChangingEventHandler(object sender, PropertyChangingEventArgs e);
+
+    public class PropertyChangingEventArgs : EventArgs
+    {
+        private readonly string _propertyName;
+
+        public PropertyChangingEventArgs(string propertyName)
+        {
+            _propertyName = propertyName;
+        }
+
+        public virtual string PropertyName
+        {
+            get { return _propertyName; }
+        }
+    }
+}
+
+#endif

--- a/src/Microsoft.Data.Entity/Metadata/Compiled/CompiledEntityType.cs
+++ b/src/Microsoft.Data.Entity/Metadata/Compiled/CompiledEntityType.cs
@@ -82,7 +82,20 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
 
         public int ShadowPropertyCount
         {
+            // TODO:
             get { return 0; }
+        }
+
+        public int OriginalValueCount
+        {
+            // TODO:
+            get { return 0; }
+        }
+
+        public bool UseLazyOriginalValues
+        {
+            // TODO:
+            get { return true; }
         }
 
         public bool HasClrType

--- a/src/Microsoft.Data.Entity/Metadata/Compiled/CompiledProperty.cs
+++ b/src/Microsoft.Data.Entity/Metadata/Compiled/CompiledProperty.cs
@@ -37,5 +37,17 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
         {
             get { return true; }
         }
+
+        public bool IsConcurrencyToken
+        {
+            // TODO:
+            get { return true; }
+        }
+
+        public int OriginalValueIndex
+        {
+            // TODO:
+            get { return -1; }
+        }
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/Compiled/CompiledPropertyNoAnnotations.cs
+++ b/src/Microsoft.Data.Entity/Metadata/Compiled/CompiledPropertyNoAnnotations.cs
@@ -37,5 +37,17 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
         {
             get { return true; }
         }
+
+        public bool IsConcurrencyToken
+        {
+            // TODO:
+            get { return true; }
+        }
+
+        public int OriginalValueIndex
+        {
+            // TODO:
+            get { return -1; }
+        }
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/EntityMaterializerSource.cs
+++ b/src/Microsoft.Data.Entity/Metadata/EntityMaterializerSource.cs
@@ -70,7 +70,8 @@ namespace Microsoft.Data.Entity.Metadata
             var allFields = entityType.Type.GetRuntimeFields().ToArray();
             return entityType.Properties
                 .Where(p => p.IsClrProperty)
-                .Select(p => Tuple.Create(p, allFields.Single(f => f.Name == "<" + p.Name + ">k__BackingField")));
+                .Select(p => Tuple.Create(p, allFields.Single(f => f.Name == "<" + p.Name + ">k__BackingField"
+                                                                   || f.Name.ToUpperInvariant() == "_" + p.Name.ToUpperInvariant())));
         }
 
         // TODO: This is a temporary workaround for conveting DBNull into null

--- a/src/Microsoft.Data.Entity/Metadata/IEntityType.cs
+++ b/src/Microsoft.Data.Entity/Metadata/IEntityType.cs
@@ -25,6 +25,8 @@ namespace Microsoft.Data.Entity.Metadata
         IReadOnlyList<IForeignKey> ForeignKeys { get; }
         IReadOnlyList<INavigation> Navigations { get; }
         int ShadowPropertyCount { get; }
+        int OriginalValueCount { get; }
         bool HasClrType { get; }
+        bool UseLazyOriginalValues { get; }
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/IProperty.cs
+++ b/src/Microsoft.Data.Entity/Metadata/IProperty.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
 using System;
+using JetBrains.Annotations;
 
 namespace Microsoft.Data.Entity.Metadata
 {
@@ -11,6 +12,8 @@ namespace Microsoft.Data.Entity.Metadata
         ValueGenerationStrategy ValueGenerationStrategy { get; }
         int Index { get; }
         int ShadowIndex { get; }
+        int OriginalValueIndex { get; }
         bool IsClrProperty { get; }
+        bool IsConcurrencyToken { get; }
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/Property.cs
+++ b/src/Microsoft.Data.Entity/Metadata/Property.cs
@@ -11,12 +11,19 @@ namespace Microsoft.Data.Entity.Metadata
     public class Property : NamedMetadataBase, IProperty
     {
         private readonly Type _propertyType;
+        private readonly bool _isConcurrencyToken;
 
         private bool _isNullable = true;
         private int _shadowIndex;
+        private int _originalValueIndex = -1;
         private int _index;
 
-        internal Property([NotNull] string name, [NotNull] Type propertyType, bool shadowProperty)
+        internal Property([NotNull] string name, [NotNull] Type propertyType)
+            : this(name, propertyType, shadowProperty: false, concurrencyToken: false)
+        {
+        }
+
+        internal Property([NotNull] string name, [NotNull] Type propertyType, bool shadowProperty, bool concurrencyToken)
             : base(Check.NotEmpty(name, "name"))
         {
             Check.NotNull(propertyType, "propertyType");
@@ -24,6 +31,7 @@ namespace Microsoft.Data.Entity.Metadata
             _propertyType = propertyType;
             _shadowIndex = shadowProperty ? 0 : -1;
             _isNullable = propertyType.IsNullableType();
+            _isConcurrencyToken = concurrencyToken;
         }
 
         public virtual Type PropertyType
@@ -52,6 +60,11 @@ namespace Microsoft.Data.Entity.Metadata
             get { return !IsClrProperty; }
         }
 
+        public virtual bool IsConcurrencyToken
+        {
+            get { return _isConcurrencyToken; }
+        }
+
         public virtual int Index
         {
             get { return _index; }
@@ -76,6 +89,20 @@ namespace Microsoft.Data.Entity.Metadata
                 }
 
                 _shadowIndex = value;
+            }
+        }
+
+        public virtual int OriginalValueIndex
+        {
+            get { return _originalValueIndex; }
+            set
+            {
+                if (value < -1)
+                {
+                    throw new ArgumentOutOfRangeException("value");
+                }
+
+                _originalValueIndex = value;
             }
         }
 

--- a/src/Microsoft.Data.Entity/Properties/Strings.Designer.cs
+++ b/src/Microsoft.Data.Entity/Properties/Strings.Designer.cs
@@ -362,6 +362,38 @@ namespace Microsoft.Data.Entity
             return GetString("IQueryableProviderNotAsync");
         }
 
+        /// <summary>
+        /// Lazy original value tracking cannot be turned on for entity type '{entityType}'. Entities that do not implement both INotifyPropertyChanging and INotifyPropertyChanged require original values to be stored eagerly in order to correct detect changes made to entities.
+        /// </summary>
+        internal static string EagerOriginalValuesRequired
+        {
+            get { return GetString("EagerOriginalValuesRequired"); }
+        }
+
+        /// <summary>
+        /// Lazy original value tracking cannot be turned on for entity type '{entityType}'. Entities that do not implement both INotifyPropertyChanging and INotifyPropertyChanged require original values to be stored eagerly in order to correct detect changes made to entities.
+        /// </summary>
+        internal static string FormatEagerOriginalValuesRequired(object entityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("EagerOriginalValuesRequired", "entityType"), entityType);
+        }
+
+        /// <summary>
+        /// The original value for property '{property}' of entity type '{entityType}' cannot be accessed because it is not being tracked. To access all original values set 'UseLazyOriginalValues' to false on the entity type.
+        /// </summary>
+        internal static string OriginalValueNotTracked
+        {
+            get { return GetString("OriginalValueNotTracked"); }
+        }
+
+        /// <summary>
+        /// The original value for property '{property}' of entity type '{entityType}' cannot be accessed because it is not being tracked. To access all original values set 'UseLazyOriginalValues' to false on the entity type.
+        /// </summary>
+        internal static string FormatOriginalValueNotTracked(object property, object entityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("OriginalValueNotTracked", "property", "entityType"), property, entityType);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.Data.Entity/Properties/Strings.resx
+++ b/src/Microsoft.Data.Entity/Properties/Strings.resx
@@ -183,4 +183,10 @@
   <data name="IQueryableProviderNotAsync" xml:space="preserve">
     <value>The provider for the source IQueryable doesn't implement IAsyncQueryProvider. Only providers that implement IEntityQueryProvider can be used for Entity Framework asynchronous operations.</value>
   </data>
+  <data name="EagerOriginalValuesRequired" xml:space="preserve">
+    <value>Lazy original value tracking cannot be turned on for entity type '{entityType}'. Entities that do not implement both INotifyPropertyChanging and INotifyPropertyChanged require original values to be stored eagerly in order to correct detect changes made to entities.</value>
+  </data>
+  <data name="OriginalValueNotTracked" xml:space="preserve">
+    <value>The original value for property '{property}' of entity type '{entityType}' cannot be accessed because it is not being tracked. To access all original values set 'UseLazyOriginalValues' to false on the entity type.</value>
+  </data>
 </root>

--- a/src/Microsoft.Data.Entity/project.json
+++ b/src/Microsoft.Data.Entity/project.json
@@ -30,6 +30,7 @@
         "System.Linq": "4.0.0.0",
         "System.Linq.Expressions": "4.0.0.0",
         "System.Linq.Queryable": "4.0.0.0",
+        "System.ObjectModel": "4.0.0.0",
         "System.Reflection": "4.0.10.0",
         "System.Reflection.Extensions": "4.0.0.0",
         "System.Resources.ResourceManager": "4.0.0.0",

--- a/test/Microsoft.Data.Entity.FunctionalTests/Metadata/CompiledModelTest.cs
+++ b/test/Microsoft.Data.Entity.FunctionalTests/Metadata/CompiledModelTest.cs
@@ -104,12 +104,9 @@ namespace Microsoft.Data.Entity.FunctionalTests.Metadata
                 var stateEntry = context.ChangeTracker.StateManager.GetOrMaterializeEntry(
                     entityType, new object[] { "Foo", gu, 77 });
 
-                Assert.False(entityType.CreateEntityWasUsed);
-
                 var entity = (KoolEntity15)stateEntry.Entity;
 
                 Assert.True(entityType.CreateEntityWasUsed);
-
                 Assert.Equal(77, entity.Id);
                 Assert.Equal("Foo", entity.Foo15);
                 Assert.Equal(gu, entity.Goo15);
@@ -351,21 +348,21 @@ namespace Microsoft.Data.Entity.FunctionalTests.Metadata
             builder.Annotation("ModelAnnotation2", "ModelValue2");
 
             var entityType1 = new EntityType(typeof(KoolEntity1));
-            var property = entityType1.AddProperty("Id1", typeof(int), shadowProperty: false);
+            var property = entityType1.AddProperty("Id1", typeof(int));
             property.StorageName = "MyKey1";
             entityType1.SetKey(property);
-            entityType1.AddProperty("Id2", typeof(Guid), shadowProperty: false).StorageName = "MyKey2";
-            entityType1.AddProperty("KoolEntity2Id", typeof(int), shadowProperty: false);
+            entityType1.AddProperty("Id2", typeof(Guid)).StorageName = "MyKey2";
+            entityType1.AddProperty("KoolEntity2Id", typeof(int));
             model.AddEntityType(entityType1);
 
             var entityType2 = new EntityType(typeof(KoolEntity2));
-            entityType2.AddProperty("KoolEntity1Id1", typeof(int), shadowProperty: false);
-            entityType2.AddProperty("KoolEntity1Id2", typeof(Guid), shadowProperty: false);
-            entityType2.AddProperty("KoolEntity3Id", typeof(int), shadowProperty: false);
+            entityType2.AddProperty("KoolEntity1Id1", typeof(int));
+            entityType2.AddProperty("KoolEntity1Id2", typeof(Guid));
+            entityType2.AddProperty("KoolEntity3Id", typeof(int));
             model.AddEntityType(entityType2);
 
             var entityType3 = new EntityType(typeof(KoolEntity3));
-            entityType3.AddProperty("KoolEntity4Id", typeof(int), shadowProperty: false);
+            entityType3.AddProperty("KoolEntity4Id", typeof(int));
             model.AddEntityType(entityType3);
 
             var entityType4 = new EntityType(typeof(KoolEntity4));
@@ -375,7 +372,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.Metadata
             model.AddEntityType(entityType5);
 
             var entityType6 = new EntityType(typeof(KoolEntity6));
-            entityType6.AddProperty("Kool5Id", typeof(int), shadowProperty: false);
+            entityType6.AddProperty("Kool5Id", typeof(int));
             model.AddEntityType(entityType6);
 
             for (var i = 7; i <= 20; i++)

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/MixedStateEntryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/MixedStateEntryTest.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Data.Entity.Metadata;
 using Xunit;
 
@@ -25,10 +26,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var model = BuildModel();
             var entityType = model.GetEntityType("SomeEntity");
             var keyProperty = entityType.GetProperty("Id");
-            var nonKeyProperty = entityType.GetProperty("Kool");
+            var nonKeyProperty = entityType.GetProperty("Name");
             var configuration = CreateConfiguration(model);
 
-            var entity = new SomeEntity { Id = 77, Kool = "Magic Tree House" };
+            var entity = new SomeEntity { Id = 77, Name = "Magic Tree House" };
             var entry = CreateStateEntry(configuration, entityType, entity);
 
             Assert.Null(entry.GetPropertyValue(keyProperty)); // In shadow
@@ -38,7 +39,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry.SetPropertyValue(nonKeyProperty, "Normal Tree House");
 
             Assert.Equal(77, entity.Id); // In shadow
-            Assert.Equal("Normal Tree House", entity.Kool);
+            Assert.Equal("Normal Tree House", entity.Name);
         }
 
         [Fact]
@@ -52,25 +53,91 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var entity = (SomeEntity)entry.Entity;
 
-            Assert.Equal("Kool", entity.Kool);
+            Assert.Equal("Kool", entity.Name);
         }
 
-        protected override IModel BuildModel()
+        [Fact]
+        public void All_original_values_can_be_accessed_for_entity_that_does_no_notifiction()
+        {
+            var model = BuildModel();
+            var entityType = model.GetEntityType("SomeEntity");
+
+            AllOriginalValuesTest(model, entityType);
+        }
+
+        [Fact]
+        public void All_original_values_can_be_accessed_for_entity_that_does_changed_only_notifictions_if_eager_values_on()
+        {
+            var model = BuildModel();
+            var entityType = model.GetEntityType("ChangedOnlyEntity");
+            entityType.UseLazyOriginalValues = false;
+
+            AllOriginalValuesTest(model, entityType);
+        }
+
+        [Fact]
+        public void Setting_CLR_property_with_snapshot_change_tracking_requires_DetectChanges()
+        {
+            SetPropertyClrTest<SomeEntity>(needsDetectChanges: true);
+        }
+
+        [Fact]
+        public void Setting_CLR_property_with_changed_only_notifications_does_not_require_DetectChanges()
+        {
+            SetPropertyClrTest<ChangedOnlyEntity>(needsDetectChanges: false);
+        }
+
+        [Fact]
+        public void Setting_CLR_property_with_full_notifications_does_not_require_DetectChanges()
+        {
+            SetPropertyClrTest<FullNotificationEntity>(needsDetectChanges: false);
+        }
+
+        [Fact]
+        public void Original_values_are_not_tracked_unless_needed_by_default_for_properties_of_full_notifications_entity()
+        {
+            var model = BuildModel();
+            var entityType = model.GetEntityType("FullNotificationEntity");
+            var idProperty = entityType.GetProperty("Id");
+            var configuration = CreateConfiguration(model);
+
+            var entry = CreateStateEntry(configuration, entityType, new object[] { 1, "Kool" });
+
+            Assert.Equal(
+                Strings.FormatOriginalValueNotTracked("Id", "FullNotificationEntity"),
+                Assert.Throws<InvalidOperationException>(() => entry.SetPropertyOriginalValue(idProperty, 1)).Message);
+
+            Assert.Equal(
+                Strings.FormatOriginalValueNotTracked("Id", "FullNotificationEntity"),
+                Assert.Throws<InvalidOperationException>(() => entry.GetPropertyOriginalValue(idProperty)).Message);
+        }
+
+        protected override Model BuildModel()
         {
             var model = new Model();
 
             var entityType1 = new EntityType(typeof(SomeEntity));
             model.AddEntityType(entityType1);
-            var key1 = entityType1.AddProperty("Id", typeof(int), shadowProperty: true);
+            var key1 = entityType1.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false);
             entityType1.SetKey(key1);
-            entityType1.AddProperty("Kool", typeof(string), shadowProperty: false);
+            entityType1.AddProperty("Name", typeof(string));
 
             var entityType2 = new EntityType(typeof(SomeDependentEntity));
             model.AddEntityType(entityType2);
-            var key2 = entityType2.AddProperty("Id", typeof(int), shadowProperty: false);
+            var key2 = entityType2.AddProperty("Id", typeof(int));
             entityType2.SetKey(key2);
-            var fk = entityType2.AddProperty("SomeEntityId", typeof(int), shadowProperty: true);
+            var fk = entityType2.AddProperty("SomeEntityId", typeof(int), shadowProperty: true, concurrencyToken: false);
             entityType2.AddForeignKey(entityType1.GetKey(), new[] { fk });
+
+            var entityType3 = new EntityType(typeof(FullNotificationEntity));
+            model.AddEntityType(entityType3);
+            entityType3.SetKey(entityType3.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityType3.AddProperty("Name", typeof(string), shadowProperty: false, concurrencyToken: true);
+
+            var entityType4 = new EntityType(typeof(ChangedOnlyEntity));
+            model.AddEntityType(entityType4);
+            entityType4.SetKey(entityType4.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityType4.AddProperty("Name", typeof(string), shadowProperty: false, concurrencyToken: true);
 
             return model;
         }

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/NavigationFixerTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/NavigationFixerTest.cs
@@ -87,8 +87,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var stateManager = new StateManager(
                 configMock.Object,
-                new StateEntryFactory(configMock.Object),
-                new EntityKeyFactorySource());
+                new StateEntryFactory(configMock.Object, new EntityMaterializerSource()),
+                new EntityKeyFactorySource(),
+                new StateEntrySubscriber());
 
             configMock.Setup(m => m.StateManager).Returns(stateManager);
 

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/ShadowStateEntryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/ShadowStateEntryTest.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-using Microsoft.Data.Entity.ChangeTracking;
+using System;
 using Microsoft.Data.Entity.Metadata;
 using Xunit;
 
@@ -19,33 +19,52 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.Null(entry.Entity);
         }
 
-        protected override StateEntry CreateStateEntry(ContextConfiguration stateManager, IEntityType entityType, object entity)
+        [Fact]
+        public void Original_values_are_not_tracked_unless_needed_by_default_for_shadow_properties()
         {
-            return new ShadowStateEntry(stateManager, entityType);
+            var model = BuildModel();
+            var entityType = model.GetEntityType("SomeEntity");
+            var idProperty = entityType.GetProperty("Id");
+            var configuration = CreateConfiguration(model);
+
+            var entry = CreateStateEntry(configuration, entityType, new object[] { 1, "Kool" });
+
+            Assert.Equal(
+                Strings.FormatOriginalValueNotTracked("Id", "SomeEntity"),
+                Assert.Throws<InvalidOperationException>(() => entry.SetPropertyOriginalValue(idProperty, 1)).Message);
+
+            Assert.Equal(
+                Strings.FormatOriginalValueNotTracked("Id", "SomeEntity"),
+                Assert.Throws<InvalidOperationException>(() => entry.GetPropertyOriginalValue(idProperty)).Message);
         }
 
-        protected override StateEntry CreateStateEntry(ContextConfiguration stateManager, IEntityType entityType, object[] valueBuffer)
-        {
-            return new ShadowStateEntry(stateManager, entityType, valueBuffer);
-        }
-
-        protected override IModel BuildModel()
+        protected override Model BuildModel()
         {
             var model = new Model();
 
             var entityType1 = new EntityType("SomeEntity");
             model.AddEntityType(entityType1);
-            var key1 = entityType1.AddProperty("Id", typeof(int), shadowProperty: true);
+            var key1 = entityType1.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false);
             entityType1.SetKey(key1);
-            entityType1.AddProperty("Kool", typeof(string), shadowProperty: true);
+            entityType1.AddProperty("Name", typeof(string), shadowProperty: true, concurrencyToken: true);
 
             var entityType2 = new EntityType("SomeDependentEntity");
             model.AddEntityType(entityType2);
-            var key2 = entityType2.AddProperty("Id", typeof(int), shadowProperty: true);
+            var key2 = entityType2.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false);
             entityType2.SetKey(key2);
-            var fk = entityType2.AddProperty("SomeEntityId", typeof(int), shadowProperty: true);
+            var fk = entityType2.AddProperty("SomeEntityId", typeof(int), shadowProperty: true, concurrencyToken: false);
             entityType2.AddForeignKey(entityType1.GetKey(), new[] { fk });
 
+            var entityType3 = new EntityType(typeof(FullNotificationEntity));
+            model.AddEntityType(entityType3);
+            entityType3.SetKey(entityType3.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityType3.AddProperty("Name", typeof(string), shadowProperty: true, concurrencyToken: true);
+
+            var entityType4 = new EntityType(typeof(ChangedOnlyEntity));
+            model.AddEntityType(entityType4);
+            entityType4.SetKey(entityType4.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityType4.AddProperty("Name", typeof(string), shadowProperty: true, concurrencyToken: true);
+            
             return model;
         }
     }

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateEntrySubscriberTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateEntrySubscriberTest.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Metadata;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.ChangeTracking
+{
+    public class StateEntrySubscriberTest
+    {
+        [Fact]
+        public void Snapshot_is_performed_when_not_using_eager_original_values()
+        {
+            var mockEntityType = new Mock<IEntityType>();
+            mockEntityType.Setup(m => m.UseLazyOriginalValues).Returns(false);
+
+            var entryMock = new Mock<StateEntry>();
+            entryMock.Setup(m => m.EntityType).Returns(mockEntityType.Object);
+
+            new StateEntrySubscriber().SnapshotAndSubscribe(entryMock.Object);
+
+            entryMock.Verify(m => m.SnapshotOriginalValues());
+        }
+
+        [Fact]
+        public void Snapshot_is_not_performed_when_not_using_lazy_original_values()
+        {
+            var mockEntityType = new Mock<IEntityType>();
+            mockEntityType.Setup(m => m.UseLazyOriginalValues).Returns(true);
+
+            var entryMock = new Mock<StateEntry>();
+            entryMock.Setup(m => m.EntityType).Returns(mockEntityType.Object);
+
+            new StateEntrySubscriber().SnapshotAndSubscribe(entryMock.Object);
+
+            entryMock.Verify(m => m.SnapshotOriginalValues(), Times.Never);
+        }
+
+        [Fact]
+        public void Entry_subscribes_to_INotifyPropertyChanging_and_INotifyPropertyChanged()
+        {
+            var entityType = new EntityType(typeof(FullNotificationEntity));
+            var property = entityType.AddProperty("Name", typeof(string));
+
+            var entity = new FullNotificationEntity();
+
+            var entryMock = new Mock<StateEntry>();
+            entryMock.Setup(m => m.EntityType).Returns(entityType);
+            entryMock.Setup(m => m.Entity).Returns(entity);
+
+            new StateEntrySubscriber().SnapshotAndSubscribe(entryMock.Object);
+
+            entity.Name = "George";
+
+            entryMock.Verify(m => m.PropertyChanging(property));
+            entryMock.Verify(m => m.PropertyChanged(property));
+        }
+
+        [Fact]
+        public void Subscriptions_to_INotifyPropertyChanging_and_INotifyPropertyChanged_ignore_unmapped_properties()
+        {
+            var entityType = new EntityType(typeof(FullNotificationEntity));
+            entityType.AddProperty("Name", typeof(string));
+
+            var entity = new FullNotificationEntity();
+
+            var entryMock = new Mock<StateEntry>();
+            entryMock.Setup(m => m.EntityType).Returns(entityType);
+            entryMock.Setup(m => m.Entity).Returns(entity);
+
+            new StateEntrySubscriber().SnapshotAndSubscribe(entryMock.Object);
+
+            entity.NotMapped = "Formby";
+
+            entryMock.Verify(m => m.PropertyChanging(It.IsAny<IProperty>()), Times.Never);
+            entryMock.Verify(m => m.PropertyChanged(It.IsAny<IProperty>()), Times.Never);
+        }
+
+        private class FullNotificationEntity : INotifyPropertyChanging, INotifyPropertyChanged
+        {
+            private string _name;
+
+            public string Name
+            {
+                get { return _name; }
+                set
+                {
+                    if (_name != value)
+                    {
+                        NotifyChanging();
+                        _name = value;
+                        NotifyChanged();
+                    }
+                }
+            }
+
+            private string _notMapped;
+
+            public string NotMapped
+            {
+                get { return _notMapped; }
+                set
+                {
+                    if (_notMapped != value)
+                    {
+                        NotifyChanging();
+                        _notMapped = value;
+                        NotifyChanged();
+                    }
+                }
+            }
+
+            public event PropertyChangingEventHandler PropertyChanging;
+            public event PropertyChangedEventHandler PropertyChanged;
+
+            private void NotifyChanged([CallerMemberName] String propertyName = "")
+            {
+                if (PropertyChanged != null)
+                {
+                    PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+                }
+            }
+
+            private void NotifyChanging([CallerMemberName] String propertyName = "")
+            {
+                if (PropertyChanging != null)
+                {
+                    PropertyChanging(this, new PropertyChangingEventArgs(propertyName));
+                }
+            }
+        }
+    }
+}

--- a/test/Microsoft.Data.Entity.Tests/EntityConfigurationBuilderTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/EntityConfigurationBuilderTest.cs
@@ -375,7 +375,7 @@ namespace Microsoft.Data.Entity.Tests
             // Should get overridden generator
             Assert.Same(
                 generator2,
-                configuration.IdentityGeneratorFactory.Create(new Property("Goo", typeof(int), shadowProperty: false)));
+                configuration.IdentityGeneratorFactory.Create(new Property("Goo", typeof(int))));
 
             customFactoryMock.Verify(m => m.Create(It.IsAny<IProperty>()), Times.Once);
             defaultFactoryMock.Verify(m => m.Create(It.IsAny<IProperty>()), Times.Never);
@@ -383,7 +383,7 @@ namespace Microsoft.Data.Entity.Tests
             // Should fall back to the service provider
             Assert.Same(
                 generator1,
-                configuration.IdentityGeneratorFactory.Create(new Property("Foo", typeof(int), shadowProperty: false)));
+                configuration.IdentityGeneratorFactory.Create(new Property("Foo", typeof(int))));
 
             customFactoryMock.Verify(m => m.Create(It.IsAny<IProperty>()), Times.Exactly(2));
             defaultFactoryMock.Verify(m => m.Create(It.IsAny<IProperty>()), Times.Once);

--- a/test/Microsoft.Data.Entity.Tests/EntityContextTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/EntityContextTest.cs
@@ -91,6 +91,36 @@ namespace Microsoft.Data.Entity.Tests
         }
 
         [Fact]
+        public void SaveChanges_calls_DetectChanges()
+        {
+            var configuration = new EntityConfigurationBuilder()
+                .UseStateManager<FakeStateManager>()
+                .BuildConfiguration();
+
+            using (var context = new EntityContext(configuration))
+            {
+                var stateManager = (FakeStateManager)context.Configuration.StateManager;
+                
+                Assert.False(stateManager.DetectChangesCalled);
+
+                context.SaveChanges();
+
+                Assert.True(stateManager.DetectChangesCalled);
+            }
+        }
+
+        private class FakeStateManager : StateManager
+        {
+            public bool DetectChangesCalled { get; set; }
+
+            public override bool DetectChanges()
+            {
+                DetectChangesCalled = true;
+                return false;
+            }
+        }
+
+        [Fact]
         public void Can_add_new_entities_to_context()
         {
             TrackEntitiesTest((c, e) => c.Add(e), (c, e) => c.Add(e), EntityState.Added);

--- a/test/Microsoft.Data.Entity.Tests/Metadata/ClrPropertyGetterSourceTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Metadata/ClrPropertyGetterSourceTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Delegate_getter_is_returned_for_IProperty_property()
         {
             var entityType = new EntityType(typeof(Customer));
-            var idProperty = entityType.AddProperty("Id", typeof(int), shadowProperty: false);
+            var idProperty = entityType.AddProperty("Id", typeof(int));
 
             Assert.Equal(7, new ClrPropertyGetterSource().GetAccessor(idProperty).GetClrValue(new Customer { Id = 7 }));
         }
@@ -38,7 +38,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Delegate_getter_is_cached_by_type_and_property_name()
         {
             var entityType = new EntityType(typeof(Customer));
-            var idProperty = entityType.AddProperty("Id", typeof(int), shadowProperty: false);
+            var idProperty = entityType.AddProperty("Id", typeof(int));
 
             var source = new ClrPropertyGetterSource();
 

--- a/test/Microsoft.Data.Entity.Tests/Metadata/ClrPropertySetterSourceTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Metadata/ClrPropertySetterSourceTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Delegate_setter_is_returned_for_IProperty_property()
         {
             var entityType = new EntityType(typeof(Customer));
-            var idProperty = entityType.AddProperty("Id", typeof(int), shadowProperty: false);
+            var idProperty = entityType.AddProperty("Id", typeof(int));
 
             var customer = new Customer { Id = 7 };
 
@@ -46,7 +46,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Delegate_setter_is_cached_by_type_and_property_name()
         {
             var entityType = new EntityType(typeof(Customer));
-            var idProperty = entityType.AddProperty("Id", typeof(int), shadowProperty: false);
+            var idProperty = entityType.AddProperty("Id", typeof(int));
 
             var source = new ClrPropertySetterSource();
 

--- a/test/Microsoft.Data.Entity.Tests/Metadata/EntityMaterializerSourceTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Metadata/EntityMaterializerSourceTest.cs
@@ -25,9 +25,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Can_create_materializer_for_entity()
         {
             var entityType = new EntityType(typeof(SomeEntity));
-            entityType.AddProperty("Id", typeof(int), shadowProperty: false);
-            entityType.AddProperty("Foo", typeof(string), shadowProperty: false);
-            entityType.AddProperty("Goo", typeof(Guid), shadowProperty: false);
+            entityType.AddProperty("Id", typeof(int));
+            entityType.AddProperty("Foo", typeof(string));
+            entityType.AddProperty("Goo", typeof(Guid));
 
             var factory = new EntityMaterializerSource().GetMaterializer(entityType);
 
@@ -43,9 +43,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void DBNulls_are_converted_to_nulls()
         {
             var entityType = new EntityType(typeof(SomeEntity));
-            entityType.AddProperty("Id", typeof(int), shadowProperty: false);
-            entityType.AddProperty("Foo", typeof(string), shadowProperty: false);
-            entityType.AddProperty("Goo", typeof(Guid?), shadowProperty: false);
+            entityType.AddProperty("Id", typeof(int));
+            entityType.AddProperty("Foo", typeof(string));
+            entityType.AddProperty("Goo", typeof(Guid?));
 
             var factory = new EntityMaterializerSource().GetMaterializer(entityType);
 
@@ -60,12 +60,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Can_create_materializer_for_entity_ignoring_shadow_fields()
         {
             var entityType = new EntityType(typeof(SomeEntity));
-            entityType.AddProperty("Id", typeof(int), shadowProperty: false);
-            entityType.AddProperty("IdShadow", typeof(int), shadowProperty: true);
-            entityType.AddProperty("Foo", typeof(string), shadowProperty: false);
-            entityType.AddProperty("FooShadow", typeof(string), shadowProperty: true);
-            entityType.AddProperty("Goo", typeof(Guid), shadowProperty: false);
-            entityType.AddProperty("GooShadow", typeof(Guid), shadowProperty: true);
+            entityType.AddProperty("Id", typeof(int));
+            entityType.AddProperty("IdShadow", typeof(int), shadowProperty: true, concurrencyToken: false);
+            entityType.AddProperty("Foo", typeof(string));
+            entityType.AddProperty("FooShadow", typeof(string), shadowProperty: true, concurrencyToken: false);
+            entityType.AddProperty("Goo", typeof(Guid));
+            entityType.AddProperty("GooShadow", typeof(Guid), shadowProperty: true, concurrencyToken: false);
 
             var factory = new EntityMaterializerSource().GetMaterializer(entityType);
 

--- a/test/Microsoft.Data.Entity.Tests/Metadata/ForeignKeyTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Metadata/ForeignKeyTest.cs
@@ -12,8 +12,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Can_create_foreign_key()
         {
             var entityType = new EntityType("E");
-            var dependentProp = entityType.AddProperty("P", typeof(int), shadowProperty: false);
-            var principalProp = entityType.AddProperty("Id", typeof(int), shadowProperty: false);
+            var dependentProp = entityType.AddProperty("P", typeof(int));
+            var principalProp = entityType.AddProperty("Id", typeof(int));
             entityType.SetKey(principalProp);
 
             var foreignKey
@@ -34,9 +34,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Can_create_foreign_key_with_non_pk_principal()
         {
             var entityType = new EntityType("E");
-            var keyProp = entityType.AddProperty("Id", typeof(int), shadowProperty: false);
-            var dependentProp = entityType.AddProperty("P", typeof(int), shadowProperty: false);
-            var principalProp = entityType.AddProperty("U", typeof(int), shadowProperty: false);
+            var keyProp = entityType.AddProperty("Id", typeof(int));
+            var dependentProp = entityType.AddProperty("P", typeof(int));
+            var principalProp = entityType.AddProperty("U", typeof(int));
             entityType.SetKey(keyProp);
 
             var foreignKey
@@ -57,8 +57,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void IsRequired_when_dependent_property_not_nullable()
         {
             var entityType = new EntityType("E");
-            entityType.SetKey(entityType.AddProperty("Id", typeof(int), shadowProperty: false));
-            var dependentProp = entityType.AddProperty("P", typeof(int), shadowProperty: false);
+            entityType.SetKey(entityType.AddProperty("Id", typeof(int)));
+            var dependentProp = entityType.AddProperty("P", typeof(int));
 
             var foreignKey = new ForeignKey(entityType.GetKey(), new[] { dependentProp });
 
@@ -69,8 +69,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void IsRequired_when_dependent_property_nullable()
         {
             var entityType = new EntityType("E");
-            entityType.SetKey(entityType.AddProperty("Id", typeof(int), shadowProperty: false));
-            var dependentProp = entityType.AddProperty("P", typeof(int?), shadowProperty: false);
+            entityType.SetKey(entityType.AddProperty("Id", typeof(int)));
+            var dependentProp = entityType.AddProperty("P", typeof(int?));
 
             var foreignKey = new ForeignKey(entityType.GetKey(), new[] { dependentProp });
 

--- a/test/Microsoft.Data.Entity.Tests/Metadata/ModelTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Metadata/ModelTest.cs
@@ -126,13 +126,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             public void Sort_simple()
             {
                 var entityTypeA = new EntityType(typeof(A));
-                entityTypeA.SetKey(entityTypeA.AddProperty("Id", typeof(int), shadowProperty: true));
+                entityTypeA.SetKey(entityTypeA.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
 
                 var entityTypeB = new EntityType(typeof(B));
-                entityTypeB.SetKey(entityTypeB.AddProperty("Id", typeof(int), shadowProperty: true));
+                entityTypeB.SetKey(entityTypeB.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
 
                 var entityTypeC = new EntityType(typeof(C));
-                entityTypeC.SetKey(entityTypeC.AddProperty("Id", typeof(int), shadowProperty: true));
+                entityTypeC.SetKey(entityTypeC.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
 
                 var model = new Model();
 
@@ -141,8 +141,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 model.AddEntityType(entityTypeC);
 
                 // B -> A -> C
-                entityTypeC.AddForeignKey(entityTypeA.GetKey(), entityTypeC.AddProperty("P", typeof(int), shadowProperty: false));
-                entityTypeA.AddForeignKey(entityTypeB.GetKey(), entityTypeA.AddProperty("P", typeof(int), shadowProperty: false));
+                entityTypeC.AddForeignKey(entityTypeA.GetKey(), entityTypeC.AddProperty("P", typeof(int)));
+                entityTypeA.AddForeignKey(entityTypeB.GetKey(), entityTypeA.AddProperty("P", typeof(int)));
 
                 Assert.Equal(
                     new IEntityType[] { entityTypeB, entityTypeA, entityTypeC },
@@ -153,13 +153,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             public void Sort_reverse()
             {
                 var entityTypeA = new EntityType(typeof(A));
-                entityTypeA.SetKey(entityTypeA.AddProperty("Id", typeof(int), shadowProperty: true));
+                entityTypeA.SetKey(entityTypeA.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
 
                 var entityTypeB = new EntityType(typeof(B));
-                entityTypeB.SetKey(entityTypeB.AddProperty("Id", typeof(int), shadowProperty: true));
+                entityTypeB.SetKey(entityTypeB.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
 
                 var entityTypeC = new EntityType(typeof(C));
-                entityTypeC.SetKey(entityTypeC.AddProperty("Id", typeof(int), shadowProperty: true));
+                entityTypeC.SetKey(entityTypeC.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
 
                 var model = new Model();
 
@@ -168,8 +168,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 model.AddEntityType(entityTypeC);
 
                 // C -> B -> A
-                entityTypeA.AddForeignKey(entityTypeB.GetKey(), entityTypeA.AddProperty("P", typeof(int), shadowProperty: false));
-                entityTypeB.AddForeignKey(entityTypeC.GetKey(), entityTypeB.AddProperty("P", typeof(int), shadowProperty: false));
+                entityTypeA.AddForeignKey(entityTypeB.GetKey(), entityTypeA.AddProperty("P", typeof(int)));
+                entityTypeB.AddForeignKey(entityTypeC.GetKey(), entityTypeB.AddProperty("P", typeof(int)));
 
                 Assert.Equal(
                     new IEntityType[] { entityTypeC, entityTypeB, entityTypeA },
@@ -180,13 +180,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             public void Sort_tree()
             {
                 var entityTypeA = new EntityType(typeof(A));
-                entityTypeA.SetKey(entityTypeA.AddProperty("Id", typeof(int), shadowProperty: true));
+                entityTypeA.SetKey(entityTypeA.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
 
                 var entityTypeB = new EntityType(typeof(B));
-                entityTypeB.SetKey(entityTypeB.AddProperty("Id", typeof(int), shadowProperty: true));
+                entityTypeB.SetKey(entityTypeB.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
 
                 var entityTypeC = new EntityType(typeof(C));
-                entityTypeC.SetKey(entityTypeC.AddProperty("Id", typeof(int), shadowProperty: true));
+                entityTypeC.SetKey(entityTypeC.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
 
                 var model = new Model();
 
@@ -195,9 +195,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 model.AddEntityType(entityTypeC);
 
                 // A -> B, C -> B
-                entityTypeB.AddForeignKey(entityTypeA.GetKey(), entityTypeB.AddProperty("P", typeof(int), shadowProperty: false));
-                entityTypeC.AddForeignKey(entityTypeA.GetKey(), entityTypeC.AddProperty("P", typeof(int), shadowProperty: false));
-                entityTypeB.AddForeignKey(entityTypeC.GetKey(), entityTypeB.AddProperty("P", typeof(int), shadowProperty: false));
+                entityTypeB.AddForeignKey(entityTypeA.GetKey(), entityTypeB.AddProperty("P", typeof(int)));
+                entityTypeC.AddForeignKey(entityTypeA.GetKey(), entityTypeC.AddProperty("P", typeof(int)));
+                entityTypeB.AddForeignKey(entityTypeC.GetKey(), entityTypeB.AddProperty("P", typeof(int)));
 
                 Assert.Equal(
                     new IEntityType[] { entityTypeA, entityTypeC, entityTypeB },
@@ -208,13 +208,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             public void Sort_no_edges()
             {
                 var entityTypeA = new EntityType(typeof(A));
-                entityTypeA.SetKey(entityTypeA.AddProperty("Id", typeof(int), shadowProperty: true));
+                entityTypeA.SetKey(entityTypeA.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
 
                 var entityTypeB = new EntityType(typeof(B));
-                entityTypeB.SetKey(entityTypeB.AddProperty("Id", typeof(int), shadowProperty: true));
+                entityTypeB.SetKey(entityTypeB.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
 
                 var entityTypeC = new EntityType(typeof(C));
-                entityTypeC.SetKey(entityTypeC.AddProperty("Id", typeof(int), shadowProperty: true));
+                entityTypeC.SetKey(entityTypeC.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
 
                 var model = new Model();
 
@@ -232,14 +232,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             public void Sort_self_ref()
             {
                 var entityTypeA = new EntityType(typeof(A));
-                entityTypeA.SetKey(entityTypeA.AddProperty("Id", typeof(int), shadowProperty: true));
+                entityTypeA.SetKey(entityTypeA.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
 
                 var model = new Model();
 
                 model.AddEntityType(entityTypeA);
 
                 // A -> A
-                entityTypeA.AddForeignKey(entityTypeA.GetKey(), entityTypeA.AddProperty("P", typeof(int), shadowProperty: false));
+                entityTypeA.AddForeignKey(entityTypeA.GetKey(), entityTypeA.AddProperty("P", typeof(int)));
 
                 Assert.Equal(
                     Strings.FormatCircularDependency("A -> A"),
@@ -250,10 +250,10 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             public void Sort_circular_direct()
             {
                 var entityTypeA = new EntityType(typeof(A));
-                entityTypeA.SetKey(entityTypeA.AddProperty("Id", typeof(int), shadowProperty: true));
+                entityTypeA.SetKey(entityTypeA.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
 
                 var entityTypeB = new EntityType(typeof(B));
-                entityTypeB.SetKey(entityTypeB.AddProperty("Id", typeof(int), shadowProperty: true));
+                entityTypeB.SetKey(entityTypeB.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
 
                 var model = new Model();
 
@@ -261,8 +261,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 model.AddEntityType(entityTypeB);
 
                 // A -> B -> A
-                entityTypeA.AddForeignKey(entityTypeB.GetKey(), entityTypeA.AddProperty("P", typeof(int), shadowProperty: false));
-                entityTypeB.AddForeignKey(entityTypeA.GetKey(), entityTypeB.AddProperty("P", typeof(int), shadowProperty: false));
+                entityTypeA.AddForeignKey(entityTypeB.GetKey(), entityTypeA.AddProperty("P", typeof(int)));
+                entityTypeB.AddForeignKey(entityTypeA.GetKey(), entityTypeB.AddProperty("P", typeof(int)));
 
                 Assert.Equal(
                     Strings.FormatCircularDependency("A -> B -> A"),
@@ -273,13 +273,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             public void Sort_circular_transitive()
             {
                 var entityTypeA = new EntityType(typeof(A));
-                entityTypeA.SetKey(entityTypeA.AddProperty("Id", typeof(int), shadowProperty: true));
+                entityTypeA.SetKey(entityTypeA.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
 
                 var entityTypeB = new EntityType(typeof(B));
-                entityTypeB.SetKey(entityTypeB.AddProperty("Id", typeof(int), shadowProperty: true));
+                entityTypeB.SetKey(entityTypeB.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
 
                 var entityTypeC = new EntityType(typeof(C));
-                entityTypeC.SetKey(entityTypeC.AddProperty("Id", typeof(int), shadowProperty: true));
+                entityTypeC.SetKey(entityTypeC.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
 
                 var model = new Model();
 
@@ -288,9 +288,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 model.AddEntityType(entityTypeC);
 
                 // A -> B -> C -> A
-                entityTypeA.AddForeignKey(entityTypeB.GetKey(), entityTypeA.AddProperty("P", typeof(int), shadowProperty: false));
-                entityTypeB.AddForeignKey(entityTypeC.GetKey(), entityTypeB.AddProperty("P", typeof(int), shadowProperty: false));
-                entityTypeC.AddForeignKey(entityTypeA.GetKey(), entityTypeC.AddProperty("P", typeof(int), shadowProperty: false));
+                entityTypeA.AddForeignKey(entityTypeB.GetKey(), entityTypeA.AddProperty("P", typeof(int)));
+                entityTypeB.AddForeignKey(entityTypeC.GetKey(), entityTypeB.AddProperty("P", typeof(int)));
+                entityTypeC.AddForeignKey(entityTypeA.GetKey(), entityTypeC.AddProperty("P", typeof(int)));
 
                 Assert.Equal(
                     Strings.FormatCircularDependency("A -> B -> C -> A"),

--- a/test/Microsoft.Data.Entity.Tests/Metadata/PropertyTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Metadata/PropertyTest.cs
@@ -32,13 +32,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(
                 "name",
                 // ReSharper disable once AssignNullToNotNullAttribute
-                Assert.Throws<ArgumentNullException>(() => new Property(null, null, shadowProperty: true)).ParamName);
+                Assert.Throws<ArgumentNullException>(() => new Property(null, null)).ParamName);
         }
 
         [Fact]
         public void Storage_name_defaults_to_name()
         {
-            var property = new Property("Name", typeof(string), shadowProperty: true);
+            var property = new Property("Name", typeof(string));
 
             Assert.Equal("Name", property.StorageName);
         }
@@ -46,7 +46,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         [Fact]
         public void Storage_name_can_be_different_from_name()
         {
-            var property = new Property("Name", typeof(string), shadowProperty: true)
+            var property = new Property("Name", typeof(string))
                 {
                     StorageName = "CustomerName"
                 };
@@ -57,7 +57,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         [Fact]
         public void Can_create_property_from_property_info()
         {
-            var property = new Property("Name", typeof(string), shadowProperty: true);
+            var property = new Property("Name", typeof(string));
 
             Assert.Equal("Name", property.Name);
             Assert.Same(typeof(string), property.PropertyType);
@@ -67,14 +67,27 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         [Fact]
         public void HasClrProperty_is_set_appropriately()
         {
-            Assert.True(new Property("Kake", typeof(int), shadowProperty: false).IsClrProperty);
-            Assert.False(new Property("Kake", typeof(int), shadowProperty: true).IsClrProperty);
+            Assert.True(new Property("Kake", typeof(int)).IsClrProperty);
+            Assert.True(new Property("Kake", typeof(int), shadowProperty: false, concurrencyToken: false).IsClrProperty);
+            Assert.False(new Property("Kake", typeof(int), shadowProperty: true, concurrencyToken: false).IsClrProperty);
+        }
+
+        [Fact]
+        public void Property_is_not_concurrency_token_by_default()
+        {
+            Assert.False(new Property("Name", typeof(string)).IsConcurrencyToken);
+        }
+
+        [Fact]
+        public void Can_mark_property_as_concurrency_token()
+        {
+            Assert.True(new Property("Name", typeof(string), shadowProperty: false, concurrencyToken: true).IsConcurrencyToken);
         }
 
         [Fact]
         public void Can_get_and_set_property_index_for_normal_property()
         {
-            var property = new Property("Kake", typeof(int), shadowProperty: false);
+            var property = new Property("Kake", typeof(int));
 
             Assert.Equal(0, property.Index);
             Assert.Equal(-1, property.ShadowIndex);
@@ -100,7 +113,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         [Fact]
         public void Can_get_and_set_property_and_shadow_index_for_shadow_property()
         {
-            var property = new Property("Kake", typeof(int), shadowProperty: true);
+            var property = new Property("Kake", typeof(int), shadowProperty: true, concurrencyToken: false);
 
             Assert.Equal(0, property.Index);
             Assert.Equal(0, property.ShadowIndex);

--- a/test/Microsoft.Data.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
+++ b/test/Microsoft.Data.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Data.InMemory.FunctionalTests
             var model = new Model();
 
             var customerType = new EntityType("Customer");
-            customerType.SetKey(customerType.AddProperty("Id", typeof(int), shadowProperty: true));
-            customerType.AddProperty("Name", typeof(string), shadowProperty: true);
+            customerType.SetKey(customerType.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            customerType.AddProperty("Name", typeof(string), shadowProperty: true, concurrencyToken: false);
 
             model.AddEntityType(customerType);
 
@@ -84,8 +84,8 @@ namespace Microsoft.Data.InMemory.FunctionalTests
             var model = new Model();
 
             var customerType = new EntityType(typeof(Customer));
-            customerType.SetKey(customerType.AddProperty("Id", typeof(int), shadowProperty: false));
-            customerType.AddProperty("Name", typeof(string), shadowProperty: true);
+            customerType.SetKey(customerType.AddProperty("Id", typeof(int), shadowProperty: false, concurrencyToken: false));
+            customerType.AddProperty("Name", typeof(string), shadowProperty: true, concurrencyToken: false);
 
             model.AddEntityType(customerType);
 

--- a/test/Microsoft.Data.Migrations.Tests/ModelDifferTest.cs
+++ b/test/Microsoft.Data.Migrations.Tests/ModelDifferTest.cs
@@ -46,8 +46,8 @@ namespace Microsoft.Data.Migrations.Tests
 
             var dependentEntityType = new EntityType("Dependent") { StorageName = "dbo.MyTable0" };
             var principalEntityType = new EntityType("Principal") { StorageName = "dbo.MyTable1" };
-            var dependentProperty = dependentEntityType.AddProperty("Id", typeof(int), shadowProperty: false);
-            var principalProperty = principalEntityType.AddProperty("Id", typeof(int), shadowProperty: false);
+            var dependentProperty = dependentEntityType.AddProperty("Id", typeof(int));
+            var principalProperty = principalEntityType.AddProperty("Id", typeof(int));
 
             model.AddEntityType(principalEntityType);
             model.AddEntityType(dependentEntityType);

--- a/test/Microsoft.Data.Relational.Tests/DatabaseBuilderTest.cs
+++ b/test/Microsoft.Data.Relational.Tests/DatabaseBuilderTest.cs
@@ -172,8 +172,8 @@ namespace Microsoft.Data.Relational.Tests
 
             var dependentEntityType = new EntityType("Dependent") { StorageName = "dbo.MyTable0" };
             var principalEntityType = new EntityType("Principal") { StorageName = "dbo.MyTable1" };
-            var dependentProperty = dependentEntityType.AddProperty("Id", typeof(int), shadowProperty: false);
-            var principalProperty = principalEntityType.AddProperty("Id", typeof(int), shadowProperty: false);
+            var dependentProperty = dependentEntityType.AddProperty("Id", typeof(int));
+            var principalProperty = principalEntityType.AddProperty("Id", typeof(int));
 
             model.AddEntityType(principalEntityType);
             model.AddEntityType(dependentEntityType);


### PR DESCRIPTION
We're watching you... (Add support for change detection)

This checkin adds support for original value tracking and change detection to state entries.

We need original values for two purposes:
- Use in the update pipeline for concurrency tokens and graph ordering
- Detecting changes when using snapshot change tracking

Also, original values can be stored eagerly (snapshotting when then entity is materialized) or lazily (only when an attempt is made to change the current value).

We attempt to not store original values when not needed and to store them lazily when possible. This is fully possible for entities that implement both INotifyPropertyChanging and INotifyPropertyChanged.

If an entity implements only INotifyPropertyChanged but not INotifyPropertyChanging then only original values for updates are tracked by default but they are tracked eagerly because we don't know that a change is being made until it has already been made.

If an entity doesn't implement INotifyPropertyChanged, then original values for all properties are tracked eagerly so that DetectChanges can compare current and original values.

A flag on the entity type allows eager tracking of all original values for those users who always want original values in order to implement things like rejecting changes to entities.
