### PR TITLE
I like to ride my tricycle, I like to ride my trike...

### DIFF
--- a/src/Microsoft.Data.Entity/ChangeTracking/ArraySidecar.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/ArraySidecar.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.ChangeTracking
+{
+    public abstract class ArraySidecar : Sidecar
+    {
+        private readonly object[] _values;
+
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected ArraySidecar()
+        {
+        }
+
+        protected ArraySidecar([NotNull] StateEntry stateEntry, int count)
+            : base(stateEntry)
+        {
+            _values = new object[count];
+        }
+
+        protected abstract int Index([NotNull] IProperty property);
+        protected abstract void ThrowInvalidIndexException([NotNull] IProperty property);
+
+        public override bool CanStoreValue(IProperty property)
+        {
+            Check.NotNull(property, "property");
+
+            return Index(property) != -1;
+        }
+
+        protected override object ReadValue(IProperty property)
+        {
+            Check.NotNull(property, "property");
+
+            return _values[IndexChecked(property)];
+        }
+
+        protected override void WriteValue(IProperty property, object value)
+        {
+            Check.NotNull(property, "property");
+
+            _values[IndexChecked(property)] = value;
+        }
+
+        private int IndexChecked(IProperty property)
+        {
+            var index = Index(property);
+            if (index == -1)
+            {
+                ThrowInvalidIndexException(property);
+            }
+            return index;
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/ChangeTracking/ClrStateEntry.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/ClrStateEntry.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             get { return _entity; }
         }
 
-        public override object GetPropertyValue(IProperty property)
+        protected override object ReadPropertyValue(IProperty property)
         {
             Check.NotNull(property, "property");
 

--- a/src/Microsoft.Data.Entity/ChangeTracking/CompositeEntityKeyFactory.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/CompositeEntityKeyFactory.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             Check.NotNull(entry, "entry");
 
             // TODO: What happens if we get a null property value?
-            return new CompositeEntityKey(entityType, properties.Select(entry.GetPropertyValue).ToArray());
+            return new CompositeEntityKey(entityType, properties.Select(p => entry[p]).ToArray());
         }
 
         public override EntityKey Create(IEntityType entityType, IReadOnlyList<IProperty> properties, IValueReader valueReader)

--- a/src/Microsoft.Data.Entity/ChangeTracking/DictionarySidecar.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/DictionarySidecar.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.ChangeTracking
+{
+    public abstract class DictionarySidecar : Sidecar
+    {
+        private readonly Dictionary<IProperty, object> _values;
+
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected DictionarySidecar()
+        {
+        }
+
+        protected DictionarySidecar(
+            [NotNull] StateEntry stateEntry,
+            [NotNull] IEnumerable<IProperty> properties)
+            : base(stateEntry)
+        {
+            Check.NotNull(properties, "properties");
+
+            _values = properties.ToDictionary(p => p, p => (object)null);
+        }
+
+        public override bool CanStoreValue(IProperty property)
+        {
+            Check.NotNull(property, "property");
+
+            return _values.ContainsKey(property);
+        }
+
+        protected override object ReadValue(IProperty property)
+        {
+            Check.NotNull(property, "property");
+
+            return _values[property];
+        }
+
+        protected override void WriteValue(IProperty property, object value)
+        {
+            Check.NotNull(property, "property");
+
+            _values[property] = value;
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/ChangeTracking/MixedStateEntry.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/MixedStateEntry.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             get { return _entity; }
         }
 
-        public override object GetPropertyValue(IProperty property)
+        protected override object ReadPropertyValue(IProperty property)
         {
             Check.NotNull(property, "property");
 

--- a/src/Microsoft.Data.Entity/ChangeTracking/OriginalValues.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/OriginalValues.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.ChangeTracking
+{
+    public class OriginalValues : ArraySidecar
+    {
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected OriginalValues()
+        {
+        }
+
+        public OriginalValues([NotNull] StateEntry stateEntry)
+            : base(stateEntry, Check.NotNull(stateEntry, "stateEntry").EntityType.OriginalValueCount)
+        {
+        }
+
+        protected override int Index(IProperty property)
+        {
+            Check.NotNull(property, "property");
+
+            return property.OriginalValueIndex;
+        }
+
+        protected override void ThrowInvalidIndexException(IProperty property)
+        {
+            Check.NotNull(property, "property");
+
+            throw new InvalidOperationException(Strings.FormatOriginalValueNotTracked(property.Name, StateEntry.EntityType.Name));
+        }
+
+        public override string Name
+        {
+            get { return WellKnownNames.OriginalValues; }
+        }
+
+        public override bool TransparentRead
+        {
+            get { return false; }
+        }
+
+        public override bool TransparentWrite
+        {
+            get { return false; }
+        }
+
+        public override bool AutoCommit
+        {
+            get { return false; }
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/ChangeTracking/OriginalValuesFactory.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/OriginalValuesFactory.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.ChangeTracking
+{
+    public class OriginalValuesFactory
+    {
+        public virtual Sidecar Create([NotNull] StateEntry stateEntry)
+        {
+            Check.NotNull(stateEntry, "stateEntry");
+
+            return new OriginalValues(stateEntry);
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/ChangeTracking/PropertyEntry.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/PropertyEntry.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
 
         public virtual object CurrentValue
         {
-            get { return _stateEntry.GetPropertyValue(_property); }
+            get { return _stateEntry[_property]; }
         }
     }
 }

--- a/src/Microsoft.Data.Entity/ChangeTracking/ShadowStateEntry.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/ShadowStateEntry.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             }
         }
 
-        public override object GetPropertyValue(IProperty property)
+        protected override object ReadPropertyValue(IProperty property)
         {
             Check.NotNull(property, "property");
 

--- a/src/Microsoft.Data.Entity/ChangeTracking/Sidecar.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/Sidecar.cs
@@ -1,0 +1,137 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.ChangeTracking
+{
+    public abstract class Sidecar
+    {
+        public static class WellKnownNames
+        {
+            public const string OriginalValues = "OriginalValues";
+            public const string StoreGeneratedValues = "StoreGeneratedValues";
+        }
+
+        private readonly StateEntry _stateEntry;
+
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected Sidecar()
+        {
+        }
+
+        protected Sidecar([NotNull] StateEntry stateEntry)
+        {
+            Check.NotNull(stateEntry, "stateEntry");
+
+            _stateEntry = stateEntry;
+        }
+
+        public virtual StateEntry StateEntry
+        {
+            get { return _stateEntry; }
+        }
+
+        public abstract bool CanStoreValue([NotNull] IProperty property);
+        protected abstract object ReadValue([NotNull] IProperty property);
+        protected abstract void WriteValue([NotNull] IProperty property, [CanBeNull] object value);
+        public abstract string Name { get; }
+        public abstract bool TransparentRead { get; }
+        public abstract bool TransparentWrite { get; }
+        public abstract bool AutoCommit { get; }
+
+        public virtual bool HasValue([NotNull] IProperty property)
+        {
+            Check.NotNull(property, "property");
+
+            return CanStoreValue(property) && ReadValue(property) != null;
+        }
+        
+        public virtual object this[[param: NotNull] IProperty property]
+        {
+            get
+            {
+                Check.NotNull(property, "property");
+
+                var value = ReadValue(property);
+
+                return value != null
+                    ? (ReferenceEquals(value, NullSentinel.Value) ? null : value)
+                    : _stateEntry[property];
+            }
+            [param: CanBeNull]
+            set
+            {
+                Check.NotNull(property, "property");
+
+                WriteValue(property, value ?? NullSentinel.Value);
+            }
+        }
+
+        public virtual void Commit()
+        {
+            _stateEntry.RemoveSidecar(Name);
+
+            foreach (var property in _stateEntry.EntityType.Properties)
+            {
+                if (HasValue(property))
+                {
+                    _stateEntry[property] = this[property];
+                }
+            }
+        }
+
+        public virtual void Rollback()
+        {
+            _stateEntry.RemoveSidecar(Name);
+        }
+
+        public virtual void TakeSnapshot()
+        {
+            foreach (var property in _stateEntry.EntityType.Properties)
+            {
+                if (CanStoreValue(property))
+                {
+                    this[property] = _stateEntry[property];
+                }
+            }
+        }
+
+        public virtual void UpdateSnapshot()
+        {
+            foreach (var property in _stateEntry.EntityType.Properties)
+            {
+                if (HasValue(property))
+                {
+                    this[property] = _stateEntry[property];
+                }
+            }
+        }
+
+        public virtual void EnsureSnapshot([NotNull] IProperty property)
+        {
+            Check.NotNull(property, "property");
+
+            if (CanStoreValue(property)
+                && !HasValue(property))
+            {
+                this[property] = _stateEntry[property];
+            }
+        }
+
+        protected sealed class NullSentinel
+        {
+            public static readonly NullSentinel Value = new NullSentinel();
+
+            private NullSentinel()
+            {
+            }
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/ChangeTracking/SimpleEntityKeyFactory.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/SimpleEntityKeyFactory.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             Check.NotNull(entry, "entry");
 
             // TODO: What happens if we get a null property value?
-            return new SimpleEntityKey<TKey>(entityType, (TKey)entry.GetPropertyValue(properties[0]));
+            return new SimpleEntityKey<TKey>(entityType, (TKey)entry[properties[0]]);
         }
 
         public override EntityKey Create(IEntityType entityType, IReadOnlyList<IProperty> properties, IValueReader valueReader)

--- a/src/Microsoft.Data.Entity/ChangeTracking/StateData.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/StateData.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System.Linq;
+
+namespace Microsoft.Data.Entity.ChangeTracking
+{
+    public abstract partial class StateEntry
+    {
+        internal struct StateData
+        {
+            private const int BitsPerInt = 32;
+            private const int BitsForEntityState = 3;
+            private const int BitsForFlags = 1;
+            private const int BitsForAdditionalState = BitsForEntityState + BitsForFlags;
+            private const int EntityStateMask = 0x07;
+            private const int TransparentSidecarMask = 0x08;
+            private const int AdditionalStateMask = EntityStateMask | TransparentSidecarMask;
+
+            private readonly int[] _bits;
+
+            public StateData(int propertyCount)
+            {
+                _bits = new int[(propertyCount + BitsForAdditionalState - 1) / BitsPerInt + 1];
+            }
+
+            public void SetAllPropertiesModified(int propertyCount)
+            {
+                for (var i = 0; i < _bits.Length; i++)
+                {
+                    _bits[i] |= CreateMaskForWrite(i, propertyCount);
+                }
+            }
+
+            public EntityState EntityState
+            {
+                get { return (EntityState)(_bits[0] & EntityStateMask); }
+                set { _bits[0] = (_bits[0] & ~EntityStateMask) | (int)value; }
+            }
+
+            public bool TransparentSidecarInUse
+            {
+                get { return (_bits[0] & TransparentSidecarMask) != 0; }
+                set { _bits[0] = (_bits[0] & ~TransparentSidecarMask) | (value ? TransparentSidecarMask : 0); }
+            }
+
+            public bool IsPropertyModified(int propertyIndex)
+            {
+                propertyIndex += BitsForAdditionalState;
+
+                return (_bits[propertyIndex / BitsPerInt] & (1 << propertyIndex % BitsPerInt)) != 0;
+            }
+
+            public void SetPropertyModified(int propertyIndex, bool isModified)
+            {
+                propertyIndex += BitsForAdditionalState;
+
+                if (isModified)
+                {
+                    _bits[propertyIndex / BitsPerInt] |= 1 << propertyIndex % BitsPerInt;
+                }
+                else
+                {
+                    _bits[propertyIndex / BitsPerInt] &= ~(1 << propertyIndex % BitsPerInt);
+                }
+            }
+
+            public bool AnyPropertiesModified()
+            {
+                return _bits.Where((t, i) => (t & CreateMaskForRead(i)) != 0).Any();
+            }
+
+            private static int CreateMaskForRead(int i)
+            {
+                var mask = unchecked(((int)0xFFFFFFFF));
+                if (i == 0)
+                {
+                    mask &= ~AdditionalStateMask;
+                }
+
+                // TODO: Remove keys/readonly indexes from the mask to avoid setting them to modified
+                return mask;
+            }
+
+            private int CreateMaskForWrite(int i, int propertyCount)
+            {
+                var mask = CreateMaskForRead(i);
+
+                if (i == _bits.Length - 1)
+                {
+                    var overlay = unchecked(((int)0xFFFFFFFF));
+                    var shift = (propertyCount + BitsForAdditionalState) % BitsPerInt;
+                    overlay = shift != 0 ? overlay << shift : 0;
+                    mask &= ~overlay;
+                }
+
+                // TODO: Remove keys/readonly indexes from the mask to avoid setting them to modified
+                return mask;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/ChangeTracking/StateEntrySubscriber.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/StateEntrySubscriber.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
         {
             if (!entry.EntityType.UseLazyOriginalValues)
             {
-                entry.SnapshotOriginalValues();
+                entry.OriginalValues.TakeSnapshot();
             }
 
             var changing = entry.Entity as INotifyPropertyChanging;

--- a/src/Microsoft.Data.Entity/ChangeTracking/StoreGeneratedValues.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/StoreGeneratedValues.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.ChangeTracking
+{
+    public class StoreGeneratedValues : DictionarySidecar
+    {
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected StoreGeneratedValues()
+        {
+        }
+
+        public StoreGeneratedValues([NotNull] StateEntry stateEntry, [NotNull] IEnumerable<IProperty> properties)
+            : base(stateEntry, properties)
+        {
+        }
+
+        public override string Name
+        {
+            get { return WellKnownNames.StoreGeneratedValues; }
+        }
+
+        public override bool TransparentRead
+        {
+            get { return true; }
+        }
+
+        public override bool TransparentWrite
+        {
+            get { return true; }
+        }
+
+        public override bool AutoCommit
+        {
+            get { return true; }
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/ChangeTracking/StoreGeneratedValuesFactory.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/StoreGeneratedValuesFactory.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.ChangeTracking
+{
+    public class StoreGeneratedValuesFactory
+    {
+        public virtual StoreGeneratedValues Create([NotNull] StateEntry stateEntry, [NotNull] IEnumerable<IProperty> properties)
+        {
+            Check.NotNull(stateEntry, "stateEntry");
+
+            return new StoreGeneratedValues(stateEntry, properties);
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/EntityConfiguration.cs
+++ b/src/Microsoft.Data.Entity/EntityConfiguration.cs
@@ -99,6 +99,16 @@ namespace Microsoft.Data.Entity
             get { return _serviceProvider.GetRequiredService<EntityMaterializerSource>(); }
         }
 
+        public virtual StoreGeneratedValuesFactory StoreGeneratedValuesFactory
+        {
+            get { return _serviceProvider.GetRequiredService<StoreGeneratedValuesFactory>(); }
+        }
+
+        public virtual OriginalValuesFactory OriginalValuesFactory
+        {
+            get { return _serviceProvider.GetRequiredService<OriginalValuesFactory>(); }
+        }
+
         public virtual ILoggerFactory LoggerFactory
         {
             get { return _serviceProvider.GetRequiredService<ILoggerFactory>(); }

--- a/src/Microsoft.Data.Entity/EntityContext.cs
+++ b/src/Microsoft.Data.Entity/EntityContext.cs
@@ -62,29 +62,14 @@ namespace Microsoft.Data.Entity
             return SaveChangesAsync().Result;
         }
 
-        public virtual async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task<int> SaveChangesAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             var stateManager = _configuration.StateManager;
 
+            // TODO: Allow auto-detect changes to be switched off
             stateManager.DetectChanges();
 
-            var entriesToSave = stateManager.StateEntries
-                .Where(e => e.EntityState.IsDirty())
-                .ToList();
-
-            if (!entriesToSave.Any())
-            {
-                return 0;
-            }
-
-            var result = await _configuration
-                .DataStore
-                .SaveChangesAsync(entriesToSave, Model, cancellationToken)
-                .ConfigureAwait(false);
-
-            stateManager.AcceptAllChanges();
-
-            return result;
+            return stateManager.SaveChangesAsync(_configuration.DataStore, cancellationToken);
         }
 
         public void Dispose()

--- a/src/Microsoft.Data.Entity/EntityServices.cs
+++ b/src/Microsoft.Data.Entity/EntityServices.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Data.Entity
                 .AddSingleton<MemberMapper, MemberMapper>()
                 .AddSingleton<StateEntrySubscriber, StateEntrySubscriber>()
                 .AddSingleton<FieldMatcher, FieldMatcher>()
+                .AddSingleton<OriginalValuesFactory, OriginalValuesFactory>()
+                .AddSingleton<StoreGeneratedValuesFactory, StoreGeneratedValuesFactory>()
                 .AddScoped<StateEntryFactory, StateEntryFactory>()
                 .AddScoped<IEntityStateListener, NavigationFixer>()
                 .AddScoped<StateEntryNotifier, StateEntryNotifier>()

--- a/src/Microsoft.Data.Entity/Identity/DefaultIdentityGeneratorFactory.cs
+++ b/src/Microsoft.Data.Entity/Identity/DefaultIdentityGeneratorFactory.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Data.Entity.Identity
             {
                 case ValueGenerationStrategy.None:
                     return null;
+                case ValueGenerationStrategy.StoreIdentity:
+                    return null;
                 case ValueGenerationStrategy.Client:
                     if (property.PropertyType == typeof(Guid))
                     {

--- a/src/Microsoft.Data.Relational/Properties/Strings.Designer.cs
+++ b/src/Microsoft.Data.Relational/Properties/Strings.Designer.cs
@@ -91,38 +91,6 @@ namespace Microsoft.Data.Relational
         }
 
         /// <summary>
-        /// Propagating results failed. The table '{tableName}' has no columns with store generated values but store generated values were returned by a modification command.
-        /// </summary>
-        internal static string NoStoreGenColumnsToPropagateResults
-        {
-            get { return GetString("NoStoreGenColumnsToPropagateResults"); }
-        }
-
-        /// <summary>
-        /// Propagating results failed. The table '{tableName}' has no columns with store generated values but store generated values were returned by a modification command.
-        /// </summary>
-        internal static string FormatNoStoreGenColumnsToPropagateResults(object tableName)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("NoStoreGenColumnsToPropagateResults", "tableName"), tableName);
-        }
-
-        /// <summary>
-        /// Propagating results failed. The table '{tableName}' has columns with store generated values but no store generated values were returned by a modification command.
-        /// </summary>
-        internal static string ResultsNotPropagatedForStoreGenColumns
-        {
-            get { return GetString("ResultsNotPropagatedForStoreGenColumns"); }
-        }
-
-        /// <summary>
-        /// Propagating results failed. The table '{tableName}' has columns with store generated values but no store generated values were returned by a modification command.
-        /// </summary>
-        internal static string FormatResultsNotPropagatedForStoreGenColumns(object tableName)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("ResultsNotPropagatedForStoreGenColumns", "tableName"), tableName);
-        }
-
-        /// <summary>
         /// A modification command returned more than one row. Each modification command must return at most one row.
         /// </summary>
         internal static string TooManyRowsForModificationCommand
@@ -136,22 +104,6 @@ namespace Microsoft.Data.Relational
         internal static string FormatTooManyRowsForModificationCommand()
         {
             return GetString("TooManyRowsForModificationCommand");
-        }
-
-        /// <summary>
-        /// Store generated values has already been saved for this command.
-        /// </summary>
-        internal static string StoreGenValuesSavedMultipleTimesForCommand
-        {
-            get { return GetString("StoreGenValuesSavedMultipleTimesForCommand"); }
-        }
-
-        /// <summary>
-        /// Store generated values has already been saved for this command.
-        /// </summary>
-        internal static string FormatStoreGenValuesSavedMultipleTimesForCommand()
-        {
-            return GetString("StoreGenValuesSavedMultipleTimesForCommand");
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/Microsoft.Data.Relational/Properties/Strings.resx
+++ b/src/Microsoft.Data.Relational/Properties/Strings.resx
@@ -132,16 +132,7 @@
   <data name="UpdateConcurrencyException" xml:space="preserve">
     <value>Update failed. Expected {expectedRows} row(s) but {actualRows} row(s) returned.</value>
   </data>
-  <data name="NoStoreGenColumnsToPropagateResults" xml:space="preserve">
-    <value>Propagating results failed. The table '{tableName}' has no columns with store generated values but store generated values were returned by a modification command.</value>
-  </data>
-  <data name="ResultsNotPropagatedForStoreGenColumns" xml:space="preserve">
-    <value>Propagating results failed. The table '{tableName}' has columns with store generated values but no store generated values were returned by a modification command.</value>
-  </data>
   <data name="TooManyRowsForModificationCommand" xml:space="preserve">
     <value>A modification command returned more than one row. Each modification command must return at most one row.</value>
-  </data>
-  <data name="StoreGenValuesSavedMultipleTimesForCommand" xml:space="preserve">
-    <value>Store generated values has already been saved for this command.</value>
   </data>
 </root>

--- a/src/Microsoft.Data.Relational/RelationalDataStore.cs
+++ b/src/Microsoft.Data.Relational/RelationalDataStore.cs
@@ -59,9 +59,6 @@ namespace Microsoft.Data.Relational
 
                 var executor = new BatchExecutor(commands, SqlGenerator);
                 await executor.ExecuteAsync(connection, cancellationToken);
-
-                // TODO: this should happen when the transaction is being commited
-                executor.PropagateResults();
             }
 
             // TODO Return the actual results once we can get them

--- a/src/Microsoft.Data.Relational/SqlGenerator.cs
+++ b/src/Microsoft.Data.Relational/SqlGenerator.cs
@@ -133,16 +133,19 @@ namespace Microsoft.Data.Relational
             Check.NotNull(table, "table");
             Check.NotNull(columns, "columns");
 
+            columns = columns.ToArray();
+
             commandStringBuilder
                 .Append("INSERT INTO ")
-                .Append(table.Name)
-                .Append(" (")
-                .AppendJoin(columns.Select(c => c.Name));
+                .Append(table.Name);
 
-            // TODO: may be fine if all columns are database generated in which case we should not append brackets at all
-            Contract.Assert(commandStringBuilder[commandStringBuilder.Length - 1] != '(', "empty columnNames");
-
-            commandStringBuilder.Append(")");
+            if (columns.Any())
+            {
+                commandStringBuilder
+                    .Append(" (")
+                    .AppendJoin(columns.Select(c => c.Name))
+                    .Append(")");
+            }
         }
 
         public virtual void AppendDeleteCommandHeader([NotNull] StringBuilder commandStringBuilder, [NotNull] Table table)
@@ -195,12 +198,20 @@ namespace Microsoft.Data.Relational
             Check.NotNull(commandStringBuilder, "commandStringBuilder");
             Check.NotNull(valueParameterNames, "valueParameterNames");
 
-            commandStringBuilder
-                .Append("VALUES (")
-                .AppendJoin(valueParameterNames)
-                .Append(")");
+            valueParameterNames = valueParameterNames.ToArray();
 
-            Contract.Assert(!commandStringBuilder.ToString().EndsWith("()"), "empty valueParameterNames");
+            if (valueParameterNames.Any())
+            {
+                commandStringBuilder
+                    .Append("VALUES (")
+                    .AppendJoin(valueParameterNames)
+                    .Append(")");
+            }
+            else
+            {
+                commandStringBuilder
+                    .Append("DEFAULT VALUES");
+            }
         }
 
         public virtual void AppendWhereClause(

--- a/src/Microsoft.Data.Relational/Update/BatchExecutor.cs
+++ b/src/Microsoft.Data.Relational/Update/BatchExecutor.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
@@ -81,13 +82,14 @@ namespace Microsoft.Data.Relational.Update
 
         private static void SaveStoreGeneratedValues([NotNull] ModificationCommandBatch commandBatch, [NotNull] DbDataReader reader, int commandIndex)
         {
-            var results = new KeyValuePair<string, object>[reader.FieldCount];
-            for (var ordinal = 0; ordinal < results.Length; ordinal++)
+            // TODO: Consider if this can be done with well-known result order (like materialization) rather than column names
+            var names = new String[reader.FieldCount];
+            for (var ordinal = 0; ordinal < names.Length; ordinal++)
             {
-                results[ordinal] = new KeyValuePair<string, object>(reader.GetName(ordinal), reader.GetValue(ordinal));
+                names[ordinal] = reader.GetName(ordinal);
             }
 
-            commandBatch.SaveStoreGeneratedValues(commandIndex, results);
+            commandBatch.SaveStoreGeneratedValues(commandIndex, names, new RelationalTypedValueReader(reader));
         }
 
         private DbCommand CreateCommand([NotNull] DbConnection connection, [NotNull] ModificationCommandBatch commandBatch)
@@ -108,14 +110,6 @@ namespace Microsoft.Data.Relational.Update
             }
 
             return command;
-        }
-
-        public virtual void PropagateResults()
-        {
-            foreach (var commandbatch in _commandBatches)
-            {
-                commandbatch.PropagateResults();
-            }            
         }
     }
 }

--- a/test/Microsoft.Data.Entity.FunctionalTests/Metadata/CompiledModelTest.cs
+++ b/test/Microsoft.Data.Entity.FunctionalTests/Metadata/CompiledModelTest.cs
@@ -79,13 +79,13 @@ namespace Microsoft.Data.Entity.FunctionalTests.Metadata
                 Assert.False(property.GetterCalled);
                 Assert.False(property.SetterCalled);
 
-                Assert.Equal(0, stateEntry.GetPropertyValue(property));
+                Assert.Equal(0, stateEntry[property]);
                 Assert.True(property.GetterCalled);
 
-                stateEntry.SetPropertyValue(property, 777);
+                stateEntry[property] = 777;
 
                 Assert.True(property.SetterCalled);
-                Assert.Equal(777, stateEntry.GetPropertyValue(property));
+                Assert.Equal(777, stateEntry[property]);
             }
         }
 

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/ClrStateEntryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/ClrStateEntryTest.cs
@@ -32,11 +32,11 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entity = new SomeEntity { Id = 77, Name = "Magic Tree House" };
             var entry = CreateStateEntry(configuration, entityType, entity);
 
-            Assert.Equal(77, entry.GetPropertyValue(keyProperty));
-            Assert.Equal("Magic Tree House", entry.GetPropertyValue(nonKeyProperty));
+            Assert.Equal(77, entry[keyProperty]);
+            Assert.Equal("Magic Tree House", entry[nonKeyProperty]);
 
-            entry.SetPropertyValue(keyProperty, 78);
-            entry.SetPropertyValue(nonKeyProperty, "Normal Tree House");
+            entry[keyProperty] = 78;
+            entry[nonKeyProperty] = "Normal Tree House";
 
             Assert.Equal(78, entity.Id);
             Assert.Equal("Normal Tree House", entity.Name);
@@ -105,11 +105,11 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             Assert.Equal(
                 Strings.FormatOriginalValueNotTracked("Id", "FullNotificationEntity"),
-                Assert.Throws<InvalidOperationException>(() => entry.SetPropertyOriginalValue(idProperty, 1)).Message);
+                Assert.Throws<InvalidOperationException>(() => entry.OriginalValues[idProperty] = 1).Message);
 
             Assert.Equal(
                 Strings.FormatOriginalValueNotTracked("Id", "FullNotificationEntity"),
-                Assert.Throws<InvalidOperationException>(() => entry.GetPropertyOriginalValue(idProperty)).Message);
+                Assert.Throws<InvalidOperationException>(() => entry.OriginalValues[idProperty]).Message);
         }
     }
 }

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/CompositeEntityKeyFactoryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/CompositeEntityKeyFactoryTest.cs
@@ -22,9 +22,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var random = new Random();
             var entryMock = new Mock<StateEntry>();
-            entryMock.Setup(m => m.GetPropertyValue(keyPart1)).Returns(7);
-            entryMock.Setup(m => m.GetPropertyValue(keyPart2)).Returns("Ate");
-            entryMock.Setup(m => m.GetPropertyValue(keyPart3)).Returns(random);
+            entryMock.Setup(m => m[keyPart1]).Returns(7);
+            entryMock.Setup(m => m[keyPart2]).Returns("Ate");
+            entryMock.Setup(m => m[keyPart3]).Returns(random);
             entryMock.Setup(m => m.EntityType).Returns(typeMock.Object);
 
             var key = (CompositeEntityKey)new CompositeEntityKeyFactory().Create(
@@ -45,9 +45,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var random = new Random();
             var entryMock = new Mock<StateEntry>();
-            entryMock.Setup(m => m.GetPropertyValue(keyProp)).Returns(7);
-            entryMock.Setup(m => m.GetPropertyValue(nonKeyPart1)).Returns("Ate");
-            entryMock.Setup(m => m.GetPropertyValue(nonKeyPart2)).Returns(random);
+            entryMock.Setup(m => m[keyProp]).Returns(7);
+            entryMock.Setup(m => m[nonKeyPart1]).Returns("Ate");
+            entryMock.Setup(m => m[nonKeyPart2]).Returns(random);
             entryMock.Setup(m => m.EntityType).Returns(typeMock.Object);
 
             var key = (CompositeEntityKey)new CompositeEntityKeyFactory().Create(

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/MixedStateEntryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/MixedStateEntryTest.cs
@@ -32,11 +32,11 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entity = new SomeEntity { Id = 77, Name = "Magic Tree House" };
             var entry = CreateStateEntry(configuration, entityType, entity);
 
-            Assert.Null(entry.GetPropertyValue(keyProperty)); // In shadow
-            Assert.Equal("Magic Tree House", entry.GetPropertyValue(nonKeyProperty));
+            Assert.Null(entry[keyProperty]); // In shadow
+            Assert.Equal("Magic Tree House", entry[nonKeyProperty]);
 
-            entry.SetPropertyValue(keyProperty, 78);
-            entry.SetPropertyValue(nonKeyProperty, "Normal Tree House");
+            entry[keyProperty] = 78;
+            entry[nonKeyProperty] = "Normal Tree House";
 
             Assert.Equal(77, entity.Id); // In shadow
             Assert.Equal("Normal Tree House", entity.Name);
@@ -105,11 +105,11 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             Assert.Equal(
                 Strings.FormatOriginalValueNotTracked("Id", "FullNotificationEntity"),
-                Assert.Throws<InvalidOperationException>(() => entry.SetPropertyOriginalValue(idProperty, 1)).Message);
+                Assert.Throws<InvalidOperationException>(() => entry.OriginalValues[idProperty] = 1).Message);
 
             Assert.Equal(
                 Strings.FormatOriginalValueNotTracked("Id", "FullNotificationEntity"),
-                Assert.Throws<InvalidOperationException>(() => entry.GetPropertyOriginalValue(idProperty)).Message);
+                Assert.Throws<InvalidOperationException>(() => entry.OriginalValues[idProperty]).Message);
         }
 
         protected override Model BuildModel()
@@ -119,6 +119,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entityType1 = new EntityType(typeof(SomeEntity));
             model.AddEntityType(entityType1);
             var key1 = entityType1.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false);
+            key1.ValueGenerationStrategy = ValueGenerationStrategy.StoreIdentity;
             entityType1.SetKey(key1);
             entityType1.AddProperty("Name", typeof(string));
 

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/OriginalValuesTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/OriginalValuesTest.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.ChangeTracking;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.ChangeTracking
+{
+    public class OriginalValuesTest : SidecarTest
+    {
+        [Fact]
+        public void Is_not_set_up_for_transparent_access_and_auto_commit()
+        {
+            var sidecar = CreateSidecar();
+
+            Assert.False(sidecar.TransparentRead);
+            Assert.False(sidecar.TransparentWrite);
+            Assert.False(sidecar.AutoCommit);
+        }
+
+        [Fact]
+        public void Has_expected_name()
+        {
+            Assert.Equal(Sidecar.WellKnownNames.OriginalValues, CreateSidecar().Name);
+        }
+
+        [Fact]
+        public void Throws_on_attempt_to_read_when_original_value_cannot_be_stored()
+        {
+            Assert.Equal(
+                Strings.FormatOriginalValueNotTracked("Name", "Banana"),
+                Assert.Throws<InvalidOperationException>(() => CreateSidecar()[NameProperty]).Message);
+        }
+
+        [Fact]
+        public void Throws_on_attempt_to_write_when_original_value_cannot_be_stored()
+        {
+            Assert.Equal(
+                Strings.FormatOriginalValueNotTracked("Name", "Banana"),
+                Assert.Throws<InvalidOperationException>(() => CreateSidecar()[NameProperty] = "Yellow").Message);
+        }
+
+        protected override Sidecar CreateSidecar(StateEntry entry = null)
+        {
+            return new OriginalValuesFactory().Create(entry ?? CreateStateEntry());
+        }
+    }
+}

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/PropertyEntryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/PropertyEntryTest.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         public void Can_get_current_value()
         {
             var stateEntryMock = CreateStateEntryMock(new Mock<IProperty>());
-            stateEntryMock.Setup(m => m.GetPropertyValue(It.IsAny<IProperty>())).Returns("Chimp");
+            stateEntryMock.Setup(m => m[It.IsAny<IProperty>()]).Returns("Chimp");
 
             Assert.Equal("Chimp", new PropertyEntry(stateEntryMock.Object, "Monkey").CurrentValue);
         }

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/ShadowStateEntryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/ShadowStateEntryTest.cs
@@ -31,11 +31,11 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             Assert.Equal(
                 Strings.FormatOriginalValueNotTracked("Id", "SomeEntity"),
-                Assert.Throws<InvalidOperationException>(() => entry.SetPropertyOriginalValue(idProperty, 1)).Message);
+                Assert.Throws<InvalidOperationException>(() => entry.OriginalValues[idProperty] = 1).Message);
 
             Assert.Equal(
                 Strings.FormatOriginalValueNotTracked("Id", "SomeEntity"),
-                Assert.Throws<InvalidOperationException>(() => entry.GetPropertyOriginalValue(idProperty)).Message);
+                Assert.Throws<InvalidOperationException>(() => entry.OriginalValues[idProperty]).Message);
         }
 
         protected override Model BuildModel()
@@ -45,6 +45,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entityType1 = new EntityType("SomeEntity");
             model.AddEntityType(entityType1);
             var key1 = entityType1.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false);
+            key1.ValueGenerationStrategy = ValueGenerationStrategy.StoreIdentity;
             entityType1.SetKey(key1);
             entityType1.AddProperty("Name", typeof(string), shadowProperty: true, concurrencyToken: true);
 

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/SidecarTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/SidecarTest.cs
@@ -1,0 +1,307 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System.ComponentModel;
+using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Metadata;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.ChangeTracking
+{
+    public abstract class SidecarTest
+    {
+        private readonly Model _model;
+
+        protected SidecarTest()
+        {
+            _model = BuildModel();
+        }
+
+        [Fact]
+        public void Can_check_if_property_value_can_be_stored()
+        {
+            var sidecar = CreateSidecar();
+
+            Assert.True(sidecar.CanStoreValue(IdProperty));
+            Assert.False(sidecar.CanStoreValue(NameProperty));
+            Assert.True(sidecar.CanStoreValue(StateProperty));
+        }
+
+        [Fact]
+        public void Can_check_if_value_is_stored()
+        {
+            var sidecar = CreateSidecar();
+
+            Assert.False(sidecar.HasValue(IdProperty));
+            Assert.False(sidecar.HasValue(NameProperty));
+            Assert.False(sidecar.HasValue(StateProperty));
+
+            sidecar[IdProperty] = 78;
+            sidecar[StateProperty] = "Thawed";
+
+            Assert.True(sidecar.HasValue(IdProperty));
+            Assert.False(sidecar.HasValue(NameProperty));
+            Assert.True(sidecar.HasValue(StateProperty));
+        }
+
+        [Fact]
+        public void Can_read_and_write_values()
+        {
+            var entity = new Banana { Id = 77, Name = "Stand", State = "Frozen" }; 
+            var sidecar = CreateSidecar(CreateStateEntry(entity));
+
+            Assert.Equal(77, sidecar[IdProperty]);
+            Assert.Equal("Frozen", sidecar[StateProperty]);
+
+            sidecar[IdProperty] = 78;
+            sidecar[StateProperty] = "Thawed";
+
+            Assert.Equal(78, sidecar[IdProperty]);
+            Assert.Equal("Thawed", sidecar[StateProperty]);
+
+            Assert.Equal(77, entity.Id);
+            Assert.Equal("Frozen", entity.State);
+        }
+
+        [Fact]
+        public void Can_read_and_write_null()
+        {
+            var entity = new Banana { Id = 77, Name = "Stand", State = "Frozen" };
+            var sidecar = CreateSidecar(CreateStateEntry(entity));
+
+            sidecar[StateProperty] = null;
+
+            Assert.True(sidecar.HasValue(StateProperty));
+            Assert.Null(sidecar[StateProperty]);
+
+            Assert.Equal("Frozen", entity.State);
+        }
+
+        [Fact]
+        public void Can_commit_values_into_state_entry()
+        {
+            var entity = new Banana { Id = 77, Name = "Stand", State = "Frozen" };
+            var sidecar = CreateSidecar(CreateStateEntry(entity));
+
+            sidecar[StateProperty] = "Thawed";
+            sidecar.Commit();
+
+            Assert.Equal(77, entity.Id);
+            Assert.Equal("Thawed", entity.State);
+        }
+
+        [Fact]
+        public void Committing_detaches_sidecar()
+        {
+            var entity = new Banana { Id = 77, Name = "Stand", State = "Frozen" };
+            var stateEntry = CreateStateEntry(entity);
+
+            var sidecar = stateEntry.AddSidecar(CreateSidecar(stateEntry));
+
+            sidecar.Commit();
+
+            Assert.Null(stateEntry.TryGetSidecar(sidecar.Name));
+        }
+
+        [Fact]
+        public void Rolling_back_detaches_sidecar_without_committing_values()
+        {
+            var entity = new Banana { Id = 77, Name = "Stand", State = "Frozen" };
+            var stateEntry = CreateStateEntry(entity);
+
+            var sidecar = stateEntry.AddSidecar(CreateSidecar(stateEntry));
+
+            sidecar[StateProperty] = "Thawed";
+            sidecar.Rollback();
+
+            Assert.Null(stateEntry.TryGetSidecar(sidecar.Name));
+
+            Assert.Equal(77, entity.Id);
+            Assert.Equal("Frozen", entity.State);
+        }
+
+        [Fact]
+        public void Can_snapshot_values()
+        {
+            var entity = new Banana { Id = 77, Name = "Stand", State = "Frozen" };
+            var sidecar = CreateSidecar(CreateStateEntry(entity));
+
+            sidecar.TakeSnapshot();
+
+            Assert.Equal(77, sidecar[IdProperty]);
+            Assert.Equal("Frozen", sidecar[StateProperty]);
+
+            sidecar[IdProperty] = 78;
+            sidecar[StateProperty] = "Thawed";
+
+            Assert.Equal(78, sidecar[IdProperty]);
+            Assert.Equal("Thawed", sidecar[StateProperty]);
+
+            Assert.Equal(77, entity.Id);
+            Assert.Equal("Frozen", entity.State);
+
+            entity.Id = 76;
+            entity.State = "Banana vapor";
+
+            Assert.Equal(78, sidecar[IdProperty]);
+            Assert.Equal("Thawed", sidecar[StateProperty]);
+
+            Assert.Equal(76, entity.Id);
+            Assert.Equal("Banana vapor", entity.State);
+
+            sidecar.TakeSnapshot();
+
+            Assert.Equal(76, sidecar[IdProperty]);
+            Assert.Equal("Banana vapor", sidecar[StateProperty]);
+        }
+
+        [Fact]
+        public void Can_snapshot_null_values()
+        {
+            var entity = new Banana { Id = 77, Name = "Stand", State = null };
+            var sidecar = CreateSidecar(CreateStateEntry(entity));
+
+            sidecar.TakeSnapshot();
+
+            Assert.Null(sidecar[StateProperty]);
+            Assert.Null(entity.State);
+
+            sidecar[StateProperty] = "Thawed";
+
+            Assert.Equal("Thawed", sidecar[StateProperty]);
+            Assert.Null(entity.State);
+
+            entity.State = "Banana vapor";
+
+            Assert.Equal("Thawed", sidecar[StateProperty]);
+            Assert.Equal("Banana vapor", entity.State);
+
+            sidecar.TakeSnapshot();
+
+            Assert.Equal("Banana vapor", sidecar[StateProperty]);
+        }
+
+        [Fact]
+        public void Can_update_already_saved_values()
+        {
+            var entity = new Banana { Id = 77, Name = "Stand", State = "Frozen" };
+            var sidecar = CreateSidecar(CreateStateEntry(entity));
+
+            sidecar[IdProperty] = 78;
+            entity.Id = 76;
+            entity.State = "Banana vapor";
+
+            Assert.True(sidecar.HasValue(IdProperty));
+            Assert.False(sidecar.HasValue(StateProperty));
+
+            Assert.Equal(78, sidecar[IdProperty]);
+            Assert.Equal("Banana vapor", sidecar[StateProperty]);
+
+            sidecar.UpdateSnapshot();
+
+            Assert.True(sidecar.HasValue(IdProperty));
+            Assert.False(sidecar.HasValue(StateProperty));
+
+            Assert.Equal(76, sidecar[IdProperty]);
+            Assert.Equal("Banana vapor", sidecar[StateProperty]);
+        }
+
+        [Fact]
+        public void Can_ensure_value_is_snapshotted_but_not_overwrite_existing_snapshot_value()
+        {
+            var entity = new Banana { Id = 77, Name = "Stand", State = "Frozen" };
+            var sidecar = CreateSidecar(CreateStateEntry(entity));
+
+            sidecar.EnsureSnapshot(IdProperty);
+            
+            Assert.True(sidecar.HasValue(IdProperty));
+            Assert.Equal(77, sidecar[IdProperty]);
+
+            entity.Id = 76;
+
+            sidecar.EnsureSnapshot(IdProperty);
+
+            Assert.True(sidecar.HasValue(IdProperty));
+            Assert.Equal(77, sidecar[IdProperty]);
+        }
+
+        [Fact]
+        public void Can_ensure_null_value_is_snapshotted_but_not_overwrite_existing_snapshot_value()
+        {
+            var entity = new Banana { Id = 77, Name = "Stand", State = null};
+            var sidecar = CreateSidecar(CreateStateEntry(entity));
+
+            sidecar.EnsureSnapshot(StateProperty);
+
+            Assert.True(sidecar.HasValue(StateProperty));
+            Assert.Null(sidecar[StateProperty]);
+
+            entity.State = "Banana vapor";
+
+            sidecar.EnsureSnapshot(StateProperty);
+
+            Assert.True(sidecar.HasValue(StateProperty));
+            Assert.Null(sidecar[StateProperty]);
+        }
+
+        [Fact]
+        public void Ensuring_snapshot_does_nothing_for_property_that_cannot_be_stored()
+        {
+            var entity = new Banana { Id = 77, Name = "Stand", State = "Frozen" };
+            var sidecar = CreateSidecar(CreateStateEntry(entity));
+
+            sidecar.EnsureSnapshot(NameProperty);
+
+            Assert.False(sidecar.HasValue(NameProperty));
+        }
+
+        protected abstract Sidecar CreateSidecar(StateEntry entry = null);
+
+        protected StateEntry CreateStateEntry(Banana entity = null)
+        {
+            entity = entity ?? new Banana { Id = 77, Name = "Stand", State = "Frozen" };
+
+            var configuration = new EntityContext(
+                new EntityConfigurationBuilder().UseModel(_model).BuildConfiguration()).Configuration;
+
+            return configuration.StateEntryFactory.Create(_model.GetEntityType(typeof(Banana)), entity);
+        }
+
+        private static Model BuildModel()
+        {
+            var model = new Model();
+
+            var entityType = new EntityType(typeof(Banana));
+            entityType.AddProperty("Id", typeof(int), shadowProperty: false, concurrencyToken: true);
+            entityType.AddProperty("Name", typeof(string));
+            entityType.AddProperty("State", typeof(string), shadowProperty: false, concurrencyToken: true);
+            model.AddEntityType(entityType);
+
+            return model;
+        }
+
+        protected IProperty IdProperty
+        {
+            get { return _model.GetEntityType(typeof(Banana)).GetProperty("Id"); }
+        }
+
+        protected IProperty NameProperty
+        {
+            get { return _model.GetEntityType(typeof(Banana)).GetProperty("Name"); }
+        }
+
+        protected IProperty StateProperty
+        {
+            get { return _model.GetEntityType(typeof(Banana)).GetProperty("State"); }
+        }
+
+        protected class Banana : INotifyPropertyChanged, INotifyPropertyChanging
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public string State { get; set; }
+
+            public event PropertyChangedEventHandler PropertyChanged;
+            public event PropertyChangingEventHandler PropertyChanging;
+        }
+    }
+}

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/SimpleEntityKeyFactoryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/SimpleEntityKeyFactoryTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             typeMock.Setup(m => m.GetKey().Properties).Returns(new[] { keyProp });
 
             var entryMock = new Mock<StateEntry>();
-            entryMock.Setup(m => m.GetPropertyValue(keyProp)).Returns(7);
+            entryMock.Setup(m => m[keyProp]).Returns(7);
             entryMock.Setup(m => m.EntityType).Returns(typeMock.Object);
 
             var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>().Create(
@@ -39,8 +39,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var random = new Random();
             var entryMock = new Mock<StateEntry>();
-            entryMock.Setup(m => m.GetPropertyValue(keyProp)).Returns(7);
-            entryMock.Setup(m => m.GetPropertyValue(nonKeyProp)).Returns("Ate");
+            entryMock.Setup(m => m[keyProp]).Returns(7);
+            entryMock.Setup(m => m[nonKeyProp]).Returns("Ate");
             entryMock.Setup(m => m.EntityType).Returns(typeMock.Object);
 
             var key = (SimpleEntityKey<string>)new SimpleEntityKeyFactory<string>().Create(

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateDataTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateDataTest.cs
@@ -1,0 +1,123 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.ChangeTracking;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.ChangeTracking
+{
+    public class StateDataTest
+    {
+        [Fact]
+        public void Can_read_and_manipulate_property_state()
+        {
+            for (var i = 0; i < 70; i++)
+            {
+                PropertyManipulation(i);
+            }
+        }
+
+        public void PropertyManipulation(int propertyCount)
+        {
+            var data = new StateEntry.StateData(propertyCount);
+
+            Assert.False(data.AnyPropertiesModified());
+
+            for (var i = 0; i < propertyCount; i++)
+            {
+                data.SetPropertyModified(i, true);
+
+                for (var j = 0; j < propertyCount; j++)
+                {
+                    Assert.Equal(j <= i, data.IsPropertyModified(j));
+                }
+
+                Assert.True(data.AnyPropertiesModified());
+            }
+
+            for (var i = 0; i < propertyCount; i++)
+            {
+                data.SetPropertyModified(i, false);
+
+                for (var j = 0; j < propertyCount; j++)
+                {
+                    Assert.Equal(j > i, data.IsPropertyModified(j));
+                }
+
+                Assert.Equal(i < propertyCount - 1, data.AnyPropertiesModified());
+            }
+
+            for (var i = 0; i < propertyCount; i++)
+            {
+                Assert.False(data.IsPropertyModified(i));
+            }
+
+            data.SetAllPropertiesModified(propertyCount);
+
+            Assert.Equal(propertyCount > 0, data.AnyPropertiesModified());
+
+            for (var i = 0; i < propertyCount; i++)
+            {
+                Assert.True(data.IsPropertyModified(i));
+            }
+        }
+
+        [Fact]
+        public void Can_get_and_set_EntityState()
+        {
+            var data = new StateEntry.StateData(70);
+
+            Assert.Equal(EntityState.Unknown, data.EntityState);
+
+            data.EntityState = EntityState.Unchanged;
+            Assert.Equal(EntityState.Unchanged, data.EntityState);
+
+            data.EntityState = EntityState.Modified;
+            Assert.Equal(EntityState.Modified, data.EntityState);
+
+            data.EntityState = EntityState.Added;
+            Assert.Equal(EntityState.Added, data.EntityState);
+
+            data.EntityState = EntityState.Deleted;
+            Assert.Equal(EntityState.Deleted, data.EntityState);
+
+            data.SetAllPropertiesModified(70);
+
+            Assert.Equal(EntityState.Deleted, data.EntityState);
+
+            data.EntityState = EntityState.Unchanged;
+            Assert.Equal(EntityState.Unchanged, data.EntityState);
+
+            data.EntityState = EntityState.Modified;
+            Assert.Equal(EntityState.Modified, data.EntityState);
+
+            data.EntityState = EntityState.Added;
+            Assert.Equal(EntityState.Added, data.EntityState);
+
+            data.EntityState = EntityState.Unknown;
+            Assert.Equal(EntityState.Unknown, data.EntityState);
+        }
+
+        [Fact]
+        public void Can_get_and_set_sidecar_flag()
+        {
+            var data = new StateEntry.StateData(70);
+
+            Assert.False(data.TransparentSidecarInUse);
+
+            data.TransparentSidecarInUse = true;
+            Assert.True(data.TransparentSidecarInUse);
+
+            data.TransparentSidecarInUse = false;
+            Assert.False(data.TransparentSidecarInUse);
+
+            data.SetAllPropertiesModified(70);
+
+            Assert.False(data.TransparentSidecarInUse);
+
+            data.TransparentSidecarInUse = true;
+            Assert.True(data.TransparentSidecarInUse);
+
+            data.TransparentSidecarInUse = false;
+        }
+    }
+}

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateEntryFactoryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateEntryFactoryTest.cs
@@ -92,8 +92,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             Assert.Same(configurationMock.Object, entry.Configuration);
             Assert.Same(entityType, entry.EntityType);
-            Assert.Equal(77, entry.GetPropertyValue(property1));
-            Assert.Equal("Green", entry.GetPropertyValue(property2));
+            Assert.Equal(77, entry[property1]);
+            Assert.Equal("Green", entry[property2]);
             Assert.Null(entry.Entity);
         }
 
@@ -114,8 +114,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             Assert.Same(configurationMock.Object, entry.Configuration);
             Assert.Same(entityType, entry.EntityType);
-            Assert.Equal(77, entry.GetPropertyValue(property1));
-            Assert.Equal("Green", entry.GetPropertyValue(property2));
+            Assert.Equal(77, entry[property1]);
+            Assert.Equal("Green", entry[property2]);
 
             var entity = (RedHook)entry.Entity;
             Assert.Equal(77, entity.Long);
@@ -139,8 +139,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             Assert.Same(configurationMock.Object, entry.Configuration);
             Assert.Same(entityType, entry.EntityType);
-            Assert.Equal(77, entry.GetPropertyValue(property1));
-            Assert.Equal("Green", entry.GetPropertyValue(property2));
+            Assert.Equal(77, entry[property1]);
+            Assert.Equal("Green", entry[property2]);
 
             var entity = (RedHook)entry.Entity;
             Assert.Equal(77, entity.Long);

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateEntrySubscriberTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateEntrySubscriberTest.cs
@@ -15,29 +15,33 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         [Fact]
         public void Snapshot_is_performed_when_not_using_eager_original_values()
         {
-            var mockEntityType = new Mock<IEntityType>();
-            mockEntityType.Setup(m => m.UseLazyOriginalValues).Returns(false);
+            var entityTypeMock = new Mock<IEntityType>();
+            entityTypeMock.Setup(m => m.UseLazyOriginalValues).Returns(false);
 
+            var originalValuesMock = new Mock<OriginalValues>();
             var entryMock = new Mock<StateEntry>();
-            entryMock.Setup(m => m.EntityType).Returns(mockEntityType.Object);
+            entryMock.Setup(m => m.EntityType).Returns(entityTypeMock.Object);
+            entryMock.Setup(m => m.OriginalValues).Returns(originalValuesMock.Object);
 
             new StateEntrySubscriber().SnapshotAndSubscribe(entryMock.Object);
 
-            entryMock.Verify(m => m.SnapshotOriginalValues());
+            originalValuesMock.Verify(m => m.TakeSnapshot());
         }
 
         [Fact]
         public void Snapshot_is_not_performed_when_not_using_lazy_original_values()
         {
-            var mockEntityType = new Mock<IEntityType>();
-            mockEntityType.Setup(m => m.UseLazyOriginalValues).Returns(true);
+            var entityTypeMock = new Mock<IEntityType>();
+            entityTypeMock.Setup(m => m.UseLazyOriginalValues).Returns(true);
 
+            var originalValuesMock = new Mock<OriginalValues>();
             var entryMock = new Mock<StateEntry>();
-            entryMock.Setup(m => m.EntityType).Returns(mockEntityType.Object);
+            entryMock.Setup(m => m.EntityType).Returns(entityTypeMock.Object);
+            entryMock.Setup(m => m.OriginalValues).Returns(originalValuesMock.Object);
 
             new StateEntrySubscriber().SnapshotAndSubscribe(entryMock.Object);
 
-            entryMock.Verify(m => m.SnapshotOriginalValues(), Times.Never);
+            originalValuesMock.Verify(m => m.TakeSnapshot(), Times.Never);
         }
 
         [Fact]

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateEntryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateEntryTest.cs
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Identity;
 using Microsoft.Data.Entity.Metadata;
@@ -26,7 +28,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var configuration = CreateConfiguration(model);
 
             var entry = CreateStateEntry(configuration, entityType, new SomeEntity());
-            entry.SetPropertyValue(keyProperty, 1);
+            entry[keyProperty] = 1;
 
             entry.EntityState = EntityState.Added;
 
@@ -44,7 +46,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var configuration = CreateConfiguration(model);
 
             var entry = CreateStateEntry(configuration, entityType, new SomeEntity());
-            entry.SetPropertyValue(keyProperty, 1);
+            entry[keyProperty] = 1;
 
             entry.EntityState = EntityState.Added;
             entry.EntityState = EntityState.Unknown;
@@ -63,7 +65,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var configuration = CreateConfiguration(model);
 
             var entry = CreateStateEntry(configuration, entityType, new SomeEntity());
-            entry.SetPropertyValue(keyProperty, 1);
+            entry[keyProperty] = 1;
 
             Assert.False(entry.IsPropertyModified(keyProperty));
             Assert.False(entry.IsPropertyModified(nonKeyProperty));
@@ -102,7 +104,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             entry.EntityState = EntityState.Added;
 
-            Assert.Equal(77, entry.GetPropertyValue(keyProperty));
+            Assert.Equal(77, entry[keyProperty]);
         }
 
         [Fact]
@@ -114,7 +116,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var configuration = CreateConfiguration(model);
 
             var entry = CreateStateEntry(configuration, entityType, new SomeEntity());
-            entry.SetPropertyValue(keyProperty, 77);
+            entry[keyProperty] = 77;
 
             var keyValue = entry.GetPrimaryKeyValue();
             Assert.IsType<SimpleEntityKey<int>>(keyValue);
@@ -130,7 +132,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var configuration = CreateConfiguration(model);
 
             var entry = CreateStateEntry(configuration, entityType, new SomeDependentEntity());
-            entry.SetPropertyValue(fkProperty, 77);
+            entry[fkProperty] = 77;
 
             var keyValue = entry.GetDependentKeyValue(entityType.ForeignKeys.Single());
             Assert.IsType<SimpleEntityKey<int>>(keyValue);
@@ -147,7 +149,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var configuration = CreateConfiguration(model);
 
             var entry = CreateStateEntry(configuration, principalType, new SomeEntity());
-            entry.SetPropertyValue(key, 77);
+            entry[key] = 77;
 
             var keyValue = entry.GetPrincipalKeyValue(dependentType.ForeignKeys.Single());
             Assert.IsType<SimpleEntityKey<int>>(keyValue);
@@ -164,7 +166,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var entry = CreateStateEntry(configuration, entityType, new ObjectArrayValueReader(new object[] { 1, "Kool" }));
 
-            Assert.Equal(1, entry.GetPropertyValue(keyProperty));
+            Assert.Equal(1, entry[keyProperty]);
         }
 
         [Fact]
@@ -177,9 +179,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var entry = CreateStateEntry(configuration, entityType, new ObjectArrayValueReader(new object[] { 1, "Kool" }));
 
-            entry.SetPropertyValue(keyProperty, 77);
+            entry[keyProperty] = 77;
 
-            Assert.Equal(77, entry.GetPropertyValue(keyProperty));
+            Assert.Equal(77, entry[keyProperty]);
         }
 
         [Fact]
@@ -193,11 +195,11 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var entry = CreateStateEntry(configuration, entityType, new SomeEntity());
 
-            entry.SetPropertyValue(keyProperty, 77);
-            entry.SetPropertyValue(nonKeyProperty, "Magic Tree House");
+            entry[keyProperty] = 77;
+            entry[nonKeyProperty] = "Magic Tree House";
 
-            Assert.Equal(77, entry.GetPropertyValue(keyProperty));
-            Assert.Equal("Magic Tree House", entry.GetPropertyValue(nonKeyProperty));
+            Assert.Equal(77, entry[keyProperty]);
+            Assert.Equal("Magic Tree House", entry[nonKeyProperty]);
         }
 
         [Fact]
@@ -211,8 +213,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var entry = CreateStateEntry(configuration, entityType, new SomeEntity());
 
-            entry.SetPropertyValue(keyProperty, 77);
-            entry.SetPropertyValue(nonKeyProperty, "Magic Tree House");
+            entry[keyProperty] = 77;
+            entry[nonKeyProperty] = "Magic Tree House";
 
             Assert.Equal(new object[] { 77, "Magic Tree House" }, entry.GetValueBuffer());
         }
@@ -235,26 +237,26 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var entry = CreateStateEntry(configuration, entityType, new ObjectArrayValueReader(new object[] { 1, "Kool" }));
 
-            Assert.Equal(1, entry.GetPropertyOriginalValue(idProperty));
-            Assert.Equal("Kool", entry.GetPropertyOriginalValue(nameProperty));
-            Assert.Equal(1, entry.GetPropertyValue(idProperty));
-            Assert.Equal("Kool", entry.GetPropertyValue(nameProperty));
+            Assert.Equal(1, entry.OriginalValues[idProperty]);
+            Assert.Equal("Kool", entry.OriginalValues[nameProperty]);
+            Assert.Equal(1, entry[idProperty]);
+            Assert.Equal("Kool", entry[nameProperty]);
 
-            entry.SetPropertyValue(idProperty, 2);
-            entry.SetPropertyValue(nameProperty, "Beans");
+            entry[idProperty] = 2;
+            entry[nameProperty] = "Beans";
 
-            Assert.Equal(1, entry.GetPropertyOriginalValue(idProperty));
-            Assert.Equal("Kool", entry.GetPropertyOriginalValue(nameProperty));
-            Assert.Equal(2, entry.GetPropertyValue(idProperty));
-            Assert.Equal("Beans", entry.GetPropertyValue(nameProperty));
+            Assert.Equal(1, entry.OriginalValues[idProperty]);
+            Assert.Equal("Kool", entry.OriginalValues[nameProperty]);
+            Assert.Equal(2, entry[idProperty]);
+            Assert.Equal("Beans", entry[nameProperty]);
 
-            entry.SetPropertyOriginalValue(idProperty, 3);
-            entry.SetPropertyOriginalValue(nameProperty, "Franks");
+            entry.OriginalValues[idProperty] = 3;
+            entry.OriginalValues[nameProperty] = "Franks";
 
-            Assert.Equal(3, entry.GetPropertyOriginalValue(idProperty));
-            Assert.Equal("Franks", entry.GetPropertyOriginalValue(nameProperty));
-            Assert.Equal(2, entry.GetPropertyValue(idProperty));
-            Assert.Equal("Beans", entry.GetPropertyValue(nameProperty));
+            Assert.Equal(3, entry.OriginalValues[idProperty]);
+            Assert.Equal("Franks", entry.OriginalValues[nameProperty]);
+            Assert.Equal(2, entry[idProperty]);
+            Assert.Equal("Beans", entry[nameProperty]);
         }
 
         [Fact]
@@ -285,18 +287,18 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var entry = CreateStateEntry(configuration, entityType, new ObjectArrayValueReader(new object[] { 1, "Kool" }));
 
-            Assert.Equal("Kool", entry.GetPropertyOriginalValue(nameProperty));
-            Assert.Equal("Kool", entry.GetPropertyValue(nameProperty));
+            Assert.Equal("Kool", entry.OriginalValues[nameProperty]);
+            Assert.Equal("Kool", entry[nameProperty]);
 
-            entry.SetPropertyValue(nameProperty, "Beans");
+            entry[nameProperty] = "Beans";
 
-            Assert.Equal("Kool", entry.GetPropertyOriginalValue(nameProperty));
-            Assert.Equal("Beans", entry.GetPropertyValue(nameProperty));
+            Assert.Equal("Kool", entry.OriginalValues[nameProperty]);
+            Assert.Equal("Beans", entry[nameProperty]);
 
-            entry.SetPropertyOriginalValue(nameProperty, "Franks");
+            entry.OriginalValues[nameProperty] = "Franks";
 
-            Assert.Equal("Franks", entry.GetPropertyOriginalValue(nameProperty));
-            Assert.Equal("Beans", entry.GetPropertyValue(nameProperty));
+            Assert.Equal("Franks", entry.OriginalValues[nameProperty]);
+            Assert.Equal("Beans", entry[nameProperty]);
         }
 
         [Fact]
@@ -327,23 +329,23 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var entry = CreateStateEntry(configuration, entityType, new ObjectArrayValueReader(new object[] { 1, null }));
 
-            Assert.Null(entry.GetPropertyOriginalValue(nameProperty));
-            Assert.Null(entry.GetPropertyValue(nameProperty));
+            Assert.Null(entry.OriginalValues[nameProperty]);
+            Assert.Null(entry[nameProperty]);
 
-            entry.SetPropertyValue(nameProperty, "Beans");
+            entry[nameProperty] = "Beans";
 
-            Assert.Null(entry.GetPropertyOriginalValue(nameProperty));
-            Assert.Equal("Beans", entry.GetPropertyValue(nameProperty));
+            Assert.Null(entry.OriginalValues[nameProperty]);
+            Assert.Equal("Beans", entry[nameProperty]);
 
-            entry.SetPropertyOriginalValue(nameProperty, "Franks");
+            entry.OriginalValues[nameProperty] = "Franks";
 
-            Assert.Equal("Franks", entry.GetPropertyOriginalValue(nameProperty));
-            Assert.Equal("Beans", entry.GetPropertyValue(nameProperty));
+            Assert.Equal("Franks", entry.OriginalValues[nameProperty]);
+            Assert.Equal("Beans", entry[nameProperty]);
 
-            entry.SetPropertyOriginalValue(nameProperty, null);
+            entry.OriginalValues[nameProperty] = null;
 
-            Assert.Null(entry.GetPropertyOriginalValue(nameProperty));
-            Assert.Equal("Beans", entry.GetPropertyValue(nameProperty));
+            Assert.Null(entry.OriginalValues[nameProperty]);
+            Assert.Equal("Beans", entry[nameProperty]);
         }
 
         [Fact]
@@ -369,15 +371,15 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.False(entry.IsPropertyModified(nameProperty));
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
 
-            entry.SetPropertyValue(idProperty, 1);
-            entry.SetPropertyValue(nameProperty, "Kool");
+            entry[idProperty] = 1;
+            entry[nameProperty] = "Kool";
 
             Assert.False(entry.IsPropertyModified(idProperty));
             Assert.False(entry.IsPropertyModified(nameProperty));
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
 
-            entry.SetPropertyValue(idProperty, 2);
-            entry.SetPropertyValue(nameProperty, "Beans");
+            entry[idProperty] = 2;
+            entry[nameProperty] = "Beans";
 
             Assert.True(entry.IsPropertyModified(idProperty));
             Assert.True(entry.IsPropertyModified(nameProperty));
@@ -467,14 +469,14 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entry = CreateStateEntry(configuration, entityType, new ObjectArrayValueReader(new object[] { 1, "Kool" }));
             entry.EntityState = entityState;
 
-            entry.SetPropertyValue(nameProperty, "Pickle");
-            entry.SetPropertyOriginalValue(nameProperty, "Cheese");
+            entry[nameProperty] = "Pickle";
+            entry.OriginalValues[nameProperty] = "Cheese";
 
             entry.AcceptChanges();
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
-            Assert.Equal("Pickle", entry.GetPropertyValue(nameProperty));
-            Assert.Equal("Pickle", entry.GetPropertyOriginalValue(nameProperty));
+            Assert.Equal("Pickle", entry[nameProperty]);
+            Assert.Equal("Pickle", entry.OriginalValues[nameProperty]);
         }
 
         [Fact]
@@ -488,13 +490,13 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entry = CreateStateEntry(configuration, entityType, new ObjectArrayValueReader(new object[] { 1, "Kool" }));
             entry.EntityState = EntityState.Modified;
 
-            entry.SetPropertyValue(nameProperty, "Pickle");
+            entry[nameProperty] = "Pickle";
 
             entry.AcceptChanges();
 
             Assert.Equal(EntityState.Unchanged, entry.EntityState);
-            Assert.Equal("Pickle", entry.GetPropertyValue(nameProperty));
-            Assert.Equal("Pickle", entry.GetPropertyOriginalValue(nameProperty));
+            Assert.Equal("Pickle", entry[nameProperty]);
+            Assert.Equal("Pickle", entry.OriginalValues[nameProperty]);
         }
 
         [Fact]
@@ -512,16 +514,296 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.Equal(EntityState.Unknown, entry.EntityState);
         }
 
+        [Fact]
+        public void Can_add_and_remove_sidecars()
+        {
+            var model = BuildModel();
+            var entry = CreateStateEntry(
+                CreateConfiguration(model), 
+                model.GetEntityType("SomeEntity"), 
+                new ObjectArrayValueReader(new object[] { 1, "Kool" }));
+
+            var sidecarMock1 = new Mock<Sidecar>();
+            sidecarMock1.Setup(m => m.Name).Returns("IMZ-Ural");
+            sidecarMock1.Setup(m => m.AutoCommit).Returns(true);
+
+            var sidecarMock2 = new Mock<Sidecar>();
+            sidecarMock2.Setup(m => m.Name).Returns("GG Duetto");
+
+            var originalValues = entry.TryGetSidecar(Sidecar.WellKnownNames.OriginalValues);
+
+            Assert.True(entry.EntityType.HasClrType == (originalValues != null));
+            Assert.Null(entry.TryGetSidecar("IMZ-Ural"));
+            Assert.Null(entry.TryGetSidecar("GG Duetto"));
+
+            entry.AddSidecar(sidecarMock1.Object);
+            entry.AddSidecar(sidecarMock2.Object);
+
+            Assert.Same(originalValues, entry.TryGetSidecar(Sidecar.WellKnownNames.OriginalValues));
+            Assert.Same(sidecarMock1.Object, entry.TryGetSidecar("IMZ-Ural"));
+            Assert.Same(sidecarMock2.Object, entry.TryGetSidecar("GG Duetto"));
+
+            entry.RemoveSidecar("IMZ-Ural");
+            entry.RemoveSidecar("GG Duetto");
+
+            Assert.Same(originalValues, entry.TryGetSidecar(Sidecar.WellKnownNames.OriginalValues));
+            Assert.Null(entry.TryGetSidecar("IMZ-Ural"));
+            Assert.Null(entry.TryGetSidecar("GG Duetto"));
+
+            entry.RemoveSidecar("IMZ-Ural");
+            entry.RemoveSidecar("GG Duetto");
+
+            Assert.Same(originalValues, entry.TryGetSidecar(Sidecar.WellKnownNames.OriginalValues));
+            Assert.Null(entry.TryGetSidecar("IMZ-Ural"));
+            Assert.Null(entry.TryGetSidecar("GG Duetto"));
+
+            entry.RemoveSidecar(Sidecar.WellKnownNames.OriginalValues);
+
+            Assert.Null(entry.TryGetSidecar(Sidecar.WellKnownNames.OriginalValues));
+            Assert.Null(entry.TryGetSidecar("IMZ-Ural"));
+            Assert.Null(entry.TryGetSidecar("GG Duetto"));
+
+            entry.RemoveSidecar("IMZ-Ural");
+            entry.RemoveSidecar("GG Duetto");
+
+            Assert.Null(entry.TryGetSidecar(Sidecar.WellKnownNames.OriginalValues));
+            Assert.Null(entry.TryGetSidecar("IMZ-Ural"));
+            Assert.Null(entry.TryGetSidecar("GG Duetto"));
+
+            entry.AddSidecar(sidecarMock1.Object);
+
+            Assert.Null(entry.TryGetSidecar(Sidecar.WellKnownNames.OriginalValues));
+            Assert.Same(sidecarMock1.Object, entry.TryGetSidecar("IMZ-Ural"));
+            Assert.Null(entry.TryGetSidecar("GG Duetto"));
+        }
+
+        [Fact]
+        public void Non_transparent_sidecar_does_not_intercept_normal_property_read_and_write()
+        {
+            var model = BuildModel();
+            var entityType = model.GetEntityType("SomeEntity");
+            var idProperty = entityType.GetProperty("Id");
+            var nameProperty = entityType.GetProperty("Name");
+
+            var entry = CreateStateEntry(
+                CreateConfiguration(model), 
+                entityType, 
+                new ObjectArrayValueReader(new object[] { 1, "Kool" }));
+
+            var sidecar = entry.AddSidecar(new TheWasp(entry, new[] { idProperty }));
+
+            Assert.Equal(1, entry[idProperty]);
+            Assert.Equal("Kool", entry[nameProperty]);
+
+            sidecar[idProperty] = 7;
+
+            Assert.Equal(1, entry[idProperty]);
+            Assert.Equal("Kool", entry[nameProperty]);
+
+            entry[idProperty] = 77;
+
+            Assert.Equal(77, entry[idProperty]);
+            Assert.Equal("Kool", entry[nameProperty]);
+        }
+
+        [Fact]
+        public void Can_read_values_from_sidecar_transparently()
+        {
+            var model = BuildModel();
+            var entityType = model.GetEntityType("SomeEntity");
+            var idProperty = entityType.GetProperty("Id");
+            var nameProperty = entityType.GetProperty("Name");
+
+            var entry = CreateStateEntry(
+                CreateConfiguration(model),
+                entityType,
+                new ObjectArrayValueReader(new object[] { 1, "Kool" }));
+
+            var sidecar = entry.AddSidecar(new TheWasp(entry, new[] { idProperty }, transparentRead: true));
+
+            Assert.Equal(1, entry[idProperty]);
+            Assert.Equal(1, sidecar[idProperty]);
+            Assert.Equal("Kool", entry[nameProperty]);
+
+            sidecar[idProperty] = 7;
+
+            Assert.Equal(7, entry[idProperty]);
+            Assert.Equal(7, sidecar[idProperty]);
+            Assert.Equal("Kool", entry[nameProperty]);
+
+            entry[idProperty] = 77;
+
+            Assert.Equal(7, entry[idProperty]);
+            Assert.Equal(7, sidecar[idProperty]);
+            Assert.Equal("Kool", entry[nameProperty]);
+
+            entry.RemoveSidecar(sidecar.Name);
+
+            Assert.Equal(77, entry[idProperty]);
+            Assert.Equal("Kool", entry[nameProperty]);
+        }
+
+        [Fact]
+        public void Can_write_values_to_sidecar_transparently()
+        {
+            var model = BuildModel();
+            var entityType = model.GetEntityType("SomeEntity");
+            var idProperty = entityType.GetProperty("Id");
+            var nameProperty = entityType.GetProperty("Name");
+
+            var entry = CreateStateEntry(
+                CreateConfiguration(model),
+                entityType,
+                new ObjectArrayValueReader(new object[] { 1, "Kool" }));
+
+            var sidecar = entry.AddSidecar(new TheWasp(entry, new[] { idProperty }, transparentWrite: true));
+
+            Assert.Equal(1, entry[idProperty]);
+            Assert.Equal("Kool", entry[nameProperty]);
+
+            entry[idProperty] = 7;
+
+            Assert.Equal(1, entry[idProperty]);
+            Assert.Equal(7, sidecar[idProperty]);
+            Assert.Equal("Kool", entry[nameProperty]);
+
+            sidecar[idProperty] = 77;
+
+            Assert.Equal(1, entry[idProperty]);
+            Assert.Equal(77, sidecar[idProperty]);
+            Assert.Equal("Kool", entry[nameProperty]);
+
+            entry.RemoveSidecar(sidecar.Name);
+
+            Assert.Equal(1, entry[idProperty]);
+            Assert.Equal("Kool", entry[nameProperty]);
+        }
+
+        [Fact]
+        public void Can_auto_commit_sidecars()
+        {
+            var model = BuildModel();
+            var entityType = model.GetEntityType("SomeEntity");
+            var idProperty = entityType.GetProperty("Id");
+            var nameProperty = entityType.GetProperty("Name");
+
+            var entry = CreateStateEntry(
+                CreateConfiguration(model),
+                entityType,
+                new ObjectArrayValueReader(new object[] { 1, "Kool" }));
+
+            var sidecar = entry.AddSidecar(new TheWasp(entry, new[] { idProperty }, autoCommit: true));
+
+            sidecar[idProperty] = 77;
+
+            Assert.Equal(1, entry[idProperty]);
+            Assert.Equal(77, sidecar[idProperty]);
+            Assert.Equal("Kool", entry[nameProperty]);
+
+            entry.AutoCommitSidecars();
+            
+            Assert.Equal(77, entry[idProperty]);
+
+            Assert.Null(entry.TryGetSidecar(sidecar.Name));
+        }
+
+        [Fact]
+        public void Can_auto_rollback_sidecars()
+        {
+            var model = BuildModel();
+            var entityType = model.GetEntityType("SomeEntity");
+            var idProperty = entityType.GetProperty("Id");
+            var nameProperty = entityType.GetProperty("Name");
+
+            var entry = CreateStateEntry(
+                CreateConfiguration(model),
+                entityType,
+                new ObjectArrayValueReader(new object[] { 1, "Kool" }));
+
+            var sidecar = entry.AddSidecar(new TheWasp(entry, new[] { idProperty }, autoCommit: true));
+
+            sidecar[idProperty] = 77;
+
+            Assert.Equal(1, entry[idProperty]);
+            Assert.Equal(77, sidecar[idProperty]);
+            Assert.Equal("Kool", entry[nameProperty]);
+
+            entry.AutoRollbackSidecars();
+
+            Assert.Equal(1, entry[idProperty]);
+
+            Assert.Null(entry.TryGetSidecar(sidecar.Name));
+        }
+
+        private class TheWasp : DictionarySidecar
+        {
+            private readonly bool _transparentRead;
+            private readonly bool _transparentWrite;
+            private readonly bool _autoCommit;
+
+            public TheWasp(
+                StateEntry stateEntry, IEnumerable<IProperty> properties, 
+                bool transparentRead = false, bool transparentWrite = false, bool autoCommit = false)
+                : base(stateEntry, properties)
+            {
+                _transparentRead = transparentRead;
+                _transparentWrite = transparentWrite;
+                _autoCommit = autoCommit;
+            }
+
+            public override string Name
+            {
+                get { return "Wasp Motorcycles"; }
+            }
+
+            public override bool TransparentRead
+            {
+                get { return _transparentRead; }
+            }
+
+            public override bool TransparentWrite
+            {
+                get { return _transparentWrite; }
+            }
+
+            public override bool AutoCommit
+            {
+                get { return _autoCommit; }
+            }
+        }
+
+        [Fact]
+        public void Sidecars_are_added_for_store_generated_values_when_preparing_to_save()
+        {
+            var model = BuildModel();
+            var entityType = model.GetEntityType("SomeEntity");
+            var idProperty = entityType.GetProperty("Id");
+            var nameProperty = entityType.GetProperty("Name");
+
+            var entry = CreateStateEntry(
+                CreateConfiguration(model),
+                entityType,
+                new ObjectArrayValueReader(new object[] { 1, "Kool" }));
+
+            entry.PrepareToSave();
+
+            var storeGenValues = entry.TryGetSidecar(Sidecar.WellKnownNames.StoreGeneratedValues);
+
+            Assert.NotNull(storeGenValues);
+            Assert.True(storeGenValues.CanStoreValue(idProperty));
+            Assert.False(storeGenValues.CanStoreValue(nameProperty));
+        }
+
         protected virtual StateEntry CreateStateEntry(ContextConfiguration configuration, IEntityType entityType, object entity)
         {
             return new StateEntrySubscriber().SnapshotAndSubscribe(
-                new StateEntryFactory(configuration, new EntityMaterializerSource(new MemberMapper(new FieldMatcher()))).Create(entityType, entity));
+                new StateEntryFactory(configuration, configuration.EntityMaterializerSource).Create(entityType, entity));
         }
 
         protected virtual StateEntry CreateStateEntry(ContextConfiguration configuration, IEntityType entityType, IValueReader valueReader)
         {
             return new StateEntrySubscriber().SnapshotAndSubscribe(
-                new StateEntryFactory(configuration, new EntityMaterializerSource(new MemberMapper(new FieldMatcher()))).Create(entityType, valueReader));
+                new StateEntryFactory(configuration, configuration.EntityMaterializerSource).Create(entityType, valueReader));
         }
 
         protected virtual ContextConfiguration CreateConfiguration(IModel model)
@@ -537,9 +819,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entityType1 = new EntityType(typeof(SomeEntity));
             model.AddEntityType(entityType1);
             var key1 = entityType1.AddProperty("Id", typeof(int));
+            key1.ValueGenerationStrategy = ValueGenerationStrategy.StoreIdentity;
             entityType1.SetKey(key1);
             entityType1.AddProperty("Name", typeof(string), shadowProperty: false, concurrencyToken: true);
-
+            
             var entityType2 = new EntityType(typeof(SomeDependentEntity));
             model.AddEntityType(entityType2);
             var key2 = entityType2.AddProperty("Id", typeof(int));
@@ -670,99 +953,6 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
                 {
                     PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
                 }
-            }
-        }
-
-        public class StateDataTest
-        {
-            [Fact]
-            public void Can_read_and_manipulate_property_state()
-            {
-                for (var i = 0; i < 70; i++)
-                {
-                    PropertyManipulation(i);
-                }
-            }
-
-            public void PropertyManipulation(int propertyCount)
-            {
-                var data = new StateEntry.StateData(propertyCount);
-
-                Assert.False(data.AnyPropertiesModified());
-
-                for (var i = 0; i < propertyCount; i++)
-                {
-                    data.SetPropertyModified(i, true);
-
-                    for (var j = 0; j < propertyCount; j++)
-                    {
-                        Assert.Equal(j <= i, data.IsPropertyModified(j));
-                    }
-
-                    Assert.True(data.AnyPropertiesModified());
-                }
-
-                for (var i = 0; i < propertyCount; i++)
-                {
-                    data.SetPropertyModified(i, false);
-
-                    for (var j = 0; j < propertyCount; j++)
-                    {
-                        Assert.Equal(j > i, data.IsPropertyModified(j));
-                    }
-
-                    Assert.Equal(i < propertyCount - 1, data.AnyPropertiesModified());
-                }
-
-                for (var i = 0; i < propertyCount; i++)
-                {
-                    Assert.False(data.IsPropertyModified(i));
-                }
-
-                data.SetAllPropertiesModified(propertyCount);
-
-                Assert.Equal(propertyCount > 0, data.AnyPropertiesModified());
-
-                for (var i = 0; i < propertyCount; i++)
-                {
-                    Assert.True(data.IsPropertyModified(i));
-                }
-            }
-
-            [Fact]
-            public void Can_get_and_set_EntityState()
-            {
-                var data = new StateEntry.StateData(70);
-
-                Assert.Equal(EntityState.Unknown, data.EntityState);
-
-                data.EntityState = EntityState.Unchanged;
-                Assert.Equal(EntityState.Unchanged, data.EntityState);
-
-                data.EntityState = EntityState.Modified;
-                Assert.Equal(EntityState.Modified, data.EntityState);
-
-                data.EntityState = EntityState.Added;
-                Assert.Equal(EntityState.Added, data.EntityState);
-
-                data.EntityState = EntityState.Deleted;
-                Assert.Equal(EntityState.Deleted, data.EntityState);
-
-                data.SetAllPropertiesModified(70);
-
-                Assert.Equal(EntityState.Deleted, data.EntityState);
-
-                data.EntityState = EntityState.Unchanged;
-                Assert.Equal(EntityState.Unchanged, data.EntityState);
-
-                data.EntityState = EntityState.Modified;
-                Assert.Equal(EntityState.Modified, data.EntityState);
-
-                data.EntityState = EntityState.Added;
-                Assert.Equal(EntityState.Added, data.EntityState);
-
-                data.EntityState = EntityState.Unknown;
-                Assert.Equal(EntityState.Unknown, data.EntityState);
             }
         }
     }

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/StoreGeneratedValuesTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/StoreGeneratedValuesTest.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.ChangeTracking;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.ChangeTracking
+{
+    public class StoreGeneratedValuesTest : SidecarTest
+    {
+        [Fact]
+        public void Is_set_up_for_transparent_access_and_auto_commit()
+        {
+            var sidecar = CreateSidecar();
+
+            Assert.True(sidecar.TransparentRead);
+            Assert.True(sidecar.TransparentWrite);
+            Assert.True(sidecar.AutoCommit);
+        }
+
+        [Fact]
+        public void Has_expected_name()
+        {
+            Assert.Equal(Sidecar.WellKnownNames.StoreGeneratedValues, CreateSidecar().Name);
+        }
+
+        protected override Sidecar CreateSidecar(StateEntry entry = null)
+        {
+            return new StoreGeneratedValuesFactory().Create(entry ?? CreateStateEntry(), new[] { IdProperty, StateProperty });
+        }
+    }
+}

--- a/test/Microsoft.Data.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
+++ b/test/Microsoft.Data.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
@@ -33,14 +33,14 @@ namespace Microsoft.Data.InMemory.FunctionalTests
             {
                 // TODO: Better API for shadow state access
                 var customerEntry = context.ChangeTracker.StateManager.CreateNewEntry(customerType);
-                customerEntry.SetPropertyValue(customerType.GetProperty("Id"), 42);
-                customerEntry.SetPropertyValue(customerType.GetProperty("Name"), "Daenerys");
+                customerEntry[customerType.GetProperty("Id")] =  42;
+                customerEntry[customerType.GetProperty("Name")] = "Daenerys";
 
                 await customerEntry.SetEntityStateAsync(EntityState.Added, CancellationToken.None);
 
                 await context.SaveChangesAsync();
 
-                customerEntry.SetPropertyValue(customerType.GetProperty("Name"), "Changed!");
+                customerEntry[customerType.GetProperty("Name")] = "Changed!";
             }
 
             // TODO: Fix this when we can query shadow entities
@@ -51,8 +51,8 @@ namespace Microsoft.Data.InMemory.FunctionalTests
             using (var context = new EntityContext(configuration))
             {
                 var customerEntry = context.ChangeTracker.StateManager.CreateNewEntry(customerType);
-                customerEntry.SetPropertyValue(customerType.GetProperty("Id"), 42);
-                customerEntry.SetPropertyValue(customerType.GetProperty("Name"), "Daenerys Targaryen");
+                customerEntry[customerType.GetProperty("Id")] = 42;
+                customerEntry[customerType.GetProperty("Name")] = "Daenerys Targaryen";
 
                 await customerEntry.SetEntityStateAsync(EntityState.Modified, CancellationToken.None);
 
@@ -67,7 +67,7 @@ namespace Microsoft.Data.InMemory.FunctionalTests
             using (var context = new EntityContext(configuration))
             {
                 var customerEntry = context.ChangeTracker.StateManager.CreateNewEntry(customerType);
-                customerEntry.SetPropertyValue(customerType.GetProperty("Id"), 42);
+                customerEntry[customerType.GetProperty("Id")] = 42;
 
                 await customerEntry.SetEntityStateAsync(EntityState.Deleted, CancellationToken.None);
 
@@ -104,11 +104,11 @@ namespace Microsoft.Data.InMemory.FunctionalTests
 
                 // TODO: Better API for shadow state access
                 var customerEntry = context.ChangeTracker.Entry(customer).StateEntry;
-                customerEntry.SetPropertyValue(customerType.GetProperty("Name"), "Daenerys");
+                customerEntry[customerType.GetProperty("Name")] = "Daenerys";
 
                 await context.SaveChangesAsync();
 
-                customerEntry.SetPropertyValue(customerType.GetProperty("Name"), "Changed!");
+                customerEntry[customerType.GetProperty("Name")] = "Changed!";
             }
 
             using (var context = new EntityContext(configuration))
@@ -124,7 +124,7 @@ namespace Microsoft.Data.InMemory.FunctionalTests
             using (var context = new EntityContext(configuration))
             {
                 var customerEntry = context.ChangeTracker.Entry(customer).StateEntry;
-                customerEntry.SetPropertyValue(customerType.GetProperty("Name"), "Daenerys Targaryen");
+                customerEntry[customerType.GetProperty("Name")] = "Daenerys Targaryen";
 
                 context.Update(customer);
 


### PR DESCRIPTION
I like to ride my tricycle, I like to ride my trike... (Sidecars for storing alternate property values with state entries)

Original values are additional values that can be stored alongside the state entry and updated from or merged with the actual property values when appropriate. The update pipeline also needs to store additional values for properties that are store generated such that they can be used by the update pipeline while changes are being saved. These values cannot be stored directly in the state entries because they should be discarded if the save fails--or when the transaction is rolled back once we have transactions.

These two requirements are now captured into a single general-purpose concept of the sidecar on the state entry. This means that the state manager can be responsible for store value handling such that the data store/update pipeline doesn't need to do anything special--it just propagates values back into the state entry and can likewise read values from the state entry without fear of corrupting the state entry if the transaction is rolled back.

In addition, this change moves original values functionality out of the state entry for better separation of concerns, which in turn means that it is cleaner to change the storage for original values to be something other than just an object array if we determine that doing so is beneficial in terms of memory and/or speed.
