### PR TITLE
You can't fire me because I quit!

### DIFF
--- a/src/Microsoft.Data.Entity/ChangeTracking/StateEntry.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/StateEntry.cs
@@ -188,6 +188,14 @@ namespace Microsoft.Data.Entity.ChangeTracking
                 return;
             }
 
+            // An Added entity does not yet exist in the database. If it is then marked as deleted there is
+            // nothing to delete because it was not yet inserted, so just make sure it doesn't get inserted.
+            if (oldState == EntityState.Added
+                && newState == EntityState.Deleted)
+            {
+                newState = EntityState.Unknown;
+            }
+
             _configuration.Services.StateEntryNotifier.StateChanging(this, newState);
 
             _stateData.EntityState = newState;

--- a/test/Microsoft.Data.Entity.InMemory.Tests/InMemoryDataStoreTest.cs
+++ b/test/Microsoft.Data.Entity.InMemory.Tests/InMemoryDataStoreTest.cs
@@ -111,6 +111,9 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 
             await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry });
 
+            // Because the data store is being used directly the entity state must be manually changed after saving.
+            await entityEntry.SetEntityStateAsync(EntityState.Unchanged);
+
             customer.Name = "Unikorn, The Return";
             await entityEntry.SetEntityStateAsync(EntityState.Deleted);
 

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateEntryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateEntryTest.cs
@@ -54,6 +54,25 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.DoesNotContain(entry, configuration.Services.StateManager.StateEntries);
         }
 
+        [Fact] // GitHub #251
+        public void Changing_state_from_Added_to_Deleted_causes_entity_to_stop_tracking()
+        {
+            var model = BuildModel();
+            var entityType = model.GetEntityType("SomeEntity");
+            var keyProperty = entityType.GetProperty("Id");
+
+            var configuration = TestHelpers.CreateContextConfiguration(model);
+
+            var entry = CreateStateEntry(configuration, entityType, new SomeEntity());
+            entry[keyProperty] = 1;
+
+            entry.EntityState = EntityState.Added;
+            entry.EntityState = EntityState.Deleted;
+
+            Assert.Equal(EntityState.Unknown, entry.EntityState);
+            Assert.DoesNotContain(entry, configuration.Services.StateManager.StateEntries);
+        }
+
         [Fact]
         public void Changing_state_to_Modified_or_Unchanged_causes_all_properties_to_be_marked_accordingly()
         {


### PR DESCRIPTION
You can't fire me because I quit! (Change from Added to Deleted results in detached entity)

See issue #351. When an entity is in the Added state it means that it doesn't exist in the database and should be inserted during SaveChanges. If the state is then changed to Deleted this would mean delete an entity that doesn't exist in the database, which will fail. In the EF6 stack we instead detach the entity in this case so that it is just never inserted. This change implements the same behavior in EF7.
