### PR TITLE
Mary-Jo-Lisa; always the same...

### DIFF
--- a/src/Microsoft.Data.Entity.Relational/ConnectionStringResolver.cs
+++ b/src/Microsoft.Data.Entity.Relational/ConnectionStringResolver.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Relational.Utilities;
+using Microsoft.Framework.ConfigurationModel;
+
+namespace Microsoft.Data.Entity.Relational
+{
+    public class ConnectionStringResolver
+    {
+        private readonly IConfiguration _configuration;
+
+        public ConnectionStringResolver([CanBeNull] IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public virtual string Resolve([NotNull] string nameOrConnectionString)
+        {
+            Check.NotEmpty(nameOrConnectionString, "nameOrConnectionString");
+
+            var name = TryGetConnectionName(nameOrConnectionString);
+            if (name != null)
+            {
+                if (_configuration == null)
+                {
+                    throw new InvalidOperationException(Strings.FormatNoConfigForConnection(name));
+                }
+
+                if (!_configuration.TryGet(name, out nameOrConnectionString)
+                    && !_configuration.TryGet("Data:" + name + ":ConnectionString", out nameOrConnectionString))
+                {
+                    throw new InvalidOperationException(Strings.FormatConnectionNotFound(name));
+                }
+            }
+
+            return nameOrConnectionString;
+        }
+
+        // This is the same code as is used in EF6.
+        private static string TryGetConnectionName(string nameOrConnectionString)
+        {
+            // No '=' at all means just treat the whole string as a name
+            var firstEquals = nameOrConnectionString.IndexOf('=');
+            if (firstEquals < 0)
+            {
+                return nameOrConnectionString;
+            }
+
+            // More than one equals means treat the whole thing as a connection string
+            if (nameOrConnectionString.IndexOf('=', firstEquals + 1) >= 0)
+            {
+                return null;
+            }
+
+            // If the keyword before the single '=' is "name" then return the name value
+            if (nameOrConnectionString.Substring(0, firstEquals).Trim().Equals(
+                "name", StringComparison.OrdinalIgnoreCase))
+            {
+                return nameOrConnectionString.Substring(firstEquals + 1).Trim();
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity.Relational/Microsoft.Data.Entity.Relational.csproj
+++ b/src/Microsoft.Data.Entity.Relational/Microsoft.Data.Entity.Relational.csproj
@@ -42,6 +42,7 @@
       <Assemblies>System.Interactive.Async</Assemblies>
     </PackageReference>
     <PackageReference Include="Microsoft.Data.Common" />
+    <PackageReference Include="Microsoft.Framework.ConfigurationModel" />
     <PackageReference Include="Microsoft.Framework.DependencyInjection" />
     <PackageReference Include="Microsoft.Framework.Logging" />
     <PackageReference Include="Remotion.Linq">
@@ -49,7 +50,14 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\packages\KoreBuild\Build\Resources.cs">
+      <Link>Properties\Resources.cs</Link>
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>Resources.tt</DependentUpon>
+    </Compile>
     <Compile Include="ApiExtensions.cs" />
+    <Compile Include="ConnectionStringResolver.cs" />
     <Compile Include="DatabaseBuilder.cs" />
     <Compile Include="IDbCommandExecutor.cs" />
     <Compile Include="ModelDatabaseMapping.cs" />
@@ -113,6 +121,7 @@
       <Link>Properties\Resources.tt</Link>
       <Generator>TextTemplatingFileGenerator</Generator>
       <CustomToolNamespace>Microsoft.Data.Entity.Relational</CustomToolNamespace>
+      <LastGenOutput>Resources.cs</LastGenOutput>
     </None>
     <None Include="project.json" />
   </ItemGroup>

--- a/src/Microsoft.Data.Entity.Relational/Properties/Strings.Designer.cs
+++ b/src/Microsoft.Data.Entity.Relational/Properties/Strings.Designer.cs
@@ -171,7 +171,7 @@ namespace Microsoft.Data.Entity.Relational
         }
 
         /// <summary>
-        /// The property '{0}' cannot be mapped because it is of type '{1}' which is currently not supported.'
+        /// The property '{propertyName}' cannot be mapped because it is of type '{propertyType}' which is currently not supported.
         /// </summary>
         internal static string UnsupportedType
         {
@@ -179,11 +179,43 @@ namespace Microsoft.Data.Entity.Relational
         }
 
         /// <summary>
-        /// The property '{0}' cannot be mapped because it is of type '{1}' which is currently not supported.'
+        /// The property '{propertyName}' cannot be mapped because it is of type '{propertyType}' which is currently not supported.
         /// </summary>
-        internal static string FormatUnsupportedType(object p0, object p1)
+        internal static string FormatUnsupportedType(object propertyName, object propertyType)
         {
-            return string.Format(CultureInfo.CurrentCulture, GetString("UnsupportedType"), p0, p1);
+            return string.Format(CultureInfo.CurrentCulture, GetString("UnsupportedType", "propertyName", "propertyType"), propertyName, propertyType);
+        }
+
+        /// <summary>
+        /// The connection string '{connectionName}' could not be found because no IConfiguration object has been configured.
+        /// </summary>
+        internal static string NoConfigForConnection
+        {
+            get { return GetString("NoConfigForConnection"); }
+        }
+
+        /// <summary>
+        /// The connection string '{connectionName}' could not be found because no IConfiguration object has been configured.
+        /// </summary>
+        internal static string FormatNoConfigForConnection(object connectionName)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("NoConfigForConnection", "connectionName"), connectionName);
+        }
+
+        /// <summary>
+        /// The connection string '{connectionName}' could not be found in the application's configuration.
+        /// </summary>
+        internal static string ConnectionNotFound
+        {
+            get { return GetString("ConnectionNotFound"); }
+        }
+
+        /// <summary>
+        /// The connection string '{connectionName}' could not be found in the application's configuration.
+        /// </summary>
+        internal static string FormatConnectionNotFound(object connectionName)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ConnectionNotFound", "connectionName"), connectionName);
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/Microsoft.Data.Entity.Relational/Properties/Strings.resx
+++ b/src/Microsoft.Data.Entity.Relational/Properties/Strings.resx
@@ -148,6 +148,12 @@
     <value>A relational store has been configured without specifying either the DbConnection or connection string to use.</value>
   </data>
   <data name="UnsupportedType" xml:space="preserve">
-    <value>The property '{0}' cannot be mapped because it is of type '{1}' which is currently not supported.'</value>
+    <value>The property '{propertyName}' cannot be mapped because it is of type '{propertyType}' which is currently not supported.</value>
+  </data>
+  <data name="NoConfigForConnection" xml:space="preserve">
+    <value>The connection string '{connectionName}' could not be found because no IConfiguration object has been configured.</value>
+  </data>
+  <data name="ConnectionNotFound" xml:space="preserve">
+    <value>The connection string '{connectionName}' could not be found in the application's configuration.</value>
   </data>
 </root>

--- a/src/Microsoft.Data.Entity.Relational/RelationalEntityServicesBuilderExtensions.cs
+++ b/src/Microsoft.Data.Entity.Relational/RelationalEntityServicesBuilderExtensions.cs
@@ -22,7 +22,9 @@ namespace Microsoft.Data.Entity.Relational
                 .AddSingleton<RelationalObjectArrayValueReaderFactory>()
                 .AddSingleton<RelationalTypedValueReaderFactory>()
                 .AddSingleton<ParameterNameGeneratorFactory>()
-                .AddSingleton<CommandBatchPreparer>();
+                .AddSingleton<CommandBatchPreparer>()
+                // TODO: Is singleton correct here? What is IConfiguration scoped as?
+                .AddSingleton<ConnectionStringResolver>();
 
             return builder;
         }

--- a/src/Microsoft.Data.Entity.SQLite/SQLiteConnectionConnection.cs
+++ b/src/Microsoft.Data.Entity.SQLite/SQLiteConnectionConnection.cs
@@ -11,8 +11,10 @@ namespace Microsoft.Data.Entity.SQLite
 {
     public class SQLiteConnectionConnection : RelationalConnection
     {
-        public SQLiteConnectionConnection([NotNull] DbContextConfiguration configuration)
-            : base(configuration)
+        public SQLiteConnectionConnection(
+            [NotNull] DbContextConfiguration configuration,
+            [NotNull] ConnectionStringResolver connectionStringResolver)
+            : base(configuration, connectionStringResolver)
         {
         }
 

--- a/src/Microsoft.Data.Entity.SqlServer/SqlServerConnection.cs
+++ b/src/Microsoft.Data.Entity.SqlServer/SqlServerConnection.cs
@@ -11,8 +11,10 @@ namespace Microsoft.Data.Entity.SqlServer
 {
     public class SqlServerConnection : RelationalConnection
     {
-        public SqlServerConnection([NotNull] DbContextConfiguration configuration)
-            : base(configuration)
+        public SqlServerConnection(
+            [NotNull] DbContextConfiguration configuration,
+            [NotNull] ConnectionStringResolver connectionStringResolver)
+            : base(configuration, connectionStringResolver)
         {
         }
 

--- a/test/Microsoft.Data.Entity.Relational.Tests/ConnectionStringResolverTest.cs
+++ b/test/Microsoft.Data.Entity.Relational.Tests/ConnectionStringResolverTest.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Framework.ConfigurationModel;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Relational.Tests
+{
+    public class ConnectionStringResolverTest
+    {
+        [Fact]
+        public void Connection_string_with_multiple_keys_is_returned_unchanged_and_does_not_require_configuration()
+        {
+            const string connectionString = "Name=Lobsang;Database=DatumEarth";
+
+            Assert.Equal(connectionString, new ConnectionStringResolver(null).Resolve(connectionString));
+        }
+
+        [Fact]
+        public void Connection_string_with_single_non_name_key_is_returned_unchanged_and_does_not_require_configuration()
+        {
+            const string connectionString = "Database=DatumEarth";
+
+            Assert.Equal(connectionString, new ConnectionStringResolver(null).Resolve(connectionString));
+        }
+
+
+        [Fact]
+        public void Just_name_is_used_as_path_to_configuration_entry()
+        {
+            var configuration = new Configuration
+                {
+                    new MemoryConfigurationSource(
+                        new Dictionary<string, string>
+                            {
+                                { "Lobsang", "Database=DatumEarth" },
+                                { "Data:Lobsang:ConnectionString", "Database=Rectangles" }
+                            })
+                };
+
+            Assert.Equal("Database=DatumEarth", new ConnectionStringResolver(configuration).Resolve("Lobsang"));
+        }
+
+        [Fact]
+        public void Just_name_is_used_as_name_in_convention_path_to_entry()
+        {
+            var configuration = new Configuration
+                {
+                    new MemoryConfigurationSource(
+                        new Dictionary<string, string>
+                            {
+                                { "Data:Lobsang:ConnectionString", "Database=Rectangles" }
+                            })
+                };
+
+            Assert.Equal("Database=Rectangles", new ConnectionStringResolver(configuration).Resolve("Lobsang"));
+        }
+
+        [Fact]
+        public void Name_equals_syntax_is_used_as_path_to_configuration_entry()
+        {
+            var configuration = new Configuration
+                {
+                    new MemoryConfigurationSource(
+                        new Dictionary<string, string>
+                            {
+                                { "Lobsang", "Database=DatumEarth" },
+                                { "Data:Lobsang:ConnectionString", "Database=Rectangles" }
+                            })
+                };
+
+            Assert.Equal("Database=DatumEarth", new ConnectionStringResolver(configuration).Resolve("name=Lobsang"));
+        }
+
+        [Fact]
+        public void Name_equals_syntax_is_used_as_name_in_convention_path_to_entry()
+        {
+            var configuration = new Configuration
+                {
+                    new MemoryConfigurationSource(
+                        new Dictionary<string, string>
+                            {
+                                { "Data:Lobsang:ConnectionString", "Database=Rectangles" }
+                            })
+                };
+
+            Assert.Equal("Database=Rectangles", new ConnectionStringResolver(configuration).Resolve("name=Lobsang"));
+        }
+
+        [Fact]
+        public void Throws_if_name_is_used_but_there_is_no_configuration_available()
+        {
+            Assert.Equal(
+                Strings.FormatNoConfigForConnection("Lobsang"),
+                Assert.Throws<InvalidOperationException>(() => new ConnectionStringResolver(null).Resolve("name=Lobsang")).Message);
+        }
+
+        [Fact]
+        public void Throws_if_name_cannot_be_found()
+        {
+            var configuration = new Configuration
+                {
+                    new MemoryConfigurationSource(
+                        new Dictionary<string, string>
+                            {
+                                { "Data:Joshua:ConnectionString", "Database=Rectangles" }
+                            })
+                };
+
+            Assert.Equal(
+                Strings.FormatConnectionNotFound("Lobsang"),
+                Assert.Throws<InvalidOperationException>(() => new ConnectionStringResolver(configuration).Resolve("name=Lobsang")).Message);
+        }
+    }
+}

--- a/test/Microsoft.Data.Entity.Relational.Tests/Microsoft.Data.Entity.Relational.Tests.csproj
+++ b/test/Microsoft.Data.Entity.Relational.Tests/Microsoft.Data.Entity.Relational.Tests.csproj
@@ -70,6 +70,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApiConsistencyTest.cs" />
+    <Compile Include="ConnectionStringResolverTest.cs" />
     <Compile Include="DatabaseBuilderTest.cs" />
     <Compile Include="MetadataExtensionsTest.cs" />
     <Compile Include="RelationalConnectionTest.cs" />

--- a/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/ConnectionStringTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/ConnectionStringTest.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Framework.ConfigurationModel;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
+using Xunit;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public class ConnectionStringTest
+    {
+        [Fact]
+        public async Task Can_use_connection_string_name_in_OnConfiguring()
+        {
+            await Can_use_connection_string_name_in_OnConfiguring_test("Northwind");
+        }
+
+        [Fact]
+        public async Task Can_use_k_path_for_connection_string_in_OnConfiguring()
+        {
+            await Can_use_connection_string_name_in_OnConfiguring_test("Data:Northwind:ConnectionString");
+        }
+
+        [Fact]
+        public async Task Can_use_name_equals_syntax_for_connection_string_name_in_OnConfiguring()
+        {
+            await Can_use_connection_string_name_in_OnConfiguring_test("name=Northwind");
+        }
+
+        [Fact]
+        public async Task Can_use_name_equals_syntax_for_k_path_in_OnConfiguring()
+        {
+            await Can_use_connection_string_name_in_OnConfiguring_test("name=Data:Northwind:ConnectionString");
+        }
+
+        [Fact]
+        public async Task Can_use_actula_connection_string_in_OnConfiguring()
+        {
+            await Can_use_connection_string_name_in_OnConfiguring_test(TestDatabase.NorthwindConnectionString);
+        }
+
+        private async Task Can_use_connection_string_name_in_OnConfiguring_test(string connectionName)
+        {
+            var configuration = new Configuration
+                {
+                    new MemoryConfigurationSource(
+                        new Dictionary<string, string>
+                            {
+                                { "Data:Northwind:ConnectionString", TestDatabase.NorthwindConnectionString }
+                            })
+                };
+
+            var serviceCollection = new ServiceCollection();
+            serviceCollection
+                .AddInstance<IConfiguration>(configuration)
+                .AddEntityFramework()
+                .AddSqlServer();
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            using (await TestDatabase.Northwind())
+            {
+                using (var context = new NorthwindContext(serviceProvider, connectionName))
+                {
+                    Assert.Equal(91, await context.Customers.CountAsync());
+                }
+            }
+        }
+
+        private class NorthwindContext : DbContext
+        {
+            private readonly string _nameOrConnectionString;
+
+            public NorthwindContext(IServiceProvider serviceProvider, string nameOrConnectionString)
+                : base(serviceProvider)
+            {
+                _nameOrConnectionString = nameOrConnectionString;
+            }
+
+            public DbSet<Customer> Customers { get; set; }
+
+            protected override void OnConfiguring(DbContextOptions options)
+            {
+                options.UseSqlServer(_nameOrConnectionString);
+            }
+
+            protected override void OnModelCreating(ModelBuilder builder)
+            {
+                ConfigureModel(builder);
+            }
+        }
+
+        private class Customer
+        {
+            public string CustomerID { get; set; }
+            public string CompanyName { get; set; }
+            public string Fax { get; set; }
+        }
+
+        private static void ConfigureModel(ModelBuilder builder)
+        {
+            builder
+                .Entity<Customer>()
+                .Key(c => c.CustomerID)
+                .StorageName("Customers");
+        }
+    }
+}

--- a/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/Microsoft.Data.Entity.SqlServer.FunctionalTests.csproj
+++ b/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/Microsoft.Data.Entity.SqlServer.FunctionalTests.csproj
@@ -77,6 +77,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ConnectionStringTest.cs" />
     <Compile Include="ExistingConnectionTest.cs" />
     <Compile Include="NorthwindQueryTest.cs" />
     <Compile Include="SequenceEndToEndTest.cs" />

--- a/test/Microsoft.Data.Entity.SqlServer.Tests/SqlServerConnectionTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.Tests/SqlServerConnectionTest.cs
@@ -3,6 +3,7 @@
 
 using System.Data.SqlClient;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Relational;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Fallback;
 using Xunit;
@@ -14,7 +15,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void Creates_SQL_Server_connection_string()
         {
-            using (var connection = new SqlServerConnection(CreateConfiguration()))
+            using (var connection = new SqlServerConnection(CreateConfiguration(), new ConnectionStringResolver(null)))
             {
                 Assert.IsType<SqlConnection>(connection.DbConnection);
             }
@@ -23,7 +24,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void Can_create_master_connection_string()
         {
-            using (var connection = new SqlServerConnection(CreateConfiguration()))
+            using (var connection = new SqlServerConnection(CreateConfiguration(), new ConnectionStringResolver(null)))
             {
                 using (var master = connection.CreateMasterConnection())
                 {

--- a/test/Microsoft.Data.Entity.SqlServer.Tests/SqlServerEntityServicesBuilderExtensionsTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.Tests/SqlServerEntityServicesBuilderExtensionsTest.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
             var context = new DbContext(
                 serviceProvider,
-                new DbContextOptions().UseSqlServer("goo"));
+                new DbContextOptions().UseSqlServer("goo=boo"));
 
             var scopedProvider = context.Configuration.Services.ServiceProvider;
 
@@ -89,7 +89,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
             context = new DbContext(
                 serviceProvider,
-                new DbContextOptions().UseSqlServer("goo"));
+                new DbContextOptions().UseSqlServer("goo=boo"));
 
             scopedProvider = context.Configuration.Services.ServiceProvider;
 


### PR DESCRIPTION
Mary-Jo-Lisa; always the same... (Allow connection strings to be pulled by name from IConfiguration)

This change allows connection strings to be stored in any format supported by IConfiguration and then retrieved using just the name or the "name=" syntax in UseSqlServer and equivalent.

This change doesn't include anything to get IConfiguration registered and it doesn't include a way to get connection strings out of app.config/web.config, although that could potentially be done with an appropriate IConfiguration source.
