### PR TITLE
Add model to params for DataStoreCreator deletion

### DIFF
--- a/src/EntityFramework.InMemory/InMemoryDataStoreCreator.cs
+++ b/src/EntityFramework.InMemory/InMemoryDataStoreCreator.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Data.Entity.InMemory
             _dataStore = dataStore;
         }
 
-        public override bool EnsureDeleted()
+        public override bool EnsureDeleted(IModel model)
         {
             if (_dataStore.Database.Any())
             {
@@ -32,9 +32,9 @@ namespace Microsoft.Data.Entity.InMemory
             return false;
         }
 
-        public override Task<bool> EnsureDeletedAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public override Task<bool> EnsureDeletedAsync(IModel model, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return Task.FromResult(EnsureDeleted());
+            return Task.FromResult(EnsureDeleted(model));
         }
 
         public override bool EnsureCreated(IModel model)

--- a/src/EntityFramework.Relational/RelationalDataStoreCreator.cs
+++ b/src/EntityFramework.Relational/RelationalDataStoreCreator.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Data.Entity.Relational
 
         public abstract Task<bool> HasTablesAsync(CancellationToken cancellationToken = default(CancellationToken));
 
-        public override bool EnsureDeleted()
+        public override bool EnsureDeleted(IModel model)
         {
             if (Exists())
             {
@@ -43,7 +43,7 @@ namespace Microsoft.Data.Entity.Relational
             return false;
         }
 
-        public override async Task<bool> EnsureDeletedAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public override async Task<bool> EnsureDeletedAsync(IModel model, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (await ExistsAsync(cancellationToken))
             {

--- a/src/EntityFramework/Infrastructure/Database.cs
+++ b/src/EntityFramework/Infrastructure/Database.cs
@@ -45,13 +45,13 @@ namespace Microsoft.Data.Entity.Infrastructure
         // TODO: Make sure API docs say that return value indicates whether or not the database was deleted
         public virtual bool EnsureDeleted()
         {
-            return _configuration.DataStoreCreator.EnsureDeleted();
+            return _configuration.DataStoreCreator.EnsureDeleted(_configuration.Model);
         }
 
         // TODO: Make sure API docs say that return value indicates whether or not the database was deleted
         public virtual Task<bool> EnsureDeletedAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            return _configuration.DataStoreCreator.EnsureDeletedAsync(cancellationToken);
+            return _configuration.DataStoreCreator.EnsureDeletedAsync(_configuration.Model, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/EntityFramework/Storage/DataStoreCreator.cs
+++ b/src/EntityFramework/Storage/DataStoreCreator.cs
@@ -10,8 +10,8 @@ namespace Microsoft.Data.Entity.Storage
 {
     public abstract class DataStoreCreator
     {
-        public abstract bool EnsureDeleted();
-        public abstract Task<bool> EnsureDeletedAsync(CancellationToken cancellationToken = default(CancellationToken));
+        public abstract bool EnsureDeleted([NotNull] IModel model);
+        public abstract Task<bool> EnsureDeletedAsync([NotNull] IModel model, CancellationToken cancellationToken = default(CancellationToken));
         public abstract bool EnsureCreated([NotNull] IModel model);
         public abstract Task<bool> EnsureCreatedAsync([NotNull] IModel model, CancellationToken cancellationToken = default(CancellationToken));
     }

--- a/test/EntityFramework.Relational.Tests/RelationalDatabaseTest.cs
+++ b/test/EntityFramework.Relational.Tests/RelationalDatabaseTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
             creatorMock.Setup(m => m.Exists()).Returns(true);
             creatorMock.Setup(m => m.HasTables()).Returns(true);
             creatorMock.Setup(m => m.EnsureCreated(model)).Returns(true);
-            creatorMock.Setup(m => m.EnsureDeleted()).Returns(true);
+            creatorMock.Setup(m => m.EnsureDeleted(model)).Returns(true);
 
             var connection = Mock.Of<RelationalConnection>();
             var configurationMock = new Mock<DbContextConfiguration>();
@@ -49,7 +49,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
             creatorMock.Verify(m => m.EnsureCreated(model), Times.Once);
 
             Assert.True(database.EnsureDeleted());
-            creatorMock.Verify(m => m.EnsureDeleted(), Times.Once);
+            creatorMock.Verify(m => m.EnsureDeleted(model), Times.Once);
 
             Assert.Same(connection, database.Connection);
         }
@@ -64,7 +64,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
             creatorMock.Setup(m => m.ExistsAsync(cancellationToken)).Returns(Task.FromResult(true));
             creatorMock.Setup(m => m.HasTablesAsync(cancellationToken)).Returns(Task.FromResult(true));
             creatorMock.Setup(m => m.EnsureCreatedAsync(model, cancellationToken)).Returns(Task.FromResult(true));
-            creatorMock.Setup(m => m.EnsureDeletedAsync(cancellationToken)).Returns(Task.FromResult(true));
+            creatorMock.Setup(m => m.EnsureDeletedAsync(null, cancellationToken: cancellationToken)).Returns(Task.FromResult(true));
 
             var configurationMock = new Mock<DbContextConfiguration>();
             configurationMock.Setup(m => m.DataStoreCreator).Returns(creatorMock.Object);
@@ -91,7 +91,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
             creatorMock.Verify(m => m.EnsureCreatedAsync(model, cancellationToken), Times.Once);
 
             Assert.True(await database.EnsureDeletedAsync(cancellationToken));
-            creatorMock.Verify(m => m.EnsureDeletedAsync(cancellationToken), Times.Once);
+            creatorMock.Verify(m => m.EnsureDeletedAsync(null, cancellationToken: cancellationToken), Times.Once);
         }
     }
 }

--- a/test/EntityFramework.Tests/DatabaseTest.cs
+++ b/test/EntityFramework.Tests/DatabaseTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.Entity.Tests
             var model = Mock.Of<IModel>();
             var creatorMock = new Mock<DataStoreCreator>();
             creatorMock.Setup(m => m.EnsureCreated(model)).Returns(true);
-            creatorMock.Setup(m => m.EnsureDeleted()).Returns(true);
+            creatorMock.Setup(m => m.EnsureDeleted(model)).Returns(true);
 
             var connection = Mock.Of<DataStoreConnection>();
             var configurationMock = new Mock<DbContextConfiguration>();
@@ -33,7 +33,7 @@ namespace Microsoft.Data.Entity.Tests
             creatorMock.Verify(m => m.EnsureCreated(model), Times.Once);
 
             Assert.True(database.EnsureDeleted());
-            creatorMock.Verify(m => m.EnsureDeleted(), Times.Once);
+            creatorMock.Verify(m => m.EnsureDeleted(model), Times.Once);
 
             Assert.Same(connection, database.Connection);
         }
@@ -46,7 +46,7 @@ namespace Microsoft.Data.Entity.Tests
 
             var creatorMock = new Mock<DataStoreCreator>();
             creatorMock.Setup(m => m.EnsureCreatedAsync(model, cancellationToken)).Returns(Task.FromResult(true));
-            creatorMock.Setup(m => m.EnsureDeletedAsync(cancellationToken)).Returns(Task.FromResult(true));
+            creatorMock.Setup(m => m.EnsureDeletedAsync(null, cancellationToken: cancellationToken)).Returns(Task.FromResult(true));
 
             var configurationMock = new Mock<DbContextConfiguration>();
             configurationMock.Setup(m => m.DataStoreCreator).Returns(creatorMock.Object);
@@ -58,7 +58,7 @@ namespace Microsoft.Data.Entity.Tests
             creatorMock.Verify(m => m.EnsureCreatedAsync(model, cancellationToken), Times.Once);
 
             Assert.True(await database.EnsureDeletedAsync(cancellationToken));
-            creatorMock.Verify(m => m.EnsureDeletedAsync(cancellationToken), Times.Once);
+            creatorMock.Verify(m => m.EnsureDeletedAsync(null, cancellationToken: cancellationToken), Times.Once);
         }
     }
 }


### PR DESCRIPTION
Some providers need details on the model in order to delete correctly.
