### PR TITLE
Whippersnappers in sidecars...

### DIFF
--- a/src/Microsoft.Data.Entity/ChangeTracking/CompositeEntityKeyFactory.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/CompositeEntityKeyFactory.cs
@@ -29,6 +29,15 @@ namespace Microsoft.Data.Entity.ChangeTracking
             return Create(entityType, properties.Select(p => valueReader.ReadValue<object>(p.Index)).ToArray());
         }
 
+        public override EntityKey Create(IEntityType entityType, IReadOnlyList<IProperty> properties, Sidecar sidecar)
+        {
+            Check.NotNull(entityType, "entityType");
+            Check.NotNull(properties, "properties");
+            Check.NotNull(sidecar, "sidecar");
+
+            return Create(entityType, properties.Select(p => sidecar[p]).ToArray());
+        }
+
         private static CompositeEntityKey Create(IEntityType entityType, object[] values)
         {
             return values.Any(v => v == null) ? null : new CompositeEntityKey(entityType, values);

--- a/src/Microsoft.Data.Entity/ChangeTracking/EntityKeyFactory.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/EntityKeyFactory.cs
@@ -14,5 +14,8 @@ namespace Microsoft.Data.Entity.ChangeTracking
 
         public abstract EntityKey Create(
             [NotNull] IEntityType entityType, [NotNull] IReadOnlyList<IProperty> properties, [NotNull] IValueReader valueReader);
+
+        public abstract EntityKey Create(
+            [NotNull] IEntityType entityType, [NotNull] IReadOnlyList<IProperty> properties, [NotNull] Sidecar sidecar);
     }
 }

--- a/src/Microsoft.Data.Entity/ChangeTracking/ForeignKeysSnapshot.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/ForeignKeysSnapshot.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.ChangeTracking
+{
+    // TODO: Consider using ArraySidecar with pre-defined indexes
+    public class ForeignKeysSnapshot : DictionarySidecar
+    {
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected ForeignKeysSnapshot()
+        {
+        }
+
+        public ForeignKeysSnapshot([NotNull] StateEntry stateEntry)
+            : base(stateEntry, Check.NotNull(stateEntry, "stateEntry").EntityType.ForeignKeys.SelectMany(fk => fk.Properties).Distinct())
+        {
+        }
+
+        public override string Name
+        {
+            get { return WellKnownNames.ForeignKeysSnapshot; }
+        }
+
+        public override bool TransparentRead
+        {
+            get { return false; }
+        }
+
+        public override bool TransparentWrite
+        {
+            get { return false; }
+        }
+
+        public override bool AutoCommit
+        {
+            get { return false; }
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/ChangeTracking/ForeignKeysSnapshotFactory.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/ForeignKeysSnapshotFactory.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.ChangeTracking
+{
+    public class ForeignKeysSnapshotFactory
+    {
+        public virtual Sidecar Create([NotNull] StateEntry stateEntry)
+        {
+            Check.NotNull(stateEntry, "stateEntry");
+
+            return new ForeignKeysSnapshot(stateEntry);
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/ChangeTracking/IEntityStateListener.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/IEntityStateListener.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.ChangeTracking
 {
@@ -10,5 +11,6 @@ namespace Microsoft.Data.Entity.ChangeTracking
     {
         void StateChanging([NotNull] StateEntry entry, EntityState newState);
         void StateChanged([NotNull] StateEntry entry, EntityState oldState);
+        void ForeignKeyPropertyChanged([NotNull] StateEntry entry, [NotNull] IProperty property, [CanBeNull] object oldValue, [CanBeNull] object newValue);
     }
 }

--- a/src/Microsoft.Data.Entity/ChangeTracking/Sidecar.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/Sidecar.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
         public static class WellKnownNames
         {
             public const string OriginalValues = "OriginalValues";
+            public const string ForeignKeysSnapshot = "ForeignKeysSnapshot";
             public const string StoreGeneratedValues = "StoreGeneratedValues";
         }
 
@@ -121,6 +122,16 @@ namespace Microsoft.Data.Entity.ChangeTracking
 
             if (CanStoreValue(property)
                 && !HasValue(property))
+            {
+                this[property] = _stateEntry[property];
+            }
+        }
+
+        public virtual void TakeSnapshot([NotNull] IProperty property)
+        {
+            Check.NotNull(property, "property");
+
+            if (CanStoreValue(property))
             {
                 this[property] = _stateEntry[property];
             }

--- a/src/Microsoft.Data.Entity/ChangeTracking/SimpleEntityKeyFactory.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/SimpleEntityKeyFactory.cs
@@ -15,8 +15,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             Check.NotNull(properties, "properties");
             Check.NotNull(entry, "entry");
 
-            var value = entry[properties[0]];
-            return value == null ? null : new SimpleEntityKey<TKey>(entityType, (TKey)value);
+            return Create(entityType, entry[properties[0]]);
         }
 
         public override EntityKey Create(IEntityType entityType, IReadOnlyList<IProperty> properties, IValueReader valueReader)
@@ -26,6 +25,20 @@ namespace Microsoft.Data.Entity.ChangeTracking
             Check.NotNull(valueReader, "valueReader");
 
             return new SimpleEntityKey<TKey>(entityType, valueReader.ReadValue<TKey>(properties[0].Index));
+        }
+
+        public override EntityKey Create(IEntityType entityType, IReadOnlyList<IProperty> properties, Sidecar sidecar)
+        {
+            Check.NotNull(entityType, "entityType");
+            Check.NotNull(properties, "properties");
+            Check.NotNull(sidecar, "sidecar");
+
+            return Create(entityType, sidecar[properties[0]]);
+        }
+
+        private static SimpleEntityKey<TKey> Create(IEntityType entityType, object value)
+        {
+            return value == null ? null : new SimpleEntityKey<TKey>(entityType, (TKey)value);
         }
     }
 }

--- a/src/Microsoft.Data.Entity/ChangeTracking/StateEntrySubscriber.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/StateEntrySubscriber.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             if (!entry.EntityType.UseLazyOriginalValues)
             {
                 entry.OriginalValues.TakeSnapshot();
+                entry.ForeignKeysSnapshot.TakeSnapshot();
             }
 
             var changing = entry.Entity as INotifyPropertyChanging;

--- a/src/Microsoft.Data.Entity/ChangeTracking/StateManager.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/StateManager.cs
@@ -196,12 +196,15 @@ namespace Microsoft.Data.Entity.ChangeTracking
             get { return _configuration.Model; }
         }
 
-        public virtual StateEntry GetPrincipal([NotNull] StateEntry dependentEntry, [NotNull] IForeignKey foreignKey)
+        public virtual StateEntry GetPrincipal(
+            [NotNull] StateEntry dependentEntry, [NotNull] IForeignKey foreignKey, bool useForeignKeySnapshot)
         {
             Check.NotNull(dependentEntry, "dependentEntry");
             Check.NotNull(foreignKey, "foreignKey");
 
-            var dependentKeyValue = dependentEntry.GetDependentKeyValue(foreignKey);
+            var dependentKeyValue = useForeignKeySnapshot
+             ? dependentEntry.GetDependentKeySnapshot(foreignKey)
+             : dependentEntry.GetDependentKeyValue(foreignKey);
 
             if (dependentKeyValue == null)
             {

--- a/src/Microsoft.Data.Entity/Extensions/EntityServiceCollectionExtensions.cs
+++ b/src/Microsoft.Data.Entity/Extensions/EntityServiceCollectionExtensions.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddSingleton<StateEntrySubscriber>()
                 .AddSingleton<FieldMatcher>()
                 .AddSingleton<OriginalValuesFactory>()
+                .AddSingleton<ForeignKeysSnapshotFactory>()
                 .AddSingleton<StoreGeneratedValuesFactory>()
                 .AddSingleton<DataStoreSelector>()
                 .AddScoped<StateEntryFactory>()

--- a/src/Microsoft.Data.Entity/Infrastructure/ContextServices.cs
+++ b/src/Microsoft.Data.Entity/Infrastructure/ContextServices.cs
@@ -84,6 +84,11 @@ namespace Microsoft.Data.Entity.Infrastructure
             get { return _serviceProvider.GetService<OriginalValuesFactory>(); }
         }
 
+        public virtual ForeignKeysSnapshotFactory ForeignKeysSnapshotFactory
+        {
+            get { return _serviceProvider.GetService<ForeignKeysSnapshotFactory>(); }
+        }
+
         public virtual StateEntryNotifier StateEntryNotifier
         {
             get { return ServiceProvider.GetService<StateEntryNotifier>(); }

--- a/src/Microsoft.Data.Entity/Microsoft.Data.Entity.csproj
+++ b/src/Microsoft.Data.Entity/Microsoft.Data.Entity.csproj
@@ -58,6 +58,8 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.tt</DependentUpon>
     </Compile>
+    <Compile Include="ChangeTracking\ForeignKeysSnapshot.cs" />
+    <Compile Include="ChangeTracking\ForeignKeysSnapshotFactory.cs" />
     <Compile Include="ChangeTracking\SimpleNullableEntityKeyFactory.cs" />
     <Compile Include="DbContext.cs" />
     <Compile Include="DbContextOptions.cs" />

--- a/test/Microsoft.Data.Entity.InMemory.FunctionalTests/MonsterFixupTest.cs
+++ b/test/Microsoft.Data.Entity.InMemory.FunctionalTests/MonsterFixupTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Fallback;
@@ -18,6 +19,16 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
         protected override DbContextOptions CreateOptions(string databaseName)
         {
             return new DbContextOptions().UseInMemoryStore();
+        }
+
+        protected override async Task CreateAndSeedDatabase(IServiceProvider serviceProvider, string databaseName)
+        {
+            using (var context = new MonsterContext(serviceProvider, CreateOptions(databaseName)))
+            {
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
+                context.SeedUsingFKs();
+            }
         }
     }
 }

--- a/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/MonsterFixupTest.cs
+++ b/test/Microsoft.Data.Entity.SqlServer.FunctionalTests/MonsterFixupTest.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Data.SqlClient;
+using System.Threading.Tasks;
 using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Fallback;
 
@@ -11,6 +13,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 {
     public class MonsterFixupTest : MonsterFixupTestBase
     {
+        private static readonly AsyncLock _creationLock = new AsyncLock();
+        private static bool _databaseCreated;
+
         protected override IServiceProvider CreateServiceProvider()
         {
             return new ServiceCollection().AddEntityFramework().AddSqlServer().ServiceCollection.BuildServiceProvider();
@@ -31,6 +36,24 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     IntegratedSecurity = true,
                     ConnectTimeout = 30
                 }.ConnectionString;
+        }
+
+        protected override async Task CreateAndSeedDatabase(IServiceProvider serviceProvider, string databaseName)
+        {
+            using (await _creationLock.LockAsync())
+            {
+                if (!_databaseCreated)
+                {
+                    using (var context = new MonsterContext(serviceProvider, CreateOptions(databaseName)))
+                    {
+                        context.Database.EnsureDeleted();
+                        context.Database.EnsureCreated();
+                        context.SeedUsingFKs();
+                    }
+
+                    _databaseCreated = true;
+                }
+            }
         }
     }
 }

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateEntrySubscriberTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateEntrySubscriberTest.cs
@@ -20,13 +20,16 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entityTypeMock.Setup(m => m.UseLazyOriginalValues).Returns(false);
 
             var originalValuesMock = new Mock<OriginalValues>();
+            var fkSnapshotMock = new Mock<ForeignKeysSnapshot>();
             var entryMock = new Mock<StateEntry>();
             entryMock.Setup(m => m.EntityType).Returns(entityTypeMock.Object);
             entryMock.Setup(m => m.OriginalValues).Returns(originalValuesMock.Object);
+            entryMock.Setup(m => m.ForeignKeysSnapshot).Returns(fkSnapshotMock.Object);
 
             new StateEntrySubscriber().SnapshotAndSubscribe(entryMock.Object);
 
             originalValuesMock.Verify(m => m.TakeSnapshot());
+            fkSnapshotMock.Verify(m => m.TakeSnapshot());
         }
 
         [Fact]

--- a/test/Microsoft.Data.Entity.Tests/DbContextTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/DbContextTest.cs
@@ -860,6 +860,10 @@ namespace Microsoft.Data.Entity.Tests
             public void StateChanged(StateEntry entry, EntityState oldState)
             {
             }
+
+            public void ForeignKeyPropertyChanged(StateEntry entry, IProperty property, object oldValue, object newValue)
+            {
+            }
         }
 
         private class FakeLoggerFactory : ILoggerFactory


### PR DESCRIPTION
Whippersnappers in sidecars... (Initial work on detecting foreign key changes)

Lots still to do here--this is an attempt at a relatively small checkin for the first set of changes that will detect if an FK property has changed and trigger corresponding fixup of navigation properties. The general idea is a sidecar that tracks the last known FK property value such that it can be compared in DetectChanges and used in fixup to remove old references and add new.
