### PR TITLE
Whose column is it anyway?

### DIFF
--- a/src/Microsoft.Data.Entity.Migrations/MigrationOperationSqlGenerator.cs
+++ b/src/Microsoft.Data.Entity.Migrations/MigrationOperationSqlGenerator.cs
@@ -539,6 +539,12 @@ namespace Microsoft.Data.Entity.Migrations
                 stringBuilder.Append(" NOT NULL");
             }
 
+            // TODO: Move to SQL Server specific generation
+            if (column.ValueGenerationStrategy == StoreValueGenerationStrategy.Identity)
+            {
+                stringBuilder.Append(" IDENTITY");
+            }
+
             if (column.DefaultSql != null)
             {
                 stringBuilder

--- a/src/Microsoft.Data.Entity.SqlServer/Extensions/SqlServerEntityConfigurationBuilderExtensions.cs
+++ b/src/Microsoft.Data.Entity.SqlServer/Extensions/SqlServerEntityConfigurationBuilderExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Data.Entity
 {
     public static class SqlServerEntityConfigurationBuilderExtensions
     {
-        public static DbContextOptions SqlServerConnectionString(
+        public static DbContextOptions UseSqlServer(
             [NotNull] this DbContextOptions builder, [NotNull] string connectionString)
         {
             Check.NotNull(builder, "builder");
@@ -36,7 +36,7 @@ namespace Microsoft.Data.Entity
         }
 
         // TODO: Use SqlConnection instead of DbConnection?
-        public static DbContextOptions SqlServerConnection(
+        public static DbContextOptions UseSqlServer(
             [NotNull] this DbContextOptions builder, [NotNull] DbConnection connection)
         {
             Check.NotNull(builder, "builder");

--- a/src/Microsoft.Data.Entity.SqlServer/SqlServerIdentityGeneratorFactory.cs
+++ b/src/Microsoft.Data.Entity.SqlServer/SqlServerIdentityGeneratorFactory.cs
@@ -34,6 +34,13 @@ namespace Microsoft.Data.Entity.SqlServer
                     }
                     goto default;
 
+                case ValueGenerationStrategy.StoreIdentity:
+                    if (property.PropertyType == typeof(int))
+                    {
+                        return new TemporaryIdentityGenerator();
+                    }
+                    goto default;
+
                 case ValueGenerationStrategy.StoreSequence:
                     if (property.PropertyType == typeof(long))
                     {

--- a/src/Microsoft.Data.Entity/Identity/TemporaryIdentityGenerator.cs
+++ b/src/Microsoft.Data.Entity/Identity/TemporaryIdentityGenerator.cs
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Open Technologies, Inc.
+// All Rights Reserved
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+// WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF
+// TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR
+// NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing
+// permissions and limitations under the License.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Data.Entity.Identity
+{
+    public class TemporaryIdentityGenerator : IIdentityGenerator<int>
+    {
+        private int _current = 0;
+
+        public Task<int> NextAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return Task.FromResult(Interlocked.Decrement(ref _current));
+        }
+
+        async Task<object> IIdentityGenerator.NextAsync(CancellationToken cancellationToken)
+        {
+            return await NextAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/Metadata/ModelConventions/KeyConvention.cs
+++ b/src/Microsoft.Data.Entity/Metadata/ModelConventions/KeyConvention.cs
@@ -75,7 +75,12 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
                 property.ValueGenerationStrategy = ValueGenerationStrategy.Client;
             }
 
-            // TODO: Nullable, Identity
+            if (property.PropertyType == typeof(int))
+            {
+                property.ValueGenerationStrategy = ValueGenerationStrategy.StoreIdentity;
+            }
+
+            // TODO: Nullable, Sequence
         }
     }
 }

--- a/test/Microsoft.Data.Entity.Migrations.Tests/MigrationOperationSqlGeneratorTest.cs
+++ b/test/Microsoft.Data.Entity.Migrations.Tests/MigrationOperationSqlGeneratorTest.cs
@@ -83,6 +83,31 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         }
 
         [Fact]
+        public void Generate_when_create_table_operation_with_Identity_key()
+        {
+            Column foo, bar;
+            var table = new Table(
+                "dbo.MyTable",
+                new[]
+                    {
+                        foo = new Column("Foo", "int") { IsNullable = false, ValueGenerationStrategy = StoreValueGenerationStrategy.Identity},
+                        bar = new Column("Bar", "int") { IsNullable = true }
+                    })
+            {
+                PrimaryKey = new PrimaryKey("MyPK", new[] { foo }, isClustered: false )
+            };
+
+            Assert.Equal(
+                @"CREATE TABLE ""dbo"".""MyTable"" (
+    ""Foo"" int NOT NULL IDENTITY,
+    ""Bar"" int
+    CONSTRAINT ""MyPK"" PRIMARY KEY NONCLUSTERED (""Foo"")
+)",
+                MigrationOperationSqlGenerator.Generate(
+                    new CreateTableOperation(table), generateIdempotentSql: false).Sql);
+        }
+
+        [Fact]
         public void Generate_when_drop_table_operation()
         {
             Assert.Equal(

--- a/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/ExistingConnectionTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/ExistingConnectionTest.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             protected override void OnConfiguring(DbContextOptions builder)
             {
-                builder.SqlServerConnection(_connection);
+                builder.UseSqlServer(_connection);
             }
 
             protected override void OnModelCreating(ModelBuilder builder)

--- a/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/NorthwindQueryTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/NorthwindQueryTest.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             _configuration
                 = new DbContextOptions()
                     .UseModel(CreateModel())
-                    .SqlServerConnectionString(_testDatabase.Connection.ConnectionString)
+                    .UseSqlServer(_testDatabase.Connection.ConnectionString)
                     .BuildConfiguration();
         }
 

--- a/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/SqlServerConfigPatternsTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/SqlServerConfigPatternsTest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 protected override void OnConfiguring(DbContextOptions builder)
                 {
-                    builder.SqlServerConnectionString(TestDatabase.NorthwindConnectionString);
+                    builder.UseSqlServer(TestDatabase.NorthwindConnectionString);
                 }
 
                 protected override void OnModelCreating(ModelBuilder builder)
@@ -69,7 +69,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 using (await TestDatabase.Northwind())
                 {
                     var configuration = new DbContextOptions()
-                        .SqlServerConnectionString(TestDatabase.NorthwindConnectionString)
+                        .UseSqlServer(TestDatabase.NorthwindConnectionString)
                         .BuildConfiguration();
 
                     using (var context = new NorthwindContext(configuration))
@@ -124,7 +124,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 protected override void OnConfiguring(DbContextOptions builder)
                 {
-                    builder.SqlServerConnectionString(TestDatabase.NorthwindConnectionString);
+                    builder.UseSqlServer(TestDatabase.NorthwindConnectionString);
                 }
 
                 protected override void OnModelCreating(ModelBuilder builder)
@@ -146,7 +146,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                         .BuildServiceProvider();
 
                     var configuration = new DbContextOptions()
-                        .SqlServerConnectionString(TestDatabase.NorthwindConnectionString)
+                        .UseSqlServer(TestDatabase.NorthwindConnectionString)
                         .BuildConfiguration();
 
                     using (var context = new NorthwindContext(serviceProvider, configuration))
@@ -275,7 +275,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 protected override void OnConfiguring(DbContextOptions builder)
                 {
-                    builder.SqlServerConnectionString(TestDatabase.NorthwindConnectionString);
+                    builder.UseSqlServer(TestDatabase.NorthwindConnectionString);
                 }
 
                 protected override void OnModelCreating(ModelBuilder builder)
@@ -331,7 +331,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 protected override void OnConfiguring(DbContextOptions builder)
                 {
-                    builder.SqlServerConnectionString(TestDatabase.NorthwindConnectionString);
+                    builder.UseSqlServer(TestDatabase.NorthwindConnectionString);
                 }
 
                 protected override void OnModelCreating(ModelBuilder builder)
@@ -347,7 +347,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             public async Task Can_register_context_and_configuration_with_DI_container_and_have_both_injected()
             {
                 var configuration = new DbContextOptions()
-                    .SqlServerConnectionString(TestDatabase.NorthwindConnectionString)
+                    .UseSqlServer(TestDatabase.NorthwindConnectionString)
                     .BuildConfiguration();
 
                 var serviceProvider = new ServiceCollection()
@@ -407,7 +407,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             public async Task Can_register_configuration_with_DI_container_and_have_it_injected()
             {
                 var configuration = new DbContextOptions()
-                    .SqlServerConnectionString(TestDatabase.NorthwindConnectionString)
+                    .UseSqlServer(TestDatabase.NorthwindConnectionString)
                     .BuildConfiguration();
 
                 var serviceProvider = new ServiceCollection()
@@ -475,7 +475,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             {
                 public NorthwindContext(string connectionString)
                     : base(new DbContextOptions()
-                        .SqlServerConnectionString(connectionString)
+                        .UseSqlServer(connectionString)
                         .BuildConfiguration())
                 {
                 }
@@ -516,7 +516,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 protected override void OnConfiguring(DbContextOptions builder)
                 {
-                    builder.SqlServerConnectionString(_connectionString);
+                    builder.UseSqlServer(_connectionString);
                 }
 
                 protected override void OnModelCreating(ModelBuilder builder)
@@ -574,7 +574,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 protected override void OnConfiguring(DbContextOptions builder)
                 {
-                    builder.SqlServerConnectionString(TestDatabase.NorthwindConnectionString);
+                    builder.UseSqlServer(TestDatabase.NorthwindConnectionString);
                 }
             }
         }
@@ -676,7 +676,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 protected override void OnConfiguring(DbContextOptions builder)
                 {
-                    builder.SqlServerConnectionString(TestDatabase.NorthwindConnectionString);
+                    builder.UseSqlServer(TestDatabase.NorthwindConnectionString);
                 }
             }
         }

--- a/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/SqlServerDataStoreCreatorTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/SqlServerDataStoreCreatorTest.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     .AddEntityFramework(s => s.AddSqlServer())
                     .BuildServiceProvider(),
                 new DbContextOptions()
-                    .SqlServerConnectionString(testDatabase.Connection.ConnectionString)
+                    .UseSqlServer(testDatabase.Connection.ConnectionString)
                     .BuildConfiguration())
                 .Configuration;
         }
@@ -205,7 +205,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 .BuildServiceProvider();
 
             var configuration = new DbContextOptions()
-                .SqlServerConnectionString(testDatabase.Connection.ConnectionString)
+                .UseSqlServer(testDatabase.Connection.ConnectionString)
                 .BuildConfiguration();
 
             using (var context = new BloggingContext(serviceProvider, configuration))

--- a/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/SqlServerDatabaseCreationTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/SqlServerDatabaseCreationTest.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     .AddEntityFramework(s => s.AddSqlServer())
                     .BuildServiceProvider(),
                 new DbContextOptions()
-                    .SqlServerConnectionString(testDatabase.Connection.ConnectionString)
+                    .UseSqlServer(testDatabase.Connection.ConnectionString)
                     .BuildConfiguration())
                 .Configuration;
         }
@@ -292,7 +292,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             protected override void OnConfiguring(DbContextOptions builder)
             {
-                builder.SqlServerConnectionString(_testDatabase.Connection.ConnectionString);
+                builder.UseSqlServer(_testDatabase.Connection.ConnectionString);
             }
 
             protected override void OnModelCreating(ModelBuilder builder)

--- a/test/Microsoft.Data.Entity.SqlServer.Tests/SqlServerConnectionTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.Tests/SqlServerConnectionTest.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                 .AddEntityFramework(s => s.AddSqlServer())
                 .BuildServiceProvider(),
                 new DbContextOptions()
-                    .SqlServerConnectionString("Server=(localdb)\v11.0;Database=SqlServerConnectionTest;Trusted_Connection=True;")
+                    .UseSqlServer("Server=(localdb)\v11.0;Database=SqlServerConnectionTest;Trusted_Connection=True;")
                     .BuildConfiguration()).Configuration;
         }
     }

--- a/test/Microsoft.Data.Entity.SqlServer.Tests/SqlServerEntityServicesBuilderExtensionsTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.Tests/SqlServerEntityServicesBuilderExtensionsTest.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
             var context = new DbContext(
                 serviceProvider,
-                new DbContextOptions().SqlServerConnectionString("goo").BuildConfiguration());
+                new DbContextOptions().UseSqlServer("goo").BuildConfiguration());
 
             var scopedProvider = context.Configuration.Services.ServiceProvider;
 
@@ -105,7 +105,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
             context = new DbContext(
                 serviceProvider,
-                new DbContextOptions().SqlServerConnectionString("goo").BuildConfiguration());
+                new DbContextOptions().UseSqlServer("goo").BuildConfiguration());
 
             scopedProvider = context.Configuration.Services.ServiceProvider;
 

--- a/test/Microsoft.Data.Entity.Tests/Identity/TemporaryIdentityGeneratorTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Identity/TemporaryIdentityGeneratorTest.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc.
+// All Rights Reserved
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+// WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF
+// TITLE, FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR
+// NON-INFRINGEMENT.
+// See the Apache 2 License for the specific language governing
+// permissions and limitations under the License.
+
+using System.Threading.Tasks;
+using Microsoft.Data.Entity.Identity;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.Identity
+{
+    public class TemporaryIdentityGeneratorTest
+    {
+        [Fact]
+        public async Task Creates_negative_keys()
+        {
+            var generator = new TemporaryIdentityGenerator();
+
+            Assert.Equal(-1, await generator.NextAsync());
+            Assert.Equal(-2, await generator.NextAsync());
+            Assert.Equal(-3, await generator.NextAsync());
+
+            Assert.Equal(-4, await ((IIdentityGenerator)generator).NextAsync());
+            Assert.Equal(-5, await ((IIdentityGenerator)generator).NextAsync());
+            Assert.Equal(-6, await ((IIdentityGenerator)generator).NextAsync());
+        }
+    }
+}

--- a/test/Microsoft.Data.Entity.Tests/Metadata/ModelConventions/KeyConventionTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Metadata/ModelConventions/KeyConventionTest.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             var key = entityType.TryGetKey();
             Assert.NotNull(key);
             Assert.Equal(new[] { "Id" }, key.Properties.Select(p => p.Name));
+            Assert.Equal(ValueGenerationStrategy.StoreIdentity, key.Properties.Single().ValueGenerationStrategy);
         }
 
         private class EntityWithTypeId
@@ -90,6 +91,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             var key = entityType.TryGetKey();
             Assert.NotNull(key);
             Assert.Equal(new[] { "EntityWithTypeIdId" }, key.Properties.Select(p => p.Name));
+            Assert.Equal(ValueGenerationStrategy.StoreIdentity, key.Properties.Single().ValueGenerationStrategy);
         }
 
         private class EntityWithIdAndTypeId
@@ -108,6 +110,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             var key = entityType.TryGetKey();
             Assert.NotNull(key);
             Assert.Equal(new[] { "Id" }, key.Properties.Select(p => p.Name));
+            Assert.Equal(ValueGenerationStrategy.StoreIdentity, key.Properties.Single().ValueGenerationStrategy);
         }
 
         private class EntityWithMultipleIds


### PR DESCRIPTION
Whose column is it anyway? (Make Identity columns work end-to-end)
- Migrations now creates a identity columns
- ConventionModelBuilder configures int keys as Identity (this may change to Sequence in the future)
- A temporary key generator is used to create -1, -2, etc. keys before insert happens

Also included here is a missed rename from the API review--SQL server config methods renamed to UseSqlServer
