### PR TITLE
Ensure objects in database model always have names

### DIFF
--- a/src/Microsoft.Data.Relational/Model/Database.cs
+++ b/src/Microsoft.Data.Relational/Model/Database.cs
@@ -9,21 +9,8 @@ namespace Microsoft.Data.Relational.Model
 {
     public class Database
     {
-        private readonly string _name;
         private readonly List<Sequence> _sequences = new List<Sequence>();
         private readonly List<Table> _tables = new List<Table>();
-
-        public Database([NotNull] string name)
-        {
-            Check.NotEmpty(name, "name");
-
-            _name = name;
-        }
-
-        public virtual string Name
-        {
-            get { return _name; }
-        }
 
         public virtual IReadOnlyList<Sequence> Sequences
         {

--- a/test/Microsoft.Data.Relational.Tests/DatabaseBuilderTest.cs
+++ b/test/Microsoft.Data.Relational.Tests/DatabaseBuilderTest.cs
@@ -1,7 +1,11 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Data.Entity.Metadata;
+using Moq;
 using Xunit;
+using Microsoft.Data.Relational.Model;
 
 namespace Microsoft.Data.Relational.Tests
 {
@@ -13,7 +17,6 @@ namespace Microsoft.Data.Relational.Tests
             var database = new DatabaseBuilder().Build(CreateModel());
 
             Assert.NotNull(database);
-            Assert.Equal("MyDatabase", database.Name);
             Assert.Equal(2, database.Tables.Count);
 
             var table0 = database.Tables[0];
@@ -45,6 +48,122 @@ namespace Microsoft.Data.Relational.Tests
             Assert.Same(table0.Columns[0], foreignKey.Columns[0]);
             Assert.Same(table1.Columns[0], foreignKey.ReferencedColumns[0]);
             Assert.True(foreignKey.CascadeDelete);
+        }
+
+        [Fact]
+        public void Build_fills_in_names_if_StorageName_not_specified()
+        {
+            // TODO: Add and Index when supported by DatabaseBuilder.
+            
+            // Using Moq because real types will fill in StorageName in some places
+            var blogEntity = new Mock<IEntityType>();
+            var blogProperty = new Mock<IProperty>();
+            var blogKey = new Mock<IKey>();
+
+            blogEntity.Setup(e => e.Name).Returns("Blog");
+            blogEntity.Setup(e => e.GetKey()).Returns(blogKey.Object);
+            blogEntity.Setup(e => e.Properties).Returns(new List<IProperty> { blogProperty.Object });
+            blogEntity.Setup(e => e.ForeignKeys).Returns(new List<IForeignKey>());
+            
+            blogProperty.Setup(e => e.Name).Returns("BlogId");
+            blogProperty.Setup(e => e.PropertyType).Returns(typeof(int));
+
+            blogKey.Setup(k => k.Properties).Returns(new List<IProperty> { blogProperty.Object });
+            blogKey.Setup(k => k.EntityType).Returns(blogEntity.Object);
+
+            var postEntity = new Mock<IEntityType>();
+            var postKeyProperty = new Mock<IProperty>();
+            var postKey = new Mock<IKey>();
+            var postForeignKeyProperty = new Mock<IProperty>();
+            var postForeignKey = new Mock<IForeignKey>();
+
+            postEntity.Setup(e => e.Name).Returns("Post");
+            postEntity.Setup(e => e.GetKey()).Returns(postKey.Object);
+            postEntity.Setup(e => e.Properties).Returns(new List<IProperty> { postKeyProperty.Object, postForeignKeyProperty.Object });
+            postEntity.Setup(e => e.ForeignKeys).Returns(new List<IForeignKey> { postForeignKey.Object });
+
+            postKeyProperty.Setup(e => e.Name).Returns("PostId");
+            postKeyProperty.Setup(e => e.PropertyType).Returns(typeof(int));
+
+            postForeignKeyProperty.Setup(e => e.Name).Returns("BelongsToBlogId");
+            postForeignKeyProperty.Setup(e => e.PropertyType).Returns(typeof(int));
+
+            postKey.Setup(k => k.Properties).Returns(new List<IProperty> { postKeyProperty.Object });
+            postKey.Setup(k => k.EntityType).Returns(postEntity.Object);
+
+            postForeignKey.Setup(f => f.EntityType).Returns(postEntity.Object);
+            postForeignKey.Setup(f => f.Properties).Returns(new List<IProperty> { postForeignKeyProperty.Object });
+            postForeignKey.Setup(f => f.ReferencedEntityType).Returns(blogEntity.Object);
+            postForeignKey.Setup(f => f.ReferencedProperties).Returns(new List<IProperty> { blogProperty.Object });
+
+            var model = new Mock<IModel>();
+            model.Setup(m => m.EntityTypes).Returns(new List<IEntityType> { blogEntity.Object, postEntity.Object });
+
+            // Ensure we have a valid test
+            Assert.Null(blogEntity.Object.StorageName);
+            Assert.Null(blogEntity.Object.GetKey().StorageName);
+            Assert.Null(blogEntity.Object.Properties.Single().StorageName);
+            Assert.Null(postEntity.Object.StorageName);
+            Assert.Null(postEntity.Object.GetKey().StorageName);
+            Assert.False(postEntity.Object.Properties.Any(p => p.StorageName != null));
+            Assert.Null(postEntity.Object.ForeignKeys.Single().StorageName);
+
+            var builder = new DatabaseBuilder();
+            var database = builder.Build(model.Object);
+
+            Assert.True(database.Tables.Any(t => t.Name == "Blog"));
+            Assert.True(database.Tables.Any(t => t.Name == "Post"));
+
+            Assert.Equal("BlogId", database.GetTable("Blog").Columns.Single().Name);
+            Assert.Equal("PostId", database.GetTable("Post").Columns[0].Name);
+            Assert.Equal("BelongsToBlogId", database.GetTable("Post").Columns[1].Name);
+
+            Assert.Equal("PK_Blog", database.GetTable("Blog").PrimaryKey.Name);
+            Assert.Equal("PK_Post", database.GetTable("Post").PrimaryKey.Name);
+
+            Assert.Equal("FK_Post_Blog_BelongsToBlogId", database.GetTable("Post").ForeignKeys.Single().Name);
+        }
+
+        [Fact]
+        public void Name_for_multi_column_FKs()
+        {
+            var principalEntity = new Mock<IEntityType>();
+            var dependentEntity = new Mock<IEntityType>();
+            var fkPropertyOne = new Mock<IProperty>();
+            var fkPropertyTwo = new Mock<IProperty>();
+            var foreignKey = new Mock<IForeignKey>();
+
+            principalEntity.Setup(e => e.Name).Returns("Principal");
+
+            dependentEntity.Setup(e => e.Name).Returns("Dependent");
+
+            fkPropertyOne.Setup(e => e.Name).Returns("FkZZZ");
+            fkPropertyOne.Setup(e => e.PropertyType).Returns(typeof(int));
+
+            fkPropertyTwo.Setup(e => e.Name).Returns("FkAAA");
+            fkPropertyTwo.Setup(e => e.PropertyType).Returns(typeof(int));
+
+            foreignKey.Setup(f => f.EntityType).Returns(dependentEntity.Object);
+            foreignKey.Setup(f => f.Properties).Returns(new List<IProperty> { fkPropertyOne.Object, fkPropertyTwo.Object });
+            foreignKey.Setup(f => f.ReferencedEntityType).Returns(principalEntity.Object);
+
+            var builder = new DatabaseBuilder();
+            var name = builder.ForeignKeyName(foreignKey.Object);
+
+            Assert.Equal("FK_Dependent_Principal_FkAAA_FkZZZ", name);
+        }
+
+        [Fact]
+        public void Name_for_multi_column_Indexes()
+        {
+            var table = new Table("MyTable");
+            var columnOne = new Column("ColumnZzz", "int");
+            var columnTwo = new Column("ColumnAaa", "int");
+            
+            var builder = new DatabaseBuilder();
+            var name = builder.IndexName(table, new List<Column>{ columnOne, columnTwo });
+
+            Assert.Equal("IX_MyTable_ColumnAaa_ColumnZzz", name);
         }
 
         private static IModel CreateModel()

--- a/test/Microsoft.Data.Relational.Tests/Model/DatabaseTest.cs
+++ b/test/Microsoft.Data.Relational.Tests/Model/DatabaseTest.cs
@@ -11,15 +11,15 @@ namespace Microsoft.Data.Relational.Tests.Model
         [Fact]
         public void Create_and_initialize_database()
         {
-            var database = new Database("MyDatabase");
+            var database = new Database();
 
-            Assert.Equal("MyDatabase", database.Name);
+            Assert.NotNull(database.Tables);
         }
 
         [Fact]
         public void Sequences_gets_read_only_list_of_sequences()
         {
-            var database = new Database("MyDatabase");
+            var database = new Database();
             var sequence0 = new Sequence("dbo.MySequence0");
             var sequence1 = new Sequence("dbo.MySequence1");
 
@@ -35,7 +35,7 @@ namespace Microsoft.Data.Relational.Tests.Model
         [Fact]
         public void AddSequence_adds_specified_sequence()
         {
-            var database = new Database("MyDatabase");
+            var database = new Database();
 
             Assert.Equal(0, database.Sequences.Count);
 
@@ -50,7 +50,7 @@ namespace Microsoft.Data.Relational.Tests.Model
         [Fact]
         public void GetSequence_finds_sequence_by_name()
         {
-            var database = new Database("MyDatabase");
+            var database = new Database();
             var sequence0 = new Sequence("dbo.MySequence0");
             var sequence1 = new Sequence("dbo.MySequence1");
 
@@ -64,7 +64,7 @@ namespace Microsoft.Data.Relational.Tests.Model
         [Fact]
         public void Tables_gets_read_only_list_of_tables()
         {
-            var database = new Database("MyDatabase");
+            var database = new Database();
             var table0 = new Table("dbo.MyTable0");
             var table1 = new Table("dbo.MyTable1");
 
@@ -80,7 +80,7 @@ namespace Microsoft.Data.Relational.Tests.Model
         [Fact]
         public void AddTable_adds_specified_table()
         {
-            var database = new Database("MyDatabase");
+            var database = new Database();
 
             Assert.Equal(0, database.Tables.Count);
 
@@ -95,7 +95,7 @@ namespace Microsoft.Data.Relational.Tests.Model
         [Fact]
         public void GetTable_finds_table_by_name()
         {
-            var database = new Database("MyDatabase");
+            var database = new Database();
             var table0 = new Table("dbo.MyTable0");
             var table1 = new Table("dbo.MyTable1");
 


### PR DESCRIPTION
Adding logic to calculate default names of objects that do not have a
StorageName specified in the IModel.
Made them instance methods on DatabaseBuilder (had to swap some other
methods to be instance as well) so that you could derive from
DatabaseBuilder and change the default naming.
Also removed the Name property from Database since we don't always know
the database name when creating a Database model (i.e. scripting etc.) -
we weren't using the name anywhere.
