### PR TITLE
ATS functional tests configured from environment or config file

### DIFF
--- a/test/Microsoft.Data.Entity.AzureTableStorage.FunctionalTests/App.config.example
+++ b/test/Microsoft.Data.Entity.AzureTableStorage.FunctionalTests/App.config.example
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <appSettings>
-    <add key="TestConnectionString" value="DefaultEndpointsProtocol=https;AccountName=name;AccountKey=key;"/>
-  </appSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1"/></startup></configuration>
+<config>
+	<TestAccount>
+		<ConnectionString>DefaultEndpointsProtocol=https;AccountName=name;AccountKey=key;</ConnectionString>
+	</TestAccount>
+</config>

--- a/test/Microsoft.Data.Entity.AzureTableStorage.FunctionalTests/AtsTestFramework.cs
+++ b/test/Microsoft.Data.Entity.AzureTableStorage.FunctionalTests/AtsTestFramework.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Data.Entity.AzureTableStorage.FunctionalTests
+{
+    public class AtsTestFramework : XunitTestFramework
+    {
+        protected override ITestFrameworkDiscoverer CreateDiscoverer(IAssemblyInfo assemblyInfo)
+        {
+            return new AtsTestDiscoverer(assemblyInfo, SourceInformationProvider);
+        }
+    }
+
+    public class AtsTestDiscoverer : XunitTestFrameworkDiscoverer
+    {
+        public AtsTestDiscoverer(IAssemblyInfo assemblyInfo, ISourceInformationProvider sourceProvider)
+            : base(assemblyInfo, sourceProvider)
+        {
+        }
+
+        protected override bool FindTestsForType(ITypeInfo type, bool includeSourceInformation, IMessageBus messageBus)
+        {
+            if (type.GetCustomAttributes(typeof(RunIfConfiguredAttribute)) == null
+                || TestConfig.Instance.IsConfigured)
+            {
+                return base.FindTestsForType(type, includeSourceInformation, messageBus);
+            }
+            throw new Exception(String.Format("Warning: could not run tests for {0} because configuration is missing", type.Name));
+        }
+    }
+
+    public class RunIfConfiguredAttribute : Attribute
+    {
+    }
+}

--- a/test/Microsoft.Data.Entity.AzureTableStorage.FunctionalTests/BatchTests.cs
+++ b/test/Microsoft.Data.Entity.AzureTableStorage.FunctionalTests/BatchTests.cs
@@ -2,11 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Configuration;
 using Xunit;
 
 namespace Microsoft.Data.Entity.AzureTableStorage.FunctionalTests
 {
+    [RunIfConfigured]
     public class BatchTests : IClassFixture<EndToEndFixture>
     {
         private readonly string _testPartition;
@@ -15,6 +15,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.FunctionalTests
         public BatchTests(EndToEndFixture fixture)
         {
             _testPartition = "unittests-" + DateTime.UtcNow.ToBinary();
+            fixture.UseTableNamePrefixAndLock("Batch");
             fixture.SetContextOptions(useBatching: true);
             _context = fixture.CreateContext();
         }

--- a/test/Microsoft.Data.Entity.AzureTableStorage.FunctionalTests/EndToEndTests.cs
+++ b/test/Microsoft.Data.Entity.AzureTableStorage.FunctionalTests/EndToEndTests.cs
@@ -5,9 +5,11 @@ using System;
 using System.Globalization;
 using System.Linq;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Microsoft.Data.Entity.AzureTableStorage.FunctionalTests
 {
+    [RunIfConfigured]
     public class EndToEndTests : IClassFixture<EndToEndFixture>
     {
         private readonly DbContext _context;
@@ -16,6 +18,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.FunctionalTests
         public EndToEndTests(EndToEndFixture fixture)
         {
             _testPartition = "unittests-" + DateTime.UtcNow.ToBinary();
+            fixture.UseTableNamePrefixAndLock("EndToEnd");
             _context = fixture.CreateContext();
             _context.Set<Purchase>().AddRange(EndToEndFixture.SampleData(_testPartition));
             _context.SaveChanges();

--- a/test/Microsoft.Data.Entity.AzureTableStorage.FunctionalTests/Microsoft.Data.Entity.AzureTableStorage.FunctionalTests.csproj
+++ b/test/Microsoft.Data.Entity.AzureTableStorage.FunctionalTests/Microsoft.Data.Entity.AzureTableStorage.FunctionalTests.csproj
@@ -33,7 +33,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -41,6 +40,9 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <PackageReference Include="Microsoft.Framework.ConfigurationModel">
+      <TargetFramework>net45</TargetFramework>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Framework.ConfigurationModel.Xml">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>
     <PackageReference Include="Microsoft.Framework.DependencyInjection">
@@ -77,10 +79,13 @@
     <Compile Include="..\Shared\NorthwindQueryTestBase.cs">
       <Link>NorthwindQueryTestBase.cs</Link>
     </Compile>
+    <Compile Include="AtsTestFramework.cs" />
     <Compile Include="BatchTests.cs" />
     <Compile Include="EndToEndFixture.cs" />
     <Compile Include="EndToEndTests.cs" />
+    <Compile Include="TestConfig.cs" />
     <Compile Include="NorthwindQueryTest.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Data.Entity\Microsoft.Data.Entity.csproj">
@@ -94,16 +99,13 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
     <None Include="project.json" />
     <None Include="README.md" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/test/Microsoft.Data.Entity.AzureTableStorage.FunctionalTests/NorthwindQueryTest.cs
+++ b/test/Microsoft.Data.Entity.AzureTableStorage.FunctionalTests/NorthwindQueryTest.cs
@@ -2,8 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Configuration;
-using System.Linq;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.FunctionalTests;
 using Northwind;
@@ -11,6 +9,7 @@ using Xunit;
 
 namespace Microsoft.Data.Entity.AzureTableStorage.FunctionalTests
 {
+    [RunIfConfigured]
     public class NorthwindQueryTest : NorthwindQueryTestBase, IClassFixture<NorthwindQueryFixture>
     {
         private readonly NorthwindQueryFixture _fixture;
@@ -33,7 +32,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.FunctionalTests
         public IModel CreateAzureTableStorageModel()
         {
             var model = CreateModel();
-            var tableSuffix = DateTime.UtcNow.ToBinary(); //keep separate from other tests
+            var tableSuffix = "FunctionalTests";
             var builder = new ModelBuilder(model);
             builder.Entity<Customer>()
                 .AzureTableProperties(atp =>
@@ -84,7 +83,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.FunctionalTests
             _options
                 = new DbContextOptions()
                     .UseModel(CreateAzureTableStorageModel())
-                    .UseAzureTableStorage(ConfigurationManager.AppSettings["TestConnectionString"], batchRequests: false);
+                    .UseAzureTableStorage(TestConfig.Instance.ConnectionString, batchRequests: false);
 
             using (var context = new DbContext(_options))
             {

--- a/test/Microsoft.Data.Entity.AzureTableStorage.FunctionalTests/Properties/AssemblyInfo.cs
+++ b/test/Microsoft.Data.Entity.AzureTableStorage.FunctionalTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+[assembly: TestFramework("Microsoft.Data.Entity.AzureTableStorage.FunctionalTests.AtsTestFramework", "Microsoft.Data.Entity.AzureTableStorage.FunctionalTests")]

--- a/test/Microsoft.Data.Entity.AzureTableStorage.FunctionalTests/README.md
+++ b/test/Microsoft.Data.Entity.AzureTableStorage.FunctionalTests/README.md
@@ -1,16 +1,21 @@
 AzureTableStorage.FunctionalTests
 =====
-These tests require a Azure Storage account (for now). You can run them using [Azure Storage Emulator](http://www.microsoft.com/en-us/download/details.aspx?id=42317), but the results may not be the same as testing against a real account.
+These tests require a Azure Storage account. They can also run on the [Azure Storage Emulator](http://www.microsoft.com/en-us/download/details.aspx?id=42317), but the results and performance may vary.
 
 ## Configuration
-To run the tests, you must create a file called app.config and add a valid connection string for an Azure Storage account. ConfigurationManager may require the file be included in CSPROJ.
+To configure these tests, provide a connection string as an environment variable or in a config file. If there is no connection string, **all tests will be skipped** rather than failing.
+
+#### Environment Variable
+Set `CUSTOMCONNSTR_TestAccount` to a valid Azure Storage connection string.
+
+#### Config File
+Create a file called `app.config` in the source root for this project. Add a valid connection string for an Azure Storage account. See app.config.example. 
 
 Example:
 ```xml
-<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-  <appSettings>
-    <add key="TestConnectionString" value="DefaultEndpointsProtocol=https;AccountName=testaccount1;AccountKey=(key);"/>
-  </appSettings>
-</configuration>
+<config>
+	<TestAccount>
+		<ConnectionString>DefaultEndpointsProtocol=https;AccountName=name;AccountKey=key;</ConnectionString>
+	</TestAccount>
+</config>
 ```

--- a/test/Microsoft.Data.Entity.AzureTableStorage.FunctionalTests/TestConfig.cs
+++ b/test/Microsoft.Data.Entity.AzureTableStorage.FunctionalTests/TestConfig.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.Framework.ConfigurationModel;
+
+namespace Microsoft.Data.Entity.AzureTableStorage.FunctionalTests
+{
+    public class TestConfig
+    {
+        private TestConfig()
+        {
+            _cstr = Environment.GetEnvironmentVariable("CUSTOMCONNSTR_TestAccount");
+            const string cliConfigPath = "App.config";
+            const string vsConfigPath = "..\\..\\App.config";
+            if (_cstr == null)
+            {
+                var configuration = new Configuration();
+                if (File.Exists(cliConfigPath))
+                {
+                    configuration.AddXmlFile(cliConfigPath);
+                }
+                else if (File.Exists(vsConfigPath))
+                {
+                    configuration.AddXmlFile(vsConfigPath);
+                }
+
+                if (configuration.TryGet("TestAccount:ConnectionString", out _cstr))
+                {
+                    _cstr = _cstr.Trim();
+                }
+            }
+        }
+
+        private static TestConfig _instance;
+        private readonly string _cstr;
+
+        public static TestConfig Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    _instance = new TestConfig();
+                }
+                return _instance;
+            }
+        }
+
+        public bool IsConfigured
+        {
+            get { return !String.IsNullOrEmpty(ConnectionString); }
+        }
+
+        public string ConnectionString
+        {
+            get { return _cstr; }
+        }
+    }
+}

--- a/test/Microsoft.Data.Entity.AzureTableStorage.FunctionalTests/project.json
+++ b/test/Microsoft.Data.Entity.AzureTableStorage.FunctionalTests/project.json
@@ -7,18 +7,18 @@
     "Microsoft.Data.Entity": "",
     "Microsoft.Data.Entity.AzureTableStorage": "",
     "Microsoft.Framework.ConfigurationModel":"0.1-alpha-*",
+    "Microsoft.Framework.ConfigurationModel.Xml": "0.1-alpha-*",
     "Microsoft.Framework.DependencyInjection": "0.1-alpha-*",
     "Moq":  "4.2.1402.2112",
     "Xunit.KRunner": "0.1-alpha-*"
   },
-  "include": "App.config",
   "commands": {
     "test": "Xunit.KRunner"
   },
+  "code": "**\\*.cs;..\\Shared\\TestFileLogger.cs;..\\Shared\\Northwind.cs;..\\Shared\\NorthwindQueryTestBase.cs;..\\Shared\\NorthwindQueryFixtureBase.cs;",
   "configurations": {
-    "net45": {
+    "net451": {
       "dependencies": {
-        "System.Configuration": "",
         "System.Threading.Tasks": ""
       }
     }

--- a/test/Microsoft.Data.Entity.AzureTableStorage.Tests/project.json
+++ b/test/Microsoft.Data.Entity.AzureTableStorage.Tests/project.json
@@ -17,6 +17,7 @@
   "commands": {
     "test": "Xunit.KRunner"
   },
+  "code": "**\\*.cs;..\\Shared\\ApiConsistencyTestBase.cs",
   "configurations": {
     "net451": {
       "dependencies": {


### PR DESCRIPTION
All functional tests are skipped if no connection string is available.
Depends on https://github.com/aspnet/Testing/pull/32 to load the custom test framework.
