### PR TITLE
Even beer pipelines exist...

### DIFF
--- a/EntityFramework.sln
+++ b/EntityFramework.sln
@@ -27,7 +27,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Data.Entity.InMem
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Data.Entity.Relational.net45", "src\Microsoft.Data.Entity.Relational\Microsoft.Data.Entity.Relational.net45.csproj", "{75C5A774-A3F3-43EB-97D3-DBE0CF2825D8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Data.Entity.SQLite.net45", "src\Microsoft.Data.Entity.SQLite\Microsoft.Data.Entity.SQLite.net45.csproj", "{4CC98896-FE91-4F16-AE60-D6FF9E905836}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Data.Entity.SQLite.net451", "src\Microsoft.Data.Entity.SQLite\Microsoft.Data.Entity.SQLite.net451.csproj", "{4CC98896-FE91-4F16-AE60-D6FF9E905836}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Data.Entity.SqlServer.net45", "src\Microsoft.Data.Entity.SqlServer\Microsoft.Data.Entity.SqlServer.net45.csproj", "{04E6620B-5B41-45FE-981A-F40EB7686B0E}"
 EndProject
@@ -57,7 +57,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Data.Entity.SqlSe
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Data.Entity.InMemory.FunctionalTests.net45", "test\Microsoft.Data.Entity.InMemory.FunctionalTests\Microsoft.Data.Entity.InMemory.FunctionalTests.net45.csproj", "{7E1A1A1B-6D0B-4C66-8026-326EFC0B4625}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Data.Entity.SQLite.Tests.net45", "test\Microsoft.Data.Entity.SQLite.Tests\Microsoft.Data.Entity.SQLite.Tests.net45.csproj", "{1F060759-25F6-47FB-AEBB-3D88195F3DF7}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Data.Entity.SQLite.Tests.net451", "test\Microsoft.Data.Entity.SQLite.Tests\Microsoft.Data.Entity.SQLite.Tests.net451.csproj", "{1F060759-25F6-47FB-AEBB-3D88195F3DF7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Microsoft.Data.Entity.InMemory/InMemoryDataStore.cs
+++ b/src/Microsoft.Data.Entity.InMemory/InMemoryDataStore.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Data.Entity.InMemory
         }
 
         public override Task<int> SaveChangesAsync(
-            IEnumerable<StateEntry> stateEntries,
+            IReadOnlyList<StateEntry> stateEntries,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             Check.NotNull(stateEntries, "stateEntries");

--- a/src/Microsoft.Data.Entity.Relational/Model/RelationalDecimalTypeMapping.cs
+++ b/src/Microsoft.Data.Entity.Relational/Model/RelationalDecimalTypeMapping.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Data;
+using System.Data.Common;
+using Microsoft.Data.Entity.Relational.Update;
+using Microsoft.Data.Entity.Relational.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Model
+{
+    public class RelationalDecimalTypeMapping : RelationalTypeMapping
+    {
+        private readonly byte _scale;
+        private readonly byte _precision;
+
+        public RelationalDecimalTypeMapping(byte scale, byte precision)
+            : base("decimal(" + scale + ", " + precision + ")", DbType.Decimal)
+        {
+            _scale = scale;
+            _precision = precision;
+        }
+
+        protected override void ConfigureParameter(DbParameter parameter, ColumnModification columnModification)
+        {
+            Check.NotNull(parameter, "parameter");
+            Check.NotNull(columnModification, "columnModification");
+
+            // Note: Precision/scale should not be set for input parameters because this will cause truncation
+            // TODO: Uncomment this--not doing for alpha because it requires all dependencies updated to 4.5.1
+            //if (parameter.Direction == ParameterDirection.Output)
+            //{
+            //    parameter.Scale = _scale;
+            //    parameter.Precision = _precision;
+            //}
+
+            base.ConfigureParameter(parameter, columnModification);
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity.Relational/Model/RelationalSizedTypeMapping.cs
+++ b/src/Microsoft.Data.Entity.Relational/Model/RelationalSizedTypeMapping.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Data;
+using System.Data.Common;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Relational.Update;
+using Microsoft.Data.Entity.Relational.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Model
+{
+    public class RelationalSizedTypeMapping : RelationalTypeMapping
+    {
+        private readonly int _size;
+
+        public RelationalSizedTypeMapping([NotNull] string storeTypeName, DbType storeType, int size)
+            : base(storeTypeName, storeType)
+        {
+            _size = size;
+        }
+
+        protected override void ConfigureParameter(DbParameter parameter, ColumnModification columnModification)
+        {
+            Check.NotNull(parameter, "parameter");
+            Check.NotNull(columnModification, "columnModification");
+
+            parameter.Size = _size;
+
+            base.ConfigureParameter(parameter, columnModification);
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity.Relational/Model/RelationalTypeMapper.cs
+++ b/src/Microsoft.Data.Entity.Relational/Model/RelationalTypeMapper.cs
@@ -1,0 +1,111 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Relational.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Model
+{
+    // TODO: Some of this is SQL Server specific and should be moved into that class
+    public class RelationalTypeMapper
+    {
+        // This dictionary is for invariant mappings from a sealed CLR type to a single
+        // store type. If the CLR type is unsealed or if the mapping varies based on how the
+        // type is used (e.g. in keys), then add custom mapping below.
+        private readonly IDictionary<Type, RelationalTypeMapping> _simpleMappings = new Dictionary<Type, RelationalTypeMapping>()
+            {
+                { typeof(int), new RelationalTypeMapping("int", DbType.Int32) },
+                { typeof(DateTime), new RelationalTypeMapping("datetime2", DbType.DateTime2) },
+                { typeof(Guid), new RelationalTypeMapping("uniqueidentifier", DbType.Guid) },
+                { typeof(bool), new RelationalTypeMapping("bit", DbType.Boolean) },
+                { typeof(byte), new RelationalTypeMapping("tinyint", DbType.Byte) },
+                { typeof(char), new RelationalTypeMapping("int", DbType.Int32) },
+                { typeof(double), new RelationalTypeMapping("float", DbType.Double) },
+                { typeof(short), new RelationalTypeMapping("smallint", DbType.Int16) },
+                { typeof(long), new RelationalTypeMapping("bigint", DbType.Int64) },
+                { typeof(sbyte), new RelationalTypeMapping("smallint", DbType.SByte) },
+                { typeof(float), new RelationalTypeMapping("real", DbType.Single) },
+                { typeof(ushort), new RelationalTypeMapping("int", DbType.UInt16) },
+                { typeof(uint), new RelationalTypeMapping("bigint", DbType.UInt32) },
+                { typeof(ulong), new RelationalTypeMapping("numeric(20, 0)", DbType.UInt64) },
+                { typeof(DateTimeOffset), new RelationalTypeMapping("datetimeoffset", DbType.DateTimeOffset) },
+            };
+
+        private readonly RelationalTypeMapping _nonKeyStringMapping
+            = new RelationalTypeMapping("nvarchar(max)", DbType.String);
+
+        // TODO: It may be possible to increase 128 to 900, at least for SQL Server
+        private readonly RelationalTypeMapping _keyStringMapping
+            = new RelationalSizedTypeMapping("nvarchar(128)", DbType.String, 128);
+
+        private readonly RelationalTypeMapping _nonKeyByteArrayMapping
+            = new RelationalTypeMapping("varbinary(max)", DbType.Binary);
+
+        // TODO: It may be possible to increase 128 to 900, at least for SQL Server
+        private readonly RelationalTypeMapping _keyByteArrayMapping
+            = new RelationalSizedTypeMapping("varbinary(128)", DbType.Binary, 128);
+
+        private readonly RelationalTypeMapping _rowVersionMapping
+            = new RelationalSizedTypeMapping("rowversion", DbType.Binary, 8);
+
+        private readonly RelationalDecimalTypeMapping _decimalMapping
+            = new RelationalDecimalTypeMapping(18, 2);
+
+        // TODO: It would be nice to just pass IProperty into this method, but Migrations uses its own
+        // store model for which there is no easy way to get an IProperty.
+        public virtual RelationalTypeMapping GetTypeMapping(
+            [CanBeNull] string specifiedType,
+            [NotNull] string storageName,
+            [NotNull] Type propertyType,
+            bool isKey,
+            bool isConcurrencyToken)
+        {
+            Check.NotNull(storageName, "storageName");
+            Check.NotNull(propertyType, "propertyType");
+
+            // TODO: if specifiedType is non-null then parse it to create a type mapping
+
+            RelationalTypeMapping mapping;
+            if (_simpleMappings.TryGetValue(propertyType, out mapping))
+            {
+                return mapping;
+            }
+
+            if (propertyType == typeof(string))
+            {
+                if (isKey)
+                {
+                    return _keyStringMapping;
+                }
+                return _nonKeyStringMapping;
+            }
+
+            if (propertyType == typeof(byte[]))
+            {
+                if (isKey)
+                {
+                    return _keyByteArrayMapping;
+                }
+
+                if (isConcurrencyToken)
+                {
+                    return _rowVersionMapping;
+                }
+                return _nonKeyByteArrayMapping;
+            }
+
+            if (propertyType == typeof(decimal))
+            {
+                // TODO: If scale/precision have been configured for the property, then create parameter appropriately
+                return _decimalMapping;
+            }
+
+            //// TODO: Consider TimeSpan mapping
+
+            throw new NotSupportedException(Strings.FormatUnsupportedType(storageName, propertyType.Name));
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity.Relational/Model/RelationalTypeMapping.cs
+++ b/src/Microsoft.Data.Entity.Relational/Model/RelationalTypeMapping.cs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data;
+using System.Data.Common;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Relational.Update;
+using Microsoft.Data.Entity.Relational.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Model
+{
+    public class RelationalTypeMapping
+    {
+        private readonly string _storeTypeName;
+        private readonly DbType _storeType;
+
+        public RelationalTypeMapping([NotNull] string storeTypeName, DbType storeType)
+        {
+            Check.NotEmpty(storeTypeName, "storeTypeName");
+
+            _storeTypeName = storeTypeName;
+            _storeType = storeType;
+        }
+
+        public virtual string StoreTypeName
+        {
+            get { return _storeTypeName; }
+        }
+
+        public virtual DbType StoreType
+        {
+            get { return _storeType; }
+        }
+
+        public virtual DbParameter CreateParameter([NotNull] DbCommand command, [NotNull] ColumnModification columnModification)
+        {
+            Check.NotNull(command, "command");
+            Check.NotNull(columnModification, "columnModification");
+
+            var parameter = command.CreateParameter();
+            parameter.Direction = ParameterDirection.Input;
+            parameter.ParameterName = columnModification.ParameterName;
+
+            ConfigureParameter(parameter, columnModification);
+
+            return parameter;
+        }
+
+        protected virtual void ConfigureParameter([NotNull] DbParameter parameter, [NotNull] ColumnModification columnModification)
+        {
+            Check.NotNull(parameter, "parameter");
+            Check.NotNull(columnModification, "columnModification");
+
+            parameter.DbType = _storeType;
+            parameter.IsNullable = columnModification.Property.IsNullable;
+            parameter.Value = columnModification.StateEntry[columnModification.Property] ?? DBNull.Value;
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity.Relational/Properties/Strings.Designer.cs
+++ b/src/Microsoft.Data.Entity.Relational/Properties/Strings.Designer.cs
@@ -170,6 +170,22 @@ namespace Microsoft.Data.Entity.Relational
             return GetString("NoConnectionOrConnectionString");
         }
 
+        /// <summary>
+        /// The property '{0}' cannot be mapped because it is of type '{1}' which is currently not supported.'
+        /// </summary>
+        internal static string UnsupportedType
+        {
+            get { return GetString("UnsupportedType"); }
+        }
+
+        /// <summary>
+        /// The property '{0}' cannot be mapped because it is of type '{1}' which is currently not supported.'
+        /// </summary>
+        internal static string FormatUnsupportedType(object p0, object p1)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("UnsupportedType"), p0, p1);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.Data.Entity.Relational/Properties/Strings.resx
+++ b/src/Microsoft.Data.Entity.Relational/Properties/Strings.resx
@@ -147,4 +147,7 @@
   <data name="NoConnectionOrConnectionString" xml:space="preserve">
     <value>A relational store has been configured without specifying either the DbConnection or connection string to use.</value>
   </data>
+  <data name="UnsupportedType" xml:space="preserve">
+    <value>The property '{0}' cannot be mapped because it is of type '{1}' which is currently not supported.'</value>
+  </data>
 </root>

--- a/src/Microsoft.Data.Entity.Relational/RelationalDataStore.cs
+++ b/src/Microsoft.Data.Entity.Relational/RelationalDataStore.cs
@@ -57,13 +57,12 @@ namespace Microsoft.Data.Entity.Relational
         }
 
         public override async Task<int> SaveChangesAsync(
-            IEnumerable<StateEntry> stateEntries,
+            IReadOnlyList<StateEntry> stateEntries,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             Check.NotNull(stateEntries, "stateEntries");
 
-            var database = _databaseBuilder.GetDatabase(Model);
-            var commands = _batchPreparer.BatchCommands(stateEntries, database);
+            var commands = _batchPreparer.BatchCommands(stateEntries);
 
             await _connection.OpenAsync(cancellationToken);
             try

--- a/src/Microsoft.Data.Entity.Relational/RelationalEntityServicesBuilderExtensions.cs
+++ b/src/Microsoft.Data.Entity.Relational/RelationalEntityServicesBuilderExtensions.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddSingleton<DatabaseBuilder, DatabaseBuilder>()
                 .AddSingleton<RelationalObjectArrayValueReaderFactory, RelationalObjectArrayValueReaderFactory>()
                 .AddSingleton<RelationalTypedValueReaderFactory, RelationalTypedValueReaderFactory>()
+                .AddSingleton<ParameterNameGeneratorFactory, ParameterNameGeneratorFactory>()
                 .AddSingleton<CommandBatchPreparer, CommandBatchPreparer>();
 
             return builder;

--- a/src/Microsoft.Data.Entity.Relational/Update/ColumnModification.cs
+++ b/src/Microsoft.Data.Entity.Relational/Update/ColumnModification.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Update
+{
+    public class ColumnModification
+    {
+        private readonly StateEntry _stateEntry;
+        private readonly IProperty _property;
+        private readonly string _columnName;
+        private readonly string _parameterName;
+        private readonly bool _isRead;
+        private readonly bool _isWrite;
+        private readonly bool _isKey;
+        private readonly bool _isCondition;
+
+        public ColumnModification(
+            [NotNull] StateEntry stateEntry,
+            [NotNull] IProperty property,
+            [CanBeNull] string parameterName,
+            bool isRead,
+            bool isWrite,
+            bool isKey,
+            bool isCondition)
+        {
+            Check.NotNull(stateEntry, "stateEntry");
+            Check.NotNull(property, "property");
+
+            _stateEntry = stateEntry;
+            _property = property;
+            _columnName = property.StorageName;
+            _parameterName = parameterName;
+            _isRead = isRead;
+            _isWrite = isWrite;
+            _isKey = isKey;
+            _isCondition = isCondition;
+        }
+
+        public virtual StateEntry StateEntry
+        {
+            get { return _stateEntry; }
+        }
+
+        public virtual IProperty Property
+        {
+            get { return _property; }
+        }
+
+        public virtual bool IsRead
+        {
+            get { return _isRead; }
+        }
+
+        public virtual bool IsWrite
+        {
+            get { return _isWrite; }
+        }
+
+        public virtual bool IsCondition
+        {
+            get { return _isCondition; }
+        }
+
+        public virtual bool IsKey
+        {
+            get { return _isKey; }
+        }
+
+        public virtual string ParameterName
+        {
+            get { return _parameterName; }
+        }
+
+        public virtual string ColumnName
+        {
+            get { return _columnName; }
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity.Relational/Update/CommandBatchPreparer.cs
+++ b/src/Microsoft.Data.Entity.Relational/Update/CommandBatchPreparer.cs
@@ -5,25 +5,33 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking;
-using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Relational.Utilities;
 
 namespace Microsoft.Data.Entity.Relational.Update
 {
     public class CommandBatchPreparer
     {
-        public virtual IEnumerable<ModificationCommandBatch> BatchCommands(
-            [NotNull] IEnumerable<StateEntry> stateEntries, [NotNull] DatabaseModel database)
-        {
-            Check.NotNull(stateEntries, "database");
-            Check.NotNull(database, "stateEntries");
+        private readonly ParameterNameGeneratorFactory _parameterNameGeneratorFactory;
 
-            return
-                stateEntries.Select(
-                    e => new ModificationCommandBatch(new[]
-                        {
-                            new ModificationCommand(e, database.GetTable(e.EntityType.StorageName))
-                        }));
+        public CommandBatchPreparer([NotNull] ParameterNameGeneratorFactory parameterNameGeneratorFactory)
+        {
+            Check.NotNull(parameterNameGeneratorFactory, "parameterNameGeneratorFactory");
+
+            _parameterNameGeneratorFactory = parameterNameGeneratorFactory;
+        }
+
+        public virtual IEnumerable<ModificationCommandBatch> BatchCommands([NotNull] IReadOnlyList<StateEntry> stateEntries)
+        {
+            Check.NotNull(stateEntries, "stateEntries");
+
+            var parameterNameGenerator = _parameterNameGeneratorFactory.Create();
+
+            // TODO: Use topological sort for ordering
+            // TODO: Handle multiple state entries that update the same row
+            // TODO: Note that the code below appears to do batching, but it doesn't really do it because
+            // it always creates a new batch for each insert, update, or delete operation.
+            return stateEntries.Select(e => new ModificationCommandBatch(
+                new[] { new ModificationCommand(e.EntityType.StorageName, parameterNameGenerator).AddStateEntry(e) }));
         }
     }
 }

--- a/src/Microsoft.Data.Entity.Relational/Update/ModificationCommandBatch.cs
+++ b/src/Microsoft.Data.Entity.Relational/Update/ModificationCommandBatch.cs
@@ -2,41 +2,28 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
-using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.ChangeTracking;
-using Microsoft.Data.Entity.Metadata;
-using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Relational.Utilities;
 
 namespace Microsoft.Data.Entity.Relational.Update
 {
     public class ModificationCommandBatch
     {
-        private readonly ModificationCommand[] _batchCommands;
+        private readonly IReadOnlyList<ModificationCommand> _modificationCommands;
 
-        public ModificationCommandBatch([NotNull] ModificationCommand[] batchCommands)
+        public ModificationCommandBatch([NotNull] IReadOnlyList<ModificationCommand> modificationCommands)
         {
-            Check.NotNull(batchCommands, "batchCommands");
+            Check.NotNull(modificationCommands, "modificationCommands");
 
-            Contract.Assert(batchCommands.Any(), "batchCommands array is empty");
-
-            _batchCommands = batchCommands;
+            _modificationCommands = modificationCommands;
         }
 
-        public virtual IEnumerable<ModificationCommand> BatchCommands
-        {
-            get { return _batchCommands; }
-        }
-
-        public virtual string CompileBatch([NotNull] SqlGenerator sqlGenerator, [NotNull] out List<KeyValuePair<string, object>> parameters)
+        public virtual string CompileBatch([NotNull] SqlGenerator sqlGenerator)
         {
             Check.NotNull(sqlGenerator, "sqlGenerator");
 
             var stringBuilder = new StringBuilder();
-            parameters = new List<KeyValuePair<string, object>>();
 
             sqlGenerator.AppendBatchHeader(stringBuilder);
             if (stringBuilder.Length > 0)
@@ -44,21 +31,25 @@ namespace Microsoft.Data.Entity.Relational.Update
                 stringBuilder.Append(sqlGenerator.BatchCommandSeparator).AppendLine();
             }
 
-            foreach (var command in _batchCommands)
+            foreach (var modificationCommand in _modificationCommands)
             {
-                if (command.Operation == ModificationOperation.Insert)
+                var entityState = modificationCommand.EntityState;
+                var operations = modificationCommand.ColumnModifications;
+                var tableName = modificationCommand.TableName;
+
+                if (entityState == EntityState.Added)
                 {
-                    AppendInsertCommand(command, sqlGenerator, stringBuilder, parameters);
+                    sqlGenerator.AppendInsertOperation(stringBuilder, tableName, operations);
                 }
 
-                if (command.Operation == ModificationOperation.Update)
+                if (entityState == EntityState.Modified)
                 {
-                    AppendUpdateCommand(command, sqlGenerator, stringBuilder, parameters);
+                    sqlGenerator.AppendUpdateOperation(stringBuilder, tableName, operations);
                 }
 
-                if (command.Operation == ModificationOperation.Delete)
+                if (entityState == EntityState.Deleted)
                 {
-                    AppendDeleteCommand(command, sqlGenerator, stringBuilder, parameters);
+                    sqlGenerator.AppendDeleteOperation(stringBuilder, tableName, operations);
                 }
 
                 stringBuilder.Append(sqlGenerator.BatchCommandSeparator).AppendLine();
@@ -67,83 +58,9 @@ namespace Microsoft.Data.Entity.Relational.Update
             return stringBuilder.ToString();
         }
 
-        private void AppendInsertCommand(ModificationCommand modificationCommand, SqlGenerator sqlGenerator,
-            StringBuilder stringBuilder, List<KeyValuePair<string, object>> parameters)
+        public virtual IReadOnlyList<ModificationCommand> ModificationCommands
         {
-            var commandParameters = CreateParameters(modificationCommand.ColumnValues, parameters);
-
-            sqlGenerator.AppendInsertOperation(
-                stringBuilder,
-                modificationCommand.Table,
-                modificationCommand.ColumnValues.Zip(
-                    commandParameters,
-                    (c, p) => new KeyValuePair<Column, string>(c.Key, p.Key)).ToArray());
-        }
-
-        private void AppendUpdateCommand(ModificationCommand modificationCommand, SqlGenerator sqlGenerator,
-            StringBuilder stringBuilder, List<KeyValuePair<string, object>> parameters)
-        {
-            var updateParameters = CreateParameters(modificationCommand.ColumnValues, parameters);
-            var whereClauseParameters = CreateParameters(modificationCommand.WhereClauses, parameters);
-
-            sqlGenerator.AppendUpdateOperation(stringBuilder, modificationCommand.Table,
-                modificationCommand.ColumnValues.Zip(
-                    updateParameters, (c, p) => new KeyValuePair<Column, string>(c.Key, p.Key)).ToArray(),
-                modificationCommand.WhereClauses.Zip(
-                    whereClauseParameters, (c, p) => new KeyValuePair<Column, string>(c.Key, p.Key)).ToArray());
-        }
-
-        private void AppendDeleteCommand(ModificationCommand modificationCommand, SqlGenerator sqlGenerator,
-            StringBuilder stringBuilder, List<KeyValuePair<string, object>> parameters)
-        {
-            var whereClauseParameters = CreateParameters(modificationCommand.WhereClauses, parameters);
-
-            sqlGenerator.AppendDeleteCommand(
-                stringBuilder,
-                modificationCommand.Table,
-                modificationCommand.WhereClauses.Zip(
-                    whereClauseParameters, (c, p) => new KeyValuePair<Column, string>(c.Key, p.Key)));
-        }
-
-        private static List<KeyValuePair<string, object>> CreateParameters(IEnumerable<KeyValuePair<Column, object>> values,
-            List<KeyValuePair<string, object>> parameters)
-        {
-            var newParameters = new List<KeyValuePair<string, object>>();
-
-            foreach (var parameter in values.Select(value => new KeyValuePair<string, object>("@p" + parameters.Count, value.Value)))
-            {
-                parameters.Add(parameter);
-                newParameters.Add(parameter);
-            }
-
-            return newParameters;
-        }
-
-        public virtual void SaveStoreGeneratedValues(
-            int commandIndex, [NotNull] IReadOnlyList<string> columnNames, [NotNull] IValueReader reader)
-        {
-            Check.NotNull(columnNames, "columnNames");
-            Check.NotNull(reader, "reader");
-
-            var stateEntry = _batchCommands[commandIndex].StateEntry;
-            for (var i = 0; i < columnNames.Count; i++)
-            {
-                // TODO: Consider using strongly typed ReadValue instead of just <object>
-                // Note that this call sets the value into a sidecar and will only commit to the actual entity
-                // if SaveChanges is successful.
-                stateEntry[GetProperty(stateEntry, columnNames[i])] = reader.ReadValue<object>(i);
-            }
-        }
-
-        private static IProperty GetProperty(StateEntry stateEntry, string columnName)
-        {
-            // TODO: poor man's model to store mapping
-            return stateEntry.EntityType.Properties.Single(p => p.StorageName == columnName);
-        }
-
-        public virtual bool CommandRequiresResultPropagation(int commandIndex)
-        {
-            return _batchCommands[commandIndex].RequiresResultPropagation;
+            get { return _modificationCommands; }
         }
     }
 }

--- a/src/Microsoft.Data.Entity.Relational/Update/ParameterNameGenerator.cs
+++ b/src/Microsoft.Data.Entity.Relational/Update/ParameterNameGenerator.cs
@@ -3,10 +3,13 @@
 
 namespace Microsoft.Data.Entity.Relational.Update
 {
-    public enum ModificationOperation : byte
+    public class ParameterNameGenerator
     {
-        Insert,
-        Update,
-        Delete
+        private int _count;
+
+        public virtual string GenerateNext()
+        {
+            return "@p" + _count++;
+        }
     }
 }

--- a/src/Microsoft.Data.Entity.Relational/Update/ParameterNameGeneratorFactory.cs
+++ b/src/Microsoft.Data.Entity.Relational/Update/ParameterNameGeneratorFactory.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.Relational.Update
+{
+    public class ParameterNameGeneratorFactory
+    {
+        public virtual ParameterNameGenerator Create()
+        {
+            return new ParameterNameGenerator();
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity.SQLite/Extensions/SQLiteEntityServicesBuilderExtensions.cs
+++ b/src/Microsoft.Data.Entity.SQLite/Extensions/SQLiteEntityServicesBuilderExtensions.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddSingleton<DataStoreSource, SQLiteDataStoreSource>()
                 .AddSingleton<SQLiteSqlGenerator>()
                 .AddSingleton<SqlStatementExecutor>()
+                .AddSingleton<SQLiteTypeMapper>()
                 .AddScoped<SQLiteDataStore>()
                 .AddScoped<SQLiteConnectionConnection>()
                 .AddScoped<SQLiteBatchExecutor>()

--- a/src/Microsoft.Data.Entity.SQLite/SQLiteBatchExecutor.cs
+++ b/src/Microsoft.Data.Entity.SQLite/SQLiteBatchExecutor.cs
@@ -10,8 +10,9 @@ namespace Microsoft.Data.Entity.SQLite
     {
         public SQLiteBatchExecutor(
             [NotNull] SQLiteSqlGenerator sqlGenerator,
-            [NotNull] SQLiteConnectionConnection connection)
-            : base(sqlGenerator, connection)
+            [NotNull] SQLiteConnectionConnection connection,
+            [NotNull] SQLiteTypeMapper parameterFactory)
+            : base(sqlGenerator, connection, parameterFactory)
         {
         }
     }

--- a/src/Microsoft.Data.Entity.SQLite/SQLiteMigrationOperationSqlGenerator.cs
+++ b/src/Microsoft.Data.Entity.SQLite/SQLiteMigrationOperationSqlGenerator.cs
@@ -1,34 +1,18 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Diagnostics.Contracts;
-using System.Linq;
+using JetBrains.Annotations;
 using Microsoft.Data.Entity.Migrations;
-using Microsoft.Data.Entity.Relational.Model;
-using Microsoft.Data.Entity.SQLite.Utilities;
 using Microsoft.Data.Entity.Utilities;
-using Microsoft.Data.SQLite.Utilities;
 
 namespace Microsoft.Data.Entity.SQLite
 {
     public class SQLiteMigrationOperationSqlGenerator : MigrationOperationSqlGenerator
     {
-        public override string GenerateDataType(Column column)
+        public SQLiteMigrationOperationSqlGenerator([NotNull] SQLiteTypeMapper typeMapper)
+            : base(typeMapper)
         {
-            Check.NotNull(column, "column");
-
-            if (column.DataType != null)
-            {
-                return column.DataType;
-            }
-
-            var types = SQLiteTypeMap.FromClrType(Nullable.GetUnderlyingType(column.ClrType) ?? column.ClrType)
-                .DeclaredTypes;
-            Contract.Assert(types.Any(), "types is empty.");
-
-            return types.First();
         }
 
         protected override void GeneratePrimaryKey(

--- a/src/Microsoft.Data.Entity.SQLite/SQLiteSqlGenerator.cs
+++ b/src/Microsoft.Data.Entity.SQLite/SQLiteSqlGenerator.cs
@@ -1,21 +1,20 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.Linq;
+using System.Text;
 using Microsoft.Data.Entity.Relational;
-using Microsoft.Data.Entity.Relational.Model;
+using Microsoft.Data.Entity.Relational.Update;
 
 namespace Microsoft.Data.Entity.SQLite
 {
     public class SQLiteSqlGenerator : SqlGenerator
     {
-        public override IEnumerable<KeyValuePair<Column, string>> CreateWhereConditionsForStoreGeneratedKeys(
-            Column[] storeGeneratedKeyColumns)
+        protected override void AppendIdentityWhereCondition(StringBuilder commandStringBuilder, ColumnModification columnModification)
         {
-            return from k in storeGeneratedKeyColumns
-                   where k.ValueGenerationStrategy == StoreValueGenerationStrategy.Identity
-                   select new KeyValuePair<Column, string>(k, "last_insert_rowid()");
+            commandStringBuilder
+                .Append(QuoteIdentifier(columnModification.ColumnName))
+                .Append(" = ")
+                .Append("last_insert_rowid()");
         }
     }
 }

--- a/src/Microsoft.Data.Entity.SQLite/SQLiteTypeMapper.cs
+++ b/src/Microsoft.Data.Entity.SQLite/SQLiteTypeMapper.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using Microsoft.Data.Entity.Relational.Model;
+using Microsoft.Data.SQLite.Utilities;
+
+namespace Microsoft.Data.Entity.SQLite
+{
+    public class SQLiteTypeMapper : RelationalTypeMapper
+    {
+        public override RelationalTypeMapping GetTypeMapping(
+            string specifiedType, string storageName, Type propertyType, bool isKey, bool isConcurrencyToken)
+        {
+            // TODO: This is a hacky implementation for getting the DbType to use.
+
+            var baseMapping = base.GetTypeMapping(specifiedType, storageName, propertyType, isKey, isConcurrencyToken);
+
+            if (specifiedType != null)
+            {
+                return new RelationalTypeMapping(specifiedType, baseMapping.StoreType);
+            }
+
+            var types = SQLiteTypeMap.FromClrType(Nullable.GetUnderlyingType(propertyType) ?? propertyType)
+                .DeclaredTypes;
+            Contract.Assert(types.Any(), "types is empty.");
+
+            return new RelationalTypeMapping(types.First(), baseMapping.StoreType);
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity.SqlServer/Extensions/SqlServerEntityServicesBuilderExtensions.cs
+++ b/src/Microsoft.Data.Entity.SqlServer/Extensions/SqlServerEntityServicesBuilderExtensions.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddSingleton<DataStoreSource, SqlServerDataStoreSource>()
                 .AddSingleton<SqlServerSqlGenerator, SqlServerSqlGenerator>()
                 .AddSingleton<SqlStatementExecutor, SqlStatementExecutor>()
+                .AddSingleton<SqlServerTypeMapper, SqlServerTypeMapper>()
                 .AddScoped<SqlServerDataStore, SqlServerDataStore>()
                 .AddScoped<SqlServerConnection, SqlServerConnection>()
                 .AddScoped<SqlServerBatchExecutor, SqlServerBatchExecutor>()

--- a/src/Microsoft.Data.Entity.SqlServer/Properties/Strings.Designer.cs
+++ b/src/Microsoft.Data.Entity.SqlServer/Properties/Strings.Designer.cs
@@ -42,22 +42,6 @@ namespace Microsoft.Data.Entity.SqlServer
             return string.Format(CultureInfo.CurrentCulture, GetString("InvalidEnumValue", "argumentName", "enumType"), argumentName, enumType);
         }
 
-        /// <summary>
-        /// The property '{0}' cannot be mapped because it is of type '{1}' which is currently not supported.'
-        /// </summary>
-        internal static string UnsupportedType
-        {
-            get { return GetString("UnsupportedType"); }
-        }
-
-        /// <summary>
-        /// The property '{0}' cannot be mapped because it is of type '{1}' which is currently not supported.'
-        /// </summary>
-        internal static string FormatUnsupportedType(object p0, object p1)
-        {
-            return string.Format(CultureInfo.CurrentCulture, GetString("UnsupportedType"), p0, p1);
-        }
-
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.Data.Entity.SqlServer/Properties/Strings.resx
+++ b/src/Microsoft.Data.Entity.SqlServer/Properties/Strings.resx
@@ -123,7 +123,4 @@
   <data name="InvalidEnumValue" xml:space="preserve">
     <value>The value provided for argument '{argumentName}' must be a valid value of enum type '{enumType}'.</value>
   </data>
-  <data name="UnsupportedType" xml:space="preserve">
-    <value>The property '{0}' cannot be mapped because it is of type '{1}' which is currently not supported.'</value>
-  </data>
 </root>

--- a/src/Microsoft.Data.Entity.SqlServer/SequenceIdentityGenerator.cs
+++ b/src/Microsoft.Data.Entity.SqlServer/SequenceIdentityGenerator.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Data.Entity.SqlServer
                 = string.Format(
                     CultureInfo.InvariantCulture,
                     "SELECT NEXT VALUE FOR {0}",
-                    new SqlServerMigrationOperationSqlGenerator().DelimitIdentifier(_sequenceName));
+                    new SqlServerMigrationOperationSqlGenerator(new SqlServerTypeMapper()).DelimitIdentifier(_sequenceName));
         }
 
         public virtual async Task<long> NextAsync(CancellationToken cancellationToken = default(CancellationToken))

--- a/src/Microsoft.Data.Entity.SqlServer/SqlServerBatchExecutor.cs
+++ b/src/Microsoft.Data.Entity.SqlServer/SqlServerBatchExecutor.cs
@@ -10,8 +10,9 @@ namespace Microsoft.Data.Entity.SqlServer
     {
         public SqlServerBatchExecutor(
             [NotNull] SqlServerSqlGenerator sqlGenerator,
-            [NotNull] SqlServerConnection connection)
-            : base(sqlGenerator, connection)
+            [NotNull] SqlServerConnection connection,
+            [NotNull] SqlServerTypeMapper parameterFactory)
+            : base(sqlGenerator, connection, parameterFactory)
         {
         }
     }

--- a/src/Microsoft.Data.Entity.SqlServer/SqlServerSqlGenerator.cs
+++ b/src/Microsoft.Data.Entity.SqlServer/SqlServerSqlGenerator.cs
@@ -1,13 +1,9 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
-using System.Diagnostics.Contracts;
-using System.Linq;
 using System.Text;
-using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational;
-using Microsoft.Data.Entity.Relational.Model;
+using Microsoft.Data.Entity.Relational.Update;
 using Microsoft.Data.Entity.SqlServer.Utilities;
 
 namespace Microsoft.Data.Entity.SqlServer
@@ -21,78 +17,12 @@ namespace Microsoft.Data.Entity.SqlServer
             commandStringBuilder.Append("SET NOCOUNT OFF");
         }
 
-        public override void AppendInsertOperation(StringBuilder commandStringBuilder, Table table,
-            KeyValuePair<Column, string>[] columnsToParameters)
+        protected override void AppendIdentityWhereCondition(StringBuilder commandStringBuilder, ColumnModification columnModification)
         {
-            Check.NotNull(commandStringBuilder, "commandStringBuilder");
-            Check.NotNull(table, "table");
-            Check.NotNull(columnsToParameters, "columnsToParameters");
-
-            var dbGeneratedNonIdentityKeys =
-                table.PrimaryKey.Columns.Where(c => c.ValueGenerationStrategy == StoreValueGenerationStrategy.Computed);
-
-            if (dbGeneratedNonIdentityKeys.Any())
-            {
-                var tableVariableName = CreateTableVariableName(table.Name);
-
-                // TODO: do not create the variable multiple times (multiple inserts to the same table in a batch)
-                commandStringBuilder
-                    .Append("DECLARE ")
-                    .Append(tableVariableName)
-                    .Append(" TABLE(")
-                    .AppendJoin(table.PrimaryKey.Columns, (sb, k) => sb.Append(k.Name).Append(" ").Append(k.DataType), ", ")
-                    .Append(")")
-                    .Append(BatchCommandSeparator)
-                    .AppendLine();
-
-                AppendInsertCommandHeader(commandStringBuilder, table, columnsToParameters.Select(c => c.Key));
-                commandStringBuilder
-                    .AppendLine()
-                    .Append("OUTPUT ")
-                    .AppendJoin(table.PrimaryKey.Columns, (sb, k) => sb.Append("inserted.").Append(k.Name), ", ")
-                    .Append(" INTO ")
-                    .Append(tableVariableName)
-                    .AppendLine();
-                AppendValues(commandStringBuilder, columnsToParameters.Select(c => c.Value));
-                commandStringBuilder
-                    .Append(BatchCommandSeparator)
-                    .AppendLine();
-
-                commandStringBuilder
-                    .Append("SELECT ")
-                    .AppendJoin(table.GetStoreGeneratedColumns(), (sb, c) => sb.Append("t.").Append(c.Name), ", ");
-
-                commandStringBuilder
-                    .Append(" FROM ")
-                    .Append(tableVariableName)
-                    .Append(" AS g JOIN ")
-                    .Append(table.Name)
-                    .Append(" AS t ON ")
-                    .AppendJoin(
-                        table.PrimaryKey.Columns,
-                        (sb, c) => sb.Append("g.").Append(c.Name).Append(" = ").Append("t.").Append(c.Name), " AND ");
-            }
-            else
-            {
-                base.AppendInsertOperation(commandStringBuilder, table, columnsToParameters);
-            }
-        }
-
-        public override IEnumerable<KeyValuePair<Column, string>> CreateWhereConditionsForStoreGeneratedKeys(Column[] storeGeneratedKeyColumns)
-        {
-            Check.NotNull(storeGeneratedKeyColumns, "storeGeneratedKeyColumns");
-
-            Contract.Assert(
-                storeGeneratedKeyColumns.All(k => k.ValueGenerationStrategy == StoreValueGenerationStrategy.Identity),
-                "Non-identity store generated keys should be handled elsewhere");
-
-            return storeGeneratedKeyColumns.Where(k => k.ValueGenerationStrategy == StoreValueGenerationStrategy.Identity)
-                .Select(k => new KeyValuePair<Column, string>(k, "scope_identity()"));
-        }
-
-        private static string CreateTableVariableName(string tableName)
-        {
-            return string.Format("@generated_keys_{0}", tableName);
+            commandStringBuilder
+                .Append(QuoteIdentifier(columnModification.ColumnName))
+                .Append(" = ")
+                .Append("scope_identity()");
         }
     }
 }

--- a/src/Microsoft.Data.Entity.SqlServer/SqlServerTypeMapper.cs
+++ b/src/Microsoft.Data.Entity.SqlServer/SqlServerTypeMapper.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational.Model;
+
+namespace Microsoft.Data.Entity.SqlServer
+{
+    public class SqlServerTypeMapper : RelationalTypeMapper
+    {
+    }
+}

--- a/src/Microsoft.Data.Entity/Storage/DataStore.cs
+++ b/src/Microsoft.Data.Entity/Storage/DataStore.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Data.Entity.Storage
         }
 
         public abstract Task<int> SaveChangesAsync(
-            [NotNull] IEnumerable<StateEntry> stateEntries,
+            [NotNull] IReadOnlyList<StateEntry> stateEntries,
             CancellationToken cancellationToken = default(CancellationToken));
 
         public abstract IEnumerable<TResult> Query<TResult>(

--- a/test/Microsoft.Data.Entity.Migrations.Tests/MigrationOperationSqlGeneratorTest.cs
+++ b/test/Microsoft.Data.Entity.Migrations.Tests/MigrationOperationSqlGeneratorTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using Microsoft.Data.Entity.Migrations.Model;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Relational.Model;
@@ -15,7 +16,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         {
             Assert.Equal(
                 @"CREATE DATABASE ""MyDatabase""",
-                MigrationOperationSqlGenerator.Generate(new CreateDatabaseOperation("MyDatabase"), generateIdempotentSql: false).Sql);
+                Generate(new CreateDatabaseOperation("MyDatabase"), generateIdempotentSql: false).Sql);
         }
 
         [Fact]
@@ -23,7 +24,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         {
             Assert.Equal(
                 @"DROP DATABASE ""MyDatabase""",
-                MigrationOperationSqlGenerator.Generate(new DropDatabaseOperation("MyDatabase"), generateIdempotentSql: false).Sql);
+                Generate(new DropDatabaseOperation("MyDatabase"), generateIdempotentSql: false).Sql);
         }
 
         [Fact]
@@ -31,7 +32,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         {
             Assert.Equal(
                 @"CREATE SEQUENCE ""dbo"".""MySequence"" AS BIGINT START WITH 0 INCREMENT BY 1",
-                MigrationOperationSqlGenerator.Generate(
+                Generate(
                     new CreateSequenceOperation(new Sequence("dbo.MySequence")), generateIdempotentSql: false).Sql);
         }
 
@@ -40,7 +41,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         {
             Assert.Equal(
                 @"DROP SEQUENCE ""dbo"".""MySequence""",
-                MigrationOperationSqlGenerator.Generate(new DropSequenceOperation("dbo.MySequence"), generateIdempotentSql: false).Sql);
+                Generate(new DropSequenceOperation("dbo.MySequence"), generateIdempotentSql: false).Sql);
         }
 
         [Fact]
@@ -64,7 +65,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
     ""Bar"" int,
     CONSTRAINT ""MyPK"" PRIMARY KEY NONCLUSTERED (""Foo"", ""Bar"")
 )",
-                MigrationOperationSqlGenerator.Generate(
+                Generate(
                     new CreateTableOperation(table), generateIdempotentSql: false).Sql);
         }
 
@@ -89,7 +90,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
     ""Bar"" int,
     CONSTRAINT ""MyPK"" PRIMARY KEY NONCLUSTERED (""Foo"")
 )",
-                MigrationOperationSqlGenerator.Generate(
+                Generate(
                     new CreateTableOperation(table), generateIdempotentSql: false).Sql);
         }
 
@@ -98,7 +99,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         {
             Assert.Equal(
                 @"DROP TABLE ""dbo"".""MyTable""",
-                MigrationOperationSqlGenerator.Generate(new DropTableOperation("dbo.MyTable"), generateIdempotentSql: false).Sql);
+                Generate(new DropTableOperation("dbo.MyTable"), generateIdempotentSql: false).Sql);
         }
 
         [Fact]
@@ -106,7 +107,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         {
             Assert.Equal(
                 @"EXECUTE sp_rename @objname = N'dbo.MyTable', @newname = N'MyTable2', @objtype = N'OBJECT'",
-                MigrationOperationSqlGenerator.Generate(
+                Generate(
                     new RenameTableOperation("dbo.MyTable", "MyTable2"), generateIdempotentSql: false).Sql);
         }
 
@@ -115,7 +116,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         {
             Assert.Equal(
                 @"ALTER SCHEMA ""dbo2"" TRANSFER ""dbo"".""MyTable""",
-                MigrationOperationSqlGenerator.Generate(
+                Generate(
                     new MoveTableOperation("dbo.MyTable", "dbo2"), generateIdempotentSql: false).Sql);
         }
 
@@ -126,7 +127,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
 
             Assert.Equal(
                 @"ALTER TABLE ""dbo"".""MyTable"" ADD ""Bar"" int NOT NULL DEFAULT 5",
-                MigrationOperationSqlGenerator.Generate(
+                Generate(
                     new AddColumnOperation("dbo.MyTable", column), generateIdempotentSql: false).Sql);
         }
 
@@ -135,7 +136,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         {
             Assert.Equal(
                 @"ALTER TABLE ""dbo"".""MyTable"" DROP COLUMN ""Foo""",
-                MigrationOperationSqlGenerator.Generate(
+                Generate(
                     new DropColumnOperation("dbo.MyTable", "Foo"), generateIdempotentSql: false).Sql);
         }
 
@@ -144,7 +145,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         {
             Assert.Equal(
                 @"ALTER TABLE ""dbo"".""MyTable"" ALTER COLUMN ""Foo"" int NULL",
-                MigrationOperationSqlGenerator.Generate(
+                Generate(
                     new AlterColumnOperation("dbo.MyTable",
                         new Column("Foo", "int") { IsNullable = true }, isDestructiveChange: false),
                     generateIdempotentSql: false).Sql);
@@ -155,7 +156,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         {
             Assert.Equal(
                 @"ALTER TABLE ""dbo"".""MyTable"" ALTER COLUMN ""Foo"" int NOT NULL",
-                MigrationOperationSqlGenerator.Generate(
+                Generate(
                     new AlterColumnOperation("dbo.MyTable",
                         new Column("Foo", "int") { IsNullable = false }, isDestructiveChange: false),
                     generateIdempotentSql: false).Sql);
@@ -166,7 +167,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         {
             Assert.Equal(
                 @"ALTER TABLE ""dbo"".""MyTable"" ALTER COLUMN ""Foo"" SET DEFAULT 'MyDefault'",
-                MigrationOperationSqlGenerator.Generate(
+                Generate(
                     new AddDefaultConstraintOperation("dbo.MyTable", "Foo", "MyDefault", null), generateIdempotentSql: false).Sql);
         }
 
@@ -175,7 +176,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         {
             Assert.Equal(
                 @"ALTER TABLE ""dbo"".""MyTable"" ALTER COLUMN ""Foo"" SET DEFAULT GETDATE()",
-                MigrationOperationSqlGenerator.Generate(
+                Generate(
                     new AddDefaultConstraintOperation("dbo.MyTable", "Foo", null, "GETDATE()"), generateIdempotentSql: false).Sql);
         }
 
@@ -184,7 +185,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         {
             Assert.Equal(
                 @"ALTER TABLE ""dbo"".""MyTable"" ALTER COLUMN ""Foo"" DROP DEFAULT",
-                MigrationOperationSqlGenerator.Generate(
+                Generate(
                     new DropDefaultConstraintOperation("dbo.MyTable", "Foo"), generateIdempotentSql: false).Sql);
         }
 
@@ -193,7 +194,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         {
             Assert.Equal(
                 @"EXECUTE sp_rename @objname = N'dbo.MyTable.Foo', @newname = N'Bar', @objtype = N'COLUMN'",
-                MigrationOperationSqlGenerator.Generate(
+                Generate(
                     new RenameColumnOperation("dbo.MyTable", "Foo", "Bar"), generateIdempotentSql: false).Sql);
         }
 
@@ -202,7 +203,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         {
             Assert.Equal(
                 @"ALTER TABLE ""dbo"".""MyTable"" ADD CONSTRAINT ""MyPK"" PRIMARY KEY NONCLUSTERED (""Foo"", ""Bar"")",
-                MigrationOperationSqlGenerator.Generate(
+                Generate(
                     new AddPrimaryKeyOperation("dbo.MyTable", "MyPK", new[] { "Foo", "Bar" }, isClustered: false),
                     generateIdempotentSql: false).Sql);
         }
@@ -212,7 +213,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         {
             Assert.Equal(
                 @"ALTER TABLE ""dbo"".""MyTable"" DROP CONSTRAINT ""MyPK""",
-                MigrationOperationSqlGenerator.Generate(new DropPrimaryKeyOperation("dbo.MyTable", "MyPK"), generateIdempotentSql: false).Sql);
+                Generate(new DropPrimaryKeyOperation("dbo.MyTable", "MyPK"), generateIdempotentSql: false).Sql);
         }
 
         [Fact]
@@ -220,7 +221,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         {
             Assert.Equal(
                 @"ALTER TABLE ""dbo"".""MyTable"" ADD CONSTRAINT ""MyFK"" FOREIGN KEY (""Foo"", ""Bar"") REFERENCES ""dbo"".""MyTable2"" (""Foo2"", ""Bar2"") ON DELETE CASCADE",
-                MigrationOperationSqlGenerator.Generate(
+                Generate(
                     new AddForeignKeyOperation("dbo.MyTable", "MyFK", new[] { "Foo", "Bar" },
                         "dbo.MyTable2", new[] { "Foo2", "Bar2" }, cascadeDelete: true),
                     generateIdempotentSql: false).Sql);
@@ -231,7 +232,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         {
             Assert.Equal(
                 @"ALTER TABLE ""dbo"".""MyTable"" DROP CONSTRAINT ""MyFK""",
-                MigrationOperationSqlGenerator.Generate(new DropForeignKeyOperation("dbo.MyTable", "MyFK"), generateIdempotentSql: false).Sql);
+                Generate(new DropForeignKeyOperation("dbo.MyTable", "MyFK"), generateIdempotentSql: false).Sql);
         }
 
         [Fact]
@@ -239,7 +240,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         {
             Assert.Equal(
                 @"CREATE UNIQUE CLUSTERED INDEX ""MyIndex"" ON ""dbo"".""MyTable"" (""Foo"", ""Bar"")",
-                MigrationOperationSqlGenerator.Generate(
+                Generate(
                     new CreateIndexOperation("dbo.MyTable", "MyIndex", new[] { "Foo", "Bar" },
                         isUnique: true, isClustered: true),
                     generateIdempotentSql: false).Sql);
@@ -250,7 +251,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         {
             Assert.Equal(
                 @"DROP INDEX ""MyIndex"" ON ""dbo"".""MyTable""",
-                MigrationOperationSqlGenerator.Generate(new DropIndexOperation("dbo.MyTable", "MyIndex"), generateIdempotentSql: false).Sql);
+                Generate(new DropIndexOperation("dbo.MyTable", "MyIndex"), generateIdempotentSql: false).Sql);
         }
 
         [Fact]
@@ -258,14 +259,14 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         {
             Assert.Equal(
                 @"EXECUTE sp_rename @objname = N'dbo.MyTable.MyIndex', @newname = N'MyIndex2', @objtype = N'INDEX'",
-                MigrationOperationSqlGenerator.Generate(
+                Generate(
                     new RenameIndexOperation("dbo.MyTable", "MyIndex", "MyIndex2"), generateIdempotentSql: false).Sql);
         }
 
         [Fact]
         public void Delimit_identifier()
         {
-            var sqlGenerator = new MigrationOperationSqlGenerator();
+            var sqlGenerator = new MigrationOperationSqlGenerator(new RelationalTypeMapper());
 
             Assert.Equal("\"foo\"\"bar\"", sqlGenerator.DelimitIdentifier("foo\"bar"));
         }
@@ -273,7 +274,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         [Fact]
         public void Delimit_identifier_when_schema_qualified()
         {
-            var sqlGenerator = new MigrationOperationSqlGenerator();
+            var sqlGenerator = new MigrationOperationSqlGenerator(new RelationalTypeMapper());
 
             Assert.Equal("\"foo\".\"bar\"", sqlGenerator.DelimitIdentifier(SchemaQualifiedName.Parse("foo.bar")));
         }
@@ -281,7 +282,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         [Fact]
         public void Escape_identifier()
         {
-            var sqlGenerator = new MigrationOperationSqlGenerator();
+            var sqlGenerator = new MigrationOperationSqlGenerator(new RelationalTypeMapper());
 
             Assert.Equal("foo\"\"bar", sqlGenerator.EscapeIdentifier("foo\"bar"));
         }
@@ -289,7 +290,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         [Fact]
         public void Delimit_literal()
         {
-            var sqlGenerator = new MigrationOperationSqlGenerator();
+            var sqlGenerator = new MigrationOperationSqlGenerator(new RelationalTypeMapper());
 
             Assert.Equal("'foo''bar'", sqlGenerator.DelimitLiteral("foo'bar"));
         }
@@ -297,9 +298,16 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         [Fact]
         public void Escape_literal()
         {
-            var sqlGenerator = new MigrationOperationSqlGenerator();
+            var sqlGenerator = new MigrationOperationSqlGenerator(new RelationalTypeMapper());
 
             Assert.Equal("foo''bar", sqlGenerator.EscapeLiteral("foo'bar"));
+        }
+
+        private static SqlStatement Generate(MigrationOperation migrationOperation, bool generateIdempotentSql)
+        {
+            var sqlGenerator = new MigrationOperationSqlGenerator(new RelationalTypeMapper());
+
+            return sqlGenerator.Generate(new[] { migrationOperation }, generateIdempotentSql).Single();
         }
     }
 }

--- a/test/Microsoft.Data.Entity.Migrations.Tests/Model/AddColumnOperationTest.cs
+++ b/test/Microsoft.Data.Entity.Migrations.Tests/Model/AddColumnOperationTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Model
         public void Dispatches_visitor()
         {
             var addColumnOperation = new AddColumnOperation("dbo.MyTable", new Column("Foo", "int"));
-            var mockVisitor = new Mock<MigrationOperationSqlGenerator>();
+            var mockVisitor = new Mock<MigrationOperationSqlGenerator>(new RelationalTypeMapper());
             var builder = new Mock<IndentedStringBuilder>();
             addColumnOperation.GenerateSql(mockVisitor.Object, builder.Object, false);
 

--- a/test/Microsoft.Data.Entity.Migrations.Tests/Model/AddDefaultConstraintOperationTest.cs
+++ b/test/Microsoft.Data.Entity.Migrations.Tests/Model/AddDefaultConstraintOperationTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Migrations.Model;
+using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Utilities;
 using Moq;
 using Xunit;
@@ -37,7 +38,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Model
         {
             var addDefaultConstraintOperation = new AddDefaultConstraintOperation(
                 "dbo.MyTable", "Foo", "MyDefault", null);
-            var mockVisitor = new Mock<MigrationOperationSqlGenerator>();
+            var mockVisitor = new Mock<MigrationOperationSqlGenerator>(new RelationalTypeMapper());
             var builder = new Mock<IndentedStringBuilder>();
             addDefaultConstraintOperation.GenerateSql(mockVisitor.Object, builder.Object, false);
 

--- a/test/Microsoft.Data.Entity.Migrations.Tests/Model/AddForeignKeyOperationTest.cs
+++ b/test/Microsoft.Data.Entity.Migrations.Tests/Model/AddForeignKeyOperationTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Migrations.Model;
+using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Utilities;
 using Moq;
 using Xunit;
@@ -34,7 +35,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Model
                 "dbo.MyTable", "MyFK", new[] { "Foo", "Bar" },
                 "dbo.MyTable2", new[] { "Foo2", "Bar2" },
                 cascadeDelete: true);
-            var mockVisitor = new Mock<MigrationOperationSqlGenerator>();
+            var mockVisitor = new Mock<MigrationOperationSqlGenerator>(new RelationalTypeMapper());
             var builder = new Mock<IndentedStringBuilder>();
             addForeignKeyOperation.GenerateSql(mockVisitor.Object, builder.Object, false);
 

--- a/test/Microsoft.Data.Entity.Migrations.Tests/Model/AddPrimaryKeyOperationTest.cs
+++ b/test/Microsoft.Data.Entity.Migrations.Tests/Model/AddPrimaryKeyOperationTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Migrations.Model;
+using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Utilities;
 using Moq;
 using Xunit;
@@ -27,7 +28,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Model
         {
             var addPrimaryKeyOperation = new AddPrimaryKeyOperation(
                 "dbo.MyTable", "MyPK", new[] { "Foo", "Bar" }, isClustered: true);
-            var mockVisitor = new Mock<MigrationOperationSqlGenerator>();
+            var mockVisitor = new Mock<MigrationOperationSqlGenerator>(new RelationalTypeMapper());
             var builder = new Mock<IndentedStringBuilder>();
             addPrimaryKeyOperation.GenerateSql(mockVisitor.Object, builder.Object, false);
 

--- a/test/Microsoft.Data.Entity.Migrations.Tests/Model/AlterColumnOperationTest.cs
+++ b/test/Microsoft.Data.Entity.Migrations.Tests/Model/AlterColumnOperationTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Model
             var newColumn = new Column("Foo", "int") { IsNullable = true };
             var alterColumnOperation = new AlterColumnOperation(
                 "dbo.MyTable", newColumn, isDestructiveChange: true);
-            var mockVisitor = new Mock<MigrationOperationSqlGenerator>();
+            var mockVisitor = new Mock<MigrationOperationSqlGenerator>(new RelationalTypeMapper());
             var builder = new Mock<IndentedStringBuilder>();
             alterColumnOperation.GenerateSql(mockVisitor.Object, builder.Object, false);
 

--- a/test/Microsoft.Data.Entity.Migrations.Tests/Model/CreateDatabaseOperationTest.cs
+++ b/test/Microsoft.Data.Entity.Migrations.Tests/Model/CreateDatabaseOperationTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Migrations.Model;
+using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Utilities;
 using Moq;
 using Xunit;
@@ -23,7 +24,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Model
         public void Dispatches_visitor()
         {
             var createDatabaseOperation = new CreateDatabaseOperation("MyDatabase");
-            var mockVisitor = new Mock<MigrationOperationSqlGenerator>();
+            var mockVisitor = new Mock<MigrationOperationSqlGenerator>(new RelationalTypeMapper());
             var builder = new Mock<IndentedStringBuilder>();
             createDatabaseOperation.GenerateSql(mockVisitor.Object, builder.Object, false);
 

--- a/test/Microsoft.Data.Entity.Migrations.Tests/Model/CreateIndexOperationTest.cs
+++ b/test/Microsoft.Data.Entity.Migrations.Tests/Model/CreateIndexOperationTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Migrations.Model;
+using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Utilities;
 using Moq;
 using Xunit;
@@ -31,7 +32,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Model
             var createIndexOperation = new CreateIndexOperation(
                 "dbo.MyTable", "MyIndex", new[] { "Foo", "Bar" },
                 isUnique: true, isClustered: true);
-            var mockVisitor = new Mock<MigrationOperationSqlGenerator>();
+            var mockVisitor = new Mock<MigrationOperationSqlGenerator>(new RelationalTypeMapper());
             var builder = new Mock<IndentedStringBuilder>();
             createIndexOperation.GenerateSql(mockVisitor.Object, builder.Object, false);
 

--- a/test/Microsoft.Data.Entity.Migrations.Tests/Model/CreateSequenceOperationTest.cs
+++ b/test/Microsoft.Data.Entity.Migrations.Tests/Model/CreateSequenceOperationTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Model
         public void Dispatches_visitor()
         {
             var createSequenceOperation = new CreateSequenceOperation(new Sequence("dbo.MySequence"));
-            var mockVisitor = new Mock<MigrationOperationSqlGenerator>();
+            var mockVisitor = new Mock<MigrationOperationSqlGenerator>(new RelationalTypeMapper());
             var builder = new Mock<IndentedStringBuilder>();
             createSequenceOperation.GenerateSql(mockVisitor.Object, builder.Object, false);
 

--- a/test/Microsoft.Data.Entity.Migrations.Tests/Model/CreateTableOperationTest.cs
+++ b/test/Microsoft.Data.Entity.Migrations.Tests/Model/CreateTableOperationTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Model
         {
             var table = new Table("dbo.MyTable", new[] { new Column("Id", "int") });
             var createTableOperation = new CreateTableOperation(table);
-            var mockVisitor = new Mock<MigrationOperationSqlGenerator>();
+            var mockVisitor = new Mock<MigrationOperationSqlGenerator>(new RelationalTypeMapper());
             var builder = new Mock<IndentedStringBuilder>();
             createTableOperation.GenerateSql(mockVisitor.Object, builder.Object, false);
 

--- a/test/Microsoft.Data.Entity.Migrations.Tests/Model/DropColumnOperationTest.cs
+++ b/test/Microsoft.Data.Entity.Migrations.Tests/Model/DropColumnOperationTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Migrations.Model;
+using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Utilities;
 using Moq;
 using Xunit;
@@ -24,7 +25,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Model
         public void Dispatches_visitor()
         {
             var dropColumnOperation = new DropColumnOperation("dbo.MyTable", "Foo");
-            var mockVisitor = new Mock<MigrationOperationSqlGenerator>();
+            var mockVisitor = new Mock<MigrationOperationSqlGenerator>(new RelationalTypeMapper());
             var builder = new Mock<IndentedStringBuilder>();
             dropColumnOperation.GenerateSql(mockVisitor.Object, builder.Object, false);
 

--- a/test/Microsoft.Data.Entity.Migrations.Tests/Model/DropDatabaseOperationTest.cs
+++ b/test/Microsoft.Data.Entity.Migrations.Tests/Model/DropDatabaseOperationTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Migrations.Model;
+using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Utilities;
 using Moq;
 using Xunit;
@@ -23,7 +24,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Model
         public void Dispatches_visitor()
         {
             var dropDatabaseOperation = new DropDatabaseOperation("MyDatabase");
-            var mockVisitor = new Mock<MigrationOperationSqlGenerator>();
+            var mockVisitor = new Mock<MigrationOperationSqlGenerator>(new RelationalTypeMapper());
             var builder = new Mock<IndentedStringBuilder>();
             dropDatabaseOperation.GenerateSql(mockVisitor.Object, builder.Object, false);
 

--- a/test/Microsoft.Data.Entity.Migrations.Tests/Model/DropDefaultConstraintOperationTest.cs
+++ b/test/Microsoft.Data.Entity.Migrations.Tests/Model/DropDefaultConstraintOperationTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Migrations.Model;
+using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Utilities;
 using Moq;
 using Xunit;
@@ -24,7 +25,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Model
         public void Dispatches_visitor()
         {
             var dropDefaultConstraintOperation = new DropDefaultConstraintOperation("dbo.MyTable", "Foo");
-            var mockVisitor = new Mock<MigrationOperationSqlGenerator>();
+            var mockVisitor = new Mock<MigrationOperationSqlGenerator>(new RelationalTypeMapper());
             var builder = new Mock<IndentedStringBuilder>();
             dropDefaultConstraintOperation.GenerateSql(mockVisitor.Object, builder.Object, false);
 

--- a/test/Microsoft.Data.Entity.Migrations.Tests/Model/DropForeignKeyOperation.cs
+++ b/test/Microsoft.Data.Entity.Migrations.Tests/Model/DropForeignKeyOperation.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Migrations.Model;
+using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Utilities;
 using Moq;
 using Xunit;
@@ -24,7 +25,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Model
         public void Dispatches_visitor()
         {
             var dropForeignKeyOperation = new DropForeignKeyOperation("dbo.MyTable", "MyFK");
-            var mockVisitor = new Mock<MigrationOperationSqlGenerator>();
+            var mockVisitor = new Mock<MigrationOperationSqlGenerator>(new RelationalTypeMapper());
             var builder = new Mock<IndentedStringBuilder>();
             dropForeignKeyOperation.GenerateSql(mockVisitor.Object, builder.Object, false);
 

--- a/test/Microsoft.Data.Entity.Migrations.Tests/Model/DropIndexOperationTest.cs
+++ b/test/Microsoft.Data.Entity.Migrations.Tests/Model/DropIndexOperationTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Migrations.Model;
+using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Utilities;
 using Moq;
 using Xunit;
@@ -24,7 +25,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Model
         public void Dispatches_visitor()
         {
             var dropIndexOperation = new DropIndexOperation("dbo.MyTable", "MyIndex");
-            var mockVisitor = new Mock<MigrationOperationSqlGenerator>();
+            var mockVisitor = new Mock<MigrationOperationSqlGenerator>(new RelationalTypeMapper());
             var builder = new Mock<IndentedStringBuilder>();
             dropIndexOperation.GenerateSql(mockVisitor.Object, builder.Object, false);
 

--- a/test/Microsoft.Data.Entity.Migrations.Tests/Model/DropPrimaryKeyOperationTest.cs
+++ b/test/Microsoft.Data.Entity.Migrations.Tests/Model/DropPrimaryKeyOperationTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Migrations.Model;
+using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Utilities;
 using Moq;
 using Xunit;
@@ -24,7 +25,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Model
         public void Dispatches_visitor()
         {
             var dropPrimaryKeyOperation = new DropPrimaryKeyOperation("dbo.MyTable", "MyPK");
-            var mockVisitor = new Mock<MigrationOperationSqlGenerator>();
+            var mockVisitor = new Mock<MigrationOperationSqlGenerator>(new RelationalTypeMapper());
             var builder = new Mock<IndentedStringBuilder>();
             dropPrimaryKeyOperation.GenerateSql(mockVisitor.Object, builder.Object, false);
 

--- a/test/Microsoft.Data.Entity.Migrations.Tests/Model/DropSequenceOperationTest.cs
+++ b/test/Microsoft.Data.Entity.Migrations.Tests/Model/DropSequenceOperationTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Migrations.Model;
+using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Utilities;
 using Moq;
 using Xunit;
@@ -23,7 +24,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Model
         public void Dispatches_visitor()
         {
             var dropSequenceOperation = new DropSequenceOperation("dbo.MySequence");
-            var mockVisitor = new Mock<MigrationOperationSqlGenerator>();
+            var mockVisitor = new Mock<MigrationOperationSqlGenerator>(new RelationalTypeMapper());
             var builder = new Mock<IndentedStringBuilder>();
             dropSequenceOperation.GenerateSql(mockVisitor.Object, builder.Object, false);
 

--- a/test/Microsoft.Data.Entity.Migrations.Tests/Model/DropTableOperationTest.cs
+++ b/test/Microsoft.Data.Entity.Migrations.Tests/Model/DropTableOperationTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Migrations.Model;
+using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Utilities;
 using Moq;
 using Xunit;
@@ -23,7 +24,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Model
         public void Dispatches_visitor()
         {
             var dropTableOperation = new DropTableOperation("dbo.MyTable");
-            var mockVisitor = new Mock<MigrationOperationSqlGenerator>();
+            var mockVisitor = new Mock<MigrationOperationSqlGenerator>(new RelationalTypeMapper());
             var builder = new Mock<IndentedStringBuilder>();
             dropTableOperation.GenerateSql(mockVisitor.Object, builder.Object, false);
 

--- a/test/Microsoft.Data.Entity.Migrations.Tests/Model/MoveTableOperationTest.cs
+++ b/test/Microsoft.Data.Entity.Migrations.Tests/Model/MoveTableOperationTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Migrations.Model;
+using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Utilities;
 using Moq;
 using Xunit;
@@ -24,7 +25,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Model
         public void Dispatches_visitor()
         {
             var moveTableOperation = new MoveTableOperation("dbo.MyTable", "dbo2");
-            var mockVisitor = new Mock<MigrationOperationSqlGenerator>();
+            var mockVisitor = new Mock<MigrationOperationSqlGenerator>(new RelationalTypeMapper());
             var builder = new Mock<IndentedStringBuilder>();
             moveTableOperation.GenerateSql(mockVisitor.Object, builder.Object, false);
 

--- a/test/Microsoft.Data.Entity.Migrations.Tests/Model/RenameColumnOperationTest.cs
+++ b/test/Microsoft.Data.Entity.Migrations.Tests/Model/RenameColumnOperationTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Migrations.Model;
+using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Utilities;
 using Moq;
 using Xunit;
@@ -25,7 +26,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Model
         public void Dispatches_visitor()
         {
             var renameColumnOperation = new RenameColumnOperation("dbo.MyTable", "Foo", "Foo2");
-            var mockVisitor = new Mock<MigrationOperationSqlGenerator>();
+            var mockVisitor = new Mock<MigrationOperationSqlGenerator>(new RelationalTypeMapper());
             var builder = new Mock<IndentedStringBuilder>();
             renameColumnOperation.GenerateSql(mockVisitor.Object, builder.Object, false);
 

--- a/test/Microsoft.Data.Entity.Migrations.Tests/Model/RenameIndexOperationTest.cs
+++ b/test/Microsoft.Data.Entity.Migrations.Tests/Model/RenameIndexOperationTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Migrations.Model;
+using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Utilities;
 using Moq;
 using Xunit;
@@ -25,7 +26,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Model
         public void Dispatches_visitor()
         {
             var renameIndexOperation = new RenameIndexOperation("dbo.MyTable", "MyIndex", "MyIndex2");
-            var mockVisitor = new Mock<MigrationOperationSqlGenerator>();
+            var mockVisitor = new Mock<MigrationOperationSqlGenerator>(new RelationalTypeMapper());
             var builder = new Mock<IndentedStringBuilder>();
             renameIndexOperation.GenerateSql(mockVisitor.Object, builder.Object, false);
 

--- a/test/Microsoft.Data.Entity.Migrations.Tests/Model/RenameTableOperationTest.cs
+++ b/test/Microsoft.Data.Entity.Migrations.Tests/Model/RenameTableOperationTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Migrations.Model;
+using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Utilities;
 using Moq;
 using Xunit;
@@ -24,7 +25,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Model
         public void Dispatches_visitor()
         {
             var renameTableOperation = new RenameTableOperation("dbo.MyTable", "MyTable2");
-            var mockVisitor = new Mock<MigrationOperationSqlGenerator>();
+            var mockVisitor = new Mock<MigrationOperationSqlGenerator>(new RelationalTypeMapper());
             var builder = new Mock<IndentedStringBuilder>();
             renameTableOperation.GenerateSql(mockVisitor.Object, builder.Object, false);
 

--- a/test/Microsoft.Data.Entity.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/Microsoft.Data.Entity.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
-using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Relational.Update;
 using Xunit;
 
@@ -18,7 +16,6 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         [Fact]
         public async Task BatchCommands_creates_valid_batch_for_added_entities()
         {
-            var database = CreateDatabase();
             var model = CreateModel();
 
             var stateEntry = new MixedStateEntry(
@@ -27,25 +24,38 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
 
             await stateEntry.SetEntityStateAsync(EntityState.Added);
 
-            var commandBatches = new CommandBatchPreparer().BatchCommands(new[] { stateEntry }, database).ToArray();
+            var commandBatches = new CommandBatchPreparer(new ParameterNameGeneratorFactory()).BatchCommands(new[] { stateEntry }).ToArray();
             Assert.Equal(1, commandBatches.Count());
-            Assert.Equal(1, commandBatches.First().BatchCommands.Count());
+            Assert.Equal(1, commandBatches.First().ModificationCommands.Count());
 
-            var command = commandBatches.First().BatchCommands.Single();
-            Assert.Equal(ModificationOperation.Insert, command.Operation);
-            Assert.Equal(
-                new[]
-                    {
-                        new KeyValuePair<string, object>("Id", 42),
-                        new KeyValuePair<string, object>("Value", "Test"),
-                    },
-                command.ColumnValues.Select(v => new KeyValuePair<string, object>(v.Key.Name, v.Value)));
+            var command = commandBatches.First().ModificationCommands.Single();
+            Assert.Equal(EntityState.Added, command.EntityState);
+            Assert.Equal(2, command.ColumnModifications.Count);
+
+            var columnMod = command.ColumnModifications[0];
+
+            Assert.Equal("Id", columnMod.ColumnName);
+            Assert.Same(stateEntry, columnMod.StateEntry);
+            Assert.Equal("Id", columnMod.Property.Name);
+            Assert.True(columnMod.IsCondition);
+            Assert.True(columnMod.IsKey);
+            Assert.False(columnMod.IsRead);
+            Assert.True(columnMod.IsWrite);
+
+            columnMod = command.ColumnModifications[1];
+
+            Assert.Equal("Value", columnMod.ColumnName);
+            Assert.Same(stateEntry, columnMod.StateEntry);
+            Assert.Equal("Value", columnMod.Property.Name);
+            Assert.False(columnMod.IsCondition);
+            Assert.False(columnMod.IsKey);
+            Assert.False(columnMod.IsRead);
+            Assert.True(columnMod.IsWrite);
         }
 
         [Fact]
         public async Task BatchCommands_creates_valid_batch_for_updated_entities()
         {
-            var database = CreateDatabase();
             var model = CreateModel();
 
             var stateEntry = new MixedStateEntry(
@@ -54,32 +64,38 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
 
             await stateEntry.SetEntityStateAsync(EntityState.Modified);
 
-            var commandBatches = new CommandBatchPreparer().BatchCommands(new[] { stateEntry }, database).ToArray();
+            var commandBatches = new CommandBatchPreparer(new ParameterNameGeneratorFactory()).BatchCommands(new[] { stateEntry }).ToArray();
             Assert.Equal(1, commandBatches.Count());
-            Assert.Equal(1, commandBatches.First().BatchCommands.Count());
+            Assert.Equal(1, commandBatches.First().ModificationCommands.Count());
 
-            var command = commandBatches.First().BatchCommands.Single();
-            Assert.Equal(ModificationOperation.Update, command.Operation);
+            var command = commandBatches.First().ModificationCommands.Single();
+            Assert.Equal(EntityState.Modified, command.EntityState);
+            Assert.Equal(2, command.ColumnModifications.Count);
 
-            Assert.Equal(
-                new[]
-                    {
-                        new KeyValuePair<string, object>("Value", "Test"),
-                    },
-                command.ColumnValues.Select(v => new KeyValuePair<string, object>(v.Key.Name, v.Value)));
+            var columnMod = command.ColumnModifications[0];
 
-            Assert.Equal(
-                new[]
-                    {
-                        new KeyValuePair<string, object>("Id", 42),
-                    },
-                command.WhereClauses.Select(v => new KeyValuePair<string, object>(v.Key.Name, v.Value)));
+            Assert.Equal("Id", columnMod.ColumnName);
+            Assert.Same(stateEntry, columnMod.StateEntry);
+            Assert.Equal("Id", columnMod.Property.Name);
+            Assert.True(columnMod.IsCondition);
+            Assert.True(columnMod.IsKey);
+            Assert.False(columnMod.IsRead);
+            Assert.False(columnMod.IsWrite);
+
+            columnMod = command.ColumnModifications[1];
+
+            Assert.Equal("Value", columnMod.ColumnName);
+            Assert.Same(stateEntry, columnMod.StateEntry);
+            Assert.Equal("Value", columnMod.Property.Name);
+            Assert.False(columnMod.IsCondition);
+            Assert.False(columnMod.IsKey);
+            Assert.False(columnMod.IsRead);
+            Assert.True(columnMod.IsWrite);
         }
 
         [Fact]
         public async Task BatchCommands_creates_valid_batch_for_deleted_entities()
         {
-            var database = CreateDatabase();
             var model = CreateModel();
 
             var stateEntry = new MixedStateEntry(
@@ -88,35 +104,28 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
 
             await stateEntry.SetEntityStateAsync(EntityState.Deleted);
 
-            var commandBatches = new CommandBatchPreparer().BatchCommands(new[] { stateEntry }, database).ToArray();
+            var commandBatches = new CommandBatchPreparer(new ParameterNameGeneratorFactory()).BatchCommands(new[] { stateEntry }).ToArray();
             Assert.Equal(1, commandBatches.Count());
-            Assert.Equal(1, commandBatches.First().BatchCommands.Count());
+            Assert.Equal(1, commandBatches.First().ModificationCommands.Count());
 
-            var command = commandBatches.First().BatchCommands.Single();
-            Assert.Equal(ModificationOperation.Delete, command.Operation);
+            var command = commandBatches.First().ModificationCommands.Single();
+            Assert.Equal(EntityState.Deleted, command.EntityState);
+            Assert.Equal(1, command.ColumnModifications.Count);
 
-            Assert.Equal(null, command.ColumnValues);
+            var columnMod = command.ColumnModifications[0];
 
-            Assert.Equal(
-                new[]
-                    {
-                        new KeyValuePair<string, object>("Id", 42),
-                    },
-                command.WhereClauses.Select(v => new KeyValuePair<string, object>(v.Key.Name, v.Value)));
+            Assert.Equal("Id", columnMod.ColumnName);
+            Assert.Same(stateEntry, columnMod.StateEntry);
+            Assert.Equal("Id", columnMod.Property.Name);
+            Assert.True(columnMod.IsCondition);
+            Assert.True(columnMod.IsKey);
+            Assert.False(columnMod.IsRead);
+            Assert.False(columnMod.IsWrite);
         }
 
         private static DbContextConfiguration CreateConfiguration()
         {
             return new DbContext(new DbContextOptions().BuildConfiguration()).Configuration;
-        }
-
-        private static DatabaseModel CreateDatabase()
-        {
-            var table = new Table("FakeEntity", new[] { new Column("Id", "_"), new Column("Value", "_") });
-            table.PrimaryKey = new PrimaryKey("PK", table.Columns.Where(c => c.Name == "Id").ToArray());
-            var database = new DatabaseModel();
-            database.AddTable(table);
-            return database;
         }
 
         private static IModel CreateModel()

--- a/test/Microsoft.Data.Entity.Relational.Tests/project.json
+++ b/test/Microsoft.Data.Entity.Relational.Tests/project.json
@@ -4,6 +4,7 @@
     "Microsoft.Data.Common": "0.1-alpha-*",
     "Microsoft.Data.Entity" : "",
     "Microsoft.Data.Entity.Relational" : "",
+    "Microsoft.Data.Entity.InMemory" : "",
     "Microsoft.Framework.ConfigurationModel" : "0.1-alpha-*",
     "Microsoft.Framework.DependencyInjection" : "0.1-alpha-*",
     "Microsoft.Framework.Logging" : "0.1-alpha-*",

--- a/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/SequenceIdentityGeneratorTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/SequenceIdentityGeneratorTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -17,8 +18,10 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 var sequenceIdentityGenerator
                     = new SequenceIdentityGenerator(testDatabase);
 
+                var generator = new SqlServerMigrationOperationSqlGenerator(new SqlServerTypeMapper());
+
                 await testDatabase.ExecuteNonQueryAsync(
-                    SqlServerMigrationOperationSqlGenerator.Generate(sequenceIdentityGenerator.CreateMigrationOperation(), generateIdempotentSql: true).Sql);
+                    generator.Generate(new[] { sequenceIdentityGenerator.CreateMigrationOperation() }, generateIdempotentSql: true).Single().Sql);
 
                 var next = sequenceIdentityGenerator.NextAsync(CancellationToken.None).Result;
 

--- a/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -250,13 +250,10 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     Assert.Equal(blog2Id, blog2.Id);
 
                     blog2.Name = null;
+                    blog2.NotFigTime = new DateTime();
+                    blog2.AndChew = null;
 
-                    var blog3 = context.Add(new TBlog()
-                        {
-                            Name = null,
-                            NotFigTime = new DateTime(1973, 9, 3, 0, 10, 33, 777),
-                            AndChew = new byte[] { 1, 2, 3, 4 }
-                        });
+                    var blog3 = context.Add(new TBlog());
 
                     await context.SaveChangesAsync();
 
@@ -270,8 +267,16 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     Assert.Equal(3, blogs.Count);
 
                     Assert.Equal("New Name", blogs.Single(b => b.Id == blog1Id).Name);
-                    Assert.Null(blogs.Single(b => b.Id == blog2Id).Name);
-                    Assert.Null(blogs.Single(b => b.Id == blog3Id).Name);
+
+                    var blog2 = blogs.Single(b => b.Id == blog2Id);
+                    Assert.Null(blog2.Name);
+                    Assert.Equal(blog2.NotFigTime, new DateTime());
+                    Assert.Null(blog2.AndChew);
+
+                    var blog3 = blogs.Single(b => b.Id == blog3Id);
+                    Assert.Null(blog3.Name);
+                    Assert.Equal(blog3.NotFigTime, new DateTime());
+                    Assert.Null(blog3.AndChew);
                 }
             }
         }

--- a/test/Microsoft.Data.Entity.SqlServer.Tests/SqlServerSqlGeneratorTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.Tests/SqlServerSqlGeneratorTest.cs
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
-using Microsoft.Data.Entity.Relational.Model;
+using Microsoft.Data.Entity.Relational.Update;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.Tests
@@ -25,134 +25,57 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void AppendInsertOperation_test_appends_Select_for_insert_operation_with_identity_key()
         {
-            var id1Column = new Column("Id1", "int") { ValueGenerationStrategy = StoreValueGenerationStrategy.Identity };
-            var id2Column = new Column("Id2", "nvarchar(max)");
-            var nameColumn = new Column("Name", "nvarchar(30)");
-            var table = new Table("table", new[] { id1Column, id2Column, nameColumn });
-            table.PrimaryKey = new PrimaryKey("PK", new[] { id1Column, id2Column });
+            var stringBuilder = new StringBuilder();
+            var operations = CreateInsertOperations();
 
-            var sb = new StringBuilder();
-            new SqlServerSqlGenerator()
-                .AppendInsertOperation(sb, table,
-                    new Dictionary<Column, string> { { id2Column, "@p0" }, { nameColumn, "@p1" } }.ToArray());
+            new SqlServerSqlGenerator().AppendInsertOperation(stringBuilder, "Ducks", operations);
 
             Assert.Equal(
-                "INSERT INTO table (Id2, Name) VALUES (@p0, @p1);\r\nSELECT Id1 FROM table WHERE Id2 = @p0 AND Id1 = scope_identity()",
-                sb.ToString());
+                "INSERT INTO [Ducks] ([Name], [Quacks]) VALUES (@p2, @p3);" + Environment.NewLine +
+                "SELECT [Id] FROM [Ducks] WHERE [Id] = scope_identity()",
+                stringBuilder.ToString());
         }
 
-        [Fact]
-        public void AppendInsertOperation_test_appends_valid_Select_for_insert_operation_with_identity_key_and_computed_non_key_column()
+        private ColumnModification[] CreateInsertOperations()
         {
-            var id1Column = new Column("Id1", "int") { ValueGenerationStrategy = StoreValueGenerationStrategy.Identity };
-            var insertedColumn = new Column("Inserted", "int") { ValueGenerationStrategy = StoreValueGenerationStrategy.Computed };
-            var nameColumn = new Column("Name", "nvarchar(30)");
-            var table = new Table("table", new[] { id1Column, nameColumn, insertedColumn });
-            table.PrimaryKey = new PrimaryKey("PK", new[] { id1Column });
-
-            var sb = new StringBuilder();
-
-            new SqlServerSqlGenerator()
-                .AppendInsertOperation(sb, table, new[] { new KeyValuePair<Column, string>(nameColumn, "@p0") });
-
-            Assert.Equal(
-                "INSERT INTO table (Name) VALUES (@p0);\r\nSELECT Id1, Inserted FROM table WHERE Id1 = scope_identity()",
-                sb.ToString());
-        }
-
-        [Fact]
-        public void AppendInsertOperation_test_appends_valid_statement_for_non_identity_auto_generated_keys()
-        {
-            var id1Column = new Column("Id1", "int") { ValueGenerationStrategy = StoreValueGenerationStrategy.Computed };
-            var id2Column = new Column("Id2", "nvarchar(max)");
-            var nameColumn = new Column("Name", "nvarchar(30)");
-            var table = new Table("Customers", new[] { id1Column, id2Column, nameColumn });
-            table.PrimaryKey = new PrimaryKey("PK", new[] { id1Column, id2Column });
-
-            var sb = new StringBuilder();
-
-            new SqlServerSqlGenerator()
-                .AppendInsertOperation(sb, table,
-                    new Dictionary<Column, string> { { id2Column, "@p0" }, { nameColumn, "@p1" } }.ToArray());
-
-            const string expected =
-                "DECLARE @generated_keys_Customers TABLE(Id1 int, Id2 nvarchar(max));\r\n" +
-                "INSERT INTO Customers (Id2, Name)\r\n" +
-                "OUTPUT inserted.Id1, inserted.Id2 INTO @generated_keys_Customers\r\n" +
-                "VALUES (@p0, @p1);\r\n" +
-                "SELECT t.Id1 FROM @generated_keys_Customers AS g JOIN Customers AS t ON g.Id1 = t.Id1 AND g.Id2 = t.Id2";
-
-            Assert.Equal(expected, sb.ToString());
-        }
-
-        [Fact]
-        public void AppendInsertOperation_test_appends_valid_statement_for_computed_and_identity_composite_key()
-        {
-            var id1Column = new Column("Id1", "int") { ValueGenerationStrategy = StoreValueGenerationStrategy.Computed };
-            var id2Column = new Column("Id2", "nvarchar(max)") { ValueGenerationStrategy = StoreValueGenerationStrategy.Identity };
-            var nameColumn = new Column("Name", "nvarchar(30)");
-            var table = new Table("Customers", new[] { id1Column, id2Column, nameColumn });
-            table.PrimaryKey = new PrimaryKey("PK", new[] { id1Column, id2Column });
-
-            var sb = new StringBuilder();
-
-            new SqlServerSqlGenerator()
-                .AppendInsertOperation(sb, table, new[] { new KeyValuePair<Column, string>(nameColumn, "@p0") });
-
-            const string expected =
-                "DECLARE @generated_keys_Customers TABLE(Id1 int, Id2 nvarchar(max));\r\n" +
-                "INSERT INTO Customers (Name)\r\n" +
-                "OUTPUT inserted.Id1, inserted.Id2 INTO @generated_keys_Customers\r\n" +
-                "VALUES (@p0);\r\n" +
-                "SELECT t.Id1, t.Id2 FROM @generated_keys_Customers AS g JOIN Customers AS t ON g.Id1 = t.Id1 AND g.Id2 = t.Id2";
-
-            Assert.Equal(expected, sb.ToString());
-        }
-
-        [Fact]
-        public void AppendInsertOperation_test_appends_valid_statement_for_computed_and_identity_composite_key_and_computed_non_key_column()
-        {
-            var id1Column = new Column("Id1", "int") { ValueGenerationStrategy = StoreValueGenerationStrategy.Computed };
-            var id2Column = new Column("Id2", "nvarchar(max)") { ValueGenerationStrategy = StoreValueGenerationStrategy.Identity };
-            var insertedColumn = new Column("Inserted", "int") { ValueGenerationStrategy = StoreValueGenerationStrategy.Computed };
-            var nameColumn = new Column("Name", "nvarchar(30)");
-            var table = new Table("Customers", new[] { id1Column, id2Column, insertedColumn, nameColumn });
-            table.PrimaryKey = new PrimaryKey("PK", new[] { id1Column, id2Column });
-            var sb = new StringBuilder();
-
-            new SqlServerSqlGenerator()
-                .AppendInsertOperation(sb, table, new[] { new KeyValuePair<Column, string>(nameColumn, "@p0") });
-
-            const string expected =
-                "DECLARE @generated_keys_Customers TABLE(Id1 int, Id2 nvarchar(max));\r\n" +
-                "INSERT INTO Customers (Name)\r\n" +
-                "OUTPUT inserted.Id1, inserted.Id2 INTO @generated_keys_Customers\r\n" +
-                "VALUES (@p0);\r\n" +
-                "SELECT t.Id1, t.Id2, t.Inserted FROM @generated_keys_Customers AS g JOIN Customers AS t ON g.Id1 = t.Id1 AND g.Id2 = t.Id2";
-
-            Assert.Equal(expected, sb.ToString());
-        }
-
-        public class ParameterValidation
-        {
-            [Fact]
-            public void AppendBatchHeader_validates_parameters()
+            using (var context = new DuckDuckGooseContext())
             {
-                Assert.Equal(
-                    "commandStringBuilder",
-                    Assert.Throws<ArgumentNullException>(
-                        () => new SqlServerSqlGenerator().AppendBatchHeader(null)).ParamName);
+                var entry = context.ChangeTracker.Entry(context.Add(new Duck())).StateEntry;
+
+                return new[]
+                    {
+                        new ColumnModification(
+                            entry, entry.EntityType.GetProperty("Id"), "@p1",
+                            isRead: true, isWrite: false, isKey: true, isCondition: true),
+                        new ColumnModification(
+                            entry, entry.EntityType.GetProperty("Name"), "@p2",
+                            isRead: false, isWrite: true, isKey: false, isCondition: false),
+                        new ColumnModification(
+                            entry, entry.EntityType.GetProperty("Quacks"), "@p3",
+                            isRead: false, isWrite: true, isKey: false, isCondition: false)
+                    };
+            }
+        }
+
+        private class DuckDuckGooseContext : DbContext
+        {
+            public DuckDuckGooseContext()
+                : base(new ServiceCollection()
+                    .AddEntityFramework()
+                    .AddSqlServer()
+                    .ServiceCollection
+                    .BuildServiceProvider())
+            {
             }
 
-            [Fact]
-            public void CreateWhereConditionsForStoreGeneratedKeys_validates_parameters()
-            {
-                Assert.Equal(
-                    "storeGeneratedKeyColumns",
-                    Assert.Throws<ArgumentNullException>(
-                        () => new SqlServerSqlGenerator()
-                            .CreateWhereConditionsForStoreGeneratedKeys(null)).ParamName);
-            }
+            public DbSet<Duck> Blogs { get; set; }
+        }
+
+        private class Duck
+        {
+            private int Id { get; set; }
+            private string Name { get; set; }
+            private bool Quacks { get; set; }
         }
     }
 }

--- a/test/Microsoft.Data.Entity.Tests/DbContextTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/DbContextTest.cs
@@ -427,7 +427,7 @@ namespace Microsoft.Data.Entity.Tests
             }
 
             store.Verify(
-                s => s.SaveChangesAsync(It.IsAny<IEnumerable<StateEntry>>(), It.IsAny<CancellationToken>()),
+                s => s.SaveChangesAsync(It.IsAny<IReadOnlyList<StateEntry>>(), It.IsAny<CancellationToken>()),
                 Times.Never);
         }
 
@@ -436,7 +436,7 @@ namespace Microsoft.Data.Entity.Tests
         {
             var passedEntries = new List<StateEntry>();
             var store = new Mock<DataStore>();
-            store.Setup(s => s.SaveChangesAsync(It.IsAny<IEnumerable<StateEntry>>(), It.IsAny<CancellationToken>()))
+            store.Setup(s => s.SaveChangesAsync(It.IsAny<IReadOnlyList<StateEntry>>(), It.IsAny<CancellationToken>()))
                 .Callback<IEnumerable<StateEntry>, CancellationToken>((e, c) => passedEntries.AddRange(e))
                 .Returns(Task.FromResult(3));
 
@@ -466,7 +466,7 @@ namespace Microsoft.Data.Entity.Tests
             Assert.Equal(3, passedEntries.Count);
 
             store.Verify(
-                s => s.SaveChangesAsync(It.IsAny<IEnumerable<StateEntry>>(), It.IsAny<CancellationToken>()),
+                s => s.SaveChangesAsync(It.IsAny<IReadOnlyList<StateEntry>>(), It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 

--- a/test/Shared/NorthwindQueryTestBase.cs
+++ b/test/Shared/NorthwindQueryTestBase.cs
@@ -332,7 +332,7 @@ namespace Microsoft.Data.FunctionalTests
                 assertOrder: true);
         }
 
-        [Fact(Skip = "Test is failing, see #153")]
+        // TODO: [Fact] See #153
         public virtual void Where_subquery_on_collection()
         {
             AssertQuery<Product, OrderDetail>((pr, od) =>


### PR DESCRIPTION
Even beer pipelines exist... (Allow typed DbParameter creation in update pipeline)

Previously we were always inferring the type of DbParameter from the parameter value. This doesn't work in general because sometimes the type cannot be inferred (e.g. nulls) and sometimes the inference is wrong (e.g. DateTime => datetime instead of datetime2).

While trying to fix this is became apparent that the pipeline was doing many transformations to ad-hoc structures of tuples, string, and objects. This made it hard to get proper parameter creation because flowing the information to the right place requires updating all these data structures. I tried to simplify this and found that once simplified the use of the store model wasn't providing any value, so I removed this as well. This got to a point where value propagation, parameter creating, and command building became simpler. For example, there was no longer any need to map reader values back to state entries using column names because the order of the columns in the reader is known and can be used directly.

I also realized that the batching code we have will only ever create a batch of one and so isn't really exercised in the code. I left the code in place with a TODO. Discussions with others leads me to believe we will need to change the SQL that is generated in the future anyway and this may change the batching code as well. I did remove the code for reading non-identity computed keys--this will be added back as part of the work to rationalize how store-generated values are handled.

Quoting of identifiers was added.

Common store type mapping is now used for Migrations and the update pipeline. This is all in the base relational provider for now, but some of it will need to move into the SQL Server provider.

Testing still underway.
