### PR TITLE
Space-age composite polymer; not a shred of sqlmetal...

### DIFF
--- a/test/Microsoft.Data.Entity.InMemory.FunctionalTests/CompositeKeyEndToEndTest.cs
+++ b/test/Microsoft.Data.Entity.InMemory.FunctionalTests/CompositeKeyEndToEndTest.cs
@@ -1,0 +1,232 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
+using Xunit;
+
+namespace Microsoft.Data.Entity.InMemory.FunctionalTests
+{
+    public class CompositeKeyEndToEndTest
+    {
+        [Fact]
+        public async Task Can_use_two_non_generated_integers_as_composite_key_end_to_end()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFramework()
+                .AddInMemoryStore()
+                .ServiceCollection
+                .BuildServiceProvider();
+
+            var ticks = DateTime.UtcNow.Ticks;
+
+            using (var context = new BronieContext(serviceProvider))
+            {
+                await context.AddAsync(new Pegasus { Id1 = ticks, Id2 = ticks + 1, Name = "Rainbow Dash" });
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new BronieContext(serviceProvider))
+            {
+                var pegasus = context.Pegasuses.Single(e => e.Id1 == ticks && e.Id2 == ticks + 1);
+
+                pegasus.Name = "Rainbow Crash";
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new BronieContext(serviceProvider))
+            {
+                var pegasus = context.Pegasuses.Single(e => e.Id1 == ticks && e.Id2 == ticks + 1);
+
+                Assert.Equal("Rainbow Crash", pegasus.Name);
+
+                context.Pegasuses.Remove(pegasus);
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new BronieContext(serviceProvider))
+            {
+                Assert.Equal(0, context.Pegasuses.Count(e => e.Id1 == ticks && e.Id2 == ticks + 1));
+            }
+        }
+
+        [Fact]
+        public async Task Can_use_generated_values_in_composite_key_end_to_end()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFramework()
+                .AddInMemoryStore()
+                .ServiceCollection
+                .BuildServiceProvider();
+
+            long id1;
+            var id2 = DateTime.UtcNow.Ticks.ToString(CultureInfo.InvariantCulture);
+            Guid id3;
+
+            using (var context = new BronieContext(serviceProvider))
+            {
+                var added = await context.AddAsync(new Unicorn { Id2 = id2, Name = "Rarity" });
+
+                Assert.True(added.Id1 > 0);
+                Assert.NotEqual(Guid.Empty, added.Id3);
+
+                await context.SaveChangesAsync();
+
+                id1 = added.Id1;
+                id3 = added.Id3;
+            }
+
+            using (var context = new BronieContext(serviceProvider))
+            {
+                Assert.Equal(1, context.Unicorns.Count(e => e.Id1 == id1 && e.Id2 == id2 && e.Id3 == id3));
+            }
+
+            using (var context = new BronieContext(serviceProvider))
+            {
+                var unicorn = context.Unicorns.Single(e => e.Id1 == id1 && e.Id2 == id2 && e.Id3 == id3);
+
+                unicorn.Name = "Bad Hair Day";
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new BronieContext(serviceProvider))
+            {
+                var unicorn = context.Unicorns.Single(e => e.Id1 == id1 && e.Id2 == id2 && e.Id3 == id3);
+
+                Assert.Equal("Bad Hair Day", unicorn.Name);
+
+                context.Unicorns.Remove(unicorn);
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new BronieContext(serviceProvider))
+            {
+                Assert.Equal(0, context.Unicorns.Count(e => e.Id1 == id1 && e.Id2 == id2 && e.Id3 == id3));
+            }
+        }
+
+        [Fact]
+        public async Task Only_one_part_of_a_composite_key_needs_to_vary_for_uniquness()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFramework()
+                .AddInMemoryStore()
+                .ServiceCollection
+                .BuildServiceProvider();
+
+            var ids = new int[3];
+
+            using (var context = new BronieContext(serviceProvider))
+            {
+                var pony1 = await context.AddAsync(new EarthPony { Id2 = 7, Name = "Apple Jack 1" });
+                var pony2 = await context.AddAsync(new EarthPony { Id2 = 7, Name = "Apple Jack 2" });
+                var pony3 = await context.AddAsync(new EarthPony { Id2 = 7, Name = "Apple Jack 3" });
+
+                await context.SaveChangesAsync();
+
+                ids[0] = pony1.Id1;
+                ids[1] = pony2.Id1;
+                ids[2] = pony3.Id1;
+            }
+
+            using (var context = new BronieContext(serviceProvider))
+            {
+                var ponies = context.EarthPonies.ToList();
+                Assert.Equal(ponies.Count, ponies.Count(e => e.Name == "Apple Jack 1") * 3);
+
+                Assert.Equal("Apple Jack 1", ponies.Single(e => e.Id1 == ids[0]).Name);
+                Assert.Equal("Apple Jack 2", ponies.Single(e => e.Id1 == ids[1]).Name);
+                Assert.Equal("Apple Jack 3", ponies.Single(e => e.Id1 == ids[2]).Name);
+
+                ponies.Single(e => e.Id1 == ids[1]).Name = "Pinky Pie 2";
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new BronieContext(serviceProvider))
+            {
+                var ponies = context.EarthPonies.ToList();
+                Assert.Equal(ponies.Count, ponies.Count(e => e.Name == "Apple Jack 1") * 3);
+
+                Assert.Equal("Apple Jack 1", ponies.Single(e => e.Id1 == ids[0]).Name);
+                Assert.Equal("Pinky Pie 2", ponies.Single(e => e.Id1 == ids[1]).Name);
+                Assert.Equal("Apple Jack 3", ponies.Single(e => e.Id1 == ids[2]).Name);
+
+                context.EarthPonies.RemoveRange(ponies);
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new BronieContext(serviceProvider))
+            {
+                Assert.Equal(0, context.EarthPonies.Count());
+            }
+        }
+
+        private class BronieContext : DbContext
+        {
+
+            public BronieContext(IServiceProvider serviceProvider)
+                : base(serviceProvider)
+            {
+            }
+
+            public DbSet<Pegasus> Pegasuses { get; set; }
+            public DbSet<Unicorn> Unicorns { get; set; }
+            public DbSet<EarthPony> EarthPonies { get; set; }
+
+            protected override void OnModelCreating(ModelBuilder builder)
+            {
+                builder.Entity<Pegasus>().Key(e => new { e.Id1, e.Id2 });
+                builder.Entity<Unicorn>().Key(e => new { e.Id1, e.Id2, e.Id3 });
+                builder.Entity<EarthPony>().Key(e => new { e.Id1, e.Id2 });
+
+                var unicornType = builder.Model.GetEntityType(typeof(Unicorn));
+
+                var id1 = unicornType.GetProperty("Id1");
+                id1.ValueGenerationOnAdd = ValueGenerationOnAdd.Client;
+                id1.ValueGenerationOnSave = ValueGenerationOnSave.WhenInserting;
+
+                var id3 = unicornType.GetProperty("Id3");
+                id3.ValueGenerationOnAdd = ValueGenerationOnAdd.Client;
+
+                var earthType = builder.Model.GetEntityType(typeof(EarthPony));
+
+                var id = earthType.GetProperty("Id1");
+                id.ValueGenerationOnAdd = ValueGenerationOnAdd.Client;
+                id.ValueGenerationOnSave = ValueGenerationOnSave.WhenInserting;
+            }
+        }
+
+        private class Pegasus
+        {
+            public long Id1 { get; set; }
+            public long Id2 { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class Unicorn
+        {
+            public int Id1 { get; set; }
+            public string Id2 { get; set; }
+            public Guid Id3 { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class EarthPony
+        {
+            public int Id1 { get; set; }
+            public int Id2 { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}

--- a/test/Microsoft.Data.Entity.InMemory.FunctionalTests/Microsoft.Data.Entity.InMemory.FunctionalTests.csproj
+++ b/test/Microsoft.Data.Entity.InMemory.FunctionalTests/Microsoft.Data.Entity.InMemory.FunctionalTests.csproj
@@ -61,6 +61,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CompositeKeyEndToEndTest.cs" />
     <Compile Include="GuidValueGeneratorEndToEndTest.cs" />
     <Compile Include="InMemoryConfigPatternsTest.cs" />
     <Compile Include="InMemoryDataStoreTest.cs" />

--- a/test/Microsoft.Data.Entity.InMemory.FunctionalTests/NorthwindQueryTest.cs
+++ b/test/Microsoft.Data.Entity.InMemory.FunctionalTests/NorthwindQueryTest.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
                 context.Set<Employee>().AddRange(NorthwindData.Employees);
                 context.Set<Order>().AddRange(NorthwindData.Orders);
                 context.Set<Product>().AddRange(NorthwindData.Products);
-                //context.Set<OrderDetail>().AddRange(NorthwindData.OrderDetails); // composite keys
+                context.Set<OrderDetail>().AddRange(NorthwindData.OrderDetails);
                 context.SaveChanges();
             }
         }

--- a/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/CompositeKeyEndToEndTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/CompositeKeyEndToEndTest.cs
@@ -1,0 +1,247 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
+using Xunit;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public class CompositeKeyEndToEndTest
+    {
+        [Fact]
+        public async Task Can_use_two_non_generated_integers_as_composite_key_end_to_end()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFramework()
+                .AddSqlServer()
+                .ServiceCollection
+                .BuildServiceProvider();
+
+            var ticks = DateTime.UtcNow.Ticks;
+
+            using (var context = new BronieContext(serviceProvider, "CompositePegasuses"))
+            {
+                context.Database.EnsureCreated();
+
+                await context.AddAsync(new Pegasus { Id1 = ticks, Id2 = ticks + 1, Name = "Rainbow Dash" });
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new BronieContext(serviceProvider, "CompositePegasuses"))
+            {
+                var pegasus = context.Pegasuses.Single(e => e.Id1 == ticks && e.Id2 == ticks + 1);
+
+                pegasus.Name = "Rainbow Crash";
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new BronieContext(serviceProvider, "CompositePegasuses"))
+            {
+                var pegasus = context.Pegasuses.Single(e => e.Id1 == ticks && e.Id2 == ticks + 1);
+
+                Assert.Equal("Rainbow Crash", pegasus.Name);
+
+                context.Pegasuses.Remove(pegasus);
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new BronieContext(serviceProvider, "CompositePegasuses"))
+            {
+                Assert.Equal(0, context.Pegasuses.Count(e => e.Id1 == ticks && e.Id2 == ticks + 1));
+            }
+        }
+
+        [Fact]
+        public async Task Can_use_generated_values_in_composite_key_end_to_end()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFramework()
+                .AddSqlServer()
+                .ServiceCollection
+                .BuildServiceProvider();
+
+            long id1;
+            var id2 = DateTime.UtcNow.Ticks.ToString(CultureInfo.InvariantCulture);
+            Guid id3;
+
+            using (var context = new BronieContext(serviceProvider, "CompositeUnicorns"))
+            {
+                context.Database.EnsureCreated();
+
+                var added = await context.AddAsync(new Unicorn { Id2 = id2, Name = "Rarity" });
+
+                Assert.True(added.Id1 < 0);
+                Assert.NotEqual(Guid.Empty, added.Id3);
+
+                await context.SaveChangesAsync();
+
+                Assert.True(added.Id1 > 0);
+
+                id1 = added.Id1;
+                id3 = added.Id3;
+            }
+
+            using (var context = new BronieContext(serviceProvider, "CompositeUnicorns"))
+            {
+                Assert.Equal(1, context.Unicorns.Count(e => e.Id1 == id1 && e.Id2 == id2 && e.Id3 == id3));
+            }
+
+            using (var context = new BronieContext(serviceProvider, "CompositeUnicorns"))
+            {
+                var unicorn = context.Unicorns.Single(e => e.Id1 == id1 && e.Id2 == id2 && e.Id3 == id3);
+
+                unicorn.Name = "Bad Hair Day";
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new BronieContext(serviceProvider, "CompositeUnicorns"))
+            {
+                var unicorn = context.Unicorns.Single(e => e.Id1 == id1 && e.Id2 == id2 && e.Id3 == id3);
+
+                Assert.Equal("Bad Hair Day", unicorn.Name);
+
+                context.Unicorns.Remove(unicorn);
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new BronieContext(serviceProvider, "CompositeUnicorns"))
+            {
+                Assert.Equal(0, context.Unicorns.Count(e => e.Id1 == id1 && e.Id2 == id2 && e.Id3 == id3));
+            }
+        }
+
+        [Fact]
+        public async Task Only_one_part_of_a_composite_key_needs_to_vary_for_uniquness()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFramework()
+                .AddSqlServer()
+                .ServiceCollection
+                .BuildServiceProvider();
+
+            var ids = new int[3];
+
+            using (var context = new BronieContext(serviceProvider, "CompositeEarthPonies"))
+            {
+                context.Database.EnsureCreated();
+
+                var pony1 = await context.AddAsync(new EarthPony { Id2 = 7, Name = "Apple Jack 1" });
+                var pony2 = await context.AddAsync(new EarthPony { Id2 = 7, Name = "Apple Jack 2" });
+                var pony3 = await context.AddAsync(new EarthPony { Id2 = 7, Name = "Apple Jack 3" });
+
+                await context.SaveChangesAsync();
+
+                ids[0] = pony1.Id1;
+                ids[1] = pony2.Id1;
+                ids[2] = pony3.Id1;
+            }
+
+            using (var context = new BronieContext(serviceProvider, "CompositeEarthPonies"))
+            {
+                var ponies = context.EarthPonies.ToList();
+                Assert.Equal(ponies.Count, ponies.Count(e => e.Name == "Apple Jack 1") * 3);
+
+                Assert.Equal("Apple Jack 1", ponies.Single(e => e.Id1 == ids[0]).Name);
+                Assert.Equal("Apple Jack 2", ponies.Single(e => e.Id1 == ids[1]).Name);
+                Assert.Equal("Apple Jack 3", ponies.Single(e => e.Id1 == ids[2]).Name);
+
+                ponies.Single(e => e.Id1 == ids[1]).Name = "Pinky Pie 2";
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new BronieContext(serviceProvider, "CompositeEarthPonies"))
+            {
+                var ponies = context.EarthPonies.ToList();
+                Assert.Equal(ponies.Count, ponies.Count(e => e.Name == "Apple Jack 1") * 3);
+
+                Assert.Equal("Apple Jack 1", ponies.Single(e => e.Id1 == ids[0]).Name);
+                Assert.Equal("Pinky Pie 2", ponies.Single(e => e.Id1 == ids[1]).Name);
+                Assert.Equal("Apple Jack 3", ponies.Single(e => e.Id1 == ids[2]).Name);
+
+                context.EarthPonies.RemoveRange(ponies);
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new BronieContext(serviceProvider, "CompositeEarthPonies"))
+            {
+                Assert.Equal(0, context.EarthPonies.Count());
+            }
+        }
+
+        private class BronieContext : DbContext
+        {
+            private readonly string _databaseName;
+
+            public BronieContext(IServiceProvider serviceProvider, string databaseName)
+                : base(serviceProvider)
+            {
+                _databaseName = databaseName;
+            }
+
+            public DbSet<Pegasus> Pegasuses { get; set; }
+            public DbSet<Unicorn> Unicorns { get; set; }
+            public DbSet<EarthPony> EarthPonies { get; set; }
+
+            protected override void OnConfiguring(DbContextOptions builder)
+            {
+                builder.UseSqlServer(TestDatabase.CreateConnectionString(_databaseName));
+            }
+
+            protected override void OnModelCreating(ModelBuilder builder)
+            {
+                builder.Entity<Pegasus>().Key(e => new { e.Id1, e.Id2 });
+                builder.Entity<Unicorn>().Key(e => new { e.Id1, e.Id2, e.Id3 });
+                builder.Entity<EarthPony>().Key(e => new { e.Id1, e.Id2 });
+
+                var unicornType = builder.Model.GetEntityType(typeof(Unicorn));
+
+                var id1 = unicornType.GetProperty("Id1");
+                id1.ValueGenerationOnAdd = ValueGenerationOnAdd.Client;
+                id1.ValueGenerationOnSave = ValueGenerationOnSave.WhenInserting;
+
+                var id3 = unicornType.GetProperty("Id3");
+                id3.ValueGenerationOnAdd = ValueGenerationOnAdd.Client;
+
+                var earthType = builder.Model.GetEntityType(typeof(EarthPony));
+
+                var id = earthType.GetProperty("Id1");
+                id.ValueGenerationOnAdd = ValueGenerationOnAdd.Client;
+                id.ValueGenerationOnSave = ValueGenerationOnSave.WhenInserting;
+            }
+        }
+
+        private class Pegasus
+        {
+            public long Id1 { get; set; }
+            public long Id2 { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class Unicorn
+        {
+            public int Id1 { get; set; }
+            public string Id2 { get; set; }
+            public Guid Id3 { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class EarthPony
+        {
+            public int Id1 { get; set; }
+            public int Id2 { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}

--- a/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/Microsoft.Data.Entity.SqlServer.FunctionalTests.csproj
+++ b/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/Microsoft.Data.Entity.SqlServer.FunctionalTests.csproj
@@ -69,6 +69,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ConnectionStringTest.cs" />
+    <Compile Include="CompositeKeyEndToEndTest.cs" />
     <Compile Include="ExistingConnectionTest.cs" />
     <Compile Include="NorthwindQueryTest.cs" />
     <Compile Include="SequenceEndToEndTest.cs" />

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/MixedStateEntryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/MixedStateEntryTest.cs
@@ -127,10 +127,14 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var entityType2 = new EntityType(typeof(SomeDependentEntity));
             model.AddEntityType(entityType2);
-            var key2 = entityType2.AddProperty("Id", typeof(int));
-            entityType2.SetKey(key2);
+            var key2a = entityType2.AddProperty("Id1", typeof(int));
+            var key2b = entityType2.AddProperty("Id2", typeof(string));
+            entityType2.SetKey(key2a, key2b);
             var fk = entityType2.AddProperty("SomeEntityId", typeof(int), shadowProperty: true, concurrencyToken: false);
             entityType2.AddForeignKey(entityType1.GetKey(), new[] { fk });
+            var justAProperty = entityType2.AddProperty("JustAProperty", typeof(int));
+            justAProperty.ValueGenerationOnSave = ValueGenerationOnSave.WhenInserting;
+            justAProperty.ValueGenerationOnAdd = ValueGenerationOnAdd.Client;
 
             var entityType3 = new EntityType(typeof(FullNotificationEntity));
             model.AddEntityType(entityType3);
@@ -141,6 +145,14 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             model.AddEntityType(entityType4);
             entityType4.SetKey(entityType4.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
             entityType4.AddProperty("Name", typeof(string), shadowProperty: false, concurrencyToken: true);
+
+            var entityType5 = new EntityType(typeof(SomeMoreDependentEntity));
+            model.AddEntityType(entityType5);
+            var key5 = entityType5.AddProperty("Id", typeof(int));
+            entityType5.SetKey(key5);
+            var fk5a = entityType5.AddProperty("Fk1", typeof(int));
+            var fk5b = entityType5.AddProperty("Fk2", typeof(string));
+            entityType5.AddForeignKey(entityType2.GetKey(), new[] { fk5a, fk5b });
 
             return model;
         }

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/ShadowStateEntryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/ShadowStateEntryTest.cs
@@ -53,10 +53,14 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var entityType2 = new EntityType("SomeDependentEntity");
             model.AddEntityType(entityType2);
-            var key2 = entityType2.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false);
-            entityType2.SetKey(key2);
+            var key2a = entityType2.AddProperty("Id1", typeof(int), shadowProperty: true, concurrencyToken: false);
+            var key2b = entityType2.AddProperty("Id2", typeof(string), shadowProperty: true, concurrencyToken: false);
+            entityType2.SetKey(key2a, key2b);
             var fk = entityType2.AddProperty("SomeEntityId", typeof(int), shadowProperty: true, concurrencyToken: false);
             entityType2.AddForeignKey(entityType1.GetKey(), new[] { fk });
+            var justAProperty = entityType2.AddProperty("JustAProperty", typeof(int), shadowProperty: true, concurrencyToken: false);
+            justAProperty.ValueGenerationOnSave = ValueGenerationOnSave.WhenInserting;
+            justAProperty.ValueGenerationOnAdd = ValueGenerationOnAdd.Client;
 
             var entityType3 = new EntityType(typeof(FullNotificationEntity));
             model.AddEntityType(entityType3);
@@ -67,6 +71,14 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             model.AddEntityType(entityType4);
             entityType4.SetKey(entityType4.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
             entityType4.AddProperty("Name", typeof(string), shadowProperty: true, concurrencyToken: true);
+
+            var entityType5 = new EntityType("SomeMoreDependentEntity");
+            model.AddEntityType(entityType5);
+            var key5 = entityType5.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false);
+            entityType5.SetKey(key5);
+            var fk5a = entityType5.AddProperty("Fk1", typeof(int), shadowProperty: true, concurrencyToken: false);
+            var fk5b = entityType5.AddProperty("Fk2", typeof(string), shadowProperty: true, concurrencyToken: false);
+            entityType5.AddForeignKey(entityType2.GetKey(), new[] { fk5a, fk5b });
 
             return model;
         }

--- a/test/Shared/Northwind.cs
+++ b/test/Shared/Northwind.cs
@@ -16937,22 +16937,7 @@ Winchester Way",
 
         public static readonly OrderDetail[] OrderDetails =
             {
-                new OrderDetail
-                    {
-                        OrderID = 10248,
-                        ProductID = 11,
-                        UnitPrice = 14.0000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10248,
-                        ProductID = 11,
-                        UnitPrice = 14.0000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
+
                 new OrderDetail
                     {
                         OrderID = 10248,
@@ -16971,30 +16956,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10249,
-                        ProductID = 14,
-                        UnitPrice = 18.6000m,
-                        Quantity = 9,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10250,
-                        ProductID = 41,
-                        UnitPrice = 7.7000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10250,
-                        ProductID = 41,
-                        UnitPrice = 7.7000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10250,
                         ProductID = 41,
                         UnitPrice = 7.7000m,
@@ -17007,38 +16968,6 @@ Winchester Way",
                         ProductID = 22,
                         UnitPrice = 16.8000m,
                         Quantity = 6,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10251,
-                        ProductID = 22,
-                        UnitPrice = 16.8000m,
-                        Quantity = 6,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10251,
-                        ProductID = 22,
-                        UnitPrice = 16.8000m,
-                        Quantity = 6,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10252,
-                        ProductID = 20,
-                        UnitPrice = 64.8000m,
-                        Quantity = 40,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10252,
-                        ProductID = 20,
-                        UnitPrice = 64.8000m,
-                        Quantity = 40,
                         Discount = 0.05f
                     },
                 new OrderDetail
@@ -17059,38 +16988,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10253,
-                        ProductID = 31,
-                        UnitPrice = 10.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10253,
-                        ProductID = 31,
-                        UnitPrice = 10.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10254,
-                        ProductID = 24,
-                        UnitPrice = 3.6000m,
-                        Quantity = 15,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10254,
-                        ProductID = 24,
-                        UnitPrice = 3.6000m,
-                        Quantity = 15,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10254,
                         ProductID = 24,
                         UnitPrice = 3.6000m,
@@ -17103,38 +17000,6 @@ Winchester Way",
                         ProductID = 2,
                         UnitPrice = 15.2000m,
                         Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10255,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10255,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10255,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10256,
-                        ProductID = 53,
-                        UnitPrice = 26.2000m,
-                        Quantity = 15,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -17155,38 +17020,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10257,
-                        ProductID = 27,
-                        UnitPrice = 35.1000m,
-                        Quantity = 25,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10257,
-                        ProductID = 27,
-                        UnitPrice = 35.1000m,
-                        Quantity = 25,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10258,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 50,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10258,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 50,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10258,
                         ProductID = 2,
                         UnitPrice = 15.2000m,
@@ -17200,38 +17033,6 @@ Winchester Way",
                         UnitPrice = 8.0000m,
                         Quantity = 10,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10259,
-                        ProductID = 21,
-                        UnitPrice = 8.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10260,
-                        ProductID = 41,
-                        UnitPrice = 7.7000m,
-                        Quantity = 16,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10260,
-                        ProductID = 41,
-                        UnitPrice = 7.7000m,
-                        Quantity = 16,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10260,
-                        ProductID = 41,
-                        UnitPrice = 7.7000m,
-                        Quantity = 16,
-                        Discount = 0.25f
                     },
                 new OrderDetail
                     {
@@ -17251,59 +17052,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10261,
-                        ProductID = 21,
-                        UnitPrice = 8.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10262,
                         ProductID = 5,
                         UnitPrice = 17.0000m,
                         Quantity = 12,
                         Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10262,
-                        ProductID = 5,
-                        UnitPrice = 17.0000m,
-                        Quantity = 12,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10262,
-                        ProductID = 5,
-                        UnitPrice = 17.0000m,
-                        Quantity = 12,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10263,
-                        ProductID = 16,
-                        UnitPrice = 13.9000m,
-                        Quantity = 60,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10263,
-                        ProductID = 16,
-                        UnitPrice = 13.9000m,
-                        Quantity = 60,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10263,
-                        ProductID = 16,
-                        UnitPrice = 13.9000m,
-                        Quantity = 60,
-                        Discount = 0.25f
                     },
                 new OrderDetail
                     {
@@ -17319,22 +17072,6 @@ Winchester Way",
                         ProductID = 2,
                         UnitPrice = 15.2000m,
                         Quantity = 35,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10264,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 35,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10265,
-                        ProductID = 17,
-                        UnitPrice = 31.2000m,
-                        Quantity = 30,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -17363,30 +17100,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10267,
-                        ProductID = 40,
-                        UnitPrice = 14.7000m,
-                        Quantity = 50,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10267,
-                        ProductID = 40,
-                        UnitPrice = 14.7000m,
-                        Quantity = 50,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10268,
-                        ProductID = 29,
-                        UnitPrice = 99.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10268,
                         ProductID = 29,
                         UnitPrice = 99.0000m,
@@ -17400,22 +17113,6 @@ Winchester Way",
                         UnitPrice = 2.0000m,
                         Quantity = 60,
                         Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10269,
-                        ProductID = 33,
-                        UnitPrice = 2.0000m,
-                        Quantity = 60,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10270,
-                        ProductID = 36,
-                        UnitPrice = 15.2000m,
-                        Quantity = 30,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -17443,67 +17140,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10272,
-                        ProductID = 20,
-                        UnitPrice = 64.8000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10272,
-                        ProductID = 20,
-                        UnitPrice = 64.8000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10273,
                         ProductID = 10,
                         UnitPrice = 24.8000m,
                         Quantity = 24,
                         Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10273,
-                        ProductID = 10,
-                        UnitPrice = 24.8000m,
-                        Quantity = 24,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10273,
-                        ProductID = 10,
-                        UnitPrice = 24.8000m,
-                        Quantity = 24,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10273,
-                        ProductID = 10,
-                        UnitPrice = 24.8000m,
-                        Quantity = 24,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10273,
-                        ProductID = 10,
-                        UnitPrice = 24.8000m,
-                        Quantity = 24,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10274,
-                        ProductID = 71,
-                        UnitPrice = 17.2000m,
-                        Quantity = 20,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -17523,22 +17164,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10275,
-                        ProductID = 24,
-                        UnitPrice = 3.6000m,
-                        Quantity = 12,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10276,
-                        ProductID = 10,
-                        UnitPrice = 24.8000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10276,
                         ProductID = 10,
                         UnitPrice = 24.8000m,
@@ -17551,38 +17176,6 @@ Winchester Way",
                         ProductID = 28,
                         UnitPrice = 36.4000m,
                         Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10277,
-                        ProductID = 28,
-                        UnitPrice = 36.4000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10278,
-                        ProductID = 44,
-                        UnitPrice = 15.5000m,
-                        Quantity = 16,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10278,
-                        ProductID = 44,
-                        UnitPrice = 15.5000m,
-                        Quantity = 16,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10278,
-                        ProductID = 44,
-                        UnitPrice = 15.5000m,
-                        Quantity = 16,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -17611,38 +17204,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10280,
-                        ProductID = 24,
-                        UnitPrice = 3.6000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10280,
-                        ProductID = 24,
-                        UnitPrice = 3.6000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10281,
-                        ProductID = 19,
-                        UnitPrice = 7.3000m,
-                        Quantity = 1,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10281,
-                        ProductID = 19,
-                        UnitPrice = 7.3000m,
-                        Quantity = 1,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10281,
                         ProductID = 19,
                         UnitPrice = 7.3000m,
@@ -17659,38 +17220,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10282,
-                        ProductID = 30,
-                        UnitPrice = 20.7000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10283,
-                        ProductID = 15,
-                        UnitPrice = 12.4000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10283,
-                        ProductID = 15,
-                        UnitPrice = 12.4000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10283,
-                        ProductID = 15,
-                        UnitPrice = 12.4000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10283,
                         ProductID = 15,
                         UnitPrice = 12.4000m,
@@ -17704,46 +17233,6 @@ Winchester Way",
                         UnitPrice = 35.1000m,
                         Quantity = 15,
                         Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10284,
-                        ProductID = 27,
-                        UnitPrice = 35.1000m,
-                        Quantity = 15,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10284,
-                        ProductID = 27,
-                        UnitPrice = 35.1000m,
-                        Quantity = 15,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10284,
-                        ProductID = 27,
-                        UnitPrice = 35.1000m,
-                        Quantity = 15,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10285,
-                        ProductID = 1,
-                        UnitPrice = 14.4000m,
-                        Quantity = 45,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10285,
-                        ProductID = 1,
-                        UnitPrice = 14.4000m,
-                        Quantity = 45,
-                        Discount = 0.2f
                     },
                 new OrderDetail
                     {
@@ -17763,43 +17252,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10286,
-                        ProductID = 35,
-                        UnitPrice = 14.4000m,
-                        Quantity = 100,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10287,
                         ProductID = 16,
                         UnitPrice = 13.9000m,
                         Quantity = 40,
                         Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10287,
-                        ProductID = 16,
-                        UnitPrice = 13.9000m,
-                        Quantity = 40,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10287,
-                        ProductID = 16,
-                        UnitPrice = 13.9000m,
-                        Quantity = 40,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10288,
-                        ProductID = 54,
-                        UnitPrice = 5.9000m,
-                        Quantity = 10,
-                        Discount = 0.1f
                     },
                 new OrderDetail
                     {
@@ -17819,59 +17276,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10289,
-                        ProductID = 3,
-                        UnitPrice = 8.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10290,
                         ProductID = 5,
                         UnitPrice = 17.0000m,
                         Quantity = 20,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10290,
-                        ProductID = 5,
-                        UnitPrice = 17.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10290,
-                        ProductID = 5,
-                        UnitPrice = 17.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10290,
-                        ProductID = 5,
-                        UnitPrice = 17.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10291,
-                        ProductID = 13,
-                        UnitPrice = 4.8000m,
-                        Quantity = 20,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10291,
-                        ProductID = 13,
-                        UnitPrice = 4.8000m,
-                        Quantity = 20,
-                        Discount = 0.1f
                     },
                 new OrderDetail
                     {
@@ -17895,62 +17304,6 @@ Winchester Way",
                         ProductID = 18,
                         UnitPrice = 50.0000m,
                         Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10293,
-                        ProductID = 18,
-                        UnitPrice = 50.0000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10293,
-                        ProductID = 18,
-                        UnitPrice = 50.0000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10293,
-                        ProductID = 18,
-                        UnitPrice = 50.0000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10294,
-                        ProductID = 1,
-                        UnitPrice = 14.4000m,
-                        Quantity = 18,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10294,
-                        ProductID = 1,
-                        UnitPrice = 14.4000m,
-                        Quantity = 18,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10294,
-                        ProductID = 1,
-                        UnitPrice = 14.4000m,
-                        Quantity = 18,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10294,
-                        ProductID = 1,
-                        UnitPrice = 14.4000m,
-                        Quantity = 18,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -17979,58 +17332,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10296,
-                        ProductID = 11,
-                        UnitPrice = 16.8000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10296,
-                        ProductID = 11,
-                        UnitPrice = 16.8000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10297,
                         ProductID = 39,
                         UnitPrice = 14.4000m,
                         Quantity = 60,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10297,
-                        ProductID = 39,
-                        UnitPrice = 14.4000m,
-                        Quantity = 60,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10298,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10298,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10298,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 40,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -18051,22 +17356,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10299,
-                        ProductID = 19,
-                        UnitPrice = 7.3000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10300,
-                        ProductID = 66,
-                        UnitPrice = 13.6000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10300,
                         ProductID = 66,
                         UnitPrice = 13.6000m,
@@ -18083,51 +17372,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10301,
-                        ProductID = 40,
-                        UnitPrice = 14.7000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10302,
                         ProductID = 17,
                         UnitPrice = 31.2000m,
                         Quantity = 40,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10302,
-                        ProductID = 17,
-                        UnitPrice = 31.2000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10302,
-                        ProductID = 17,
-                        UnitPrice = 31.2000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10303,
-                        ProductID = 40,
-                        UnitPrice = 14.7000m,
-                        Quantity = 40,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10303,
-                        ProductID = 40,
-                        UnitPrice = 14.7000m,
-                        Quantity = 40,
-                        Discount = 0.1f
                     },
                 new OrderDetail
                     {
@@ -18147,38 +17396,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10304,
-                        ProductID = 49,
-                        UnitPrice = 16.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10304,
-                        ProductID = 49,
-                        UnitPrice = 16.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10305,
-                        ProductID = 18,
-                        UnitPrice = 50.0000m,
-                        Quantity = 25,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10305,
-                        ProductID = 18,
-                        UnitPrice = 50.0000m,
-                        Quantity = 25,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10305,
                         ProductID = 18,
                         UnitPrice = 50.0000m,
@@ -18190,30 +17407,6 @@ Winchester Way",
                         OrderID = 10306,
                         ProductID = 30,
                         UnitPrice = 20.7000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10306,
-                        ProductID = 30,
-                        UnitPrice = 20.7000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10306,
-                        ProductID = 30,
-                        UnitPrice = 20.7000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10307,
-                        ProductID = 62,
-                        UnitPrice = 39.4000m,
                         Quantity = 10,
                         Discount = 0f
                     },
@@ -18235,46 +17428,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10308,
-                        ProductID = 69,
-                        UnitPrice = 28.8000m,
-                        Quantity = 1,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10309,
-                        ProductID = 4,
-                        UnitPrice = 17.6000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10309,
-                        ProductID = 4,
-                        UnitPrice = 17.6000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10309,
-                        ProductID = 4,
-                        UnitPrice = 17.6000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10309,
-                        ProductID = 4,
-                        UnitPrice = 17.6000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10309,
                         ProductID = 4,
                         UnitPrice = 17.6000m,
@@ -18291,50 +17444,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10310,
-                        ProductID = 16,
-                        UnitPrice = 13.9000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10311,
                         ProductID = 42,
                         UnitPrice = 11.2000m,
                         Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10311,
-                        ProductID = 42,
-                        UnitPrice = 11.2000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10312,
-                        ProductID = 28,
-                        UnitPrice = 36.4000m,
-                        Quantity = 4,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10312,
-                        ProductID = 28,
-                        UnitPrice = 36.4000m,
-                        Quantity = 4,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10312,
-                        ProductID = 28,
-                        UnitPrice = 36.4000m,
-                        Quantity = 4,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -18363,42 +17476,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10314,
-                        ProductID = 32,
-                        UnitPrice = 25.6000m,
-                        Quantity = 40,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10314,
-                        ProductID = 32,
-                        UnitPrice = 25.6000m,
-                        Quantity = 40,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10315,
                         ProductID = 34,
                         UnitPrice = 11.2000m,
                         Quantity = 14,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10315,
-                        ProductID = 34,
-                        UnitPrice = 11.2000m,
-                        Quantity = 14,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10316,
-                        ProductID = 41,
-                        UnitPrice = 7.7000m,
-                        Quantity = 10,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -18423,30 +17504,6 @@ Winchester Way",
                         ProductID = 41,
                         UnitPrice = 7.7000m,
                         Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10318,
-                        ProductID = 41,
-                        UnitPrice = 7.7000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10319,
-                        ProductID = 17,
-                        UnitPrice = 31.2000m,
-                        Quantity = 8,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10319,
-                        ProductID = 17,
-                        UnitPrice = 31.2000m,
-                        Quantity = 8,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -18491,54 +17548,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10323,
-                        ProductID = 15,
-                        UnitPrice = 12.4000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10323,
-                        ProductID = 15,
-                        UnitPrice = 12.4000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10324,
-                        ProductID = 16,
-                        UnitPrice = 13.9000m,
-                        Quantity = 21,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10324,
-                        ProductID = 16,
-                        UnitPrice = 13.9000m,
-                        Quantity = 21,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10324,
-                        ProductID = 16,
-                        UnitPrice = 13.9000m,
-                        Quantity = 21,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10324,
-                        ProductID = 16,
-                        UnitPrice = 13.9000m,
-                        Quantity = 21,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10324,
                         ProductID = 16,
                         UnitPrice = 13.9000m,
@@ -18551,54 +17560,6 @@ Winchester Way",
                         ProductID = 6,
                         UnitPrice = 20.0000m,
                         Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10325,
-                        ProductID = 6,
-                        UnitPrice = 20.0000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10325,
-                        ProductID = 6,
-                        UnitPrice = 20.0000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10325,
-                        ProductID = 6,
-                        UnitPrice = 20.0000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10325,
-                        ProductID = 6,
-                        UnitPrice = 20.0000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10326,
-                        ProductID = 4,
-                        UnitPrice = 17.6000m,
-                        Quantity = 24,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10326,
-                        ProductID = 4,
-                        UnitPrice = 17.6000m,
-                        Quantity = 24,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -18619,46 +17580,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10327,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 25,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10327,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 25,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10327,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 25,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10328,
-                        ProductID = 59,
-                        UnitPrice = 44.0000m,
-                        Quantity = 9,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10328,
-                        ProductID = 59,
-                        UnitPrice = 44.0000m,
-                        Quantity = 9,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10328,
                         ProductID = 59,
                         UnitPrice = 44.0000m,
@@ -18672,38 +17593,6 @@ Winchester Way",
                         UnitPrice = 7.3000m,
                         Quantity = 10,
                         Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10329,
-                        ProductID = 19,
-                        UnitPrice = 7.3000m,
-                        Quantity = 10,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10329,
-                        ProductID = 19,
-                        UnitPrice = 7.3000m,
-                        Quantity = 10,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10329,
-                        ProductID = 19,
-                        UnitPrice = 7.3000m,
-                        Quantity = 10,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10330,
-                        ProductID = 26,
-                        UnitPrice = 24.9000m,
-                        Quantity = 50,
-                        Discount = 0.15f
                     },
                 new OrderDetail
                     {
@@ -18731,38 +17620,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10332,
-                        ProductID = 18,
-                        UnitPrice = 50.0000m,
-                        Quantity = 40,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10332,
-                        ProductID = 18,
-                        UnitPrice = 50.0000m,
-                        Quantity = 40,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10333,
-                        ProductID = 14,
-                        UnitPrice = 18.6000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10333,
-                        ProductID = 14,
-                        UnitPrice = 18.6000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10333,
                         ProductID = 14,
                         UnitPrice = 18.6000m,
@@ -18776,38 +17633,6 @@ Winchester Way",
                         UnitPrice = 5.6000m,
                         Quantity = 8,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10334,
-                        ProductID = 52,
-                        UnitPrice = 5.6000m,
-                        Quantity = 8,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10335,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 7,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10335,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 7,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10335,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 7,
-                        Discount = 0.2f
                     },
                 new OrderDetail
                     {
@@ -18835,46 +17660,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10337,
-                        ProductID = 23,
-                        UnitPrice = 7.2000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10337,
-                        ProductID = 23,
-                        UnitPrice = 7.2000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10337,
-                        ProductID = 23,
-                        UnitPrice = 7.2000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10337,
-                        ProductID = 23,
-                        UnitPrice = 7.2000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10338,
-                        ProductID = 17,
-                        UnitPrice = 31.2000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10338,
                         ProductID = 17,
                         UnitPrice = 31.2000m,
@@ -18888,38 +17673,6 @@ Winchester Way",
                         UnitPrice = 17.6000m,
                         Quantity = 10,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10339,
-                        ProductID = 4,
-                        UnitPrice = 17.6000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10339,
-                        ProductID = 4,
-                        UnitPrice = 17.6000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10340,
-                        ProductID = 18,
-                        UnitPrice = 50.0000m,
-                        Quantity = 20,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10340,
-                        ProductID = 18,
-                        UnitPrice = 50.0000m,
-                        Quantity = 20,
-                        Discount = 0.05f
                     },
                 new OrderDetail
                     {
@@ -18939,38 +17692,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10341,
-                        ProductID = 33,
-                        UnitPrice = 2.0000m,
-                        Quantity = 8,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10342,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10342,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10342,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10342,
                         ProductID = 2,
                         UnitPrice = 15.2000m,
@@ -18983,30 +17704,6 @@ Winchester Way",
                         ProductID = 64,
                         UnitPrice = 26.6000m,
                         Quantity = 50,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10343,
-                        ProductID = 64,
-                        UnitPrice = 26.6000m,
-                        Quantity = 50,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10343,
-                        ProductID = 64,
-                        UnitPrice = 26.6000m,
-                        Quantity = 50,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10344,
-                        ProductID = 4,
-                        UnitPrice = 17.6000m,
-                        Quantity = 35,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -19027,30 +17724,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10345,
-                        ProductID = 8,
-                        UnitPrice = 32.0000m,
-                        Quantity = 70,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10345,
-                        ProductID = 8,
-                        UnitPrice = 32.0000m,
-                        Quantity = 70,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10346,
-                        ProductID = 17,
-                        UnitPrice = 31.2000m,
-                        Quantity = 36,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10346,
                         ProductID = 17,
                         UnitPrice = 31.2000m,
@@ -19064,38 +17737,6 @@ Winchester Way",
                         UnitPrice = 11.2000m,
                         Quantity = 10,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10347,
-                        ProductID = 25,
-                        UnitPrice = 11.2000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10347,
-                        ProductID = 25,
-                        UnitPrice = 11.2000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10347,
-                        ProductID = 25,
-                        UnitPrice = 11.2000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10348,
-                        ProductID = 1,
-                        UnitPrice = 14.4000m,
-                        Quantity = 15,
-                        Discount = 0.15f
                     },
                 new OrderDetail
                     {
@@ -19123,51 +17764,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10350,
-                        ProductID = 50,
-                        UnitPrice = 13.0000m,
-                        Quantity = 15,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10351,
                         ProductID = 38,
                         UnitPrice = 210.8000m,
                         Quantity = 20,
                         Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10351,
-                        ProductID = 38,
-                        UnitPrice = 210.8000m,
-                        Quantity = 20,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10351,
-                        ProductID = 38,
-                        UnitPrice = 210.8000m,
-                        Quantity = 20,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10351,
-                        ProductID = 38,
-                        UnitPrice = 210.8000m,
-                        Quantity = 20,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10352,
-                        ProductID = 24,
-                        UnitPrice = 3.6000m,
-                        Quantity = 10,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -19187,34 +17788,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10353,
-                        ProductID = 11,
-                        UnitPrice = 16.8000m,
-                        Quantity = 12,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10354,
                         ProductID = 1,
                         UnitPrice = 14.4000m,
                         Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10354,
-                        ProductID = 1,
-                        UnitPrice = 14.4000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10355,
-                        ProductID = 24,
-                        UnitPrice = 3.6000m,
-                        Quantity = 25,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -19235,38 +17812,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10356,
-                        ProductID = 31,
-                        UnitPrice = 10.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10356,
-                        ProductID = 31,
-                        UnitPrice = 10.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10357,
-                        ProductID = 10,
-                        UnitPrice = 24.8000m,
-                        Quantity = 30,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10357,
-                        ProductID = 10,
-                        UnitPrice = 24.8000m,
-                        Quantity = 30,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10357,
                         ProductID = 10,
                         UnitPrice = 24.8000m,
@@ -19283,75 +17828,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10358,
-                        ProductID = 24,
-                        UnitPrice = 3.6000m,
-                        Quantity = 10,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10358,
-                        ProductID = 24,
-                        UnitPrice = 3.6000m,
-                        Quantity = 10,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10359,
                         ProductID = 16,
                         UnitPrice = 13.9000m,
                         Quantity = 56,
                         Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10359,
-                        ProductID = 16,
-                        UnitPrice = 13.9000m,
-                        Quantity = 56,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10359,
-                        ProductID = 16,
-                        UnitPrice = 13.9000m,
-                        Quantity = 56,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10360,
-                        ProductID = 28,
-                        UnitPrice = 36.4000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10360,
-                        ProductID = 28,
-                        UnitPrice = 36.4000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10360,
-                        ProductID = 28,
-                        UnitPrice = 36.4000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10360,
-                        ProductID = 28,
-                        UnitPrice = 36.4000m,
-                        Quantity = 30,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -19371,30 +17852,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10361,
-                        ProductID = 39,
-                        UnitPrice = 14.4000m,
-                        Quantity = 54,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10362,
-                        ProductID = 25,
-                        UnitPrice = 11.2000m,
-                        Quantity = 50,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10362,
-                        ProductID = 25,
-                        UnitPrice = 11.2000m,
-                        Quantity = 50,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10362,
                         ProductID = 25,
                         UnitPrice = 11.2000m,
@@ -19407,30 +17864,6 @@ Winchester Way",
                         ProductID = 31,
                         UnitPrice = 10.0000m,
                         Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10363,
-                        ProductID = 31,
-                        UnitPrice = 10.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10363,
-                        ProductID = 31,
-                        UnitPrice = 10.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10364,
-                        ProductID = 69,
-                        UnitPrice = 28.8000m,
-                        Quantity = 30,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -19459,67 +17892,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10366,
-                        ProductID = 65,
-                        UnitPrice = 16.8000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10367,
                         ProductID = 34,
                         UnitPrice = 11.2000m,
                         Quantity = 36,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10367,
-                        ProductID = 34,
-                        UnitPrice = 11.2000m,
-                        Quantity = 36,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10367,
-                        ProductID = 34,
-                        UnitPrice = 11.2000m,
-                        Quantity = 36,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10367,
-                        ProductID = 34,
-                        UnitPrice = 11.2000m,
-                        Quantity = 36,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10368,
-                        ProductID = 21,
-                        UnitPrice = 8.0000m,
-                        Quantity = 5,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10368,
-                        ProductID = 21,
-                        UnitPrice = 8.0000m,
-                        Quantity = 5,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10368,
-                        ProductID = 21,
-                        UnitPrice = 8.0000m,
-                        Quantity = 5,
-                        Discount = 0.1f
                     },
                 new OrderDetail
                     {
@@ -19536,30 +17913,6 @@ Winchester Way",
                         UnitPrice = 99.0000m,
                         Quantity = 20,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10369,
-                        ProductID = 29,
-                        UnitPrice = 99.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10370,
-                        ProductID = 1,
-                        UnitPrice = 14.4000m,
-                        Quantity = 15,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10370,
-                        ProductID = 1,
-                        UnitPrice = 14.4000m,
-                        Quantity = 15,
-                        Discount = 0.15f
                     },
                 new OrderDetail
                     {
@@ -19587,38 +17940,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10372,
-                        ProductID = 20,
-                        UnitPrice = 64.8000m,
-                        Quantity = 12,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10372,
-                        ProductID = 20,
-                        UnitPrice = 64.8000m,
-                        Quantity = 12,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10372,
-                        ProductID = 20,
-                        UnitPrice = 64.8000m,
-                        Quantity = 12,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10373,
-                        ProductID = 58,
-                        UnitPrice = 10.6000m,
-                        Quantity = 80,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10373,
                         ProductID = 58,
                         UnitPrice = 10.6000m,
@@ -19631,22 +17952,6 @@ Winchester Way",
                         ProductID = 31,
                         UnitPrice = 10.0000m,
                         Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10374,
-                        ProductID = 31,
-                        UnitPrice = 10.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10375,
-                        ProductID = 14,
-                        UnitPrice = 18.6000m,
-                        Quantity = 15,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -19675,14 +17980,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10377,
-                        ProductID = 28,
-                        UnitPrice = 36.4000m,
-                        Quantity = 20,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10378,
                         ProductID = 71,
                         UnitPrice = 17.2000m,
@@ -19695,46 +17992,6 @@ Winchester Way",
                         ProductID = 41,
                         UnitPrice = 7.7000m,
                         Quantity = 8,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10379,
-                        ProductID = 41,
-                        UnitPrice = 7.7000m,
-                        Quantity = 8,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10379,
-                        ProductID = 41,
-                        UnitPrice = 7.7000m,
-                        Quantity = 8,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10380,
-                        ProductID = 30,
-                        UnitPrice = 20.7000m,
-                        Quantity = 18,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10380,
-                        ProductID = 30,
-                        UnitPrice = 20.7000m,
-                        Quantity = 18,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10380,
-                        ProductID = 30,
-                        UnitPrice = 20.7000m,
-                        Quantity = 18,
                         Discount = 0.1f
                     },
                 new OrderDetail
@@ -19763,54 +18020,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10382,
-                        ProductID = 5,
-                        UnitPrice = 17.0000m,
-                        Quantity = 32,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10382,
-                        ProductID = 5,
-                        UnitPrice = 17.0000m,
-                        Quantity = 32,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10382,
-                        ProductID = 5,
-                        UnitPrice = 17.0000m,
-                        Quantity = 32,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10382,
-                        ProductID = 5,
-                        UnitPrice = 17.0000m,
-                        Quantity = 32,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10383,
-                        ProductID = 13,
-                        UnitPrice = 4.8000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10383,
-                        ProductID = 13,
-                        UnitPrice = 4.8000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10383,
                         ProductID = 13,
                         UnitPrice = 4.8000m,
@@ -19824,30 +18033,6 @@ Winchester Way",
                         UnitPrice = 64.8000m,
                         Quantity = 28,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10384,
-                        ProductID = 20,
-                        UnitPrice = 64.8000m,
-                        Quantity = 28,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10385,
-                        ProductID = 7,
-                        UnitPrice = 24.0000m,
-                        Quantity = 10,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10385,
-                        ProductID = 7,
-                        UnitPrice = 24.0000m,
-                        Quantity = 10,
-                        Discount = 0.2f
                     },
                 new OrderDetail
                     {
@@ -19867,38 +18052,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10386,
-                        ProductID = 24,
-                        UnitPrice = 3.6000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10387,
-                        ProductID = 24,
-                        UnitPrice = 3.6000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10387,
-                        ProductID = 24,
-                        UnitPrice = 3.6000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10387,
-                        ProductID = 24,
-                        UnitPrice = 3.6000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10387,
                         ProductID = 24,
                         UnitPrice = 3.6000m,
@@ -19915,75 +18068,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10388,
-                        ProductID = 45,
-                        UnitPrice = 7.6000m,
-                        Quantity = 15,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10388,
-                        ProductID = 45,
-                        UnitPrice = 7.6000m,
-                        Quantity = 15,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10389,
                         ProductID = 10,
                         UnitPrice = 24.8000m,
                         Quantity = 16,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10389,
-                        ProductID = 10,
-                        UnitPrice = 24.8000m,
-                        Quantity = 16,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10389,
-                        ProductID = 10,
-                        UnitPrice = 24.8000m,
-                        Quantity = 16,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10389,
-                        ProductID = 10,
-                        UnitPrice = 24.8000m,
-                        Quantity = 16,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10390,
-                        ProductID = 31,
-                        UnitPrice = 10.0000m,
-                        Quantity = 60,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10390,
-                        ProductID = 31,
-                        UnitPrice = 10.0000m,
-                        Quantity = 60,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10390,
-                        ProductID = 31,
-                        UnitPrice = 10.0000m,
-                        Quantity = 60,
-                        Discount = 0.1f
                     },
                 new OrderDetail
                     {
@@ -20019,46 +18108,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10393,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 25,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10393,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 25,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10393,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 25,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10393,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 25,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10394,
-                        ProductID = 13,
-                        UnitPrice = 4.8000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10394,
                         ProductID = 13,
                         UnitPrice = 4.8000m,
@@ -20072,38 +18121,6 @@ Winchester Way",
                         UnitPrice = 9.6000m,
                         Quantity = 28,
                         Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10395,
-                        ProductID = 46,
-                        UnitPrice = 9.6000m,
-                        Quantity = 28,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10395,
-                        ProductID = 46,
-                        UnitPrice = 9.6000m,
-                        Quantity = 28,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10396,
-                        ProductID = 23,
-                        UnitPrice = 7.2000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10396,
-                        ProductID = 23,
-                        UnitPrice = 7.2000m,
-                        Quantity = 40,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -20123,22 +18140,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10397,
-                        ProductID = 21,
-                        UnitPrice = 8.0000m,
-                        Quantity = 10,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10398,
-                        ProductID = 35,
-                        UnitPrice = 14.4000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10398,
                         ProductID = 35,
                         UnitPrice = 14.4000m,
@@ -20155,74 +18156,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10399,
-                        ProductID = 68,
-                        UnitPrice = 10.0000m,
-                        Quantity = 60,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10399,
-                        ProductID = 68,
-                        UnitPrice = 10.0000m,
-                        Quantity = 60,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10399,
-                        ProductID = 68,
-                        UnitPrice = 10.0000m,
-                        Quantity = 60,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10400,
                         ProductID = 29,
                         UnitPrice = 99.0000m,
                         Quantity = 21,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10400,
-                        ProductID = 29,
-                        UnitPrice = 99.0000m,
-                        Quantity = 21,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10400,
-                        ProductID = 29,
-                        UnitPrice = 99.0000m,
-                        Quantity = 21,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10401,
-                        ProductID = 30,
-                        UnitPrice = 20.7000m,
-                        Quantity = 18,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10401,
-                        ProductID = 30,
-                        UnitPrice = 20.7000m,
-                        Quantity = 18,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10401,
-                        ProductID = 30,
-                        UnitPrice = 20.7000m,
-                        Quantity = 18,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -20243,43 +18180,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10402,
-                        ProductID = 23,
-                        UnitPrice = 7.2000m,
-                        Quantity = 60,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10403,
                         ProductID = 16,
                         UnitPrice = 13.9000m,
                         Quantity = 21,
                         Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10403,
-                        ProductID = 16,
-                        UnitPrice = 13.9000m,
-                        Quantity = 21,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10404,
-                        ProductID = 26,
-                        UnitPrice = 24.9000m,
-                        Quantity = 30,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10404,
-                        ProductID = 26,
-                        UnitPrice = 24.9000m,
-                        Quantity = 30,
-                        Discount = 0.05f
                     },
                 new OrderDetail
                     {
@@ -20307,74 +18212,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10406,
-                        ProductID = 1,
-                        UnitPrice = 14.4000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10406,
-                        ProductID = 1,
-                        UnitPrice = 14.4000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10406,
-                        ProductID = 1,
-                        UnitPrice = 14.4000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10406,
-                        ProductID = 1,
-                        UnitPrice = 14.4000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10407,
                         ProductID = 11,
                         UnitPrice = 16.8000m,
                         Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10407,
-                        ProductID = 11,
-                        UnitPrice = 16.8000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10407,
-                        ProductID = 11,
-                        UnitPrice = 16.8000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10408,
-                        ProductID = 37,
-                        UnitPrice = 20.8000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10408,
-                        ProductID = 37,
-                        UnitPrice = 20.8000m,
-                        Quantity = 10,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -20395,43 +18236,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10409,
-                        ProductID = 14,
-                        UnitPrice = 18.6000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10410,
                         ProductID = 33,
                         UnitPrice = 2.0000m,
                         Quantity = 49,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10410,
-                        ProductID = 33,
-                        UnitPrice = 2.0000m,
-                        Quantity = 49,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10411,
-                        ProductID = 41,
-                        UnitPrice = 7.7000m,
-                        Quantity = 25,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10411,
-                        ProductID = 41,
-                        UnitPrice = 7.7000m,
-                        Quantity = 25,
-                        Discount = 0.2f
                     },
                 new OrderDetail
                     {
@@ -20459,30 +18268,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10413,
-                        ProductID = 1,
-                        UnitPrice = 14.4000m,
-                        Quantity = 24,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10413,
-                        ProductID = 1,
-                        UnitPrice = 14.4000m,
-                        Quantity = 24,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10414,
-                        ProductID = 19,
-                        UnitPrice = 7.3000m,
-                        Quantity = 18,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10414,
                         ProductID = 19,
                         UnitPrice = 7.3000m,
@@ -20499,30 +18284,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10415,
-                        ProductID = 17,
-                        UnitPrice = 31.2000m,
-                        Quantity = 2,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10416,
-                        ProductID = 19,
-                        UnitPrice = 7.3000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10416,
-                        ProductID = 19,
-                        UnitPrice = 7.3000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10416,
                         ProductID = 19,
                         UnitPrice = 7.3000m,
@@ -20535,54 +18296,6 @@ Winchester Way",
                         ProductID = 38,
                         UnitPrice = 210.8000m,
                         Quantity = 50,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10417,
-                        ProductID = 38,
-                        UnitPrice = 210.8000m,
-                        Quantity = 50,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10417,
-                        ProductID = 38,
-                        UnitPrice = 210.8000m,
-                        Quantity = 50,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10417,
-                        ProductID = 38,
-                        UnitPrice = 210.8000m,
-                        Quantity = 50,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10418,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 60,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10418,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 60,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10418,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 60,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -20603,67 +18316,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10419,
-                        ProductID = 60,
-                        UnitPrice = 27.2000m,
-                        Quantity = 60,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10420,
                         ProductID = 9,
                         UnitPrice = 77.6000m,
                         Quantity = 20,
                         Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10420,
-                        ProductID = 9,
-                        UnitPrice = 77.6000m,
-                        Quantity = 20,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10420,
-                        ProductID = 9,
-                        UnitPrice = 77.6000m,
-                        Quantity = 20,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10420,
-                        ProductID = 9,
-                        UnitPrice = 77.6000m,
-                        Quantity = 20,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10421,
-                        ProductID = 19,
-                        UnitPrice = 7.3000m,
-                        Quantity = 4,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10421,
-                        ProductID = 19,
-                        UnitPrice = 7.3000m,
-                        Quantity = 4,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10421,
-                        ProductID = 19,
-                        UnitPrice = 7.3000m,
-                        Quantity = 4,
-                        Discount = 0.15f
                     },
                 new OrderDetail
                     {
@@ -20691,30 +18348,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10423,
-                        ProductID = 31,
-                        UnitPrice = 10.0000m,
-                        Quantity = 14,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10424,
-                        ProductID = 35,
-                        UnitPrice = 14.4000m,
-                        Quantity = 60,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10424,
-                        ProductID = 35,
-                        UnitPrice = 14.4000m,
-                        Quantity = 60,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10424,
                         ProductID = 35,
                         UnitPrice = 14.4000m,
@@ -20728,22 +18361,6 @@ Winchester Way",
                         UnitPrice = 19.2000m,
                         Quantity = 10,
                         Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10425,
-                        ProductID = 55,
-                        UnitPrice = 19.2000m,
-                        Quantity = 10,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10426,
-                        ProductID = 56,
-                        UnitPrice = 30.4000m,
-                        Quantity = 5,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -20779,38 +18396,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10429,
-                        ProductID = 50,
-                        UnitPrice = 13.0000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10430,
-                        ProductID = 17,
-                        UnitPrice = 31.2000m,
-                        Quantity = 45,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10430,
-                        ProductID = 17,
-                        UnitPrice = 31.2000m,
-                        Quantity = 45,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10430,
-                        ProductID = 17,
-                        UnitPrice = 31.2000m,
-                        Quantity = 45,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10430,
                         ProductID = 17,
                         UnitPrice = 31.2000m,
@@ -20824,30 +18409,6 @@ Winchester Way",
                         UnitPrice = 31.2000m,
                         Quantity = 50,
                         Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10431,
-                        ProductID = 17,
-                        UnitPrice = 31.2000m,
-                        Quantity = 50,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10431,
-                        ProductID = 17,
-                        UnitPrice = 31.2000m,
-                        Quantity = 50,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10432,
-                        ProductID = 26,
-                        UnitPrice = 24.9000m,
-                        Quantity = 10,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -20875,58 +18436,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10434,
-                        ProductID = 11,
-                        UnitPrice = 16.8000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10435,
                         ProductID = 2,
                         UnitPrice = 15.2000m,
                         Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10435,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10435,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10436,
-                        ProductID = 46,
-                        UnitPrice = 9.6000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10436,
-                        ProductID = 46,
-                        UnitPrice = 9.6000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10436,
-                        ProductID = 46,
-                        UnitPrice = 9.6000m,
-                        Quantity = 5,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -20955,75 +18468,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10438,
-                        ProductID = 19,
-                        UnitPrice = 7.3000m,
-                        Quantity = 15,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10438,
-                        ProductID = 19,
-                        UnitPrice = 7.3000m,
-                        Quantity = 15,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10439,
                         ProductID = 12,
                         UnitPrice = 30.4000m,
                         Quantity = 15,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10439,
-                        ProductID = 12,
-                        UnitPrice = 30.4000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10439,
-                        ProductID = 12,
-                        UnitPrice = 30.4000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10439,
-                        ProductID = 12,
-                        UnitPrice = 30.4000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10440,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 45,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10440,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 45,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10440,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 45,
-                        Discount = 0.15f
                     },
                 new OrderDetail
                     {
@@ -21051,30 +18500,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10442,
-                        ProductID = 11,
-                        UnitPrice = 16.8000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10442,
-                        ProductID = 11,
-                        UnitPrice = 16.8000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10443,
-                        ProductID = 11,
-                        UnitPrice = 16.8000m,
-                        Quantity = 6,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10443,
                         ProductID = 11,
                         UnitPrice = 16.8000m,
@@ -21087,38 +18512,6 @@ Winchester Way",
                         ProductID = 17,
                         UnitPrice = 31.2000m,
                         Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10444,
-                        ProductID = 17,
-                        UnitPrice = 31.2000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10444,
-                        ProductID = 17,
-                        UnitPrice = 31.2000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10444,
-                        ProductID = 17,
-                        UnitPrice = 31.2000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10445,
-                        ProductID = 39,
-                        UnitPrice = 14.4000m,
-                        Quantity = 6,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -21139,46 +18532,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10446,
-                        ProductID = 19,
-                        UnitPrice = 7.3000m,
-                        Quantity = 12,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10446,
-                        ProductID = 19,
-                        UnitPrice = 7.3000m,
-                        Quantity = 12,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10446,
-                        ProductID = 19,
-                        UnitPrice = 7.3000m,
-                        Quantity = 12,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10447,
-                        ProductID = 19,
-                        UnitPrice = 7.3000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10447,
-                        ProductID = 19,
-                        UnitPrice = 7.3000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10447,
                         ProductID = 19,
                         UnitPrice = 7.3000m,
@@ -21191,30 +18544,6 @@ Winchester Way",
                         ProductID = 26,
                         UnitPrice = 24.9000m,
                         Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10448,
-                        ProductID = 26,
-                        UnitPrice = 24.9000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10449,
-                        ProductID = 10,
-                        UnitPrice = 24.8000m,
-                        Quantity = 14,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10449,
-                        ProductID = 10,
-                        UnitPrice = 24.8000m,
-                        Quantity = 14,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -21235,51 +18564,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10450,
-                        ProductID = 10,
-                        UnitPrice = 24.8000m,
-                        Quantity = 20,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10451,
                         ProductID = 55,
                         UnitPrice = 19.2000m,
                         Quantity = 120,
                         Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10451,
-                        ProductID = 55,
-                        UnitPrice = 19.2000m,
-                        Quantity = 120,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10451,
-                        ProductID = 55,
-                        UnitPrice = 19.2000m,
-                        Quantity = 120,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10451,
-                        ProductID = 55,
-                        UnitPrice = 19.2000m,
-                        Quantity = 120,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10452,
-                        ProductID = 28,
-                        UnitPrice = 36.4000m,
-                        Quantity = 15,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -21299,30 +18588,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10453,
-                        ProductID = 48,
-                        UnitPrice = 10.2000m,
-                        Quantity = 15,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10454,
-                        ProductID = 16,
-                        UnitPrice = 13.9000m,
-                        Quantity = 20,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10454,
-                        ProductID = 16,
-                        UnitPrice = 13.9000m,
-                        Quantity = 20,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10454,
                         ProductID = 16,
                         UnitPrice = 13.9000m,
@@ -21336,38 +18601,6 @@ Winchester Way",
                         UnitPrice = 14.4000m,
                         Quantity = 20,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10455,
-                        ProductID = 39,
-                        UnitPrice = 14.4000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10455,
-                        ProductID = 39,
-                        UnitPrice = 14.4000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10455,
-                        ProductID = 39,
-                        UnitPrice = 14.4000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10456,
-                        ProductID = 21,
-                        UnitPrice = 8.0000m,
-                        Quantity = 40,
-                        Discount = 0.15f
                     },
                 new OrderDetail
                     {
@@ -21395,54 +18628,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10458,
-                        ProductID = 26,
-                        UnitPrice = 24.9000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10458,
-                        ProductID = 26,
-                        UnitPrice = 24.9000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10458,
-                        ProductID = 26,
-                        UnitPrice = 24.9000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10458,
-                        ProductID = 26,
-                        UnitPrice = 24.9000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10459,
-                        ProductID = 7,
-                        UnitPrice = 24.0000m,
-                        Quantity = 16,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10459,
-                        ProductID = 7,
-                        UnitPrice = 24.0000m,
-                        Quantity = 16,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10459,
                         ProductID = 7,
                         UnitPrice = 24.0000m,
@@ -21455,30 +18640,6 @@ Winchester Way",
                         ProductID = 68,
                         UnitPrice = 10.0000m,
                         Quantity = 21,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10460,
-                        ProductID = 68,
-                        UnitPrice = 10.0000m,
-                        Quantity = 21,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10461,
-                        ProductID = 21,
-                        UnitPrice = 8.0000m,
-                        Quantity = 40,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10461,
-                        ProductID = 21,
-                        UnitPrice = 8.0000m,
-                        Quantity = 40,
                         Discount = 0.25f
                     },
                 new OrderDetail
@@ -21499,22 +18660,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10462,
-                        ProductID = 13,
-                        UnitPrice = 4.8000m,
-                        Quantity = 1,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10463,
-                        ProductID = 19,
-                        UnitPrice = 7.3000m,
-                        Quantity = 21,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10463,
                         ProductID = 19,
                         UnitPrice = 7.3000m,
@@ -21531,74 +18676,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10464,
-                        ProductID = 4,
-                        UnitPrice = 17.6000m,
-                        Quantity = 16,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10464,
-                        ProductID = 4,
-                        UnitPrice = 17.6000m,
-                        Quantity = 16,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10464,
-                        ProductID = 4,
-                        UnitPrice = 17.6000m,
-                        Quantity = 16,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10465,
                         ProductID = 24,
                         UnitPrice = 3.6000m,
                         Quantity = 25,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10465,
-                        ProductID = 24,
-                        UnitPrice = 3.6000m,
-                        Quantity = 25,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10465,
-                        ProductID = 24,
-                        UnitPrice = 3.6000m,
-                        Quantity = 25,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10465,
-                        ProductID = 24,
-                        UnitPrice = 3.6000m,
-                        Quantity = 25,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10465,
-                        ProductID = 24,
-                        UnitPrice = 3.6000m,
-                        Quantity = 25,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10466,
-                        ProductID = 11,
-                        UnitPrice = 16.8000m,
-                        Quantity = 10,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -21619,22 +18700,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10467,
-                        ProductID = 24,
-                        UnitPrice = 3.6000m,
-                        Quantity = 28,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10468,
-                        ProductID = 30,
-                        UnitPrice = 20.7000m,
-                        Quantity = 8,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10468,
                         ProductID = 30,
                         UnitPrice = 20.7000m,
@@ -21651,49 +18716,9 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10469,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 40,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10469,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 40,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10470,
                         ProductID = 18,
                         UnitPrice = 50.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10470,
-                        ProductID = 18,
-                        UnitPrice = 50.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10470,
-                        ProductID = 18,
-                        UnitPrice = 50.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10471,
-                        ProductID = 7,
-                        UnitPrice = 24.0000m,
                         Quantity = 30,
                         Discount = 0f
                     },
@@ -21715,22 +18740,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10472,
-                        ProductID = 24,
-                        UnitPrice = 3.6000m,
-                        Quantity = 80,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10473,
-                        ProductID = 33,
-                        UnitPrice = 2.0000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10473,
                         ProductID = 33,
                         UnitPrice = 2.0000m,
@@ -21747,46 +18756,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10474,
-                        ProductID = 14,
-                        UnitPrice = 18.6000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10474,
-                        ProductID = 14,
-                        UnitPrice = 18.6000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10474,
-                        ProductID = 14,
-                        UnitPrice = 18.6000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10475,
-                        ProductID = 31,
-                        UnitPrice = 10.0000m,
-                        Quantity = 35,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10475,
-                        ProductID = 31,
-                        UnitPrice = 10.0000m,
-                        Quantity = 35,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10475,
                         ProductID = 31,
                         UnitPrice = 10.0000m,
@@ -21800,30 +18769,6 @@ Winchester Way",
                         UnitPrice = 19.2000m,
                         Quantity = 2,
                         Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10476,
-                        ProductID = 55,
-                        UnitPrice = 19.2000m,
-                        Quantity = 2,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10477,
-                        ProductID = 1,
-                        UnitPrice = 14.4000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10477,
-                        ProductID = 1,
-                        UnitPrice = 14.4000m,
-                        Quantity = 15,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -21851,50 +18796,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10479,
-                        ProductID = 38,
-                        UnitPrice = 210.8000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10479,
-                        ProductID = 38,
-                        UnitPrice = 210.8000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10479,
-                        ProductID = 38,
-                        UnitPrice = 210.8000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10480,
                         ProductID = 47,
                         UnitPrice = 7.6000m,
                         Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10480,
-                        ProductID = 47,
-                        UnitPrice = 7.6000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10481,
-                        ProductID = 49,
-                        UnitPrice = 16.0000m,
-                        Quantity = 24,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -21923,30 +18828,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10483,
-                        ProductID = 34,
-                        UnitPrice = 11.2000m,
-                        Quantity = 35,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10484,
-                        ProductID = 21,
-                        UnitPrice = 8.0000m,
-                        Quantity = 14,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10484,
-                        ProductID = 21,
-                        UnitPrice = 8.0000m,
-                        Quantity = 14,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10484,
                         ProductID = 21,
                         UnitPrice = 8.0000m,
@@ -21963,65 +18844,9 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10485,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 20,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10485,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 20,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10485,
-                        ProductID = 2,
-                        UnitPrice = 15.2000m,
-                        Quantity = 20,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10486,
                         ProductID = 11,
                         UnitPrice = 16.8000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10486,
-                        ProductID = 11,
-                        UnitPrice = 16.8000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10486,
-                        ProductID = 11,
-                        UnitPrice = 16.8000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10487,
-                        ProductID = 19,
-                        UnitPrice = 7.3000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10487,
-                        ProductID = 19,
-                        UnitPrice = 7.3000m,
                         Quantity = 5,
                         Discount = 0f
                     },
@@ -22043,43 +18868,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10488,
-                        ProductID = 59,
-                        UnitPrice = 44.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10489,
                         ProductID = 11,
                         UnitPrice = 16.8000m,
                         Quantity = 15,
                         Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10489,
-                        ProductID = 11,
-                        UnitPrice = 16.8000m,
-                        Quantity = 15,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10490,
-                        ProductID = 59,
-                        UnitPrice = 44.0000m,
-                        Quantity = 60,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10490,
-                        ProductID = 59,
-                        UnitPrice = 44.0000m,
-                        Quantity = 60,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -22099,43 +18892,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10491,
-                        ProductID = 44,
-                        UnitPrice = 15.5000m,
-                        Quantity = 15,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10492,
                         ProductID = 25,
                         UnitPrice = 11.2000m,
                         Quantity = 60,
                         Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10492,
-                        ProductID = 25,
-                        UnitPrice = 11.2000m,
-                        Quantity = 60,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10493,
-                        ProductID = 65,
-                        UnitPrice = 16.8000m,
-                        Quantity = 15,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10493,
-                        ProductID = 65,
-                        UnitPrice = 16.8000m,
-                        Quantity = 15,
-                        Discount = 0.1f
                     },
                 new OrderDetail
                     {
@@ -22151,22 +18912,6 @@ Winchester Way",
                         ProductID = 56,
                         UnitPrice = 30.4000m,
                         Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10495,
-                        ProductID = 23,
-                        UnitPrice = 7.2000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10495,
-                        ProductID = 23,
-                        UnitPrice = 7.2000m,
-                        Quantity = 10,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -22195,38 +18940,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10497,
-                        ProductID = 56,
-                        UnitPrice = 30.4000m,
-                        Quantity = 14,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10497,
-                        ProductID = 56,
-                        UnitPrice = 30.4000m,
-                        Quantity = 14,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10498,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 14,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10498,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 14,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10498,
                         ProductID = 24,
                         UnitPrice = 4.5000m,
@@ -22240,22 +18953,6 @@ Winchester Way",
                         UnitPrice = 45.6000m,
                         Quantity = 20,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10499,
-                        ProductID = 28,
-                        UnitPrice = 45.6000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10500,
-                        ProductID = 15,
-                        UnitPrice = 15.5000m,
-                        Quantity = 12,
-                        Discount = 0.05f
                     },
                 new OrderDetail
                     {
@@ -22283,58 +18980,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10502,
-                        ProductID = 45,
-                        UnitPrice = 9.5000m,
-                        Quantity = 21,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10502,
-                        ProductID = 45,
-                        UnitPrice = 9.5000m,
-                        Quantity = 21,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10503,
                         ProductID = 14,
                         UnitPrice = 23.2500m,
                         Quantity = 70,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10503,
-                        ProductID = 14,
-                        UnitPrice = 23.2500m,
-                        Quantity = 70,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10504,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10504,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10504,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 12,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -22363,35 +19012,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10506,
-                        ProductID = 25,
-                        UnitPrice = 14.0000m,
-                        Quantity = 18,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10507,
                         ProductID = 43,
                         UnitPrice = 46.0000m,
                         Quantity = 15,
                         Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10507,
-                        ProductID = 43,
-                        UnitPrice = 46.0000m,
-                        Quantity = 15,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10508,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 10,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -22419,58 +19044,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10510,
-                        ProductID = 29,
-                        UnitPrice = 123.7900m,
-                        Quantity = 36,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10511,
                         ProductID = 4,
                         UnitPrice = 22.0000m,
                         Quantity = 50,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10511,
-                        ProductID = 4,
-                        UnitPrice = 22.0000m,
-                        Quantity = 50,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10511,
-                        ProductID = 4,
-                        UnitPrice = 22.0000m,
-                        Quantity = 50,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10512,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 10,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10512,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 10,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10512,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 10,
                         Discount = 0.15f
                     },
                 new OrderDetail
@@ -22491,91 +19068,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10513,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 40,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10513,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 40,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10514,
                         ProductID = 20,
                         UnitPrice = 81.0000m,
                         Quantity = 39,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10514,
-                        ProductID = 20,
-                        UnitPrice = 81.0000m,
-                        Quantity = 39,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10514,
-                        ProductID = 20,
-                        UnitPrice = 81.0000m,
-                        Quantity = 39,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10514,
-                        ProductID = 20,
-                        UnitPrice = 81.0000m,
-                        Quantity = 39,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10514,
-                        ProductID = 20,
-                        UnitPrice = 81.0000m,
-                        Quantity = 39,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10515,
-                        ProductID = 9,
-                        UnitPrice = 97.0000m,
-                        Quantity = 16,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10515,
-                        ProductID = 9,
-                        UnitPrice = 97.0000m,
-                        Quantity = 16,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10515,
-                        ProductID = 9,
-                        UnitPrice = 97.0000m,
-                        Quantity = 16,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10515,
-                        ProductID = 9,
-                        UnitPrice = 97.0000m,
-                        Quantity = 16,
-                        Discount = 0.15f
                     },
                 new OrderDetail
                     {
@@ -22595,38 +19092,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10516,
-                        ProductID = 18,
-                        UnitPrice = 62.5000m,
-                        Quantity = 25,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10516,
-                        ProductID = 18,
-                        UnitPrice = 62.5000m,
-                        Quantity = 25,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10517,
-                        ProductID = 52,
-                        UnitPrice = 7.0000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10517,
-                        ProductID = 52,
-                        UnitPrice = 7.0000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10517,
                         ProductID = 52,
                         UnitPrice = 7.0000m,
@@ -22640,38 +19105,6 @@ Winchester Way",
                         UnitPrice = 4.5000m,
                         Quantity = 5,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10518,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10518,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10519,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 16,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10519,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 16,
-                        Discount = 0.05f
                     },
                 new OrderDetail
                     {
@@ -22691,30 +19124,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10520,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 8,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10521,
-                        ProductID = 35,
-                        UnitPrice = 18.0000m,
-                        Quantity = 3,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10521,
-                        ProductID = 35,
-                        UnitPrice = 18.0000m,
-                        Quantity = 3,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10521,
                         ProductID = 35,
                         UnitPrice = 18.0000m,
@@ -22731,54 +19140,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10522,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 40,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10522,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 40,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10522,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 40,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10523,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 25,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10523,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 25,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10523,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 25,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10523,
                         ProductID = 17,
                         UnitPrice = 39.0000m,
@@ -22791,38 +19152,6 @@ Winchester Way",
                         ProductID = 10,
                         UnitPrice = 31.0000m,
                         Quantity = 2,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10524,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 2,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10524,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 2,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10524,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 2,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10525,
-                        ProductID = 36,
-                        UnitPrice = 19.0000m,
-                        Quantity = 30,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -22843,30 +19172,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10526,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 8,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10526,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 8,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10527,
-                        ProductID = 4,
-                        UnitPrice = 22.0000m,
-                        Quantity = 50,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10527,
                         ProductID = 4,
                         UnitPrice = 22.0000m,
@@ -22883,66 +19188,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10528,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 3,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10528,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 3,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10529,
                         ProductID = 55,
                         UnitPrice = 24.0000m,
                         Quantity = 14,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10529,
-                        ProductID = 55,
-                        UnitPrice = 24.0000m,
-                        Quantity = 14,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10529,
-                        ProductID = 55,
-                        UnitPrice = 24.0000m,
-                        Quantity = 14,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10530,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10530,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10530,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 40,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -22971,30 +19220,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10532,
-                        ProductID = 30,
-                        UnitPrice = 25.8900m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10533,
-                        ProductID = 4,
-                        UnitPrice = 22.0000m,
-                        Quantity = 50,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10533,
-                        ProductID = 4,
-                        UnitPrice = 22.0000m,
-                        Quantity = 50,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10533,
                         ProductID = 4,
                         UnitPrice = 22.0000m,
@@ -23011,46 +19236,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10534,
-                        ProductID = 30,
-                        UnitPrice = 25.8900m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10534,
-                        ProductID = 30,
-                        UnitPrice = 25.8900m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10535,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 50,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10535,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 50,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10535,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 50,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10535,
                         ProductID = 11,
                         UnitPrice = 21.0000m,
@@ -23067,74 +19252,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10536,
-                        ProductID = 12,
-                        UnitPrice = 38.0000m,
-                        Quantity = 15,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10536,
-                        ProductID = 12,
-                        UnitPrice = 38.0000m,
-                        Quantity = 15,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10536,
-                        ProductID = 12,
-                        UnitPrice = 38.0000m,
-                        Quantity = 15,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10537,
                         ProductID = 31,
                         UnitPrice = 12.5000m,
                         Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10537,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10537,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10537,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10537,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10538,
-                        ProductID = 70,
-                        UnitPrice = 15.0000m,
-                        Quantity = 7,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -23155,83 +19276,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10539,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 8,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10539,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 8,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10539,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 8,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10540,
                         ProductID = 3,
                         UnitPrice = 10.0000m,
                         Quantity = 60,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10540,
-                        ProductID = 3,
-                        UnitPrice = 10.0000m,
-                        Quantity = 60,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10540,
-                        ProductID = 3,
-                        UnitPrice = 10.0000m,
-                        Quantity = 60,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10540,
-                        ProductID = 3,
-                        UnitPrice = 10.0000m,
-                        Quantity = 60,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10541,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 35,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10541,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 35,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10541,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 35,
-                        Discount = 0.1f
                     },
                 new OrderDetail
                     {
@@ -23251,35 +19300,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10542,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 15,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10543,
                         ProductID = 12,
                         UnitPrice = 38.0000m,
                         Quantity = 30,
                         Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10543,
-                        ProductID = 12,
-                        UnitPrice = 38.0000m,
-                        Quantity = 30,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10544,
-                        ProductID = 28,
-                        UnitPrice = 45.6000m,
-                        Quantity = 7,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -23307,30 +19332,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10546,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10546,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10547,
-                        ProductID = 32,
-                        UnitPrice = 32.0000m,
-                        Quantity = 24,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10547,
                         ProductID = 32,
                         UnitPrice = 32.0000m,
@@ -23347,30 +19348,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10548,
-                        ProductID = 34,
-                        UnitPrice = 14.0000m,
-                        Quantity = 10,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10549,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 55,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10549,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 55,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10549,
                         ProductID = 31,
                         UnitPrice = 12.5000m,
@@ -23384,46 +19361,6 @@ Winchester Way",
                         UnitPrice = 39.0000m,
                         Quantity = 8,
                         Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10550,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 8,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10550,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 8,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10550,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 8,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10551,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 40,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10551,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 40,
-                        Discount = 0.15f
                     },
                 new OrderDetail
                     {
@@ -23443,46 +19380,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10552,
-                        ProductID = 69,
-                        UnitPrice = 36.0000m,
-                        Quantity = 18,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10553,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10553,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10553,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10553,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10553,
                         ProductID = 11,
                         UnitPrice = 21.0000m,
@@ -23496,62 +19393,6 @@ Winchester Way",
                         UnitPrice = 17.4500m,
                         Quantity = 30,
                         Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10554,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 30,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10554,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 30,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10554,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 30,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10555,
-                        ProductID = 14,
-                        UnitPrice = 23.2500m,
-                        Quantity = 30,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10555,
-                        ProductID = 14,
-                        UnitPrice = 23.2500m,
-                        Quantity = 30,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10555,
-                        ProductID = 14,
-                        UnitPrice = 23.2500m,
-                        Quantity = 30,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10555,
-                        ProductID = 14,
-                        UnitPrice = 23.2500m,
-                        Quantity = 30,
-                        Discount = 0.2f
                     },
                 new OrderDetail
                     {
@@ -23579,46 +19420,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10557,
-                        ProductID = 64,
-                        UnitPrice = 33.2500m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10558,
-                        ProductID = 47,
-                        UnitPrice = 9.5000m,
-                        Quantity = 25,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10558,
-                        ProductID = 47,
-                        UnitPrice = 9.5000m,
-                        Quantity = 25,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10558,
-                        ProductID = 47,
-                        UnitPrice = 9.5000m,
-                        Quantity = 25,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10558,
-                        ProductID = 47,
-                        UnitPrice = 9.5000m,
-                        Quantity = 25,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10558,
                         ProductID = 47,
                         UnitPrice = 9.5000m,
@@ -23635,34 +19436,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10559,
-                        ProductID = 41,
-                        UnitPrice = 9.6500m,
-                        Quantity = 12,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10560,
                         ProductID = 30,
                         UnitPrice = 25.8900m,
                         Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10560,
-                        ProductID = 30,
-                        UnitPrice = 25.8900m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10561,
-                        ProductID = 44,
-                        UnitPrice = 19.4500m,
-                        Quantity = 10,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -23683,43 +19460,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10562,
-                        ProductID = 33,
-                        UnitPrice = 2.5000m,
-                        Quantity = 20,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10563,
                         ProductID = 36,
                         UnitPrice = 19.0000m,
                         Quantity = 25,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10563,
-                        ProductID = 36,
-                        UnitPrice = 19.0000m,
-                        Quantity = 25,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10564,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 16,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10564,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 16,
-                        Discount = 0.05f
                     },
                 new OrderDetail
                     {
@@ -23739,51 +19484,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10565,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 25,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10566,
                         ProductID = 11,
                         UnitPrice = 21.0000m,
                         Quantity = 35,
                         Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10566,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 35,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10566,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 35,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10567,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 60,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10567,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 60,
-                        Discount = 0.2f
                     },
                 new OrderDetail
                     {
@@ -23811,22 +19516,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10569,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 35,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10570,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 15,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10570,
                         ProductID = 11,
                         UnitPrice = 21.0000m,
@@ -23843,38 +19532,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10571,
-                        ProductID = 14,
-                        UnitPrice = 23.2500m,
-                        Quantity = 11,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10572,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 12,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10572,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 12,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10572,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 12,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10572,
                         ProductID = 16,
                         UnitPrice = 17.4500m,
@@ -23891,74 +19548,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10573,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 18,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10573,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 18,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10574,
                         ProductID = 33,
                         UnitPrice = 2.5000m,
                         Quantity = 14,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10574,
-                        ProductID = 33,
-                        UnitPrice = 2.5000m,
-                        Quantity = 14,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10574,
-                        ProductID = 33,
-                        UnitPrice = 2.5000m,
-                        Quantity = 14,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10574,
-                        ProductID = 33,
-                        UnitPrice = 2.5000m,
-                        Quantity = 14,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10575,
-                        ProductID = 59,
-                        UnitPrice = 55.0000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10575,
-                        ProductID = 59,
-                        UnitPrice = 55.0000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10575,
-                        ProductID = 59,
-                        UnitPrice = 55.0000m,
-                        Quantity = 12,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -23973,38 +19566,6 @@ Winchester Way",
                     {
                         OrderID = 10576,
                         ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10576,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10576,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10577,
-                        ProductID = 39,
-                        UnitPrice = 18.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10577,
-                        ProductID = 39,
                         UnitPrice = 18.0000m,
                         Quantity = 10,
                         Discount = 0f
@@ -24027,43 +19588,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10578,
-                        ProductID = 35,
-                        UnitPrice = 18.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10579,
                         ProductID = 15,
                         UnitPrice = 15.5000m,
                         Quantity = 10,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10579,
-                        ProductID = 15,
-                        UnitPrice = 15.5000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10580,
-                        ProductID = 14,
-                        UnitPrice = 23.2500m,
-                        Quantity = 15,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10580,
-                        ProductID = 14,
-                        UnitPrice = 23.2500m,
-                        Quantity = 15,
-                        Discount = 0.05f
                     },
                 new OrderDetail
                     {
@@ -24087,30 +19616,6 @@ Winchester Way",
                         ProductID = 57,
                         UnitPrice = 19.5000m,
                         Quantity = 4,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10582,
-                        ProductID = 57,
-                        UnitPrice = 19.5000m,
-                        Quantity = 4,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10583,
-                        ProductID = 29,
-                        UnitPrice = 123.7900m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10583,
-                        ProductID = 29,
-                        UnitPrice = 123.7900m,
-                        Quantity = 10,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -24155,30 +19660,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10587,
-                        ProductID = 26,
-                        UnitPrice = 31.2300m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10587,
-                        ProductID = 26,
-                        UnitPrice = 31.2300m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10588,
-                        ProductID = 18,
-                        UnitPrice = 62.5000m,
-                        Quantity = 40,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10588,
                         ProductID = 18,
                         UnitPrice = 62.5000m,
@@ -24203,30 +19684,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10590,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10591,
-                        ProductID = 3,
-                        UnitPrice = 10.0000m,
-                        Quantity = 14,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10591,
-                        ProductID = 3,
-                        UnitPrice = 10.0000m,
-                        Quantity = 14,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10591,
                         ProductID = 3,
                         UnitPrice = 10.0000m,
@@ -24240,30 +19697,6 @@ Winchester Way",
                         UnitPrice = 15.5000m,
                         Quantity = 25,
                         Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10592,
-                        ProductID = 15,
-                        UnitPrice = 15.5000m,
-                        Quantity = 25,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10593,
-                        ProductID = 20,
-                        UnitPrice = 81.0000m,
-                        Quantity = 21,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10593,
-                        ProductID = 20,
-                        UnitPrice = 81.0000m,
-                        Quantity = 21,
-                        Discount = 0.2f
                     },
                 new OrderDetail
                     {
@@ -24283,30 +19716,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10594,
-                        ProductID = 52,
-                        UnitPrice = 7.0000m,
-                        Quantity = 24,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10595,
-                        ProductID = 35,
-                        UnitPrice = 18.0000m,
-                        Quantity = 30,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10595,
-                        ProductID = 35,
-                        UnitPrice = 18.0000m,
-                        Quantity = 30,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10595,
                         ProductID = 35,
                         UnitPrice = 18.0000m,
@@ -24323,51 +19732,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10596,
-                        ProductID = 56,
-                        UnitPrice = 38.0000m,
-                        Quantity = 5,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10596,
-                        ProductID = 56,
-                        UnitPrice = 38.0000m,
-                        Quantity = 5,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10597,
                         ProductID = 24,
                         UnitPrice = 4.5000m,
                         Quantity = 35,
                         Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10597,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 35,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10597,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 35,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10598,
-                        ProductID = 27,
-                        UnitPrice = 43.9000m,
-                        Quantity = 50,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -24391,22 +19760,6 @@ Winchester Way",
                         ProductID = 54,
                         UnitPrice = 7.4500m,
                         Quantity = 4,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10600,
-                        ProductID = 54,
-                        UnitPrice = 7.4500m,
-                        Quantity = 4,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10601,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 60,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -24435,22 +19788,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10603,
-                        ProductID = 22,
-                        UnitPrice = 21.0000m,
-                        Quantity = 48,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10604,
-                        ProductID = 48,
-                        UnitPrice = 12.7500m,
-                        Quantity = 6,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10604,
                         ProductID = 48,
                         UnitPrice = 12.7500m,
@@ -24467,83 +19804,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10605,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 30,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10605,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 30,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10605,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 30,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10606,
                         ProductID = 4,
                         UnitPrice = 22.0000m,
                         Quantity = 20,
                         Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10606,
-                        ProductID = 4,
-                        UnitPrice = 22.0000m,
-                        Quantity = 20,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10606,
-                        ProductID = 4,
-                        UnitPrice = 22.0000m,
-                        Quantity = 20,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10607,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 45,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10607,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 45,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10607,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 45,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10607,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 45,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -24559,22 +19824,6 @@ Winchester Way",
                         ProductID = 56,
                         UnitPrice = 38.0000m,
                         Quantity = 28,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10609,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 3,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10609,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 3,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -24603,54 +19852,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10611,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10611,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10612,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 70,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10612,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 70,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10612,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 70,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10612,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 70,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10612,
                         ProductID = 10,
                         UnitPrice = 31.0000m,
@@ -24664,30 +19865,6 @@ Winchester Way",
                         UnitPrice = 6.0000m,
                         Quantity = 8,
                         Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10613,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 8,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10614,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 14,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10614,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 14,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -24715,30 +19892,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10616,
-                        ProductID = 38,
-                        UnitPrice = 263.5000m,
-                        Quantity = 15,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10616,
-                        ProductID = 38,
-                        UnitPrice = 263.5000m,
-                        Quantity = 15,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10616,
-                        ProductID = 38,
-                        UnitPrice = 263.5000m,
-                        Quantity = 15,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10617,
                         ProductID = 59,
                         UnitPrice = 55.0000m,
@@ -24755,30 +19908,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10618,
-                        ProductID = 6,
-                        UnitPrice = 25.0000m,
-                        Quantity = 70,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10618,
-                        ProductID = 6,
-                        UnitPrice = 25.0000m,
-                        Quantity = 70,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10619,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 42,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10619,
                         ProductID = 21,
                         UnitPrice = 10.0000m,
@@ -24790,38 +19919,6 @@ Winchester Way",
                         OrderID = 10620,
                         ProductID = 24,
                         UnitPrice = 4.5000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10620,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10621,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10621,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10621,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
                         Quantity = 5,
                         Discount = 0f
                     },
@@ -24843,66 +19940,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10622,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10623,
                         ProductID = 14,
                         UnitPrice = 23.2500m,
                         Quantity = 21,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10623,
-                        ProductID = 14,
-                        UnitPrice = 23.2500m,
-                        Quantity = 21,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10623,
-                        ProductID = 14,
-                        UnitPrice = 23.2500m,
-                        Quantity = 21,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10623,
-                        ProductID = 14,
-                        UnitPrice = 23.2500m,
-                        Quantity = 21,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10623,
-                        ProductID = 14,
-                        UnitPrice = 23.2500m,
-                        Quantity = 21,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10624,
-                        ProductID = 28,
-                        UnitPrice = 45.6000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10624,
-                        ProductID = 28,
-                        UnitPrice = 45.6000m,
-                        Quantity = 10,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -24923,50 +19964,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10625,
-                        ProductID = 14,
-                        UnitPrice = 23.2500m,
-                        Quantity = 3,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10625,
-                        ProductID = 14,
-                        UnitPrice = 23.2500m,
-                        Quantity = 3,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10626,
                         ProductID = 53,
                         UnitPrice = 32.8000m,
                         Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10626,
-                        ProductID = 53,
-                        UnitPrice = 32.8000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10626,
-                        ProductID = 53,
-                        UnitPrice = 32.8000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10627,
-                        ProductID = 62,
-                        UnitPrice = 49.3000m,
-                        Quantity = 15,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -24995,22 +19996,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10629,
-                        ProductID = 29,
-                        UnitPrice = 123.7900m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10630,
-                        ProductID = 55,
-                        UnitPrice = 24.0000m,
-                        Quantity = 12,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10630,
                         ProductID = 55,
                         UnitPrice = 24.0000m,
@@ -25035,38 +20020,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10632,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 30,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10633,
-                        ProductID = 12,
-                        UnitPrice = 38.0000m,
-                        Quantity = 36,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10633,
-                        ProductID = 12,
-                        UnitPrice = 38.0000m,
-                        Quantity = 36,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10633,
-                        ProductID = 12,
-                        UnitPrice = 38.0000m,
-                        Quantity = 36,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10633,
                         ProductID = 12,
                         UnitPrice = 38.0000m,
@@ -25080,46 +20033,6 @@ Winchester Way",
                         UnitPrice = 30.0000m,
                         Quantity = 35,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10634,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 35,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10634,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 35,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10634,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 35,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10635,
-                        ProductID = 4,
-                        UnitPrice = 22.0000m,
-                        Quantity = 10,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10635,
-                        ProductID = 4,
-                        UnitPrice = 22.0000m,
-                        Quantity = 10,
-                        Discount = 0.1f
                     },
                 new OrderDetail
                     {
@@ -25139,50 +20052,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10636,
-                        ProductID = 4,
-                        UnitPrice = 22.0000m,
-                        Quantity = 25,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10637,
                         ProductID = 11,
                         UnitPrice = 21.0000m,
                         Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10637,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10637,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10638,
-                        ProductID = 45,
-                        UnitPrice = 9.5000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10638,
-                        ProductID = 45,
-                        UnitPrice = 9.5000m,
-                        Quantity = 20,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -25211,22 +20084,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10640,
-                        ProductID = 69,
-                        UnitPrice = 36.0000m,
-                        Quantity = 20,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10641,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 50,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10641,
                         ProductID = 2,
                         UnitPrice = 19.0000m,
@@ -25243,51 +20100,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10642,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 30,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10643,
                         ProductID = 28,
                         UnitPrice = 45.6000m,
                         Quantity = 15,
                         Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10643,
-                        ProductID = 28,
-                        UnitPrice = 45.6000m,
-                        Quantity = 15,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10643,
-                        ProductID = 28,
-                        UnitPrice = 45.6000m,
-                        Quantity = 15,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10644,
-                        ProductID = 18,
-                        UnitPrice = 62.5000m,
-                        Quantity = 4,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10644,
-                        ProductID = 18,
-                        UnitPrice = 62.5000m,
-                        Quantity = 4,
-                        Discount = 0.1f
                     },
                 new OrderDetail
                     {
@@ -25307,38 +20124,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10645,
-                        ProductID = 18,
-                        UnitPrice = 62.5000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10646,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 15,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10646,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 15,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10646,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 15,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10646,
                         ProductID = 1,
                         UnitPrice = 18.0000m,
@@ -25351,22 +20136,6 @@ Winchester Way",
                         ProductID = 19,
                         UnitPrice = 9.2000m,
                         Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10647,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10648,
-                        ProductID = 22,
-                        UnitPrice = 21.0000m,
-                        Quantity = 15,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -25387,43 +20156,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10649,
-                        ProductID = 28,
-                        UnitPrice = 45.6000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10650,
                         ProductID = 30,
                         UnitPrice = 25.8900m,
                         Quantity = 30,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10650,
-                        ProductID = 30,
-                        UnitPrice = 25.8900m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10650,
-                        ProductID = 30,
-                        UnitPrice = 25.8900m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10651,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 12,
-                        Discount = 0.25f
                     },
                 new OrderDetail
                     {
@@ -25443,42 +20180,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10652,
-                        ProductID = 30,
-                        UnitPrice = 25.8900m,
-                        Quantity = 2,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10653,
                         ProductID = 16,
                         UnitPrice = 17.4500m,
                         Quantity = 30,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10653,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 30,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10654,
-                        ProductID = 4,
-                        UnitPrice = 22.0000m,
-                        Quantity = 12,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10654,
-                        ProductID = 4,
-                        UnitPrice = 22.0000m,
-                        Quantity = 12,
                         Discount = 0.1f
                     },
                 new OrderDetail
@@ -25507,62 +20212,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10656,
-                        ProductID = 14,
-                        UnitPrice = 23.2500m,
-                        Quantity = 3,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10656,
-                        ProductID = 14,
-                        UnitPrice = 23.2500m,
-                        Quantity = 3,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10657,
-                        ProductID = 15,
-                        UnitPrice = 15.5000m,
-                        Quantity = 50,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10657,
-                        ProductID = 15,
-                        UnitPrice = 15.5000m,
-                        Quantity = 50,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10657,
-                        ProductID = 15,
-                        UnitPrice = 15.5000m,
-                        Quantity = 50,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10657,
-                        ProductID = 15,
-                        UnitPrice = 15.5000m,
-                        Quantity = 50,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10657,
-                        ProductID = 15,
-                        UnitPrice = 15.5000m,
-                        Quantity = 50,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10657,
                         ProductID = 15,
                         UnitPrice = 15.5000m,
@@ -25576,46 +20225,6 @@ Winchester Way",
                         UnitPrice = 10.0000m,
                         Quantity = 60,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10658,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 60,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10658,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 60,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10658,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 60,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10659,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 20,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10659,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 20,
-                        Discount = 0.05f
                     },
                 new OrderDetail
                     {
@@ -25643,14 +20252,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10661,
-                        ProductID = 39,
-                        UnitPrice = 18.0000m,
-                        Quantity = 3,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10662,
                         ProductID = 68,
                         UnitPrice = 12.5000m,
@@ -25667,59 +20268,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10663,
-                        ProductID = 40,
-                        UnitPrice = 18.4000m,
-                        Quantity = 30,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10663,
-                        ProductID = 40,
-                        UnitPrice = 18.4000m,
-                        Quantity = 30,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10664,
                         ProductID = 10,
                         UnitPrice = 31.0000m,
                         Quantity = 24,
                         Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10664,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 24,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10664,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 24,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10665,
-                        ProductID = 51,
-                        UnitPrice = 53.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10665,
-                        ProductID = 51,
-                        UnitPrice = 53.0000m,
-                        Quantity = 20,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -25739,43 +20292,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10666,
-                        ProductID = 29,
-                        UnitPrice = 123.7900m,
-                        Quantity = 36,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10667,
                         ProductID = 69,
                         UnitPrice = 36.0000m,
                         Quantity = 45,
                         Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10667,
-                        ProductID = 69,
-                        UnitPrice = 36.0000m,
-                        Quantity = 45,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10668,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 8,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10668,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 8,
-                        Discount = 0.1f
                     },
                 new OrderDetail
                     {
@@ -25803,54 +20324,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10670,
-                        ProductID = 23,
-                        UnitPrice = 9.0000m,
-                        Quantity = 32,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10670,
-                        ProductID = 23,
-                        UnitPrice = 9.0000m,
-                        Quantity = 32,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10670,
-                        ProductID = 23,
-                        UnitPrice = 9.0000m,
-                        Quantity = 32,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10670,
-                        ProductID = 23,
-                        UnitPrice = 9.0000m,
-                        Quantity = 32,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10671,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10671,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10671,
                         ProductID = 16,
                         UnitPrice = 17.4500m,
@@ -25864,30 +20337,6 @@ Winchester Way",
                         UnitPrice = 263.5000m,
                         Quantity = 15,
                         Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10672,
-                        ProductID = 38,
-                        UnitPrice = 263.5000m,
-                        Quantity = 15,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10673,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 3,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10673,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 3,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -25915,38 +20364,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10675,
-                        ProductID = 14,
-                        UnitPrice = 23.2500m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10675,
-                        ProductID = 14,
-                        UnitPrice = 23.2500m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10676,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 2,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10676,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 2,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10676,
                         ProductID = 10,
                         UnitPrice = 31.0000m,
@@ -25960,38 +20377,6 @@ Winchester Way",
                         UnitPrice = 31.2300m,
                         Quantity = 30,
                         Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10677,
-                        ProductID = 26,
-                        UnitPrice = 31.2300m,
-                        Quantity = 30,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10678,
-                        ProductID = 12,
-                        UnitPrice = 38.0000m,
-                        Quantity = 100,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10678,
-                        ProductID = 12,
-                        UnitPrice = 38.0000m,
-                        Quantity = 100,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10678,
-                        ProductID = 12,
-                        UnitPrice = 38.0000m,
-                        Quantity = 100,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -26019,59 +20404,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10680,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 50,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10680,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 50,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10681,
                         ProductID = 19,
                         UnitPrice = 9.2000m,
                         Quantity = 30,
                         Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10681,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 30,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10681,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 30,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10682,
-                        ProductID = 33,
-                        UnitPrice = 2.5000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10682,
-                        ProductID = 33,
-                        UnitPrice = 2.5000m,
-                        Quantity = 30,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -26099,38 +20436,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10684,
-                        ProductID = 40,
-                        UnitPrice = 18.4000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10684,
-                        ProductID = 40,
-                        UnitPrice = 18.4000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10685,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10685,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10685,
                         ProductID = 10,
                         UnitPrice = 31.0000m,
@@ -26147,51 +20452,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10686,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 30,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10687,
                         ProductID = 9,
                         UnitPrice = 97.0000m,
                         Quantity = 50,
                         Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10687,
-                        ProductID = 9,
-                        UnitPrice = 97.0000m,
-                        Quantity = 50,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10687,
-                        ProductID = 9,
-                        UnitPrice = 97.0000m,
-                        Quantity = 50,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10688,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 18,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10688,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 18,
-                        Discount = 0.1f
                     },
                 new OrderDetail
                     {
@@ -26219,46 +20484,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10690,
-                        ProductID = 56,
-                        UnitPrice = 38.0000m,
-                        Quantity = 20,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10691,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10691,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10691,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10691,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10691,
                         ProductID = 1,
                         UnitPrice = 18.0000m,
@@ -26283,66 +20508,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10693,
-                        ProductID = 9,
-                        UnitPrice = 97.0000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10693,
-                        ProductID = 9,
-                        UnitPrice = 97.0000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10693,
-                        ProductID = 9,
-                        UnitPrice = 97.0000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10694,
                         ProductID = 7,
                         UnitPrice = 30.0000m,
                         Quantity = 90,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10694,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 90,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10694,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 90,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10695,
-                        ProductID = 8,
-                        UnitPrice = 40.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10695,
-                        ProductID = 8,
-                        UnitPrice = 40.0000m,
-                        Quantity = 10,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -26363,75 +20532,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10696,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10697,
                         ProductID = 19,
                         UnitPrice = 9.2000m,
                         Quantity = 7,
                         Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10697,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 7,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10697,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 7,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10697,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 7,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10698,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10698,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10698,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10698,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 15,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -26459,46 +20564,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10700,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 5,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10700,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 5,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10700,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 5,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10701,
-                        ProductID = 59,
-                        UnitPrice = 55.0000m,
-                        Quantity = 42,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10701,
-                        ProductID = 59,
-                        UnitPrice = 55.0000m,
-                        Quantity = 42,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10701,
                         ProductID = 59,
                         UnitPrice = 55.0000m,
@@ -26515,50 +20580,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10702,
-                        ProductID = 3,
-                        UnitPrice = 10.0000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10703,
                         ProductID = 2,
                         UnitPrice = 19.0000m,
                         Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10703,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10703,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10704,
-                        ProductID = 4,
-                        UnitPrice = 22.0000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10704,
-                        ProductID = 4,
-                        UnitPrice = 22.0000m,
-                        Quantity = 6,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -26579,50 +20604,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10705,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10706,
                         ProductID = 16,
                         UnitPrice = 17.4500m,
                         Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10706,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10706,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10707,
-                        ProductID = 55,
-                        UnitPrice = 24.0000m,
-                        Quantity = 21,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10707,
-                        ProductID = 55,
-                        UnitPrice = 24.0000m,
-                        Quantity = 21,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -26643,30 +20628,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10708,
-                        ProductID = 5,
-                        UnitPrice = 21.3500m,
-                        Quantity = 4,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10709,
-                        ProductID = 8,
-                        UnitPrice = 40.0000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10709,
-                        ProductID = 8,
-                        UnitPrice = 40.0000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10709,
                         ProductID = 8,
                         UnitPrice = 40.0000m,
@@ -26679,30 +20640,6 @@ Winchester Way",
                         ProductID = 19,
                         UnitPrice = 9.2000m,
                         Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10710,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10711,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10711,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 12,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -26723,75 +20660,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10712,
-                        ProductID = 53,
-                        UnitPrice = 32.8000m,
-                        Quantity = 3,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10713,
                         ProductID = 10,
                         UnitPrice = 31.0000m,
                         Quantity = 18,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10713,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 18,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10713,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 18,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10713,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 18,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10714,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 30,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10714,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 30,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10714,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 30,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10714,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 30,
-                        Discount = 0.25f
                     },
                 new OrderDetail
                     {
@@ -26811,30 +20684,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10715,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 21,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10716,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10716,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10716,
                         ProductID = 21,
                         UnitPrice = 10.0000m,
@@ -26851,46 +20700,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10717,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 32,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10717,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 32,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10718,
-                        ProductID = 12,
-                        UnitPrice = 38.0000m,
-                        Quantity = 36,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10718,
-                        ProductID = 12,
-                        UnitPrice = 38.0000m,
-                        Quantity = 36,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10718,
-                        ProductID = 12,
-                        UnitPrice = 38.0000m,
-                        Quantity = 36,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10718,
                         ProductID = 12,
                         UnitPrice = 38.0000m,
@@ -26904,30 +20713,6 @@ Winchester Way",
                         UnitPrice = 62.5000m,
                         Quantity = 12,
                         Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10719,
-                        ProductID = 18,
-                        UnitPrice = 62.5000m,
-                        Quantity = 12,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10719,
-                        ProductID = 18,
-                        UnitPrice = 62.5000m,
-                        Quantity = 12,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10720,
-                        ProductID = 35,
-                        UnitPrice = 18.0000m,
-                        Quantity = 21,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -26955,30 +20740,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10722,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 3,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10722,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 3,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10722,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 3,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10723,
                         ProductID = 26,
                         UnitPrice = 31.2300m,
@@ -26995,30 +20756,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10724,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 16,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10725,
-                        ProductID = 41,
-                        UnitPrice = 9.6500m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10725,
-                        ProductID = 41,
-                        UnitPrice = 9.6500m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10725,
                         ProductID = 41,
                         UnitPrice = 9.6500m,
@@ -27035,59 +20772,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10726,
-                        ProductID = 4,
-                        UnitPrice = 22.0000m,
-                        Quantity = 25,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10727,
                         ProductID = 17,
                         UnitPrice = 39.0000m,
                         Quantity = 20,
                         Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10727,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 20,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10727,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 20,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10728,
-                        ProductID = 30,
-                        UnitPrice = 25.8900m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10728,
-                        ProductID = 30,
-                        UnitPrice = 25.8900m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10728,
-                        ProductID = 30,
-                        UnitPrice = 25.8900m,
-                        Quantity = 15,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -27107,50 +20796,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10729,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 50,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10729,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 50,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10730,
                         ProductID = 16,
                         UnitPrice = 17.4500m,
                         Quantity = 15,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10730,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 15,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10730,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 15,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10731,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 40,
                         Discount = 0.05f
                     },
                 new OrderDetail
@@ -27179,38 +20828,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10733,
-                        ProductID = 14,
-                        UnitPrice = 23.2500m,
-                        Quantity = 16,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10733,
-                        ProductID = 14,
-                        UnitPrice = 23.2500m,
-                        Quantity = 16,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10734,
-                        ProductID = 6,
-                        UnitPrice = 25.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10734,
-                        ProductID = 6,
-                        UnitPrice = 25.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10734,
                         ProductID = 6,
                         UnitPrice = 25.0000m,
@@ -27227,34 +20844,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10735,
-                        ProductID = 61,
-                        UnitPrice = 28.5000m,
-                        Quantity = 20,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10736,
                         ProductID = 65,
                         UnitPrice = 21.0500m,
                         Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10736,
-                        ProductID = 65,
-                        UnitPrice = 21.0500m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10737,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 4,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -27283,38 +20876,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10739,
-                        ProductID = 36,
-                        UnitPrice = 19.0000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10740,
-                        ProductID = 28,
-                        UnitPrice = 45.6000m,
-                        Quantity = 5,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10740,
-                        ProductID = 28,
-                        UnitPrice = 45.6000m,
-                        Quantity = 5,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10740,
-                        ProductID = 28,
-                        UnitPrice = 45.6000m,
-                        Quantity = 5,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10740,
                         ProductID = 28,
                         UnitPrice = 45.6000m,
@@ -27328,22 +20889,6 @@ Winchester Way",
                         UnitPrice = 19.0000m,
                         Quantity = 15,
                         Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10742,
-                        ProductID = 3,
-                        UnitPrice = 10.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10742,
-                        ProductID = 3,
-                        UnitPrice = 10.0000m,
-                        Quantity = 20,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -27379,82 +20924,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10745,
-                        ProductID = 18,
-                        UnitPrice = 62.5000m,
-                        Quantity = 24,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10745,
-                        ProductID = 18,
-                        UnitPrice = 62.5000m,
-                        Quantity = 24,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10745,
-                        ProductID = 18,
-                        UnitPrice = 62.5000m,
-                        Quantity = 24,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10746,
                         ProductID = 13,
                         UnitPrice = 6.0000m,
                         Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10746,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10746,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10746,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10747,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 8,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10747,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 8,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10747,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 8,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -27475,38 +20948,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10748,
-                        ProductID = 23,
-                        UnitPrice = 9.0000m,
-                        Quantity = 44,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10748,
-                        ProductID = 23,
-                        UnitPrice = 9.0000m,
-                        Quantity = 44,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10749,
-                        ProductID = 56,
-                        UnitPrice = 38.0000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10749,
-                        ProductID = 56,
-                        UnitPrice = 38.0000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10749,
                         ProductID = 56,
                         UnitPrice = 38.0000m,
@@ -27520,46 +20961,6 @@ Winchester Way",
                         UnitPrice = 23.2500m,
                         Quantity = 5,
                         Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10750,
-                        ProductID = 14,
-                        UnitPrice = 23.2500m,
-                        Quantity = 5,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10750,
-                        ProductID = 14,
-                        UnitPrice = 23.2500m,
-                        Quantity = 5,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10751,
-                        ProductID = 26,
-                        UnitPrice = 31.2300m,
-                        Quantity = 12,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10751,
-                        ProductID = 26,
-                        UnitPrice = 31.2300m,
-                        Quantity = 12,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10751,
-                        ProductID = 26,
-                        UnitPrice = 31.2300m,
-                        Quantity = 12,
-                        Discount = 0.1f
                     },
                 new OrderDetail
                     {
@@ -27575,22 +20976,6 @@ Winchester Way",
                         ProductID = 1,
                         UnitPrice = 18.0000m,
                         Quantity = 8,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10752,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 8,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10753,
-                        ProductID = 45,
-                        UnitPrice = 9.5000m,
-                        Quantity = 4,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -27619,54 +21004,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10755,
-                        ProductID = 47,
-                        UnitPrice = 9.5000m,
-                        Quantity = 30,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10755,
-                        ProductID = 47,
-                        UnitPrice = 9.5000m,
-                        Quantity = 30,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10755,
-                        ProductID = 47,
-                        UnitPrice = 9.5000m,
-                        Quantity = 30,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10756,
-                        ProductID = 18,
-                        UnitPrice = 62.5000m,
-                        Quantity = 21,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10756,
-                        ProductID = 18,
-                        UnitPrice = 62.5000m,
-                        Quantity = 21,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10756,
-                        ProductID = 18,
-                        UnitPrice = 62.5000m,
-                        Quantity = 21,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10756,
                         ProductID = 18,
                         UnitPrice = 62.5000m,
@@ -27679,46 +21016,6 @@ Winchester Way",
                         ProductID = 34,
                         UnitPrice = 14.0000m,
                         Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10757,
-                        ProductID = 34,
-                        UnitPrice = 14.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10757,
-                        ProductID = 34,
-                        UnitPrice = 14.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10757,
-                        ProductID = 34,
-                        UnitPrice = 14.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10758,
-                        ProductID = 26,
-                        UnitPrice = 31.2300m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10758,
-                        ProductID = 26,
-                        UnitPrice = 31.2300m,
-                        Quantity = 20,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -27747,30 +21044,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10760,
-                        ProductID = 25,
-                        UnitPrice = 14.0000m,
-                        Quantity = 12,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10760,
-                        ProductID = 25,
-                        UnitPrice = 14.0000m,
-                        Quantity = 12,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10761,
-                        ProductID = 25,
-                        UnitPrice = 14.0000m,
-                        Quantity = 35,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10761,
                         ProductID = 25,
                         UnitPrice = 14.0000m,
@@ -27787,59 +21060,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10762,
-                        ProductID = 39,
-                        UnitPrice = 18.0000m,
-                        Quantity = 16,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10762,
-                        ProductID = 39,
-                        UnitPrice = 18.0000m,
-                        Quantity = 16,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10762,
-                        ProductID = 39,
-                        UnitPrice = 18.0000m,
-                        Quantity = 16,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10763,
                         ProductID = 21,
                         UnitPrice = 10.0000m,
                         Quantity = 40,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10763,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10763,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10764,
-                        ProductID = 3,
-                        UnitPrice = 10.0000m,
-                        Quantity = 20,
-                        Discount = 0.1f
                     },
                 new OrderDetail
                     {
@@ -27867,22 +21092,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10766,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10766,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10767,
                         ProductID = 42,
                         UnitPrice = 14.0000m,
@@ -27896,54 +21105,6 @@ Winchester Way",
                         UnitPrice = 21.0000m,
                         Quantity = 4,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10768,
-                        ProductID = 22,
-                        UnitPrice = 21.0000m,
-                        Quantity = 4,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10768,
-                        ProductID = 22,
-                        UnitPrice = 21.0000m,
-                        Quantity = 4,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10768,
-                        ProductID = 22,
-                        UnitPrice = 21.0000m,
-                        Quantity = 4,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10769,
-                        ProductID = 41,
-                        UnitPrice = 9.6500m,
-                        Quantity = 30,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10769,
-                        ProductID = 41,
-                        UnitPrice = 9.6500m,
-                        Quantity = 30,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10769,
-                        ProductID = 41,
-                        UnitPrice = 9.6500m,
-                        Quantity = 30,
-                        Discount = 0.05f
                     },
                 new OrderDetail
                     {
@@ -27979,30 +21140,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10772,
-                        ProductID = 29,
-                        UnitPrice = 123.7900m,
-                        Quantity = 18,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10773,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 33,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10773,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 33,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10773,
                         ProductID = 17,
                         UnitPrice = 39.0000m,
@@ -28019,51 +21156,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10774,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 2,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10775,
                         ProductID = 10,
                         UnitPrice = 31.0000m,
                         Quantity = 6,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10775,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10776,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 16,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10776,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 16,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10776,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 16,
-                        Discount = 0.05f
                     },
                 new OrderDetail
                     {
@@ -28099,43 +21196,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10779,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10780,
                         ProductID = 70,
                         UnitPrice = 15.0000m,
                         Quantity = 35,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10780,
-                        ProductID = 70,
-                        UnitPrice = 15.0000m,
-                        Quantity = 35,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10781,
-                        ProductID = 54,
-                        UnitPrice = 7.4500m,
-                        Quantity = 3,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10781,
-                        ProductID = 54,
-                        UnitPrice = 7.4500m,
-                        Quantity = 3,
-                        Discount = 0.2f
                     },
                 new OrderDetail
                     {
@@ -28163,30 +21228,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10783,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10784,
-                        ProductID = 36,
-                        UnitPrice = 19.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10784,
-                        ProductID = 36,
-                        UnitPrice = 19.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10784,
                         ProductID = 36,
                         UnitPrice = 19.0000m,
@@ -28200,30 +21241,6 @@ Winchester Way",
                         UnitPrice = 31.0000m,
                         Quantity = 10,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10785,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10786,
-                        ProductID = 8,
-                        UnitPrice = 40.0000m,
-                        Quantity = 30,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10786,
-                        ProductID = 8,
-                        UnitPrice = 40.0000m,
-                        Quantity = 30,
-                        Discount = 0.2f
                     },
                 new OrderDetail
                     {
@@ -28243,51 +21260,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10787,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 15,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10788,
                         ProductID = 19,
                         UnitPrice = 9.2000m,
                         Quantity = 50,
                         Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10788,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 50,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10789,
-                        ProductID = 18,
-                        UnitPrice = 62.5000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10789,
-                        ProductID = 18,
-                        UnitPrice = 62.5000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10789,
-                        ProductID = 18,
-                        UnitPrice = 62.5000m,
-                        Quantity = 30,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -28307,22 +21284,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10790,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 3,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10791,
-                        ProductID = 29,
-                        UnitPrice = 123.7900m,
-                        Quantity = 14,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10791,
                         ProductID = 29,
                         UnitPrice = 123.7900m,
@@ -28335,30 +21296,6 @@ Winchester Way",
                         ProductID = 2,
                         UnitPrice = 19.0000m,
                         Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10792,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10792,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10793,
-                        ProductID = 41,
-                        UnitPrice = 9.6500m,
-                        Quantity = 14,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -28379,51 +21316,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10794,
-                        ProductID = 14,
-                        UnitPrice = 23.2500m,
-                        Quantity = 15,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10795,
                         ProductID = 16,
                         UnitPrice = 17.4500m,
                         Quantity = 65,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10795,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 65,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10796,
-                        ProductID = 26,
-                        UnitPrice = 31.2300m,
-                        Quantity = 21,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10796,
-                        ProductID = 26,
-                        UnitPrice = 31.2300m,
-                        Quantity = 21,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10796,
-                        ProductID = 26,
-                        UnitPrice = 31.2300m,
-                        Quantity = 21,
-                        Discount = 0.2f
                     },
                 new OrderDetail
                     {
@@ -28451,51 +21348,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10798,
-                        ProductID = 62,
-                        UnitPrice = 49.3000m,
-                        Quantity = 2,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10799,
                         ProductID = 13,
                         UnitPrice = 6.0000m,
                         Quantity = 20,
                         Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10799,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 20,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10799,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 20,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10800,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 50,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10800,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 50,
-                        Discount = 0.1f
                     },
                 new OrderDetail
                     {
@@ -28515,38 +21372,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10801,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 40,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10802,
-                        ProductID = 30,
-                        UnitPrice = 25.8900m,
-                        Quantity = 25,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10802,
-                        ProductID = 30,
-                        UnitPrice = 25.8900m,
-                        Quantity = 25,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10802,
-                        ProductID = 30,
-                        UnitPrice = 25.8900m,
-                        Quantity = 25,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10802,
                         ProductID = 30,
                         UnitPrice = 25.8900m,
@@ -28560,38 +21385,6 @@ Winchester Way",
                         UnitPrice = 9.2000m,
                         Quantity = 24,
                         Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10803,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 24,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10803,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 24,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10804,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 36,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10804,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 36,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -28608,30 +21401,6 @@ Winchester Way",
                         UnitPrice = 14.0000m,
                         Quantity = 10,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10805,
-                        ProductID = 34,
-                        UnitPrice = 14.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10806,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 20,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10806,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 20,
-                        Discount = 0.25f
                     },
                 new OrderDetail
                     {
@@ -28659,14 +21428,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10808,
-                        ProductID = 56,
-                        UnitPrice = 38.0000m,
-                        Quantity = 20,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10809,
                         ProductID = 52,
                         UnitPrice = 7.0000m,
@@ -28683,59 +21444,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10810,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 7,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10810,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 7,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10811,
                         ProductID = 19,
                         UnitPrice = 9.2000m,
                         Quantity = 15,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10811,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10811,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10812,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 16,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10812,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 16,
-                        Discount = 0.1f
                     },
                 new OrderDetail
                     {
@@ -28752,38 +21465,6 @@ Winchester Way",
                         UnitPrice = 19.0000m,
                         Quantity = 12,
                         Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10813,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 12,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10814,
-                        ProductID = 41,
-                        UnitPrice = 9.6500m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10814,
-                        ProductID = 41,
-                        UnitPrice = 9.6500m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10814,
-                        ProductID = 41,
-                        UnitPrice = 9.6500m,
-                        Quantity = 20,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -28811,38 +21492,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10816,
-                        ProductID = 38,
-                        UnitPrice = 263.5000m,
-                        Quantity = 30,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10817,
-                        ProductID = 26,
-                        UnitPrice = 31.2300m,
-                        Quantity = 40,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10817,
-                        ProductID = 26,
-                        UnitPrice = 31.2300m,
-                        Quantity = 40,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10817,
-                        ProductID = 26,
-                        UnitPrice = 31.2300m,
-                        Quantity = 40,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10817,
                         ProductID = 26,
                         UnitPrice = 31.2300m,
@@ -28855,22 +21504,6 @@ Winchester Way",
                         ProductID = 32,
                         UnitPrice = 32.0000m,
                         Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10818,
-                        ProductID = 32,
-                        UnitPrice = 32.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10819,
-                        ProductID = 43,
-                        UnitPrice = 46.0000m,
-                        Quantity = 7,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -28899,22 +21532,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10821,
-                        ProductID = 35,
-                        UnitPrice = 18.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10822,
-                        ProductID = 62,
-                        UnitPrice = 49.3000m,
-                        Quantity = 3,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10822,
                         ProductID = 62,
                         UnitPrice = 49.3000m,
@@ -28931,49 +21548,9 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10823,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 20,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10823,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 20,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10823,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 20,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10824,
                         ProductID = 41,
                         UnitPrice = 9.6500m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10824,
-                        ProductID = 41,
-                        UnitPrice = 9.6500m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10825,
-                        ProductID = 26,
-                        UnitPrice = 31.2300m,
                         Quantity = 12,
                         Discount = 0f
                     },
@@ -28995,22 +21572,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10826,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 35,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10827,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10827,
                         ProductID = 10,
                         UnitPrice = 31.0000m,
@@ -29027,66 +21588,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10828,
-                        ProductID = 20,
-                        UnitPrice = 81.0000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10829,
                         ProductID = 2,
                         UnitPrice = 19.0000m,
                         Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10829,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10829,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10829,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10830,
-                        ProductID = 6,
-                        UnitPrice = 25.0000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10830,
-                        ProductID = 6,
-                        UnitPrice = 25.0000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10830,
-                        ProductID = 6,
-                        UnitPrice = 25.0000m,
-                        Quantity = 6,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -29107,75 +21612,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10831,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 2,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10831,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 2,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10831,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 2,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10832,
                         ProductID = 13,
                         UnitPrice = 6.0000m,
                         Quantity = 3,
                         Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10832,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 3,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10832,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 3,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10832,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 3,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10833,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 20,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10833,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 20,
-                        Discount = 0.1f
                     },
                 new OrderDetail
                     {
@@ -29195,22 +21636,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10834,
-                        ProductID = 29,
-                        UnitPrice = 123.7900m,
-                        Quantity = 8,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10835,
-                        ProductID = 59,
-                        UnitPrice = 55.0000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10835,
                         ProductID = 59,
                         UnitPrice = 55.0000m,
@@ -29227,83 +21652,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10836,
-                        ProductID = 22,
-                        UnitPrice = 21.0000m,
-                        Quantity = 52,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10836,
-                        ProductID = 22,
-                        UnitPrice = 21.0000m,
-                        Quantity = 52,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10836,
-                        ProductID = 22,
-                        UnitPrice = 21.0000m,
-                        Quantity = 52,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10836,
-                        ProductID = 22,
-                        UnitPrice = 21.0000m,
-                        Quantity = 52,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10837,
                         ProductID = 13,
                         UnitPrice = 6.0000m,
                         Quantity = 6,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10837,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10837,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10837,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10838,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 4,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10838,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 4,
-                        Discount = 0.25f
                     },
                 new OrderDetail
                     {
@@ -29323,22 +21676,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10839,
-                        ProductID = 58,
-                        UnitPrice = 13.2500m,
-                        Quantity = 30,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10840,
-                        ProductID = 25,
-                        UnitPrice = 14.0000m,
-                        Quantity = 6,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10840,
                         ProductID = 25,
                         UnitPrice = 14.0000m,
@@ -29351,54 +21688,6 @@ Winchester Way",
                         ProductID = 10,
                         UnitPrice = 31.0000m,
                         Quantity = 16,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10841,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 16,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10841,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 16,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10841,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 16,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10842,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10842,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10842,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 15,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -29435,99 +21724,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10845,
-                        ProductID = 23,
-                        UnitPrice = 9.0000m,
-                        Quantity = 70,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10845,
-                        ProductID = 23,
-                        UnitPrice = 9.0000m,
-                        Quantity = 70,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10845,
-                        ProductID = 23,
-                        UnitPrice = 9.0000m,
-                        Quantity = 70,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10845,
-                        ProductID = 23,
-                        UnitPrice = 9.0000m,
-                        Quantity = 70,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10846,
                         ProductID = 4,
                         UnitPrice = 22.0000m,
                         Quantity = 21,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10846,
-                        ProductID = 4,
-                        UnitPrice = 22.0000m,
-                        Quantity = 21,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10846,
-                        ProductID = 4,
-                        UnitPrice = 22.0000m,
-                        Quantity = 21,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10847,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 80,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10847,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 80,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10847,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 80,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10847,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 80,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10847,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 80,
-                        Discount = 0.2f
                     },
                 new OrderDetail
                     {
@@ -29547,22 +21748,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10848,
-                        ProductID = 5,
-                        UnitPrice = 21.3500m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10849,
-                        ProductID = 3,
-                        UnitPrice = 10.0000m,
-                        Quantity = 49,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10849,
                         ProductID = 3,
                         UnitPrice = 10.0000m,
@@ -29579,67 +21764,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10850,
-                        ProductID = 25,
-                        UnitPrice = 14.0000m,
-                        Quantity = 20,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10850,
-                        ProductID = 25,
-                        UnitPrice = 14.0000m,
-                        Quantity = 20,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10851,
                         ProductID = 2,
                         UnitPrice = 19.0000m,
                         Quantity = 5,
                         Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10851,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 5,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10851,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 5,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10851,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 5,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10852,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10852,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 15,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -29667,38 +21796,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10854,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 100,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10855,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 50,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10855,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 50,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10855,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 50,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10855,
                         ProductID = 16,
                         UnitPrice = 17.4500m,
@@ -29715,30 +21812,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10856,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10857,
-                        ProductID = 3,
-                        UnitPrice = 10.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10857,
-                        ProductID = 3,
-                        UnitPrice = 10.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10857,
                         ProductID = 3,
                         UnitPrice = 10.0000m,
@@ -29752,38 +21825,6 @@ Winchester Way",
                         UnitPrice = 30.0000m,
                         Quantity = 5,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10858,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10858,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10859,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 40,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10859,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 40,
-                        Discount = 0.25f
                     },
                 new OrderDetail
                     {
@@ -29799,46 +21840,6 @@ Winchester Way",
                         ProductID = 51,
                         UnitPrice = 53.0000m,
                         Quantity = 3,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10860,
-                        ProductID = 51,
-                        UnitPrice = 53.0000m,
-                        Quantity = 3,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10861,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 42,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10861,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 42,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10861,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 42,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10861,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 42,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -29859,22 +21860,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10862,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 25,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10863,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 20,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10863,
                         ProductID = 1,
                         UnitPrice = 18.0000m,
@@ -29891,43 +21876,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10864,
-                        ProductID = 35,
-                        UnitPrice = 18.0000m,
-                        Quantity = 4,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10865,
                         ProductID = 38,
                         UnitPrice = 263.5000m,
                         Quantity = 60,
                         Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10865,
-                        ProductID = 38,
-                        UnitPrice = 263.5000m,
-                        Quantity = 60,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10866,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 21,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10866,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 21,
-                        Discount = 0.25f
                     },
                 new OrderDetail
                     {
@@ -29955,46 +21908,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10868,
-                        ProductID = 26,
-                        UnitPrice = 31.2300m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10868,
-                        ProductID = 26,
-                        UnitPrice = 31.2300m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10869,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10869,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10869,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10869,
                         ProductID = 1,
                         UnitPrice = 18.0000m,
@@ -30011,30 +21924,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10870,
-                        ProductID = 35,
-                        UnitPrice = 18.0000m,
-                        Quantity = 3,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10871,
-                        ProductID = 6,
-                        UnitPrice = 25.0000m,
-                        Quantity = 50,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10871,
-                        ProductID = 6,
-                        UnitPrice = 25.0000m,
-                        Quantity = 50,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10871,
                         ProductID = 6,
                         UnitPrice = 25.0000m,
@@ -30048,38 +21937,6 @@ Winchester Way",
                         UnitPrice = 24.0000m,
                         Quantity = 10,
                         Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10872,
-                        ProductID = 55,
-                        UnitPrice = 24.0000m,
-                        Quantity = 10,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10872,
-                        ProductID = 55,
-                        UnitPrice = 24.0000m,
-                        Quantity = 10,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10872,
-                        ProductID = 55,
-                        UnitPrice = 24.0000m,
-                        Quantity = 10,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10873,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 20,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -30107,43 +21964,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10875,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 25,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10875,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 25,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10876,
                         ProductID = 46,
                         UnitPrice = 12.0000m,
                         Quantity = 21,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10876,
-                        ProductID = 46,
-                        UnitPrice = 12.0000m,
-                        Quantity = 21,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10877,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 30,
-                        Discount = 0.25f
                     },
                 new OrderDetail
                     {
@@ -30171,38 +21996,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10879,
-                        ProductID = 40,
-                        UnitPrice = 18.4000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10879,
-                        ProductID = 40,
-                        UnitPrice = 18.4000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10880,
-                        ProductID = 23,
-                        UnitPrice = 9.0000m,
-                        Quantity = 30,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10880,
-                        ProductID = 23,
-                        UnitPrice = 9.0000m,
-                        Quantity = 30,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10880,
                         ProductID = 23,
                         UnitPrice = 9.0000m,
@@ -30215,22 +22008,6 @@ Winchester Way",
                         ProductID = 73,
                         UnitPrice = 15.0000m,
                         Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10882,
-                        ProductID = 42,
-                        UnitPrice = 14.0000m,
-                        Quantity = 25,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10882,
-                        ProductID = 42,
-                        UnitPrice = 14.0000m,
-                        Quantity = 25,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -30259,66 +22036,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10884,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 40,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10884,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 40,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10885,
                         ProductID = 2,
                         UnitPrice = 19.0000m,
                         Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10885,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10885,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10885,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10886,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 70,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10886,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 70,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -30347,42 +22068,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10888,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10889,
                         ProductID = 11,
                         UnitPrice = 21.0000m,
                         Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10889,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10890,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10890,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 15,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -30419,83 +22108,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10893,
-                        ProductID = 8,
-                        UnitPrice = 40.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10893,
-                        ProductID = 8,
-                        UnitPrice = 40.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10893,
-                        ProductID = 8,
-                        UnitPrice = 40.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10893,
-                        ProductID = 8,
-                        UnitPrice = 40.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10894,
                         ProductID = 13,
                         UnitPrice = 6.0000m,
                         Quantity = 28,
                         Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10894,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 28,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10894,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 28,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10895,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 110,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10895,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 110,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10895,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 110,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -30511,22 +22128,6 @@ Winchester Way",
                         ProductID = 45,
                         UnitPrice = 9.5000m,
                         Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10896,
-                        ProductID = 45,
-                        UnitPrice = 9.5000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10897,
-                        ProductID = 29,
-                        UnitPrice = 123.7900m,
-                        Quantity = 80,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -30571,22 +22172,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10901,
-                        ProductID = 41,
-                        UnitPrice = 9.6500m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10902,
-                        ProductID = 55,
-                        UnitPrice = 24.0000m,
-                        Quantity = 30,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10902,
                         ProductID = 55,
                         UnitPrice = 24.0000m,
@@ -30599,30 +22184,6 @@ Winchester Way",
                         ProductID = 13,
                         UnitPrice = 6.0000m,
                         Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10903,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10903,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10904,
-                        ProductID = 58,
-                        UnitPrice = 13.2500m,
-                        Quantity = 15,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -30667,30 +22228,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10908,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 20,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10909,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10909,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10909,
                         ProductID = 7,
                         UnitPrice = 30.0000m,
@@ -30703,38 +22240,6 @@ Winchester Way",
                         ProductID = 19,
                         UnitPrice = 9.2000m,
                         Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10910,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10910,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10911,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10911,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 10,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -30751,30 +22256,6 @@ Winchester Way",
                         ProductID = 11,
                         UnitPrice = 21.0000m,
                         Quantity = 40,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10912,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 40,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10913,
-                        ProductID = 4,
-                        UnitPrice = 22.0000m,
-                        Quantity = 30,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10913,
-                        ProductID = 4,
-                        UnitPrice = 22.0000m,
-                        Quantity = 30,
                         Discount = 0.25f
                     },
                 new OrderDetail
@@ -30803,50 +22284,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10915,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10915,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10916,
                         ProductID = 16,
                         UnitPrice = 17.4500m,
                         Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10916,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10916,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10917,
-                        ProductID = 30,
-                        UnitPrice = 25.8900m,
-                        Quantity = 1,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -30864,30 +22305,6 @@ Winchester Way",
                         UnitPrice = 18.0000m,
                         Quantity = 60,
                         Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10918,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 60,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10919,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 24,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10919,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 24,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -30915,22 +22332,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10921,
-                        ProductID = 35,
-                        UnitPrice = 18.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10922,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10922,
                         ProductID = 17,
                         UnitPrice = 39.0000m,
@@ -30944,38 +22345,6 @@ Winchester Way",
                         UnitPrice = 14.0000m,
                         Quantity = 10,
                         Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10923,
-                        ProductID = 42,
-                        UnitPrice = 14.0000m,
-                        Quantity = 10,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10923,
-                        ProductID = 42,
-                        UnitPrice = 14.0000m,
-                        Quantity = 10,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10924,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 20,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10924,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 20,
-                        Discount = 0.1f
                     },
                 new OrderDetail
                     {
@@ -30995,38 +22364,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10925,
-                        ProductID = 36,
-                        UnitPrice = 19.0000m,
-                        Quantity = 25,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10926,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 2,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10926,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 2,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10926,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 2,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10926,
                         ProductID = 11,
                         UnitPrice = 21.0000m,
@@ -31038,30 +22375,6 @@ Winchester Way",
                         OrderID = 10927,
                         ProductID = 20,
                         UnitPrice = 81.0000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10927,
-                        ProductID = 20,
-                        UnitPrice = 81.0000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10927,
-                        ProductID = 20,
-                        UnitPrice = 81.0000m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10928,
-                        ProductID = 47,
-                        UnitPrice = 9.5000m,
                         Quantity = 5,
                         Discount = 0f
                     },
@@ -31083,46 +22396,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10929,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 60,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10929,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 60,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10930,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 36,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10930,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 36,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10930,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 36,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10930,
                         ProductID = 21,
                         UnitPrice = 10.0000m,
@@ -31139,51 +22412,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10931,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 42,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10932,
                         ProductID = 16,
                         UnitPrice = 17.4500m,
                         Quantity = 30,
                         Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10932,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 30,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10932,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 30,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10932,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 30,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10933,
-                        ProductID = 53,
-                        UnitPrice = 32.8000m,
-                        Quantity = 2,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -31199,22 +22432,6 @@ Winchester Way",
                         ProductID = 6,
                         UnitPrice = 25.0000m,
                         Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10935,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 21,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10935,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 21,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -31243,38 +22460,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10937,
-                        ProductID = 28,
-                        UnitPrice = 45.6000m,
-                        Quantity = 8,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10938,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 20,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10938,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 20,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10938,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 20,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10938,
                         ProductID = 13,
                         UnitPrice = 6.0000m,
@@ -31291,51 +22476,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10939,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 10,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10940,
                         ProductID = 7,
                         UnitPrice = 30.0000m,
                         Quantity = 8,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10940,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 8,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10941,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 44,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10941,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 44,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10941,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 44,
-                        Discount = 0.25f
                     },
                 new OrderDetail
                     {
@@ -31363,38 +22508,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10943,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10943,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10944,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 5,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10944,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 5,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10944,
                         ProductID = 11,
                         UnitPrice = 21.0000m,
@@ -31407,30 +22520,6 @@ Winchester Way",
                         ProductID = 13,
                         UnitPrice = 6.0000m,
                         Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10945,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10946,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 25,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10946,
-                        ProductID = 10,
-                        UnitPrice = 31.0000m,
-                        Quantity = 25,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -31459,46 +22548,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10948,
-                        ProductID = 50,
-                        UnitPrice = 16.2500m,
-                        Quantity = 9,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10948,
-                        ProductID = 50,
-                        UnitPrice = 16.2500m,
-                        Quantity = 9,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10949,
-                        ProductID = 6,
-                        UnitPrice = 25.0000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10949,
-                        ProductID = 6,
-                        UnitPrice = 25.0000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10949,
-                        ProductID = 6,
-                        UnitPrice = 25.0000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10949,
                         ProductID = 6,
                         UnitPrice = 25.0000m,
@@ -31523,30 +22572,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10951,
-                        ProductID = 33,
-                        UnitPrice = 2.5000m,
-                        Quantity = 15,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10951,
-                        ProductID = 33,
-                        UnitPrice = 2.5000m,
-                        Quantity = 15,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10952,
-                        ProductID = 6,
-                        UnitPrice = 25.0000m,
-                        Quantity = 16,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10952,
                         ProductID = 6,
                         UnitPrice = 25.0000m,
@@ -31560,38 +22585,6 @@ Winchester Way",
                         UnitPrice = 81.0000m,
                         Quantity = 50,
                         Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10953,
-                        ProductID = 20,
-                        UnitPrice = 81.0000m,
-                        Quantity = 50,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10954,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 28,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10954,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 28,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10954,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 28,
-                        Discount = 0.15f
                     },
                 new OrderDetail
                     {
@@ -31619,58 +22612,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10956,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10956,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10957,
                         ProductID = 30,
                         UnitPrice = 25.8900m,
                         Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10957,
-                        ProductID = 30,
-                        UnitPrice = 25.8900m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10957,
-                        ProductID = 30,
-                        UnitPrice = 25.8900m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10958,
-                        ProductID = 5,
-                        UnitPrice = 21.3500m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10958,
-                        ProductID = 5,
-                        UnitPrice = 21.3500m,
-                        Quantity = 20,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -31699,59 +22644,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10960,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 10,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10961,
                         ProductID = 52,
                         UnitPrice = 7.0000m,
                         Quantity = 6,
                         Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10961,
-                        ProductID = 52,
-                        UnitPrice = 7.0000m,
-                        Quantity = 6,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10962,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 45,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10962,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 45,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10962,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 45,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10962,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 45,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -31779,22 +22676,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10964,
-                        ProductID = 18,
-                        UnitPrice = 62.5000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10964,
-                        ProductID = 18,
-                        UnitPrice = 62.5000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10965,
                         ProductID = 51,
                         UnitPrice = 53.0000m,
@@ -31811,50 +22692,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10966,
-                        ProductID = 37,
-                        UnitPrice = 26.0000m,
-                        Quantity = 8,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10966,
-                        ProductID = 37,
-                        UnitPrice = 26.0000m,
-                        Quantity = 8,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10967,
                         ProductID = 19,
                         UnitPrice = 9.2000m,
                         Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10967,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10968,
-                        ProductID = 12,
-                        UnitPrice = 38.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10968,
-                        ProductID = 12,
-                        UnitPrice = 38.0000m,
-                        Quantity = 30,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -31899,30 +22740,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10972,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10973,
-                        ProductID = 26,
-                        UnitPrice = 31.2300m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10973,
-                        ProductID = 26,
-                        UnitPrice = 31.2300m,
-                        Quantity = 5,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10973,
                         ProductID = 26,
                         UnitPrice = 31.2300m,
@@ -31935,14 +22752,6 @@ Winchester Way",
                         ProductID = 63,
                         UnitPrice = 43.9000m,
                         Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10975,
-                        ProductID = 8,
-                        UnitPrice = 40.0000m,
-                        Quantity = 16,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -31971,99 +22780,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10977,
-                        ProductID = 39,
-                        UnitPrice = 18.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10977,
-                        ProductID = 39,
-                        UnitPrice = 18.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10977,
-                        ProductID = 39,
-                        UnitPrice = 18.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10978,
                         ProductID = 8,
                         UnitPrice = 40.0000m,
                         Quantity = 20,
                         Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10978,
-                        ProductID = 8,
-                        UnitPrice = 40.0000m,
-                        Quantity = 20,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10978,
-                        ProductID = 8,
-                        UnitPrice = 40.0000m,
-                        Quantity = 20,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10978,
-                        ProductID = 8,
-                        UnitPrice = 40.0000m,
-                        Quantity = 20,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10979,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 18,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10979,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 18,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10979,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 18,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10979,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 18,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10979,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 18,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -32099,22 +22820,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10982,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10983,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 84,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10983,
                         ProductID = 13,
                         UnitPrice = 6.0000m,
@@ -32131,38 +22836,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10984,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 55,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10984,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 55,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10985,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 36,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10985,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 36,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10985,
                         ProductID = 16,
                         UnitPrice = 17.4500m,
@@ -32179,55 +22852,7 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10986,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10986,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10986,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10987,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 60,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10987,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 60,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10987,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 60,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10988,
                         ProductID = 7,
                         UnitPrice = 30.0000m,
                         Quantity = 60,
@@ -32251,67 +22876,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10989,
-                        ProductID = 6,
-                        UnitPrice = 25.0000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10989,
-                        ProductID = 6,
-                        UnitPrice = 25.0000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10990,
                         ProductID = 21,
                         UnitPrice = 10.0000m,
                         Quantity = 65,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10990,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 65,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10990,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 65,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10990,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 65,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10991,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 50,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10991,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 50,
-                        Discount = 0.2f
                     },
                 new OrderDetail
                     {
@@ -32339,27 +22908,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10993,
-                        ProductID = 29,
-                        UnitPrice = 123.7900m,
-                        Quantity = 50,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10994,
                         ProductID = 59,
                         UnitPrice = 55.0000m,
                         Quantity = 18,
                         Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10995,
-                        ProductID = 51,
-                        UnitPrice = 53.0000m,
-                        Quantity = 20,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -32387,67 +22940,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 10997,
-                        ProductID = 32,
-                        UnitPrice = 32.0000m,
-                        Quantity = 50,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10997,
-                        ProductID = 32,
-                        UnitPrice = 32.0000m,
-                        Quantity = 50,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 10998,
                         ProductID = 24,
                         UnitPrice = 4.5000m,
                         Quantity = 12,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10998,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10998,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10998,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10999,
-                        ProductID = 41,
-                        UnitPrice = 9.6500m,
-                        Quantity = 20,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 10999,
-                        ProductID = 41,
-                        UnitPrice = 9.6500m,
-                        Quantity = 20,
-                        Discount = 0.05f
                     },
                 new OrderDetail
                     {
@@ -32467,46 +22964,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 11000,
-                        ProductID = 4,
-                        UnitPrice = 22.0000m,
-                        Quantity = 25,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11000,
-                        ProductID = 4,
-                        UnitPrice = 22.0000m,
-                        Quantity = 25,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11001,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 60,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11001,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 60,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11001,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 60,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 11001,
                         ProductID = 7,
                         UnitPrice = 30.0000m,
@@ -32519,46 +22976,6 @@ Winchester Way",
                         ProductID = 13,
                         UnitPrice = 6.0000m,
                         Quantity = 56,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11002,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 56,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11002,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 56,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11002,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 56,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11003,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 4,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11003,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 4,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -32579,22 +22996,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 11004,
-                        ProductID = 26,
-                        UnitPrice = 31.2300m,
-                        Quantity = 6,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11005,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 2,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 11005,
                         ProductID = 1,
                         UnitPrice = 18.0000m,
@@ -32611,30 +23012,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 11006,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 8,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11007,
-                        ProductID = 8,
-                        UnitPrice = 40.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11007,
-                        ProductID = 8,
-                        UnitPrice = 40.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 11007,
                         ProductID = 8,
                         UnitPrice = 40.0000m,
@@ -32651,50 +23028,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 11008,
-                        ProductID = 28,
-                        UnitPrice = 45.6000m,
-                        Quantity = 70,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11008,
-                        ProductID = 28,
-                        UnitPrice = 45.6000m,
-                        Quantity = 70,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 11009,
                         ProductID = 24,
                         UnitPrice = 4.5000m,
                         Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11009,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11009,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11010,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 20,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -32715,59 +23052,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 11011,
-                        ProductID = 58,
-                        UnitPrice = 13.2500m,
-                        Quantity = 40,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 11012,
                         ProductID = 19,
                         UnitPrice = 9.2000m,
                         Quantity = 50,
                         Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11012,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 50,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11012,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 50,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11013,
-                        ProductID = 23,
-                        UnitPrice = 9.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11013,
-                        ProductID = 23,
-                        UnitPrice = 9.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11013,
-                        ProductID = 23,
-                        UnitPrice = 9.0000m,
-                        Quantity = 10,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -32795,22 +23084,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 11015,
-                        ProductID = 30,
-                        UnitPrice = 25.8900m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11016,
-                        ProductID = 31,
-                        UnitPrice = 12.5000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 11016,
                         ProductID = 31,
                         UnitPrice = 12.5000m,
@@ -32827,50 +23100,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 11017,
-                        ProductID = 3,
-                        UnitPrice = 10.0000m,
-                        Quantity = 25,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11017,
-                        ProductID = 3,
-                        UnitPrice = 10.0000m,
-                        Quantity = 25,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 11018,
                         ProductID = 12,
                         UnitPrice = 38.0000m,
                         Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11018,
-                        ProductID = 12,
-                        UnitPrice = 38.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11018,
-                        ProductID = 12,
-                        UnitPrice = 38.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11019,
-                        ProductID = 46,
-                        UnitPrice = 12.0000m,
-                        Quantity = 3,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -32899,46 +23132,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 11021,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 11,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11021,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 11,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11021,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 11,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11021,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 11,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11022,
-                        ProductID = 19,
-                        UnitPrice = 9.2000m,
-                        Quantity = 35,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 11022,
                         ProductID = 19,
                         UnitPrice = 9.2000m,
@@ -32951,38 +23144,6 @@ Winchester Way",
                         ProductID = 7,
                         UnitPrice = 30.0000m,
                         Quantity = 4,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11023,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 4,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11024,
-                        ProductID = 26,
-                        UnitPrice = 31.2300m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11024,
-                        ProductID = 26,
-                        UnitPrice = 31.2300m,
-                        Quantity = 12,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11024,
-                        ProductID = 26,
-                        UnitPrice = 31.2300m,
-                        Quantity = 12,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -33003,35 +23164,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 11025,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 10,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 11026,
                         ProductID = 18,
                         UnitPrice = 62.5000m,
                         Quantity = 8,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11026,
-                        ProductID = 18,
-                        UnitPrice = 62.5000m,
-                        Quantity = 8,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11027,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 30,
-                        Discount = 0.25f
                     },
                 new OrderDetail
                     {
@@ -33051,22 +23188,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 11028,
-                        ProductID = 55,
-                        UnitPrice = 24.0000m,
-                        Quantity = 35,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11029,
-                        ProductID = 56,
-                        UnitPrice = 38.0000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 11029,
                         ProductID = 56,
                         UnitPrice = 38.0000m,
@@ -33083,82 +23204,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 11030,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 100,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11030,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 100,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11030,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 100,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 11031,
                         ProductID = 1,
                         UnitPrice = 18.0000m,
                         Quantity = 45,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11031,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 45,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11031,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 45,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11031,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 45,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11031,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 45,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11032,
-                        ProductID = 36,
-                        UnitPrice = 19.0000m,
-                        Quantity = 35,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11032,
-                        ProductID = 36,
-                        UnitPrice = 19.0000m,
-                        Quantity = 35,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -33179,30 +23228,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 11033,
-                        ProductID = 53,
-                        UnitPrice = 32.8000m,
-                        Quantity = 70,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11034,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 15,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11034,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 15,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 11034,
                         ProductID = 21,
                         UnitPrice = 10.0000m,
@@ -33215,38 +23240,6 @@ Winchester Way",
                         ProductID = 1,
                         UnitPrice = 18.0000m,
                         Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11035,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11035,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11035,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11036,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 7,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -33275,46 +23268,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 11038,
-                        ProductID = 40,
-                        UnitPrice = 18.4000m,
-                        Quantity = 5,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11038,
-                        ProductID = 40,
-                        UnitPrice = 18.4000m,
-                        Quantity = 5,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11039,
-                        ProductID = 28,
-                        UnitPrice = 45.6000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11039,
-                        ProductID = 28,
-                        UnitPrice = 45.6000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11039,
-                        ProductID = 28,
-                        UnitPrice = 45.6000m,
-                        Quantity = 20,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 11039,
                         ProductID = 28,
                         UnitPrice = 45.6000m,
@@ -33336,22 +23289,6 @@ Winchester Way",
                         UnitPrice = 19.0000m,
                         Quantity = 30,
                         Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11041,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 30,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11042,
-                        ProductID = 44,
-                        UnitPrice = 19.4500m,
-                        Quantity = 15,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -33387,43 +23324,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 11045,
-                        ProductID = 33,
-                        UnitPrice = 2.5000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 11046,
                         ProductID = 12,
                         UnitPrice = 38.0000m,
                         Quantity = 20,
                         Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11046,
-                        ProductID = 12,
-                        UnitPrice = 38.0000m,
-                        Quantity = 20,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11046,
-                        ProductID = 12,
-                        UnitPrice = 38.0000m,
-                        Quantity = 20,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11047,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 25,
-                        Discount = 0.25f
                     },
                 new OrderDetail
                     {
@@ -33440,14 +23345,6 @@ Winchester Way",
                         UnitPrice = 12.5000m,
                         Quantity = 42,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11049,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 10,
-                        Discount = 0.2f
                     },
                 new OrderDetail
                     {
@@ -33483,30 +23380,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 11052,
-                        ProductID = 43,
-                        UnitPrice = 46.0000m,
-                        Quantity = 30,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11053,
-                        ProductID = 18,
-                        UnitPrice = 62.5000m,
-                        Quantity = 35,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11053,
-                        ProductID = 18,
-                        UnitPrice = 62.5000m,
-                        Quantity = 35,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 11053,
                         ProductID = 18,
                         UnitPrice = 62.5000m,
@@ -33523,58 +23396,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 11054,
-                        ProductID = 33,
-                        UnitPrice = 2.5000m,
-                        Quantity = 10,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 11055,
                         ProductID = 24,
                         UnitPrice = 4.5000m,
                         Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11055,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11055,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11055,
-                        ProductID = 24,
-                        UnitPrice = 4.5000m,
-                        Quantity = 15,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11056,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 40,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11056,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 40,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -33603,50 +23428,10 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 11058,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 3,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11058,
-                        ProductID = 21,
-                        UnitPrice = 10.0000m,
-                        Quantity = 3,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 11059,
                         ProductID = 13,
                         UnitPrice = 6.0000m,
                         Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11059,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11059,
-                        ProductID = 13,
-                        UnitPrice = 6.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11060,
-                        ProductID = 60,
-                        UnitPrice = 34.0000m,
-                        Quantity = 4,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -33675,67 +23460,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 11062,
-                        ProductID = 53,
-                        UnitPrice = 32.8000m,
-                        Quantity = 10,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 11063,
                         ProductID = 34,
                         UnitPrice = 14.0000m,
                         Quantity = 30,
                         Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11063,
-                        ProductID = 34,
-                        UnitPrice = 14.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11063,
-                        ProductID = 34,
-                        UnitPrice = 14.0000m,
-                        Quantity = 30,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11064,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 77,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11064,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 77,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11064,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 77,
-                        Discount = 0.1f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11064,
-                        ProductID = 17,
-                        UnitPrice = 39.0000m,
-                        Quantity = 77,
-                        Discount = 0.1f
                     },
                 new OrderDetail
                     {
@@ -33752,30 +23481,6 @@ Winchester Way",
                         UnitPrice = 25.8900m,
                         Quantity = 4,
                         Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11065,
-                        ProductID = 30,
-                        UnitPrice = 25.8900m,
-                        Quantity = 4,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11066,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 3,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11066,
-                        ProductID = 16,
-                        UnitPrice = 17.4500m,
-                        Quantity = 3,
-                        Discount = 0f
                     },
                 new OrderDetail
                     {
@@ -33803,22 +23508,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 11068,
-                        ProductID = 28,
-                        UnitPrice = 45.6000m,
-                        Quantity = 8,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11068,
-                        ProductID = 28,
-                        UnitPrice = 45.6000m,
-                        Quantity = 8,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 11069,
                         ProductID = 39,
                         UnitPrice = 18.0000m,
@@ -33835,38 +23524,6 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 11070,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 40,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11070,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 40,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11070,
-                        ProductID = 1,
-                        UnitPrice = 18.0000m,
-                        Quantity = 40,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11071,
-                        ProductID = 7,
-                        UnitPrice = 30.0000m,
-                        Quantity = 15,
-                        Discount = 0.05f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 11071,
                         ProductID = 7,
                         UnitPrice = 30.0000m,
@@ -33879,38 +23536,6 @@ Winchester Way",
                         ProductID = 2,
                         UnitPrice = 19.0000m,
                         Quantity = 8,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11072,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 8,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11072,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 8,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11072,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 8,
-                        Discount = 0f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11073,
-                        ProductID = 11,
-                        UnitPrice = 21.0000m,
-                        Quantity = 10,
                         Discount = 0f
                     },
                 new OrderDetail
@@ -33939,235 +23564,11 @@ Winchester Way",
                     },
                 new OrderDetail
                     {
-                        OrderID = 11075,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 10,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11075,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 10,
-                        Discount = 0.15f
-                    },
-                new OrderDetail
-                    {
                         OrderID = 11076,
                         ProductID = 6,
                         UnitPrice = 25.0000m,
                         Quantity = 20,
                         Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11076,
-                        ProductID = 6,
-                        UnitPrice = 25.0000m,
-                        Quantity = 20,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11076,
-                        ProductID = 6,
-                        UnitPrice = 25.0000m,
-                        Quantity = 20,
-                        Discount = 0.25f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11077,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11077,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11077,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11077,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11077,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11077,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11077,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11077,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11077,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11077,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11077,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11077,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11077,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11077,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11077,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11077,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11077,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11077,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11077,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11077,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11077,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11077,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11077,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 24,
-                        Discount = 0.2f
-                    },
-                new OrderDetail
-                    {
-                        OrderID = 11077,
-                        ProductID = 2,
-                        UnitPrice = 19.0000m,
-                        Quantity = 24,
-                        Discount = 0.2f
                     },
                 new OrderDetail
                     {


### PR DESCRIPTION
Space-age composite polymer; not a shred of sqlmetal... (Support composite keys end-to-end)

This change adds support for value generation with composite keys which was blocking use of composite keys end-to-end. The state entry will now generate values for any property marked to have value generation on add regardless of whether that property is part of a key, composite or not.
