### PR TITLE
Rename CreateIfNotExistsAsync to CreateAsync

### DIFF
--- a/src/Microsoft.Data.Entity/Storage/DataStoreCreator.cs
+++ b/src/Microsoft.Data.Entity/Storage/DataStoreCreator.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Data.Entity.Storage
 {
     public abstract class DataStoreCreator
     {
-        public virtual Task CreateIfNotExistsAsync([NotNull] IModel model, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task CreateAsync([NotNull] IModel model, CancellationToken cancellationToken = default(CancellationToken))
         {
             throw new NotImplementedException();
         }

--- a/src/Microsoft.Data.SqlServer/SqlServerDataStoreCreator.cs
+++ b/src/Microsoft.Data.SqlServer/SqlServerDataStoreCreator.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Data.SqlServer
             _statementExecutor = statementExecutor;
         }
 
-        public async override Task CreateIfNotExistsAsync(IModel model, CancellationToken cancellationToken = default(CancellationToken))
+        public async override Task CreateAsync(IModel model, CancellationToken cancellationToken = default(CancellationToken))
         {
             using (var connection = _dataStore.CreateConnection())
             {

--- a/test/Microsoft.Data.SqlServer.FunctionalTests/SqlServerDataStoreCreatorTest.cs
+++ b/test/Microsoft.Data.SqlServer.FunctionalTests/SqlServerDataStoreCreatorTest.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Data.SqlServer.FunctionalTests
                     new SqlServerMigrationOperationSqlGenerator(),
                     new SqlStatementExecutor());
 
-                await migrator.CreateIfNotExistsAsync(context.Model);
+                await migrator.CreateAsync(context.Model);
 
                 if (testDatabase.Connection.State != System.Data.ConnectionState.Open)
                 {


### PR DESCRIPTION
This method always tries to create the schema. It uses an idempotent
script to create the physical database (so you can add schema to an
existing database) but it always tries to create the entire schema. I
missed this rename from the last commit.
