### PR TITLE
Let's call it DbDatabase!

### DIFF
--- a/src/Microsoft.Data.Entity/ChangeTracking/CompositeEntityKeyFactory.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/CompositeEntityKeyFactory.cs
@@ -9,13 +9,6 @@ namespace Microsoft.Data.Entity.ChangeTracking
 {
     public class CompositeEntityKeyFactory : EntityKeyFactory
     {
-        private static readonly CompositeEntityKeyFactory _instance = new CompositeEntityKeyFactory();
-
-        public static CompositeEntityKeyFactory Instance
-        {
-            get { return _instance; }
-        }
-
         public override EntityKey Create(IEntityType entityType, IReadOnlyList<IProperty> properties, StateEntry entry)
         {
             Check.NotNull(entityType, "entityType");

--- a/src/Microsoft.Data.Entity/ChangeTracking/EntityKeyFactorySource.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/EntityKeyFactorySource.cs
@@ -10,8 +10,26 @@ namespace Microsoft.Data.Entity.ChangeTracking
 {
     public class EntityKeyFactorySource
     {
+        private readonly CompositeEntityKeyFactory _compositeKeyFactory;
+
         private readonly ThreadSafeDictionaryCache<Type, EntityKeyFactory> _cache
             = new ThreadSafeDictionaryCache<Type, EntityKeyFactory>();
+
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected EntityKeyFactorySource()
+        {
+        }
+
+        public EntityKeyFactorySource([NotNull] CompositeEntityKeyFactory compositeKeyFactory)
+        {
+            Check.NotNull(compositeKeyFactory, "compositeKeyFactory");
+
+            _compositeKeyFactory = compositeKeyFactory;
+        }
 
         public virtual EntityKeyFactory GetKeyFactory([NotNull] IReadOnlyList<IProperty> keyProperties)
         {
@@ -21,7 +39,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
                 ? _cache.GetOrAdd(
                     keyProperties[0].PropertyType,
                     t => (EntityKeyFactory)Activator.CreateInstance(typeof(SimpleEntityKeyFactory<>).MakeGenericType(t)))
-                : CompositeEntityKeyFactory.Instance;
+                : _compositeKeyFactory;
         }
     }
 }

--- a/src/Microsoft.Data.Entity/ChangeTracking/StateManager.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/StateManager.cs
@@ -244,7 +244,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             try
             {
                 var result = await _configuration.DataStore
-                    .SaveChangesAsync(entriesToSave, Model, cancellationToken)
+                    .SaveChangesAsync(entriesToSave, cancellationToken)
                     .ConfigureAwait(false);
 
                 // TODO: When transactions supported, make it possible to commit/accept at end of all transactions

--- a/src/Microsoft.Data.Entity/ContextConfiguration.cs
+++ b/src/Microsoft.Data.Entity/ContextConfiguration.cs
@@ -24,7 +24,9 @@ namespace Microsoft.Data.Entity
         private EntityConfiguration _entityConfiguration;
         private DbContext _context;
         private LazyRef<IModel> _modelFromSource;
+        private LazyRef<DataStoreSource> _dataStoreSource;
         private LazyRef<DataStore> _dataStore;
+        private LazyRef<DataStoreConnection> _connection;
         private ServiceProviderSource _serviceProviderSource;
         private LazyRef<ILoggerFactory> _loggerFactory;
 
@@ -47,7 +49,9 @@ namespace Microsoft.Data.Entity
             _entityConfiguration = entityConfiguration;
             _context = context;
             _modelFromSource = new LazyRef<IModel>(() => _services.ModelSource.GetModel(_context));
-            _dataStore = new LazyRef<DataStore>(() => _services.DataStoreSelector.SelectDataStore(this));
+            _dataStoreSource = new LazyRef<DataStoreSource>(() => _services.DataStoreSelector.SelectDataStore(this));
+            _dataStore = new LazyRef<DataStore>(() => _dataStoreSource.Value.GetStore(this));
+            _connection = new LazyRef<DataStoreConnection>(() => _dataStoreSource.Value.GetConnection(this));
             _loggerFactory = new LazyRef<ILoggerFactory>(() => GetLoggerFactory() ?? new NullLoggerFactory());
 
             return this;
@@ -79,6 +83,16 @@ namespace Microsoft.Data.Entity
         public virtual DataStore DataStore
         {
             get { return _dataStore.Value; }
+        }
+
+        public virtual DataStoreCreator DataStoreCreator
+        {
+            get { return _dataStoreSource.Value.GetCreator(this); }
+        }
+
+        public virtual DataStoreConnection Connection
+        {
+            get { return _connection.Value; }
         }
 
         public virtual ContextServices Services

--- a/src/Microsoft.Data.Entity/ContextServices.cs
+++ b/src/Microsoft.Data.Entity/ContextServices.cs
@@ -112,5 +112,10 @@ namespace Microsoft.Data.Entity
                        ?? Enumerable.Empty<IEntityStateListener>();
             }
         }
-    }
+
+        public virtual Database Database
+        {
+            get { return _serviceProvider.GetRequiredService<Database>(); }
+        }
+     }
 }

--- a/src/Microsoft.Data.Entity/Database.cs
+++ b/src/Microsoft.Data.Entity/Database.cs
@@ -2,32 +2,56 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity
 {
     public class Database
     {
-        public virtual void Create()
+        private readonly ContextConfiguration _configuration;
+
+        public Database([NotNull] ContextConfiguration configuration)
         {
-            // TODO
+            Check.NotNull(configuration, "configuration");
+
+            _configuration = configuration;
         }
 
-        public virtual bool Delete()
+        public virtual DataStoreConnection Connection
         {
-            // TODO
-            return false;
+            get { return _configuration.Connection; }
+        }
+
+        public virtual void Create()
+        {
+            _configuration.DataStoreCreator.Create(_configuration.Model);
+        }
+
+        public virtual void Delete()
+        {
+            _configuration.DataStoreCreator.Delete();
+        }
+
+        public virtual bool Exists()
+        {
+            return _configuration.DataStoreCreator.Exists();
         }
 
         public virtual Task CreateAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            // TODO
-            return Task.FromResult(false);
+            return _configuration.DataStoreCreator.CreateAsync(_configuration.Model, cancellationToken);
         }
 
-        public virtual Task<bool> DeleteAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public virtual Task DeleteAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            // TODO
-            return Task.FromResult(false);
+            return _configuration.DataStoreCreator.DeleteAsync(cancellationToken);
+        }
+
+        public virtual Task<bool> ExistsAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return _configuration.DataStoreCreator.ExistsAsync(cancellationToken);
         }
     }
 }

--- a/src/Microsoft.Data.Entity/DbContext.cs
+++ b/src/Microsoft.Data.Entity/DbContext.cs
@@ -158,7 +158,7 @@ namespace Microsoft.Data.Entity
 
         public virtual Database Database
         {
-            get { return new Database(); }
+            get { return Configuration.Services.Database; }
         }
 
         public virtual ChangeTracker ChangeTracker

--- a/src/Microsoft.Data.Entity/EntityConfiguration.cs
+++ b/src/Microsoft.Data.Entity/EntityConfiguration.cs
@@ -37,18 +37,21 @@ namespace Microsoft.Data.Entity
             }
         }
 
-        void IEntityConfigurationConstruction.AddExtension<TExtension>(TExtension extension)
+        void IEntityConfigurationConstruction.AddOrUpdateExtension<TExtension>(Action<TExtension> updater)
         {
-            Check.NotNull(extension, "extension");
+            Check.NotNull(updater, "updater");
 
             CheckNotLocked();
 
-            foreach (var existing in _extensions.OfType<TExtension>().ToArray())
-            {
-                _extensions.Remove(existing);
-            }
+            var extension = _extensions.OfType<TExtension>().FirstOrDefault();
 
-            _extensions.Add(extension);
+            if (extension == null)
+            {
+                extension = new TExtension();
+                _extensions.Add(extension);
+            }
+            
+            updater(extension);
         }
 
         void IEntityConfigurationConstruction.Lock()

--- a/src/Microsoft.Data.Entity/EntityServiceCollectionExtensions.cs
+++ b/src/Microsoft.Data.Entity/EntityServiceCollectionExtensions.cs
@@ -36,6 +36,7 @@ namespace Microsoft.AspNet.DependencyInjection
                 .AddSingleton<ClrPropertySetterSource, ClrPropertySetterSource>()
                 .AddSingleton<ClrCollectionAccessorSource, ClrCollectionAccessorSource>()
                 .AddSingleton<EntityMaterializerSource, EntityMaterializerSource>()
+                .AddSingleton<CompositeEntityKeyFactory, CompositeEntityKeyFactory>()
                 .AddSingleton<MemberMapper, MemberMapper>()
                 .AddSingleton<StateEntrySubscriber, StateEntrySubscriber>()
                 .AddSingleton<FieldMatcher, FieldMatcher>()
@@ -47,7 +48,8 @@ namespace Microsoft.AspNet.DependencyInjection
                 .AddScoped<StateEntryNotifier, StateEntryNotifier>()
                 .AddScoped<ContextConfiguration, ContextConfiguration>()
                 .AddScoped<ContextSets, ContextSets>()
-                .AddScoped<StateManager, StateManager>();
+                .AddScoped<StateManager, StateManager>()
+                .AddScoped<Database, Database>();
 
             if (nestedBuilder != null)
             {

--- a/src/Microsoft.Data.Entity/IEntityConfigurationConstruction.cs
+++ b/src/Microsoft.Data.Entity/IEntityConfigurationConstruction.cs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 
@@ -8,7 +9,7 @@ namespace Microsoft.Data.Entity
     public interface IEntityConfigurationConstruction
     {
         IModel Model { [param: CanBeNull] set; }
-        void AddExtension<TExtension>([NotNull] TExtension configurationExtension) where TExtension : EntityConfigurationExtension;
+        void AddOrUpdateExtension<TExtension>([NotNull] Action<TExtension> updater) where TExtension : EntityConfigurationExtension, new();
         void Lock();
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/IEntityType.cs
+++ b/src/Microsoft.Data.Entity/Metadata/IEntityType.cs
@@ -28,5 +28,6 @@ namespace Microsoft.Data.Entity.Metadata
         int OriginalValueCount { get; }
         bool HasClrType { get; }
         bool UseLazyOriginalValues { get; }
+        string StorageName { get; }
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/IKey.cs
+++ b/src/Microsoft.Data.Entity/Metadata/IKey.cs
@@ -8,5 +8,6 @@ namespace Microsoft.Data.Entity.Metadata
     {
         IReadOnlyList<IProperty> Properties { get; }
         IEntityType EntityType { get; }
+        string StorageName { get; }
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/IMetadata.cs
+++ b/src/Microsoft.Data.Entity/Metadata/IMetadata.cs
@@ -9,6 +9,5 @@ namespace Microsoft.Data.Entity.Metadata
     {
         string this[[NotNull] string annotationName] { get; }
         IEnumerable<IAnnotation> Annotations { get; }
-        string StorageName { get; }
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/IModel.cs
+++ b/src/Microsoft.Data.Entity/Metadata/IModel.cs
@@ -21,5 +21,7 @@ namespace Microsoft.Data.Entity.Metadata
 
         [NotNull]
         IEntityType GetEntityType([NotNull] string name);
+
+        string StorageName { get; }
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/IPropertyBase.cs
+++ b/src/Microsoft.Data.Entity/Metadata/IPropertyBase.cs
@@ -6,5 +6,6 @@ namespace Microsoft.Data.Entity.Metadata
     {
         string Name { get; }
         IEntityType EntityType { get; }
+        string StorageName { get; }
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/Key.cs
+++ b/src/Microsoft.Data.Entity/Metadata/Key.cs
@@ -28,6 +28,8 @@ namespace Microsoft.Data.Entity.Metadata
             _properties = properties;
         }
 
+        public virtual string StorageName { get; [param: CanBeNull] set; }
+
         public virtual IReadOnlyList<Property> Properties
         {
             get { return _properties; }

--- a/src/Microsoft.Data.Entity/Metadata/MetadataBase.cs
+++ b/src/Microsoft.Data.Entity/Metadata/MetadataBase.cs
@@ -10,8 +10,6 @@ namespace Microsoft.Data.Entity.Metadata
     {
         private readonly Annotations _annotations = new Annotations();
 
-        public virtual string StorageName { get; [param: CanBeNull] set; }
-
         // ReSharper disable once AnnotationRedundanceInHierarchy
         public virtual string this[[param: NotNull] string annotationName]
         {

--- a/src/Microsoft.Data.Entity/Metadata/Model.cs
+++ b/src/Microsoft.Data.Entity/Metadata/Model.cs
@@ -138,6 +138,8 @@ namespace Microsoft.Data.Entity.Metadata
             sorted.Add(entityType);
         }
 
+        public virtual string StorageName { get; [param: CanBeNull] set; }
+
         IEntityType IModel.TryGetEntityType(Type type)
         {
             return TryGetEntityType(type);

--- a/src/Microsoft.Data.Entity/Metadata/ModelBuilder.cs
+++ b/src/Microsoft.Data.Entity/Metadata/ModelBuilder.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Data.Entity.Metadata
 
                     public ForeignKeyBuilder StorageName([NotNull] string storageName)
                     {
-                        Metadata.StorageName = storageName;
+                        ((ForeignKey)Metadata).StorageName = storageName;
 
                         return this;
                     }

--- a/src/Microsoft.Data.Entity/Metadata/NamedMetadataBase.cs
+++ b/src/Microsoft.Data.Entity/Metadata/NamedMetadataBase.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Data.Entity.Metadata
     public abstract class NamedMetadataBase : MetadataBase
     {
         private readonly string _name;
+        private string _storageName;
 
         /// <summary>
         ///     This constructor is intended only for use when creating test doubles that will override members
@@ -31,10 +32,11 @@ namespace Microsoft.Data.Entity.Metadata
             get { return _name; }
         }
 
-        public override string StorageName
+        public virtual string StorageName
         {
-            get { return base.StorageName ?? Name; }
-            set { base.StorageName = value; }
+            get { return _storageName ?? Name; }
+            [param: CanBeNull]
+            set { _storageName = value; }
         }
     }
 }

--- a/src/Microsoft.Data.Entity/Query/EntityQueryExecutor.cs
+++ b/src/Microsoft.Data.Entity/Query/EntityQueryExecutor.cs
@@ -75,10 +75,7 @@ namespace Microsoft.Data.Entity.Query
             }
 
             return _context.Configuration.DataStore
-                .Query<T>(
-                    queryModel,
-                    _context.Configuration.Model,
-                    _context.Configuration.Services.StateManager);
+                .Query<T>(queryModel, _context.Configuration.Services.StateManager);
         }
     }
 }

--- a/src/Microsoft.Data.Entity/Query/QueryContext.cs
+++ b/src/Microsoft.Data.Entity/Query/QueryContext.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.AspNet.Logging;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
@@ -10,22 +11,31 @@ namespace Microsoft.Data.Entity.Query
     public class QueryContext
     {
         private readonly IModel _model;
+        private readonly ILogger _logger;
         private readonly StateManager _stateManager;
 
         public QueryContext(
             [NotNull] IModel model,
+            [NotNull] ILogger logger,
             [NotNull] StateManager stateManager)
         {
             Check.NotNull(model, "model");
+            Check.NotNull(logger, "logger");
             Check.NotNull(stateManager, "stateManager");
 
             _model = model;
+            _logger = logger;
             _stateManager = stateManager;
         }
 
         public virtual IModel Model
         {
             get { return _model; }
+        }
+
+        public virtual ILogger Logger
+        {
+            get { return _logger; }
         }
 
         public virtual StateManager StateManager

--- a/src/Microsoft.Data.Entity/Storage/DataStore.cs
+++ b/src/Microsoft.Data.Entity/Storage/DataStore.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Data.Entity.Storage
     public abstract class DataStore
     {
         private readonly ILogger _logger;
+        private readonly IModel _model;
 
         /// <summary>
         ///     This constructor is intended only for use when creating test doubles that will override members
@@ -32,6 +33,7 @@ namespace Microsoft.Data.Entity.Storage
             Check.NotNull(configuration, "configuration");
 
             _logger = configuration.LoggerFactory.Create(GetType().Name);
+            _model = configuration.Model;
         }
 
         public virtual ILogger Logger
@@ -39,20 +41,17 @@ namespace Microsoft.Data.Entity.Storage
             get { return _logger; }
         }
 
-        public virtual Task<int> SaveChangesAsync(
-            [NotNull] IEnumerable<StateEntry> stateEntries,
-            [NotNull] IModel model,
-            CancellationToken cancellationToken = default(CancellationToken))
+        public virtual IModel Model
         {
-            throw new NotImplementedException();
+            get { return _model; }
         }
 
-        public virtual IAsyncEnumerable<TResult> Query<TResult>(
+        public abstract Task<int> SaveChangesAsync(
+            [NotNull] IEnumerable<StateEntry> stateEntries,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        public abstract IAsyncEnumerable<TResult> Query<TResult>(
             [NotNull] QueryModel queryModel,
-            [NotNull] IModel model,
-            [NotNull] StateManager stateManager)
-        {
-            throw new NotImplementedException();
-        }
+            [NotNull] StateManager stateManager);
     }
 }

--- a/src/Microsoft.Data.Entity/Storage/DataStoreConnection.cs
+++ b/src/Microsoft.Data.Entity/Storage/DataStoreConnection.cs
@@ -1,0 +1,8 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.Storage
+{
+    public abstract class DataStoreConnection
+    {
+    }
+}

--- a/src/Microsoft.Data.Entity/Storage/DataStoreCreator.cs
+++ b/src/Microsoft.Data.Entity/Storage/DataStoreCreator.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -10,19 +9,17 @@ namespace Microsoft.Data.Entity.Storage
 {
     public abstract class DataStoreCreator
     {
-        public virtual Task CreateAsync([NotNull] IModel model, CancellationToken cancellationToken = default(CancellationToken))
-        {
-            throw new NotImplementedException();
-        }
+        public abstract Task CreateAsync(
+            [NotNull] IModel model, CancellationToken cancellationToken = default(CancellationToken));
 
-        public virtual Task<bool> ExistsAsync(CancellationToken cancellationToken = default(CancellationToken))
-        {
-            throw new NotImplementedException();
-        }
+        public abstract Task<bool> ExistsAsync(CancellationToken cancellationToken = default(CancellationToken));
 
-        public virtual Task DeleteAsync(CancellationToken cancellationToken = default(CancellationToken))
-        {
-            throw new NotImplementedException();
-        }
+        public abstract Task DeleteAsync(CancellationToken cancellationToken = default(CancellationToken));
+
+        public abstract void Create([NotNull] IModel model);
+
+        public abstract bool Exists();
+
+        public abstract void Delete();
     }
 }

--- a/src/Microsoft.Data.Entity/Storage/DataStoreSource.cs
+++ b/src/Microsoft.Data.Entity/Storage/DataStoreSource.cs
@@ -6,7 +6,9 @@ namespace Microsoft.Data.Entity.Storage
 {
     public abstract class DataStoreSource
     {
-        public abstract DataStore GetDataStore([NotNull] ContextConfiguration configuration);
+        public abstract DataStore GetStore([NotNull] ContextConfiguration configuration);
+        public abstract DataStoreCreator GetCreator([NotNull] ContextConfiguration configuration);
+        public abstract DataStoreConnection GetConnection([NotNull] ContextConfiguration configuration);
         public abstract bool IsAvailable([NotNull] ContextConfiguration configuration);
         public abstract bool IsConfigured([NotNull] ContextConfiguration configuration);
         public abstract string Name { get; }

--- a/src/Microsoft.Data.Entity/Storage/DataStoreSource`.cs
+++ b/src/Microsoft.Data.Entity/Storage/DataStoreSource`.cs
@@ -6,11 +6,13 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Storage
 {
-    public abstract class DataStoreSource<TDataStore, TConfigurationExtension> : DataStoreSource
+    public abstract class DataStoreSource<TDataStore, TConfiguration, TCreator, TConnection> : DataStoreSource
         where TDataStore : DataStore
-        where TConfigurationExtension : EntityConfigurationExtension
+        where TConfiguration : EntityConfigurationExtension
+        where TCreator : DataStoreCreator
+        where TConnection : DataStoreConnection
     {
-        public override DataStore GetDataStore(ContextConfiguration configuration)
+        public override DataStore GetStore(ContextConfiguration configuration)
         {
             Check.NotNull(configuration, "configuration");
 
@@ -18,11 +20,27 @@ namespace Microsoft.Data.Entity.Storage
             return configuration.Services.ServiceProvider.GetService<TDataStore>();
         }
 
+        public override DataStoreCreator GetCreator(ContextConfiguration configuration)
+        {
+            Check.NotNull(configuration, "configuration");
+
+            // TODO: Use GetRequiredService, by sharing source if possible
+            return configuration.Services.ServiceProvider.GetService<TCreator>();
+        }
+
+        public override DataStoreConnection GetConnection(ContextConfiguration configuration)
+        {
+            Check.NotNull(configuration, "configuration");
+
+            // TODO: Use GetRequiredService, by sharing source if possible
+            return configuration.Services.ServiceProvider.GetService<TConnection>();
+        }
+
         public override bool IsConfigured(ContextConfiguration configuration)
         {
             Check.NotNull(configuration, "configuration");
 
-            return configuration.EntityConfiguration.Extensions.OfType<TConfigurationExtension>().Any();
+            return configuration.EntityConfiguration.Extensions.OfType<TConfiguration>().Any();
         }
     }
 }

--- a/src/Microsoft.Data.InMemory/InMemoryConnection.cs
+++ b/src/Microsoft.Data.InMemory/InMemoryConnection.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Storage;
+
+namespace Microsoft.Data.InMemory
+{
+    public class InMemoryConnection : DataStoreConnection
+    {
+    }
+}

--- a/src/Microsoft.Data.InMemory/InMemoryDataStoreCreator.cs
+++ b/src/Microsoft.Data.InMemory/InMemoryDataStoreCreator.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.InMemory.Utilities;
+
+namespace Microsoft.Data.InMemory
+{
+    public class InMemoryDataStoreCreator : DataStoreCreator
+    {
+        private readonly InMemoryDataStore _dataStore;
+
+        public InMemoryDataStoreCreator([NotNull] InMemoryDataStore dataStore)
+        {
+            Check.NotNull(dataStore, "dataStore");
+
+            _dataStore = dataStore;
+        }
+
+        public override Task CreateAsync(IModel model, CancellationToken cancellationToken = new CancellationToken())
+        {
+            return Task.FromResult(0);
+        }
+
+        public override Task<bool> ExistsAsync(CancellationToken cancellationToken = new CancellationToken())
+        {
+            return Task.FromResult(true);
+        }
+
+        public override Task DeleteAsync(CancellationToken cancellationToken = new CancellationToken())
+        {
+            _dataStore.Database.Clear();
+
+            return Task.FromResult(0);
+        }
+
+        public override void Create(IModel model)
+        {
+        }
+
+        public override bool Exists()
+        {
+            return true;
+        }
+
+        public override void Delete()
+        {
+            _dataStore.Database.Clear();
+        }
+    }
+}

--- a/src/Microsoft.Data.InMemory/InMemoryDataStoreSource.cs
+++ b/src/Microsoft.Data.InMemory/InMemoryDataStoreSource.cs
@@ -6,7 +6,8 @@ using Microsoft.Data.InMemory.Utilities;
 
 namespace Microsoft.Data.InMemory
 {
-    public class InMemoryDataStoreSource : DataStoreSource<InMemoryDataStore, InMemoryConfigurationExtension>
+    public class InMemoryDataStoreSource
+        : DataStoreSource<InMemoryDataStore, InMemoryConfigurationExtension, InMemoryDataStoreCreator, InMemoryConnection>
     {
         public override bool IsAvailable(ContextConfiguration configuration)
         {

--- a/src/Microsoft.Data.InMemory/InMemoryDatabase.cs
+++ b/src/Microsoft.Data.InMemory/InMemoryDatabase.cs
@@ -28,6 +28,11 @@ namespace Microsoft.Data.InMemory
             _logger = (loggerFactory ?? new NullLoggerFactory()).Create(typeof(InMemoryDatabase).Name);
         }
 
+        public virtual void Clear()
+        {
+            _tables.ExchangeValue(ts => ImmutableDictionary<IEntityType, InMemoryTable>.Empty);
+        }
+
         public virtual InMemoryTable GetTable([NotNull] IEntityType entityType)
         {
             InMemoryTable table;

--- a/src/Microsoft.Data.InMemory/InMemoryEntityConfigurationBuilderExtensions.cs
+++ b/src/Microsoft.Data.InMemory/InMemoryEntityConfigurationBuilderExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Data.InMemory
         {
             Check.NotNull(builder, "builder");
 
-            builder.AddBuildAction(c => c.AddExtension(new InMemoryConfigurationExtension { Persist = persist }));
+            builder.AddBuildAction(c => c.AddOrUpdateExtension<InMemoryConfigurationExtension>(x => x.Persist = persist));
 
             return builder;
         }

--- a/src/Microsoft.Data.InMemory/InMemoryEntityServicesBuilderExtensions.cs
+++ b/src/Microsoft.Data.InMemory/InMemoryEntityServicesBuilderExtensions.cs
@@ -15,11 +15,13 @@ namespace Microsoft.Data.InMemory
             Check.NotNull(builder, "builder");
 
             builder.ServiceCollection
-                .AddScoped<InMemoryDataStore, InMemoryDataStore>()
+                // TODO: Need to be able to pick the appropriate identity generator for the data store in use
+                .AddSingleton<IdentityGeneratorFactory, InMemoryIdentityGeneratorFactory>()
                 .AddSingleton<DataStoreSource, InMemoryDataStoreSource>()
                 .AddSingleton<InMemoryDatabase, InMemoryDatabase>()
-                // TODO: Need to be able to pick the appropriate identity generator for the data store in use
-                .AddSingleton<IdentityGeneratorFactory, InMemoryIdentityGeneratorFactory>();
+                .AddScoped<InMemoryDataStore, InMemoryDataStore>()
+                .AddScoped<InMemoryConnection, InMemoryConnection>()
+                .AddScoped<InMemoryDataStoreCreator, InMemoryDataStoreCreator>();
 
             return builder;
         }

--- a/src/Microsoft.Data.InMemory/InMemoryQueryContext.cs
+++ b/src/Microsoft.Data.InMemory/InMemoryQueryContext.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.AspNet.Logging;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query;
@@ -14,10 +15,10 @@ namespace Microsoft.Data.InMemory
 
         public InMemoryQueryContext(
             [NotNull] IModel model,
+            [NotNull] ILogger logger,
             [NotNull] StateManager stateManager,
             [NotNull] InMemoryDatabase database)
-            : base(Check.NotNull(model, "model"),
-                Check.NotNull(stateManager, "stateManager"))
+            : base(model, logger, stateManager)
         {
             Check.NotNull(database, "database");
 

--- a/src/Microsoft.Data.Migrations/ModelDiffer.cs
+++ b/src/Microsoft.Data.Migrations/ModelDiffer.cs
@@ -18,13 +18,22 @@ namespace Microsoft.Data.Migrations
         private ModelDatabaseMapping _sourceMapping;
         private ModelDatabaseMapping _targetMapping;
         private MigrationOperationCollection _operations;
+        
+        private readonly DatabaseBuilder _databaseBuilder;
+
+        public ModelDiffer([NotNull] DatabaseBuilder databaseBuilder)
+        {
+            Check.NotNull(databaseBuilder, "databaseBuilder");
+
+            _databaseBuilder = databaseBuilder;
+        }
 
         // TODO: Rename this method because it is not suggestive of what it does.
         public virtual IReadOnlyList<MigrationOperation> DiffSource([NotNull] IModel model)
         {
             Check.NotNull(model, "model");
 
-            var database = new DatabaseBuilder().Build(model);
+            var database = _databaseBuilder.GetDatabase(model);
 
             var createSequenceOperations = database.Sequences.Select(
                 s => new CreateSequenceOperation(s));
@@ -63,7 +72,7 @@ namespace Microsoft.Data.Migrations
         {
             Check.NotNull(model, "model");
 
-            var database = new DatabaseBuilder().Build(model);
+            var database = _databaseBuilder.GetDatabase(model);
 
             var dropSequenceOperations = database.Sequences.Select(
                 s => new DropSequenceOperation(s.Name));
@@ -87,8 +96,8 @@ namespace Microsoft.Data.Migrations
             Check.NotNull(sourceModel, "sourceModel");
             Check.NotNull(targetModel, "targetModel");
 
-            _sourceMapping = new DatabaseBuilder().BuildMapping(sourceModel);
-            _targetMapping = new DatabaseBuilder().BuildMapping(targetModel);
+            _sourceMapping = _databaseBuilder.GetMapping(sourceModel);
+            _targetMapping = _databaseBuilder.GetMapping(targetModel);
             _operations = new MigrationOperationCollection();
 
             DiffSequences();

--- a/src/Microsoft.Data.Relational/RelationalConfigurationExtension.cs
+++ b/src/Microsoft.Data.Relational/RelationalConfigurationExtension.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System.Data.Common;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity;
+using Microsoft.Data.Relational.Utilities;
+
+namespace Microsoft.Data.Relational
+{
+    public abstract class RelationalConfigurationExtension : EntityConfigurationExtension
+    {
+        private string _connectionString;
+        private DbConnection _connection;
+
+        public virtual string ConnectionString
+        {
+            get { return _connectionString; }
+
+            [param: NotNull]
+            set
+            {
+                Check.NotEmpty(value, "value");
+
+                _connectionString = value;
+            }
+        }
+
+        public virtual DbConnection Connection
+        {
+            get { return _connection; }
+            [param: NotNull]
+            set
+            {
+                Check.NotNull(value, "value");
+
+                _connection = value;
+            }
+        }
+    }
+}

--- a/src/Microsoft.Data.Relational/RelationalConnection.cs
+++ b/src/Microsoft.Data.Relational/RelationalConnection.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity;
+using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Utilities;
+using Microsoft.Data.Relational.Utilities;
+
+namespace Microsoft.Data.Relational
+{
+    public abstract class RelationalConnection : DataStoreConnection, IDisposable
+    {
+        private readonly string _connectionString;
+        private readonly LazyRef<DbConnection> _connection;
+        private readonly bool _connectionOwned;
+        private int _openedCount;
+
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected RelationalConnection()
+        {
+        }
+
+        protected RelationalConnection([NotNull] ContextConfiguration configuration)
+        {
+            Check.NotNull(configuration, "configuration");
+
+            var storeConfigs = configuration.EntityConfiguration.Extensions
+                .OfType<RelationalConfigurationExtension>()
+                .ToArray();
+
+            if (storeConfigs.Length == 0)
+            {
+                // TODO: Proper message
+                throw new InvalidOperationException("Configuration not found.");
+            }
+
+            if (storeConfigs.Length > 1)
+            {
+                // TODO: Proper message
+                throw new InvalidOperationException("Multiple configurations found.");
+            }
+
+            var storeConfig = storeConfigs[0];
+
+            if (storeConfig.Connection != null)
+            {
+                _connection = new LazyRef<DbConnection>(() => storeConfig.Connection);
+                _connectionOwned = false;
+                _openedCount = storeConfig.Connection.State == ConnectionState.Open ? 1 : 0;
+            }
+            else if (!string.IsNullOrWhiteSpace(storeConfig.ConnectionString))
+            {
+                _connectionString = storeConfig.ConnectionString;
+                _connection = new LazyRef<DbConnection>(CreateDbConnection);
+                _connectionOwned = true;
+            }
+            else
+            {
+                // TODO: Proper message
+                throw new InvalidOperationException("No connection.");
+            }
+        }
+
+        protected abstract DbConnection CreateDbConnection();
+
+        public virtual string ConnectionString
+        {
+            get { return _connectionString ?? _connection.Value.ConnectionString; }
+        }
+
+        public virtual DbConnection DbConnection
+        {
+            get { return _connection.Value; }
+        }
+
+        public virtual void Open()
+        {
+            if (_openedCount++ == 0)
+            {
+                _connection.Value.Open();
+            }
+        }
+
+        public async virtual Task OpenAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (_openedCount == 0)
+            {
+                await _connection.Value.OpenAsync(cancellationToken);
+                // Only increment count if Open call succeeds
+                _openedCount++;
+            }
+        }
+
+        public virtual void Close()
+        {
+            if (--_openedCount == 0)
+            {
+                _connection.Value.Close();
+            }
+        }
+
+        public virtual void Dispose()
+        {
+            if (_connectionOwned && _connection.HasValue)
+            {
+                _connection.Value.Dispose();
+                _connection.Reset(CreateDbConnection);
+            }
+        }
+    }
+}

--- a/src/Microsoft.Data.Relational/RelationalDataStore.cs
+++ b/src/Microsoft.Data.Relational/RelationalDataStore.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
-using System.Data.Common;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity;
 using Microsoft.Data.Entity.ChangeTracking;
-using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Relational.Update;
@@ -19,36 +18,61 @@ namespace Microsoft.Data.Relational
 {
     public abstract partial class RelationalDataStore : DataStore
     {
+        private readonly DatabaseBuilder _databaseBuilder;
+        private readonly CommandBatchPreparer _batchPreparer;
+        private readonly BatchExecutor _batchExecutor;
+        private readonly RelationalConnection _connection;
+
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
         protected RelationalDataStore()
         {
         }
 
-        protected RelationalDataStore([NotNull] ContextConfiguration configuration)
+        protected RelationalDataStore(
+            [NotNull] ContextConfiguration configuration,
+            [NotNull] RelationalConnection connection,
+            [NotNull] DatabaseBuilder databaseBuilder,
+            [NotNull] CommandBatchPreparer batchPreparer,
+            [NotNull] BatchExecutor batchExecutor)
             : base(configuration)
         {
+            Check.NotNull(connection, "connection");
+            Check.NotNull(databaseBuilder, "databaseBuilder");
+            Check.NotNull(batchPreparer, "batchPreparer");
+            Check.NotNull(batchExecutor, "batchExecutor");
+
+            _databaseBuilder = databaseBuilder;
+            _batchPreparer = batchPreparer;
+            _batchExecutor = batchExecutor;
+            _connection = connection;
         }
 
-        protected abstract SqlGenerator SqlGenerator { get; }
+        protected virtual RelationalValueReaderFactory ValueReaderFactory
+        {
+            get { return new RelationalTypedValueReaderFactory(); }
+        }
 
         public override async Task<int> SaveChangesAsync(
             IEnumerable<StateEntry> stateEntries,
-            IModel model,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             Check.NotNull(stateEntries, "stateEntries");
-            Check.NotNull(model, "model");
 
-            //TODO: this should be cached
-            var database = new DatabaseBuilder().Build(model);
+            var database = _databaseBuilder.GetDatabase(Model);
+            var commands = _batchPreparer.BatchCommands(stateEntries, database);
 
-            var commands = new CommandBatchPreparer().BatchCommands(stateEntries, database);
-
-            using (var connection = CreateConnection())
+            try
             {
-                await connection.OpenAsync(cancellationToken);
-
-                var executor = new BatchExecutor(commands, SqlGenerator);
-                await executor.ExecuteAsync(connection, cancellationToken);
+                await _connection.OpenAsync(cancellationToken);
+                await _batchExecutor.ExecuteAsync(commands, cancellationToken);
+            }
+            finally
+            {
+                _connection.Close();
             }
 
             // TODO Return the actual results once we can get them
@@ -56,20 +80,17 @@ namespace Microsoft.Data.Relational
         }
 
         public override IAsyncEnumerable<TResult> Query<TResult>(
-            QueryModel queryModel, IModel model, StateManager stateManager)
+            QueryModel queryModel, StateManager stateManager)
         {
             Check.NotNull(queryModel, "queryModel");
-            Check.NotNull(model, "model");
             Check.NotNull(stateManager, "stateManager");
 
             var queryModelVisitor = new QueryModelVisitor();
             var queryExecutor = queryModelVisitor.CreateQueryExecutor<TResult>(queryModel);
-            var queryContext = new RelationalQueryContext(model, stateManager, this);
+            var queryContext = new RelationalQueryContext(Model, Logger, stateManager, _connection, ValueReaderFactory);
 
             // TODO: Need async in query compiler
             return new CompletedAsyncEnumerable<TResult>(queryExecutor(queryContext));
         }
-
-        public abstract DbConnection CreateConnection();
     }
 }

--- a/src/Microsoft.Data.Relational/RelationalEntityServicesBuilderExtensions.cs
+++ b/src/Microsoft.Data.Relational/RelationalEntityServicesBuilderExtensions.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.AspNet.DependencyInjection;
+using Microsoft.Data.Relational.Update;
+using Microsoft.Data.Relational.Utilities;
+
+// Intentionally in this namespace since this is for use by other relational providers rather than
+// by top-level app developers.
+namespace Microsoft.Data.Relational
+{
+    public static class RelationalEntityServicesBuilderExtensions
+    {
+        public static EntityServicesBuilder AddRelational([NotNull] this EntityServicesBuilder builder)
+        {
+            Check.NotNull(builder, "builder");
+
+            builder.ServiceCollection
+                .AddSingleton<DatabaseBuilder, DatabaseBuilder>()
+                .AddSingleton<RelationalObjectArrayValueReaderFactory, RelationalObjectArrayValueReaderFactory>()
+                .AddSingleton<RelationalTypedValueReaderFactory, RelationalTypedValueReaderFactory>()
+                .AddSingleton<CommandBatchPreparer, CommandBatchPreparer>();
+
+            return builder;
+        }
+    }
+}

--- a/src/Microsoft.Data.Relational/RelationalObjectArrayValueReaderFactory.cs
+++ b/src/Microsoft.Data.Relational/RelationalObjectArrayValueReaderFactory.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System.Data.Common;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Relational.Utilities;
+
+namespace Microsoft.Data.Relational
+{
+    public class RelationalObjectArrayValueReaderFactory : RelationalValueReaderFactory
+    {
+        public override IValueReader Create(DbDataReader dataReader)
+        {
+            Check.NotNull(dataReader, "dataReader");
+
+            return new RelationalObjectArrayValueReader(dataReader);
+        }
+    }
+}

--- a/src/Microsoft.Data.Relational/RelationalQueryContext.cs
+++ b/src/Microsoft.Data.Relational/RelationalQueryContext.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.AspNet.Logging;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query;
@@ -10,22 +11,32 @@ namespace Microsoft.Data.Relational
 {
     public class RelationalQueryContext : QueryContext
     {
-        private readonly RelationalDataStore _dataStore;
+        private readonly RelationalConnection _connection;
+        private readonly RelationalValueReaderFactory _valueReaderFactory;
 
         public RelationalQueryContext(
             [NotNull] IModel model,
+            [NotNull] ILogger logger,
             [NotNull] StateManager stateManager,
-            [NotNull] RelationalDataStore dataStore)
-            : base(Check.NotNull(model, "model"), Check.NotNull(stateManager, "stateManager"))
+            [NotNull] RelationalConnection connection,
+            [NotNull] RelationalValueReaderFactory valueReaderFactory)
+            : base(model, logger, stateManager)
         {
-            Check.NotNull(dataStore, "dataStore");
+            Check.NotNull(connection, "connection");
+            Check.NotNull(valueReaderFactory, "valueReaderFactory");
 
-            _dataStore = dataStore;
+            _connection = connection;
+            _valueReaderFactory = valueReaderFactory;
         }
 
-        public virtual RelationalDataStore DataStore
+        public virtual RelationalValueReaderFactory ValueReaderFactory
         {
-            get { return _dataStore; }
+            get { return _valueReaderFactory; }
+        }
+
+        public virtual RelationalConnection Connection
+        {
+            get { return _connection; }
         }
     }
 }

--- a/src/Microsoft.Data.Relational/RelationalTypedValueReaderFactory.cs
+++ b/src/Microsoft.Data.Relational/RelationalTypedValueReaderFactory.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System.Data.Common;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Relational.Utilities;
+
+namespace Microsoft.Data.Relational
+{
+    public class RelationalTypedValueReaderFactory : RelationalValueReaderFactory
+    {
+        public override IValueReader Create(DbDataReader dataReader)
+        {
+            Check.NotNull(dataReader, "dataReader");
+
+            return new RelationalTypedValueReader(dataReader);
+        }
+    }
+}

--- a/src/Microsoft.Data.Relational/RelationalValueReaderFactory.cs
+++ b/src/Microsoft.Data.Relational/RelationalValueReaderFactory.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System.Data.Common;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Relational
+{
+    public abstract class RelationalValueReaderFactory
+    {
+        public abstract IValueReader Create([NotNull] DbDataReader dataReader);
+    }
+}

--- a/src/Microsoft.Data.Relational/Update/CommandBatchPreparer.cs
+++ b/src/Microsoft.Data.Relational/Update/CommandBatchPreparer.cs
@@ -5,13 +5,18 @@ using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Relational.Model;
+using Microsoft.Data.Relational.Utilities;
 
 namespace Microsoft.Data.Relational.Update
 {
-    internal class CommandBatchPreparer
+    public class CommandBatchPreparer
     {
-        public IEnumerable<ModificationCommandBatch> BatchCommands([NotNull] IEnumerable<StateEntry> stateEntries, [NotNull] Database database)
+        public virtual IEnumerable<ModificationCommandBatch> BatchCommands(
+            [NotNull] IEnumerable<StateEntry> stateEntries, [NotNull] Database database)
         {
+            Check.NotNull(stateEntries, "database");
+            Check.NotNull(database, "stateEntries");
+
             return
                 stateEntries.Select(
                     e => new ModificationCommandBatch(new[]

--- a/src/Microsoft.Data.Relational/project.json
+++ b/src/Microsoft.Data.Relational/project.json
@@ -5,6 +5,8 @@
   },
   "dependencies": {
     "Microsoft.Data.Entity": "",
+    "Microsoft.AspNet.ConfigurationModel" : "0.1-alpha-*",
+    "Microsoft.AspNet.DependencyInjection" : "0.1-alpha-*",
     "Microsoft.AspNet.Logging": "0.1-alpha-*",
     "Remotion.Linq": "1.16-alpha",
     "System.Data.Common": "0.1-alpha-*"

--- a/src/Microsoft.Data.SqlServer/SqlServerBatchExecutor.cs
+++ b/src/Microsoft.Data.SqlServer/SqlServerBatchExecutor.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Relational.Update;
+
+namespace Microsoft.Data.SqlServer
+{
+    public class SqlServerBatchExecutor : BatchExecutor
+    {
+        public SqlServerBatchExecutor(
+            [NotNull] SqlServerSqlGenerator sqlGenerator,
+            [NotNull] SqlServerConnection connection)
+            : base(sqlGenerator, connection)
+        {
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlServer/SqlServerConfigurationExtension.cs
+++ b/src/Microsoft.Data.SqlServer/SqlServerConfigurationExtension.cs
@@ -2,14 +2,13 @@
 
 using Microsoft.AspNet.DependencyInjection;
 using Microsoft.Data.Entity;
+using Microsoft.Data.Relational;
 using Microsoft.Data.SqlServer.Utilities;
 
 namespace Microsoft.Data.SqlServer
 {
-    public class SqlServerConfigurationExtension : EntityConfigurationExtension
+    public class SqlServerConfigurationExtension : RelationalConfigurationExtension
     {
-        public virtual string ConnectionString { get; internal set; }
-
         protected override void ApplyServices(EntityServicesBuilder builder)
         {
             Check.NotNull(builder, "builder");

--- a/src/Microsoft.Data.SqlServer/SqlServerConnection.cs
+++ b/src/Microsoft.Data.SqlServer/SqlServerConnection.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System.Data.Common;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity;
+using Microsoft.Data.Relational;
+#if NET45
+using System.Data.SqlClient;
+
+#else
+using System;
+#endif
+
+namespace Microsoft.Data.SqlServer
+{
+    public class SqlServerConnection : RelationalConnection
+    {
+        public SqlServerConnection([NotNull] ContextConfiguration configuration)
+            : base(configuration)
+        {
+        }
+
+        protected override DbConnection CreateDbConnection()
+        {
+#if NET45
+            // TODO: Consider using DbProviderFactory to create connection instance
+            return new SqlConnection(ConnectionString);
+#else
+            throw new NotImplementedException();
+#endif
+        }
+
+        public virtual DbConnection CreateMasterConnection()
+        {
+#if NET45
+            var builder = new DbConnectionStringBuilder { ConnectionString = ConnectionString };
+            builder.Add("Initial Catalog", "master");
+            return new SqlConnection(builder.ConnectionString);
+#else
+            throw new NotImplementedException();
+#endif
+        }
+    }
+}

--- a/src/Microsoft.Data.SqlServer/SqlServerDataStore.cs
+++ b/src/Microsoft.Data.SqlServer/SqlServerDataStore.cs
@@ -1,87 +1,22 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
-using System;
-using System.Data.Common;
-using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Data.Relational;
-using Microsoft.Data.SqlServer.Utilities;
-#if NET45
-using System.Data.SqlClient;
-
-#endif
+using Microsoft.Data.Relational.Update;
 
 namespace Microsoft.Data.SqlServer
 {
     public class SqlServerDataStore : RelationalDataStore
     {
-        private readonly SqlServerSqlGenerator _sqlGenerator;
-        private readonly LazyRef<string> _masterConnectionString;
-        private readonly string _connectionString;
-
-        /// <summary>
-        ///     This constructor is intended only for use when creating test doubles that will override members
-        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
-        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
-        /// </summary>
-        protected SqlServerDataStore()
-        {
-        }
-
         public SqlServerDataStore(
             [NotNull] ContextConfiguration configuration,
-            [NotNull] SqlServerSqlGenerator sqlGenerator)
-            : base(configuration)
+            [NotNull] SqlServerConnection connection,
+            [NotNull] DatabaseBuilder databaseBuilder,
+            [NotNull] CommandBatchPreparer batchPreparer,
+            [NotNull] SqlServerBatchExecutor batchExecutor)
+            : base(configuration, connection, databaseBuilder, batchPreparer, batchExecutor)
         {
-            Check.NotNull(sqlGenerator, "sqlGenerator");
-
-            _sqlGenerator = sqlGenerator;
-
-            var storeConfig = configuration.EntityConfiguration.Extensions
-                .OfType<SqlServerConfigurationExtension>()
-                .FirstOrDefault();
-
-            // TODO: Consider finding connection string in config file by convention
-            _connectionString = storeConfig == null ? null : storeConfig.ConnectionString;
-
-            if (_connectionString == null)
-            {
-                // TODO: Proper message
-                throw new InvalidOperationException("No connection string configured.");
-            }
-
-            _masterConnectionString = new LazyRef<string>(() =>
-                {
-                    var builder = new DbConnectionStringBuilder { ConnectionString = _connectionString };
-                    builder.Add("Initial Catalog", "master");
-                    return builder.ConnectionString;
-                });
-        }
-
-        protected override SqlGenerator SqlGenerator
-        {
-            get { return _sqlGenerator; }
-        }
-
-        public override DbConnection CreateConnection()
-        {
-            return CreateConnection(_connectionString);
-        }
-
-        public virtual DbConnection CreateMasterConnection()
-        {
-            return CreateConnection(_masterConnectionString.Value);
-        }
-
-        private DbConnection CreateConnection(string connectionString)
-        {
-#if NET45
-            return new SqlConnection(connectionString);
-#else
-            throw new System.NotImplementedException();
-#endif
         }
     }
 }

--- a/src/Microsoft.Data.SqlServer/SqlServerDataStoreSource.cs
+++ b/src/Microsoft.Data.SqlServer/SqlServerDataStoreSource.cs
@@ -6,7 +6,8 @@ using Microsoft.Data.SqlServer.Utilities;
 
 namespace Microsoft.Data.SqlServer
 {
-    public class SqlServerDataStoreSource : DataStoreSource<SqlServerDataStore, SqlServerConfigurationExtension>
+    public class SqlServerDataStoreSource 
+        : DataStoreSource<SqlServerDataStore, SqlServerConfigurationExtension, SqlServerDataStoreCreator, SqlServerConnection>
     {
         public override bool IsAvailable(ContextConfiguration configuration)
         {

--- a/src/Microsoft.Data.SqlServer/SqlServerEntityConfigurationBuilderExtensions.cs
+++ b/src/Microsoft.Data.SqlServer/SqlServerEntityConfigurationBuilderExtensions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
+using System.Data.Common;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity;
 using Microsoft.Data.SqlServer.Utilities;
@@ -14,7 +15,19 @@ namespace Microsoft.Data.SqlServer
             Check.NotNull(builder, "builder");
             Check.NotEmpty(connectionString, "connectionString");
 
-            builder.AddBuildAction(c => c.AddExtension(new SqlServerConfigurationExtension { ConnectionString = connectionString }));
+            builder.AddBuildAction(c => c.AddOrUpdateExtension<SqlServerConfigurationExtension>(x => x.ConnectionString = connectionString));
+
+            return builder;
+        }
+
+        // TODO: Use SqlConnection instead of DbConnection?
+        public static EntityConfigurationBuilder SqlServerConnection(
+            [NotNull] this EntityConfigurationBuilder builder, [NotNull] DbConnection connection)
+        {
+            Check.NotNull(builder, "builder");
+            Check.NotNull(connection, "connection");
+
+            builder.AddBuildAction(c => c.AddOrUpdateExtension<SqlServerConfigurationExtension>(x => x.Connection = connection));
 
             return builder;
         }

--- a/src/Microsoft.Data.SqlServer/SqlServerEntityServicesBuilderExtensions.cs
+++ b/src/Microsoft.Data.SqlServer/SqlServerEntityServicesBuilderExtensions.cs
@@ -17,16 +17,18 @@ namespace Microsoft.Data.Entity
         {
             Check.NotNull(builder, "builder");
 
-            builder.ServiceCollection
-                .AddScoped<SqlServerDataStore, SqlServerDataStore>()
+            builder.AddRelational().ServiceCollection
+                // TODO: Need to be able to pick the appropriate identity generator for the data store in use
+                .AddSingleton<IdentityGeneratorFactory, SqlServerIdentityGeneratorFactory>()
                 .AddSingleton<DataStoreSource, SqlServerDataStoreSource>()
                 .AddSingleton<SqlServerSqlGenerator, SqlServerSqlGenerator>()
-                .AddScoped<ModelDiffer, ModelDiffer>()
-                .AddScoped<MigrationOperationSqlGenerator, MigrationOperationSqlGenerator>()
                 .AddSingleton<SqlStatementExecutor, SqlStatementExecutor>()
-                .AddScoped<SqlServerDataStoreCreator, SqlServerDataStoreCreator>()
-                // TODO: Need to be able to pick the appropriate identity generator for the data store in use
-                .AddSingleton<IdentityGeneratorFactory, SqlServerIdentityGeneratorFactory>();
+                .AddScoped<SqlServerDataStore, SqlServerDataStore>()
+                .AddScoped<SqlServerConnection, SqlServerConnection>()
+                .AddScoped<SqlServerBatchExecutor, SqlServerBatchExecutor>()
+                .AddScoped<ModelDiffer, ModelDiffer>()
+                .AddScoped<SqlServerMigrationOperationSqlGenerator, SqlServerMigrationOperationSqlGenerator>()
+                .AddScoped<SqlServerDataStoreCreator, SqlServerDataStoreCreator>();
 
             return builder;
         }

--- a/src/Microsoft.Data.SqlServer/SqlServerMigrationOperationSqlGenerator.cs
+++ b/src/Microsoft.Data.SqlServer/SqlServerMigrationOperationSqlGenerator.cs
@@ -543,6 +543,11 @@ namespace Microsoft.Data.SqlServer
                 return "decimal(18,2)";
             }
 
+            if (column.ClrType == typeof(Guid))
+            {
+                return "uniqueidentifier";
+            }
+
             throw new NotSupportedException();
         }
 

--- a/test/Microsoft.Data.Entity.FunctionalTests/project.json
+++ b/test/Microsoft.Data.Entity.FunctionalTests/project.json
@@ -2,6 +2,8 @@
   "version" : "0.1-alpha-*",
   "dependencies": {
     "Microsoft.Data.Entity" : "",
+    "Microsoft.AspNet.ConfigurationModel" : "0.1-alpha-*",
+    "Microsoft.AspNet.DependencyInjection" : "0.1-alpha-*",
     "Microsoft.AspNet.Logging" : "0.1-alpha-*",
     "Xunit.KRunner": "0.1-alpha-*",
     "xunit.abstractions": "2.0.0-aspnet-*",

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/EntityKeyFactorySourceTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/EntityKeyFactorySourceTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var keyMock = new Mock<IProperty>();
             keyMock.Setup(m => m.PropertyType).Returns(typeof(int));
 
-            Assert.IsType<SimpleEntityKeyFactory<int>>(new EntityKeyFactorySource().GetKeyFactory(new[] { keyMock.Object }));
+            Assert.IsType<SimpleEntityKeyFactory<int>>(CreateKeyFactorySource().GetKeyFactory(new[] { keyMock.Object }));
         }
 
         [Fact]
@@ -28,7 +28,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var keyMock2 = new Mock<IProperty>();
             keyMock2.Setup(m => m.PropertyType).Returns(typeof(Guid));
 
-            var factorySource = new EntityKeyFactorySource();
+            var factorySource = CreateKeyFactorySource();
             Assert.Same(factorySource.GetKeyFactory(new[] { keyMock1.Object }), factorySource.GetKeyFactory(new[] { keyMock2.Object }));
         }
 
@@ -36,7 +36,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         public void Returns_a_composite_entity_key_factory_for_composite_property_key()
         {
             Assert.IsType<CompositeEntityKeyFactory>(
-                new EntityKeyFactorySource().GetKeyFactory(new[] { new Mock<IProperty>().Object, new Mock<IProperty>().Object }));
+                CreateKeyFactorySource().GetKeyFactory(new[] { new Mock<IProperty>().Object, new Mock<IProperty>().Object }));
+        }
+
+        private static EntityKeyFactorySource CreateKeyFactorySource()
+        {
+            return new EntityKeyFactorySource(new CompositeEntityKeyFactory());
         }
     }
 }

--- a/test/Microsoft.Data.Entity.Tests/DatabaseTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/DatabaseTest.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Storage;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests
+{
+    public class DatabaseTest
+    {
+        [Fact]
+        public void Methods_delegate_to_configured_store_creator()
+        {
+            var creatorMock = new Mock<DataStoreCreator>();
+            creatorMock.Setup(m => m.Exists()).Returns(true);
+
+            var model = Mock.Of<IModel>();
+            var connection = Mock.Of<DataStoreConnection>();
+            var configurationMock = new Mock<ContextConfiguration>();
+            configurationMock.Setup(m => m.DataStoreCreator).Returns(creatorMock.Object);
+            configurationMock.Setup(m => m.Model).Returns(model);
+            configurationMock.Setup(m => m.Connection).Returns(connection);
+
+            var database = new Database(configurationMock.Object);
+
+            Assert.True(database.Exists());
+            creatorMock.Verify(m => m.Exists(), Times.Once);
+
+            database.Create();
+            creatorMock.Verify(m => m.Create(model), Times.Once);
+
+            database.Delete();
+            creatorMock.Verify(m => m.Delete(), Times.Once);
+
+            Assert.Same(connection, database.Connection);
+        }
+
+        [Fact]
+        public async void Async_methods_delegate_to_configured_store_creator()
+        {
+            var cancellationToken = new CancellationTokenSource().Token;
+
+            var creatorMock = new Mock<DataStoreCreator>();
+            creatorMock.Setup(m => m.ExistsAsync(cancellationToken)).Returns(Task.FromResult(true));
+
+            var model = Mock.Of<IModel>();
+            var configurationMock = new Mock<ContextConfiguration>();
+            configurationMock.Setup(m => m.DataStoreCreator).Returns(creatorMock.Object);
+            configurationMock.Setup(m => m.Model).Returns(model);
+
+            var database = new Database(configurationMock.Object);
+
+            Assert.True(await database.ExistsAsync(cancellationToken));
+            creatorMock.Verify(m => m.ExistsAsync(cancellationToken), Times.Once);
+
+            await database.CreateAsync(cancellationToken);
+            creatorMock.Verify(m => m.CreateAsync(model, cancellationToken), Times.Once);
+
+            await database.DeleteAsync(cancellationToken);
+            creatorMock.Verify(m => m.DeleteAsync(cancellationToken), Times.Once);
+        }
+    }
+}

--- a/test/Microsoft.Data.Entity.Tests/EntityConfigurationBuilderTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/EntityConfigurationBuilderTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.AspNet.DependencyInjection;
 using Microsoft.Data.Entity.Metadata;
 using Moq;
 using Xunit;
@@ -30,25 +31,28 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Build_actions_are_applied_to_configuration()
         {
-            var extension1 = Mock.Of<FakeEntityConfigurationExtension1>();
-            var extension2 = Mock.Of<FakeEntityConfigurationExtension2>();
-
             var configuration = new EntityConfigurationBuilder()
-                .AddBuildAction(c => c.AddExtension(extension1))
-                .AddBuildAction(c => c.AddExtension(extension2))
+                .AddBuildAction(c => c.AddOrUpdateExtension<FakeEntityConfigurationExtension1>(e => { }))
+                .AddBuildAction(c => c.AddOrUpdateExtension<FakeEntityConfigurationExtension2>(e => { }))
                 .BuildConfiguration();
 
             Assert.Equal(2, configuration.Extensions.Count);
-            Assert.Same(extension1, configuration.Extensions[0]);
-            Assert.Same(extension2, configuration.Extensions[1]);
+            Assert.IsType<FakeEntityConfigurationExtension1>(configuration.Extensions[0]);
+            Assert.IsType<FakeEntityConfigurationExtension2>(configuration.Extensions[1]);
         }
 
-        public abstract class FakeEntityConfigurationExtension1 : EntityConfigurationExtension
+        private class FakeEntityConfigurationExtension1 : EntityConfigurationExtension
         {
+            protected internal override void ApplyServices(EntityServicesBuilder builder)
+            {
+            }
         }
 
-        public abstract class FakeEntityConfigurationExtension2 : EntityConfigurationExtension
+        private class FakeEntityConfigurationExtension2 : EntityConfigurationExtension
         {
+            protected internal override void ApplyServices(EntityServicesBuilder builder)
+            {
+            }
         }
 
         [Fact]

--- a/test/Microsoft.Data.Entity.Tests/Storage/DataStoreSelectorTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Storage/DataStoreSelectorTest.cs
@@ -12,12 +12,11 @@ namespace Microsoft.Data.Entity.Tests.Storage
         [Fact]
         public void Selects_single_configured_store()
         {
-            var store = Mock.Of<DataStore>();
-            var source = CreateSource("DataStore1", configured: true, available: false, store: store);
+            var source = CreateSource("DataStore1", configured: true, available: false, store: Mock.Of<DataStore>());
 
             var selector = new DataStoreSelector(new[] { source });
 
-            Assert.Same(store, selector.SelectDataStore(new ContextConfiguration()));
+            Assert.Same(source, selector.SelectDataStore(new ContextConfiguration()));
         }
 
         [Fact]
@@ -85,12 +84,11 @@ namespace Microsoft.Data.Entity.Tests.Storage
         [Fact]
         public void Selects_single_available_store()
         {
-            var store = Mock.Of<DataStore>();
-            var source = CreateSource("DataStore1", configured: false, available: true, store: store);
+            var source = CreateSource("DataStore1", configured: false, available: true, store: Mock.Of<DataStore>());
 
             var selector = new DataStoreSelector(new[] { source });
 
-            Assert.Same(store, selector.SelectDataStore(new ContextConfiguration()));
+            Assert.Same(source, selector.SelectDataStore(new ContextConfiguration()));
         }
 
         private static DataStoreSource CreateSource(string name, bool configured, bool available, DataStore store = null)
@@ -98,7 +96,7 @@ namespace Microsoft.Data.Entity.Tests.Storage
             var sourceMock = new Mock<DataStoreSource>();
             sourceMock.Setup(m => m.IsConfigured(It.IsAny<ContextConfiguration>())).Returns(configured);
             sourceMock.Setup(m => m.IsAvailable(It.IsAny<ContextConfiguration>())).Returns(available);
-            sourceMock.Setup(m => m.GetDataStore(It.IsAny<ContextConfiguration>())).Returns(store);
+            sourceMock.Setup(m => m.GetStore(It.IsAny<ContextConfiguration>())).Returns(store);
             sourceMock.Setup(m => m.Name).Returns(name);
 
             return sourceMock.Object;

--- a/test/Microsoft.Data.InMemory.Tests/InMemoryDataStoreSourceTest.cs
+++ b/test/Microsoft.Data.InMemory.Tests/InMemoryDataStoreSourceTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Data.InMemory.Tests
         public void Is_configured_when_configuration_contains_associated_extension()
         {
             var configuration = new EntityConfigurationBuilder()
-                .AddBuildAction(c => c.AddExtension(new InMemoryConfigurationExtension()))
+                .AddBuildAction(c => c.AddOrUpdateExtension<InMemoryConfigurationExtension>(e => { }))
                 .BuildConfiguration();
 
             var configurationMock = new Mock<ContextConfiguration>();
@@ -30,9 +30,7 @@ namespace Microsoft.Data.InMemory.Tests
         [Fact]
         public void Is_not_configured_when_configuration_does_not_contain_associated_extension()
         {
-            var configuration = new EntityConfigurationBuilder()
-                .AddBuildAction(c => c.AddExtension(Mock.Of<EntityConfigurationExtension>()))
-                .BuildConfiguration();
+            var configuration = new EntityConfigurationBuilder().BuildConfiguration();
 
             var configurationMock = new Mock<ContextConfiguration>();
             configurationMock.Setup(m => m.EntityConfiguration).Returns(configuration);

--- a/test/Microsoft.Data.InMemory.Tests/InMemoryDataStoreTest.cs
+++ b/test/Microsoft.Data.InMemory.Tests/InMemoryDataStoreTest.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Data.InMemory.Tests
 
             var inMemoryDataStore = new InMemoryDataStore(configuration, new InMemoryDatabase(new NullLoggerFactory()));
 
-            await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry }, model);
+            await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry });
 
             Assert.Equal(1, inMemoryDataStore.Database.SelectMany(t => t).Count());
             Assert.Equal(new object[] { 42, "Unikorn" }, inMemoryDataStore.Database.Single().Single());
@@ -89,12 +89,12 @@ namespace Microsoft.Data.InMemory.Tests
 
             var inMemoryDataStore = new InMemoryDataStore(configuration, new InMemoryDatabase(new NullLoggerFactory()));
             
-            await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry }, model);
+            await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry });
 
             customer.Name = "Unikorn, The Return";
             await entityEntry.SetEntityStateAsync(EntityState.Modified, CancellationToken.None);
 
-            await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry }, model);
+            await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry });
 
             Assert.Equal(1, inMemoryDataStore.Database.SelectMany(t => t).Count());
             Assert.Equal(new object[] { 42, "Unikorn, The Return" }, inMemoryDataStore.Database.Single().Single());
@@ -113,12 +113,12 @@ namespace Microsoft.Data.InMemory.Tests
 
             var inMemoryDataStore = new InMemoryDataStore(configuration, new InMemoryDatabase(new NullLoggerFactory()));
 
-            await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry }, model);
+            await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry });
 
             customer.Name = "Unikorn, The Return";
             await entityEntry.SetEntityStateAsync(EntityState.Deleted, CancellationToken.None);
 
-            await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry }, model);
+            await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry });
 
             Assert.Equal(0, inMemoryDataStore.Database.SelectMany(t => t).Count());
         }
@@ -141,7 +141,7 @@ namespace Microsoft.Data.InMemory.Tests
 
             var inMemoryDataStore = new InMemoryDataStore(configuration, new InMemoryDatabase(mockFactory.Object));
 
-            await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry }, model);
+            await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry });
 
             mockLogger.Verify(
                 l => l.WriteCore(

--- a/test/Microsoft.Data.Migrations.Tests/ModelDifferTest.cs
+++ b/test/Microsoft.Data.Migrations.Tests/ModelDifferTest.cs
@@ -3,6 +3,7 @@
 using System;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Migrations.Model;
+using Microsoft.Data.Relational;
 using Xunit;
 
 namespace Microsoft.Data.Migrations.Tests
@@ -12,7 +13,7 @@ namespace Microsoft.Data.Migrations.Tests
         [Fact]
         public void DiffSource_creates_operations()
         {
-            var operations = new ModelDiffer().DiffSource(CreateModel());
+            var operations = new ModelDiffer(new DatabaseBuilder()).DiffSource(CreateModel());
 
             Assert.Equal(3, operations.Count);
 
@@ -28,7 +29,7 @@ namespace Microsoft.Data.Migrations.Tests
         [Fact]
         public void DiffTarget_creates_operations()
         {
-            var operations = new ModelDiffer().DiffTarget(CreateModel());
+            var operations = new ModelDiffer(new DatabaseBuilder()).DiffTarget(CreateModel());
 
             Assert.Equal(3, operations.Count);
 
@@ -49,7 +50,7 @@ namespace Microsoft.Data.Migrations.Tests
 
             targetModel.GetEntityType("Dependent").StorageName = "newdbo.MyTable0";
 
-            var operations = new ModelDiffer().Diff(sourceModel, targetModel);
+            var operations = new ModelDiffer(new DatabaseBuilder()).Diff(sourceModel, targetModel);
 
             Assert.Equal(1, operations.Count);
             Assert.IsType<MoveTableOperation>(operations[0]);
@@ -68,7 +69,7 @@ namespace Microsoft.Data.Migrations.Tests
 
             targetModel.GetEntityType("Dependent").StorageName = "dbo.MyNewTable0";
 
-            var operations = new ModelDiffer().Diff(sourceModel, targetModel);
+            var operations = new ModelDiffer(new DatabaseBuilder()).Diff(sourceModel, targetModel);
 
             Assert.Equal(1, operations.Count);
             Assert.IsType<RenameTableOperation>(operations[0]);
@@ -102,7 +103,7 @@ namespace Microsoft.Data.Migrations.Tests
             foreignKey.Annotations.Add(new Annotation(
                 MetadataExtensions.Annotations.CascadeDelete, "True"));
 
-            var operations = new ModelDiffer().Diff(sourceModel, targetModel);
+            var operations = new ModelDiffer(new DatabaseBuilder()).Diff(sourceModel, targetModel);
 
             Assert.Equal(2, operations.Count);
             Assert.IsType<CreateTableOperation>(operations[0]);
@@ -153,7 +154,7 @@ namespace Microsoft.Data.Migrations.Tests
             foreignKey.Annotations.Add(new Annotation(
                 MetadataExtensions.Annotations.CascadeDelete, "True"));
 
-            var operations = new ModelDiffer().Diff(sourceModel, targetModel);
+            var operations = new ModelDiffer(new DatabaseBuilder()).Diff(sourceModel, targetModel);
 
             Assert.Equal(1, operations.Count);
             Assert.IsType<DropTableOperation>(operations[0]);
@@ -171,7 +172,7 @@ namespace Microsoft.Data.Migrations.Tests
 
             targetModel.GetEntityType("Dependent").GetProperty("Id").StorageName = "NewId";
 
-            var operations = new ModelDiffer().Diff(sourceModel, targetModel);
+            var operations = new ModelDiffer(new DatabaseBuilder()).Diff(sourceModel, targetModel);
 
             Assert.Equal(1, operations.Count);
             Assert.IsType<RenameColumnOperation>(operations[0]);
@@ -192,7 +193,7 @@ namespace Microsoft.Data.Migrations.Tests
             var property = targetModel.GetEntityType("Dependent").AddProperty("MyNewProperty", typeof(string));
             property.StorageName = "MyNewColumn";
 
-            var operations = new ModelDiffer().Diff(sourceModel, targetModel);
+            var operations = new ModelDiffer(new DatabaseBuilder()).Diff(sourceModel, targetModel);
 
             Assert.Equal(1, operations.Count);
             Assert.IsType<AddColumnOperation>(operations[0]);
@@ -213,7 +214,7 @@ namespace Microsoft.Data.Migrations.Tests
             var property = sourceModel.GetEntityType("Dependent").AddProperty("MyOldProperty", typeof(string));
             property.StorageName = "MyOldColumn";
 
-            var operations = new ModelDiffer().Diff(sourceModel, targetModel);
+            var operations = new ModelDiffer(new DatabaseBuilder()).Diff(sourceModel, targetModel);
 
             Assert.Equal(1, operations.Count);
             Assert.IsType<DropColumnOperation>(operations[0]);
@@ -233,7 +234,7 @@ namespace Microsoft.Data.Migrations.Tests
             var property = targetModel.GetEntityType("Dependent").GetProperty("MyProperty");
             property.IsNullable = false;
 
-            var operations = new ModelDiffer().Diff(sourceModel, targetModel);
+            var operations = new ModelDiffer(new DatabaseBuilder()).Diff(sourceModel, targetModel);
 
             Assert.Equal(1, operations.Count);
             Assert.IsType<AlterColumnOperation>(operations[0]);
@@ -258,7 +259,7 @@ namespace Microsoft.Data.Migrations.Tests
             property = entityType.AddProperty("MyProperty", typeof(double));
             property.StorageName = "MyColumn";
 
-            var operations = new ModelDiffer().Diff(sourceModel, targetModel);
+            var operations = new ModelDiffer(new DatabaseBuilder()).Diff(sourceModel, targetModel);
 
             Assert.Equal(1, operations.Count);
             Assert.IsType<AlterColumnOperation>(operations[0]);
@@ -280,7 +281,7 @@ namespace Microsoft.Data.Migrations.Tests
             property.Annotations.Add(new Annotation(
                 MetadataExtensions.Annotations.StorageTypeName, "nvarchar(10)"));
 
-            var operations = new ModelDiffer().Diff(sourceModel, targetModel);
+            var operations = new ModelDiffer(new DatabaseBuilder()).Diff(sourceModel, targetModel);
 
             Assert.Equal(1, operations.Count);
             Assert.IsType<AlterColumnOperation>(operations[0]);
@@ -302,7 +303,7 @@ namespace Microsoft.Data.Migrations.Tests
             property.Annotations.Add(new Annotation(
                 MetadataExtensions.Annotations.ColumnDefaultValue, "MyDefaultValue"));
 
-            var operations = new ModelDiffer().Diff(sourceModel, targetModel);
+            var operations = new ModelDiffer(new DatabaseBuilder()).Diff(sourceModel, targetModel);
 
             Assert.Equal(1, operations.Count);
             Assert.IsType<AddDefaultConstraintOperation>(operations[0]);
@@ -325,7 +326,7 @@ namespace Microsoft.Data.Migrations.Tests
             property.Annotations.Add(new Annotation(
                 MetadataExtensions.Annotations.ColumnDefaultSql, "MyDefaultSql"));
 
-            var operations = new ModelDiffer().Diff(sourceModel, targetModel);
+            var operations = new ModelDiffer(new DatabaseBuilder()).Diff(sourceModel, targetModel);
 
             Assert.Equal(1, operations.Count);
             Assert.IsType<AddDefaultConstraintOperation>(operations[0]);
@@ -348,7 +349,7 @@ namespace Microsoft.Data.Migrations.Tests
             property.Annotations.Add(new Annotation(
                 MetadataExtensions.Annotations.ColumnDefaultValue, "MyDefaultValue"));
 
-            var operations = new ModelDiffer().Diff(sourceModel, targetModel);
+            var operations = new ModelDiffer(new DatabaseBuilder()).Diff(sourceModel, targetModel);
 
             Assert.Equal(1, operations.Count);
             Assert.IsType<DropDefaultConstraintOperation>(operations[0]);
@@ -369,7 +370,7 @@ namespace Microsoft.Data.Migrations.Tests
             property.Annotations.Add(new Annotation(
                 MetadataExtensions.Annotations.ColumnDefaultSql, "MyDefaultSql"));
 
-            var operations = new ModelDiffer().Diff(sourceModel, targetModel);
+            var operations = new ModelDiffer(new DatabaseBuilder()).Diff(sourceModel, targetModel);
 
             Assert.Equal(1, operations.Count);
             Assert.IsType<DropDefaultConstraintOperation>(operations[0]);
@@ -390,7 +391,7 @@ namespace Microsoft.Data.Migrations.Tests
             entityType.SetKey(entityType.GetProperty("MyProperty"));
             entityType.GetKey().StorageName = "MyNewPK";
 
-            var operations = new ModelDiffer().Diff(sourceModel, targetModel);
+            var operations = new ModelDiffer(new DatabaseBuilder()).Diff(sourceModel, targetModel);
 
             Assert.Equal(2, operations.Count);
             Assert.IsType<DropPrimaryKeyOperation>(operations[0]);
@@ -415,7 +416,7 @@ namespace Microsoft.Data.Migrations.Tests
             var entityType = sourceModel.GetEntityType("Dependent");
             entityType.RemoveForeignKey(entityType.ForeignKeys[0]);
 
-            var operations = new ModelDiffer().Diff(sourceModel, targetModel);
+            var operations = new ModelDiffer(new DatabaseBuilder()).Diff(sourceModel, targetModel);
 
             Assert.Equal(1, operations.Count);
             Assert.IsType<AddForeignKeyOperation>(operations[0]);
@@ -437,7 +438,7 @@ namespace Microsoft.Data.Migrations.Tests
             var entityType = targetModel.GetEntityType("Dependent");
             entityType.RemoveForeignKey(entityType.ForeignKeys[0]);
 
-            var operations = new ModelDiffer().Diff(sourceModel, targetModel);
+            var operations = new ModelDiffer(new DatabaseBuilder()).Diff(sourceModel, targetModel);
 
             Assert.Equal(1, operations.Count);
             Assert.IsType<DropForeignKeyOperation>(operations[0]);
@@ -459,7 +460,7 @@ namespace Microsoft.Data.Migrations.Tests
             targetModel.RemoveEntityType(dependentEntityType);
             principalEntityType.StorageName = dependentEntityType.StorageName;
 
-            var operations = new ModelDiffer().Diff(sourceModel, targetModel);
+            var operations = new ModelDiffer(new DatabaseBuilder()).Diff(sourceModel, targetModel);
 
             Assert.Equal(3, operations.Count);
 

--- a/test/Microsoft.Data.Relational.Tests/RelationalConnectionTest.cs
+++ b/test/Microsoft.Data.Relational.Tests/RelationalConnectionTest.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using System.Data.Common;
+using JetBrains.Annotations;
+using Microsoft.AspNet.DependencyInjection;
+using Microsoft.Data.Entity;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Data.Relational.Tests
+{
+    public class RelationalConnectionTest
+    {
+        [Fact]
+        public void Can_create_new_connection_with_connection_string()
+        {
+            using (var connection = new FakeConnection(CreateConfiguration(e => e.ConnectionString = "Database=FrodoLives")))
+            {
+                var dbConnection = connection.DbConnection;
+
+                Assert.Equal("Database=FrodoLives", dbConnection.ConnectionString);
+            }
+        }
+
+        private static ContextConfiguration CreateConfiguration(Action<FakeConfigurationExtension> configUpdater)
+        {
+            IEntityConfigurationConstruction entityConfiguration = new EntityConfiguration();
+            entityConfiguration.AddOrUpdateExtension(configUpdater);
+
+            var contextConfigurationMock = new Mock<ContextConfiguration>();
+            contextConfigurationMock.Setup(m => m.EntityConfiguration).Returns((EntityConfiguration)entityConfiguration);
+
+            return contextConfigurationMock.Object;
+        }
+
+        private class FakeConnection : RelationalConnection
+        {
+            public FakeConnection([NotNull] ContextConfiguration configuration)
+                : base(configuration)
+            {
+            }
+
+            protected override DbConnection CreateDbConnection()
+            {
+                var connectionMock = new Mock<DbConnection>();
+                connectionMock.Setup(m => m.ConnectionString).Returns(ConnectionString);
+                return connectionMock.Object;
+            }
+        }
+
+        private class FakeConfigurationExtension : RelationalConfigurationExtension
+        {
+            protected override void ApplyServices(EntityServicesBuilder builder)
+            {
+            }
+        }
+    }
+}

--- a/test/Microsoft.Data.SqlServer.FunctionalTests/TestDatabase.cs
+++ b/test/Microsoft.Data.SqlServer.FunctionalTests/TestDatabase.cs
@@ -267,6 +267,10 @@ namespace Microsoft.Data.SqlServer.FunctionalTests
             return new SqlConnectionStringBuilder
                 {
                     DataSource = @"(localdb)\v11.0",
+                    // TODO: Currently nested queries are run while processing the results of outer queries
+                    // This either requires MARS or creation of a new connection for each query. Currently using
+                    // MARS since cloning connections is known to be problematic.
+                    MultipleActiveResultSets = true,
                     InitialCatalog = name,
                     IntegratedSecurity = true,
                     ConnectTimeout = 30

--- a/test/Microsoft.Data.SqlServer.FunctionalTests/project.json
+++ b/test/Microsoft.Data.SqlServer.FunctionalTests/project.json
@@ -2,6 +2,7 @@
   "version": "0.1-alpha-*",
   "dependencies": {
     "Microsoft.Data.Entity": "",
+    "Microsoft.Data.InMemory" : "",
     "Microsoft.Data.Migrations": "",
     "Microsoft.Data.Relational": "",
     "Microsoft.Data.SqlServer": "",

--- a/test/Microsoft.Data.SqlServer.Tests/SqlServerDataStoreSourceTest.cs
+++ b/test/Microsoft.Data.SqlServer.Tests/SqlServerDataStoreSourceTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Data.SqlServer.Tests
         public void Is_configured_when_configuration_contains_associated_extension()
         {
             var configuration = new EntityConfigurationBuilder()
-                .AddBuildAction(c => c.AddExtension(new SqlServerConfigurationExtension()))
+                .AddBuildAction(c => c.AddOrUpdateExtension<SqlServerConfigurationExtension>(e => { }))
                 .BuildConfiguration();
 
             var configurationMock = new Mock<ContextConfiguration>();
@@ -30,9 +30,7 @@ namespace Microsoft.Data.SqlServer.Tests
         [Fact]
         public void Is_not_configured_when_configuration_does_not_contain_associated_extension()
         {
-            var configuration = new EntityConfigurationBuilder()
-                .AddBuildAction(c => c.AddExtension(Mock.Of<EntityConfigurationExtension>()))
-                .BuildConfiguration();
+            var configuration = new EntityConfigurationBuilder().BuildConfiguration();
 
             var configurationMock = new Mock<ContextConfiguration>();
             configurationMock.Setup(m => m.EntityConfiguration).Returns(configuration);
@@ -44,7 +42,7 @@ namespace Microsoft.Data.SqlServer.Tests
         public void Is_available_when_configured()
         {
             var configuration = new EntityConfigurationBuilder()
-                .AddBuildAction(c => c.AddExtension(new SqlServerConfigurationExtension()))
+                .AddBuildAction(c => c.AddOrUpdateExtension<SqlServerConfigurationExtension>(e => { }))
                 .BuildConfiguration();
 
             var configurationMock = new Mock<ContextConfiguration>();
@@ -56,9 +54,7 @@ namespace Microsoft.Data.SqlServer.Tests
         [Fact]
         public void Is_not_available_when_not_configured()
         {
-            var configuration = new EntityConfigurationBuilder()
-                .AddBuildAction(c => c.AddExtension(Mock.Of<EntityConfigurationExtension>()))
-                .BuildConfiguration();
+            var configuration = new EntityConfigurationBuilder().BuildConfiguration();
 
             var configurationMock = new Mock<ContextConfiguration>();
             configurationMock.Setup(m => m.EntityConfiguration).Returns(configuration);

--- a/test/Microsoft.Data.SqlServer.Tests/SqlServerEntityServicesBuilderExtensionsTest.cs
+++ b/test/Microsoft.Data.SqlServer.Tests/SqlServerEntityServicesBuilderExtensionsTest.cs
@@ -8,6 +8,7 @@ using Microsoft.Data.Entity.Identity;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Migrations;
 using Microsoft.Data.Relational;
+using Microsoft.Data.Relational.Update;
 using Xunit;
 
 namespace Microsoft.Data.SqlServer.Tests
@@ -19,14 +20,25 @@ namespace Microsoft.Data.SqlServer.Tests
         {
             var services = new ServiceCollection().AddEntityFramework(s => s.AddSqlServer());
 
+            // Relational
+            Assert.True(services.Any(sd => sd.ServiceType == typeof(DatabaseBuilder)));
+            Assert.True(services.Any(sd => sd.ServiceType == typeof(RelationalObjectArrayValueReaderFactory)));
+            Assert.True(services.Any(sd => sd.ServiceType == typeof(RelationalTypedValueReaderFactory)));
+            Assert.True(services.Any(sd => sd.ServiceType == typeof(CommandBatchPreparer)));
+
+            // SQL Server dingletones
             Assert.True(services.Any(sd => sd.ServiceType == typeof(IdentityGeneratorFactory)));
-            Assert.True(services.Any(sd => sd.ServiceType == typeof(SqlServerSqlGenerator)));
-            Assert.True(services.Any(sd => sd.ServiceType == typeof(SqlServerDataStoreCreator)));
-            Assert.True(services.Any(sd => sd.ServiceType == typeof(SqlServerDataStore)));
             Assert.True(services.Any(sd => sd.ServiceType == typeof(DataStoreSource)));
-            Assert.True(services.Any(sd => sd.ServiceType == typeof(ModelDiffer)));
-            Assert.True(services.Any(sd => sd.ServiceType == typeof(MigrationOperationSqlGenerator)));
+            Assert.True(services.Any(sd => sd.ServiceType == typeof(SqlServerSqlGenerator)));
             Assert.True(services.Any(sd => sd.ServiceType == typeof(SqlStatementExecutor)));
+
+            // SQL Server scoped
+            Assert.True(services.Any(sd => sd.ServiceType == typeof(SqlServerDataStore)));
+            Assert.True(services.Any(sd => sd.ServiceType == typeof(SqlServerConnection)));
+            Assert.True(services.Any(sd => sd.ServiceType == typeof(SqlServerBatchExecutor)));
+            Assert.True(services.Any(sd => sd.ServiceType == typeof(ModelDiffer)));
+            Assert.True(services.Any(sd => sd.ServiceType == typeof(SqlServerMigrationOperationSqlGenerator)));
+            Assert.True(services.Any(sd => sd.ServiceType == typeof(SqlServerDataStoreCreator)));
         }
 
         [Fact]
@@ -34,21 +46,74 @@ namespace Microsoft.Data.SqlServer.Tests
         {
             var serviceProvider = new ServiceCollection().AddEntityFramework(s => s.AddSqlServer()).BuildServiceProvider();
 
-            using (var context = new DbContext(
+            var context = new DbContext(
                 serviceProvider,
-                new EntityConfigurationBuilder().SqlServerConnectionString("goo").BuildConfiguration()))
-            {
-                var scopedProvider = context.Configuration.Services.ServiceProvider;
+                new EntityConfigurationBuilder().SqlServerConnectionString("goo").BuildConfiguration());
 
-                Assert.NotNull(scopedProvider.GetService<IdentityGeneratorFactory>());
-                Assert.NotNull(scopedProvider.GetService<SqlServerDataStore>());
-                Assert.NotNull(scopedProvider.GetService<DataStoreSource>());
-                Assert.NotNull(scopedProvider.GetService<SqlServerDataStoreCreator>());
-                Assert.NotNull(scopedProvider.GetService<SqlServerSqlGenerator>());
-                Assert.NotNull(scopedProvider.GetService<ModelDiffer>());
-                Assert.NotNull(scopedProvider.GetService<MigrationOperationSqlGenerator>());
-                Assert.NotNull(scopedProvider.GetService<SqlStatementExecutor>());
-            }
+            var scopedProvider = context.Configuration.Services.ServiceProvider;
+
+            var databaseBuilder = scopedProvider.GetService<DatabaseBuilder>();
+            var arrayReaderFactory = scopedProvider.GetService<RelationalObjectArrayValueReaderFactory>();
+            var typedReaderFactory = scopedProvider.GetService<RelationalTypedValueReaderFactory>();
+            var batchPreparer = scopedProvider.GetService<CommandBatchPreparer>();
+
+            var identityGeneratorFactory = scopedProvider.GetService<IdentityGeneratorFactory>();
+            var dataStoreSource = scopedProvider.GetService<DataStoreSource>();
+            var sqlServerSqlGenerator = scopedProvider.GetService<SqlServerSqlGenerator>();
+            var sqlStatementExecutor = scopedProvider.GetService<SqlStatementExecutor>();
+
+            var sqlServerDataStore = scopedProvider.GetService<SqlServerDataStore>();
+            var sqlServerConnection = scopedProvider.GetService<SqlServerConnection>();
+            var sqlServerBatchExecutor = scopedProvider.GetService<SqlServerBatchExecutor>();
+            var modelDiffer = scopedProvider.GetService<ModelDiffer>();
+            var sqlServerMigrationOperationSqlGenerator = scopedProvider.GetService<SqlServerMigrationOperationSqlGenerator>();
+            var sqlServerDataStoreCreator = scopedProvider.GetService<SqlServerDataStoreCreator>();
+
+            Assert.NotNull(databaseBuilder);
+            Assert.NotNull(arrayReaderFactory);
+            Assert.NotNull(typedReaderFactory);
+            Assert.NotNull(batchPreparer);
+
+            Assert.NotNull(identityGeneratorFactory);
+            Assert.NotNull(dataStoreSource);
+            Assert.NotNull(sqlServerSqlGenerator);
+            Assert.NotNull(sqlStatementExecutor);
+
+            Assert.NotNull(sqlServerDataStore);
+            Assert.NotNull(sqlServerConnection);
+            Assert.NotNull(sqlServerBatchExecutor);
+            Assert.NotNull(modelDiffer);
+            Assert.NotNull(sqlServerMigrationOperationSqlGenerator);
+            Assert.NotNull(sqlServerDataStoreCreator);
+
+            context.Dispose();
+
+            context = new DbContext(
+                serviceProvider,
+                new EntityConfigurationBuilder().SqlServerConnectionString("goo").BuildConfiguration());
+
+            scopedProvider = context.Configuration.Services.ServiceProvider;
+
+            // Dingletons
+            Assert.Same(databaseBuilder, scopedProvider.GetService<DatabaseBuilder>());
+            Assert.Same(arrayReaderFactory, scopedProvider.GetService<RelationalObjectArrayValueReaderFactory>());
+            Assert.Same(typedReaderFactory, scopedProvider.GetService<RelationalTypedValueReaderFactory>());
+            Assert.Same(batchPreparer, scopedProvider.GetService<CommandBatchPreparer>());
+
+            Assert.Same(identityGeneratorFactory, scopedProvider.GetService<IdentityGeneratorFactory>());
+            Assert.Same(dataStoreSource, scopedProvider.GetService<DataStoreSource>());
+            Assert.Same(sqlServerSqlGenerator, scopedProvider.GetService<SqlServerSqlGenerator>());
+            Assert.Same(sqlStatementExecutor, scopedProvider.GetService<SqlStatementExecutor>());
+
+            // Scoped
+            Assert.NotSame(sqlServerDataStore, scopedProvider.GetService<SqlServerDataStore>());
+            Assert.NotSame(sqlServerConnection, scopedProvider.GetService<SqlServerConnection>());
+            Assert.NotSame(sqlServerBatchExecutor, scopedProvider.GetService<SqlServerBatchExecutor>());
+            Assert.NotSame(modelDiffer, scopedProvider.GetService<ModelDiffer>());
+            Assert.NotSame(sqlServerMigrationOperationSqlGenerator, scopedProvider.GetService<SqlServerMigrationOperationSqlGenerator>());
+            Assert.NotSame(sqlServerDataStoreCreator, scopedProvider.GetService<SqlServerDataStoreCreator>());
+
+            context.Dispose();
         }
     }
 }


### PR DESCRIPTION
Let's call it DbDatabase! (Enable top-level database creation APIs)

This change includes:
- Some refactoring of the DataStore code to use DI for more Services
- Separation of connection handling from data store handling, including introduction of a connection abstraction
- Initial caching of database mapping by Model
- Updates to SqlServerDataStoreCreator to be dependent on connection but not store
- Simple implementation of DataStoreCreator for in-memory databases
- Wiring up of context.Database methods to database creators

Still working on some of the tests.
