### PR TITLE
Playing my recorder...

### DIFF
--- a/src/EntityFramework.SqlServer/SqlServerSequenceValueGenerator.cs
+++ b/src/EntityFramework.SqlServer/SqlServerSequenceValueGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Data.Common;
 using System.Globalization;
 using System.Threading;
@@ -83,6 +84,9 @@ namespace Microsoft.Data.Entity.SqlServer
             return Convert.ChangeType(newValue.Current, property.PropertyType);
         }
 
+        // TODO: This is temporary instrumentation to root out concurrency issue--GitHub #266
+        public ConcurrentStack<long> ReturnedSequences = new ConcurrentStack<long>();
+
         public virtual async Task<object> NextAsync(
             DbContextConfiguration contextConfiguration,
             IProperty property,
@@ -107,6 +111,7 @@ namespace Microsoft.Data.Entity.SqlServer
                         var commandInfo = PrepareCommand(contextConfiguration);
 
                         var newCurrent = (long)await _executor.ExecuteScalarAsync(commandInfo.Item1, commandInfo.Item2, cancellationToken).ConfigureAwait(false);
+                        ReturnedSequences.Push(newCurrent);
                         newValue = new SequenceValue(newCurrent, newCurrent + _blockSize);
                         _currentValue = newValue;
                     }


### PR DESCRIPTION
Playing my recorder... (Instrument SQL Server sequence concurrency test)

I have been unable to repro the concurrency failure (Issue #266) that we occasionally see on the CI machine. This change re-enables the test with some instrumentation such that some more information can be obtained when it next fails. To start with the information gathered is the sequence blocks actually returned from SQL Server. Hopefully this will confirm that SQL Server is never returning duplicates which then narrows the scope of the problem.
