### PR TITLE
Flying the nested closure...

### DIFF
--- a/src/Microsoft.Data.Entity/Extensions/EntityServiceCollectionExtensions.cs
+++ b/src/Microsoft.Data.Entity/Extensions/EntityServiceCollectionExtensions.cs
@@ -15,7 +15,6 @@
 // See the Apache 2 License for the specific language governing
 // permissions and limitations under the License.
 
-using System;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Identity;
@@ -28,15 +27,7 @@ namespace Microsoft.Framework.DependencyInjection
 {
     public static class EntityServiceCollectionExtensions
     {
-        public static IServiceCollection AddEntityFramework([NotNull] this IServiceCollection serviceCollection)
-        {
-            Check.NotNull(serviceCollection, "serviceCollection");
-
-            return AddEntityFramework(serviceCollection, null);
-        }
-
-        public static IServiceCollection AddEntityFramework(
-            [NotNull] this IServiceCollection serviceCollection, [CanBeNull] Action<EntityServicesBuilder> nestedBuilder)
+        public static EntityServicesBuilder AddEntityFramework([NotNull] this IServiceCollection serviceCollection)
         {
             Check.NotNull(serviceCollection, "serviceCollection");
 
@@ -66,12 +57,7 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddScoped<StateManager, StateManager>()
                 .AddScoped<Database, Database>();
 
-            if (nestedBuilder != null)
-            {
-                nestedBuilder(new EntityServicesBuilder(serviceCollection));
-            }
-
-            return serviceCollection;
+            return new EntityServicesBuilder(serviceCollection);
         }
     }
 }

--- a/src/Microsoft.Data.Entity/ServiceProviderCache.cs
+++ b/src/Microsoft.Data.Entity/ServiceProviderCache.cs
@@ -37,8 +37,8 @@ namespace Microsoft.Data.Entity
 
         public virtual IServiceProvider GetOrAdd(ImmutableDbContextOptions contextOptions)
         {
-            var services = new ServiceCollection().AddEntityFramework();
-            var builder = new EntityServicesBuilder(services);
+            var services = new ServiceCollection();
+            var builder = services.AddEntityFramework();
             foreach (var extension in contextOptions.Extensions)
             {
                 extension.ApplyServices(builder);

--- a/test/Microsoft.Data.Entity.InMemory.FunctionalTests/InMemoryConfigPatternsTest.cs
+++ b/test/Microsoft.Data.Entity.InMemory.FunctionalTests/InMemoryConfigPatternsTest.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Open Technologies, Inc.
 // All Rights Reserved
-//
+// 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-//
+// 
 // http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
 // WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF
@@ -20,7 +20,6 @@ using System.Linq;
 using System.Reflection;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Data.Entity;
 using Xunit;
 
 namespace Microsoft.Data.Entity.InMemory.FunctionalTests
@@ -98,9 +97,9 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             [Fact]
             public void Can_save_and_query_with_explicit_services_and_OnConfiguring()
             {
-                var serviceProvider = new ServiceCollection()
-                    .AddEntityFramework(s => s.AddInMemoryStore())
-                    .BuildServiceProvider();
+                var services = new ServiceCollection();
+                services.AddEntityFramework().AddInMemoryStore();
+                var serviceProvider = services.BuildServiceProvider();
 
                 using (var context = new BlogContext(serviceProvider))
                 {
@@ -138,9 +137,9 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             [Fact]
             public void Can_save_and_query_with_explicit_services_and_explicit_config()
             {
-                var serviceProvider = new ServiceCollection()
-                    .AddEntityFramework(s => s.AddInMemoryStore())
-                    .BuildServiceProvider();
+                var services = new ServiceCollection();
+                services.AddEntityFramework().AddInMemoryStore();
+                var serviceProvider = services.BuildServiceProvider();
 
                 var configuration = new DbContextOptions()
                     .UseInMemoryStore()
@@ -177,9 +176,9 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             [Fact]
             public void Can_save_and_query_with_explicit_services_and_no_config()
             {
-                var serviceProvider = new ServiceCollection()
-                    .AddEntityFramework(s => s.AddInMemoryStore())
-                    .BuildServiceProvider();
+                var services = new ServiceCollection();
+                services.AddEntityFramework().AddInMemoryStore();
+                var serviceProvider = services.BuildServiceProvider();
 
                 using (var context = new BlogContext(serviceProvider))
                 {
@@ -236,9 +235,9 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             [Fact]
             public void Throws_on_attempt_to_use_store_with_no_store_services()
             {
-                var serviceProvider = new ServiceCollection()
-                    .AddEntityFramework()
-                    .BuildServiceProvider();
+                var serviceCollection = new ServiceCollection();
+                serviceCollection.AddEntityFramework();
+                var serviceProvider = serviceCollection.BuildServiceProvider();
 
                 Assert.Equal(
                     GetString("FormatNoDataStoreService"),
@@ -274,11 +273,12 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             [Fact]
             public void Can_register_context_with_DI_container_and_have_it_injected()
             {
-                var serviceProvider = new ServiceCollection()
-                    .AddEntityFramework(s => s.AddInMemoryStore())
-                    .AddTransient<BlogContext, BlogContext>()
+                var services = new ServiceCollection();
+                services.AddTransient<BlogContext, BlogContext>()
                     .AddTransient<MyController, MyController>()
-                    .BuildServiceProvider();
+                    .AddEntityFramework()
+                    .AddInMemoryStore();
+                var serviceProvider = services.BuildServiceProvider();
 
                 serviceProvider.GetService<MyController>().Test();
             }
@@ -327,12 +327,13 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
                     .UseInMemoryStore()
                     .BuildConfiguration();
 
-                var serviceProvider = new ServiceCollection()
-                    .AddEntityFramework(s => s.AddInMemoryStore())
-                    .AddTransient<BlogContext, BlogContext>()
+                var services = new ServiceCollection();
+                services.AddTransient<BlogContext, BlogContext>()
                     .AddTransient<MyController, MyController>()
-                    .AddInstance<ImmutableDbContextOptions>(configuration)
-                    .BuildServiceProvider();
+                    .AddInstance(configuration)
+                    .AddEntityFramework()
+                    .AddInMemoryStore();
+                var serviceProvider = services.BuildServiceProvider();
 
                 serviceProvider.GetService<MyController>().Test();
             }
@@ -385,12 +386,13 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
                     .UseInMemoryStore()
                     .BuildConfiguration();
 
-                var serviceProvider = new ServiceCollection()
-                    .AddEntityFramework(s => s.AddInMemoryStore())
-                    .AddTransient<BlogContext, BlogContext>()
+                var services = new ServiceCollection();
+                services.AddTransient<BlogContext, BlogContext>()
                     .AddTransient<MyController, MyController>()
-                    .AddInstance<ImmutableDbContextOptions>(configuration)
-                    .BuildServiceProvider();
+                    .AddInstance(configuration)
+                    .AddEntityFramework()
+                    .AddInMemoryStore();
+                var serviceProvider = services.BuildServiceProvider();
 
                 serviceProvider.GetService<MyController>().Test();
             }
@@ -443,15 +445,17 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
                     .UseInMemoryStore()
                     .BuildConfiguration(() => new AccountConfiguration());
 
-                var serviceProvider = new ServiceCollection()
-                    .AddEntityFramework(s => s.AddInMemoryStore())
+                var services = new ServiceCollection();
+                services.AddTransient<BlogContext, BlogContext>()
                     .AddTransient<BlogContext, BlogContext>()
                     .AddTransient<AccountContext, AccountContext>()
                     .AddTransient<MyBlogController, MyBlogController>()
                     .AddTransient<MyAccountController, MyAccountController>()
-                    .AddInstance<BlogConfiguration>(blogCofiguration)
-                    .AddInstance<AccountConfiguration>(accountCofiguration)
-                    .BuildServiceProvider();
+                    .AddInstance(blogCofiguration)
+                    .AddInstance(accountCofiguration)
+                    .AddEntityFramework()
+                    .AddInMemoryStore();
+                var serviceProvider = services.BuildServiceProvider();
 
                 serviceProvider.GetService<MyBlogController>().Test();
                 serviceProvider.GetService<MyAccountController>().Test();

--- a/test/Microsoft.Data.Entity.InMemory.FunctionalTests/InMemoryDataStoreTest.cs
+++ b/test/Microsoft.Data.Entity.InMemory.FunctionalTests/InMemoryDataStoreTest.cs
@@ -34,9 +34,9 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
         {
             var model = CreateModel();
 
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFramework(s => s.AddInMemoryStore().UseLoggerFactory(TestFileLogger.Factory))
-                .BuildServiceProvider();
+            var services = new ServiceCollection();
+            services.AddEntityFramework().AddInMemoryStore().UseLoggerFactory(TestFileLogger.Factory);
+            var serviceProvider = services.BuildServiceProvider();
 
             var configuration = new DbContextOptions()
                 .UseModel(model)

--- a/test/Microsoft.Data.Entity.InMemory.Tests/InMemoryEntityServicesBuilderExtensionsTest.cs
+++ b/test/Microsoft.Data.Entity.InMemory.Tests/InMemoryEntityServicesBuilderExtensionsTest.cs
@@ -30,7 +30,8 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         [Fact]
         public void Can_get_default_services()
         {
-            var services = new ServiceCollection().AddEntityFramework(s => s.AddInMemoryStore());
+            var services = new ServiceCollection();
+            services.AddEntityFramework().AddInMemoryStore();
 
             Assert.True(services.Any(sd => sd.ServiceType == typeof(IdentityGeneratorFactory)));
             Assert.True(services.Any(sd => sd.ServiceType == typeof(InMemoryDataStore)));
@@ -40,7 +41,9 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         [Fact]
         public void Services_wire_up_correctly()
         {
-            var serviceProvider = new ServiceCollection().AddEntityFramework(s => s.AddInMemoryStore()).BuildServiceProvider();
+            var services = new ServiceCollection();
+            services.AddEntityFramework().AddInMemoryStore();
+            var serviceProvider = services.BuildServiceProvider();
 
             using (var context = new DbContext(serviceProvider, new DbContextOptions().BuildConfiguration()))
             {

--- a/test/Microsoft.Data.Entity.Relational.Tests/Update/BatchExecutorTest.cs
+++ b/test/Microsoft.Data.Entity.Relational.Tests/Update/BatchExecutorTest.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Open Technologies, Inc.
 // All Rights Reserved
-//
+// 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-//
+// 
 // http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
 // WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF
@@ -20,14 +20,13 @@ using System.Data;
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Data.Entity;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Relational.Update;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
 using Moq;
 using Moq.Protected;
 using Xunit;
@@ -230,7 +229,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
 
         private static IModel BuildModel(ValueGenerationStrategy keyStrategy, ValueGenerationStrategy nonKeyStrategy)
         {
-            var model = new Entity.Metadata.Model();
+            var model = new Metadata.Model();
 
             var entityType = new EntityType(typeof(T1));
 
@@ -248,10 +247,9 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
 
         private static DbContextConfiguration CreateConfiguration(IModel model)
         {
-            return new DbContext(
-                new ServiceCollection()
-                    .AddEntityFramework()
-                    .BuildServiceProvider(),
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddEntityFramework();
+            return new DbContext(serviceCollection.BuildServiceProvider(),
                 new DbContextOptions()
                     .UseModel(model)
                     .BuildConfiguration())

--- a/test/Microsoft.Data.Entity.Relational.Tests/Update/ModificationCommandTest.cs
+++ b/test/Microsoft.Data.Entity.Relational.Tests/Update/ModificationCommandTest.cs
@@ -255,10 +255,9 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
 
         private static DbContextConfiguration CreateConfiguration(IModel model)
         {
-            return new DbContext(
-                new ServiceCollection()
-                    .AddEntityFramework()
-                    .BuildServiceProvider(),
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddEntityFramework();
+            return new DbContext(serviceCollection.BuildServiceProvider(),
                 new DbContextOptions()
                     .UseModel(model)
                     .BuildConfiguration())

--- a/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/ExistingConnectionTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/ExistingConnectionTest.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Open Technologies, Inc.
 // All Rights Reserved
-//
+// 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-//
+// 
 // http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
 // WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF
@@ -20,10 +20,9 @@ using System.Data;
 using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Metadata;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
@@ -47,9 +46,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
         private static async Task Can_use_an_existing_closed_connection_test(bool openConnection)
         {
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFramework(s => s.AddSqlServer())
-                .BuildServiceProvider();
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddEntityFramework().AddSqlServer();
+            var serviceProvider = serviceCollection.BuildServiceProvider();
 
             using (await TestDatabase.Northwind())
             {
@@ -65,16 +64,16 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     }
 
                     connection.StateChange += (_, a) =>
-                    {
-                        if (a.CurrentState == ConnectionState.Open)
                         {
-                            openCount++;
-                        }
-                        else if (a.CurrentState == ConnectionState.Closed)
-                        {
-                            closeCount++;
-                        }
-                    };
+                            if (a.CurrentState == ConnectionState.Open)
+                            {
+                                openCount++;
+                            }
+                            else if (a.CurrentState == ConnectionState.Closed)
+                            {
+                                closeCount++;
+                            }
+                        };
 #if NET45
                     connection.Disposed += (_, __) => disposeCount++;
 #endif

--- a/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/SqlServerDataStoreCreatorTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/SqlServerDataStoreCreatorTest.cs
@@ -183,10 +183,10 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
         private static DbContextConfiguration CreateConfiguration(TestDatabase testDatabase)
         {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddEntityFramework().AddSqlServer();
             return new DbContext(
-                new ServiceCollection()
-                    .AddEntityFramework(s => s.AddSqlServer())
-                    .BuildServiceProvider(),
+                serviceCollection.BuildServiceProvider(),
                 new DbContextOptions()
                     .UseSqlServer(testDatabase.Connection.ConnectionString)
                     .BuildConfiguration())
@@ -200,9 +200,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
         private static async Task RunDatabaseCreationTest(TestDatabase testDatabase, bool async)
         {
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFramework(s => s.AddSqlServer())
-                .BuildServiceProvider();
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddEntityFramework().AddSqlServer();
+            var serviceProvider = serviceCollection.BuildServiceProvider();
 
             var configuration = new DbContextOptions()
                 .UseSqlServer(testDatabase.Connection.ConnectionString)

--- a/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/SqlServerDatabaseCreationTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/SqlServerDatabaseCreationTest.cs
@@ -201,10 +201,10 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
         private static DbContextConfiguration CreateConfiguration(TestDatabase testDatabase)
         {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddEntityFramework().AddSqlServer();
             return new DbContext(
-                new ServiceCollection()
-                    .AddEntityFramework(s => s.AddSqlServer())
-                    .BuildServiceProvider(),
+                serviceCollection.BuildServiceProvider(),
                 new DbContextOptions()
                     .UseSqlServer(testDatabase.Connection.ConnectionString)
                     .BuildConfiguration())
@@ -275,9 +275,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
         private static IServiceProvider CreateServiceProvider()
         {
-            return new ServiceCollection()
-                .AddEntityFramework(s => s.AddSqlServer())
-                .BuildServiceProvider();
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddEntityFramework().AddSqlServer();
+            return serviceCollection.BuildServiceProvider();
         }
 
         private class BloggingContext : DbContext

--- a/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -66,13 +66,10 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             using (await TestDatabase.Northwind())
             {
-                var serviceProvider = new ServiceCollection()
-                    .AddEntityFramework(s =>
-                        {
-                            s.AddSqlServer();
-                            s.ServiceCollection.AddScoped<SqlServerDataStore, SqlStoreWithBufferReader>();
-                        })
-                    .BuildServiceProvider();
+                var serviceCollection = new ServiceCollection();
+                serviceCollection.AddEntityFramework().AddSqlServer();
+                serviceCollection.AddScoped<SqlServerDataStore, SqlStoreWithBufferReader>();
+                var serviceProvider = serviceCollection.BuildServiceProvider();
 
                 using (var db = new NorthwindContext(serviceProvider))
                 {

--- a/test/Microsoft.Data.Entity.SqlServer.Tests/SqlServerConnectionTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.Tests/SqlServerConnectionTest.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Open Technologies, Inc.
 // All Rights Reserved
-//
+// 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-//
+// 
 // http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
 // WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF
@@ -16,10 +16,9 @@
 // permissions and limitations under the License.
 
 using System.Data.SqlClient;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Data.Entity;
-using Microsoft.Data.Entity.Infrastructure;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.Tests
@@ -49,9 +48,9 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
         public static DbContextConfiguration CreateConfiguration()
         {
-            return new DbContext(new ServiceCollection()
-                .AddEntityFramework(s => s.AddSqlServer())
-                .BuildServiceProvider(),
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddEntityFramework().AddSqlServer();
+            return new DbContext(serviceCollection.BuildServiceProvider(),
                 new DbContextOptions()
                     .UseSqlServer("Server=(localdb)\v11.0;Database=SqlServerConnectionTest;Trusted_Connection=True;")
                     .BuildConfiguration()).Configuration;

--- a/test/Microsoft.Data.Entity.SqlServer.Tests/SqlServerEntityServicesBuilderExtensionsTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.Tests/SqlServerEntityServicesBuilderExtensionsTest.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Open Technologies, Inc.
 // All Rights Reserved
-//
+// 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-//
+// 
 // http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
 // WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF
@@ -16,14 +16,13 @@
 // permissions and limitations under the License.
 
 using System.Linq;
-using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Data.Entity;
 using Microsoft.Data.Entity.Identity;
-using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Migrations;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Relational.Update;
+using Microsoft.Data.Entity.Storage;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.Tests
@@ -33,7 +32,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void Can_get_default_services()
         {
-            var services = new ServiceCollection().AddEntityFramework(s => s.AddSqlServer());
+            var services = new ServiceCollection();
+            services.AddEntityFramework().AddSqlServer();
 
             // Relational
             Assert.True(services.Any(sd => sd.ServiceType == typeof(DatabaseBuilder)));
@@ -59,7 +59,9 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void Services_wire_up_correctly()
         {
-            var serviceProvider = new ServiceCollection().AddEntityFramework(s => s.AddSqlServer()).BuildServiceProvider();
+            var services = new ServiceCollection();
+            services.AddEntityFramework().AddSqlServer();
+            var serviceProvider = services.BuildServiceProvider();
 
             var context = new DbContext(
                 serviceProvider,

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateEntryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateEntryTest.cs
@@ -112,9 +112,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var generatorFactory = new Mock<IdentityGeneratorFactory>();
             generatorFactory.Setup(m => m.Create(keyProperty)).Returns(generatorMock.Object);
 
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFramework(s => s.UseIdentityGeneratorFactory(generatorFactory.Object))
-                .BuildServiceProvider();
+            var services = new ServiceCollection();
+            services.AddEntityFramework().UseIdentityGeneratorFactory(generatorFactory.Object);
+            var serviceProvider = services.BuildServiceProvider();
 
             var configuration = TestHelpers.CreateContextConfiguration(serviceProvider, model);
 

--- a/test/Microsoft.Data.Entity.Tests/ContextConfigurationTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ContextConfigurationTest.cs
@@ -97,9 +97,9 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Scoped_data_store_services_can_be_obtained_from_configuration()
         {
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFramework(s => s.AddInMemoryStore())
-                .BuildServiceProvider();
+            var services = new ServiceCollection();
+            services.AddEntityFramework().AddInMemoryStore();
+            var serviceProvider = services.BuildServiceProvider();
 
             DataStore store;
             DataStoreCreator creator;
@@ -160,9 +160,9 @@ namespace Microsoft.Data.Entity.Tests
 
         private static IServiceProvider CreateDefaultProvider()
         {
-            return new ServiceCollection()
-                .AddEntityFramework(s => s.AddInMemoryStore())
-                .BuildServiceProvider();
+            var services = new ServiceCollection();
+            services.AddEntityFramework().AddInMemoryStore();
+            return services.BuildServiceProvider();
         }
 
         private static DbContextConfiguration CreateEmptyConfiguration()

--- a/test/Microsoft.Data.Entity.Tests/DbContextTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/DbContextTest.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Open Technologies, Inc.
 // All Rights Reserved
-//
+// 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-//
+// 
 // http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
 // WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF
@@ -20,15 +20,15 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
-using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Identity;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Advanced;
+using Microsoft.Framework.DependencyInjection.Fallback;
+using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
 
@@ -72,9 +72,9 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Each_context_gets_new_scoped_context_configuration()
         {
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFramework()
-                .BuildServiceProvider();
+            var services = new ServiceCollection();
+            services.AddEntityFramework();
+            var serviceProvider = services.BuildServiceProvider();
 
             DbContextConfiguration configuration;
             using (var context = new DbContext(serviceProvider))
@@ -108,9 +108,9 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Each_context_gets_new_scoped_context_configuration_with_explicit_config()
         {
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFramework()
-                .BuildServiceProvider();
+            var services = new ServiceCollection();
+            services.AddEntityFramework();
+            var serviceProvider = services.BuildServiceProvider();
 
             var entityConfig = new DbContextOptions().BuildConfiguration();
 
@@ -148,9 +148,9 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void SaveChanges_calls_DetectChanges()
         {
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFramework(s => s.UseStateManager<FakeStateManager>())
-                .BuildServiceProvider();
+            var services = new ServiceCollection();
+            services.AddEntityFramework().UseStateManager<FakeStateManager>();
+            var serviceProvider = services.BuildServiceProvider();
 
             var configuration = new DbContextOptions().BuildConfiguration();
 
@@ -169,9 +169,9 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void SaveChanges_calls_state_manager_SaveChanges()
         {
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFramework(s => s.UseStateManager<FakeStateManager>())
-                .BuildServiceProvider();
+            var services = new ServiceCollection();
+            services.AddEntityFramework().UseStateManager<FakeStateManager>();
+            var serviceProvider = services.BuildServiceProvider();
 
             var configuration = new DbContextOptions().BuildConfiguration();
 
@@ -424,9 +424,10 @@ namespace Microsoft.Data.Entity.Tests
             sourceMock.Setup(m => m.IsConfigured(It.IsAny<DbContextConfiguration>())).Returns(true);
             sourceMock.Setup(m => m.GetStore(It.IsAny<DbContextConfiguration>())).Returns(store.Object);
 
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFramework(s => s.ServiceCollection.AddInstance<DataStoreSource>(sourceMock.Object))
-                .BuildServiceProvider();
+            var services = new ServiceCollection();
+            services.AddEntityFramework();
+            services.AddInstance(sourceMock.Object);
+            var serviceProvider = services.BuildServiceProvider();
 
             var configuration = new DbContextOptions().BuildConfiguration();
 
@@ -458,9 +459,10 @@ namespace Microsoft.Data.Entity.Tests
             sourceMock.Setup(m => m.IsConfigured(It.IsAny<DbContextConfiguration>())).Returns(true);
             sourceMock.Setup(m => m.GetStore(It.IsAny<DbContextConfiguration>())).Returns(store.Object);
 
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFramework(s => s.ServiceCollection.AddInstance<DataStoreSource>(sourceMock.Object))
-                .BuildServiceProvider();
+            var services = new ServiceCollection();
+            services.AddEntityFramework();
+            services.AddInstance(sourceMock.Object);
+            var serviceProvider = services.BuildServiceProvider();
 
             var configuration = new DbContextOptions().BuildConfiguration();
 
@@ -554,9 +556,9 @@ namespace Microsoft.Data.Entity.Tests
         public void Can_replace_already_registered_service_with_new_service()
         {
             var factory = Mock.Of<OriginalValuesFactory>();
-            var serviceCollection = new ServiceCollection()
-                .AddEntityFramework()
-                .AddInstance<OriginalValuesFactory>(factory);
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddEntityFramework();
+            serviceCollection.AddInstance(factory);
 
             var provider = serviceCollection.BuildServiceProvider();
 
@@ -583,19 +585,21 @@ namespace Microsoft.Data.Entity.Tests
             var loggerFactory = Mock.Of<ILoggerFactory>();
             var modelSource = Mock.Of<IModelSource>();
 
-            var provider = new ServiceCollection()
-                .AddEntityFramework(s => s.UseActiveIdentityGenerators(identityGenerators)
-                    .UseClrCollectionAccessorSource(collectionSource)
-                    .UseClrPropertyGetterSource(getterSource)
-                    .UseClrPropertySetterSource(setterSource)
-                    .UseEntityKeyFactorySource(keyFactorySource)
-                    .UseEntityMaterializerSource(materializerSource)
-                    .UseDbSetFinder(setFinder)
-                    .UseDbSetInitializer(setInitializer)
-                    .UseIdentityGeneratorFactory(generatorFactory)
-                    .UseLoggerFactory(loggerFactory)
-                    .UseModelSource(modelSource))
-                .BuildServiceProvider();
+            var services = new ServiceCollection();
+            services.AddEntityFramework()
+                .UseActiveIdentityGenerators(identityGenerators)
+                .UseClrCollectionAccessorSource(collectionSource)
+                .UseClrPropertyGetterSource(getterSource)
+                .UseClrPropertySetterSource(setterSource)
+                .UseEntityKeyFactorySource(keyFactorySource)
+                .UseEntityMaterializerSource(materializerSource)
+                .UseDbSetFinder(setFinder)
+                .UseDbSetInitializer(setInitializer)
+                .UseIdentityGeneratorFactory(generatorFactory)
+                .UseLoggerFactory(loggerFactory)
+                .UseModelSource(modelSource);
+
+            var provider = services.BuildServiceProvider();
 
             using (var context = new EarlyLearningCenter(provider))
             {
@@ -618,21 +622,23 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Can_set_known_singleton_services_using_type_activation()
         {
-            var provider = new ServiceCollection()
-                .AddEntityFramework(s => s.UseActiveIdentityGenerators<FakeActiveIdentityGenerators>()
-                    .UseClrCollectionAccessorSource<FakeClrCollectionAccessorSource>()
-                    .UseClrPropertyGetterSource<FakeClrPropertyGetterSource>()
-                    .UseClrPropertySetterSource<FakeClrPropertySetterSource>()
-                    .UseEntityKeyFactorySource<FakeEntityKeyFactorySource>()
-                    .UseEntityMaterializerSource<FakeEntityMaterializerSource>()
-                    .UseDbSetFinder<FakeDbSetFinder>()
-                    .UseDbSetInitializer<FakeDbSetInitializer>()
-                    .UseEntityStateListener<FakeEntityStateListener>()
-                    .UseIdentityGeneratorFactory<FakeIdentityGeneratorFactory>()
-                    .UseContextSets<FakeContextSets>()
-                    .UseLoggerFactory<FakeLoggerFactory>()
-                    .UseModelSource<FakeModelSource>())
-                .BuildServiceProvider();
+            var services = new ServiceCollection();
+            services.AddEntityFramework()
+                .UseActiveIdentityGenerators<FakeActiveIdentityGenerators>()
+                .UseClrCollectionAccessorSource<FakeClrCollectionAccessorSource>()
+                .UseClrPropertyGetterSource<FakeClrPropertyGetterSource>()
+                .UseClrPropertySetterSource<FakeClrPropertySetterSource>()
+                .UseEntityKeyFactorySource<FakeEntityKeyFactorySource>()
+                .UseEntityMaterializerSource<FakeEntityMaterializerSource>()
+                .UseDbSetFinder<FakeDbSetFinder>()
+                .UseDbSetInitializer<FakeDbSetInitializer>()
+                .UseEntityStateListener<FakeEntityStateListener>()
+                .UseIdentityGeneratorFactory<FakeIdentityGeneratorFactory>()
+                .UseContextSets<FakeContextSets>()
+                .UseLoggerFactory<FakeLoggerFactory>()
+                .UseModelSource<FakeModelSource>();
+
+            var provider = services.BuildServiceProvider();
 
             using (var context = new EarlyLearningCenter(provider))
             {
@@ -655,13 +661,15 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Can_set_known_context_scoped_services_using_type_activation()
         {
-            var provider = new ServiceCollection()
-                .AddEntityFramework(s => s.UseStateEntryFactory<FakeStateEntryFactory>()
-                    .UseStateEntryNotifier<FakeStateEntryNotifier>()
-                    .UseContextSets<FakeContextSets>()
-                    .UseStateManager<FakeStateManager>()
-                    .UseEntityStateListener<FakeNavigationFixer>())
-                .BuildServiceProvider();
+            var services = new ServiceCollection();
+            services.AddEntityFramework()
+                .UseStateEntryFactory<FakeStateEntryFactory>()
+                .UseStateEntryNotifier<FakeStateEntryNotifier>()
+                .UseContextSets<FakeContextSets>()
+                .UseStateManager<FakeStateManager>()
+                .UseEntityStateListener<FakeNavigationFixer>();
+
+            var provider = services.BuildServiceProvider();
 
             using (var context = new EarlyLearningCenter(provider))
             {
@@ -681,25 +689,27 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Replaced_services_are_scoped_appropriately()
         {
-            var provider = new ServiceCollection().AddEntityFramework(
-                s => s.UseActiveIdentityGenerators<FakeActiveIdentityGenerators>()
-                    .UseClrCollectionAccessorSource<FakeClrCollectionAccessorSource>()
-                    .UseClrPropertyGetterSource<FakeClrPropertyGetterSource>()
-                    .UseClrPropertySetterSource<FakeClrPropertySetterSource>()
-                    .UseEntityKeyFactorySource<FakeEntityKeyFactorySource>()
-                    .UseEntityMaterializerSource<FakeEntityMaterializerSource>()
-                    .UseDbSetFinder<FakeDbSetFinder>()
-                    .UseDbSetInitializer<FakeDbSetInitializer>()
-                    .UseEntityStateListener<FakeEntityStateListener>()
-                    .UseIdentityGeneratorFactory<FakeIdentityGeneratorFactory>()
-                    .UseLoggerFactory<FakeLoggerFactory>()
-                    .UseModelSource<FakeModelSource>()
-                    .UseStateEntryFactory<FakeStateEntryFactory>()
-                    .UseStateEntryNotifier<FakeStateEntryNotifier>()
-                    .UseContextSets<FakeContextSets>()
-                    .UseStateManager<FakeStateManager>()
-                    .UseEntityStateListener<FakeNavigationFixer>())
-                .BuildServiceProvider();
+            var services = new ServiceCollection();
+            services.AddEntityFramework()
+                .UseActiveIdentityGenerators<FakeActiveIdentityGenerators>()
+                .UseClrCollectionAccessorSource<FakeClrCollectionAccessorSource>()
+                .UseClrPropertyGetterSource<FakeClrPropertyGetterSource>()
+                .UseClrPropertySetterSource<FakeClrPropertySetterSource>()
+                .UseEntityKeyFactorySource<FakeEntityKeyFactorySource>()
+                .UseEntityMaterializerSource<FakeEntityMaterializerSource>()
+                .UseDbSetFinder<FakeDbSetFinder>()
+                .UseDbSetInitializer<FakeDbSetInitializer>()
+                .UseEntityStateListener<FakeEntityStateListener>()
+                .UseIdentityGeneratorFactory<FakeIdentityGeneratorFactory>()
+                .UseLoggerFactory<FakeLoggerFactory>()
+                .UseModelSource<FakeModelSource>()
+                .UseStateEntryFactory<FakeStateEntryFactory>()
+                .UseStateEntryNotifier<FakeStateEntryNotifier>()
+                .UseContextSets<FakeContextSets>()
+                .UseStateManager<FakeStateManager>()
+                .UseEntityStateListener<FakeNavigationFixer>();
+
+            var provider = services.BuildServiceProvider();
 
             StateEntryFactory stateEntryFactory;
             StateEntryNotifier stateEntryNotifier;
@@ -780,8 +790,9 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Can_get_replaced_singleton_service_from_scoped_configuration()
         {
-            var provider = new ServiceCollection().AddEntityFramework(
-                s => s.UseEntityMaterializerSource<FakeEntityMaterializerSource>()).BuildServiceProvider();
+            var services = new ServiceCollection();
+            services.AddEntityFramework().UseEntityMaterializerSource<FakeEntityMaterializerSource>();
+            var provider = services.BuildServiceProvider();
 
             using (var context = new EarlyLearningCenter(provider))
             {

--- a/test/Microsoft.Data.Entity.Tests/DbSetInitializerTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/DbSetInitializerTest.cs
@@ -57,9 +57,11 @@ namespace Microsoft.Data.Entity.Tests
                         new DbSetFinder.DbSetProperty(typeof(JustAContext), "Four", typeof(string), hasSetter: false)
                     });
 
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFramework(s => s.UseDbSetInitializer(new DbSetInitializer(setFinderMock.Object, new ClrPropertySetterSource())))
-                .BuildServiceProvider();
+            var serviceCollection = new ServiceCollection();
+            serviceCollection
+                .AddEntityFramework()
+                .UseDbSetInitializer(new DbSetInitializer(setFinderMock.Object, new ClrPropertySetterSource()));
+            var serviceProvider = serviceCollection.BuildServiceProvider();
 
             var configuration = new DbContextOptions().BuildConfiguration();
 

--- a/test/Microsoft.Data.Entity.Tests/TestHelpers.cs
+++ b/test/Microsoft.Data.Entity.Tests/TestHelpers.cs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Open Technologies, Inc.
 // All Rights Reserved
-//
+// 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-//
+// 
 // http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
 // WITHOUT LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF
@@ -16,11 +16,10 @@
 // permissions and limitations under the License.
 
 using System;
-using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Fallback;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
-using Microsoft.Data.Entity.InMemory;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
 
 namespace Microsoft.Data.Entity.Tests
 {
@@ -41,9 +40,9 @@ namespace Microsoft.Data.Entity.Tests
 
         public static IServiceProvider CreateServiceProvider()
         {
-            return new ServiceCollection()
-                .AddEntityFramework(s => s.AddInMemoryStore())
-                .BuildServiceProvider();
+            var services = new ServiceCollection();
+            services.AddEntityFramework().AddInMemoryStore();
+            return services.BuildServiceProvider();
         }
 
         public static DbContextConfiguration CreateContextConfiguration(IServiceProvider serviceProvider, IModel model)


### PR DESCRIPTION
Flying the nested closure... (Change AddEntityFramework to return EF-specific builder)

Allow direct chaining of EF services setup, but prevent direct changing or other services setup.
