### PR TITLE
Time may change me... 

### DIFF
--- a/src/Microsoft.Data.Entity/ChangeTracking/ChangeDetector.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/ChangeDetector.cs
@@ -1,0 +1,153 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.ChangeTracking
+{
+    public class ChangeDetector
+    {
+        public virtual void PropertyChanged([NotNull] StateEntry entry, [NotNull] IPropertyBase propertyBase)
+        {
+            Check.NotNull(entry, "entry");
+            Check.NotNull(propertyBase, "propertyBase");
+
+            var property = propertyBase as IProperty;
+
+            if (property != null)
+            {
+                entry.SetPropertyModified(property, true);
+
+                if (DetectForeignKeyChange(entry, property))
+                {
+                    entry.RelationshipsSnapshot.TakeSnapshot(property);
+                }
+            }
+            else
+            {
+                var navigation = propertyBase as INavigation;
+
+                if (navigation != null)
+                {
+                    if (DetectNavigationChange(entry, navigation))
+                    {
+                        entry.RelationshipsSnapshot.TakeSnapshot(navigation);
+                    }
+                }
+            }
+        }
+
+        public virtual void PropertyChanging([NotNull] StateEntry entry, [NotNull] IPropertyBase propertyBase)
+        {
+            Check.NotNull(entry, "entry");
+            Check.NotNull(propertyBase, "propertyBase");
+
+            if (entry.EntityType.UseLazyOriginalValues)
+            {
+                entry.OriginalValues.EnsureSnapshot(propertyBase);
+
+                // TODO: Consider making snapshot temporary here since it is no longer required after PropertyChanged is called
+                entry.RelationshipsSnapshot.TakeSnapshot(propertyBase);
+            }
+        }
+
+        public virtual bool DetectChanges([NotNull] StateEntry entry)
+        {
+            Check.NotNull(entry, "entry");
+
+            var entityType = entry.EntityType;
+            var originalValues = entry.TryGetSidecar(Sidecar.WellKnownNames.OriginalValues);
+
+            // TODO: Consider more efficient/higher-level/abstract mechanism for checking if DetectChanges is needed
+            if (entityType.Type == null
+                || originalValues == null
+                || typeof(INotifyPropertyChanged).GetTypeInfo().IsAssignableFrom(entityType.Type.GetTypeInfo()))
+            {
+                return false;
+            }
+
+            var changedFkProperties = new List<IProperty>();
+            var foundChanges = false;
+            foreach (var property in entityType.Properties)
+            {
+                // TODO: Perf: don't lookup accessor twice
+                if (!Equals(entry[property], originalValues[property]))
+                {
+                    entry.SetPropertyModified(property, true);
+                    foundChanges = true;
+                }
+
+                if (DetectForeignKeyChange(entry, property))
+                {
+                    changedFkProperties.Add(property);
+                }
+            }
+
+            foreach (var property in changedFkProperties)
+            {
+                entry.RelationshipsSnapshot.TakeSnapshot(property);
+            }
+
+            foreach (var navigation in entityType.Navigations)
+            {
+                if (DetectNavigationChange(entry, navigation))
+                {
+                    entry.RelationshipsSnapshot.TakeSnapshot(navigation);
+                }
+            }
+
+            return foundChanges;
+        }
+
+        private bool DetectForeignKeyChange(StateEntry entry, IProperty property)
+        {
+            // TODO: Consider flag/index for fast check for FK
+            if (entry.EntityType.ForeignKeys.SelectMany(fk => fk.Properties).Contains(property))
+            {
+                var snapshotValue = entry.RelationshipsSnapshot[property];
+                var currentValue = entry[property];
+
+                // TODO: Ensure structural equality where necessary--e.g. byte arrays
+                if (!Equals(currentValue, snapshotValue))
+                {
+                    // TODO: Constructor injection
+                    var notifier = entry.Configuration.Services.StateEntryNotifier;
+                    notifier.ForeignKeyPropertyChanged(entry, property, snapshotValue, currentValue);
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private bool DetectNavigationChange(StateEntry entry, INavigation navigation)
+        {
+            if (navigation.IsCollection())
+            {
+                // TODO: Handle collections
+            }
+            else
+            {
+                var snapshotValue = entry.RelationshipsSnapshot[navigation];
+                var currentValue = entry[navigation];
+
+                if (!ReferenceEquals(currentValue, snapshotValue))
+                {
+                    var notifier = entry.Configuration.Services.StateEntryNotifier;
+                    notifier.NavigationReferenceChanged(entry, navigation, snapshotValue, currentValue);
+
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/ChangeTracking/StateEntrySubscriber.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/StateEntrySubscriber.cs
@@ -5,11 +5,21 @@ using System.ComponentModel;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.ChangeTracking
 {
     public class StateEntrySubscriber
     {
+        private readonly ChangeDetector _changeDetector;
+
+        public StateEntrySubscriber([NotNull] ChangeDetector changeDetector)
+        {
+            Check.NotNull(changeDetector, "changeDetector");
+
+            _changeDetector = changeDetector;
+        }
+
         public virtual StateEntry SnapshotAndSubscribe([NotNull] StateEntry entry)
         {
             var entityType = entry.EntityType;
@@ -28,7 +38,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
                         var property = TryGetPropertyBase(entityType, e.PropertyName);
                         if (property != null)
                         {
-                            entry.PropertyChanging(property);
+                            _changeDetector.PropertyChanging(entry, property);
                         }
                     };
             }
@@ -41,7 +51,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
                         var property = TryGetPropertyBase(entityType, e.PropertyName);
                         if (property != null)
                         {
-                            entry.PropertyChanged(property);
+                            _changeDetector.PropertyChanged(entry, property);
                         }
                     };
             }

--- a/src/Microsoft.Data.Entity/ChangeTracking/StateManager.cs
+++ b/src/Microsoft.Data.Entity/ChangeTracking/StateManager.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
         private readonly StateEntryFactory _factory;
         private readonly StateEntrySubscriber _subscriber;
         private readonly DbContextConfiguration _configuration;
+        private readonly ChangeDetector _changeDetector;
 
         /// <summary>
         ///     This constructor is intended only for use when creating test doubles that will override members
@@ -38,16 +39,19 @@ namespace Microsoft.Data.Entity.ChangeTracking
             [NotNull] DbContextConfiguration configuration,
             [NotNull] StateEntryFactory factory,
             [NotNull] EntityKeyFactorySource entityKeyFactorySource,
-            [NotNull] StateEntrySubscriber subscriber)
+            [NotNull] StateEntrySubscriber subscriber,
+            [NotNull] ChangeDetector changeDetector)
         {
             Check.NotNull(entityKeyFactorySource, "entityKeyFactorySource");
             Check.NotNull(factory, "factory");
             Check.NotNull(entityKeyFactorySource, "entityKeyFactorySource");
+            Check.NotNull(changeDetector, "changeDetector");
 
             _configuration = configuration;
             _keyFactorySource = entityKeyFactorySource;
             _factory = factory;
             _subscriber = subscriber;
+            _changeDetector = changeDetector;
         }
 
         public virtual StateEntry CreateNewEntry([NotNull] IEntityType entityType)
@@ -115,7 +119,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             var foundChanges = false;
             foreach (var entry in _identityMap.Values)
             {
-                if (entry.DetectChanges())
+                if (_changeDetector.DetectChanges(entry))
                 {
                     foundChanges = true;
                 }

--- a/src/Microsoft.Data.Entity/Extensions/EntityServiceCollectionExtensions.cs
+++ b/src/Microsoft.Data.Entity/Extensions/EntityServiceCollectionExtensions.cs
@@ -34,7 +34,6 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddSingleton<EntityMaterializerSource>()
                 .AddSingleton<CompositeEntityKeyFactory>()
                 .AddSingleton<MemberMapper>()
-                .AddSingleton<StateEntrySubscriber>()
                 .AddSingleton<FieldMatcher>()
                 .AddSingleton<OriginalValuesFactory>()
                 .AddSingleton<RelationshipsSnapshotFactory>()
@@ -43,6 +42,8 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddScoped<StateEntryFactory>()
                 .AddScoped<IEntityStateListener, NavigationFixer>()
                 .AddScoped<StateEntryNotifier>()
+                .AddScoped<ChangeDetector>()
+                .AddScoped<StateEntrySubscriber>()
                 .AddScoped<DbContextConfiguration>()
                 .AddScoped<ContextSets>()
                 .AddScoped<StateManager>();

--- a/src/Microsoft.Data.Entity/Infrastructure/ContextServices.cs
+++ b/src/Microsoft.Data.Entity/Infrastructure/ContextServices.cs
@@ -94,6 +94,11 @@ namespace Microsoft.Data.Entity.Infrastructure
             get { return ServiceProvider.GetService<StateEntryNotifier>(); }
         }
 
+        public virtual ChangeDetector ChangeDetector
+        {
+            get { return ServiceProvider.GetService<ChangeDetector>(); }
+        }
+
         public virtual StoreGeneratedValuesFactory StoreGeneratedValuesFactory
         {
             get { return _serviceProvider.GetService<StoreGeneratedValuesFactory>(); }

--- a/src/Microsoft.Data.Entity/Metadata/NavigationAccessorSource.cs
+++ b/src/Microsoft.Data.Entity/Metadata/NavigationAccessorSource.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 
@@ -43,14 +41,14 @@ namespace Microsoft.Data.Entity.Metadata
 
         private NavigationAccessor Create(INavigation navigation)
         {
-            return navigation.PointsToPrincipal || navigation.ForeignKey.IsUnique
-                ? new NavigationAccessor(
-                    () => _getterSource.GetAccessor(navigation),
-                    () => _setterSource.GetAccessor(navigation))
-                : new CollectionNavigationAccessor(
+            return navigation.IsCollection()
+                ? new CollectionNavigationAccessor(
                     () => _getterSource.GetAccessor(navigation),
                     () => _setterSource.GetAccessor(navigation),
-                    () => _collectionAccessorSource.GetAccessor(navigation));
+                    () => _collectionAccessorSource.GetAccessor(navigation))
+                : new NavigationAccessor(
+                    () => _getterSource.GetAccessor(navigation),
+                    () => _setterSource.GetAccessor(navigation));
         }
     }
 }

--- a/src/Microsoft.Data.Entity/Metadata/NavigationExtensions.cs
+++ b/src/Microsoft.Data.Entity/Metadata/NavigationExtensions.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Metadata
+{
+    public static class NavigationExtensions
+    {
+        public static bool IsCollection([NotNull] this INavigation navigation)
+        {
+            Check.NotNull(navigation, "navigation");
+
+            return !navigation.PointsToPrincipal && !navigation.ForeignKey.IsUnique;
+        }
+    }
+}

--- a/src/Microsoft.Data.Entity/Microsoft.Data.Entity.csproj
+++ b/src/Microsoft.Data.Entity/Microsoft.Data.Entity.csproj
@@ -58,6 +58,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.tt</DependentUpon>
     </Compile>
+    <Compile Include="ChangeTracking\ChangeDetector.cs" />
     <Compile Include="ChangeTracking\RelationshipsSnapshot.cs" />
     <Compile Include="ChangeTracking\RelationshipsSnapshotFactory.cs" />
     <Compile Include="ChangeTracking\SimpleNullableEntityKeyFactory.cs" />
@@ -86,6 +87,7 @@
     <Compile Include="Metadata\CollectionNavigationAccessor.cs" />
     <Compile Include="Metadata\NavigationAccessor.cs" />
     <Compile Include="Metadata\NavigationAccessorSource.cs" />
+    <Compile Include="Metadata\NavigationExtensions.cs" />
     <Compile Include="Query\AsyncResultOperatorHandler.cs" />
     <Compile Include="Query\IResultOperatorHandler.cs" />
     <Compile Include="Query\QueryCompilationContext.cs" />

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateEntrySubscriberTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateEntrySubscriberTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entryMock.Setup(m => m.OriginalValues).Returns(originalValuesMock.Object);
             entryMock.Setup(m => m.RelationshipsSnapshot).Returns(fkSnapshotMock.Object);
 
-            new StateEntrySubscriber().SnapshotAndSubscribe(entryMock.Object);
+            new StateEntrySubscriber(new ChangeDetector()).SnapshotAndSubscribe(entryMock.Object);
 
             originalValuesMock.Verify(m => m.TakeSnapshot());
             fkSnapshotMock.Verify(m => m.TakeSnapshot());
@@ -43,7 +43,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entryMock.Setup(m => m.EntityType).Returns(entityTypeMock.Object);
             entryMock.Setup(m => m.OriginalValues).Returns(originalValuesMock.Object);
 
-            new StateEntrySubscriber().SnapshotAndSubscribe(entryMock.Object);
+            new StateEntrySubscriber(new ChangeDetector()).SnapshotAndSubscribe(entryMock.Object);
 
             originalValuesMock.Verify(m => m.TakeSnapshot(), Times.Never);
         }
@@ -60,12 +60,13 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entryMock.Setup(m => m.EntityType).Returns(entityType);
             entryMock.Setup(m => m.Entity).Returns(entity);
 
-            new StateEntrySubscriber().SnapshotAndSubscribe(entryMock.Object);
+            var detectorMock = new Mock<ChangeDetector>();
+            new StateEntrySubscriber(detectorMock.Object).SnapshotAndSubscribe(entryMock.Object);
 
             entity.Name = "George";
 
-            entryMock.Verify(m => m.PropertyChanging(property));
-            entryMock.Verify(m => m.PropertyChanged(property));
+            detectorMock.Verify(m => m.PropertyChanging(entryMock.Object, property));
+            detectorMock.Verify(m => m.PropertyChanged(entryMock.Object, property));
         }
 
         [Fact]
@@ -80,12 +81,13 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entryMock.Setup(m => m.EntityType).Returns(entityType);
             entryMock.Setup(m => m.Entity).Returns(entity);
 
-            new StateEntrySubscriber().SnapshotAndSubscribe(entryMock.Object);
+            var detectorMock = new Mock<ChangeDetector>();
+            new StateEntrySubscriber(detectorMock.Object).SnapshotAndSubscribe(entryMock.Object);
 
             entity.NotMapped = "Formby";
 
-            entryMock.Verify(m => m.PropertyChanging(It.IsAny<IProperty>()), Times.Never);
-            entryMock.Verify(m => m.PropertyChanged(It.IsAny<IProperty>()), Times.Never);
+            detectorMock.Verify(m => m.PropertyChanging(It.IsAny<StateEntry>(), It.IsAny<IProperty>()), Times.Never);
+            detectorMock.Verify(m => m.PropertyChanged(It.IsAny<StateEntry>(), It.IsAny<IProperty>()), Times.Never);
         }
 
         private class FullNotificationEntity : INotifyPropertyChanging, INotifyPropertyChanged

--- a/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateEntryTest.cs
+++ b/test/Microsoft.Data.Entity.Tests/ChangeTracking/StateEntryTest.cs
@@ -967,7 +967,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
         protected virtual StateEntry CreateStateEntry(DbContextConfiguration configuration, IEntityType entityType, object entity)
         {
-            return new StateEntrySubscriber().SnapshotAndSubscribe(
+            return new StateEntrySubscriber(new ChangeDetector()).SnapshotAndSubscribe(
                 new StateEntryFactory(
                     configuration,
                     configuration.Services.ServiceProvider.GetService<EntityMaterializerSource>())
@@ -976,7 +976,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
         protected virtual StateEntry CreateStateEntry(DbContextConfiguration configuration, IEntityType entityType, IValueReader valueReader)
         {
-            return new StateEntrySubscriber().SnapshotAndSubscribe(
+            return new StateEntrySubscriber(new ChangeDetector()).SnapshotAndSubscribe(
                 new StateEntryFactory(
                     configuration,
                     configuration.Services.ServiceProvider.GetService<EntityMaterializerSource>())


### PR DESCRIPTION
Time may change me... (Refactor change detection out of the StateEntry class)

The StateEntry class was accumulating logic used only for detecting changes. This checkin extracts this functionality into a separate service to reduce the amount of code an responsibilities in StateEntry and make change detection easier to test.

(Depends on "That's not my name...again" and "Shut up and put your RelatedEnd in my Sidecar... ")
