### PR TITLE
Fix building/running in Visual Studio

### DIFF
--- a/src/EntityFramework.InMemory/EntityFramework.InMemory.csproj
+++ b/src/EntityFramework.InMemory/EntityFramework.InMemory.csproj
@@ -82,7 +82,7 @@
     <Compile Include="..\Shared\StringBuilderExtensions.cs" />
     <Compile Include="..\Shared\SharedTypeExtensions.cs" />
     <EmbeddedResource Include="Properties\Strings.resx">
-      <LogicalName>Microsoft.Data.Entity.InMemory.Strings.resources</LogicalName>
+      <LogicalName>EntityFramework.InMemory.Strings.resources</LogicalName>
     </EmbeddedResource>
     <None Include="..\..\packages\KoreBuild\build\Resources.tt">
       <Link>Properties\Resources.tt</Link>

--- a/src/EntityFramework.Migrations.Design/EntityFramework.Migrations.Design.csproj
+++ b/src/EntityFramework.Migrations.Design/EntityFramework.Migrations.Design.csproj
@@ -60,7 +60,7 @@
     <Compile Include="Utilities\DbContextConfigurationExtensions.cs" />
     <Compile Include="Utilities\EnumerableExtensions.cs" />
     <EmbeddedResource Include="Properties\Strings.resx">
-      <LogicalName>Microsoft.Data.Entity.Migrations.Design.Strings.resources</LogicalName>
+      <LogicalName>EntityFramework.Migrations.Design.Strings.resources</LogicalName>
     </EmbeddedResource>
     <None Include="..\..\packages\KoreBuild\build\Resources.tt">
       <Link>Properties\Resources.tt</Link>

--- a/src/EntityFramework.Migrations/EntityFramework.Migrations.csproj
+++ b/src/EntityFramework.Migrations/EntityFramework.Migrations.csproj
@@ -98,7 +98,7 @@
     <Compile Include="..\Shared\CodeAnnotations.cs" />
     <Compile Include="..\Shared\StringBuilderExtensions.cs" />
     <EmbeddedResource Include="Properties\Strings.resx">
-      <LogicalName>Microsoft.Data.Entity.Migrations.Strings.resources</LogicalName>
+      <LogicalName>EntityFramework.Migrations.Strings.resources</LogicalName>
     </EmbeddedResource>
     <None Include="..\..\packages\KoreBuild\build\Resources.tt">
       <Link>Properties\Resources.tt</Link>

--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -134,7 +134,7 @@
     <Compile Include="..\Shared\SharedTypeExtensions.cs" />
     <Compile Include="Utilities\ExpressionExtensions.cs" />
     <EmbeddedResource Include="Properties\Strings.resx">
-      <LogicalName>Microsoft.Data.Entity.Relational.Strings.resources</LogicalName>
+      <LogicalName>EntityFramework.Relational.Strings.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <None Include="..\..\packages\KoreBuild\build\Resources.tt">

--- a/src/EntityFramework.SQLite/EntityFramework.SQLite.csproj
+++ b/src/EntityFramework.SQLite/EntityFramework.SQLite.csproj
@@ -77,7 +77,7 @@
     <Compile Include="..\Shared\CodeAnnotations.cs" />
     <Compile Include="..\Shared\StringBuilderExtensions.cs" />
     <EmbeddedResource Include="Properties\Strings.resx">
-      <LogicalName>Microsoft.Data.Entity.SQLite.Strings.resources</LogicalName>
+      <LogicalName>EntityFramework.SQLite.Strings.resources</LogicalName>
     </EmbeddedResource>
     <None Include="..\..\packages\KoreBuild\build\Resources.tt">
       <Link>Properties\Resources.tt</Link>

--- a/src/EntityFramework.SqlServer/EntityFramework.SqlServer.csproj
+++ b/src/EntityFramework.SqlServer/EntityFramework.SqlServer.csproj
@@ -86,7 +86,7 @@
     <Compile Include="..\Shared\CodeAnnotations.cs" />
     <Compile Include="..\Shared\StringBuilderExtensions.cs" />
     <Compile Include="..\Shared\SharedTypeExtensions.cs" />
-    <EmbeddedResource Include="..\Microsoft.Data.Entity.SqlServer\Properties\Strings.resx">
+    <EmbeddedResource Include="Properties\Strings.resx">
       <LogicalName>Microsoft.Data.Entity.SqlServer.Strings.resources</LogicalName>
     </EmbeddedResource>
     <None Include="..\..\packages\KoreBuild\build\Resources.tt">

--- a/src/EntityFramework/EntityFramework.csproj
+++ b/src/EntityFramework/EntityFramework.csproj
@@ -241,7 +241,7 @@
     <Compile Include="..\Shared\StringBuilderExtensions.cs" />
     <Compile Include="..\Shared\SharedTypeExtensions.cs" />
     <EmbeddedResource Include="Properties\Strings.resx">
-      <LogicalName>Microsoft.Data.Entity.Strings.resources</LogicalName>
+      <LogicalName>EntityFramework.Strings.resources</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <None Include="..\..\packages\KoreBuild\build\Resources.tt">


### PR DESCRIPTION
Fix building/running in Visual Studio by renaming resource file logical names  to match new assembly names.
