### PR TITLE
Stroll of the navigator...

### DIFF
--- a/src/Microsoft.Data.Entity/Extensions/EntityServiceCollectionExtensions.cs
+++ b/src/Microsoft.Data.Entity/Extensions/EntityServiceCollectionExtensions.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddSingleton<ClrPropertyGetterSource>()
                 .AddSingleton<ClrPropertySetterSource>()
                 .AddSingleton<ClrCollectionAccessorSource>()
+                .AddSingleton<NavigationAccessorSource>()
                 .AddSingleton<EntityMaterializerSource>()
                 .AddSingleton<CompositeEntityKeyFactory>()
                 .AddSingleton<MemberMapper>()

--- a/src/Microsoft.Data.Entity/Metadata/CollectionNavigationAccessor.cs
+++ b/src/Microsoft.Data.Entity/Metadata/CollectionNavigationAccessor.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Metadata
+{
+    public class CollectionNavigationAccessor : NavigationAccessor
+    {
+        private readonly ThreadSafeLazyRef<IClrCollectionAccessor> _collectionAccessor;
+
+        public CollectionNavigationAccessor(
+            [NotNull] Func<IClrPropertyGetter> getter,
+            [NotNull] Func<IClrPropertySetter> setter,
+            [NotNull] Func<IClrCollectionAccessor> collectionAccessor)
+            : base(getter, setter)
+        {
+            Check.NotNull(collectionAccessor, "collectionAccessor");
+
+            _collectionAccessor = new ThreadSafeLazyRef<IClrCollectionAccessor>(collectionAccessor);
+        }
+
+        public virtual IClrCollectionAccessor Collection
+        {
+            get { return _collectionAccessor.Value; }
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/Metadata/NavigationAccessor.cs
+++ b/src/Microsoft.Data.Entity/Metadata/NavigationAccessor.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Metadata
+{
+    public class NavigationAccessor
+    {
+        private readonly ThreadSafeLazyRef<IClrPropertyGetter> _getter;
+        private readonly ThreadSafeLazyRef<IClrPropertySetter> _setter;
+
+        public NavigationAccessor(
+            [NotNull] Func<IClrPropertyGetter> getter,
+            [NotNull] Func<IClrPropertySetter> setter)
+        {
+            Check.NotNull(getter, "getter");
+            Check.NotNull(setter, "setter");
+
+            _getter = new ThreadSafeLazyRef<IClrPropertyGetter>(getter);
+            _setter = new ThreadSafeLazyRef<IClrPropertySetter>(setter);
+        }
+
+        public virtual IClrPropertyGetter Getter
+        {
+            get { return _getter.Value; }
+        }
+
+        public virtual IClrPropertySetter Setter
+        {
+            get { return _setter.Value; }
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/Metadata/NavigationAccessorSource.cs
+++ b/src/Microsoft.Data.Entity/Metadata/NavigationAccessorSource.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Metadata
+{
+    public class NavigationAccessorSource
+    {
+        private readonly ThreadSafeDictionaryCache<Tuple<Type, string>, NavigationAccessor> _cache
+            = new ThreadSafeDictionaryCache<Tuple<Type, string>, NavigationAccessor>();
+
+        private readonly ClrCollectionAccessorSource _collectionAccessorSource;
+        private readonly ClrPropertySetterSource _setterSource;
+        private readonly ClrPropertyGetterSource _getterSource;
+
+        public NavigationAccessorSource(
+            [NotNull] ClrPropertyGetterSource getterSource,
+            [NotNull] ClrPropertySetterSource setterSource,
+            [NotNull] ClrCollectionAccessorSource collectionAccessorSource)
+        {
+            Check.NotNull(getterSource, "getterSource");
+            Check.NotNull(setterSource, "setterSource");
+            Check.NotNull(collectionAccessorSource, "collectionAccessorSource");
+
+            _getterSource = getterSource;
+            _setterSource = setterSource;
+            _collectionAccessorSource = collectionAccessorSource;
+        }
+
+        public virtual NavigationAccessor GetAccessor([NotNull] INavigation navigation)
+        {
+            Check.NotNull(navigation, "navigation");
+
+            return _cache.GetOrAdd(
+                Tuple.Create(navigation.EntityType.Type, navigation.Name),
+                k => Create(navigation));
+        }
+
+        private NavigationAccessor Create(INavigation navigation)
+        {
+            var elementType = navigation.EntityType.Type.GetAnyProperty(navigation.Name).PropertyType.TryGetElementType(typeof(IEnumerable<>));
+
+            var targetType = navigation.PointsToPrincipal
+                ? navigation.ForeignKey.ReferencedEntityType
+                : navigation.ForeignKey.EntityType;
+
+            // TODO: Consider allowing an annotation to force treating a reference to an Entity which is an IEnumerable of
+            // itself as a reference instead of a collection. Currently it will be considered a collection nav prop, which it isn't.
+
+            return elementType != null && elementType == targetType.Type
+                ? new CollectionNavigationAccessor(
+                    () => _getterSource.GetAccessor(navigation),
+                    () => _setterSource.GetAccessor(navigation),
+                    () => _collectionAccessorSource.GetAccessor(navigation))
+                : new NavigationAccessor(
+                    () => _getterSource.GetAccessor(navigation),
+                    () => _setterSource.GetAccessor(navigation));
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/Microsoft.Data.Entity.csproj
+++ b/src/Microsoft.Data.Entity/Microsoft.Data.Entity.csproj
@@ -75,6 +75,9 @@
     <Compile Include="Identity\ValueGeneratorSelector.cs" />
     <Compile Include="Infrastructure\IDbContextOptionsExtensions.cs" />
     <Compile Include="INotifyPropertyChanging.cs" />
+    <Compile Include="Metadata\CollectionNavigationAccessor.cs" />
+    <Compile Include="Metadata\NavigationAccessor.cs" />
+    <Compile Include="Metadata\NavigationAccessorSource.cs" />
     <Compile Include="Query\AsyncQueryCompilationContext.cs" />
     <Compile Include="Query\AsyncResultOperatorHandler.cs" />
     <Compile Include="Query\IResultOperatorHandler.cs" />

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/NavigationFixerTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/NavigationFixerTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
@@ -15,8 +16,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         [Fact]
         public void Members_check_arguments()
         {
-            var fixer = new NavigationFixer(
-                Mock.Of<StateManager>(), new ClrCollectionAccessorSource(), new ClrPropertySetterSource());
+            var fixer = new NavigationFixer(Mock.Of<StateManager>(), CreateAccessorSource());
 
             Assert.Equal(
                 "entry",
@@ -42,7 +42,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var dependentEntry = manager.GetOrCreateEntry(dependent);
             manager.StartTracking(dependentEntry);
 
-            var fixer = new NavigationFixer(manager, new ClrCollectionAccessorSource(), new ClrPropertySetterSource());
+            var fixer = new NavigationFixer(manager, CreateAccessorSource());
             fixer.StateChanged(dependentEntry, EntityState.Unknown);
 
             Assert.Same(dependent.Category, principal2);
@@ -68,7 +68,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var principalEntry = manager.GetOrCreateEntry(principal);
             manager.StartTracking(principalEntry);
 
-            var fixer = new NavigationFixer(manager, new ClrCollectionAccessorSource(), new ClrPropertySetterSource());
+            var fixer = new NavigationFixer(manager, CreateAccessorSource());
             fixer.StateChanged(principalEntry, EntityState.Unknown);
 
             Assert.Same(dependent1.Category, principal);
@@ -78,6 +78,114 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.Contains(dependent1, principal.Products);
             Assert.DoesNotContain(dependent2, principal.Products);
             Assert.Contains(dependent3, principal.Products);
+        }
+
+        [Fact]
+        public void Does_fixup_of_one_to_one_relationship()
+        {
+            var manager = CreateStateManager();
+
+            var principal1 = new Product { Id = 21 };
+            var principal2 = new Product { Id = 22 };
+            var principal3 = new Product { Id = 23 };
+
+            var dependent1 = new ProductDetail { Id = 21 };
+            var dependent2 = new ProductDetail { Id = 22 };
+            var dependent4 = new ProductDetail { Id = 24 };
+
+            var principalEntry1 = manager.GetOrCreateEntry(principal1);
+            var principalEntry2 = manager.GetOrCreateEntry(principal2);
+            var principalEntry3 = manager.GetOrCreateEntry(principal3);
+
+            var dependentEntry1 = manager.GetOrCreateEntry(dependent1);
+            var dependentEntry2 = manager.GetOrCreateEntry(dependent2);
+            var dependentEntry4 = manager.GetOrCreateEntry(dependent4);
+
+            manager.StartTracking(principalEntry1);
+            manager.StartTracking(principalEntry2);
+            manager.StartTracking(principalEntry3);
+
+            manager.StartTracking(dependentEntry1);
+            manager.StartTracking(dependentEntry2);
+            manager.StartTracking(dependentEntry4);
+
+            var fixer = new NavigationFixer(manager, CreateAccessorSource());
+
+            Assert.Null(principal1.Detail);
+            Assert.Null(dependent1.Product);
+
+            fixer.StateChanged(principalEntry1, EntityState.Unknown);
+
+            Assert.Same(principal1, dependent1.Product);
+            Assert.Same(dependent1, principal1.Detail);
+
+            Assert.Null(principal2.Detail);
+            Assert.Null(dependent2.Product);
+
+            fixer.StateChanged(dependentEntry2, EntityState.Unknown);
+
+            Assert.Same(principal2, dependent2.Product);
+            Assert.Same(dependent2, principal2.Detail);
+
+            Assert.Null(principal3.Detail);
+            Assert.Null(dependent4.Product);
+
+            fixer.StateChanged(principalEntry3, EntityState.Unknown);
+            fixer.StateChanged(dependentEntry4, EntityState.Unknown);
+
+            Assert.Null(principal3.Detail);
+            Assert.Null(dependent4.Product);
+        }
+
+        [Fact]
+        public void Does_fixup_of_one_to_one_self_referencing_relationship()
+        {
+            var manager = CreateStateManager();
+
+            var entity1 = new Product { Id = 21, AlternateProductId = 22 };
+            var entity2 = new Product { Id = 22, AlternateProductId = 23 };
+            var entity3 = new Product { Id = 23 };
+
+            var entry1 = manager.GetOrCreateEntry(entity1);
+            var entry2 = manager.GetOrCreateEntry(entity2);
+            var entry3 = manager.GetOrCreateEntry(entity3);
+
+            manager.StartTracking(entry1);
+            manager.StartTracking(entry2);
+            manager.StartTracking(entry3);
+
+            var fixer = new NavigationFixer(manager, CreateAccessorSource());
+
+            Assert.Null(entity1.AlternateProduct);
+            Assert.Null(entity1.OriginalProduct);
+            
+            Assert.Null(entity2.AlternateProduct);
+            Assert.Null(entity2.OriginalProduct);
+            
+            Assert.Null(entity3.AlternateProduct);
+            Assert.Null(entity3.OriginalProduct);
+
+            fixer.StateChanged(entry1, EntityState.Unknown);
+
+            Assert.Same(entity2, entity1.AlternateProduct);
+            Assert.Null(entity1.OriginalProduct);
+
+            Assert.Null(entity2.AlternateProduct);
+            Assert.Same(entity1, entity2.OriginalProduct);
+
+            Assert.Null(entity3.AlternateProduct);
+            Assert.Null(entity3.OriginalProduct);
+
+            fixer.StateChanged(entry3, EntityState.Unknown);
+
+            Assert.Same(entity2, entity1.AlternateProduct);
+            Assert.Null(entity1.OriginalProduct);
+
+            Assert.Same(entity3, entity2.AlternateProduct);
+            Assert.Same(entity1, entity2.OriginalProduct);
+
+            Assert.Null(entity3.AlternateProduct);
+            Assert.Same(entity2, entity3.OriginalProduct);
         }
 
         private static StateManager CreateStateManager()
@@ -103,6 +211,29 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             public int CategoryId { get; set; }
             public Category Category { get; set; }
+
+            public ProductDetail Detail { get; set; }
+
+            public int? AlternateProductId { get; set; }
+            public Product AlternateProduct { get; set; }
+            public Product OriginalProduct { get; set; }
+        }
+
+        private class ProductDetail : IEnumerable<Product>
+        {
+            public int Id { get; set; }
+
+            public Product Product { get; set; }
+
+            public IEnumerator<Product> GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
         }
 
         private static IModel BuildModel()
@@ -112,19 +243,31 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             builder.Entity<Product>();
             builder.Entity<Category>();
+            builder.Entity<ProductDetail>();
 
             var categoryType = model.GetEntityType(typeof(Category));
             var productType = model.GetEntityType(typeof(Product));
+            var productDetailType = model.GetEntityType(typeof(ProductDetail));
 
-            var categoryIdFk
-                = productType.AddForeignKey(categoryType.GetKey(), productType.GetProperty("CategoryId"));
+            var categoryFk = productType.AddForeignKey(categoryType.GetKey(), productType.GetProperty("CategoryId"));
+            var alternateProductFk = productType.AddForeignKey(productType.GetKey(), productType.GetProperty("AlternateProductId"));
+            var productDetailFk = productDetailType.AddForeignKey(productType.GetKey(), productDetailType.GetProperty("Id"));
 
-            categoryIdFk.StorageName = "Category_Products";
+            categoryType.AddNavigation(new Navigation(categoryFk, "Products", pointsToPrincipal: false));
+            productType.AddNavigation(new Navigation(categoryFk, "Category", pointsToPrincipal: true));
 
-            categoryType.AddNavigation(new Navigation(categoryIdFk, "Products", pointsToPrincipal: false));
-            productType.AddNavigation(new Navigation(categoryIdFk, "Category", pointsToPrincipal: true));
+            productType.AddNavigation(new Navigation(alternateProductFk, "AlternateProduct", pointsToPrincipal: true));
+            productType.AddNavigation(new Navigation(alternateProductFk, "OriginalProduct", pointsToPrincipal: false));
+
+            productDetailType.AddNavigation(new Navigation(productDetailFk, "Product", pointsToPrincipal: true));
+            productType.AddNavigation(new Navigation(productDetailFk, "Detail", pointsToPrincipal: false));
 
             return model;
+        }
+
+        private static NavigationAccessorSource CreateAccessorSource()
+        {
+            return new NavigationAccessorSource(new ClrPropertyGetterSource(), new ClrPropertySetterSource(), new ClrCollectionAccessorSource());
         }
     }
 }

--- a/test/Microsoft.Data.Entity.Tests/Metadata/NavigationAccessorSourceTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/Metadata/NavigationAccessorSourceTest.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Data.Entity.Metadata;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.Metadata
+{
+    public class NavigationAccessorSourceTest
+    {
+        [Fact]
+        public void Creates_collection_accessor_for_appropriate_IEnumerable_property()
+        {
+            var model = BuildModel();
+            var source = CreateAccessorSource();
+
+            var productsNavigation = model.GetEntityType(typeof(Category)).Navigations.Single(n => n.Name == "Products");
+            Assert.IsType<CollectionNavigationAccessor>(source.GetAccessor(productsNavigation));
+
+            var categoriesNavigation = model.GetEntityType(typeof(Product)).Navigations.Single(n => n.Name == "Categories");
+            Assert.IsType<CollectionNavigationAccessor>(source.GetAccessor(categoriesNavigation));
+        }
+
+        [Fact]
+        public void Creates_reference_accessor_for_non_matching_IEnumerable_property()
+        {
+            var model = BuildModel();
+            var source = CreateAccessorSource();
+
+            var productNavigation = model.GetEntityType(typeof(Category)).Navigations.Single(n => n.Name == "Product");
+            Assert.IsType<NavigationAccessor>(source.GetAccessor(productNavigation));
+
+            var categoryNavigation = model.GetEntityType(typeof(Product)).Navigations.Single(n => n.Name == "Category");
+            Assert.IsType<NavigationAccessor>(source.GetAccessor(categoryNavigation));
+        }
+
+        [Fact]
+        public void Caches_accessor_for_given_property_on_given_type()
+        {
+            var model = BuildModel();
+            var source = CreateAccessorSource();
+
+            var productNavigation = model.GetEntityType(typeof(Category)).Navigations.Single(n => n.Name == "Product");
+
+            Assert.Same(source.GetAccessor(productNavigation), source.GetAccessor(productNavigation));
+        }
+
+        private static NavigationAccessorSource CreateAccessorSource()
+        {
+            return new NavigationAccessorSource(new ClrPropertyGetterSource(), new ClrPropertySetterSource(), new ClrCollectionAccessorSource());
+        }
+
+        private class Category : IEnumerable<Product>
+        {
+            public int Id { get; set; }
+
+            public IEnumerable<Product> Products { get; set; }
+
+            public int ProductId { get; set; }
+            public Product Product { get; set; }
+
+            public IEnumerator<Product> GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+
+        private class Product : IEnumerable<Category>
+        {
+            public int Id { get; set; }
+
+            public int CategoryId { get; set; }
+            public Category Category { get; set; }
+
+            public List<Category> Categories { get; set; }
+
+            public IEnumerator<Category> GetEnumerator()
+            {
+                throw new NotImplementedException();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
+
+        private static IModel BuildModel()
+        {
+            var model = new Model();
+            var builder = new ConventionModelBuilder(model);
+
+            builder.Entity<Product>();
+            builder.Entity<Category>();
+
+            var categoryType = model.GetEntityType(typeof(Category));
+            var productType = model.GetEntityType(typeof(Product));
+
+            var categoryFk = productType.AddForeignKey(categoryType.GetKey(), productType.GetProperty("CategoryId"));
+            var productFk = categoryType.AddForeignKey(productType.GetKey(), categoryType.GetProperty("ProductId"));
+
+            categoryType.AddNavigation(new Navigation(categoryFk, "Products", pointsToPrincipal: false));
+            productType.AddNavigation(new Navigation(categoryFk, "Category", pointsToPrincipal: true));
+
+            productType.AddNavigation(new Navigation(productFk, "Categories", pointsToPrincipal: false));
+            categoryType.AddNavigation(new Navigation(productFk, "Product", pointsToPrincipal: true));
+
+            return model;
+        }
+
+    }
+}

--- a/test/Microsoft.Data.Entity.Tests/Microsoft.Data.Entity.Tests.csproj
+++ b/test/Microsoft.Data.Entity.Tests/Microsoft.Data.Entity.Tests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Identity\ValueGeneratorCacheTest.cs" />
     <Compile Include="Identity\ValueGeneratorPoolTest.cs" />
     <Compile Include="Identity\ValueGeneratorSelectorTest.cs" />
+    <Compile Include="Metadata\NavigationAccessorSourceTest.cs" />
     <Compile Include="QueryableExtensionsTest.cs" />
     <Compile Include="ServiceProviderCacheTest.cs" />
     <Compile Include="TestHelpers.cs" />


### PR DESCRIPTION
Stroll of the navigator... (Consolidate and better cache navigation access code)

Dependent navigations may be for collections or references. This code moves the check for collection/reference inside the cache lookup to avoid doing it over and over. Also, the property setter/getter are made available for collection nav props because these are needed for creating an setting a new collection automatically.
