### PR TITLE
Magic emerges from simplicity...

### DIFF
--- a/src/Microsoft.Data.Entity.InMemory/InMemoryDataStoreCreator.cs
+++ b/src/Microsoft.Data.Entity.InMemory/InMemoryDataStoreCreator.cs
@@ -21,14 +21,37 @@ namespace Microsoft.Data.Entity.InMemory
             _dataStore = dataStore;
         }
 
-        public override Task CreateAsync(IModel model, CancellationToken cancellationToken = new CancellationToken())
+        public override void Create()
+        {
+        }
+
+        public override Task CreateAsync(CancellationToken cancellationToken = new CancellationToken())
         {
             return Task.FromResult(0);
+        }
+
+        public override void CreateTables(IModel model)
+        {
+        }
+
+        public override Task CreateTablesAsync(IModel model, CancellationToken cancellationToken = new CancellationToken())
+        {
+            return Task.FromResult(0);
+        }
+
+        public override bool Exists()
+        {
+            return true;
         }
 
         public override Task<bool> ExistsAsync(CancellationToken cancellationToken = new CancellationToken())
         {
             return Task.FromResult(true);
+        }
+
+        public override void Delete()
+        {
+            _dataStore.Database.Clear();
         }
 
         public override Task DeleteAsync(CancellationToken cancellationToken = new CancellationToken())
@@ -38,18 +61,14 @@ namespace Microsoft.Data.Entity.InMemory
             return Task.FromResult(0);
         }
 
-        public override void Create(IModel model)
-        {
-        }
-
-        public override bool Exists()
+        public override bool HasTables()
         {
             return true;
         }
 
-        public override void Delete()
+        public override Task<bool> HasTablesAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            _dataStore.Database.Clear();
+            return Task.FromResult(true);
         }
     }
 }

--- a/src/Microsoft.Data.Entity.SQLite/SQLiteConnectionConnection.cs
+++ b/src/Microsoft.Data.Entity.SQLite/SQLiteConnectionConnection.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Data.Entity.SQLite
             return new SQLiteConnection(ConnectionString);
         }
 
-        public virtual SQLiteConnection CreateConnectionWithCreate()
+        public virtual SQLiteConnection CreateConnectionReadWriteCreate()
         {
             // TODO: Handle uris
             var builder = new SQLiteConnectionStringBuilder(ConnectionString) { Mode = "RWC" };
@@ -29,7 +29,15 @@ namespace Microsoft.Data.Entity.SQLite
             return new SQLiteConnection(builder.ConnectionString);
         }
 
-        public virtual SQLiteConnection CreateConnectionWithoutCreate()
+        public virtual SQLiteConnection CreateConnectionReadWrite()
+        {
+            // TODO: Handle in-memory & uris
+            var builder = new SQLiteConnectionStringBuilder(ConnectionString) { Mode = "RW" };
+
+            return new SQLiteConnection(builder.ConnectionString);
+        }
+
+        public virtual SQLiteConnection CreateConnectionReadOnly()
         {
             // TODO: Handle in-memory & uris
             var builder = new SQLiteConnectionStringBuilder(ConnectionString) { Mode = "RO" };

--- a/src/Microsoft.Data.Entity/Infrastructure/Database.cs
+++ b/src/Microsoft.Data.Entity/Infrastructure/Database.cs
@@ -27,7 +27,22 @@ namespace Microsoft.Data.Entity.Infrastructure
 
         public virtual void Create()
         {
-            _configuration.DataStoreCreator.Create(_configuration.Model);
+            _configuration.DataStoreCreator.Create();
+        }
+
+        public virtual Task CreateAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return _configuration.DataStoreCreator.CreateAsync(cancellationToken);
+        }
+
+        public virtual void CreateTables()
+        {
+            _configuration.DataStoreCreator.CreateTables(_configuration.Model);
+        }
+
+        public virtual Task CreateTablesAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return _configuration.DataStoreCreator.CreateTablesAsync(_configuration.Model, cancellationToken);
         }
 
         public virtual void Delete()
@@ -35,24 +50,49 @@ namespace Microsoft.Data.Entity.Infrastructure
             _configuration.DataStoreCreator.Delete();
         }
 
-        public virtual bool Exists()
-        {
-            return _configuration.DataStoreCreator.Exists();
-        }
-
-        public virtual Task CreateAsync(CancellationToken cancellationToken = default(CancellationToken))
-        {
-            return _configuration.DataStoreCreator.CreateAsync(_configuration.Model, cancellationToken);
-        }
-
         public virtual Task DeleteAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return _configuration.DataStoreCreator.DeleteAsync(cancellationToken);
         }
 
+        public virtual bool Exists()
+        {
+            return _configuration.DataStoreCreator.Exists();
+        }
+
         public virtual Task<bool> ExistsAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return _configuration.DataStoreCreator.ExistsAsync(cancellationToken);
+        }
+
+        public virtual bool HasTables()
+        {
+            return _configuration.DataStoreCreator.HasTables();
+        }
+
+        public virtual Task<bool> HasTablesAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return _configuration.DataStoreCreator.HasTablesAsync(cancellationToken);
+        }
+
+        public virtual bool EnsureCreated()
+        {
+            return _configuration.DataStoreCreator.EnsureCreated(_configuration.Model);
+        }
+
+        public virtual Task<bool> EnsureCreatedAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return _configuration.DataStoreCreator.EnsureCreatedAsync(_configuration.Model, cancellationToken);
+        }
+
+        public virtual bool EnsureDeleted()
+        {
+            return _configuration.DataStoreCreator.EnsureDeleted();
+        }
+
+        public virtual Task<bool> EnsureDeletedAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return _configuration.DataStoreCreator.EnsureDeletedAsync(cancellationToken);
         }
     }
 }

--- a/src/Microsoft.Data.Entity/Storage/DataStoreCreator.cs
+++ b/src/Microsoft.Data.Entity/Storage/DataStoreCreator.cs
@@ -5,22 +5,90 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Storage
 {
     public abstract class DataStoreCreator
     {
-        public abstract Task CreateAsync(
-            [NotNull] IModel model, CancellationToken cancellationToken = default(CancellationToken));
+        public abstract bool Exists();
 
         public abstract Task<bool> ExistsAsync(CancellationToken cancellationToken = default(CancellationToken));
 
-        public abstract Task DeleteAsync(CancellationToken cancellationToken = default(CancellationToken));
+        public abstract void Create();
 
-        public abstract void Create([NotNull] IModel model);
-
-        public abstract bool Exists();
+        public abstract Task CreateAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         public abstract void Delete();
+
+        public abstract Task DeleteAsync(CancellationToken cancellationToken = default(CancellationToken));
+
+        public abstract void CreateTables([NotNull] IModel model);
+
+        public abstract Task CreateTablesAsync(
+            [NotNull] IModel model, CancellationToken cancellationToken = default(CancellationToken));
+
+        public abstract bool HasTables();
+
+        public abstract Task<bool> HasTablesAsync(CancellationToken cancellationToken = default(CancellationToken));
+
+        public virtual bool EnsureDeleted()
+        {
+            if (Exists())
+            {
+                Delete();
+                return true;
+            }
+            return false;
+        }
+
+        public async virtual Task<bool> EnsureDeletedAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (await ExistsAsync(cancellationToken))
+            {
+                await DeleteAsync(cancellationToken);
+                return true;
+            }
+            return false;
+        }
+
+        public virtual bool EnsureCreated([NotNull] IModel model)
+        {
+            Check.NotNull(model, "model");
+
+            if (!Exists())
+            {
+                Create();
+                CreateTables(model);
+                return true;
+            }
+
+            if (!HasTables())
+            {
+                CreateTables(model);
+                return true;
+            }
+
+            return false;
+        }
+
+        public async virtual Task<bool> EnsureCreatedAsync(
+            [NotNull] IModel model, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (!await ExistsAsync(cancellationToken))
+            {
+                await CreateAsync(cancellationToken);
+                await CreateTablesAsync(model, cancellationToken);
+                return true;
+            }
+
+            if (!await HasTablesAsync(cancellationToken))
+            {
+                await CreateTablesAsync(model, cancellationToken);
+                return true;
+            }
+
+            return false;
+        }
     }
 }

--- a/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/SqlServerDataStoreCreatorTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/SqlServerDataStoreCreatorTest.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Data;
+using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Fallback;
 using Xunit;
@@ -59,6 +61,78 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         }
 
         [Fact]
+        public async Task HasTables_throws_when_database_doesnt_exist()
+        {
+            await HasTables_throws_when_database_doesnt_exist_test(async: false);
+        }
+
+        [Fact]
+        public async Task HasTablesAsync_throws_when_database_doesnt_exist()
+        {
+            await HasTables_throws_when_database_doesnt_exist_test(async: true);
+        }
+
+        private static async Task HasTables_throws_when_database_doesnt_exist_test(bool async)
+        {
+            using (var testDatabase = await TestDatabase.Scratch(createDatabase: false))
+            {
+                var creator = GetDataStoreCreator(testDatabase);
+
+                Assert.Equal(
+                    4060, // Login failed error number
+                    async
+                        ? (await Assert.ThrowsAsync<SqlException>(() => creator.HasTablesAsync())).Number
+                        : Assert.Throws<SqlException>(() => creator.HasTables()).Number);
+            }
+        }
+
+        [Fact]
+        public async Task HasTables_returns_false_when_database_exists_but_has_no_tables()
+        {
+            await HasTables_returns_false_when_database_exists_but_has_no_tables_test(async: false);
+        }
+
+        [Fact]
+        public async Task HasTablesAsync_returns_false_when_database_exists_but_has_no_tables()
+        {
+            await HasTables_returns_false_when_database_exists_but_has_no_tables_test(async: true);
+        }
+
+        private static async Task HasTables_returns_false_when_database_exists_but_has_no_tables_test(bool async)
+        {
+            using (var testDatabase = await TestDatabase.Scratch(createDatabase: true))
+            {
+                var creator = GetDataStoreCreator(testDatabase);
+
+                Assert.False(async ? await creator.HasTablesAsync() : creator.HasTables());
+            }
+        }
+
+        [Fact]
+        public async Task HasTables_returns_true_when_database_exists_and_has_any_tables()
+        {
+            await HasTables_returns_true_when_database_exists_and_has_any_tables_test(async: false);
+        }
+
+        [Fact]
+        public async Task HasTablesAsync_returns_true_when_database_exists_and_has_any_tables()
+        {
+            await HasTables_returns_true_when_database_exists_and_has_any_tables_test(async: true);
+        }
+
+        private static async Task HasTables_returns_true_when_database_exists_and_has_any_tables_test(bool async)
+        {
+            using (var testDatabase = await TestDatabase.Scratch(createDatabase: true))
+            {
+                await testDatabase.ExecuteNonQueryAsync("CREATE TABLE SomeTable (Id uniqueidentifier)");
+
+                var creator = GetDataStoreCreator(testDatabase);
+
+                Assert.True(async ? await creator.HasTablesAsync() : creator.HasTables());
+            }
+        }
+
+        [Fact]
         public async Task Delete_will_delete_database()
         {
             await Delete_will_delete_database_test(async: false);
@@ -94,75 +168,174 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         }
 
         [Fact]
-        public async Task Delete_noop_when_database_doesnt_exist()
+        public async Task Delete_throws_when_database_doesnt_exist()
         {
-            await Delete_noop_when_database_doesnt_exist_test(async: false);
+            await Delete_throws_when_database_doesnt_exist_test(async: false);
         }
 
         [Fact]
-        public async Task DeleteAsync_noop_when_database_doesnt_exist()
+        public async Task DeleteAsync_throws_when_database_doesnt_exist()
         {
-            await Delete_noop_when_database_doesnt_exist_test(async: true);
+            await Delete_throws_when_database_doesnt_exist_test(async: true);
         }
 
-        private static async Task Delete_noop_when_database_doesnt_exist_test(bool async)
+        private static async Task Delete_throws_when_database_doesnt_exist_test(bool async)
         {
             using (var testDatabase = await TestDatabase.Scratch(createDatabase: false))
             {
                 var creator = GetDataStoreCreator(testDatabase);
 
-                Assert.False(async ? await creator.ExistsAsync() : creator.Exists());
-
-                if (async)
-                {
-                    await creator.DeleteAsync();
-                }
-                else
-                {
-                    creator.Delete();
-                }
-
-                Assert.False(async ? await creator.ExistsAsync() : creator.Exists());
+                Assert.Equal(
+                    3701, // Database does not exist
+                    async
+                        ? (await Assert.ThrowsAsync<SqlException>(() => creator.DeleteAsync())).Number
+                        : Assert.Throws<SqlException>(() => creator.Delete()).Number);
             }
         }
 
         [Fact]
-        public async Task Can_create_schema_in_existing_database()
+        public async Task CreateTables_creates_schema_in_existing_database()
         {
-            await Can_create_schema_in_existing_database_test(async: false);
+            await CreateTables_creates_schema_in_existing_database_test(async: false);
         }
 
         [Fact]
-        public async Task Can_create_schema_in_existing_database_async()
+        public async Task CreateTablesAsync_creates_schema_in_existing_database()
         {
-            await Can_create_schema_in_existing_database_test(async: true);
+            await CreateTables_creates_schema_in_existing_database_test(async: true);
         }
 
-        private static async Task Can_create_schema_in_existing_database_test(bool async)
+        private static async Task CreateTables_creates_schema_in_existing_database_test(bool async)
         {
             using (var testDatabase = await TestDatabase.Scratch())
             {
-                await RunDatabaseCreationTest(testDatabase, async);
+                var serviceCollection = new ServiceCollection();
+                serviceCollection.AddEntityFramework().AddSqlServer();
+                var serviceProvider = serviceCollection.BuildServiceProvider();
+
+                var configuration = new DbContextOptions()
+                    .UseSqlServer(testDatabase.Connection.ConnectionString)
+                    .BuildConfiguration();
+
+                using (var context = new BloggingContext(serviceProvider, configuration))
+                {
+                    var creator = context.Configuration.DataStoreCreator;
+
+                    if (async)
+                    {
+                        await creator.CreateTablesAsync(context.Model);
+                    }
+                    else
+                    {
+                        creator.CreateTables(context.Model);
+                    }
+
+                    if (testDatabase.Connection.State != ConnectionState.Open)
+                    {
+                        await testDatabase.Connection.OpenAsync();
+                    }
+
+                    var tables = await testDatabase.QueryAsync<string>("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES");
+                    Assert.Equal(1, tables.Count());
+                    Assert.Equal("Blog", tables.Single());
+
+                    var columns = await testDatabase.QueryAsync<string>("SELECT TABLE_NAME + '.' + COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS");
+                    Assert.Equal(2, columns.Count());
+                    Assert.True(columns.Any(c => c == "Blog.Id"));
+                    Assert.True(columns.Any(c => c == "Blog.Name"));
+                }
             }
         }
 
         [Fact]
-        public async Task Can_create_physical_database_and_schema()
+        public async Task CreateTables_throws_if_database_does_not_exist()
         {
-            await Can_create_physical_database_and_schema_test(async: false);
+            await CreateTables_throws_if_database_does_not_exist_test(async: false);
         }
 
         [Fact]
-        public async Task Can_create_physical_database_and_schema_async()
+        public async Task CreateTablesAsync_throws_if_database_does_not_exist()
         {
-            await Can_create_physical_database_and_schema_test(async: true);
+            await CreateTables_throws_if_database_does_not_exist_test(async: true);
         }
 
-        private static async Task Can_create_physical_database_and_schema_test(bool async)
+        private static async Task CreateTables_throws_if_database_does_not_exist_test(bool async)
         {
             using (var testDatabase = await TestDatabase.Scratch(createDatabase: false))
             {
-                await RunDatabaseCreationTest(testDatabase, async);
+                var creator = GetDataStoreCreator(testDatabase);
+
+                Assert.Equal(
+                    4060, // Login failed error number
+                    async
+                        ? (await Assert.ThrowsAsync<SqlException>(() => creator.CreateTablesAsync(new Model()))).Number
+                        : Assert.Throws<SqlException>(() => creator.CreateTables(new Model())).Number);
+            }
+        }
+
+        [Fact]
+        public async Task Create_creates_physical_database_but_not_tables()
+        {
+            await Create_creates_physical_database_but_not_tables_test(async: false);
+        }
+
+        [Fact]
+        public async Task CreateAsync_creates_physical_database_but_not_tables()
+        {
+            await Create_creates_physical_database_but_not_tables_test(async: true);
+        }
+
+        private static async Task Create_creates_physical_database_but_not_tables_test(bool async)
+        {
+            using (var testDatabase = await TestDatabase.Scratch(createDatabase: false))
+            {
+                var creator = GetDataStoreCreator(testDatabase);
+
+                Assert.False(creator.Exists());
+
+                if (async)
+                {
+                    await creator.CreateAsync();
+                }
+                else
+                {
+                    creator.Create();
+                }
+
+                Assert.True(creator.Exists());
+
+                if (testDatabase.Connection.State != ConnectionState.Open)
+                {
+                    await testDatabase.Connection.OpenAsync();
+                }
+
+                Assert.Equal(0, (await testDatabase.QueryAsync<string>("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES")).Count());
+            }
+        }
+
+        [Fact]
+        public async Task Create_throws_if_database_already_exists()
+        {
+            await Create_throws_if_database_already_exists_test(async: false);
+        }
+
+        [Fact]
+        public async Task CreateAsync_throws_if_database_already_exists()
+        {
+            await Create_throws_if_database_already_exists_test(async: true);
+        }
+
+        private static async Task Create_throws_if_database_already_exists_test(bool async)
+        {
+            using (var testDatabase = await TestDatabase.Scratch(createDatabase: true))
+            {
+                var creator = GetDataStoreCreator(testDatabase);
+
+                Assert.Equal(
+                    1801, // Database with given name already exists
+                    async
+                        ? (await Assert.ThrowsAsync<SqlException>(() => creator.CreateAsync())).Number
+                        : Assert.Throws<SqlException>(() => creator.Create()).Number);
             }
         }
 
@@ -181,45 +354,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         private static SqlServerDataStoreCreator GetDataStoreCreator(TestDatabase testDatabase)
         {
             return CreateConfiguration(testDatabase).Services.ServiceProvider.GetService<SqlServerDataStoreCreator>();
-        }
-
-        private static async Task RunDatabaseCreationTest(TestDatabase testDatabase, bool async)
-        {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddEntityFramework().AddSqlServer();
-            var serviceProvider = serviceCollection.BuildServiceProvider();
-
-            var configuration = new DbContextOptions()
-                .UseSqlServer(testDatabase.Connection.ConnectionString)
-                .BuildConfiguration();
-
-            using (var context = new BloggingContext(serviceProvider, configuration))
-            {
-                var creator = context.Configuration.DataStoreCreator;
-
-                if (async)
-                {
-                    await creator.CreateAsync(context.Model);
-                }
-                else
-                {
-                    creator.Create(context.Model);
-                }
-
-                if (testDatabase.Connection.State != ConnectionState.Open)
-                {
-                    await testDatabase.Connection.OpenAsync();
-                }
-
-                var tables = await testDatabase.QueryAsync<string>("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES");
-                Assert.Equal(1, tables.Count());
-                Assert.Equal("Blog", tables.Single());
-
-                var columns = await testDatabase.QueryAsync<string>("SELECT TABLE_NAME + '.' + COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS");
-                Assert.Equal(2, columns.Count());
-                Assert.True(columns.Any(c => c == "Blog.Id"));
-                Assert.True(columns.Any(c => c == "Blog.Name"));
-            }
         }
 
         private class BloggingContext : DbContext

--- a/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/SqlServerDatabaseCreationTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/SqlServerDatabaseCreationTest.cs
@@ -67,18 +67,18 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         }
 
         [Fact]
-        public async Task Delete_will_delete_database()
+        public async Task EnsureDeleted_will_delete_database()
         {
-            await Delete_will_delete_database_test(async: false);
+            await EnsureDeleted_will_delete_database_test(async: false);
         }
 
         [Fact]
-        public async Task DeleteAsync_will_delete_database()
+        public async Task EnsureDeletedAsync_will_delete_database()
         {
-            await Delete_will_delete_database_test(async: true);
+            await EnsureDeleted_will_delete_database_test(async: true);
         }
 
-        private static async Task Delete_will_delete_database_test(bool async)
+        private static async Task EnsureDeleted_will_delete_database_test(bool async)
         {
             using (var testDatabase = await TestDatabase.Scratch(createDatabase: true))
             {
@@ -90,11 +90,11 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                     if (async)
                     {
-                        await context.Database.DeleteAsync();
+                        Assert.True(await context.Database.EnsureDeletedAsync());
                     }
                     else
                     {
-                        context.Database.Delete();
+                        Assert.True(context.Database.EnsureDeleted());
                     }
 
                     Assert.Equal(ConnectionState.Closed, ((RelationalConnection)context.Database.Connection).DbConnection.State);
@@ -107,18 +107,18 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         }
 
         [Fact]
-        public async Task Delete_noop_when_database_doesnt_exist()
+        public async Task EnsuredDeleted_noop_when_database_doesnt_exist()
         {
-            await Delete_noop_when_database_doesnt_exist_test(async: false);
+            await EnsuredDeleted_noop_when_database_doesnt_exist_test(async: false);
         }
 
         [Fact]
-        public async Task DeleteAsync_noop_when_database_doesnt_exist()
+        public async Task EnsuredDeletedAsync_noop_when_database_doesnt_exist()
         {
-            await Delete_noop_when_database_doesnt_exist_test(async: true);
+            await EnsuredDeleted_noop_when_database_doesnt_exist_test(async: true);
         }
 
-        private static async Task Delete_noop_when_database_doesnt_exist_test(bool async)
+        private static async Task EnsuredDeleted_noop_when_database_doesnt_exist_test(bool async)
         {
             using (var testDatabase = await TestDatabase.Scratch(createDatabase: false))
             {
@@ -128,11 +128,11 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                     if (async)
                     {
-                        await context.Database.DeleteAsync();
+                        Assert.False(await context.Database.EnsureDeletedAsync());
                     }
                     else
                     {
-                        context.Database.Delete();
+                        Assert.False(context.Database.EnsureDeleted());
                     }
 
                     Assert.Equal(ConnectionState.Closed, ((RelationalConnection)context.Database.Connection).DbConnection.State);
@@ -145,18 +145,18 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         }
 
         [Fact]
-        public async Task Can_create_schema_in_existing_database()
+        public async Task EnsureCreated_can_create_schema_in_existing_database()
         {
-            await Can_create_schema_in_existing_database_test(async: false);
+            await EnsureCreated_can_create_schema_in_existing_database_test(async: false);
         }
 
         [Fact]
-        public async Task Can_create_schema_in_existing_database_async()
+        public async Task EnsureCreatedAsync_can_create_schema_in_existing_database()
         {
-            await Can_create_schema_in_existing_database_test(async: true);
+            await EnsureCreated_can_create_schema_in_existing_database_test(async: true);
         }
 
-        private static async Task Can_create_schema_in_existing_database_test(bool async)
+        private static async Task EnsureCreated_can_create_schema_in_existing_database_test(bool async)
         {
             using (var testDatabase = await TestDatabase.Scratch())
             {
@@ -165,18 +165,18 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         }
 
         [Fact]
-        public async Task Can_create_physical_database_and_schema()
+        public async Task EnsureCreated_can_create_physical_database_and_schema()
         {
-            await Can_create_physical_database_and_schema_test(async: false);
+            await EnsureCreated_can_create_physical_database_and_schema_test(async: false);
         }
 
         [Fact]
-        public async Task Can_create_physical_database_and_schema_async()
+        public async Task EnsureCreatedAsync_can_create_physical_database_and_schema()
         {
-            await Can_create_physical_database_and_schema_test(async: true);
+            await EnsureCreated_can_create_physical_database_and_schema_test(async: true);
         }
 
-        private static async Task Can_create_physical_database_and_schema_test(bool async)
+        private static async Task EnsureCreated_can_create_physical_database_and_schema_test(bool async)
         {
             using (var testDatabase = await TestDatabase.Scratch(createDatabase: false))
             {
@@ -196,11 +196,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 .Configuration;
         }
 
-        private static SqlServerDataStoreCreator GetDataStoreCreator(TestDatabase testDatabase)
-        {
-            return CreateConfiguration(testDatabase).Services.ServiceProvider.GetService<SqlServerDataStoreCreator>();
-        }
-
         private static async Task RunDatabaseCreationTest(TestDatabase testDatabase, bool async)
         {
             using (var context = new BloggingContext(testDatabase))
@@ -209,11 +204,11 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 if (async)
                 {
-                    await context.Database.CreateAsync();
+                    Assert.True(await context.Database.EnsureCreatedAsync());
                 }
                 else
                 {
-                    context.Database.Create();
+                    Assert.True(context.Database.EnsureCreated());
                 }
 
                 Assert.Equal(ConnectionState.Closed, ((RelationalConnection)context.Database.Connection).DbConnection.State);
@@ -255,6 +250,41 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                             "Blog.WayRound (bigint)"
                         },
                     columns);
+            }
+        }
+
+
+        [Fact]
+        public async Task EnsuredCreated_is_noop_when_database_exists_and_has_schema()
+        {
+            await EnsuredCreated_is_noop_when_database_exists_and_has_schema_test(async: false);
+        }
+
+        [Fact]
+        public async Task EnsuredCreatedAsync_is_noop_when_database_exists_and_has_schema()
+        {
+            await EnsuredCreated_is_noop_when_database_exists_and_has_schema_test(async: true);
+        }
+
+        private static async Task EnsuredCreated_is_noop_when_database_exists_and_has_schema_test(bool async)
+        {
+            using (var testDatabase = await TestDatabase.Scratch(createDatabase: false))
+            {
+                using (var context = new BloggingContext(testDatabase))
+                {
+                    context.Database.EnsureCreated();
+
+                    if (async)
+                    {
+                        Assert.False(await context.Database.EnsureCreatedAsync());
+                    }
+                    else
+                    {
+                        Assert.False(context.Database.EnsureCreated());
+                    }
+
+                    Assert.Equal(ConnectionState.Closed, ((RelationalConnection)context.Database.Connection).DbConnection.State);
+                }
             }
         }
 

--- a/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -283,7 +283,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
         private static async Task<TBlog[]> CreateBlogDatabase<TBlog>(DbContext context) where TBlog : class, IBlog, new()
         {
-            await context.Database.CreateAsync();
+            await context.Database.EnsureCreatedAsync();
             var blog1 = await context.AddAsync(new TBlog()
                 {
                     Name = "Blog1",

--- a/test/Microsoft.Data.Entity.Tests/DatabaseTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/DatabaseTest.cs
@@ -16,10 +16,13 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Methods_delegate_to_configured_store_creator()
         {
+            var model = Mock.Of<IModel>();
             var creatorMock = new Mock<DataStoreCreator>();
             creatorMock.Setup(m => m.Exists()).Returns(true);
+            creatorMock.Setup(m => m.HasTables()).Returns(true);
+            creatorMock.Setup(m => m.EnsureCreated(model)).Returns(true);
+            creatorMock.Setup(m => m.EnsureDeleted()).Returns(true);
 
-            var model = Mock.Of<IModel>();
             var connection = Mock.Of<DataStoreConnection>();
             var configurationMock = new Mock<DbContextConfiguration>();
             configurationMock.Setup(m => m.DataStoreCreator).Returns(creatorMock.Object);
@@ -32,10 +35,22 @@ namespace Microsoft.Data.Entity.Tests
             creatorMock.Verify(m => m.Exists(), Times.Once);
 
             database.Create();
-            creatorMock.Verify(m => m.Create(model), Times.Once);
+            creatorMock.Verify(m => m.Create(), Times.Once);
+
+            database.CreateTables();
+            creatorMock.Verify(m => m.CreateTables(model), Times.Once);
+
+            Assert.True(database.HasTables());
+            creatorMock.Verify(m => m.HasTables(), Times.Once);
 
             database.Delete();
             creatorMock.Verify(m => m.Delete(), Times.Once);
+
+            Assert.True(database.EnsureCreated());
+            creatorMock.Verify(m => m.EnsureCreated(model), Times.Once);
+
+            Assert.True(database.EnsureDeleted());
+            creatorMock.Verify(m => m.EnsureDeleted(), Times.Once);
 
             Assert.Same(connection, database.Connection);
         }
@@ -43,12 +58,15 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public async void Async_methods_delegate_to_configured_store_creator()
         {
+            var model = Mock.Of<IModel>();
             var cancellationToken = new CancellationTokenSource().Token;
 
             var creatorMock = new Mock<DataStoreCreator>();
             creatorMock.Setup(m => m.ExistsAsync(cancellationToken)).Returns(Task.FromResult(true));
+            creatorMock.Setup(m => m.HasTablesAsync(cancellationToken)).Returns(Task.FromResult(true));
+            creatorMock.Setup(m => m.EnsureCreatedAsync(model, cancellationToken)).Returns(Task.FromResult(true));
+            creatorMock.Setup(m => m.EnsureDeletedAsync(cancellationToken)).Returns(Task.FromResult(true));
 
-            var model = Mock.Of<IModel>();
             var configurationMock = new Mock<DbContextConfiguration>();
             configurationMock.Setup(m => m.DataStoreCreator).Returns(creatorMock.Object);
             configurationMock.Setup(m => m.Model).Returns(model);
@@ -59,10 +77,22 @@ namespace Microsoft.Data.Entity.Tests
             creatorMock.Verify(m => m.ExistsAsync(cancellationToken), Times.Once);
 
             await database.CreateAsync(cancellationToken);
-            creatorMock.Verify(m => m.CreateAsync(model, cancellationToken), Times.Once);
+            creatorMock.Verify(m => m.CreateAsync(cancellationToken), Times.Once);
+
+            await database.CreateTablesAsync(cancellationToken);
+            creatorMock.Verify(m => m.CreateTablesAsync(model, cancellationToken), Times.Once);
+
+            Assert.True(await database.HasTablesAsync(cancellationToken));
+            creatorMock.Verify(m => m.HasTablesAsync(cancellationToken), Times.Once);
 
             await database.DeleteAsync(cancellationToken);
             creatorMock.Verify(m => m.DeleteAsync(cancellationToken), Times.Once);
+
+            Assert.True(await database.EnsureCreatedAsync(cancellationToken));
+            creatorMock.Verify(m => m.EnsureCreatedAsync(model, cancellationToken), Times.Once);
+
+            Assert.True(await database.EnsureDeletedAsync(cancellationToken));
+            creatorMock.Verify(m => m.EnsureDeletedAsync(cancellationToken), Times.Once);
         }
     }
 }


### PR DESCRIPTION
Magic emerges from simplicity... (Updates to database creation APIs)

The idea here is to follow a pattern of very simple, very non-magical, commands for the basic operations which can then be composed into more complex operations. The simple commands are:
- Exists: True if database exists; false if it doesn't
- HasTables: True if the database has any tables; false if it doesn't; potentially throw if the database doesn't exist
- Create: Create an empty database or potentially throw if a database with the given name already exists
- Delete: Delete an exist database or potentially throw if the database doesn't exist

None of these commands do existence checking because this has proven to be problematic in many situations and providing these building block commands thus allows the most flexibility for people to get the behavior they need without being dependent on things like exists checks that may not work. For example, you may have some mechanism in your app/infrastructure that tells you this is the first run and therefore the database cannot exist and needs to be created. With these commands this can still be mad to work even if there the exists check we would do does not work with the provider/environment you have.

All that being said, there are two common things that people do, so there are two higher-level composed commands provided out-of-the-box:
- EnsureCreated will create the database if it doesn't exist and create tables for the model if the database doesn't have any tables. It will do nothing if the database exists and has any tables in it.
- EnsureDeleted will delete the database if it exists or do nothing if the database doesn't exist.

SQL Server and In Memory implementations provided and tested, although not yet tested against SQL Azure. SQLite implementation provided but not tested since there are currently no SQLite tests.

See Issue #161
