### PR TITLE
I accept your reality and substitute my own...

### DIFF
--- a/src/Microsoft.Data.Entity/ChangeTracking/EntityEntry.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/EntityEntry.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-using System.Threading;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 
@@ -29,7 +28,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             {
                 Check.IsDefined(value, "value");
 
-                _stateEntry.SetEntityStateAsync(value, CancellationToken.None).Wait();
+                _stateEntry.EntityState = value;
             }
         }
 

--- a/src/Microsoft.Data.Entity/ChangeTracking/StateManager.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/StateManager.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
                 _entityReferenceMap[entity] = newEntry;
             }
 
-            newEntry.SetAttached();
+            newEntry.EntityState = EntityState.Unchanged;
 
             return newEntry;
         }
@@ -224,6 +224,14 @@ namespace Microsoft.Data.Entity.ChangeTracking
         private EntityKey CreateKey(IEntityType entityType, IReadOnlyList<IProperty> properties, StateEntry entry)
         {
             return _keyFactorySource.GetKeyFactory(properties).Create(entityType, properties, entry);
+        }
+
+        public virtual void AcceptAllChanges()
+        {
+            foreach (var entry in _identityMap.Values.ToList())
+            {
+                entry.AcceptChanges();
+            }
         }
     }
 }

--- a/src/Microsoft.Data.Entity/EntityContext.cs
+++ b/src/Microsoft.Data.Entity/EntityContext.cs
@@ -62,19 +62,29 @@ namespace Microsoft.Data.Entity
             return SaveChangesAsync().Result;
         }
 
-        public virtual Task<int> SaveChangesAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             var stateManager = _configuration.StateManager;
-            
+
             stateManager.DetectChanges();
 
             var entriesToSave = stateManager.StateEntries
                 .Where(e => e.EntityState.IsDirty())
                 .ToList();
 
-            return entriesToSave.Any()
-                ? _configuration.DataStore.SaveChangesAsync(entriesToSave, Model, cancellationToken)
-                : Task.FromResult(0);
+            if (!entriesToSave.Any())
+            {
+                return 0;
+            }
+
+            var result = await _configuration
+                .DataStore
+                .SaveChangesAsync(entriesToSave, Model, cancellationToken)
+                .ConfigureAwait(false);
+
+            stateManager.AcceptAllChanges();
+
+            return result;
         }
 
         public void Dispose()

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/EntityEntryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/EntityEntryTest.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             new EntityEntry<Random>(stateEntryMock.Object) { State = EntityState.Added };
 
-            stateEntryMock.Verify(m => m.SetEntityStateAsync(EntityState.Added, CancellationToken.None));
+            stateEntryMock.VerifySet(m => m.EntityState = EntityState.Added);
         }
 
         [Fact]


### PR DESCRIPTION
I accept your reality and substitute my own... (Add AcceptAllChanges to StateManager)

Adds AcceptChanges to state entries which will:
- Mark modified/added entities as unchanged
- Propagate current values to original values
- Detach deleted entities

AcceptAllChanges calls this for every entity in the state manager and SaveChanges calls AcceptAllChanges.
