### PR TITLE
It's null Jim, but not as we know it...

### DIFF
--- a/src/Microsoft.Data.Entity.Relational/Update/BatchExecutor.cs
+++ b/src/Microsoft.Data.Entity.Relational/Update/BatchExecutor.cs
@@ -127,7 +127,12 @@ namespace Microsoft.Data.Entity.Relational.Update
                 var dbParam = command.CreateParameter();
                 dbParam.Direction = ParameterDirection.Input;
                 dbParam.ParameterName = parameter.Key;
-                dbParam.Value = parameter.Value;
+                
+                // TODO: This is a hack that allows nullable strings to be saved. We actually need proper handling
+                // for parameter types, but this unblocks saving nullable strings for now. Other nullable types
+                // may not work.
+                dbParam.Value = parameter.Value ?? DBNull.Value;
+                
                 command.Parameters.Add(dbParam);
             }
 

--- a/test/Microsoft.Data.Entity.FunctionalTests/project.json
+++ b/test/Microsoft.Data.Entity.FunctionalTests/project.json
@@ -2,6 +2,7 @@
   "version" : "0.1-alpha-*",
   "dependencies": {
     "Microsoft.Data.Entity" : "",
+    "Microsoft.Framework.ConfigurationModel" : "0.1-alpha-*",
     "Microsoft.Framework.DependencyInjection" : "0.1-alpha-*",
     "Microsoft.Framework.Logging" : "0.1-alpha-*",
     "Xunit.KRunner": "0.1-alpha-*",

--- a/test/Microsoft.Data.Entity.InMemory.FunctionalTests/project.json
+++ b/test/Microsoft.Data.Entity.InMemory.FunctionalTests/project.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "Microsoft.Data.Entity" : "",
     "Microsoft.Data.Entity.InMemory" : "",
+    "Microsoft.Framework.ConfigurationModel" : "0.1-alpha-*",
     "Microsoft.Framework.DependencyInjection" : "0.1-alpha-*",
     "Microsoft.Framework.Logging" : "0.1-alpha-*",
     "Xunit.KRunner": "0.1-alpha-*",

--- a/test/Microsoft.Data.Entity.InMemory.Tests/project.json
+++ b/test/Microsoft.Data.Entity.InMemory.Tests/project.json
@@ -6,6 +6,7 @@
     "Microsoft.Data.Entity.Relational": "",
     "Microsoft.Data.Entity.SqlServer": "",
     "Microsoft.Data.Common": "0.1-alpha-*",
+    "Microsoft.Framework.ConfigurationModel" : "0.1-alpha-*",
     "Microsoft.Framework.DependencyInjection" : "0.1-alpha-*",
     "Microsoft.Framework.Logging" : "0.1-alpha-*",
     "Xunit.KRunner": "0.1-alpha-*",

--- a/test/Microsoft.Data.Entity.Migrations.Tests/project.json
+++ b/test/Microsoft.Data.Entity.Migrations.Tests/project.json
@@ -4,6 +4,7 @@
     "Microsoft.Data.Entity" : "",
     "Microsoft.Data.Entity.Migrations" : "",
     "Microsoft.Data.Entity.Relational" : "",
+    "Microsoft.Framework.ConfigurationModel" : "0.1-alpha-*",
     "Microsoft.Framework.DependencyInjection" : "0.1-alpha-*",
     "Microsoft.Framework.Logging" : "0.1-alpha-*",
     "Xunit.KRunner": "0.1-alpha-*",

--- a/test/Microsoft.Data.Entity.Relational.Tests/project.json
+++ b/test/Microsoft.Data.Entity.Relational.Tests/project.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "Microsoft.Data.Entity" : "",
     "Microsoft.Data.Entity.Relational" : "",
+    "Microsoft.Framework.ConfigurationModel" : "0.1-alpha-*",
     "Microsoft.Framework.DependencyInjection" : "0.1-alpha-*",
     "Microsoft.Framework.Logging" : "0.1-alpha-*",
     "Microsoft.Data.Common": "0.1-alpha-*",

--- a/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -239,21 +239,32 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     var blogs = context.Blogs.ToList();
                     Assert.Equal(2, blogs.Count);
 
-                    var blog = blogs.Single(b => b.Id == 77);
+                    var blog77 = blogs.Single(b => b.Id == 77);
 
-                    Assert.Equal(77, blog.Id);
-                    Assert.Equal("Blog1", blog.Name);
-                    Assert.True(blog.George);
-                    Assert.Equal(new Guid("0456AEF1-B7FC-47AA-8102-975D6BA3A9BF"), blog.TheGu);
-                    Assert.Equal(new DateTime(1973, 9, 3, 0, 10, 33, 777), blog.NotFigTime);
-                    Assert.Equal(64, blog.ToEat);
-                    Assert.Equal(0.123456789, blog.OrNothing);
-                    Assert.Equal(777, blog.Fuse);
-                    Assert.Equal(9876543210, blog.WayRound);
-                    Assert.Equal(0.12345f, blog.Away);
-                    Assert.Equal(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, blog.AndChew);
+                    Assert.Equal(77, blog77.Id);
+                    Assert.Equal("Blog1", blog77.Name);
+                    Assert.True(blog77.George);
+                    Assert.Equal(new Guid("0456AEF1-B7FC-47AA-8102-975D6BA3A9BF"), blog77.TheGu);
+                    Assert.Equal(new DateTime(1973, 9, 3, 0, 10, 33, 777), blog77.NotFigTime);
+                    Assert.Equal(64, blog77.ToEat);
+                    Assert.Equal(0.123456789, blog77.OrNothing);
+                    Assert.Equal(777, blog77.Fuse);
+                    Assert.Equal(9876543210, blog77.WayRound);
+                    Assert.Equal(0.12345f, blog77.Away);
+                    Assert.Equal(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, blog77.AndChew);
 
-                    blog.Name = "New Name";
+                    blog77.Name = "New Name";
+
+                    var blog78 = blogs.Single(b => b.Id == 78);
+                    blog78.Name = null;
+
+                    context.Add(new TBlog()
+                    {
+                        Id = 79,
+                        Name = null,
+                        NotFigTime = new DateTime(1973, 9, 3, 0, 10, 33, 777),
+                        AndChew = new byte[] { 1, 2, 3, 4 }
+                    });
 
                     await context.SaveChangesAsync();
                 }
@@ -261,10 +272,11 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 using (var context = new BloggingContext<TBlog>(configuration))
                 {
                     var blogs = context.Blogs.ToList();
-                    Assert.Equal(2, blogs.Count);
+                    Assert.Equal(3, blogs.Count);
 
                     Assert.Equal("New Name", blogs.Single(b => b.Id == 77).Name);
-                    Assert.Equal("Blog2", blogs.Single(b => b.Id == 78).Name);
+                    Assert.Null(blogs.Single(b => b.Id == 78).Name);
+                    Assert.Null(blogs.Single(b => b.Id == 79).Name);
                 }
             }
         }

--- a/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/project.json
+++ b/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/project.json
@@ -8,6 +8,7 @@
     "Microsoft.Data.Entity.SqlServer": "",
     "Microsoft.Data.Common": "0.1-alpha-*",
     "Microsoft.Data.SqlServer": "0.1-alpha-*",
+    "Microsoft.Framework.ConfigurationModel" : "0.1-alpha-*",
     "Microsoft.Framework.DependencyInjection" : "0.1-alpha-*",
     "Microsoft.Framework.Logging" : "0.1-alpha-*",
     "Xunit.KRunner": "0.1-alpha-*",

--- a/test/Microsoft.Data.Entity.SqlServer.Tests/project.json
+++ b/test/Microsoft.Data.Entity.SqlServer.Tests/project.json
@@ -7,6 +7,7 @@
     "Microsoft.Data.Entity.SqlServer": "",
     "Microsoft.Framework.Logging" : "0.1-alpha-*",
     "Microsoft.Data.Common": "0.1-alpha-*",
+    "Microsoft.Framework.ConfigurationModel" : "0.1-alpha-*",
     "Microsoft.Framework.DependencyInjection": "0.1-alpha-*",
     "Xunit.KRunner": "0.1-alpha-*",
     "xunit.abstractions": "2.0.0-aspnet-*",

--- a/test/Microsoft.Data.Entity.Tests/project.json
+++ b/test/Microsoft.Data.Entity.Tests/project.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "Microsoft.Data.Entity" : "",
     "Microsoft.Data.Entity.InMemory": "",
+    "Microsoft.Framework.ConfigurationModel" : "0.1-alpha-*",
     "Microsoft.Framework.DependencyInjection" : "0.1-alpha-*",
     "Microsoft.Framework.Logging" : "0.1-alpha-*",
     "Xunit.KRunner": "0.1-alpha-*",


### PR DESCRIPTION
It's null Jim, but not as we know it... (Temporary fix to allow saving null strings)

This is for Issue #142. The fix is to specify DBNull if the value being saved is null. In general we need to create correctly typed parameters, but that change is more involved, so getting this fix in to unblock Identity.

Also added missing dependencies to allow tests to pass in Visual Studio again.
