### PR TITLE
More Monster Munch...

### DIFF
--- a/src/EntityFramework/Metadata/NavigationExtensions.cs
+++ b/src/EntityFramework/Metadata/NavigationExtensions.cs
@@ -20,13 +20,18 @@ namespace Microsoft.Data.Entity.Metadata
         {
             Check.NotNull(navigation, "navigation");
 
-            var foreignKey = navigation.ForeignKey;
+            return GetTargetType(navigation).Navigations.FirstOrDefault(
+                i => i.ForeignKey == navigation.ForeignKey && i.PointsToPrincipal != navigation.PointsToPrincipal);
+        }
+
+        public static IEntityType GetTargetType([NotNull] this INavigation navigation)
+        {
+            Check.NotNull(navigation, "navigation");
 
             // TODO: Ensure only one inverse can be created when building metadata
-            var otherType = navigation.PointsToPrincipal ? foreignKey.ReferencedEntityType : foreignKey.EntityType;
-
-            return otherType.Navigations.FirstOrDefault(
-                i => i.ForeignKey == foreignKey && i.PointsToPrincipal != navigation.PointsToPrincipal);
+            return navigation.PointsToPrincipal
+                ? navigation.ForeignKey.ReferencedEntityType
+                : navigation.ForeignKey.EntityType;
         }
     }
 }

--- a/test/EntityFramework.SqlServer.FunctionalTests/TestModels/ConcurrencyModel/ConcurrencyModelInitializer.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/TestModels/ConcurrencyModel/ConcurrencyModelInitializer.cs
@@ -84,12 +84,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests.TestModels.Concurrency
                     EngineSupplier = engineSuppliers.Single(s => s.Name == "Cosworth")
                 };
 
-            //TODO: Remove once #384 is fixed
-            mercedesEngine.EngineSupplierId = mercedesEngine.EngineSupplier.Id;
-            renaultEngine.EngineSupplierId = renaultEngine.EngineSupplier.Id;
-            ferrariEngine.EngineSupplierId = ferrariEngine.EngineSupplier.Id;
-            cosworthEngine.EngineSupplierId = cosworthEngine.EngineSupplier.Id;
-
             foreach (var engine in new List<Engine>
                 {
                     mercedesEngine,

--- a/test/EntityFramework.Tests/Metadata/NavigationExtensionsTest.cs
+++ b/test/EntityFramework.Tests/Metadata/NavigationExtensionsTest.cs
@@ -34,6 +34,21 @@ namespace Microsoft.Data.Entity.Metadata
         }
 
         [Fact]
+        public void Can_get_target_ends()
+        {
+            var model = BuildModel();
+
+            var productType = model.GetEntityType(typeof(Product));
+            var categoryType = model.GetEntityType(typeof(Category));
+
+            var category = productType.Navigations.Single(e => e.Name == "Category");
+            var products = categoryType.Navigations.Single(e => e.Name == "Products");
+
+            Assert.Same(productType, products.GetTargetType());
+            Assert.Same(categoryType, category.GetTargetType());
+        }
+
+        [Fact]
         public void Returns_null_when_no_inverse()
         {
             var products = BuildModel(createCategory: false).GetEntityType(typeof(Category)).Navigations.Single(e => e.Name == "Products");

--- a/test/Shared/MonsterContext.cs
+++ b/test/Shared/MonsterContext.cs
@@ -46,5 +46,6 @@ namespace Microsoft.Data.Entity.MonsterModel
         public abstract IQueryable<ILicense> Licenses { get; }
 
         public abstract void SeedUsingFKs(bool saveChanges = true);
+        public abstract void SeedUsingNavigations(bool dependentNavs, bool principalNavs, bool saveChanges = true);
     }
 }

--- a/test/Shared/MonsterFixupTestBase.cs
+++ b/test/Shared/MonsterFixupTestBase.cs
@@ -49,6 +49,120 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void Can_build_monster_model_and_seed_data_using_all_navigations()
+        {
+            const string databaseName = SnapshotDatabaseName + "_AllNavs";
+            Can_build_monster_model_and_seed_data_using_all_navigations_test(p => CreateSnapshotMonsterContext(p, databaseName), databaseName);
+        }
+
+        [Fact]
+        public virtual void Can_build_monster_model_with_full_notification_entities_and_seed_data_using_all_navigations()
+        {
+            const string databaseName = FullNotifyDatabaseName + "_AllNavs";
+            Can_build_monster_model_and_seed_data_using_all_navigations_test(p => CreateChangedChangingMonsterContext(p, databaseName), databaseName);
+        }
+
+        [Fact]
+        public virtual void Can_build_monster_model_with_changed_only_notification_entities_and_seed_data_using_all_navigations()
+        {
+            const string databaseName = ChangedOnlyDatabaseName + "_AllNavs";
+            Can_build_monster_model_and_seed_data_using_all_navigations_test(p => CreateChangedOnlyMonsterContext(p, databaseName), databaseName);
+        }
+
+        private void Can_build_monster_model_and_seed_data_using_all_navigations_test(
+            Func<IServiceProvider, MonsterContext> createContext, string databaseName)
+        {
+            var serviceProvider = CreateServiceProvider();
+
+            using (var context = createContext(serviceProvider))
+            {
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
+                context.SeedUsingNavigations(principalNavs: true, dependentNavs: true);
+            }
+
+            SimpleVerification(() => createContext(serviceProvider));
+            FkVerification(() => createContext(serviceProvider));
+            NavigationVerification(() => createContext(serviceProvider));
+        }
+
+        [Fact]
+        public virtual void Can_build_monster_model_and_seed_data_using_dependent_navigations()
+        {
+            const string databaseName = SnapshotDatabaseName + "_DependentNavs";
+            Can_build_monster_model_and_seed_data_using_dependent_navigations_test(p => CreateSnapshotMonsterContext(p, databaseName), databaseName);
+        }
+
+        [Fact]
+        public virtual void Can_build_monster_model_with_full_notification_entities_and_seed_data_using_dependent_navigations()
+        {
+            const string databaseName = FullNotifyDatabaseName + "_DependentNavs";
+            Can_build_monster_model_and_seed_data_using_dependent_navigations_test(p => CreateChangedChangingMonsterContext(p, databaseName), databaseName);
+        }
+
+        [Fact]
+        public virtual void Can_build_monster_model_with_changed_only_notification_entities_and_seed_data_using_dependent_navigations()
+        {
+            const string databaseName = ChangedOnlyDatabaseName + "_DependentNavs";
+            Can_build_monster_model_and_seed_data_using_dependent_navigations_test(p => CreateChangedOnlyMonsterContext(p, databaseName), databaseName);
+        }
+
+        private void Can_build_monster_model_and_seed_data_using_dependent_navigations_test(
+            Func<IServiceProvider, MonsterContext> createContext, string databaseName)
+        {
+            var serviceProvider = CreateServiceProvider();
+
+            using (var context = createContext(serviceProvider))
+            {
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
+                context.SeedUsingNavigations(principalNavs: false, dependentNavs: true);
+            }
+
+            SimpleVerification(() => createContext(serviceProvider));
+            FkVerification(() => createContext(serviceProvider));
+            NavigationVerification(() => createContext(serviceProvider));
+        }
+
+        [Fact]
+        public virtual void Can_build_monster_model_and_seed_data_using_principal_navigations()
+        {
+            const string databaseName = SnapshotDatabaseName + "_PrincipalNavs";
+            Can_build_monster_model_and_seed_data_using_principal_navigations_test(p => CreateSnapshotMonsterContext(p, databaseName), databaseName);
+        }
+
+        //[Fact] TODO: Support INotifyCollectionChanging so that collection change detection without DetectChanges works
+        public virtual void Can_build_monster_model_with_full_notification_entities_and_seed_data_using_principal_navigations()
+        {
+            const string databaseName = FullNotifyDatabaseName + "_PrincipalNavs";
+            Can_build_monster_model_and_seed_data_using_principal_navigations_test(p => CreateChangedChangingMonsterContext(p, databaseName), databaseName);
+        }
+
+        //[Fact] TODO: Support INotifyCollectionChanging so that collection change detection without DetectChanges works
+        public virtual void Can_build_monster_model_with_changed_only_notification_entities_and_seed_data_using_principal_navigations()
+        {
+            const string databaseName = ChangedOnlyDatabaseName + "_PrincipalNavs";
+            Can_build_monster_model_and_seed_data_using_principal_navigations_test(p => CreateChangedOnlyMonsterContext(p, databaseName), databaseName);
+        }
+
+        private void Can_build_monster_model_and_seed_data_using_principal_navigations_test(
+            Func<IServiceProvider, MonsterContext> createContext, string databaseName)
+        {
+            var serviceProvider = CreateServiceProvider();
+
+            using (var context = createContext(serviceProvider))
+            {
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
+                context.SeedUsingNavigations(principalNavs: true, dependentNavs: false);
+            }
+
+            SimpleVerification(() => createContext(serviceProvider));
+            FkVerification(() => createContext(serviceProvider));
+            NavigationVerification(() => createContext(serviceProvider));
+        }
+
+        [Fact]
         public virtual async Task Store_generated_values_are_discarded_if_saving_changes_fails()
         {
             const string databaseName = SnapshotDatabaseName + "_Bad";


### PR DESCRIPTION
More Monster Munch... (Fixup FKs using navigations when entity is first tracked)

This allows a graph to be specified using navigation properties only with the state manager taking care of setting FK properties to appropriate values.

Note that FK properties that are also PK properties must still be set because the state manager requires a unique key. This is an area that needs more work.
