### PR TITLE
Varying double precision with time zone...

### DIFF
--- a/src/Microsoft.Data.Entity.Relational/Model/RelationalDecimalTypeMapping.cs
+++ b/src/Microsoft.Data.Entity.Relational/Model/RelationalDecimalTypeMapping.cs
@@ -10,14 +10,14 @@ namespace Microsoft.Data.Entity.Relational.Model
 {
     public class RelationalDecimalTypeMapping : RelationalTypeMapping
     {
-        private readonly byte _scale;
         private readonly byte _precision;
+        private readonly byte _scale;
 
-        public RelationalDecimalTypeMapping(byte scale, byte precision)
-            : base("decimal(" + scale + ", " + precision + ")", DbType.Decimal)
+        public RelationalDecimalTypeMapping(byte precision, byte scale)
+            : base("decimal(" + precision + ", " + scale + ")", DbType.Decimal)
         {
-            _scale = scale;
             _precision = precision;
+            _scale = scale;
         }
 
         protected override void ConfigureParameter(DbParameter parameter, ColumnModification columnModification)
@@ -34,6 +34,16 @@ namespace Microsoft.Data.Entity.Relational.Model
             //}
 
             base.ConfigureParameter(parameter, columnModification);
+        }
+
+        public virtual byte Precision
+        {
+            get { return _precision; }
+        }
+
+        public virtual byte Scale
+        {
+            get { return _scale; }
         }
     }
 }

--- a/src/Microsoft.Data.Entity.Relational/Model/RelationalSizedTypeMapping.cs
+++ b/src/Microsoft.Data.Entity.Relational/Model/RelationalSizedTypeMapping.cs
@@ -28,5 +28,10 @@ namespace Microsoft.Data.Entity.Relational.Model
 
             base.ConfigureParameter(parameter, columnModification);
         }
+
+        public virtual int Size
+        {
+            get { return _size; }
+        }
     }
 }

--- a/src/Microsoft.Data.Entity.Relational/Model/RelationalTypeMapper.cs
+++ b/src/Microsoft.Data.Entity.Relational/Model/RelationalTypeMapper.cs
@@ -2,57 +2,42 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Relational.Utilities;
 
 namespace Microsoft.Data.Entity.Relational.Model
 {
-    // TODO: Some of this is SQL Server specific and should be moved into that class
     public class RelationalTypeMapper
     {
-        // This dictionary is for invariant mappings from a sealed CLR type to a single
+        // This table is for invariant mappings from a sealed CLR type to a single
         // store type. If the CLR type is unsealed or if the mapping varies based on how the
         // type is used (e.g. in keys), then add custom mapping below.
-        private readonly IDictionary<Type, RelationalTypeMapping> _simpleMappings = new Dictionary<Type, RelationalTypeMapping>()
-            {
-                { typeof(int), new RelationalTypeMapping("int", DbType.Int32) },
-                { typeof(DateTime), new RelationalTypeMapping("datetime2", DbType.DateTime2) },
-                { typeof(Guid), new RelationalTypeMapping("uniqueidentifier", DbType.Guid) },
-                { typeof(bool), new RelationalTypeMapping("bit", DbType.Boolean) },
-                { typeof(byte), new RelationalTypeMapping("tinyint", DbType.Byte) },
-                { typeof(char), new RelationalTypeMapping("int", DbType.Int32) },
-                { typeof(double), new RelationalTypeMapping("float", DbType.Double) },
-                { typeof(short), new RelationalTypeMapping("smallint", DbType.Int16) },
-                { typeof(long), new RelationalTypeMapping("bigint", DbType.Int64) },
-                { typeof(sbyte), new RelationalTypeMapping("smallint", DbType.SByte) },
-                { typeof(float), new RelationalTypeMapping("real", DbType.Single) },
-                { typeof(ushort), new RelationalTypeMapping("int", DbType.UInt16) },
-                { typeof(uint), new RelationalTypeMapping("bigint", DbType.UInt32) },
-                { typeof(ulong), new RelationalTypeMapping("numeric(20, 0)", DbType.UInt64) },
-                { typeof(DateTimeOffset), new RelationalTypeMapping("datetimeoffset", DbType.DateTimeOffset) },
-            };
+        private readonly Tuple<Type, RelationalTypeMapping>[] _simpleMappings =
+        {
+            Tuple.Create(typeof(int), new RelationalTypeMapping("integer", DbType.Int32)),
+            Tuple.Create(typeof(DateTime), new RelationalTypeMapping("timestamp", DbType.DateTime)),
+            Tuple.Create(typeof(bool), new RelationalTypeMapping("boolean", DbType.Boolean)),
+            Tuple.Create(typeof(double), new RelationalTypeMapping("double precision", DbType.Double)),
+            Tuple.Create(typeof(long), new RelationalTypeMapping("bigint", DbType.Int64)),
+            Tuple.Create(typeof(DateTimeOffset), new RelationalTypeMapping("timestamp with time zone", DbType.DateTimeOffset)),
+            Tuple.Create(typeof(short), new RelationalTypeMapping("smallint", DbType.Int16)),
+            Tuple.Create(typeof(float), new RelationalTypeMapping("real", DbType.Single))
+        };
 
+        // TODO: What is the best size value for the base provider mapping?
         private readonly RelationalTypeMapping _nonKeyStringMapping
-            = new RelationalTypeMapping("nvarchar(max)", DbType.String);
+            = new RelationalSizedTypeMapping("varchar(4000)", DbType.AnsiString, 4000);
 
-        // TODO: It may be possible to increase 128 to 900, at least for SQL Server
+        // TODO: What is the best size value for the base provider mapping?
         private readonly RelationalTypeMapping _keyStringMapping
-            = new RelationalSizedTypeMapping("nvarchar(128)", DbType.String, 128);
-
-        private readonly RelationalTypeMapping _nonKeyByteArrayMapping
-            = new RelationalTypeMapping("varbinary(max)", DbType.Binary);
-
-        // TODO: It may be possible to increase 128 to 900, at least for SQL Server
-        private readonly RelationalTypeMapping _keyByteArrayMapping
-            = new RelationalSizedTypeMapping("varbinary(128)", DbType.Binary, 128);
+            = new RelationalSizedTypeMapping("varchar(128)", DbType.AnsiString, 128);
 
         private readonly RelationalTypeMapping _rowVersionMapping
             = new RelationalSizedTypeMapping("rowversion", DbType.Binary, 8);
 
-        private readonly RelationalDecimalTypeMapping _decimalMapping
-            = new RelationalDecimalTypeMapping(18, 2);
+        private readonly RelationalDecimalTypeMapping _decimalMapping = new RelationalDecimalTypeMapping(18, 2);
 
         // TODO: It would be nice to just pass IProperty into this method, but Migrations uses its own
         // store model for which there is no easy way to get an IProperty.
@@ -67,11 +52,19 @@ namespace Microsoft.Data.Entity.Relational.Model
             Check.NotNull(propertyType, "propertyType");
 
             // TODO: if specifiedType is non-null then parse it to create a type mapping
+            // TODO: Consider allowing Code First to specify an actual type mapping instead of just the string
+            // type since that would remove the need to parse the string.
 
-            RelationalTypeMapping mapping;
-            if (_simpleMappings.TryGetValue(propertyType, out mapping))
+            var mapping = _simpleMappings.FirstOrDefault(m => m.Item1 == propertyType);
+            if (mapping != null)
             {
-                return mapping;
+                return mapping.Item2;
+            }
+
+            if (propertyType == typeof(decimal))
+            {
+                // TODO: If scale/precision have been configured for the property, then create parameter appropriately
+                return _decimalMapping;
             }
 
             if (propertyType == typeof(string))
@@ -83,27 +76,12 @@ namespace Microsoft.Data.Entity.Relational.Model
                 return _nonKeyStringMapping;
             }
 
-            if (propertyType == typeof(byte[]))
+            if (propertyType == typeof(byte[]) && isConcurrencyToken)
             {
-                if (isKey)
-                {
-                    return _keyByteArrayMapping;
-                }
-
-                if (isConcurrencyToken)
-                {
-                    return _rowVersionMapping;
-                }
-                return _nonKeyByteArrayMapping;
+                return _rowVersionMapping;
             }
 
-            if (propertyType == typeof(decimal))
-            {
-                // TODO: If scale/precision have been configured for the property, then create parameter appropriately
-                return _decimalMapping;
-            }
-
-            //// TODO: Consider TimeSpan mapping
+            // TODO: Consider TimeSpan mapping
 
             throw new NotSupportedException(Strings.FormatUnsupportedType(storageName, propertyType.Name));
         }

--- a/src/Microsoft.Data.Entity.SqlServer/SqlServerTypeMapper.cs
+++ b/src/Microsoft.Data.Entity.SqlServer/SqlServerTypeMapper.cs
@@ -1,11 +1,80 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Data;
+using System.Linq;
 using Microsoft.Data.Entity.Relational.Model;
 
 namespace Microsoft.Data.Entity.SqlServer
 {
     public class SqlServerTypeMapper : RelationalTypeMapper
     {
+        // This dictionary is for invariant mappings from a sealed CLR type to a single
+        // store type. If the CLR type is unsealed or if the mapping varies based on how the
+        // type is used (e.g. in keys), then add custom mapping below.
+        private readonly Tuple<Type, RelationalTypeMapping>[] _simpleMappings =
+            {
+                Tuple.Create(typeof(int), new RelationalTypeMapping("int", DbType.Int32)),
+                Tuple.Create(typeof(DateTime), new RelationalTypeMapping("datetime2", DbType.DateTime2)),
+                Tuple.Create(typeof(Guid), new RelationalTypeMapping("uniqueidentifier", DbType.Guid)),
+                Tuple.Create(typeof(bool), new RelationalTypeMapping("bit", DbType.Boolean)),
+                Tuple.Create(typeof(byte), new RelationalTypeMapping("tinyint", DbType.Byte)),
+                Tuple.Create(typeof(double), new RelationalTypeMapping("float", DbType.Double)),
+                Tuple.Create(typeof(DateTimeOffset), new RelationalTypeMapping("datetimeoffset", DbType.DateTimeOffset)),
+                Tuple.Create(typeof(char), new RelationalTypeMapping("int", DbType.Int32)),
+                Tuple.Create(typeof(sbyte), new RelationalTypeMapping("smallint", DbType.SByte)),
+                Tuple.Create(typeof(ushort), new RelationalTypeMapping("int", DbType.UInt16)),
+                Tuple.Create(typeof(uint), new RelationalTypeMapping("bigint", DbType.UInt32)),
+                Tuple.Create(typeof(ulong), new RelationalTypeMapping("numeric(20, 0)", DbType.UInt64)),
+            };
+
+        private readonly RelationalTypeMapping _nonKeyStringMapping
+            = new RelationalTypeMapping("nvarchar(max)", DbType.String);
+
+        // TODO: It may be possible to increase 128 to 900, at least for SQL Server
+        private readonly RelationalTypeMapping _keyStringMapping
+            = new RelationalSizedTypeMapping("nvarchar(128)", DbType.String, 128);
+
+        private readonly RelationalTypeMapping _nonKeyByteArrayMapping
+            = new RelationalTypeMapping("varbinary(max)", DbType.Binary);
+
+        // TODO: It may be possible to increase 128 to 900, at least for SQL Server
+        private readonly RelationalTypeMapping _keyByteArrayMapping
+            = new RelationalSizedTypeMapping("varbinary(128)", DbType.Binary, 128);
+
+        public override RelationalTypeMapping GetTypeMapping(
+            string specifiedType, string storageName, Type propertyType, bool isKey, bool isConcurrencyToken)
+        {
+            var mapping = _simpleMappings.FirstOrDefault(m => m.Item1 == propertyType);
+            if (mapping != null)
+            {
+                return mapping.Item2;
+            }
+
+            if (propertyType == typeof(string))
+            {
+                if (isKey)
+                {
+                    return _keyStringMapping;
+                }
+                return _nonKeyStringMapping;
+            }
+
+            if (propertyType == typeof(byte[]))
+            {
+                if (isKey)
+                {
+                    return _keyByteArrayMapping;
+                }
+
+                if (!isConcurrencyToken)
+                {
+                    return _nonKeyByteArrayMapping;
+                }
+            }
+
+            return base.GetTypeMapping(specifiedType, storageName, propertyType, isKey, isConcurrencyToken);
+        }
     }
 }

--- a/test/Microsoft.Data.Entity.Relational.Tests/Model/RelationalTypeMapperTest.cs
+++ b/test/Microsoft.Data.Entity.Relational.Tests/Model/RelationalTypeMapperTest.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data;
+using Microsoft.Data.Entity.Relational.Model;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Relational.Tests.Model
+{
+    public class RelationalTypeMapperTest
+    {
+        [Fact]
+        public void Does_simple_ANSI_mappings_to_DDL_types()
+        {
+            Assert.Equal("integer", GetTypeMapping(typeof(int)).StoreTypeName);
+            Assert.Equal("timestamp", GetTypeMapping(typeof(DateTime)).StoreTypeName);
+            Assert.Equal("boolean", GetTypeMapping(typeof(bool)).StoreTypeName);
+            Assert.Equal("double precision", GetTypeMapping(typeof(double)).StoreTypeName);
+            Assert.Equal("smallint", GetTypeMapping(typeof(short)).StoreTypeName);
+            Assert.Equal("bigint", GetTypeMapping(typeof(long)).StoreTypeName);
+            Assert.Equal("real", GetTypeMapping(typeof(float)).StoreTypeName);
+            Assert.Equal("timestamp with time zone", GetTypeMapping(typeof(DateTimeOffset)).StoreTypeName);
+        }
+
+        [Fact]
+        public void Does_simple_ANSI_mappings_to_DbTypes()
+        {
+            Assert.Equal(DbType.Int32, GetTypeMapping(typeof(int)).StoreType);
+            Assert.Equal(DbType.DateTime, GetTypeMapping(typeof(DateTime)).StoreType);
+            Assert.Equal(DbType.Boolean, GetTypeMapping(typeof(bool)).StoreType);
+            Assert.Equal(DbType.Double, GetTypeMapping(typeof(double)).StoreType);
+            Assert.Equal(DbType.Int16, GetTypeMapping(typeof(short)).StoreType);
+            Assert.Equal(DbType.Int64, GetTypeMapping(typeof(long)).StoreType);
+            Assert.Equal(DbType.Single, GetTypeMapping(typeof(float)).StoreType);
+            Assert.Equal(DbType.DateTimeOffset, GetTypeMapping(typeof(DateTimeOffset)).StoreType);
+        }
+
+        [Fact]
+        public void Does_decimal_mapping()
+        {
+            var typeMapping = (RelationalDecimalTypeMapping)GetTypeMapping(typeof(decimal));
+
+            Assert.Equal(DbType.Decimal, typeMapping.StoreType);
+            Assert.Equal(18, typeMapping.Precision);
+            Assert.Equal(2, typeMapping.Scale);
+            Assert.Equal("decimal(18, 2)", typeMapping.StoreTypeName);
+        }
+
+        [Fact]
+        public void Does_non_key_ANSI_string_mapping()
+        {
+            var typeMapping = (RelationalSizedTypeMapping)new ConcreteTypeMapper()
+                .GetTypeMapping(null, "MyColumn", typeof(string), isKey: false, isConcurrencyToken: false);
+
+            Assert.Equal(DbType.AnsiString, typeMapping.StoreType);
+            Assert.Equal(4000, typeMapping.Size);
+            Assert.Equal("varchar(4000)", typeMapping.StoreTypeName);
+        }
+
+        [Fact]
+        public void Does_key_ANSI_string_mapping()
+        {
+            var typeMapping = (RelationalSizedTypeMapping)new ConcreteTypeMapper()
+                .GetTypeMapping(null, "MyColumn", typeof(string), isKey: true, isConcurrencyToken: false);
+
+            Assert.Equal(DbType.AnsiString, typeMapping.StoreType);
+            Assert.Equal(128, typeMapping.Size);
+            Assert.Equal("varchar(128)", typeMapping.StoreTypeName);
+        }
+
+        [Fact]
+        public void Does_rowversion_mapping()
+        {
+            var typeMapping = (RelationalSizedTypeMapping)new ConcreteTypeMapper()
+                .GetTypeMapping(null, "MyColumn", typeof(byte[]), isKey: false, isConcurrencyToken: true);
+
+            Assert.Equal(DbType.Binary, typeMapping.StoreType);
+            Assert.Equal(8, typeMapping.Size);
+            Assert.Equal("rowversion", typeMapping.StoreTypeName);
+        }
+
+        [Fact]
+        public void Throws_for_type_that_has_no_default_mapping()
+        {
+            Assert.Equal(
+                Strings.FormatUnsupportedType("MyColumn", "Byte[]"),
+                Assert.Throws<NotSupportedException>(() => GetTypeMapping(typeof(byte[]))).Message);
+        }
+
+        private static RelationalTypeMapping GetTypeMapping(Type propertyType)
+        {
+            return new ConcreteTypeMapper().GetTypeMapping(null, "MyColumn", propertyType, isKey: false, isConcurrencyToken: false);
+        }
+
+        private class ConcreteTypeMapper : RelationalTypeMapper
+        {
+        }
+    }
+}

--- a/test/Microsoft.Data.Entity.Relational.Tests/Update/BatchExecutorTest.cs
+++ b/test/Microsoft.Data.Entity.Relational.Tests/Update/BatchExecutorTest.cs
@@ -268,16 +268,5 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
 
             return stateEntry;
         }
-
-        //private static Table CreateTable(
-        //    StoreValueGenerationStrategy keyStrategy = StoreValueGenerationStrategy.None,
-        //    StoreValueGenerationStrategy nonKeyStrategy = StoreValueGenerationStrategy.None)
-        //{
-        //    var key = new Column("Col1", "_") { ValueGenerationStrategy = keyStrategy };
-        //    return new Table("T1", new[] { key, new Column("Col2", "_") { ValueGenerationStrategy = nonKeyStrategy } })
-        //        {
-        //            PrimaryKey = new PrimaryKey("PK", new[] { key })
-        //        };
-        //}
     }
 }

--- a/test/Microsoft.Data.Entity.SqlServer.Tests/SqlServerTypeMapperTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.Tests/SqlServerTypeMapperTest.cs
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data;
+using Microsoft.Data.Entity.Relational.Model;
+using Xunit;
+
+namespace Microsoft.Data.Entity.SqlServer.Tests
+{
+    public class SqlServerTypeMapperTest
+    {
+        [Fact]
+        public void Does_simple_SQL_Server_mappings_to_DDL_types()
+        {
+            Assert.Equal("int", GetTypeMapping(typeof(int)).StoreTypeName);
+            Assert.Equal("datetime2", GetTypeMapping(typeof(DateTime)).StoreTypeName);
+            Assert.Equal("uniqueidentifier", GetTypeMapping(typeof(Guid)).StoreTypeName);
+            Assert.Equal("int", GetTypeMapping(typeof(char)).StoreTypeName);
+            Assert.Equal("tinyint", GetTypeMapping(typeof(byte)).StoreTypeName);
+            Assert.Equal("float", GetTypeMapping(typeof(double)).StoreTypeName);
+            Assert.Equal("smallint", GetTypeMapping(typeof(sbyte)).StoreTypeName);
+            Assert.Equal("int", GetTypeMapping(typeof(ushort)).StoreTypeName);
+            Assert.Equal("bigint", GetTypeMapping(typeof(uint)).StoreTypeName);
+            Assert.Equal("numeric(20, 0)", GetTypeMapping(typeof(ulong)).StoreTypeName);
+            Assert.Equal("bit", GetTypeMapping(typeof(bool)).StoreTypeName);
+            Assert.Equal("smallint", GetTypeMapping(typeof(short)).StoreTypeName);
+            Assert.Equal("bigint", GetTypeMapping(typeof(long)).StoreTypeName);
+            Assert.Equal("real", GetTypeMapping(typeof(float)).StoreTypeName);
+            Assert.Equal("datetimeoffset", GetTypeMapping(typeof(DateTimeOffset)).StoreTypeName);
+        }
+
+        [Fact]
+        public void Does_simple_SQL_Server_mappings_to_DbTypes()
+        {
+            Assert.Equal(DbType.Int32, GetTypeMapping(typeof(int)).StoreType);
+            Assert.Equal(DbType.DateTime2, GetTypeMapping(typeof(DateTime)).StoreType);
+            Assert.Equal(DbType.Guid, GetTypeMapping(typeof(Guid)).StoreType);
+            Assert.Equal(DbType.Int32, GetTypeMapping(typeof(char)).StoreType);
+            Assert.Equal(DbType.Byte, GetTypeMapping(typeof(byte)).StoreType);
+            Assert.Equal(DbType.Double, GetTypeMapping(typeof(double)).StoreType);
+            Assert.Equal(DbType.SByte, GetTypeMapping(typeof(sbyte)).StoreType);
+            Assert.Equal(DbType.UInt16, GetTypeMapping(typeof(ushort)).StoreType);
+            Assert.Equal(DbType.UInt32, GetTypeMapping(typeof(uint)).StoreType);
+            Assert.Equal(DbType.UInt64, GetTypeMapping(typeof(ulong)).StoreType);
+            Assert.Equal(DbType.Boolean, GetTypeMapping(typeof(bool)).StoreType);
+            Assert.Equal(DbType.Int16, GetTypeMapping(typeof(short)).StoreType);
+            Assert.Equal(DbType.Int64, GetTypeMapping(typeof(long)).StoreType);
+            Assert.Equal(DbType.Single, GetTypeMapping(typeof(float)).StoreType);
+            Assert.Equal(DbType.DateTimeOffset, GetTypeMapping(typeof(DateTimeOffset)).StoreType);
+        }
+
+        [Fact]
+        public void Does_decimal_mapping()
+        {
+            var typeMapping = (RelationalDecimalTypeMapping)GetTypeMapping(typeof(decimal));
+
+            Assert.Equal(DbType.Decimal, typeMapping.StoreType);
+            Assert.Equal(18, typeMapping.Precision);
+            Assert.Equal(2, typeMapping.Scale);
+            Assert.Equal("decimal(18, 2)", typeMapping.StoreTypeName);
+        }
+
+        [Fact]
+        public void Does_non_key_SQL_Server_string_mapping()
+        {
+            var typeMapping = new SqlServerTypeMapper()
+                .GetTypeMapping(null, "MyColumn", typeof(string), isKey: false, isConcurrencyToken: false);
+
+            Assert.Equal(DbType.String, typeMapping.StoreType);
+            Assert.Equal("nvarchar(max)", typeMapping.StoreTypeName);
+        }
+
+        [Fact]
+        public void Does_key_SQL_Server_string_mapping()
+        {
+            var typeMapping = (RelationalSizedTypeMapping)new SqlServerTypeMapper()
+                .GetTypeMapping(null, "MyColumn", typeof(string), isKey: true, isConcurrencyToken: false);
+
+            Assert.Equal(DbType.String, typeMapping.StoreType);
+            Assert.Equal(128, typeMapping.Size);
+            Assert.Equal("nvarchar(128)", typeMapping.StoreTypeName);
+        }
+
+        [Fact]
+        public void Does_rowversion_mapping()
+        {
+            var typeMapping = (RelationalSizedTypeMapping)new SqlServerTypeMapper()
+                .GetTypeMapping(null, "MyColumn", typeof(byte[]), isKey: false, isConcurrencyToken: true);
+
+            Assert.Equal(DbType.Binary, typeMapping.StoreType);
+            Assert.Equal(8, typeMapping.Size);
+            Assert.Equal("rowversion", typeMapping.StoreTypeName);
+        }
+
+        private static RelationalTypeMapping GetTypeMapping(Type propertyType)
+        {
+            return new SqlServerTypeMapper().GetTypeMapping(null, "MyColumn", propertyType, isKey: false, isConcurrencyToken: false);
+        }
+    }
+}


### PR DESCRIPTION
Varying double precision with time zone... (Moved SQL Server-specific type mapping into SQL Server assembly and added tests)

Added tests for type mapping code checked in previously and at the same time moved the SQL Server specific mappings into the SQL Server assembly and checked that providers can override mappings.
