### PR TITLE
Splat: Squashed concurrency bugs

### DIFF
--- a/src/EntityFramework.AzureTableStorage/EntityFramework.AzureTableStorage.csproj
+++ b/src/EntityFramework.AzureTableStorage/EntityFramework.AzureTableStorage.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Utilities\Check.cs" />
     <Compile Include="Utilities\EntityTypeExtensions.cs" />
     <Compile Include="..\Shared\StringBuilderExtensions.cs" />
+    <Compile Include="Utilities\StorageErrorCodes.cs" />
     <EmbeddedResource Include="Properties\Strings.resx">
       <LogicalName>EntityFramework.AzureTableStorage.Strings.resources</LogicalName>
     </EmbeddedResource>

--- a/src/EntityFramework.AzureTableStorage/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.AzureTableStorage/Properties/Strings.Designer.cs
@@ -218,6 +218,38 @@ namespace Microsoft.Data.Entity.AzureTableStorage
             return GetString("SaveChangesFailed");
         }
 
+        /// <summary>
+        /// Table or row not found on server
+        /// </summary>
+        internal static string ResourceNotFound
+        {
+            get { return GetString("ResourceNotFound"); }
+        }
+
+        /// <summary>
+        /// Table or row not found on server
+        /// </summary>
+        internal static string FormatResourceNotFound()
+        {
+            return GetString("ResourceNotFound");
+        }
+
+        /// <summary>
+        /// Table not found on server
+        /// </summary>
+        internal static string TableNotFound
+        {
+            get { return GetString("TableNotFound"); }
+        }
+
+        /// <summary>
+        /// Table not found on server
+        /// </summary>
+        internal static string FormatTableNotFound()
+        {
+            return GetString("TableNotFound");
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EntityFramework.AzureTableStorage/Properties/Strings.resx
+++ b/src/EntityFramework.AzureTableStorage/Properties/Strings.resx
@@ -156,4 +156,10 @@
   <data name="SaveChangesFailed" xml:space="preserve">
     <value>Could not save changes. See inner exception for details.</value>
   </data>
+  <data name="ResourceNotFound" xml:space="preserve">
+    <value>Table or row not found on server</value>
+  </data>
+  <data name="TableNotFound" xml:space="preserve">
+    <value>Table not found on server</value>
+  </data>
 </root>

--- a/src/EntityFramework.AzureTableStorage/Query/AtsQueryModelVisitor.FilteringExpressionVisitor.cs
+++ b/src/EntityFramework.AzureTableStorage/Query/AtsQueryModelVisitor.FilteringExpressionVisitor.cs
@@ -211,7 +211,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Query
                 if (constantExpression != null
                     && constantExpression.Value != null)
                 {
-                    return new QueryableConstantExpression(constantExpression.Value);
+                    return new QueryableConstantExpression(constantExpression.Type, constantExpression.Value);
                 }
                 return null;
             }

--- a/src/EntityFramework.AzureTableStorage/Query/Expressions/QueryableConstantExpression.cs
+++ b/src/EntityFramework.AzureTableStorage/Query/Expressions/QueryableConstantExpression.cs
@@ -16,9 +16,11 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Query.Expressions
     {
         private readonly dynamic _constant;
 
-        public QueryableConstantExpression([NotNull] object constant)
-            : base(Check.NotNull(constant, "constant").GetType())
+        public QueryableConstantExpression([NotNull] Type type, [NotNull] object constant)
+            : base(Check.NotNull(type, "type"))
         {
+            Check.NotNull(constant, "constant");
+
             IsStringProperty = false;
             _constant = constant;
         }
@@ -46,7 +48,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Query.Expressions
             {
                 if (IsStringProperty)
                 {
-                    Escape(_constant.ToString());
+                    return Escape(_constant.ToString());
                 }
                 return Escape(_constant);
             }

--- a/src/EntityFramework.AzureTableStorage/Utilities/StorageErrorCodes.cs
+++ b/src/EntityFramework.AzureTableStorage/Utilities/StorageErrorCodes.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+namespace Microsoft.Data.Entity.AzureTableStorage.Utilities
+{
+    public class StorageErrorCodes
+    {
+        public const string TableNotFoundError = "TableNotFound";
+        public const string ResourceNotFound = "ResourceNotFound";
+        public const string UpdateConditionNotSatisfied = "UpdateConditionNotSatisfied";
+    }
+}

--- a/test/EntityFramework.AzureTableStorage.FunctionalTests/EntityFramework.AzureTableStorage.FunctionalTests.csproj
+++ b/test/EntityFramework.AzureTableStorage.FunctionalTests/EntityFramework.AzureTableStorage.FunctionalTests.csproj
@@ -75,6 +75,7 @@
   <ItemGroup>
     <Compile Include="AtsTestFramework.cs" />
     <Compile Include="BatchTests.cs" />
+    <Compile Include="OptimisticConcurrencyTests.cs" />
     <Compile Include="TestFixture.cs" />
     <Compile Include="EndToEndTests.cs" />
     <Compile Include="TestBase.cs" />

--- a/test/EntityFramework.AzureTableStorage.FunctionalTests/OptimisticConcurrencyTests.cs
+++ b/test/EntityFramework.AzureTableStorage.FunctionalTests/OptimisticConcurrencyTests.cs
@@ -1,0 +1,146 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading.Tasks;
+using ConcurrencyModel;
+using Microsoft.Data.Entity.AzureTableStorage.Metadata;
+using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.Identity;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
+
+namespace Microsoft.Data.Entity.AzureTableStorage.FunctionalTests
+{
+    [RunIfConfigured]
+    public class OptimisticConcurrencyTests : OptimisticConcurrencyTestBase<OptimisticConcurrencyTests.AtsTestStore>, IDisposable
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly IModel _model;
+
+        public OptimisticConcurrencyTests()
+        {
+            var tableSuffix = Guid.NewGuid().ToString().Replace("-", "");
+            _model = AddAtsMetadata(F1Context.CreateModel(), tableSuffix);
+
+            _serviceProvider = new ServiceCollection()
+                .AddEntityFramework()
+                .AddAzureTableStorage()
+                .ServiceCollection
+                .AddScoped<AtsValueGeneratorCache, TestValueGeneratorCache>()
+                .BuildServiceProvider();
+        }
+
+        protected override async Task<AtsTestStore> CreateTestDatabaseAsync()
+        {
+            var db = new AtsTestStore();
+            using (var context = await CreateF1ContextAsync(db))
+            {
+                await ConcurrencyModelInitializer.SeedAsync(context);
+            }
+            return db;
+        }
+
+        protected override void ResolveConcurrencyTokens(StateEntry stateEntry)
+        {
+            var property = stateEntry.EntityType.GetProperty("ETag");
+            stateEntry[property] = "*";
+            //TODO use the actual ETag instead of force rewrite. This will require refactoring the test base to read shadow state properties
+        }
+
+        protected override Task<F1Context> CreateF1ContextAsync(AtsTestStore testDatabase)
+        {
+            var options = new DbContextOptions()
+                .UseModel(_model)
+                .UseAzureTableStorage(TestConfig.Instance.ConnectionString);
+            return Task.FromResult(new F1Context(_serviceProvider, options));
+        }
+
+        private static IModel AddAtsMetadata(ModelBuilder builder, string tableSuffix)
+        {
+            builder.Entity<Chassis>()
+                .PartitionAndRowKey(c => c.Name, c => c.TeamId)
+                .Key(c => c.TeamId)
+                .Properties(pb => pb.Property<Chassis>("ETag", true))
+                .TableName("Chassis" + tableSuffix);
+            builder.Entity<Team>()
+                .PartitionAndRowKey(c => c.Name, c => c.Id)
+                .Key(c => c.Id)
+                .Properties(pb => pb.Property<Team>("ETag", true))
+                .TableName("Teams" + tableSuffix);
+            builder.Entity<Driver>()
+                .PartitionAndRowKey(c => c.Name, c => c.Id)
+                .Key(c => c.Id)
+                .Properties(pb => pb.Property<Driver>("ETag", true))
+                .TableName("Drivers" + tableSuffix);
+            builder.Entity<Engine>()
+                .PartitionAndRowKey(c => c.Name, c => c.Id)
+                .Key(c => c.Id)
+                .Properties(pb => pb.Property<Engine>("ETag", true))
+                .TableName("Engines" + tableSuffix);
+            builder.Entity<EngineSupplier>()
+                .PartitionAndRowKey(c => c.Name, c => c.Id)
+                .Key(c => c.Id)
+                .Properties(pb => pb.Property<EngineSupplier>("ETag", true))
+                .TableName("EngineSuppliers" + tableSuffix);
+            builder.Entity<Gearbox>()
+                .PartitionAndRowKey(c => c.Name, c => c.Id)
+                .Key(c => c.Id)
+                .Properties(pb => pb.Property<Gearbox>("ETag", true))
+                .TableName("Gearboxes" + tableSuffix);
+            builder.Entity<Sponsor>()
+                .PartitionAndRowKey(c => c.Name, c => c.Id)
+                .Key(c => c.Id)
+                .Properties(pb => pb.Property<Sponsor>("ETag", true))
+                .TableName("Sponsors" + tableSuffix);
+            builder.Entity<TestDriver>()
+                .PartitionAndRowKey(c => c.Name, c => c.Id)
+                .Key(c => c.Id)
+                .Properties(pb => pb.Property<TestDriver>("ETag", true))
+                .TableName("TestDrivers" + tableSuffix);
+            builder.Entity<TitleSponsor>()
+                .PartitionAndRowKey(c => c.Name, c => c.Id)
+                .Key(c => c.Id)
+                .Properties(pb => pb.Property<TitleSponsor>("ETag", true))
+                .TableName("TitleSponsors" + tableSuffix);
+            return builder.Model;
+        }
+
+        public class AtsTestStore : TestStore
+        {
+            public override void Dispose()
+            {
+            }
+        }
+
+        public void Dispose()
+        {
+            using (var db = CreateF1ContextAsync(null).Result)
+            {
+                db.Database.EnsureDeleted();
+            }
+        }
+
+        // Added as a hack to get these tests working correctly
+        //TODO consider adding this to the provider
+
+        internal class TestValueGeneratorCache : AtsValueGeneratorCache
+        {
+            private class IntGenerator : SimpleValueGenerator
+            {
+                public override object Next(DbContextConfiguration contextConfiguration, IProperty property)
+                {
+                    return Guid.NewGuid().GetHashCode();
+                }
+            }
+
+            public override IValueGenerator GetGenerator(IProperty property)
+            {
+                return new IntGenerator();
+            }
+        }
+    }
+}

--- a/test/EntityFramework.AzureTableStorage.Tests/Adapters/StateEntryTableEntityAdapterTest.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Adapters/StateEntryTableEntityAdapterTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Microsoft.Data.Entity.AzureTableStorage.Adapters;
 using Microsoft.Data.Entity.AzureTableStorage.Metadata;
 using Microsoft.Data.Entity.AzureTableStorage.Query;
+using Microsoft.Data.Entity.AzureTableStorage.Tests.Helpers;
 using Microsoft.Data.Entity.AzureTableStorage.Utilities;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Infrastructure;
@@ -23,31 +24,6 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Adapters
         private static DbContextConfiguration CreateConfiguration()
         {
             return new DbContext(new DbContextOptions().UseAzureTableStorage("Moria", "mellon")).Configuration;
-        }
-
-        public class ClrPoco
-        {
-            public string PartitionKey { get; set; }
-            public string RowKey { get; set; }
-            public DateTimeOffset Timestamp { get; set; }
-        }
-
-        public class GuidKeysPoco
-        {
-            public Guid PartitionGuid { get; set; }
-            public Guid RowGuid { get; set; }
-        }
-
-        public class IntKeysPoco
-        {
-            public int PartitionID { get; set; }
-            public int RowID { get; set; }
-        }
-
-        public class ClrPocoWithProp : ClrPoco
-        {
-            public string StringProp { get; set; }
-            public int IntProp { get; set; }
         }
 
         private IModel CreateModel()

--- a/test/EntityFramework.AzureTableStorage.Tests/EntityFramework.AzureTableStorage.Tests.csproj
+++ b/test/EntityFramework.AzureTableStorage.Tests/EntityFramework.AzureTableStorage.Tests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Extensions\DataStoreConnectionExtensionsTests.cs" />
     <Compile Include="Extensions\AtsDbContextExtensionsTests.cs" />
     <Compile Include="Extensions\EntityBuilderExtensionsTests.cs" />
+    <Compile Include="Helpers\SimpleTestTypes.cs" />
     <Compile Include="Helpers\PocoTestType.cs" />
     <Compile Include="Helpers\TestStateEntry.cs" />
     <Compile Include="Helpers\TestTableResult.cs" />

--- a/test/EntityFramework.AzureTableStorage.Tests/Helpers/SimpleTestTypes.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Helpers/SimpleTestTypes.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.AzureTableStorage.Metadata;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Helpers
+{
+    public class IntKeysPoco
+    {
+        public int PartitionID { get; set; }
+        public int RowID { get; set; }
+
+        public static EntityType EntityType()
+        {
+            var entityType = new EntityType(typeof(IntKeysPoco));
+            entityType.AddProperty("PartitionID", typeof(int)).SetColumnName("PartitionKey");
+            entityType.AddProperty("RowID", typeof(int)).SetColumnName("RowKey");
+            return entityType;
+        }
+    }
+
+    public class NullablePoco
+    {
+        public int? NullInt { get; set; }
+        public double? NullDouble { get; set; }
+
+        public static EntityType EntityType()
+        {
+            var entityType = new EntityType(typeof(NullablePoco));
+            entityType.AddProperty("NullInt", typeof(int?));
+            entityType.AddProperty("NullDouble", typeof(double?));
+            return entityType;
+        }
+    }
+    
+    public class ClrPoco
+    {
+        public string PartitionKey { get; set; }
+        public string RowKey { get; set; }
+        public DateTimeOffset Timestamp { get; set; }
+    }
+
+    public class GuidKeysPoco
+    {
+        public Guid PartitionGuid { get; set; }
+        public Guid RowGuid { get; set; }
+    }
+
+    public class ClrPocoWithProp : ClrPoco
+    {
+        public string StringProp { get; set; }
+        public int IntProp { get; set; }
+    }
+}

--- a/test/EntityFramework.AzureTableStorage.Tests/Query/QueryGenerationTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Query/QueryGenerationTests.cs
@@ -44,7 +44,8 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Query
         [MemberData("SimpleWhereExpressions")]
         [MemberData("DataTypeWhereExpressions")]
         [MemberData("CompositeLogicWhereExpressions")]
-        public void It_generates_where_queries(QueryModel queryModel, string expectedQuery)
+        [MemberData("PartitionAndRowKeyExpression")]
+        public void It_generates_where_queries(string expectedQuery, QueryModel queryModel)
         {
             var selectExpression = GetSelectExpression(queryModel);
             var tableQuery = _generator.GenerateTableQuery(selectExpression);
@@ -64,18 +65,18 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Query
             {
                 return new[]
                     {
-                        new object[] { Query(q => q.Where(s => s.Count == 5)), "Count eq 5" },
-                        new object[] { Query(q => q.Where(s => 5 == s.Count)), "Count eq 5" },
-                        new object[] { Query(q => q.Where(s => s.Count != 10)), "Count ne 10" },
-                        new object[] { Query(q => q.Where(s => 10 != s.Count)), "Count ne 10" },
-                        new object[] { Query(q => q.Where(s => s.Count < 15)), "Count lt 15" },
-                        new object[] { Query(q => q.Where(s => 15 > s.Count)), "Count lt 15" },
-                        new object[] { Query(q => q.Where(s => s.Count <= 20)), "Count le 20" },
-                        new object[] { Query(q => q.Where(s => 20 >= s.Count)), "Count le 20" },
-                        new object[] { Query(q => q.Where(s => 25 <= s.Count)), "Count ge 25" },
-                        new object[] { Query(q => q.Where(s => s.Count >= 25)), "Count ge 25" },
-                        new object[] { Query(q => q.Where(s => 30 < s.Count)), "Count gt 30" },
-                        new object[] { Query(q => q.Where(s => s.Count > 30)), "Count gt 30" },
+                        new object[] { "Count eq 5", Query<PocoTestType>(q => q.Where(s => s.Count == 5)),},
+                        new object[] { "Count eq 5", Query<PocoTestType>(q => q.Where(s => 5 == s.Count)),},
+                        new object[] { "Count ne 10", Query<PocoTestType>(q => q.Where(s => s.Count != 10)),},
+                        new object[] { "Count ne 10", Query<PocoTestType>(q => q.Where(s => 10 != s.Count)),},
+                        new object[] { "Count lt 15", Query<PocoTestType>(q => q.Where(s => s.Count < 15)),},
+                        new object[] { "Count lt 15", Query<PocoTestType>(q => q.Where(s => 15 > s.Count)),},
+                        new object[] { "Count le 20", Query<PocoTestType>(q => q.Where(s => s.Count <= 20)),},
+                        new object[] { "Count le 20", Query<PocoTestType>(q => q.Where(s => 20 >= s.Count)),},
+                        new object[] { "Count ge 25", Query<PocoTestType>(q => q.Where(s => 25 <= s.Count)),},
+                        new object[] { "Count ge 25", Query<PocoTestType>(q => q.Where(s => s.Count >= 25)),},
+                        new object[] { "Count gt 30", Query<PocoTestType>(q => q.Where(s => 30 < s.Count)),},
+                        new object[] { "Count gt 30", Query<PocoTestType>(q => q.Where(s => s.Count > 30)),},
                     };
             }
         }
@@ -89,24 +90,27 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Query
             {
                 return new[]
                     {
-                        new object[] { Query(q => q.Where(s => s.Name == "Unicorn")), "Name eq 'Unicorn'" },
-                        new object[] { Query(q => q.Where(s => s.Name == " has ' quotes ' \" ")), "Name eq ' has '' quotes '' \" '" },
-                        new object[] { Query(q => q.Where(s => s.Name == "rtl أنا لا أتكلم العربية rtl")), "Name eq 'rtl أنا لا أتكلم العربية rtl'" },
-                        new object[] { Query(q => q.Where(s => s.Name == "獨角獸")), "Name eq '獨角獸'" },
-                        new object[] { Query(q => q.Where(s => s.Count == 2147483647)), "Count eq 2147483647" },
-                        new object[] { Query(q => q.Where(s => s.BigCount == 2147483648)), "BigCount eq 2147483648L" },
-                        new object[] { Query(q => q.Where(s => s.Price == 100.75)), "Price eq 100.75" },
+                        new object[] { "Name eq 'Unicorn'", Query<PocoTestType>(q => q.Where(s => s.Name == "Unicorn")),},
+                        new object[] { "Name eq ' has '' quotes '' \" '", Query<PocoTestType>(q => q.Where(s => s.Name == " has ' quotes ' \" ")),},
+                        new object[] { "Name eq 'rtl أنا لا أتكلم العربية rtl'", Query<PocoTestType>(q => q.Where(s => s.Name == "rtl أنا لا أتكلم العربية rtl")),},
+                        new object[] { "Name eq '獨角獸'", Query<PocoTestType>(q => q.Where(s => s.Name == "獨角獸")),},
+                        new object[] { "Count eq 2147483647", Query<PocoTestType>(q => q.Where(s => s.Count == 2147483647)),},
+                        new object[] { "BigCount eq 2147483648L", Query<PocoTestType>(q => q.Where(s => s.BigCount == 2147483648)),},
+                        new object[] { "Price eq 100.75", Query<PocoTestType>(q => q.Where(s => s.Price == 100.75)),},
                         new object[]
                             {
-                                Query(q => q.Where(s =>
-                                    s.CustomerSince == ConstantDateTime)),
-                                "CustomerSince eq datetime'2014-05-23T18:00:00.0000000Z'"
+                                "CustomerSince eq datetime'2014-05-23T18:00:00.0000000Z'",
+                                Query<PocoTestType>(q => q.Where(s =>
+                                    s.CustomerSince == ConstantDateTime))
                             },
-                        new object[] { Query(q => q.Where(s => s.IsEnchanted)), "IsEnchanted eq true" },
-                        new object[] { Query(q => q.Where(s => !s.IsEnchanted)), "IsEnchanted eq false" },
-                        new object[] { Query(q => q.Where(s => s.Buffer == TestByteArray)), "Buffer eq X'05080f10172a'" },
-                        new object[] { Query(q => q.Where(s => s.Guid == new Guid("ca761232ed4211cebacd00aa0057b223"))), "Guid eq guid'ca761232-ed42-11ce-bacd-00aa0057b223'" },
-                        new object[] { Query(q => q.Where(s => s.NestedObj.Count == 3)), "" },
+                        new object[] { "IsEnchanted eq true", Query<PocoTestType>(q => q.Where(s => s.IsEnchanted)),},
+                        new object[] { "IsEnchanted eq false", Query<PocoTestType>(q => q.Where(s => !s.IsEnchanted)),},
+                        new object[] { "Buffer eq X'05080f10172a'", Query<PocoTestType>(q => q.Where(s => s.Buffer == TestByteArray)),},
+                        new object[] { "Guid eq guid'ca761232-ed42-11ce-bacd-00aa0057b223'", Query<PocoTestType>(q => q.Where(s => s.Guid == new Guid("ca761232ed4211cebacd00aa0057b223"))),},
+                        new object[] { "", Query<PocoTestType>(q => q.Where(s => s.NestedObj.Count == 3)),},
+                        new object[] { "NullInt eq 9", Query<NullablePoco>(q => q.Where(s => s.NullInt == 9)),},
+                        new object[] { "NullDouble eq 3.149", Query<NullablePoco>(q => q.Where(s => s.NullDouble == 3.149)),},
+                        new object[] { "", Query<NullablePoco>(q => q.Where(s => s.NullInt.HasValue)),},
                     };
             }
         }
@@ -117,25 +121,39 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Query
             {
                 return new[]
                     {
-                        new object[] { Query(q => q.Where(s => s.Count == 10 && s.Count == 20)), "(Count eq 10) and (Count eq 20)" },
-                        new object[] { Query(q => q.Where(s => s.Name == "Dijkstra" && (s.Count == 10 || s.Count == 20))), "(Name eq 'Dijkstra') and ((Count eq 10) or (Count eq 20))" },
-                        new object[] { Query(q => q.Where(s => (s.Name == "Dijkstra" && !s.IsEnchanted) || (s.IsEnchanted && s.Count == 20))), "((Name eq 'Dijkstra') and (IsEnchanted eq false)) or ((IsEnchanted eq true) and (Count eq 20))" },
-                        new object[] { Query(q => q.Where(s => s.Count == 10 || s.Count == 20)), "(Count eq 10) or (Count eq 20)" },
-                        new object[] { Query(q => q.Where(s => s.Count < -10 && s.Name == "The Real Deal")), "(Count lt -10) and (Name eq 'The Real Deal')" },
+                        new object[] { "(Count eq 10) and (Count eq 20)", Query<PocoTestType>(q => q.Where(s => s.Count == 10 && s.Count == 20)),},
+                        new object[] { "(Name eq 'Dijkstra') and ((Count eq 10) or (Count eq 20))", Query<PocoTestType>(q => q.Where(s => s.Name == "Dijkstra" && (s.Count == 10 || s.Count == 20))),},
+                        new object[] { "((Name eq 'Dijkstra') and (IsEnchanted eq false)) or ((IsEnchanted eq true) and (Count eq 20))", Query<PocoTestType>(q => q.Where(s => (s.Name == "Dijkstra" && !s.IsEnchanted) || (s.IsEnchanted && s.Count == 20))),},
+                        new object[] { "(Count eq 10) or (Count eq 20)", Query<PocoTestType>(q => q.Where(s => s.Count == 10 || s.Count == 20)),},
+                        new object[] { "(Count lt -10) and (Name eq 'The Real Deal')", Query<PocoTestType>(q => q.Where(s => s.Count < -10 && s.Name == "The Real Deal")),},
                     };
             }
         }
 
+        public static IEnumerable<object[]> PartitionAndRowKeyExpression
+        {
+            get
+            {
+                return new[]
+                    {
+                        new object[] { "(RowKey eq '15') and (PartitionKey eq '16')", Query<IntKeysPoco>(s => s.Where(t => t.RowID == 15 && t.PartitionID == 16)),},
+                    };
+            }
+        }
+
+      
         private static IModel SetupModel()
         {
             var model = new Model { StorageName = "TestModel" };
             model.AddEntityType(PocoTestType.EntityType());
+            model.AddEntityType(IntKeysPoco.EntityType());
+            model.AddEntityType(NullablePoco.EntityType());
             return model;
         }
 
-        private static QueryModel Query(Expression<Func<DbSet<PocoTestType>, IQueryable>> expression)
+        private static QueryModel Query<T>(Expression<Func<DbSet<T>, IQueryable>> expression) where T : class
         {
-            var query = expression.Compile()(new DbSet<PocoTestType>(Mock.Of<DbContext>()));
+            var query = expression.Compile()(new DbSet<T>(Mock.Of<DbContext>()));
             return new EntityQueryProvider(new EntityQueryExecutor(Mock.Of<DbContext>())).GenerateQueryModel(query.Expression);
         }
 

--- a/test/EntityFramework.AzureTableStorage.Tests/Query/TableQueryGeneratorTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Query/TableQueryGeneratorTests.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Query
             return Expression.MakeBinary(
                 expressionType,
                 new PropertyExpression(new Property(propertyName, constant.GetType())),
-                new QueryableConstantExpression(constant));
+                new QueryableConstantExpression(constant.GetType(), constant));
         }
     }
 }

--- a/test/EntityFramework.FunctionalTests/OptimisticConcurrencyTestBase.cs
+++ b/test/EntityFramework.FunctionalTests/OptimisticConcurrencyTestBase.cs
@@ -139,6 +139,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     {
                         var driverEntry = ex.StateEntries.Single();
                         driverEntry.OriginalValues.SetValues(driverEntry.GetDatabaseValues(c));
+                        ResolveConcurrencyTokens(driverEntry);
                     });
         }
 
@@ -152,6 +153,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         var storeValues = driverEntry.GetDatabaseValues(c);
                         driverEntry.SetValues(storeValues);
                         driverEntry.OriginalValues.SetValues(storeValues);
+                        ResolveConcurrencyTokens(driverEntry);
                     });
         }
 
@@ -163,6 +165,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     {
                         var driverEntry = ex.StateEntries.Single();
                         driverEntry.OriginalValues.SetValues(driverEntry.GetDatabaseValues(c));
+                        ResolveConcurrencyTokens(driverEntry);
                         ((Driver)driverEntry.Entity).Podiums = 10;
                     });
         }
@@ -480,6 +483,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                         var storeValues = entry.GetDatabaseValues(c);
                         entry.OriginalValues.SetValues(storeValues);
                         entry.SetValues(storeValues);
+                        ResolveConcurrencyTokens(entry);
                     },
                 c => Assert.Equal(1, c.Drivers.Single(d => d.Name == "Fernando Alonso").Wins));
         }
@@ -696,6 +700,11 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
         private const int StorePodiums = 20;
         private const int ClientPodiums = 30;
+
+        protected virtual void ResolveConcurrencyTokens(StateEntry stateEntry)
+        {
+            // default do nothing. Allow provider-specific entry reset
+        }
 
         protected abstract Task<TTestStore> CreateTestDatabaseAsync();
 


### PR DESCRIPTION
Add the optimistic concurrency tests, and fix bugs they revealed. 

:bug: fixed:
- Ats query pipeline support for nullable types
- Query string type mismatch when querying on rowkey and partitionkey
- Concurrency errors when row has been deleted

(Will squash to one commit before merge.)
