### PR TITLE
Add portable-net451+win81 configuration

### DIFF
--- a/src/Microsoft.Data.Entity/project.json
+++ b/src/Microsoft.Data.Entity/project.json
@@ -38,6 +38,27 @@
         "System.Threading": "4.0.0.0",
         "System.Threading.Tasks": "4.0.10.0"
       }
+    },
+    ".NETPortable,Version=v4.6,Profile=Profile44": {
+      "dependencies": {
+        "System.Collections": "",
+        "System.Collections.Concurrent": "",
+        "System.ComponentModel": "",
+        "System.Diagnostics.Contracts": "",
+        "System.Diagnostics.Debug": "",
+        "System.Globalization": "",
+        "System.Linq": "",
+        "System.Linq.Expressions": "",
+        "System.Linq.Queryable": "",
+        "System.ObjectModel": "",
+        "System.Reflection": "",
+        "System.Reflection.Extensions": "",
+        "System.Resources.ResourceManager": "",
+        "System.Runtime": "",
+        "System.Runtime.Extensions": "",
+        "System.Threading": "",
+        "System.Threading.Tasks": ""
+      }
     }
   }
 }

--- a/src/Microsoft.Data.InMemory/project.json
+++ b/src/Microsoft.Data.InMemory/project.json
@@ -24,6 +24,18 @@
         "System.Threading": "4.0.0.0",
         "System.Threading.Tasks": "4.0.10.0"
       }
+    },
+    ".NETPortable,Version=v4.6,Profile=Profile44": {
+      "dependencies": {
+        "System.Diagnostics.Debug": "",
+        "System.Globalization": "",
+        "System.Linq": "",
+        "System.Reflection": "",
+        "System.Resources.ResourceManager": "",
+        "System.Runtime": "",
+        "System.Threading": "",
+        "System.Threading.Tasks": ""
+      }
     }
   }
 }

--- a/src/Microsoft.Data.Migrations/project.json
+++ b/src/Microsoft.Data.Migrations/project.json
@@ -27,6 +27,24 @@
         "System.Runtime.Extensions": "4.0.10.0",
         "System.Text.RegularExpressions": "4.0.0.0"
       }
+    },
+    ".NETPortable,Version=v4.6,Profile=Profile44": {
+      "dependencies": {
+        "Microsoft.CSharp": "",
+        "System.Collections": "",
+        "System.Diagnostics.Debug": "",
+        "System.Dynamic.Runtime": "",
+        "System.Globalization": "",
+        "System.Linq": "",
+        "System.Linq.Expressions": "",
+        "System.Reflection": "",
+        "System.Reflection.Extensions": "",
+        "System.Reflection.Primitives": "",
+        "System.Resources.ResourceManager": "",
+        "System.Runtime": "",
+        "System.Runtime.Extensions": "",
+        "System.Text.RegularExpressions": ""
+      }
     }
   }
 }

--- a/src/Microsoft.Data.Relational/project.json
+++ b/src/Microsoft.Data.Relational/project.json
@@ -31,6 +31,19 @@
         "System.Text.RegularExpressions": "4.0.0.0",
         "System.Threading.Tasks": "4.0.10.0"
       }
+    },
+    ".NETPortable,Version=v4.6,Profile=Profile44": {
+      "dependencies": {
+        "System.Diagnostics.Debug": "",
+        "System.Globalization": "",
+        "System.Linq": "",
+        "System.Reflection": "",
+        "System.Resources.ResourceManager": "",
+        "System.Runtime": "",
+        "System.Text.RegularExpressions": "",
+        "System.Threading": "",
+        "System.Threading.Tasks": ""
+      }
     }
   }
 }

--- a/src/Microsoft.Data.SQLite.Entity/project.json
+++ b/src/Microsoft.Data.SQLite.Entity/project.json
@@ -14,6 +14,15 @@
         "System.Resources.ResourceManager": "4.0.0.0",
         "System.Runtime": "4.0.20.0"
       }
+    },
+    ".NETPortable,Version=v4.6,Profile=Profile44": {
+      "dependencies": {
+        "System.Diagnostics.Debug": "",
+        "System.Globalization": "",
+        "System.Reflection": "",
+        "System.Resources.ResourceManager": "",
+        "System.Runtime": ""
+      }
     }
   }
 }


### PR DESCRIPTION
Note, wpa81 support is currently blocked on the Remotion.Linq and Microsoft.Bcl.Immutable packages.
