### PR TITLE
Sidecars 7, Brazil 0...

### DIFF
--- a/src/EntityFramework/ChangeTracking/ChangeTracker.cs
+++ b/src/EntityFramework/ChangeTracking/ChangeTracker.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
     public class ChangeTracker
     {
         private readonly StateManager _stateManager;
+        private readonly ChangeDetector _changeDetector;
 
         /// <summary>
         ///     This constructor is intended only for use when creating test doubles that will override members
@@ -23,11 +24,13 @@ namespace Microsoft.Data.Entity.ChangeTracking
         {
         }
 
-        public ChangeTracker([NotNull] StateManager stateManager)
+        public ChangeTracker([NotNull] StateManager stateManager, [NotNull] ChangeDetector changeDetector)
         {
             Check.NotNull(stateManager, "stateManager");
+            Check.NotNull(changeDetector, "changeDetector");
 
             _stateManager = stateManager;
+            _changeDetector = changeDetector;
         }
 
         public virtual EntityEntry<TEntity> Entry<TEntity>([NotNull] TEntity entity)
@@ -59,6 +62,12 @@ namespace Microsoft.Data.Entity.ChangeTracking
         public virtual StateManager StateManager
         {
             get { return _stateManager; }
+        }
+
+
+        public virtual bool DetectChanges()
+        {
+            return _changeDetector.DetectChanges(_stateManager);
         }
     }
 }

--- a/src/EntityFramework/ChangeTracking/IEntityStateListener.cs
+++ b/src/EntityFramework/ChangeTracking/IEntityStateListener.cs
@@ -15,5 +15,6 @@ namespace Microsoft.Data.Entity.ChangeTracking
         void ForeignKeyPropertyChanged([NotNull] StateEntry entry, [NotNull] IProperty property, [CanBeNull] object oldValue, [CanBeNull] object newValue);
         void NavigationReferenceChanged([NotNull] StateEntry entry, [NotNull] INavigation property, [CanBeNull] object oldValue, [CanBeNull] object newValue);
         void NavigationCollectionChanged([NotNull] StateEntry entry, [NotNull] INavigation navigation, [NotNull] ISet<object> added, [NotNull] ISet<object> removed);
+        void PrincipalKeyPropertyChanged([NotNull] StateEntry entry, [NotNull] IProperty property, [CanBeNull] object oldValue, [CanBeNull] object newValue);
     }
 }

--- a/src/EntityFramework/ChangeTracking/PropertyBagExtensions.cs
+++ b/src/EntityFramework/ChangeTracking/PropertyBagExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
@@ -26,14 +24,16 @@ namespace Microsoft.Data.Entity.ChangeTracking
             Check.NotNull(propertyBagEntry, "propertyBagEntry");
             Check.NotNull(foreignKey, "foreignKey");
 
-            var keyValue = propertyBagEntry.StateEntry.CreateKey(foreignKey.ReferencedEntityType, foreignKey.ReferencedProperties, propertyBagEntry);
-            if (keyValue == EntityKey.NullEntityKey)
-            {
-                throw new InvalidOperationException(
-                    Strings.FormatNullPrincipalKey(
-                        propertyBagEntry.StateEntry.EntityType.Name,
-                        string.Join(", ", foreignKey.ReferencedProperties.Select(p => p.Name))));
-            }
+            return propertyBagEntry.StateEntry.CreateKey(foreignKey.ReferencedEntityType, foreignKey.ReferencedProperties, propertyBagEntry);
+        }
+
+        [NotNull]
+        public static EntityKey GetPrimaryKeyValue([NotNull] this IPropertyBagEntry propertyBagEntry)
+        {
+            Check.NotNull(propertyBagEntry, "propertyBagEntry");
+
+            var entityType = propertyBagEntry.StateEntry.EntityType;
+            var keyValue = propertyBagEntry.StateEntry.CreateKey(entityType, entityType.GetKey().Properties, propertyBagEntry);
 
             return keyValue;
         }

--- a/src/EntityFramework/ChangeTracking/RelationshipsSnapshot.cs
+++ b/src/EntityFramework/ChangeTracking/RelationshipsSnapshot.cs
@@ -32,7 +32,8 @@ namespace Microsoft.Data.Entity.ChangeTracking
         {
             var entityType = stateEntry.EntityType;
 
-            return entityType.ForeignKeys.SelectMany(fk => fk.Properties).Distinct()
+            return entityType.GetKey().Properties.Concat(
+                entityType.ForeignKeys.SelectMany(fk => fk.Properties)).Distinct()
                 .Concat<IPropertyBase>(entityType.Navigations);
         }
 

--- a/src/EntityFramework/ChangeTracking/StateEntryNotifier.cs
+++ b/src/EntityFramework/ChangeTracking/StateEntryNotifier.cs
@@ -77,6 +77,15 @@ namespace Microsoft.Data.Entity.ChangeTracking
             Dispatch(l => l.NavigationCollectionChanged(entry, navigation, added, removed));
         }
 
+        public virtual void PrincipalKeyPropertyChanged(
+             [NotNull] StateEntry entry, [NotNull] IProperty property, [CanBeNull] object oldValue, [CanBeNull] object newValue)
+        {
+            Check.NotNull(entry, "entry");
+            Check.NotNull(property, "property");
+
+            Dispatch(l => l.PrincipalKeyPropertyChanged(entry, property, oldValue, newValue));
+        }
+        
         private void Dispatch(Action<IEntityStateListener> action)
         {
             if (_entityStateListeners == null)

--- a/src/EntityFramework/ChangeTracking/StoreGeneratedValuesFactory.cs
+++ b/src/EntityFramework/ChangeTracking/StoreGeneratedValuesFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
@@ -10,11 +11,18 @@ namespace Microsoft.Data.Entity.ChangeTracking
 {
     public class StoreGeneratedValuesFactory
     {
-        public virtual StoreGeneratedValues Create([NotNull] StateEntry stateEntry, [NotNull] IEnumerable<IProperty> properties)
+        public virtual StoreGeneratedValues Create([NotNull] StateEntry stateEntry)
         {
             Check.NotNull(stateEntry, "stateEntry");
 
-            return new StoreGeneratedValues(stateEntry, properties);
+            var entityType = stateEntry.EntityType;
+
+            return new StoreGeneratedValues(
+                stateEntry,
+                entityType.Properties.Where(p => p.ValueGenerationOnSave != ValueGenerationOnSave.None)
+                    .Concat(entityType.ForeignKeys.SelectMany(f => f.Properties))
+                    .Distinct()
+                    .ToArray());
         }
     }
 }

--- a/src/EntityFramework/DbContext.cs
+++ b/src/EntityFramework/DbContext.cs
@@ -117,12 +117,11 @@ namespace Microsoft.Data.Entity
 
         public virtual Task<int> SaveChangesAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            var stateManager = Configuration.Services.StateManager;
-
+            var stateManager = Configuration.StateManager;
+            
             // TODO: Allow auto-detect changes to be switched off
-            stateManager.DetectChanges();
+            Configuration.Services.ChangeDetector.DetectChanges(stateManager);
 
-            // TODO: StateManager could get data store from config itself
             return stateManager.SaveChangesAsync(cancellationToken);
         }
 
@@ -147,7 +146,7 @@ namespace Microsoft.Data.Entity
         {
             Check.NotNull(entity, "entity");
 
-            await Configuration.Services.StateManager.GetOrCreateEntry(entity).SetEntityStateAsync(EntityState.Added, cancellationToken).ConfigureAwait(false);
+            await Configuration.StateManager.GetOrCreateEntry(entity).SetEntityStateAsync(EntityState.Added, cancellationToken).ConfigureAwait(false);
 
             return entity;
         }
@@ -184,7 +183,7 @@ namespace Microsoft.Data.Entity
 
         public virtual ChangeTracker ChangeTracker
         {
-            get { return new ChangeTracker(Configuration.Services.StateManager); }
+            get { return new ChangeTracker(Configuration.StateManager, Configuration.Services.ChangeDetector); }
         }
 
         public virtual IModel Model

--- a/src/EntityFramework/Infrastructure/DbContextConfiguration.cs
+++ b/src/EntityFramework/Infrastructure/DbContextConfiguration.cs
@@ -3,6 +3,7 @@
 
 using System;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Identity;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Services;
@@ -29,6 +30,7 @@ namespace Microsoft.Data.Entity.Infrastructure
         private LazyRef<DataStoreSource> _dataStoreSource;
         private LazyRef<DataStore> _dataStore;
         private LazyRef<DataStoreConnection> _connection;
+        private LazyRef<StateManager> _stateManager;
         private ServiceProviderSource _serviceProviderSource;
         private LazyRef<ILoggerFactory> _loggerFactory;
         private LazyRef<Database> _database;
@@ -57,6 +59,7 @@ namespace Microsoft.Data.Entity.Infrastructure
             _connection = new LazyRef<DataStoreConnection>(() => _dataStoreSource.Value.GetConnection(this));
             _loggerFactory = new LazyRef<ILoggerFactory>(() => _externalProvider.TryGetService<ILoggerFactory>() ?? new NullLoggerFactory());
             _database = new LazyRef<Database>(() => _dataStoreSource.Value.GetDatabase(this));
+            _stateManager = new LazyRef<StateManager>(() => _services.StateManager);
 
             return this;
         }
@@ -114,6 +117,11 @@ namespace Microsoft.Data.Entity.Infrastructure
         public virtual ILoggerFactory LoggerFactory
         {
             get { return _loggerFactory.Value; }
+        }
+
+        public virtual StateManager StateManager
+        {
+            get { return _stateManager.Value; }
         }
     }
 }

--- a/src/EntityFramework/Metadata/Compiled/CompiledModel.cs
+++ b/src/EntityFramework/Metadata/Compiled/CompiledModel.cs
@@ -45,5 +45,12 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
             // TODO: Perf: Add additional indexes so that this isn't a linear lookup
             return EntityTypes.SelectMany(et => et.ForeignKeys).Where(fk => fk.ReferencedEntityType == entityType);
         }
+
+        public virtual IEnumerable<IForeignKey> GetReferencingForeignKeys([NotNull] IProperty property)
+        {
+            // TODO: Perf: Add additional indexes so that this isn't a linear lookup
+            return EntityTypes.SelectMany(e => e.ForeignKeys.Where(f => f.ReferencedProperties.Contains(property))).ToArray();
+        }
+
     }
 }

--- a/src/EntityFramework/Metadata/IModel.cs
+++ b/src/EntityFramework/Metadata/IModel.cs
@@ -25,5 +25,8 @@ namespace Microsoft.Data.Entity.Metadata
 
         [NotNull]
         IEnumerable<IForeignKey> GetReferencingForeignKeys([NotNull] IEntityType entityType);
+
+        [NotNull]
+        IEnumerable<IForeignKey> GetReferencingForeignKeys([NotNull] IProperty property);
     }
 }

--- a/src/EntityFramework/Metadata/Model.cs
+++ b/src/EntityFramework/Metadata/Model.cs
@@ -92,8 +92,18 @@ namespace Microsoft.Data.Entity.Metadata
 
         public virtual IEnumerable<IForeignKey> GetReferencingForeignKeys(IEntityType entityType)
         {
+            Check.NotNull(entityType, "entityType");
+
             // TODO: Perf: Add additional indexes so that this isn't a linear lookup
             return EntityTypes.SelectMany(et => et.ForeignKeys).Where(fk => fk.ReferencedEntityType == entityType);
+        }
+
+        public virtual IEnumerable<IForeignKey> GetReferencingForeignKeys(IProperty property)
+        {
+            Check.NotNull(property, "property");
+
+            // TODO: Perf: Add additional indexes so that this isn't a linear lookup
+            return EntityTypes.SelectMany(e => e.ForeignKeys.Where(f => f.ReferencedProperties.Contains(property))).ToArray();
         }
 
         public virtual string StorageName { get; [param: CanBeNull] set; }

--- a/src/EntityFramework/Query/EntityQueryExecutor.cs
+++ b/src/EntityFramework/Query/EntityQueryExecutor.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Data.Entity.Query
             LogQueryModel(queryModel);
 
             return _context.Configuration.DataStore
-                .Query<T>(queryModel, _context.Configuration.Services.StateManager);
+                .Query<T>(queryModel, _context.Configuration.StateManager);
         }
 
         public virtual IAsyncEnumerable<T> AsyncExecuteCollection<T>([NotNull] QueryModel queryModel)
@@ -91,7 +91,7 @@ namespace Microsoft.Data.Entity.Query
             LogQueryModel(queryModel);
 
             return _context.Configuration.DataStore
-                .AsyncQuery<T>(queryModel, _context.Configuration.Services.StateManager);
+                .AsyncQuery<T>(queryModel, _context.Configuration.StateManager);
         }
 
         private void LogQueryModel(QueryModel queryModel)

--- a/test/EntityFramework.InMemory.FunctionalTests/EntityFramework.InMemory.FunctionalTests.csproj
+++ b/test/EntityFramework.InMemory.FunctionalTests/EntityFramework.InMemory.FunctionalTests.csproj
@@ -80,6 +80,7 @@
     <Compile Include="..\Shared\MonsterContext`.cs" />
     <Compile Include="..\Shared\MonsterModel.cs" />
     <Compile Include="..\Shared\SnapshotMonsterContext.cs" />
+    <Compile Include="..\Shared\ThrowingMonsterStateManager.cs" />
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>

--- a/test/EntityFramework.InMemory.FunctionalTests/MonsterFixupTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/MonsterFixupTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.MonsterModel;
 using Microsoft.Framework.DependencyInjection;
@@ -12,9 +13,16 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 {
     public class MonsterFixupTest : MonsterFixupTestBase
     {
-        protected override IServiceProvider CreateServiceProvider()
+        protected override IServiceProvider CreateServiceProvider(bool throwingStateManager = false)
         {
-            return new ServiceCollection().AddEntityFramework().AddInMemoryStore().ServiceCollection.BuildServiceProvider();
+            var serviceCollection = new ServiceCollection().AddEntityFramework().AddInMemoryStore().ServiceCollection;
+
+            if (throwingStateManager)
+            {
+                serviceCollection.AddScoped<StateManager, ThrowingMonsterStateManager>();
+            }
+
+            return serviceCollection.BuildServiceProvider();
         }
 
         protected override DbContextOptions CreateOptions(string databaseName)

--- a/test/EntityFramework.SQLite.FunctionalTests/EntityFramework.SQLite.FunctionalTests.csproj
+++ b/test/EntityFramework.SQLite.FunctionalTests/EntityFramework.SQLite.FunctionalTests.csproj
@@ -88,6 +88,7 @@
     <Compile Include="..\Shared\MonsterContext`.cs" />
     <Compile Include="..\Shared\MonsterModel.cs" />
     <Compile Include="..\Shared\SnapshotMonsterContext.cs" />
+    <Compile Include="..\Shared\ThrowingMonsterStateManager.cs" />
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>

--- a/test/EntityFramework.SQLite.FunctionalTests/MonsterFixupTest.cs
+++ b/test/EntityFramework.SQLite.FunctionalTests/MonsterFixupTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.MonsterModel;
 using Microsoft.Data.Entity.Utilities;
@@ -22,9 +23,16 @@ namespace Microsoft.Data.Entity.SQLite.FunctionalTests
         private static readonly ConcurrentDictionary<string, AsyncLock> _creationLocks
             = new ConcurrentDictionary<string, AsyncLock>();
 
-        protected /*override*/ IServiceProvider CreateServiceProvider()
+        protected /*override*/ IServiceProvider CreateServiceProvider(bool throwingStateManager = false)
         {
-            return new ServiceCollection().AddEntityFramework().AddSQLite().ServiceCollection.BuildServiceProvider();
+            var serviceCollection = new ServiceCollection().AddEntityFramework().AddSQLite().ServiceCollection;
+
+            if (throwingStateManager)
+            {
+                serviceCollection.AddScoped<StateManager, ThrowingMonsterStateManager>();
+            }
+
+            return serviceCollection.BuildServiceProvider();
         }
 
         protected /*override*/ DbContextOptions CreateOptions(string databaseName)

--- a/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
@@ -94,6 +94,7 @@
     <Compile Include="..\Shared\MonsterContext`.cs" />
     <Compile Include="..\Shared\MonsterModel.cs" />
     <Compile Include="..\Shared\SnapshotMonsterContext.cs" />
+    <Compile Include="..\Shared\ThrowingMonsterStateManager.cs" />
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>

--- a/test/EntityFramework.SqlServer.FunctionalTests/MonsterFixupTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/MonsterFixupTest.cs
@@ -6,11 +6,13 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Threading.Tasks;
+using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.MonsterModel;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Fallback;
+using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 {
@@ -21,9 +23,16 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         private static readonly ConcurrentDictionary<string, AsyncLock> _creationLocks
             = new ConcurrentDictionary<string, AsyncLock>();
 
-        protected override IServiceProvider CreateServiceProvider()
+        protected override IServiceProvider CreateServiceProvider(bool throwingStateManager = false)
         {
-            return new ServiceCollection().AddEntityFramework().AddSqlServer().ServiceCollection.BuildServiceProvider();
+            var serviceCollection = new ServiceCollection().AddEntityFramework().AddSqlServer().ServiceCollection;
+
+            if (throwingStateManager)
+            {
+                serviceCollection.AddScoped<StateManager, ThrowingMonsterStateManager>();
+            }
+
+            return serviceCollection.BuildServiceProvider();
         }
 
         protected override DbContextOptions CreateOptions(string databaseName)

--- a/test/EntityFramework.Tests/ChangeTracking/ChangeDetectorTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/ChangeDetectorTest.cs
@@ -1,0 +1,286 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.ChangeTracking
+{
+    public class ChangeDetectorTest
+    {
+        [Fact]
+        public void Detects_principal_key_change()
+        {
+            var model = BuildModel();
+            var configuration = TestHelpers.CreateContextConfiguration(model);
+            var stateManager = configuration.Services.StateManager;
+
+            var entityType = model.GetEntityType(typeof(Category));
+            var keyProperty = entityType.GetProperty("PrincipalId");
+
+            var category = new Category { Id = -1, PrincipalId = 77 };
+            var principalEntry = stateManager.StartTracking(stateManager.GetOrCreateEntry(category));
+            principalEntry.RelationshipsSnapshot[keyProperty] = 77;
+            principalEntry.EntityState = EntityState.Added;
+
+            var notifierMock = new Mock<StateEntryNotifier>();
+            var changeDetector = new ChangeDetector(configuration, notifierMock.Object);
+
+            Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
+
+            category.PrincipalId = 78;
+            changeDetector.PropertyChanged(principalEntry, keyProperty);
+
+            notifierMock.Verify(m => m.PrincipalKeyPropertyChanged(principalEntry, keyProperty, 77, 78));
+
+            Assert.Equal(78, principalEntry.RelationshipsSnapshot[keyProperty]);
+            Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
+        }
+
+        [Fact]
+        public void Reacts_to_principal_key_change_in_sidecar()
+        {
+            var model = BuildModel();
+            var configuration = TestHelpers.CreateContextConfiguration(model);
+            var stateManager = configuration.Services.StateManager;
+
+            var entityType = model.GetEntityType(typeof(Category));
+            var keyProperty = entityType.GetProperty("PrincipalId");
+
+            var category = new Category { Id = -1, PrincipalId = 77 };
+            var principalEntry = stateManager.StartTracking(stateManager.GetOrCreateEntry(category));
+            principalEntry.RelationshipsSnapshot[keyProperty] = 77;
+            principalEntry.EntityState = EntityState.Added;
+
+            var notifierMock = new Mock<StateEntryNotifier>();
+            var changeDetector = new ChangeDetector(configuration, notifierMock.Object);
+
+            Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
+
+            principalEntry.AddSidecar(new StoreGeneratedValuesFactory().Create(principalEntry))[keyProperty] = 78;
+            changeDetector.SidecarPropertyChanged(principalEntry, keyProperty);
+
+            notifierMock.Verify(m => m.PrincipalKeyPropertyChanged(principalEntry, keyProperty, 77, 78));
+
+            Assert.Equal(78, principalEntry.RelationshipsSnapshot[keyProperty]);
+            Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
+        }
+
+        [Fact]
+        public void Detects_primary_key_change()
+        {
+            var model = BuildModel();
+            var configuration = TestHelpers.CreateContextConfiguration(model);
+            var stateManager = configuration.Services.StateManager;
+
+            var entityType = model.GetEntityType(typeof(Category));
+            var keyProperty = entityType.GetProperty("Id");
+
+            var category = new Category { Id = -1 };
+            var principalEntry = stateManager.StartTracking(stateManager.GetOrCreateEntry(category));
+            principalEntry.RelationshipsSnapshot[keyProperty] = -1;
+            principalEntry.EntityState = EntityState.Added;
+
+            var notifierMock = new Mock<StateEntryNotifier>();
+            var changeDetector = new ChangeDetector(configuration, notifierMock.Object);
+
+            Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
+
+            category.Id = 1;
+            changeDetector.PropertyChanged(principalEntry, keyProperty);
+
+            notifierMock.Verify(m => m.PrincipalKeyPropertyChanged(principalEntry, keyProperty, -1, 1));
+
+            Assert.Equal(1, principalEntry.RelationshipsSnapshot[keyProperty]);
+            Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, 1)));
+        }
+
+        [Fact]
+        public void Reacts_to_primary_key_change_in_sidecar()
+        {
+            var model = BuildModel();
+            var configuration = TestHelpers.CreateContextConfiguration(model);
+            var stateManager = configuration.Services.StateManager;
+
+            var entityType = model.GetEntityType(typeof(Category));
+            var keyProperty = entityType.GetProperty("Id");
+
+            var category = new Category { Id = -1 };
+            var principalEntry = stateManager.StartTracking(stateManager.GetOrCreateEntry(category));
+            principalEntry.RelationshipsSnapshot[keyProperty] = -1;
+            principalEntry.EntityState = EntityState.Added;
+
+            var notifierMock = new Mock<StateEntryNotifier>();
+            var changeDetector = new ChangeDetector(configuration, notifierMock.Object);
+
+            Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
+
+            principalEntry.AddSidecar(new StoreGeneratedValuesFactory().Create(principalEntry))[keyProperty] = 1;
+            changeDetector.SidecarPropertyChanged(principalEntry, keyProperty);
+
+            notifierMock.Verify(m => m.PrincipalKeyPropertyChanged(principalEntry, keyProperty, -1, 1));
+
+            Assert.Equal(1, principalEntry.RelationshipsSnapshot[keyProperty]);
+            Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, 1)));
+        }
+
+        [Fact]
+        public void Ignores_non_principal_key_change()
+        {
+            var model = BuildModel();
+            var configuration = TestHelpers.CreateContextConfiguration(model);
+            var stateManager = configuration.Services.StateManager;
+
+            var entityType = model.GetEntityType(typeof(Category));
+            var property = entityType.GetProperty("Name");
+
+            var category = new Category { Id = -1, Name = "Blue" };
+            var principalEntry = stateManager.StartTracking(stateManager.GetOrCreateEntry(category));
+            principalEntry.RelationshipsSnapshot[property] = "Blue";
+            principalEntry.EntityState = EntityState.Added;
+
+            var notifierMock = new Mock<StateEntryNotifier>();
+            var changeDetector = new ChangeDetector(configuration, notifierMock.Object);
+
+            Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
+
+            category.Name = "Red";
+            changeDetector.PropertyChanged(principalEntry, property);
+
+            notifierMock.Verify(m => m.PrincipalKeyPropertyChanged(
+                    It.IsAny<StateEntry>(), It.IsAny<IProperty>(), It.IsAny<object>(), It.IsAny<object>()), Times.Never);
+
+            Assert.Equal("Blue", principalEntry.RelationshipsSnapshot[property]);
+            Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
+        }
+
+        [Fact]
+        public void Ignores_non_principal_key_change_in_sidecar()
+        {
+            var model = BuildModel();
+            var configuration = TestHelpers.CreateContextConfiguration(model);
+            var stateManager = configuration.Services.StateManager;
+
+            var entityType = model.GetEntityType(typeof(Category));
+            var property = entityType.GetProperty("Name");
+
+            var category = new Category { Id = -1, Name = "Blue" };
+            var principalEntry = stateManager.StartTracking(stateManager.GetOrCreateEntry(category));
+            principalEntry.RelationshipsSnapshot[property] = "Blue";
+            principalEntry.EntityState = EntityState.Added;
+
+            var notifierMock = new Mock<StateEntryNotifier>();
+            var changeDetector = new ChangeDetector(configuration, notifierMock.Object);
+
+            Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
+
+            principalEntry.AddSidecar(new StoreGeneratedValuesFactory().Create(principalEntry))[property] = "Red";
+            changeDetector.SidecarPropertyChanged(principalEntry, property);
+
+            notifierMock.Verify(m => m.PrincipalKeyPropertyChanged(
+                    It.IsAny<StateEntry>(), It.IsAny<IProperty>(), It.IsAny<object>(), It.IsAny<object>()), Times.Never);
+
+            Assert.Equal("Blue", principalEntry.RelationshipsSnapshot[property]);
+            Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
+        }
+
+        [Fact]
+        public void Ignores_no_change_to_principal_key()
+        {
+            var model = BuildModel();
+            var configuration = TestHelpers.CreateContextConfiguration(model);
+            var stateManager = configuration.Services.StateManager;
+
+            var entityType = model.GetEntityType(typeof(Category));
+            var keyProperty = entityType.GetProperty("PrincipalId");
+
+            var category = new Category { Id = -1, PrincipalId = 77 };
+            var principalEntry = stateManager.StartTracking(stateManager.GetOrCreateEntry(category));
+            principalEntry.RelationshipsSnapshot[keyProperty] = 77;
+            principalEntry.EntityState = EntityState.Added;
+
+            var notifierMock = new Mock<StateEntryNotifier>();
+            var changeDetector = new ChangeDetector(configuration, notifierMock.Object);
+
+            Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
+
+            changeDetector.PropertyChanged(principalEntry, keyProperty);
+
+            notifierMock.Verify(m => m.PrincipalKeyPropertyChanged(
+                    It.IsAny<StateEntry>(), It.IsAny<IProperty>(), It.IsAny<object>(), It.IsAny<object>()), Times.Never);
+
+            Assert.Equal(77, principalEntry.RelationshipsSnapshot[keyProperty]);
+            Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
+        }
+
+        [Fact]
+        public void Ignores_no_change_to_principal_key_in_sidecar()
+        {
+            var model = BuildModel();
+            var configuration = TestHelpers.CreateContextConfiguration(model);
+            var stateManager = configuration.Services.StateManager;
+
+            var entityType = model.GetEntityType(typeof(Category));
+            var keyProperty = entityType.GetProperty("PrincipalId");
+
+            var category = new Category { Id = -1, PrincipalId = 77 };
+            var principalEntry = stateManager.StartTracking(stateManager.GetOrCreateEntry(category));
+            principalEntry.RelationshipsSnapshot[keyProperty] = 77;
+            principalEntry.EntityState = EntityState.Added;
+
+            var notifierMock = new Mock<StateEntryNotifier>();
+            var changeDetector = new ChangeDetector(configuration, notifierMock.Object);
+
+            Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
+
+            principalEntry.AddSidecar(new StoreGeneratedValuesFactory().Create(principalEntry))[keyProperty] = 77;
+            changeDetector.PropertyChanged(principalEntry, keyProperty);
+
+            notifierMock.Verify(m => m.PrincipalKeyPropertyChanged(
+                    It.IsAny<StateEntry>(), It.IsAny<IProperty>(), It.IsAny<object>(), It.IsAny<object>()), Times.Never);
+
+            Assert.Equal(77, principalEntry.RelationshipsSnapshot[keyProperty]);
+            Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
+        }
+
+
+        private class Category
+        {
+            public int Id { get; set; }
+            public int? PrincipalId { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class Product
+        {
+            public Guid Id { get; set; }
+            public int? DependentId { get; set; }
+            public string Name { get; set; }
+        }
+
+        private static IModel BuildModel()
+        {
+            var model = new Model();
+            var builder = new ConventionModelBuilder(model);
+
+            builder.Entity<Product>();
+            builder.Entity<Category>();
+
+            var productType = model.GetEntityType(typeof(Product));
+            var categoryType = model.GetEntityType(typeof(Category));
+
+            categoryType.GetProperty("Id").ValueGenerationOnAdd = ValueGenerationOnAdd.None;
+
+            productType.AddForeignKey(new Key(new[] { categoryType.GetProperty("PrincipalId") }), productType.GetProperty("DependentId"));
+
+            return model;
+        }
+    }
+}

--- a/test/EntityFramework.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -17,9 +17,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.Equal(
                 "stateManager",
                 // ReSharper disable once AssignNullToNotNullAttribute
-                Assert.Throws<ArgumentNullException>(() => new ChangeTracker(null)).ParamName);
+                Assert.Throws<ArgumentNullException>(() => new ChangeTracker(null, null)).ParamName);
 
-            var changeTracker = new ChangeTracker(new Mock<StateManager>().Object);
+            var changeTracker = new ChangeTracker(Mock.Of<StateManager>(), Mock.Of<ChangeDetector>());
 
             Assert.Equal(
                 "entity",
@@ -39,7 +39,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var stateEntry = new Mock<StateEntry>().Object;
             stateManagerMock.Setup(m => m.GetOrCreateEntry(entity)).Returns(stateEntry);
 
-            var changeTracker = new ChangeTracker(stateManagerMock.Object);
+            var changeTracker = new ChangeTracker(stateManagerMock.Object, Mock.Of<ChangeDetector>());
 
             Assert.Same(stateEntry, changeTracker.Entry(entity).StateEntry);
             Assert.Same(stateEntry, changeTracker.Entry((object)entity).StateEntry);
@@ -54,7 +54,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             Assert.Equal(
                 stateEntries,
-                new ChangeTracker(stateManagerMock.Object).Entries().Select(e => e.StateEntry).ToArray());
+                new ChangeTracker(stateManagerMock.Object, Mock.Of<ChangeDetector>()).Entries().Select(e => e.StateEntry).ToArray());
         }
 
         [Fact]
@@ -73,15 +73,15 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             Assert.Equal(
                 new[] { stateEntryMock1.Object, stateEntryMock3.Object },
-                new ChangeTracker(stateManagerMock.Object).Entries<Random>().Select(e => e.StateEntry).ToArray());
+                new ChangeTracker(stateManagerMock.Object, Mock.Of<ChangeDetector>()).Entries<Random>().Select(e => e.StateEntry).ToArray());
 
             Assert.Equal(
                 new[] { stateEntryMock2.Object },
-                new ChangeTracker(stateManagerMock.Object).Entries<string>().Select(e => e.StateEntry).ToArray());
+                new ChangeTracker(stateManagerMock.Object, Mock.Of<ChangeDetector>()).Entries<string>().Select(e => e.StateEntry).ToArray());
 
             Assert.Equal(
                 new[] { stateEntryMock1.Object, stateEntryMock2.Object, stateEntryMock3.Object },
-                new ChangeTracker(stateManagerMock.Object).Entries<object>().Select(e => e.StateEntry).ToArray());
+                new ChangeTracker(stateManagerMock.Object, Mock.Of<ChangeDetector>()).Entries<object>().Select(e => e.StateEntry).ToArray());
         }
 
         [Fact]
@@ -89,7 +89,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var stateManager = new Mock<StateManager>().Object;
 
-            Assert.Same(stateManager, new ChangeTracker(stateManager).StateManager);
+            Assert.Same(stateManager, new ChangeTracker(stateManager, Mock.Of<ChangeDetector>()).StateManager);
         }
     }
 }

--- a/test/EntityFramework.Tests/ChangeTracking/NavigationFixerTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/NavigationFixerTest.cs
@@ -6,6 +6,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Moq;
 using Xunit;
@@ -17,7 +18,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         [Fact]
         public void Members_check_arguments()
         {
-            var fixer = CreateNavigationFixer();
+            var fixer = CreateNavigationFixer(CreateContextConfiguration());
 
             Assert.Equal(
                 "entry",
@@ -31,7 +32,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         [Fact]
         public void Does_fixup_of_related_principals()
         {
-            var manager = CreateStateManager();
+            var configuration = CreateContextConfiguration();
+            var manager = configuration.StateManager;
 
             var principal1 = new Category { Id = 11 };
             var principal2 = new Category { Id = 12 };
@@ -42,7 +44,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var dependentEntry = manager.StartTracking(manager.GetOrCreateEntry(dependent));
 
-            var fixer = CreateNavigationFixer(manager);
+            var fixer = CreateNavigationFixer(configuration);
             fixer.StateChanged(dependentEntry, EntityState.Unknown);
 
             Assert.Same(dependent.Category, principal2);
@@ -53,7 +55,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         [Fact]
         public void Does_fixup_of_related_dependents()
         {
-            var manager = CreateStateManager();
+            var configuration = CreateContextConfiguration();
+            var manager = configuration.StateManager;
 
             var dependent1 = new Product { Id = 21, CategoryId = 11 };
             var dependent2 = new Product { Id = 22, CategoryId = 12 };
@@ -67,7 +70,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var principalEntry = manager.StartTracking(manager.GetOrCreateEntry(principal));
 
-            var fixer = CreateNavigationFixer(manager);
+            var fixer = CreateNavigationFixer(configuration);
             fixer.StateChanged(principalEntry, EntityState.Unknown);
 
             Assert.Same(dependent1.Category, principal);
@@ -82,7 +85,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         [Fact]
         public void Does_fixup_of_one_to_one_relationship()
         {
-            var manager = CreateStateManager();
+            var configuration = CreateContextConfiguration();
+            var manager = configuration.StateManager;
 
             var principal1 = new Product { Id = 21 };
             var principal2 = new Product { Id = 22 };
@@ -100,7 +104,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var dependentEntry2 = manager.StartTracking(manager.GetOrCreateEntry(dependent2));
             var dependentEntry4 = manager.StartTracking(manager.GetOrCreateEntry(dependent4));
 
-            var fixer = CreateNavigationFixer(manager);
+            var fixer = CreateNavigationFixer(configuration);
 
             Assert.Null(principal1.Detail);
             Assert.Null(dependent1.Product);
@@ -131,7 +135,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         [Fact]
         public void Does_fixup_of_one_to_one_self_referencing_relationship()
         {
-            var manager = CreateStateManager();
+            var configuration = CreateContextConfiguration();
+            var manager = configuration.StateManager;
 
             var entity1 = new Product { Id = 21, AlternateProductId = 22 };
             var entity2 = new Product { Id = 22, AlternateProductId = 23 };
@@ -141,7 +146,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entry2 = manager.StartTracking(manager.GetOrCreateEntry(entity2));
             var entry3 = manager.StartTracking(manager.GetOrCreateEntry(entity3));
 
-            var fixer = CreateNavigationFixer(manager);
+            var fixer = CreateNavigationFixer(configuration);
 
             Assert.Null(entity1.AlternateProduct);
             Assert.Null(entity1.OriginalProduct);
@@ -179,7 +184,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         public void Does_fixup_of_related_principals_when_FK_is_set()
         {
             var model = BuildModel();
-            var manager = CreateStateManager(model);
+            var configuration = CreateContextConfiguration(model);
+            var manager = configuration.StateManager;
 
             var principal1 = new Category { Id = 11 };
             var principal2 = new Category { Id = 12 };
@@ -190,7 +196,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var dependentEntry = manager.StartTracking(manager.GetOrCreateEntry(dependent));
 
-            var fixer = CreateNavigationFixer(manager);
+            var fixer = CreateNavigationFixer(configuration);
             fixer.StateChanged(dependentEntry, EntityState.Unknown);
 
             Assert.Null(dependent.Category);
@@ -210,7 +216,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         public void Does_fixup_of_related_principals_when_FK_is_cleared()
         {
             var model = BuildModel();
-            var manager = CreateStateManager(model);
+            var configuration = CreateContextConfiguration(model);
+            var manager = configuration.StateManager;
 
             var principal1 = new Category { Id = 11 };
             var principal2 = new Category { Id = 12 };
@@ -221,7 +228,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var dependentEntry = manager.StartTracking(manager.GetOrCreateEntry(dependent));
 
-            var fixer = CreateNavigationFixer(manager);
+            var fixer = CreateNavigationFixer(configuration);
             fixer.StateChanged(dependentEntry, EntityState.Unknown);
 
             Assert.Same(dependent.Category, principal2);
@@ -241,7 +248,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         public void Does_fixup_of_related_principals_when_FK_is_changed()
         {
             var model = BuildModel();
-            var manager = CreateStateManager(model);
+            var configuration = CreateContextConfiguration(model);
+            var manager = configuration.StateManager;
 
             var principal1 = new Category { Id = 11 };
             var principal2 = new Category { Id = 12 };
@@ -252,7 +260,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var dependentEntry = manager.StartTracking(manager.GetOrCreateEntry(dependent));
 
-            var fixer = CreateNavigationFixer(manager);
+            var fixer = CreateNavigationFixer(configuration);
             fixer.StateChanged(dependentEntry, EntityState.Unknown);
 
             Assert.Same(dependent.Category, principal2);
@@ -272,7 +280,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         public void Does_fixup_of_one_to_one_relationship_when_FK_changes()
         {
             var model = BuildModel();
-            var manager = CreateStateManager(model);
+            var configuration = CreateContextConfiguration(model);
+            var manager = configuration.StateManager;
 
             var principal1 = new Product { Id = 21 };
             var principal2 = new Product { Id = 22 };
@@ -282,7 +291,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var principalEntry2 = manager.StartTracking(manager.GetOrCreateEntry(principal2));
             var dependentEntry = manager.StartTracking(manager.GetOrCreateEntry(dependent));
 
-            var fixer = CreateNavigationFixer(manager);
+            var fixer = CreateNavigationFixer(configuration);
 
             fixer.StateChanged(principalEntry1, EntityState.Unknown);
 
@@ -303,7 +312,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         public void Does_fixup_of_one_to_one_relationship_when_FK_cleared()
         {
             var model = BuildModel();
-            var manager = CreateStateManager(model);
+            var configuration = CreateContextConfiguration(model);
+            var manager = configuration.StateManager;
 
             var principal = new Product { Id = 21 };
             var dependent = new ProductDetail { Id = 21 };
@@ -311,7 +321,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var principalEntry = manager.StartTracking(manager.GetOrCreateEntry(principal));
             var dependentEntry = manager.StartTracking(manager.GetOrCreateEntry(dependent));
 
-            var fixer = CreateNavigationFixer(manager);
+            var fixer = CreateNavigationFixer(configuration);
 
             fixer.StateChanged(principalEntry, EntityState.Unknown);
 
@@ -330,7 +340,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         public void Does_fixup_of_one_to_one_relationship_when_FK_set()
         {
             var model = BuildModel();
-            var manager = CreateStateManager(model);
+            var configuration = CreateContextConfiguration(model);
+            var manager = configuration.StateManager;
 
             var principal = new Product { Id = 21 };
             var dependent = new ProductDetail { Id = 0 };
@@ -338,7 +349,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var principalEntry = manager.StartTracking(manager.GetOrCreateEntry(principal));
             var dependentEntry = manager.StartTracking(manager.GetOrCreateEntry(dependent));
 
-            var fixer = CreateNavigationFixer(manager);
+            var fixer = CreateNavigationFixer(configuration);
 
             fixer.StateChanged(principalEntry, EntityState.Unknown);
 
@@ -357,7 +368,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         public void Can_steal_reference_of_one_to_one_relationship_when_FK_changes()
         {
             var model = BuildModel();
-            var manager = CreateStateManager(model);
+            var configuration = CreateContextConfiguration(model);
+            var manager = configuration.StateManager;
 
             var principal1 = new Product { Id = 21 };
             var principal2 = new Product { Id = 22 };
@@ -369,7 +381,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var dependentEntry1 = manager.StartTracking(manager.GetOrCreateEntry(dependent1));
             var dependentEntry2 = manager.StartTracking(manager.GetOrCreateEntry(dependent2));
 
-            var fixer = CreateNavigationFixer(manager);
+            var fixer = CreateNavigationFixer(configuration);
 
             fixer.StateChanged(principalEntry1, EntityState.Unknown);
             fixer.StateChanged(principalEntry2, EntityState.Unknown);
@@ -393,7 +405,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         public void Does_fixup_of_one_to_one_self_referencing_relationship_when_FK_changes()
         {
             var model = BuildModel();
-            var manager = CreateStateManager(model);
+            var configuration = CreateContextConfiguration(model);
+            var manager = configuration.StateManager;
 
             var entity1 = new Product { Id = 21, AlternateProductId = 22 };
             var entity2 = new Product { Id = 22 };
@@ -403,7 +416,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entry2 = manager.StartTracking(manager.GetOrCreateEntry(entity2));
             var entry3 = manager.StartTracking(manager.GetOrCreateEntry(entity3));
 
-            var fixer = CreateNavigationFixer(manager);
+            var fixer = CreateNavigationFixer(configuration);
 
             fixer.StateChanged(entry1, EntityState.Unknown);
             fixer.StateChanged(entry1, EntityState.Unknown);
@@ -436,7 +449,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         public void Can_steal_reference_of_one_to_one_self_referencing_relationship_when_FK_changes()
         {
             var model = BuildModel();
-            var manager = CreateStateManager(model);
+            var configuration = CreateContextConfiguration(model);
+            var manager = configuration.StateManager;
 
             var entity1 = new Product { Id = 21, AlternateProductId = 22 };
             var entity2 = new Product { Id = 22, AlternateProductId = 23 };
@@ -446,7 +460,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entry2 = manager.StartTracking(manager.GetOrCreateEntry(entity2));
             var entry3 = manager.StartTracking(manager.GetOrCreateEntry(entity3));
 
-            var fixer = CreateNavigationFixer(manager);
+            var fixer = CreateNavigationFixer(configuration);
 
             fixer.StateChanged(entry1, EntityState.Unknown);
             fixer.StateChanged(entry1, EntityState.Unknown);
@@ -481,7 +495,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         public void Does_fixup_of_all_related_principals_when_part_of_overlapping_composite_FK_is_changed()
         {
             var model = BuildModel();
-            var manager = CreateStateManager(model);
+            var configuration = CreateContextConfiguration(model);
+            var manager = configuration.StateManager;
 
             var photo1 = new ProductPhoto { ProductId = 1, PhotoId = "Photo1" };
             var photo2 = new ProductPhoto { ProductId = 1, PhotoId = "Photo2" };
@@ -523,7 +538,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var tagEntry7 = manager.StartTracking(manager.GetOrCreateEntry(tag7));
             var tagEntry8 = manager.StartTracking(manager.GetOrCreateEntry(tag8));
 
-            var fixer = CreateNavigationFixer(manager);
+            var fixer = CreateNavigationFixer(configuration);
 
             fixer.StateChanged(photoEntry1, EntityState.Unknown);
             fixer.StateChanged(photoEntry2, EntityState.Unknown);
@@ -602,9 +617,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.Same(review4, tag8.Review);
         }
 
-        private static StateManager CreateStateManager(IModel model = null)
+        private static DbContextConfiguration CreateContextConfiguration(IModel model = null)
         {
-            return TestHelpers.CreateContextConfiguration(model ?? BuildModel()).Services.StateManager;
+            return TestHelpers.CreateContextConfiguration(model ?? BuildModel());
         }
 
         private class Category
@@ -733,9 +748,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             return model;
         }
 
-        private static NavigationFixer CreateNavigationFixer(StateManager stateManager = null)
+        private static NavigationFixer CreateNavigationFixer(DbContextConfiguration contextConfiguration)
         {
-            return new NavigationFixer(stateManager ?? Mock.Of<StateManager>(), new ClrPropertyGetterSource(), new ClrPropertySetterSource(), new ClrCollectionAccessorSource());
+            return new NavigationFixer(contextConfiguration, new ClrPropertyGetterSource(), new ClrPropertySetterSource(), new ClrCollectionAccessorSource());
         }
     }
 }

--- a/test/EntityFramework.Tests/ChangeTracking/RelationshipsSnapshotTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/RelationshipsSnapshotTest.cs
@@ -42,11 +42,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
-        public void Can_store_properties_for_FKs_and_navigations()
+        public void Can_store_properties_for_PKs_FKs_and_navigations()
         {
             var sidecar = CreateSidecar();
 
-            Assert.False(sidecar.CanStoreValue(IdProperty));
+            Assert.False(sidecar.CanStoreValue(NameProperty));
+            Assert.True(sidecar.CanStoreValue(IdProperty));
             Assert.True(sidecar.CanStoreValue(FkProperty));
             Assert.True(sidecar.CanStoreValue(CollectionNavigation));
             Assert.True(sidecar.CanStoreValue(ReferenceNavigation));
@@ -57,16 +58,19 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var sidecar = CreateSidecar();
 
+            Assert.False(sidecar.HasValue(NameProperty));
             Assert.False(sidecar.HasValue(IdProperty));
             Assert.False(sidecar.HasValue(FkProperty));
             Assert.False(sidecar.HasValue(CollectionNavigation));
             Assert.False(sidecar.HasValue(ReferenceNavigation));
 
+            sidecar[IdProperty] = 11;
             sidecar[FkProperty] = 78;
             sidecar[CollectionNavigation] = new List<Banana>();
             sidecar[ReferenceNavigation] = new Banana();
 
-            Assert.False(sidecar.HasValue(IdProperty));
+            Assert.False(sidecar.HasValue(NameProperty));
+            Assert.True(sidecar.HasValue(IdProperty));
             Assert.True(sidecar.HasValue(FkProperty));
             Assert.True(sidecar.HasValue(CollectionNavigation));
             Assert.True(sidecar.HasValue(ReferenceNavigation));
@@ -297,6 +301,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entityType.SetKey(pkProperty);
             var fk = entityType.AddForeignKey(entityType.GetKey(), fkProperty);
 
+            entityType.AddProperty("Name", typeof(string));
+
             model.AddEntityType(entityType);
 
             entityType.AddNavigation(new Navigation(fk, "LesserBananas", pointsToPrincipal: false));
@@ -313,6 +319,11 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         protected IProperty FkProperty
         {
             get { return _model.GetEntityType(typeof(Banana)).GetProperty("Fk"); }
+        }
+
+        protected IProperty NameProperty
+        {
+            get { return _model.GetEntityType(typeof(Banana)).GetProperty("Name"); }
         }
 
         protected INavigation CollectionNavigation
@@ -334,6 +345,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             public int Id { get; set; }
             public int Fk { get; set; }
+            public string Name { get; set; }
             public ICollection<Banana> LesserBananas { get; set; }
             public Banana TopBanana { get; set; }
 

--- a/test/EntityFramework.Tests/ChangeTracking/SidecarTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/SidecarTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
 
             Assert.True(sidecar.CanStoreValue(IdProperty));
             Assert.False(sidecar.CanStoreValue(NameProperty));
-            Assert.True(sidecar.CanStoreValue(StateProperty));
+            Assert.True(sidecar.CanStoreValue(FkProperty));
         }
 
         [Fact]
@@ -35,66 +35,66 @@ namespace Microsoft.Data.Entity.ChangeTracking
 
             Assert.False(sidecar.HasValue(IdProperty));
             Assert.False(sidecar.HasValue(NameProperty));
-            Assert.False(sidecar.HasValue(StateProperty));
+            Assert.False(sidecar.HasValue(FkProperty));
 
             sidecar[IdProperty] = 78;
-            sidecar[StateProperty] = "Thawed";
+            sidecar[FkProperty] = 89;
 
             Assert.True(sidecar.HasValue(IdProperty));
             Assert.False(sidecar.HasValue(NameProperty));
-            Assert.True(sidecar.HasValue(StateProperty));
+            Assert.True(sidecar.HasValue(FkProperty));
         }
 
         [Fact]
         public void Can_read_and_write_values()
         {
-            var entity = new Banana { Id = 77, Name = "Stand", State = "Frozen" };
+            var entity = new Banana { Id = 77, Name = "Stand", Fk = 88 };
             var sidecar = CreateSidecar(CreateStateEntry(entity));
 
             Assert.Equal(77, sidecar[IdProperty]);
-            Assert.Equal("Frozen", sidecar[StateProperty]);
+            Assert.Equal(88, sidecar[FkProperty]);
 
             sidecar[IdProperty] = 78;
-            sidecar[StateProperty] = "Thawed";
+            sidecar[FkProperty] = 89;
 
             Assert.Equal(78, sidecar[IdProperty]);
-            Assert.Equal("Thawed", sidecar[StateProperty]);
+            Assert.Equal(89, sidecar[FkProperty]);
 
             Assert.Equal(77, entity.Id);
-            Assert.Equal("Frozen", entity.State);
+            Assert.Equal(88, entity.Fk);
         }
 
         [Fact]
         public void Can_read_and_write_null()
         {
-            var entity = new Banana { Id = 77, Name = "Stand", State = "Frozen" };
+            var entity = new Banana { Id = 77, Name = "Stand", Fk = 88 };
             var sidecar = CreateSidecar(CreateStateEntry(entity));
 
-            sidecar[StateProperty] = null;
+            sidecar[FkProperty] = null;
 
-            Assert.True(sidecar.HasValue(StateProperty));
-            Assert.Null(sidecar[StateProperty]);
+            Assert.True(sidecar.HasValue(FkProperty));
+            Assert.Null(sidecar[FkProperty]);
 
-            Assert.Equal("Frozen", entity.State);
+            Assert.Equal(88, entity.Fk);
         }
 
         [Fact]
         public void Can_commit_values_into_state_entry()
         {
-            var entity = new Banana { Id = 77, Name = "Stand", State = "Frozen" };
+            var entity = new Banana { Id = 77, Name = "Stand", Fk = 88 };
             var sidecar = CreateSidecar(CreateStateEntry(entity));
 
-            sidecar[StateProperty] = "Thawed";
+            sidecar[FkProperty] = 89;
             sidecar.Commit();
 
             Assert.Equal(77, entity.Id);
-            Assert.Equal("Thawed", entity.State);
+            Assert.Equal(89, entity.Fk);
         }
 
         [Fact]
         public void Committing_detaches_sidecar()
         {
-            var entity = new Banana { Id = 77, Name = "Stand", State = "Frozen" };
+            var entity = new Banana { Id = 77, Name = "Stand", Fk = 88 };
             var stateEntry = CreateStateEntry(entity);
 
             var sidecar = stateEntry.AddSidecar(CreateSidecar(stateEntry));
@@ -107,87 +107,87 @@ namespace Microsoft.Data.Entity.ChangeTracking
         [Fact]
         public void Rolling_back_detaches_sidecar_without_committing_values()
         {
-            var entity = new Banana { Id = 77, Name = "Stand", State = "Frozen" };
+            var entity = new Banana { Id = 77, Name = "Stand", Fk = 88 };
             var stateEntry = CreateStateEntry(entity);
 
             var sidecar = stateEntry.AddSidecar(CreateSidecar(stateEntry));
 
-            sidecar[StateProperty] = "Thawed";
+            sidecar[FkProperty] = 89;
             sidecar.Rollback();
 
             Assert.Null(stateEntry.TryGetSidecar(sidecar.Name));
 
             Assert.Equal(77, entity.Id);
-            Assert.Equal("Frozen", entity.State);
+            Assert.Equal(88, entity.Fk);
         }
 
         [Fact]
         public void Can_snapshot_values()
         {
-            var entity = new Banana { Id = 77, Name = "Stand", State = "Frozen" };
+            var entity = new Banana { Id = 77, Name = "Stand", Fk = 88 };
             var sidecar = CreateSidecar(CreateStateEntry(entity));
 
             sidecar.TakeSnapshot();
 
             Assert.Equal(77, sidecar[IdProperty]);
-            Assert.Equal("Frozen", sidecar[StateProperty]);
+            Assert.Equal(88, sidecar[FkProperty]);
 
             sidecar[IdProperty] = 78;
-            sidecar[StateProperty] = "Thawed";
+            sidecar[FkProperty] = 89;
 
             Assert.Equal(78, sidecar[IdProperty]);
-            Assert.Equal("Thawed", sidecar[StateProperty]);
+            Assert.Equal(89, sidecar[FkProperty]);
 
             Assert.Equal(77, entity.Id);
-            Assert.Equal("Frozen", entity.State);
+            Assert.Equal(88, entity.Fk);
 
             entity.Id = 76;
-            entity.State = "Banana vapor";
+            entity.Fk = 90;
 
             Assert.Equal(78, sidecar[IdProperty]);
-            Assert.Equal("Thawed", sidecar[StateProperty]);
+            Assert.Equal(89, sidecar[FkProperty]);
 
             Assert.Equal(76, entity.Id);
-            Assert.Equal("Banana vapor", entity.State);
+            Assert.Equal(90, entity.Fk);
 
             sidecar.TakeSnapshot();
 
             Assert.Equal(76, sidecar[IdProperty]);
-            Assert.Equal("Banana vapor", sidecar[StateProperty]);
+            Assert.Equal(90, sidecar[FkProperty]);
         }
 
         [Fact]
         public void Can_snapshot_individual_values()
         {
-            var entity = new Banana { Id = 77, Name = "Stand", State = "Frozen" };
+            var entity = new Banana { Id = 77, Name = "Stand", Fk = 88 };
             var sidecar = CreateSidecar(CreateStateEntry(entity));
 
-            sidecar.TakeSnapshot(StateProperty);
+            sidecar.TakeSnapshot(FkProperty);
 
             Assert.Equal(77, sidecar[IdProperty]);
-            Assert.Equal("Frozen", sidecar[StateProperty]);
+            Assert.Equal(88, sidecar[FkProperty]);
 
-            sidecar[StateProperty] = "Thawed";
+            sidecar[FkProperty] = 89;
 
             Assert.Equal(77, sidecar[IdProperty]);
-            Assert.Equal("Thawed", sidecar[StateProperty]);
+            Assert.Equal(89, sidecar[FkProperty]);
 
             Assert.Equal(77, entity.Id);
-            Assert.Equal("Frozen", entity.State);
+            Assert.Equal(88, entity.Fk);
 
             entity.Id = 76;
-            entity.State = "Banana vapor";
+            entity.Fk = 90;
 
             Assert.Equal(76, sidecar[IdProperty]);
-            Assert.Equal("Thawed", sidecar[StateProperty]);
+            Assert.Equal(89, sidecar[FkProperty]);
 
             Assert.Equal(76, entity.Id);
-            Assert.Equal("Banana vapor", entity.State);
+            Assert.Equal(90, entity.Fk);
 
-            sidecar.TakeSnapshot(StateProperty);
+            sidecar.TakeSnapshot(FkProperty);
 
             Assert.Equal(76, sidecar[IdProperty]);
-            Assert.Equal("Banana vapor", sidecar[StateProperty]);
+            Assert.Equal(90, sidecar[FkProperty]);
         }
 
         [Fact]
@@ -198,53 +198,53 @@ namespace Microsoft.Data.Entity.ChangeTracking
 
             sidecar.TakeSnapshot();
 
-            Assert.Null(sidecar[StateProperty]);
+            Assert.Null(sidecar[FkProperty]);
             Assert.Null(entity.State);
 
-            sidecar[StateProperty] = "Thawed";
+            sidecar[FkProperty] = 89;
 
-            Assert.Equal("Thawed", sidecar[StateProperty]);
+            Assert.Equal(89, sidecar[FkProperty]);
             Assert.Null(entity.State);
 
-            entity.State = "Banana vapor";
+            entity.Fk = 90;
 
-            Assert.Equal("Thawed", sidecar[StateProperty]);
-            Assert.Equal("Banana vapor", entity.State);
+            Assert.Equal(89, sidecar[FkProperty]);
+            Assert.Equal(90, entity.Fk);
 
             sidecar.TakeSnapshot();
 
-            Assert.Equal("Banana vapor", sidecar[StateProperty]);
+            Assert.Equal(90, sidecar[FkProperty]);
         }
 
         [Fact]
         public void Can_update_already_saved_values()
         {
-            var entity = new Banana { Id = 77, Name = "Stand", State = "Frozen" };
+            var entity = new Banana { Id = 77, Name = "Stand", Fk = 88 };
             var sidecar = CreateSidecar(CreateStateEntry(entity));
 
             sidecar[IdProperty] = 78;
             entity.Id = 76;
-            entity.State = "Banana vapor";
+            entity.Fk = 90;
 
             Assert.True(sidecar.HasValue(IdProperty));
-            Assert.False(sidecar.HasValue(StateProperty));
+            Assert.False(sidecar.HasValue(FkProperty));
 
             Assert.Equal(78, sidecar[IdProperty]);
-            Assert.Equal("Banana vapor", sidecar[StateProperty]);
+            Assert.Equal(90, sidecar[FkProperty]);
 
             sidecar.UpdateSnapshot();
 
             Assert.True(sidecar.HasValue(IdProperty));
-            Assert.False(sidecar.HasValue(StateProperty));
+            Assert.False(sidecar.HasValue(FkProperty));
 
             Assert.Equal(76, sidecar[IdProperty]);
-            Assert.Equal("Banana vapor", sidecar[StateProperty]);
+            Assert.Equal(90, sidecar[FkProperty]);
         }
 
         [Fact]
         public void Can_ensure_value_is_snapshotted_but_not_overwrite_existing_snapshot_value()
         {
-            var entity = new Banana { Id = 77, Name = "Stand", State = "Frozen" };
+            var entity = new Banana { Id = 77, Name = "Stand", Fk = 88 };
             var sidecar = CreateSidecar(CreateStateEntry(entity));
 
             sidecar.EnsureSnapshot(IdProperty);
@@ -266,23 +266,23 @@ namespace Microsoft.Data.Entity.ChangeTracking
             var entity = new Banana { Id = 77, Name = "Stand", State = null };
             var sidecar = CreateSidecar(CreateStateEntry(entity));
 
-            sidecar.EnsureSnapshot(StateProperty);
+            sidecar.EnsureSnapshot(FkProperty);
 
-            Assert.True(sidecar.HasValue(StateProperty));
-            Assert.Null(sidecar[StateProperty]);
+            Assert.True(sidecar.HasValue(FkProperty));
+            Assert.Null(sidecar[FkProperty]);
 
-            entity.State = "Banana vapor";
+            entity.Fk = 90;
 
-            sidecar.EnsureSnapshot(StateProperty);
+            sidecar.EnsureSnapshot(FkProperty);
 
-            Assert.True(sidecar.HasValue(StateProperty));
-            Assert.Null(sidecar[StateProperty]);
+            Assert.True(sidecar.HasValue(FkProperty));
+            Assert.Null(sidecar[FkProperty]);
         }
 
         [Fact]
         public void Ensuring_snapshot_does_nothing_for_property_that_cannot_be_stored()
         {
-            var entity = new Banana { Id = 77, Name = "Stand", State = "Frozen" };
+            var entity = new Banana { Id = 77, Name = "Stand", Fk = 88 };
             var sidecar = CreateSidecar(CreateStateEntry(entity));
 
             sidecar.EnsureSnapshot(NameProperty);
@@ -316,6 +316,18 @@ namespace Microsoft.Data.Entity.ChangeTracking
             sidecar[foreignKey.ReferencedProperties.Single()] = 42;
 
             var keyValue = sidecar.GetPrincipalKeyValue(foreignKey);
+            Assert.IsType<SimpleEntityKey<int>>(keyValue);
+            Assert.Equal(42, keyValue.Value);
+        }
+
+        [Fact]
+        public void Can_create_primary_key()
+        {
+            var entry = CreateStateEntry();
+            var sidecar = CreateSidecar(entry);
+            sidecar[IdProperty] = 42;
+
+            var keyValue = sidecar.GetPrimaryKeyValue();
             Assert.IsType<SimpleEntityKey<int>>(keyValue);
             Assert.Equal(42, keyValue.Value);
         }
@@ -356,7 +368,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
 
         protected StateEntry CreateStateEntry(Banana entity = null)
         {
-            entity = entity ?? new Banana { Id = 77, Name = "Stand", State = "Frozen" };
+            entity = entity ?? new Banana { Id = 77, Name = "Stand", Fk = 88 };
 
             return CreateStateEntry<Banana>(entity);
         }
@@ -373,11 +385,15 @@ namespace Microsoft.Data.Entity.ChangeTracking
             var model = new Model();
 
             var entityType = new EntityType(typeof(Banana));
+            
             var idProperty = entityType.AddProperty("Id", typeof(int), shadowProperty: false, concurrencyToken: true);
+            idProperty.ValueGenerationOnSave = ValueGenerationOnSave.WhenInserting;
             entityType.SetKey(idProperty);
+
             entityType.AddProperty("Name", typeof(string));
             entityType.AddProperty("State", typeof(string), shadowProperty: false, concurrencyToken: true);
-            var fkProperty = entityType.AddProperty("RelatedId", typeof(int), shadowProperty: true, concurrencyToken: true);
+            
+            var fkProperty = entityType.AddProperty("Fk", typeof(int?), shadowProperty: false, concurrencyToken: true);
             entityType.AddForeignKey(new Key(new[] { idProperty }), fkProperty);
 
             model.AddEntityType(entityType);
@@ -414,9 +430,9 @@ namespace Microsoft.Data.Entity.ChangeTracking
             get { return _model.GetEntityType(typeof(Banana)).GetProperty("Name"); }
         }
 
-        protected IProperty StateProperty
+        protected IProperty FkProperty
         {
-            get { return _model.GetEntityType(typeof(Banana)).GetProperty("State"); }
+            get { return _model.GetEntityType(typeof(Banana)).GetProperty("Fk"); }
         }
 
         protected class Banana : INotifyPropertyChanged, INotifyPropertyChanging
@@ -424,7 +440,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             public int Id { get; set; }
             public string Name { get; set; }
             public string State { get; set; }
-            public int Fk { get; set; }
+            public int? Fk { get; set; }
 
 #pragma warning disable 67
             public event PropertyChangedEventHandler PropertyChanged;

--- a/test/EntityFramework.Tests/ChangeTracking/StateEntrySubscriberTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/StateEntrySubscriberTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Moq;
 using Xunit;
@@ -92,7 +93,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
         private static StateEntrySubscriber CreateSubscriber()
         {
-            return new StateEntrySubscriber(new ChangeDetector());
+            return new StateEntrySubscriber(new ChangeDetector(Mock.Of<DbContextConfiguration>(), Mock.Of<StateEntryNotifier>()));
         }
 
         private class FullNotificationEntity : INotifyPropertyChanging, INotifyPropertyChanged

--- a/test/EntityFramework.Tests/ChangeTracking/StoreGeneratedValuesTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/StoreGeneratedValuesTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
         protected override Sidecar CreateSidecar(StateEntry entry = null)
         {
-            return new StoreGeneratedValuesFactory().Create(entry ?? CreateStateEntry(), new[] { IdProperty, StateProperty });
+            return new StoreGeneratedValuesFactory().Create(entry ?? CreateStateEntry());
         }
     }
 }

--- a/test/EntityFramework.Tests/EntityFramework.Tests.csproj
+++ b/test/EntityFramework.Tests/EntityFramework.Tests.csproj
@@ -64,6 +64,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ApiConsistencyTest.cs" />
+    <Compile Include="ChangeTracking\ChangeDetectorTest.cs" />
     <Compile Include="ChangeTracking\RelationshipsSnapshotTest.cs" />
     <Compile Include="ChangeTracking\SimpleNullableEntityKeyFactoryTest.cs" />
     <Compile Include="ContextConfigurationTest.cs" />

--- a/test/Shared/MonsterContext.cs
+++ b/test/Shared/MonsterContext.cs
@@ -45,6 +45,6 @@ namespace Microsoft.Data.Entity.MonsterModel
         public abstract IQueryable<IDriver> Drivers { get; }
         public abstract IQueryable<ILicense> Licenses { get; }
 
-        public abstract void SeedUsingFKs();
+        public abstract void SeedUsingFKs(bool saveChanges = true);
     }
 }

--- a/test/Shared/MonsterContext`.cs
+++ b/test/Shared/MonsterContext`.cs
@@ -259,6 +259,7 @@ namespace Microsoft.Data.Entity.MonsterModel
             builder.Entity<TProductDetail>().ForeignKeys(fk => fk.ForeignKey<TProduct>(e => e.ProductId, isUnique: true));
             builder.Entity<TProductReview>().ForeignKeys(fk => fk.ForeignKey<TProduct>(e => e.ProductId));
             builder.Entity<TProductPhoto>().ForeignKeys(fk => fk.ForeignKey<TProduct>(e => e.ProductId));
+            builder.Entity<TProductWebFeature>().ForeignKeys(fk => fk.ForeignKey<TProduct>(e => e.ProductId));
             builder.Entity<TProductWebFeature>().ForeignKeys(fk => fk.ForeignKey<TProductPhoto>(e => new { e.ProductId, e.PhotoId }));
             builder.Entity<TProductWebFeature>().ForeignKeys(fk => fk.ForeignKey<TProductReview>(e => new { e.ProductId, e.ReviewId }));
             builder.Entity<TResolution>().ForeignKeys(fk => fk.ForeignKey<TComplaint>(e => e.ResolutionId, isUnique: true));
@@ -454,35 +455,24 @@ namespace Microsoft.Data.Entity.MonsterModel
                         navigation, pointsToPrincipal: true));
         }
 
-        public override void SeedUsingFKs()
+        public override void SeedUsingFKs(bool saveChanges = true)
         {
             var customer0 = Add(new TCustomer { Name = "Eeky Bear" });
             var customer1 = Add(new TCustomer { Name = "Sheila Koalie" });
             var customer3 = Add(new TCustomer { Name = "Tarquin Tiger" });
 
-            // TODO: Key propagation so all the additional SaveChanges calls can be removed
-            SaveChanges();
-
             var customer2 = Add(new TCustomer { Name = "Sue Pandy", HusbandId = customer0.CustomerId });
-
-            SaveChanges();
 
             var product1 = Add(new TProduct { Description = "Mrs Koalie's Famous Waffles", BaseConcurrency = "Pounds Sterling" });
             var product2 = Add(new TProduct { Description = "Chocolate Donuts", BaseConcurrency = "US Dollars" });
             var product3 = Add(new TProduct { Description = "Assorted Dog Treats", BaseConcurrency = "Stuffy Money" });
 
-            SaveChanges();
-
             var barcode1 = Add(new TBarcode { Code = new byte[] { 1, 2, 3, 4 }, ProductId = product1.ProductId, Text = "Barcode 1 2 3 4" });
             var barcode2 = Add(new TBarcode { Code = new byte[] { 2, 2, 3, 4 }, ProductId = product2.ProductId, Text = "Barcode 2 2 3 4" });
             var barcode3 = Add(new TBarcode { Code = new byte[] { 3, 2, 3, 4 }, ProductId = product3.ProductId, Text = "Barcode 3 2 3 4" });
 
-            SaveChanges();
-
             var barcodeDetails1 = Add(new TBarcodeDetail { Code = barcode1.Code, RegisteredTo = "Eeky Bear" });
             var barcodeDetails2 = Add(new TBarcodeDetail { Code = barcode2.Code, RegisteredTo = "Trent" });
-
-            SaveChanges();
 
             var incorrectScan1 = Add(
                 new TIncorrectScan
@@ -502,8 +492,6 @@ namespace Microsoft.Data.Entity.MonsterModel
                         ExpectedCode = barcode1.Code
                     });
 
-            SaveChanges();
-
             var complaint1 = Add(new TComplaint
                 {
                     CustomerId = customer2.CustomerId,
@@ -518,33 +506,21 @@ namespace Microsoft.Data.Entity.MonsterModel
                     Logged = new DateTime(2014, 5, 28, 19, 22, 26)
                 });
 
-            SaveChanges();
-
             var resolution = Add(new TResolution { ResolutionId = complaint2.ComplaintId, Details = "Destroyed all coffee in Redmond area." });
-
-            SaveChanges();
 
             var login1 = Add(new TLogin { CustomerId = customer1.CustomerId, Username = "MrsKoalie73" });
             var login2 = Add(new TLogin { CustomerId = customer2.CustomerId, Username = "MrsBossyPants" });
             var login3 = Add(new TLogin { CustomerId = customer3.CustomerId, Username = "TheStripedMenace" });
 
-            SaveChanges();
-
             var suspiciousActivity1 = Add(new TSuspiciousActivity { Activity = "Pig prints on keyboard", Username = login3.Username });
             var suspiciousActivity2 = Add(new TSuspiciousActivity { Activity = "Crumbs in the cupboard", Username = login3.Username });
             var suspiciousActivity3 = Add(new TSuspiciousActivity { Activity = "Donuts gone missing", Username = login3.Username });
 
-            SaveChanges();
-
             var rsaToken1 = Add(new TRsaToken { Issued = DateTime.Now, Serial = "1234", Username = login1.Username });
             var rsaToken2 = Add(new TRsaToken { Issued = DateTime.Now, Serial = "2234", Username = login2.Username });
 
-            SaveChanges();
-
             var smartCard1 = Add(new TSmartCard { Username = login1.Username, CardSerial = rsaToken1.Serial, Issued = rsaToken1.Issued });
             var smartCard2 = Add(new TSmartCard { Username = login2.Username, CardSerial = rsaToken2.Serial, Issued = rsaToken2.Issued });
-
-            SaveChanges();
 
             var reset1 = Add(new TPasswordReset
                 {
@@ -554,13 +530,9 @@ namespace Microsoft.Data.Entity.MonsterModel
                     Username = login3.Username
                 });
 
-            SaveChanges();
-
             var pageView1 = Add(new TPageView { PageUrl = "somePage1", Username = login1.Username, Viewed = DateTime.Now });
             var pageView2 = Add(new TPageView { PageUrl = "somePage2", Username = login1.Username, Viewed = DateTime.Now });
             var pageView3 = Add(new TPageView { PageUrl = "somePage3", Username = login1.Username, Viewed = DateTime.Now });
-
-            SaveChanges();
 
             var lastLogin1 = Add(new TLastLogin
                 {
@@ -577,8 +549,6 @@ namespace Microsoft.Data.Entity.MonsterModel
                     Username = login2.Username,
                     SmartcardUsername = smartCard2.Username
                 });
-
-            SaveChanges();
 
             var message1 = Add(new TMessage
                 {
@@ -607,25 +577,17 @@ namespace Microsoft.Data.Entity.MonsterModel
                     Sent = DateTime.Now,
                 });
 
-            SaveChanges();
-
             var order1 = Add(new TAnOrder { CustomerId = customer1.CustomerId, Username = login1.Username });
             var order2 = Add(new TAnOrder { CustomerId = customer2.CustomerId, Username = login2.Username });
             var order3 = Add(new TAnOrder { CustomerId = customer3.CustomerId, Username = login3.Username });
-
-            SaveChanges();
 
             var orderNote1 = Add(new TOrderNote { Note = "Must have tea!", OrderId = order1.AnOrderId });
             var orderNote2 = Add(new TOrderNote { Note = "And donuts!", OrderId = order1.AnOrderId });
             var orderNote3 = Add(new TOrderNote { Note = "But no coffee. :-(", OrderId = order1.AnOrderId });
 
-            SaveChanges();
-
             var orderQualityCheck1 = Add(new TOrderQualityCheck { OrderId = order1.AnOrderId, CheckedBy = "Eeky Bear" });
             var orderQualityCheck2 = Add(new TOrderQualityCheck { OrderId = order2.AnOrderId, CheckedBy = "Eeky Bear" });
             var orderQualityCheck3 = Add(new TOrderQualityCheck { OrderId = order3.AnOrderId, CheckedBy = "Eeky Bear" });
-
-            SaveChanges();
 
             var orderLine1 = Add(new TOrderLine { OrderId = order1.AnOrderId, ProductId = product1.ProductId, Quantity = 7 });
             var orderLine2 = Add(new TOrderLine { OrderId = order1.AnOrderId, ProductId = product2.ProductId, Quantity = 1 });
@@ -634,24 +596,16 @@ namespace Microsoft.Data.Entity.MonsterModel
             var orderLine5 = Add(new TOrderLine { OrderId = order2.AnOrderId, ProductId = product1.ProductId, Quantity = 4 });
             var orderLine6 = Add(new TOrderLine { OrderId = order3.AnOrderId, ProductId = product2.ProductId, Quantity = 5 });
 
-            SaveChanges();
-
             var productDetail1 = Add(new TProductDetail { Details = "A Waffle Cart specialty!", ProductId = product1.ProductId });
             var productDetail2 = Add(new TProductDetail { Details = "Eeky Bear's favorite!", ProductId = product2.ProductId });
-
-            SaveChanges();
 
             var productReview1 = Add(new TProductReview { ProductId = product1.ProductId, Review = "Better than Tarqies!" });
             var productReview2 = Add(new TProductReview { ProductId = product1.ProductId, Review = "Good with maple syrup." });
             var productReview3 = Add(new TProductReview { ProductId = product2.ProductId, Review = "Eeky says yes!" });
 
-            SaveChanges();
-
             var productPhoto1 = Add(new TProductPhoto { ProductId = product1.ProductId, Photo = new byte[] { 101, 102 } });
             var productPhoto2 = Add(new TProductPhoto { ProductId = product1.ProductId, Photo = new byte[] { 103, 104 } });
             var productPhoto3 = Add(new TProductPhoto { ProductId = product3.ProductId, Photo = new byte[] { 105, 106 } });
-
-            SaveChanges();
 
             var productWebFeature1 = Add(new TProductWebFeature
                 {
@@ -668,32 +622,20 @@ namespace Microsoft.Data.Entity.MonsterModel
                     ReviewId = productReview3.ReviewId
                 });
 
-            SaveChanges();
-
             var supplier1 = Add(new TSupplier { Name = "Trading As Trent" });
             var supplier2 = Add(new TSupplier { Name = "Ants By Boris" });
 
-            SaveChanges();
-
             var supplierLogo1 = Add(new TSupplierLogo { SupplierId = supplier1.SupplierId, Logo = new byte[] { 201, 202 } });
-
-            SaveChanges();
 
             var supplierInfo1 = Add(new TSupplierInfo { SupplierId = supplier1.SupplierId, Information = "Seems a bit dodgy." });
             var supplierInfo2 = Add(new TSupplierInfo { SupplierId = supplier1.SupplierId, Information = "Orange fur?" });
             var supplierInfo3 = Add(new TSupplierInfo { SupplierId = supplier2.SupplierId, Information = "Very expensive!" });
 
-            SaveChanges();
-
             var customerInfo1 = Add(new TCustomerInfo { CustomerInfoId = customer1.CustomerId, Information = "Really likes tea." });
             var customerInfo2 = Add(new TCustomerInfo { CustomerInfoId = customer2.CustomerId, Information = "Mrs Bossy Pants!" });
 
-            SaveChanges();
-
             var computer1 = Add(new TComputer { Name = "markash420" });
             var computer2 = Add(new TComputer { Name = "unicorns420" });
-
-            SaveChanges();
 
             var computerDetail1 = Add(new TComputerDetail
                 {
@@ -715,12 +657,8 @@ namespace Microsoft.Data.Entity.MonsterModel
                     Specifications = "It's not a Dell!"
                 });
 
-            SaveChanges();
-
             var driver1 = Add(new TDriver { BirthDate = new DateTime(2006, 9, 19), Name = "Eeky Bear" });
             var driver2 = Add(new TDriver { BirthDate = new DateTime(2007, 9, 19), Name = "Splash Bear" });
-
-            SaveChanges();
 
             var license1 = Add(new TLicense
                 {
@@ -742,7 +680,10 @@ namespace Microsoft.Data.Entity.MonsterModel
                     ExpirationDate = new DateTime(2018, 9, 19)
                 });
 
-            SaveChanges();
+            if (saveChanges)
+            {
+                SaveChanges();
+            }
         }
     }
 }

--- a/test/Shared/ThrowingMonsterStateManager.cs
+++ b/test/Shared/ThrowingMonsterStateManager.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Infrastructure;
+
+namespace Microsoft.Data.Entity.MonsterModel
+{
+    public class ThrowingMonsterStateManager : StateManager
+    {
+        public ThrowingMonsterStateManager(
+            DbContextConfiguration configuration,
+            StateEntryFactory factory,
+            EntityKeyFactorySource entityKeyFactorySource,
+            StateEntrySubscriber subscriber)
+            : base(configuration, factory, entityKeyFactorySource, subscriber)
+        {
+        }
+
+        protected override async Task<int> SaveChangesAsync(
+            IReadOnlyList<StateEntry> entriesToSave, CancellationToken cancellationToken = new CancellationToken())
+        {
+            await base.SaveChangesAsync(entriesToSave, cancellationToken);
+
+            throw new Exception("Aborting.");
+        }
+    }
+}


### PR DESCRIPTION
Sidecars 7, Brazil 0... (Propagate generated principal values to FKs on SaveChanges)

Some primary/principal key values are generated in the store when the entity is saved--for example, for Identity columns. These values are written back into the state entry by the update pipeline. Foreign keys that reference these principal key values also need to be updated with the generated values so that the entire graph stays in sync and so that subsequent commands issued by the update pipeline make use of the newly generated values. Also, if the save transaction is not committed, then these generated values should be discarded.

Values written into the state manager by the update pipeline are placed in a temporary transparent sidecar so that they can be discarded later. When a change is detected (or notification is made) that a principal property has changed, then the state manager now finds dependents and updates FK values appropriately. These are also written into the transparent sidecar so that the update pipeline can read them like normal values for subsequent commands, but the values can still be discarded if SaveChanges fails.

Still working on some tests.
