### PR TITLE
PushingBack - enabling propagating store generated values

### DIFF
--- a/src/Microsoft.Data.Relational/ApiExtensions.cs
+++ b/src/Microsoft.Data.Relational/ApiExtensions.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Relational;
+using Microsoft.Data.Relational.Model;
 using Microsoft.Data.Relational.Utilities;
 
 namespace Microsoft.Data.Entity.Metadata
@@ -118,6 +121,15 @@ namespace Microsoft.Data.Entity.Metadata
             }
 
             return cascadeDelete;
+        }
+
+        public static IEnumerable<Column> GetStoreGeneratedColumns([NotNull] this Table table)
+        {
+            Check.NotNull(table, "table");
+
+            return table.Columns.Where(
+                c => c.ValueGenerationStrategy == StoreValueGenerationStrategy.Identity ||
+                     c.ValueGenerationStrategy == StoreValueGenerationStrategy.Computed);
         }
     }
 }

--- a/src/Microsoft.Data.Relational/DatabaseBuilder.cs
+++ b/src/Microsoft.Data.Relational/DatabaseBuilder.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Data.Relational
                     IsNullable = property.IsNullable,
                     DefaultValue = property.ColumnDefaultValue(),
                     DefaultSql = property.ColumnDefaultSql(),
-                    GenerationStrategy = TranslateValueGenerationStrategy(property.ValueGenerationStrategy)
+                    ValueGenerationStrategy = TranslateValueGenerationStrategy(property.ValueGenerationStrategy)
                 });
         }
 

--- a/src/Microsoft.Data.Relational/Model/Column.cs
+++ b/src/Microsoft.Data.Relational/Model/Column.cs
@@ -64,6 +64,6 @@ namespace Microsoft.Data.Relational.Model
 
         public virtual string DefaultSql { get; [param: CanBeNull] set; }
 
-        public virtual StoreValueGenerationStrategy GenerationStrategy { get; set; }
+        public virtual StoreValueGenerationStrategy ValueGenerationStrategy { get; set; }
     }
 }

--- a/src/Microsoft.Data.Relational/Properties/Strings.Designer.cs
+++ b/src/Microsoft.Data.Relational/Properties/Strings.Designer.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Data.Relational
         }
 
         /// <summary>
-        /// Update failed. Expected rows affected '{expectedRowsAffected}'. Actual rows affected '{actualRowsAffected}'.
+        /// Update failed. Expected {expectedRows} row(s) but {actualRows} row(s) returned.
         /// </summary>
         internal static string UpdateConcurrencyException
         {
@@ -83,11 +83,75 @@ namespace Microsoft.Data.Relational
         }
 
         /// <summary>
-        /// Update failed. Expected rows affected '{expectedRowsAffected}'. Actual rows affected '{actualRowsAffected}'.
+        /// Update failed. Expected {expectedRows} row(s) but {actualRows} row(s) returned.
         /// </summary>
-        internal static string FormatUpdateConcurrencyException(object expectedRowsAffected, object actualRowsAffected)
+        internal static string FormatUpdateConcurrencyException(object expectedRows, object actualRows)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("UpdateConcurrencyException", "expectedRowsAffected", "actualRowsAffected"), expectedRowsAffected, actualRowsAffected);
+            return string.Format(CultureInfo.CurrentCulture, GetString("UpdateConcurrencyException", "expectedRows", "actualRows"), expectedRows, actualRows);
+        }
+
+        /// <summary>
+        /// Propagating results failed. The table '{tableName}' has no columns with store generated values but store generated values were returned by a modification command.
+        /// </summary>
+        internal static string NoStoreGenColumnsToPropagateResults
+        {
+            get { return GetString("NoStoreGenColumnsToPropagateResults"); }
+        }
+
+        /// <summary>
+        /// Propagating results failed. The table '{tableName}' has no columns with store generated values but store generated values were returned by a modification command.
+        /// </summary>
+        internal static string FormatNoStoreGenColumnsToPropagateResults(object tableName)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("NoStoreGenColumnsToPropagateResults", "tableName"), tableName);
+        }
+
+        /// <summary>
+        /// Propagating results failed. The table '{tableName}' has columns with store generated values but no store generated values were returned by a modification command.
+        /// </summary>
+        internal static string ResultsNotPropagatedForStoreGenColumns
+        {
+            get { return GetString("ResultsNotPropagatedForStoreGenColumns"); }
+        }
+
+        /// <summary>
+        /// Propagating results failed. The table '{tableName}' has columns with store generated values but no store generated values were returned by a modification command.
+        /// </summary>
+        internal static string FormatResultsNotPropagatedForStoreGenColumns(object tableName)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ResultsNotPropagatedForStoreGenColumns", "tableName"), tableName);
+        }
+
+        /// <summary>
+        /// A modification command returned more than one row. Each modification command must return at most one row.
+        /// </summary>
+        internal static string TooManyRowsForModificationCommand
+        {
+            get { return GetString("TooManyRowsForModificationCommand"); }
+        }
+
+        /// <summary>
+        /// A modification command returned more than one row. Each modification command must return at most one row.
+        /// </summary>
+        internal static string FormatTooManyRowsForModificationCommand()
+        {
+            return GetString("TooManyRowsForModificationCommand");
+        }
+
+        /// <summary>
+        /// Store generated values has already been saved for this command.
+        /// </summary>
+        internal static string StoreGenValuesSavedMultipleTimesForCommand
+        {
+            get { return GetString("StoreGenValuesSavedMultipleTimesForCommand"); }
+        }
+
+        /// <summary>
+        /// Store generated values has already been saved for this command.
+        /// </summary>
+        internal static string FormatStoreGenValuesSavedMultipleTimesForCommand()
+        {
+            return GetString("StoreGenValuesSavedMultipleTimesForCommand");
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/Microsoft.Data.Relational/Properties/Strings.resx
+++ b/src/Microsoft.Data.Relational/Properties/Strings.resx
@@ -130,6 +130,18 @@
     <value>Can not create a ModificationFunction for an entity in state '{entityState}'.</value>
   </data>
   <data name="UpdateConcurrencyException" xml:space="preserve">
-    <value>Update failed. Expected rows affected '{expectedRowsAffected}'. Actual rows affected '{actualRowsAffected}'.</value>
+    <value>Update failed. Expected {expectedRows} row(s) but {actualRows} row(s) returned.</value>
+  </data>
+  <data name="NoStoreGenColumnsToPropagateResults" xml:space="preserve">
+    <value>Propagating results failed. The table '{tableName}' has no columns with store generated values but store generated values were returned by a modification command.</value>
+  </data>
+  <data name="ResultsNotPropagatedForStoreGenColumns" xml:space="preserve">
+    <value>Propagating results failed. The table '{tableName}' has columns with store generated values but no store generated values were returned by a modification command.</value>
+  </data>
+  <data name="TooManyRowsForModificationCommand" xml:space="preserve">
+    <value>A modification command returned more than one row. Each modification command must return at most one row.</value>
+  </data>
+  <data name="StoreGenValuesSavedMultipleTimesForCommand" xml:space="preserve">
+    <value>Store generated values has already been saved for this command.</value>
   </data>
 </root>

--- a/src/Microsoft.Data.Relational/RelationalDataStore.cs
+++ b/src/Microsoft.Data.Relational/RelationalDataStore.cs
@@ -59,6 +59,9 @@ namespace Microsoft.Data.Relational
 
                 var executor = new BatchExecutor(commands, SqlGenerator);
                 await executor.ExecuteAsync(connection, cancellationToken);
+
+                // TODO: this should happen when the transaction is being commited
+                executor.PropagateResults();
             }
 
             // TODO Return the actual results once we can get them

--- a/src/Microsoft.Data.SqlServer/SqlServerSqlGenerator.cs
+++ b/src/Microsoft.Data.SqlServer/SqlServerSqlGenerator.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Linq;
 using System.Text;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Relational;
 using Microsoft.Data.Relational.Model;
 using Microsoft.Data.SqlServer.Utilities;
@@ -23,7 +24,7 @@ namespace Microsoft.Data.SqlServer
             KeyValuePair<Column, string>[] columnsToParameters)
         {
             var dbGeneratedNonIdentityKeys = 
-                table.PrimaryKey.Columns.Where(c => c.GenerationStrategy == StoreValueGenerationStrategy.Computed);
+                table.PrimaryKey.Columns.Where(c => c.ValueGenerationStrategy == StoreValueGenerationStrategy.Computed);
 
             if (dbGeneratedNonIdentityKeys.Any())
             {
@@ -54,7 +55,7 @@ namespace Microsoft.Data.SqlServer
 
                 commandStringBuilder
                     .Append("SELECT ")
-                    .AppendJoin(GetStoreGeneratedColumns(table), (sb, c) => sb.Append("t.").Append(c.Name), ", ");
+                    .AppendJoin(table.GetStoreGeneratedColumns(), (sb, c) => sb.Append("t.").Append(c.Name), ", ");
 
                 commandStringBuilder
                     .Append(" FROM ")
@@ -77,10 +78,10 @@ namespace Microsoft.Data.SqlServer
             Check.NotNull(storeGeneratedKeyColumns, "storeGeneratedKeyColumns");
 
             Contract.Assert(
-                storeGeneratedKeyColumns.All(k => k.GenerationStrategy == StoreValueGenerationStrategy.Identity),
+                storeGeneratedKeyColumns.All(k => k.ValueGenerationStrategy == StoreValueGenerationStrategy.Identity),
                 "Non-identity store generated keys should be handled elsewhere");
 
-            return storeGeneratedKeyColumns.Where(k => k.GenerationStrategy == StoreValueGenerationStrategy.Identity)
+            return storeGeneratedKeyColumns.Where(k => k.ValueGenerationStrategy == StoreValueGenerationStrategy.Identity)
                 .Select(k => new KeyValuePair<Column, string>(k, "scope_identity()"));
         }
 

--- a/test/Microsoft.Data.Relational.Tests/DatabaseBuilderTest.cs
+++ b/test/Microsoft.Data.Relational.Tests/DatabaseBuilderTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Data.Relational.Tests
             Assert.Equal(1, table0.Columns.Count);
             Assert.Equal("Id", table0.Columns[0].Name);
             Assert.Equal("int", table0.Columns[0].DataType);
-            Assert.Equal(StoreValueGenerationStrategy.None, table0.Columns[0].GenerationStrategy);
+            Assert.Equal(StoreValueGenerationStrategy.None, table0.Columns[0].ValueGenerationStrategy);
             Assert.NotNull(table1.PrimaryKey.Name);
             Assert.Equal("MyPK0", table0.PrimaryKey.Name);
             Assert.Same(table0.Columns[0], table0.PrimaryKey.Columns[0]);
@@ -37,7 +37,7 @@ namespace Microsoft.Data.Relational.Tests
             Assert.Equal(1, table1.Columns.Count);
             Assert.Equal("Id", table1.Columns[0].Name);
             Assert.Equal("int", table1.Columns[0].DataType);
-            Assert.Equal(StoreValueGenerationStrategy.Identity, table1.Columns[0].GenerationStrategy);
+            Assert.Equal(StoreValueGenerationStrategy.Identity, table1.Columns[0].ValueGenerationStrategy);
             Assert.NotNull(table1.PrimaryKey.Name);
             Assert.Equal("MyPK1", table1.PrimaryKey.Name);
             Assert.Same(table1.Columns[0], table1.PrimaryKey.Columns[0]);

--- a/test/Microsoft.Data.Relational.Tests/MetadataExtensionsTest.cs
+++ b/test/Microsoft.Data.Relational.Tests/MetadataExtensionsTest.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Relational.Model;
 using Xunit;
 
 namespace Microsoft.Data.Relational.Tests
@@ -48,6 +50,27 @@ namespace Microsoft.Data.Relational.Tests
             modelBuilder.Entity<Customer>().Properties(ps => ps.Property(c => c.Id).ColumnType("bigint"));
 
             Assert.Equal("bigint", model.EntityTypes.Single().Properties.Single()[MetadataExtensions.Annotations.StorageTypeName]);
+        }
+
+        [Fact]
+        public void GetStoreGeneratedColumns_returns_store_generated_columns()
+        {
+            var table = new Table("table", 
+                new[]
+                    {
+                        new Column("Id", "storetype") { ValueGenerationStrategy = StoreValueGenerationStrategy.Identity },
+                        new Column("Name", "_"), 
+                        new Column("LastUpdate", "_") { ValueGenerationStrategy = StoreValueGenerationStrategy.Computed }
+                    });
+
+            Assert.Equal(table.Columns.Where(c => c.Name != "Name"), table.GetStoreGeneratedColumns());
+        }
+
+        [Fact]
+        public void GetStoreGeneratedColumns_validates_parameter_not_null()
+        {
+            Assert.Equal("table",
+                Assert.Throws<ArgumentNullException>(() => MetadataExtensions.GetStoreGeneratedColumns(null)).ParamName);
         }
     }
 }

--- a/test/Microsoft.Data.Relational.Tests/SqlGeneratorTest.cs
+++ b/test/Microsoft.Data.Relational.Tests/SqlGeneratorTest.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Data.Relational.Tests
                     {
                         new Column("Id", "storetype"),
                         new Column("Name", "_"),
-                        new Column("Timestamp", "_") { GenerationStrategy = StoreValueGenerationStrategy.Computed }
+                        new Column("Timestamp", "_") { ValueGenerationStrategy = StoreValueGenerationStrategy.Computed }
                     });
             table.PrimaryKey = new PrimaryKey("PK", table.Columns.Where(c => c.Name == "Id").ToArray());
 
@@ -204,7 +204,7 @@ namespace Microsoft.Data.Relational.Tests
             var table = new Table("table",
                 new[]
                     {
-                        new Column("Id", "storetype") { GenerationStrategy = StoreValueGenerationStrategy.Computed}, 
+                        new Column("Id", "storetype") { ValueGenerationStrategy = StoreValueGenerationStrategy.Computed}, 
                         new Column("Name", "_")
                     });
             table.PrimaryKey = new PrimaryKey("PK", table.Columns.Where(c => c.Name == "Id").ToArray());
@@ -280,7 +280,7 @@ namespace Microsoft.Data.Relational.Tests
                     {
                         new Column("Id", "storetype"), 
                         new Column("Name", "_"), 
-                        new Column("LastUpdate", "_") { GenerationStrategy = StoreValueGenerationStrategy.Computed }
+                        new Column("LastUpdate", "_") { ValueGenerationStrategy = StoreValueGenerationStrategy.Computed }
                     });
 
             table.PrimaryKey = new PrimaryKey("PK", table.Columns.Where(c => c.Name == "Id").ToArray());

--- a/test/Microsoft.Data.Relational.Tests/Update/BatchExecutorTest.cs
+++ b/test/Microsoft.Data.Relational.Tests/Update/BatchExecutorTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
@@ -28,7 +29,7 @@ namespace Microsoft.Data.Relational.Tests.Update
 
             var executor = new BatchExecutor(new[] { batch }, new Mock<SqlGenerator> { CallBase = true }.Object);
 
-            var connection = SetupMockConnection(1);
+            var connection = SetupMockConnection(SetupMockDataReader(1).Object);
 
             await executor.ExecuteAsync(connection, CancellationToken.None);
 
@@ -42,25 +43,105 @@ namespace Microsoft.Data.Relational.Tests.Update
         }
 
         [Fact]
-        public async void ExecuteAsync_throws_if_records_affected_and_command_count_dont_match()
+        public async void ExecuteAsync_saves_store_generated_values()
         {
             var mockModificationCommand = new Mock<ModificationCommand>();
             mockModificationCommand.Setup(c => c.Table).Returns(new Table("table"));
             mockModificationCommand.Setup(c => c.ColumnValues)
                 .Returns(new[] { new KeyValuePair<Column, object>(new Column("Id", "_"), 1) });
             mockModificationCommand.Setup(c => c.WhereClauses).Returns(new KeyValuePair<Column, object>[0]);
+            mockModificationCommand.Setup(c => c.RequiresResultPropagation).Returns(true);
+
+            var mockBatch = 
+                new Mock<ModificationCommandBatch>(
+                    new object[] { new[] { mockModificationCommand.Object } }) 
+                    { CallBase = true };
+
+            var executor = new BatchExecutor(new[] { mockBatch.Object }, new Mock<SqlGenerator> { CallBase = true }.Object);
+
+            var connection =
+                SetupMockConnection(
+                    SetupMockDataReader(1, new[] { "Id" }, new List<object[]> { new object[] { 42 } }).Object);
+
+            await executor.ExecuteAsync(connection, CancellationToken.None);
+
+            mockBatch.Verify(m => m.SaveStoreGeneratedValues(0,
+                It.Is<KeyValuePair<string, object>[]>(
+                    values => values.Length == 1 && values[0].Key == "Id" && (int)values[0].Value == 42)));
+        }
+
+        [Fact]
+        public async void Exception_thrown_for_more_than_one_row_returned_for_single_command()
+        {
+            var mockModificationCommand = new Mock<ModificationCommand>();
+            mockModificationCommand.Setup(c => c.Table).Returns(new Table("table"));
+            mockModificationCommand.Setup(c => c.ColumnValues)
+                .Returns(new[] { new KeyValuePair<Column, object>(new Column("Id", "_"), 1) });
+            mockModificationCommand.Setup(c => c.WhereClauses).Returns(new KeyValuePair<Column, object>[0]);
+            mockModificationCommand.Setup(c => c.RequiresResultPropagation).Returns(true);
 
             var batch = new ModificationCommandBatch(new[] { mockModificationCommand.Object });
 
             var executor = new BatchExecutor(new[] { batch }, new Mock<SqlGenerator> { CallBase = true }.Object);
 
-            Assert.Equal(
-                Strings.FormatUpdateConcurrencyException(1, 0),
-                (await Assert.ThrowsAsync<DbUpdateConcurrencyException>(async () =>
-                    await executor.ExecuteAsync(SetupMockConnection(0), CancellationToken.None))).Message);
+            var connection =
+                SetupMockConnection(
+                    SetupMockDataReader(1, new[] { "Id" }, new List<object[]>
+                        {
+                            new object[] { 42 },
+                            new object[] { -42 }
+                        }).Object);
+
+            Assert.Equal(Strings.TooManyRowsForModificationCommand,
+                (await Assert.ThrowsAsync<DbUpdateException>(
+                    async () => await executor.ExecuteAsync(connection, CancellationToken.None))).Message);
         }
 
-        private DbConnection SetupMockConnection(int recordsAffected)
+        [Fact]
+        public async void Exception_thrown_if_rows_returned_for_command_without_store_generated_values()
+        {
+            var mockModificationCommand = new Mock<ModificationCommand>();
+            mockModificationCommand.Setup(c => c.Table).Returns(new Table("table"));
+            mockModificationCommand.Setup(c => c.ColumnValues)
+                .Returns(new[] { new KeyValuePair<Column, object>(new Column("Id", "_"), 1) });
+            mockModificationCommand.Setup(c => c.WhereClauses).Returns(new KeyValuePair<Column, object>[0]);
+            mockModificationCommand.Setup(c => c.RequiresResultPropagation).Returns(false);
+
+            var batch = new ModificationCommandBatch(new[] { mockModificationCommand.Object });
+
+            var executor = new BatchExecutor(new[] { batch }, new Mock<SqlGenerator> { CallBase = true }.Object);
+
+            var connection =
+                SetupMockConnection(
+                    SetupMockDataReader(1, new[] { "Id" }, new List<object[]> { new object[] { 42 } }).Object);
+
+            Assert.Equal(Strings.FormatUpdateConcurrencyException(0, 1),
+                (await Assert.ThrowsAsync<DbUpdateConcurrencyException>(
+                    async () => await executor.ExecuteAsync(connection, CancellationToken.None))).Message);
+        }
+
+        [Fact]
+        public async void Exception_thrown_if_no_rows_returned_for_command_with_store_generated_values()
+        {
+            var mockModificationCommand = new Mock<ModificationCommand>();
+            mockModificationCommand.Setup(c => c.Table).Returns(new Table("table"));
+            mockModificationCommand.Setup(c => c.ColumnValues)
+                .Returns(new[] { new KeyValuePair<Column, object>(new Column("Id", "_"), 1) });
+            mockModificationCommand.Setup(c => c.WhereClauses).Returns(new KeyValuePair<Column, object>[0]);
+            mockModificationCommand.Setup(c => c.RequiresResultPropagation).Returns(true);
+
+            var batch = new ModificationCommandBatch(new[] { mockModificationCommand.Object });
+
+            var executor = new BatchExecutor(new[] { batch }, new Mock<SqlGenerator> { CallBase = true }.Object);
+
+            var connection = SetupMockConnection(SetupMockDataReader(0).Object);
+
+            Assert.Equal(Strings.FormatUpdateConcurrencyException(1, 0),
+                (await Assert.ThrowsAsync<DbUpdateConcurrencyException>(
+                    async () => await executor.ExecuteAsync(connection, CancellationToken.None))).Message);
+        }
+
+        private DbConnection SetupMockConnection(DbDataReader dataReader)
         {
             var mockConnection = new Mock<DbConnection>();
             var mockCommand = new Mock<DbCommand>();
@@ -77,12 +158,8 @@ namespace Microsoft.Data.Relational.Tests.Update
                 .SetupGet<DbParameterCollection>("DbParameterCollection")
                 .Returns(Mock.Of<DbParameterCollection>());
 
-            var mockDataReader = new Mock<DbDataReader>();
-            mockDataReader
-                .Setup(r => r.RecordsAffected)
-                .Returns(recordsAffected);
             var tcs = new TaskCompletionSource<DbDataReader>();
-            tcs.SetResult(mockDataReader.Object);
+            tcs.SetResult(dataReader);
 
             mockCommand
                 .Protected()
@@ -90,6 +167,36 @@ namespace Microsoft.Data.Relational.Tests.Update
                 .Returns(tcs.Task);
 
             return mockConnection.Object;
+        }
+
+        private static Mock<DbDataReader> SetupMockDataReader(int recordsAffected, string[] columnNames = null, IList<object[]> results = null)
+        {
+            var mockDataReader = new Mock<DbDataReader>();
+            mockDataReader
+                .Setup(r => r.RecordsAffected)
+                .Returns(recordsAffected);
+
+            if (results != null && columnNames != null)
+            {
+                var rowIndex = 0;
+                object[] currentRow = null;
+
+                mockDataReader.Setup(r => r.FieldCount).Returns(columnNames.Length);
+                mockDataReader.Setup(r => r.GetName(It.IsAny<int>())).Returns((int columnIdx) => columnNames[columnIdx]);
+                mockDataReader.Setup(r => r.GetValue(It.IsAny<int>())).Returns((int columnIdx) => currentRow[columnIdx]);
+
+                mockDataReader
+                    .Setup(r => r.ReadAsync(It.IsAny<CancellationToken>()))
+                    .Callback(() => currentRow = rowIndex < results.Count ? results[rowIndex++] : null)
+                    .Returns(() =>
+                        {
+                            var tcs = new TaskCompletionSource<bool>();
+                            tcs.SetResult(currentRow != null);
+                            return tcs.Task;
+                        });
+            }
+
+            return mockDataReader;
         }
     }
 }

--- a/test/Microsoft.Data.Relational.Tests/Update/ModificationCommandBatchTest.cs
+++ b/test/Microsoft.Data.Relational.Tests/Update/ModificationCommandBatchTest.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -34,9 +35,12 @@ namespace Microsoft.Data.Relational.Tests.Update
         [Fact]
         public void CompileBatch_compiles_updates()
         {
+            var id1Column = new Column("Id1", "int") { ValueGenerationStrategy = StoreValueGenerationStrategy.Identity };
+            var table = new Table("Table", new[] { id1Column }) { PrimaryKey = new PrimaryKey("PK", new[] { id1Column }) };
+
             var batch =
                 CreateCommandBatch(
-                    new Table("Table"),
+                    table,
                     new Dictionary<Column, object> { { new Column("Name", "_"), "Test" } }.ToArray(),
                     new Dictionary<Column, object>
                         {
@@ -80,6 +84,74 @@ namespace Microsoft.Data.Relational.Tests.Update
             var sql = batch.CompileBatch(new Mock<SqlGenerator> { CallBase = true }.Object, out parameters);
 
             Assert.True(sql.StartsWith("DELETE"));
+        }
+
+        [Fact]
+        public void Cannot_save_store_generated_results_multiple_times()
+        {
+            var mockCommand = new Mock<ModificationCommand>();
+            mockCommand.Setup(c => c.RequiresResultPropagation).Returns(true);
+
+            var batch = new ModificationCommandBatch(new[] { mockCommand.Object });
+            batch.SaveStoreGeneratedValues(0, new KeyValuePair<string, object>[0]);
+
+            Assert.Equal(Strings.StoreGenValuesSavedMultipleTimesForCommand,
+                Assert.Throws<InvalidOperationException>(
+                    () => batch.SaveStoreGeneratedValues(0, new KeyValuePair<string, object>[0])).Message);
+        }
+
+        [Fact]
+        public void SaveStoreGeneratedValues_validates_parameter()
+        {
+            Assert.Equal("storeGeneratedValues",
+                Assert.Throws<ArgumentNullException>(
+                    () => new ModificationCommandBatch(new ModificationCommand[1])
+                        .SaveStoreGeneratedValues(0, null)).ParamName);
+        }
+
+        [Fact]
+        public void Propagate_results_propagates_results_for_commands()
+        {
+            var mockCommand1 = new Mock<ModificationCommand>();
+            mockCommand1.Setup(c => c.RequiresResultPropagation).Returns(true);
+            var values1 = new[] { new KeyValuePair<string, object>("Col1", 42) };
+
+            var mockCommand2 = new Mock<ModificationCommand>();
+            mockCommand2.Setup(c => c.RequiresResultPropagation).Returns(true);
+            var values2 = new[] { new KeyValuePair<string, object>("1loC", -42) };
+
+            var batch = new ModificationCommandBatch(new[] { mockCommand1.Object, mockCommand2.Object });
+            batch.SaveStoreGeneratedValues(0, values1);
+            batch.SaveStoreGeneratedValues(1, values2);
+            batch.PropagateResults();
+
+            mockCommand1.Verify(c => c.PropagateResults(values1), Times.Once);
+            mockCommand2.Verify(c => c.PropagateResults(values2), Times.Once);
+        }
+
+        [Fact]
+        public void Propagate_results_throws_when_propagating_results_for_commands_without_store_generated_values()
+        {
+            var mockCommand = new Mock<ModificationCommand>();
+            mockCommand.Setup(c => c.RequiresResultPropagation).Returns(false);
+            mockCommand.Setup(c => c.Table).Returns(new Table("table"));
+
+            var batch = new ModificationCommandBatch(new[] { mockCommand.Object });
+            batch.SaveStoreGeneratedValues(0, new[] { new KeyValuePair<string, object>("Col1", 42) });
+            Assert.Equal(Strings.FormatNoStoreGenColumnsToPropagateResults("table"),
+                Assert.Throws<InvalidOperationException>(() => batch.PropagateResults()).Message);
+        }
+
+        [Fact]
+        public void Propagate_results_throws_when_results_not_propagated_for_commands_with_store_generated_values()
+        {
+            var mockCommand = new Mock<ModificationCommand>();
+            mockCommand.Setup(c => c.RequiresResultPropagation).Returns(true);
+            mockCommand.Setup(c => c.Table).Returns(new Table("table"));
+
+            Assert.Equal(Strings.FormatResultsNotPropagatedForStoreGenColumns("table"),
+                Assert.Throws<InvalidOperationException>(
+                    () => new ModificationCommandBatch(new[] { mockCommand.Object }).PropagateResults()).Message);
         }
 
         private static SqlGenerator CreateMockSqlGenerator()

--- a/test/Microsoft.Data.SqlServer.Tests/SqlServerSqlGeneratorTest.cs
+++ b/test/Microsoft.Data.SqlServer.Tests/SqlServerSqlGeneratorTest.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Relational.Model;
 using Xunit;
 
@@ -25,7 +24,7 @@ namespace Microsoft.Data.SqlServer.Tests
         [Fact]
         public void AppendInsertOperation_test_appends_Select_for_insert_operation_with_identity_key()
         {
-            var id1Column = new Column("Id1", "int") { GenerationStrategy = StoreValueGenerationStrategy.Identity };
+            var id1Column = new Column("Id1", "int") { ValueGenerationStrategy = StoreValueGenerationStrategy.Identity };
             var id2Column = new Column("Id2", "nvarchar(max)");
             var nameColumn = new Column("Name", "nvarchar(30)");
             var table = new Table("table", new[] { id1Column, id2Column, nameColumn });
@@ -44,8 +43,8 @@ namespace Microsoft.Data.SqlServer.Tests
         [Fact]
         public void AppendInsertOperation_test_appends_valid_Select_for_insert_operation_with_identity_key_and_computed_non_key_column()
         {
-            var id1Column = new Column("Id1", "int") { GenerationStrategy = StoreValueGenerationStrategy.Identity };
-            var insertedColumn = new Column("Inserted", "int") { GenerationStrategy = StoreValueGenerationStrategy.Computed };
+            var id1Column = new Column("Id1", "int") { ValueGenerationStrategy = StoreValueGenerationStrategy.Identity };
+            var insertedColumn = new Column("Inserted", "int") { ValueGenerationStrategy = StoreValueGenerationStrategy.Computed };
             var nameColumn = new Column("Name", "nvarchar(30)");
             var table = new Table("table", new[] { id1Column, nameColumn, insertedColumn });
             table.PrimaryKey = new PrimaryKey("PK", new[] { id1Column });
@@ -63,7 +62,7 @@ namespace Microsoft.Data.SqlServer.Tests
         [Fact]
         public void AppendInsertOperation_test_appends_valid_statement_for_non_identity_auto_generated_keys()
         {
-            var id1Column = new Column("Id1", "int") { GenerationStrategy = StoreValueGenerationStrategy.Computed };
+            var id1Column = new Column("Id1", "int") { ValueGenerationStrategy = StoreValueGenerationStrategy.Computed };
             var id2Column = new Column("Id2", "nvarchar(max)");
             var nameColumn = new Column("Name", "nvarchar(30)");
             var table = new Table("Customers", new[] { id1Column, id2Column, nameColumn });
@@ -88,8 +87,8 @@ namespace Microsoft.Data.SqlServer.Tests
         [Fact]
         public void AppendInsertOperation_test_appends_valid_statement_for_computed_and_identity_composite_key()
         {
-            var id1Column = new Column("Id1", "int") { GenerationStrategy = StoreValueGenerationStrategy.Computed };
-            var id2Column = new Column("Id2", "nvarchar(max)") { GenerationStrategy = StoreValueGenerationStrategy.Identity };
+            var id1Column = new Column("Id1", "int") { ValueGenerationStrategy = StoreValueGenerationStrategy.Computed };
+            var id2Column = new Column("Id2", "nvarchar(max)") { ValueGenerationStrategy = StoreValueGenerationStrategy.Identity };
             var nameColumn = new Column("Name", "nvarchar(30)");
             var table = new Table("Customers", new[] { id1Column, id2Column, nameColumn });
             table.PrimaryKey = new PrimaryKey("PK", new[] { id1Column, id2Column });
@@ -112,9 +111,9 @@ namespace Microsoft.Data.SqlServer.Tests
         [Fact]
         public void AppendInsertOperation_test_appends_valid_statement_for_computed_and_identity_composite_key_and_computed_non_key_column()
         {
-            var id1Column = new Column("Id1", "int") { GenerationStrategy = StoreValueGenerationStrategy.Computed };
-            var id2Column = new Column("Id2", "nvarchar(max)") { GenerationStrategy = StoreValueGenerationStrategy.Identity };
-            var insertedColumn = new Column("Inserted", "int") { GenerationStrategy = StoreValueGenerationStrategy.Computed };
+            var id1Column = new Column("Id1", "int") { ValueGenerationStrategy = StoreValueGenerationStrategy.Computed };
+            var id2Column = new Column("Id2", "nvarchar(max)") { ValueGenerationStrategy = StoreValueGenerationStrategy.Identity };
+            var insertedColumn = new Column("Inserted", "int") { ValueGenerationStrategy = StoreValueGenerationStrategy.Computed };
             var nameColumn = new Column("Name", "nvarchar(30)");
             var table = new Table("Customers", new[] { id1Column, id2Column, insertedColumn, nameColumn });
             table.PrimaryKey = new PrimaryKey("PK", new[] { id1Column, id2Column });


### PR DESCRIPTION
PushingBack - enabling propagating store generated values back to state entries + making BatchExecutor overridable

Minor refactorings:
- renaming Column.GenerationStrategy to Column.ValueGenerationStrategy
- encapsulating logic for retrieving store generated columns in an extension method on Table
