### PR TITLE
Shut up and put your RelatedEnd in my Sidecar...

### DIFF
--- a/src/Microsoft.Data.Entity/ChangeTracking/ArraySidecar.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/ArraySidecar.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
@@ -26,31 +27,31 @@ namespace Microsoft.Data.Entity.ChangeTracking
             _values = new object[count];
         }
 
-        protected abstract int Index([NotNull] IProperty property);
-        protected abstract void ThrowInvalidIndexException([NotNull] IProperty property);
+        protected abstract int Index([NotNull] IPropertyBase property);
+        protected abstract void ThrowInvalidIndexException([NotNull] IPropertyBase property);
 
-        public override bool CanStoreValue(IProperty property)
+        public override bool CanStoreValue(IPropertyBase property)
         {
             Check.NotNull(property, "property");
 
             return Index(property) != -1;
         }
 
-        protected override object ReadValue(IProperty property)
+        protected override object ReadValue(IPropertyBase property)
         {
             Check.NotNull(property, "property");
 
             return _values[IndexChecked(property)];
         }
 
-        protected override void WriteValue(IProperty property, object value)
+        protected override void WriteValue(IPropertyBase property, object value)
         {
             Check.NotNull(property, "property");
 
             _values[IndexChecked(property)] = value;
         }
 
-        private int IndexChecked(IProperty property)
+        private int IndexChecked(IPropertyBase property)
         {
             var index = Index(property);
             if (index == -1)

--- a/src/Microsoft.Data.Entity/ChangeTracking/ClrStateEntry.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/ClrStateEntry.cs
@@ -38,19 +38,5 @@ namespace Microsoft.Data.Entity.ChangeTracking
         {
             get { return _entity; }
         }
-
-        protected override object ReadPropertyValue(IProperty property)
-        {
-            Check.NotNull(property, "property");
-
-            return Configuration.Services.ClrPropertyGetterSource.GetAccessor(property).GetClrValue(_entity);
-        }
-
-        protected override void WritePropertyValue(IProperty property, object value)
-        {
-            Check.NotNull(property, "property");
-
-            Configuration.Services.ClrPropertySetterSource.GetAccessor(property).SetClrValue(_entity, value);
-        }
     }
 }

--- a/src/Microsoft.Data.Entity/ChangeTracking/DictionarySidecar.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/DictionarySidecar.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
@@ -11,7 +12,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
 {
     public abstract class DictionarySidecar : Sidecar
     {
-        private readonly Dictionary<IProperty, object> _values;
+        private readonly Dictionary<IPropertyBase, object> _values;
 
         /// <summary>
         ///     This constructor is intended only for use when creating test doubles that will override members
@@ -24,7 +25,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
 
         protected DictionarySidecar(
             [NotNull] StateEntry stateEntry,
-            [NotNull] IEnumerable<IProperty> properties)
+            [NotNull] IEnumerable<IPropertyBase> properties)
             : base(stateEntry)
         {
             Check.NotNull(properties, "properties");
@@ -32,21 +33,21 @@ namespace Microsoft.Data.Entity.ChangeTracking
             _values = properties.ToDictionary(p => p, p => (object)null);
         }
 
-        public override bool CanStoreValue(IProperty property)
+        public override bool CanStoreValue(IPropertyBase property)
         {
             Check.NotNull(property, "property");
 
             return _values.ContainsKey(property);
         }
 
-        protected override object ReadValue(IProperty property)
+        protected override object ReadValue(IPropertyBase property)
         {
             Check.NotNull(property, "property");
 
             return _values[property];
         }
 
-        protected override void WriteValue(IProperty property, object value)
+        protected override void WriteValue(IPropertyBase property, object value)
         {
             Check.NotNull(property, "property");
 

--- a/src/Microsoft.Data.Entity/ChangeTracking/ForeignKeysSnapshot.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/ForeignKeysSnapshot.cs
@@ -2,13 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.ChangeTracking
 {
     // TODO: Consider using ArraySidecar with pre-defined indexes
+    // TODO: Rename to reflect that navigations are now also handled
     public class ForeignKeysSnapshot : DictionarySidecar
     {
         /// <summary>
@@ -21,8 +24,16 @@ namespace Microsoft.Data.Entity.ChangeTracking
         }
 
         public ForeignKeysSnapshot([NotNull] StateEntry stateEntry)
-            : base(stateEntry, Check.NotNull(stateEntry, "stateEntry").EntityType.ForeignKeys.SelectMany(fk => fk.Properties).Distinct())
+            : base(stateEntry, GetProperties(Check.NotNull(stateEntry, "stateEntry")))
         {
+        }
+
+        private static IEnumerable<IPropertyBase> GetProperties(StateEntry stateEntry)
+        {
+            var entityType = stateEntry.EntityType;
+
+            return entityType.ForeignKeys.SelectMany(fk => fk.Properties).Distinct()
+                .Concat<IPropertyBase>(entityType.Navigations);
         }
 
         public override string Name

--- a/src/Microsoft.Data.Entity/ChangeTracking/IEntityStateListener.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/IEntityStateListener.cs
@@ -12,5 +12,6 @@ namespace Microsoft.Data.Entity.ChangeTracking
         void StateChanging([NotNull] StateEntry entry, EntityState newState);
         void StateChanged([NotNull] StateEntry entry, EntityState oldState);
         void ForeignKeyPropertyChanged([NotNull] StateEntry entry, [NotNull] IProperty property, [CanBeNull] object oldValue, [CanBeNull] object newValue);
+        void NavigationReferenceChanged([NotNull] StateEntry entry, [NotNull] INavigation property, [CanBeNull] object oldValue, [CanBeNull] object newValue);
     }
 }

--- a/src/Microsoft.Data.Entity/ChangeTracking/MixedStateEntry.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/MixedStateEntry.cs
@@ -55,22 +55,26 @@ namespace Microsoft.Data.Entity.ChangeTracking
             get { return _entity; }
         }
 
-        protected override object ReadPropertyValue(IProperty property)
+        protected override object ReadPropertyValue(IPropertyBase propertyBase)
         {
-            Check.NotNull(property, "property");
+            Check.NotNull(propertyBase, "propertyBase");
 
-            return property.IsClrProperty
-                ? Configuration.Services.ClrPropertyGetterSource.GetAccessor(property).GetClrValue(_entity)
+            var property = propertyBase as IProperty;
+
+            return property == null || property.IsClrProperty
+                ? base.ReadPropertyValue(propertyBase)
                 : _shadowValues[property.ShadowIndex];
         }
 
-        protected override void WritePropertyValue(IProperty property, object value)
+        protected override void WritePropertyValue(IPropertyBase propertyBase, object value)
         {
-            Check.NotNull(property, "property");
+            Check.NotNull(propertyBase, "propertyBase");
 
-            if (property.IsClrProperty)
+            var property = propertyBase as IProperty;
+
+            if (property == null || property.IsClrProperty)
             {
-                Configuration.Services.ClrPropertySetterSource.GetAccessor(property).SetClrValue(_entity, value);
+                base.WritePropertyValue(propertyBase, value);
             }
             else
             {

--- a/src/Microsoft.Data.Entity/ChangeTracking/OriginalValues.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/OriginalValues.cs
@@ -24,14 +24,16 @@ namespace Microsoft.Data.Entity.ChangeTracking
         {
         }
 
-        protected override int Index(IProperty property)
+        protected override int Index(IPropertyBase property)
         {
             Check.NotNull(property, "property");
 
-            return property.OriginalValueIndex;
+            var asProperty = property as IProperty;
+
+            return asProperty != null ? asProperty.OriginalValueIndex : -1;
         }
 
-        protected override void ThrowInvalidIndexException(IProperty property)
+        protected override void ThrowInvalidIndexException(IPropertyBase property)
         {
             Check.NotNull(property, "property");
 

--- a/src/Microsoft.Data.Entity/ChangeTracking/ShadowStateEntry.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/ShadowStateEntry.cs
@@ -53,18 +53,22 @@ namespace Microsoft.Data.Entity.ChangeTracking
             }
         }
 
-        protected override object ReadPropertyValue(IProperty property)
+        protected override object ReadPropertyValue(IPropertyBase propertyBase)
         {
-            Check.NotNull(property, "property");
+            Check.NotNull(propertyBase, "propertyBase");
 
-            Contract.Assert(!property.IsClrProperty);
+            var property = propertyBase as IProperty;
+            Contract.Assert(property != null && !property.IsClrProperty);
 
             return _propertyValues[property.ShadowIndex];
         }
 
-        protected override void WritePropertyValue(IProperty property, object value)
+        protected override void WritePropertyValue(IPropertyBase propertyBase, object value)
         {
-            Check.NotNull(property, "property");
+            Check.NotNull(propertyBase, "propertyBase");
+
+            var property = propertyBase as IProperty;
+            Contract.Assert(property != null && !property.IsClrProperty);
 
             _propertyValues[property.ShadowIndex] = value;
         }

--- a/src/Microsoft.Data.Entity/ChangeTracking/Sidecar.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/Sidecar.cs
@@ -40,22 +40,22 @@ namespace Microsoft.Data.Entity.ChangeTracking
             get { return _stateEntry; }
         }
 
-        public abstract bool CanStoreValue([NotNull] IProperty property);
-        protected abstract object ReadValue([NotNull] IProperty property);
-        protected abstract void WriteValue([NotNull] IProperty property, [CanBeNull] object value);
+        public abstract bool CanStoreValue([NotNull] IPropertyBase property);
+        protected abstract object ReadValue([NotNull] IPropertyBase property);
+        protected abstract void WriteValue([NotNull] IPropertyBase property, [CanBeNull] object value);
         public abstract string Name { get; }
         public abstract bool TransparentRead { get; }
         public abstract bool TransparentWrite { get; }
         public abstract bool AutoCommit { get; }
 
-        public virtual bool HasValue([NotNull] IProperty property)
+        public virtual bool HasValue([NotNull] IPropertyBase property)
         {
             Check.NotNull(property, "property");
 
             return CanStoreValue(property) && ReadValue(property) != null;
         }
 
-        public virtual object this[[param: NotNull] IProperty property]
+        public virtual object this[[param: NotNull] IPropertyBase property]
         {
             get
             {
@@ -116,7 +116,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             }
         }
 
-        public virtual void EnsureSnapshot([NotNull] IProperty property)
+        public virtual void EnsureSnapshot([NotNull] IPropertyBase property)
         {
             Check.NotNull(property, "property");
 
@@ -127,7 +127,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             }
         }
 
-        public virtual void TakeSnapshot([NotNull] IProperty property)
+        public virtual void TakeSnapshot([NotNull] IPropertyBase property)
         {
             Check.NotNull(property, "property");
 

--- a/src/Microsoft.Data.Entity/ChangeTracking/StateEntryNotifier.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/StateEntryNotifier.cs
@@ -57,6 +57,15 @@ namespace Microsoft.Data.Entity.ChangeTracking
             Dispatch(l => l.ForeignKeyPropertyChanged(entry, property, oldValue, newValue));
         }
 
+        public virtual void NavigationReferenceChanged(
+            [NotNull] StateEntry entry, [NotNull] INavigation navigation, [CanBeNull] object oldValue, [CanBeNull] object newValue)
+        {
+            Check.NotNull(entry, "entry");
+            Check.NotNull(navigation, "navigation");
+
+            Dispatch(l => l.NavigationReferenceChanged(entry, navigation, oldValue, newValue));
+        }
+
         private void Dispatch(Action<IEntityStateListener> action)
         {
             if (_entityStateListeners == null)

--- a/src/Microsoft.Data.Entity/ChangeTracking/StoreGeneratedValues.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/StoreGeneratedValues.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;

--- a/test/Microsoft.Data.Entity.Tests/DbContextTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/DbContextTest.cs
@@ -864,6 +864,10 @@ namespace Microsoft.Data.Entity.Tests
             public void ForeignKeyPropertyChanged(StateEntry entry, IProperty property, object oldValue, object newValue)
             {
             }
+
+            public void NavigationReferenceChanged(StateEntry entry, INavigation navigation, object oldValue, object newValue)
+            {
+            }
         }
 
         private class FakeLoggerFactory : ILoggerFactory


### PR DESCRIPTION
Shut up and put your RelatedEnd in my Sidecar... (Initial support for navigation to FK fixup)

This is very early support for fixup of FKs following navigation property change. Only fixup of dependent to principal reference navigations is supported for now--no collection fixup or inverse property fixup. Specific changes:
- Refactor Sidecar to allow it to be used with IPropertyBase and hence navigations as well as normal properties
- Similar updates to StateEntry to allow navigation property values to be obtained in the same way as normal property values
- Update FK snapshot to also snapshot navigations--will rename in a different checkin
- Simple detection of reference changes using the snaphot or notifications triggering a call on the listener that then does simple fixup
