### PR TITLE
The kangaroos are hopping...

### DIFF
--- a/src/EntityFramework.InMemory/InMemoryValueGenerator.cs
+++ b/src/EntityFramework.InMemory/InMemoryValueGenerator.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Threading;
+using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Identity;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.InMemory.Utilities;
 using Microsoft.Data.Entity.Metadata;
 
@@ -14,9 +14,9 @@ namespace Microsoft.Data.Entity.InMemory
     {
         private long _current;
 
-        public override object Next(DbContextConfiguration contextConfiguration, IProperty property)
+        public override object Next(StateEntry entry, IProperty property)
         {
-            Check.NotNull(contextConfiguration, "contextConfiguration");
+            Check.NotNull(entry, "entry");
             Check.NotNull(property, "property");
 
             return Convert.ChangeType(Interlocked.Increment(ref _current), property.PropertyType);

--- a/src/EntityFramework.InMemory/InMemoryValueGeneratorCache.cs
+++ b/src/EntityFramework.InMemory/InMemoryValueGeneratorCache.cs
@@ -8,8 +8,10 @@ namespace Microsoft.Data.Entity.InMemory
 {
     public class InMemoryValueGeneratorCache : ValueGeneratorCache
     {
-        public InMemoryValueGeneratorCache([NotNull] InMemoryValueGeneratorSelector selector)
-            : base(selector)
+        public InMemoryValueGeneratorCache(
+            [NotNull] InMemoryValueGeneratorSelector selector, 
+            [NotNull] ForeignKeyValueGenerator foreignKeyValueGenerator)
+            : base(selector, foreignKeyValueGenerator)
         {
         }
     }

--- a/src/EntityFramework.Relational/Update/ModificationCommand.cs
+++ b/src/EntityFramework.Relational/Update/ModificationCommand.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Data.Entity.Relational.Update
 
                 foreach (var property in entityType.Properties)
                 {
-                    var isKey = entityType.GetKey().Properties.Contains(property);
+                    var isKey = property.IsPrimaryKey();
 
                     var isCondition = !adding && (isKey || property.IsConcurrencyToken);
 

--- a/src/EntityFramework.Relational/Update/ModificationCommandBatch.cs
+++ b/src/EntityFramework.Relational/Update/ModificationCommandBatch.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Data.Entity.Relational.Update
 
                     // TODO: Perf: Avoid doing Contains check everywhere we need to know if a property is part of a foreign key
                     var isKey = columnModification.IsKey
-                                || property.EntityType.ForeignKeys.SelectMany(k => k.Properties).Contains(property);
+                                || property.IsForeignKey();
 
                     var typeMapping = typeMapper
                         .GetTypeMapping(

--- a/src/EntityFramework.SQLite/SQLiteValueGeneratorCache.cs
+++ b/src/EntityFramework.SQLite/SQLiteValueGeneratorCache.cs
@@ -8,8 +8,10 @@ namespace Microsoft.Data.Entity.SQLite
 {
     public class SQLiteValueGeneratorCache : ValueGeneratorCache
     {
-        public SQLiteValueGeneratorCache([NotNull] SQLiteValueGeneratorSelector selector)
-            : base(selector)
+        public SQLiteValueGeneratorCache(
+            [NotNull] SQLiteValueGeneratorSelector selector,
+            [NotNull] ForeignKeyValueGenerator foreignKeyValueGenerator)
+            : base(selector, foreignKeyValueGenerator)
         {
         }
     }

--- a/src/EntityFramework.SqlServer/SequentialGuidValueGenerator.cs
+++ b/src/EntityFramework.SqlServer/SequentialGuidValueGenerator.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Threading;
+using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Identity;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.SqlServer.Utilities;
 
@@ -14,9 +14,9 @@ namespace Microsoft.Data.Entity.SqlServer
     {
         private long _counter = DateTime.UtcNow.Ticks;
 
-        public override object Next(DbContextConfiguration contextConfiguration, IProperty property)
+        public override object Next(StateEntry entry, IProperty property)
         {
-            Check.NotNull(contextConfiguration, "contextConfiguration");
+            Check.NotNull(entry, "entry");
             Check.NotNull(property, "property");
 
             var guidBytes = Guid.NewGuid().ToByteArray();

--- a/src/EntityFramework.SqlServer/SqlServerValueGeneratorCache.cs
+++ b/src/EntityFramework.SqlServer/SqlServerValueGeneratorCache.cs
@@ -8,8 +8,10 @@ namespace Microsoft.Data.Entity.SqlServer
 {
     public class SqlServerValueGeneratorCache : ValueGeneratorCache
     {
-        public SqlServerValueGeneratorCache([NotNull] SqlServerValueGeneratorSelector selector)
-            : base(selector)
+        public SqlServerValueGeneratorCache(
+            [NotNull] SqlServerValueGeneratorSelector selector, 
+            [NotNull] ForeignKeyValueGenerator foreignKeyValueGenerator)
+            : base(selector, foreignKeyValueGenerator)
         {
         }
     }

--- a/src/EntityFramework/ChangeTracking/ChangeDetector.cs
+++ b/src/EntityFramework/ChangeTracking/ChangeDetector.cs
@@ -168,8 +168,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
 
         private bool DetectForeignKeyChange(StateEntry entry, IProperty property)
         {
-            // TODO: Consider flag/index for fast check for FK
-            if (entry.EntityType.ForeignKeys.SelectMany(fk => fk.Properties).Contains(property))
+            if (property.IsForeignKey())
             {
                 var snapshotValue = entry.RelationshipsSnapshot[property];
                 var currentValue = entry[property];
@@ -234,7 +233,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
         private bool DetectPrincipalKeyChange(StateEntry entry, IProperty property)
         {
             // TODO: Perf: make it fast to check if a property is part of the primary key
-            var isPrimaryKey = entry.EntityType.GetKey().Properties.Contains(property);
+            var isPrimaryKey = property.IsPrimaryKey();
 
             // TODO: Perf: make it faster to check if the property is at the principal end or not
             var foreignKeys = _configuration.Model.GetReferencingForeignKeys(property).ToArray();

--- a/src/EntityFramework/ChangeTracking/StateEntry.cs
+++ b/src/EntityFramework/ChangeTracking/StateEntry.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             return generators == null
                 ? null
                 : generators
-                    .Select(t => t.Item2 == null ? null : Tuple.Create(t.Item1, t.Item2.Next(_configuration, t.Item1)))
+                    .Select(t => t.Item2 == null ? null : Tuple.Create(t.Item1, t.Item2.Next(this, t.Item1)))
                     .ToArray();
         }
 
@@ -165,7 +165,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
                 if (generator != null)
                 {
                     var property = generators[i].Item1;
-                    values[i] = Tuple.Create(property, await generator.NextAsync(_configuration, property, cancellationToken));
+                    values[i] = Tuple.Create(property, await generator.NextAsync(this, property, cancellationToken: cancellationToken));
                 }
             }
             return values;
@@ -178,7 +178,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             {
                 return null;
             }
-            var properties = _entityType.Properties.Where(p => p.ValueGenerationOnAdd != ValueGenerationOnAdd.None);
+            var properties = _entityType.Properties.Where(p => p.ValueGenerationOnAdd != ValueGenerationOnAdd.None || p.IsForeignKey());
             return properties.Select(p => Tuple.Create(p, _configuration.ValueGeneratorCache.GetGenerator(p))).ToArray();
         }
 
@@ -219,7 +219,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
 
             if (newState == EntityState.Added)
             {
-                foreach (var generatedValue in generatedValues.Where(v => v != null))
+                foreach (var generatedValue in generatedValues.Where(v => v != null && v.Item2 != null))
                 {
                     this[generatedValue.Item1] = generatedValue.Item2;
                 }

--- a/src/EntityFramework/EntityFramework.csproj
+++ b/src/EntityFramework/EntityFramework.csproj
@@ -72,6 +72,7 @@
     <Compile Include="EntityState.cs" />
     <Compile Include="EntityStateExtensions.cs" />
     <Compile Include="ChangeTracking\PropertyBagExtensions.cs" />
+    <Compile Include="Identity\ForeignKeyValueGenerator.cs" />
     <Compile Include="Identity\GuidValueGenerator.cs" />
     <Compile Include="Identity\IValueGenerator.cs" />
     <Compile Include="Identity\IValueGeneratorFactory.cs" />
@@ -91,6 +92,7 @@
     <Compile Include="Metadata\Index.cs" />
     <Compile Include="Metadata\NavigationExtensions.cs" />
     <Compile Include="Metadata\EntityTypeNameComparer.cs" />
+    <Compile Include="Metadata\PropertyExtensions.cs" />
     <Compile Include="Query\AsyncResultOperatorHandler.cs" />
     <Compile Include="Query\IResultOperatorHandler.cs" />
     <Compile Include="Query\QueryCompilationContext.cs" />

--- a/src/EntityFramework/Extensions/EntityServiceCollectionExtensions.cs
+++ b/src/EntityFramework/Extensions/EntityServiceCollectionExtensions.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddSingleton<ClrCollectionAccessorSource>()
                 .AddSingleton<EntityMaterializerSource>()
                 .AddSingleton<CompositeEntityKeyFactory>()
+                .AddSingleton<ForeignKeyValueGenerator>()
                 .AddSingleton<MemberMapper>()
                 .AddSingleton<FieldMatcher>()
                 .AddSingleton<OriginalValuesFactory>()

--- a/src/EntityFramework/Identity/ForeignKeyValueGenerator.cs
+++ b/src/EntityFramework/Identity/ForeignKeyValueGenerator.cs
@@ -1,0 +1,102 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Identity
+{
+    public class ForeignKeyValueGenerator : SimpleValueGenerator
+    {
+        private readonly ClrPropertyGetterSource _getterSource;
+        private readonly ClrCollectionAccessorSource _collectionAccessorSource;
+
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected ForeignKeyValueGenerator()
+        {
+        }
+
+        public ForeignKeyValueGenerator(
+            [NotNull] ClrPropertyGetterSource getterSource,
+            [NotNull] ClrCollectionAccessorSource collectionAccessorSource)
+        {
+            Check.NotNull(getterSource, "getterSource");
+            Check.NotNull(collectionAccessorSource, "collectionAccessorSource");
+
+            _getterSource = getterSource;
+            _collectionAccessorSource = collectionAccessorSource;
+        }
+
+        public override object Next(StateEntry entry, IProperty property)
+        {
+            Check.NotNull(property, "property");
+
+            Contract.Assert(property.IsForeignKey());
+
+            var entityType = property.EntityType;
+            var stateManager = entry.Configuration.StateManager;
+
+            foreach (var foreignKey in entityType.ForeignKeys)
+            {
+                for (var propertyIndex = 0; propertyIndex < foreignKey.Properties.Count; propertyIndex++)
+                {
+                    if (property == foreignKey.Properties[propertyIndex])
+                    {
+                        foreach (var navigation in entityType.Navigations
+                            .Concat(foreignKey.ReferencedEntityType.Navigations)
+                            .Where(n => n.ForeignKey == foreignKey)
+                            .Distinct())
+                        {
+                            var principal = TryFindPrincipal(stateManager, navigation, entry.Entity);
+
+                            if (principal != null)
+                            {
+                                var principalEntry = stateManager.GetOrCreateEntry(principal);
+
+                                return principalEntry[foreignKey.ReferencedProperties[propertyIndex]];
+                            }
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private object TryFindPrincipal(StateManager stateManager, INavigation navigation, object dependentEntity)
+        {
+            if (navigation.PointsToPrincipal)
+            {
+                return _getterSource.GetAccessor(navigation).GetClrValue(dependentEntity);
+            }
+
+            // TODO: Perf
+            foreach (var principalEntry in stateManager.StateEntries
+                .Where(e => e.EntityType == navigation.ForeignKey.ReferencedEntityType))
+            {
+                if (navigation.IsCollection())
+                {
+                    if (_collectionAccessorSource.GetAccessor(navigation).Contains(principalEntry.Entity, dependentEntity))
+                    {
+                        return principalEntry.Entity;
+                    }
+                }
+                else if (_getterSource.GetAccessor(navigation).GetClrValue(principalEntry.Entity) == dependentEntity)
+                {
+                    return principalEntry.Entity;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/EntityFramework/Identity/GuidValueGenerator.cs
+++ b/src/EntityFramework/Identity/GuidValueGenerator.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 
@@ -10,9 +10,9 @@ namespace Microsoft.Data.Entity.Identity
 {
     public class GuidValueGenerator : SimpleValueGenerator
     {
-        public override object Next(DbContextConfiguration contextConfiguration, IProperty property)
+        public override object Next(StateEntry entry, IProperty property)
         {
-            Check.NotNull(contextConfiguration, "contextConfiguration");
+            Check.NotNull(entry, "entry");
             Check.NotNull(property, "property");
 
             return Guid.NewGuid();

--- a/src/EntityFramework/Identity/IValueGenerator.cs
+++ b/src/EntityFramework/Identity/IValueGenerator.cs
@@ -4,17 +4,17 @@
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.Identity
 {
     public interface IValueGenerator
     {
-        object Next([NotNull] DbContextConfiguration contextConfiguration, [NotNull] IProperty property);
+        object Next([NotNull] StateEntry entry, [NotNull] IProperty property);
 
         Task<object> NextAsync(
-            [NotNull] DbContextConfiguration contextConfiguration,
+            [NotNull] StateEntry stateEntry,
             [NotNull] IProperty property,
             CancellationToken cancellationToken = default(CancellationToken));
     }

--- a/src/EntityFramework/Identity/SimpleValueGenerator.cs
+++ b/src/EntityFramework/Identity/SimpleValueGenerator.cs
@@ -3,7 +3,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 
@@ -11,17 +11,17 @@ namespace Microsoft.Data.Entity.Identity
 {
     public abstract class SimpleValueGenerator : IValueGenerator
     {
-        public abstract object Next(DbContextConfiguration contextConfiguration, IProperty property);
+        public abstract object Next(StateEntry entry, IProperty property);
 
         public virtual Task<object> NextAsync(
-            DbContextConfiguration contextConfiguration,
+            StateEntry stateEntry,
             IProperty property,
-            CancellationToken cancellationToken = new CancellationToken())
+            CancellationToken cancellationToken = default(CancellationToken))
         {
-            Check.NotNull(contextConfiguration, "contextConfiguration");
+            Check.NotNull(stateEntry, "stateEntry");
             Check.NotNull(property, "property");
 
-            return Task.FromResult(Next(contextConfiguration, property));
+            return Task.FromResult(Next(stateEntry, property));
         }
     }
 }

--- a/src/EntityFramework/Identity/TemporaryValueGenerator.cs
+++ b/src/EntityFramework/Identity/TemporaryValueGenerator.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Threading;
-using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 
@@ -13,9 +13,9 @@ namespace Microsoft.Data.Entity.Identity
     {
         private long _current;
 
-        public override object Next(DbContextConfiguration contextConfiguration, IProperty property)
+        public override object Next(StateEntry entry, IProperty property)
         {
-            Check.NotNull(contextConfiguration, "contextConfiguration");
+            Check.NotNull(entry, "entry");
             Check.NotNull(property, "property");
 
             return Convert.ChangeType(Interlocked.Decrement(ref _current), property.PropertyType);

--- a/src/EntityFramework/Identity/ValueGeneratorCache.cs
+++ b/src/EntityFramework/Identity/ValueGeneratorCache.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Data.Entity.Identity
     public class ValueGeneratorCache
     {
         private readonly ValueGeneratorSelector _selector;
+        private readonly ForeignKeyValueGenerator _foreignKeyValueGenerator;
 
         private readonly ThreadSafeDictionaryCache<string, IValueGeneratorPool> _cache
             = new ThreadSafeDictionaryCache<string, IValueGeneratorPool>();
@@ -24,11 +25,15 @@ namespace Microsoft.Data.Entity.Identity
         {
         }
 
-        public ValueGeneratorCache([NotNull] ValueGeneratorSelector selector)
+        public ValueGeneratorCache(
+            [NotNull] ValueGeneratorSelector selector,
+            [NotNull] ForeignKeyValueGenerator foreignKeyValueGenerator)
         {
             Check.NotNull(selector, "selector");
+            Check.NotNull(foreignKeyValueGenerator, "foreignKeyValueGenerator");
 
             _selector = selector;
+            _foreignKeyValueGenerator = foreignKeyValueGenerator;
         }
 
         public virtual IValueGenerator GetGenerator([NotNull] IProperty property)
@@ -36,6 +41,11 @@ namespace Microsoft.Data.Entity.Identity
             Check.NotNull(property, "property");
 
             // TODO: Consider if a specific generator has been set on the property then use it instead
+
+            if (property.IsForeignKey())
+            {
+                return _foreignKeyValueGenerator;
+            }
 
             var factory = _selector.Select(property);
 

--- a/src/EntityFramework/Metadata/PropertyExtensions.cs
+++ b/src/EntityFramework/Metadata/PropertyExtensions.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Metadata
+{
+    public static class PropertyExtensions
+    {
+        public static bool IsForeignKey([NotNull] this IProperty property)
+        {
+            Check.NotNull(property, "property");
+
+            // TODO: Perf: Avoid doing Contains check everywhere we need to know if a property is part of a foreign key
+            return property.EntityType.ForeignKeys.SelectMany(k => k.Properties).Contains(property);
+        }
+
+        public static bool IsPrimaryKey([NotNull] this IProperty property)
+        {
+            Check.NotNull(property, "property");
+
+            // TODO: Perf: make it fast to check if a property is part of the primary key
+            return property.EntityType.GetKey().Properties.Contains(property);
+        }
+    }
+}

--- a/test/EntityFramework.AzureTableStorage.FunctionalTests/OptimisticConcurrencyTests.cs
+++ b/test/EntityFramework.AzureTableStorage.FunctionalTests/OptimisticConcurrencyTests.cs
@@ -8,7 +8,6 @@ using Microsoft.Data.Entity.AzureTableStorage.Metadata;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.Identity;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Fallback;
@@ -131,7 +130,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.FunctionalTests
         {
             private class IntGenerator : SimpleValueGenerator
             {
-                public override object Next(DbContextConfiguration contextConfiguration, IProperty property)
+                public override object Next(StateEntry entry, IProperty property)
                 {
                     return Guid.NewGuid().GetHashCode();
                 }

--- a/test/EntityFramework.FunctionalTests/MonsterFixupTestBase.cs
+++ b/test/EntityFramework.FunctionalTests/MonsterFixupTestBase.cs
@@ -163,6 +163,44 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void Can_build_monster_model_and_seed_data_using_navigations_with_deferred_add()
+        {
+            const string databaseName = SnapshotDatabaseName + "_AllNavsDeferred";
+            Can_build_monster_model_and_seed_data_using_navigations_with_deferred_add_test(p => CreateSnapshotMonsterContext(p, databaseName), databaseName);
+        }
+
+        [Fact]
+        public virtual void Can_build_monster_model_with_full_notification_entities_and_seed_data_using_navigations_with_deferred_add()
+        {
+            const string databaseName = FullNotifyDatabaseName + "_AllNavsDeferred";
+            Can_build_monster_model_and_seed_data_using_navigations_with_deferred_add_test(p => CreateChangedChangingMonsterContext(p, databaseName), databaseName);
+        }
+
+        [Fact]
+        public virtual void Can_build_monster_model_with_changed_only_notification_entities_and_seed_data_using_navigations_with_deferred_add()
+        {
+            const string databaseName = ChangedOnlyDatabaseName + "_AllNavsDeferred";
+            Can_build_monster_model_and_seed_data_using_navigations_with_deferred_add_test(p => CreateChangedOnlyMonsterContext(p, databaseName), databaseName);
+        }
+
+        private void Can_build_monster_model_and_seed_data_using_navigations_with_deferred_add_test(
+            Func<IServiceProvider, MonsterContext> createContext, string databaseName)
+        {
+            var serviceProvider = CreateServiceProvider();
+
+            using (var context = createContext(serviceProvider))
+            {
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
+                context.SeedUsingNavigationsWithDeferredAdd();
+            }
+
+            SimpleVerification(() => createContext(serviceProvider));
+            FkVerification(() => createContext(serviceProvider));
+            NavigationVerification(() => createContext(serviceProvider));
+        }
+
+        [Fact]
         public virtual async Task Store_generated_values_are_discarded_if_saving_changes_fails()
         {
             const string databaseName = SnapshotDatabaseName + "_Bad";
@@ -1129,10 +1167,9 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     new[] { "Better than Tarqies!", "Eeky says yes!", "Good with maple syrup." },
                     context.ProductReviews.Select(c => c.Review).OrderBy(n => n));
 
-                // TODO: Remove ToArray once LINQ to EF7 can support this query
                 Assert.Equal(
                     new[] { "101", "103", "105" },
-                    context.ProductPhotos.ToArray().Select(c => c.Photo.First().ToString()).OrderBy(n => n));
+                    context.ProductPhotos.Select(c => c.Photo.First().ToString()).OrderBy(n => n));
 
                 Assert.Equal(
                     new[] { "Waffle Style", "What does the waffle say?" },

--- a/test/EntityFramework.FunctionalTests/TestModels/MonsterContext.cs
+++ b/test/EntityFramework.FunctionalTests/TestModels/MonsterContext.cs
@@ -47,5 +47,6 @@ namespace Microsoft.Data.Entity.MonsterModel
 
         public abstract void SeedUsingFKs(bool saveChanges = true);
         public abstract void SeedUsingNavigations(bool dependentNavs, bool principalNavs, bool saveChanges = true);
+        public abstract void SeedUsingNavigationsWithDeferredAdd(bool saveChanges = true);
     }
 }

--- a/test/EntityFramework.FunctionalTests/TestModels/MonsterContext`.cs
+++ b/test/EntityFramework.FunctionalTests/TestModels/MonsterContext`.cs
@@ -265,7 +265,6 @@ namespace Microsoft.Data.Entity.MonsterModel
             builder.Entity<TProductWebFeature>().ForeignKeys(fk => fk.ForeignKey<TProductReview>(e => new { e.ProductId, e.ReviewId }));
             builder.Entity<TResolution>().ForeignKeys(fk => fk.ForeignKey<TComplaint>(e => e.ResolutionId, isUnique: true));
             builder.Entity<TIncorrectScan>().ForeignKeys(fk => fk.ForeignKey<TBarcode>(e => e.ExpectedCode));
-            builder.Entity<TCustomer>().ForeignKeys(fk => fk.ForeignKey<TCustomer>(e => e.CustomerId));
             builder.Entity<TCustomer>().ForeignKeys(fk => fk.ForeignKey<TCustomer>(e => e.HusbandId, isUnique: true));
             builder.Entity<TIncorrectScan>().ForeignKeys(fk => fk.ForeignKey<TBarcode>(e => e.ActualCode));
             builder.Entity<TBarcode>().ForeignKeys(fk => fk.ForeignKey<TProduct>(e => e.ProductId));
@@ -784,17 +783,15 @@ namespace Microsoft.Data.Entity.MonsterModel
             var rsaToken1 = Add(new TRsaToken { Issued = DateTime.Now, Serial = "1234", Login = login1 });
             var rsaToken2 = Add(new TRsaToken { Issued = DateTime.Now, Serial = "2234", Login = login2 });
 
-            // TODO: Dependent PK of identifying relationship should not need to be set
-            var smartCard1 = Add(new TSmartCard { Username = login1.Username, Login = dependentNavs ? login1 : null, CardSerial = rsaToken1.Serial, Issued = rsaToken1.Issued });
-            var smartCard2 = Add(new TSmartCard { Username = login2.Username, Login = dependentNavs ? login2 : null, CardSerial = rsaToken2.Serial, Issued = rsaToken2.Issued });
+            var smartCard1 = Add(new TSmartCard { Login = login1, CardSerial = rsaToken1.Serial, Issued = rsaToken1.Issued });
+            var smartCard2 = Add(new TSmartCard { Login = login2, CardSerial = rsaToken2.Serial, Issued = rsaToken2.Issued });
 
             var reset1 = Add(new TPasswordReset
                 {
                     EmailedTo = "trent@example.com",
                     ResetNo = 1,
                     TempPassword = "Rent-A-Mole",
-                    Username = login3.Username, // TODO: Dependent PK of identifying relationship should not need to be set
-                    Login = dependentNavs ? login3 : null
+                    Login = login3
                 });
 
             var pageView1 = Add(new TPageView { PageUrl = "somePage1", Login = login1, Viewed = DateTime.Now });
@@ -805,8 +802,7 @@ namespace Microsoft.Data.Entity.MonsterModel
                 {
                     LoggedIn = new DateTime(2014, 5, 27, 10, 22, 26),
                     LoggedOut = new DateTime(2014, 5, 27, 11, 22, 26),
-                    Username = login1.Username, // TODO: Dependent PK of identifying relationship should not need to be set
-                    Login = dependentNavs ? login1 : null,
+                    Login = login1,
                     SmartcardUsername = smartCard1.Username
                 });
             if (principalNavs)
@@ -819,8 +815,7 @@ namespace Microsoft.Data.Entity.MonsterModel
                 {
                     LoggedIn = new DateTime(2014, 5, 27, 12, 22, 26),
                     LoggedOut = new DateTime(2014, 5, 27, 13, 22, 26),
-                    Username = login2.Username, // TODO: Dependent PK of identifying relationship should not need to be set
-                    Login = dependentNavs ? login2 : null,
+                    Login = login2,
                     SmartcardUsername = smartCard2.Username
                 });
             if (principalNavs)
@@ -833,8 +828,7 @@ namespace Microsoft.Data.Entity.MonsterModel
                 {
                     Subject = "Tea?",
                     Body = "Fancy a cup of tea?",
-                    FromUsername = login1.Username, // TODO: Dependent PK of identifying relationship should not need to be set
-                    Sender = dependentNavs ? login1 : null,
+                    Sender = login1,
                     Recipient = dependentNavs ? login2 : null,
                     Sent = DateTime.Now,
                 });
@@ -848,8 +842,7 @@ namespace Microsoft.Data.Entity.MonsterModel
                 {
                     Subject = "Re: Tea?",
                     Body = "Love one!",
-                    FromUsername = login2.Username, // TODO: Dependent PK of identifying relationship should not need to be set
-                    Sender = dependentNavs ? login2 : null,
+                    Sender = login2,
                     Recipient = dependentNavs ? login1 : null,
                     Sent = DateTime.Now,
                 });
@@ -863,8 +856,7 @@ namespace Microsoft.Data.Entity.MonsterModel
                 {
                     Subject = "Re: Tea?",
                     Body = "I'll put the kettle on.",
-                    FromUsername = login1.Username, // TODO: Dependent PK of identifying relationship should not need to be set
-                    Sender = dependentNavs ? login1 : null,
+                    Sender = login1,
                     Recipient = dependentNavs ? login2 : null,
                     Sent = DateTime.Now,
                 });
@@ -897,18 +889,16 @@ namespace Microsoft.Data.Entity.MonsterModel
                 order1.Notes.Add(orderNote3);
             }
 
-            // TODO: Dependent PK of identifying relationship should not need to be set
-            var orderQualityCheck1 = Add(new TOrderQualityCheck { OrderId = order1.AnOrderId, Order = dependentNavs ? order1 : null, CheckedBy = "Eeky Bear" });
-            var orderQualityCheck2 = Add(new TOrderQualityCheck { OrderId = order2.AnOrderId, Order = dependentNavs ? order2 : null, CheckedBy = "Eeky Bear" });
-            var orderQualityCheck3 = Add(new TOrderQualityCheck { OrderId = order3.AnOrderId, Order = dependentNavs ? order3 : null, CheckedBy = "Eeky Bear" });
+            var orderQualityCheck1 = Add(new TOrderQualityCheck { Order = order1, CheckedBy = "Eeky Bear" });
+            var orderQualityCheck2 = Add(new TOrderQualityCheck { Order = order2, CheckedBy = "Eeky Bear" });
+            var orderQualityCheck3 = Add(new TOrderQualityCheck { Order = order3, CheckedBy = "Eeky Bear" });
 
-            // TODO: Dependent PK of identifying relationship should not need to be set
-            var orderLine1 = Add(new TOrderLine { OrderId = order1.AnOrderId, ProductId = product1.ProductId, Order = dependentNavs ? order1 : null, Product = dependentNavs ? product1 : null, Quantity = 7 });
-            var orderLine2 = Add(new TOrderLine { OrderId = order1.AnOrderId, ProductId = product2.ProductId, Order = dependentNavs ? order1 : null, Product = dependentNavs ? product2 : null, Quantity = 1 });
-            var orderLine3 = Add(new TOrderLine { OrderId = order2.AnOrderId, ProductId = product3.ProductId, Order = dependentNavs ? order2 : null, Product = dependentNavs ? product3 : null, Quantity = 2 });
-            var orderLine4 = Add(new TOrderLine { OrderId = order2.AnOrderId, ProductId = product2.ProductId, Order = dependentNavs ? order2 : null, Product = dependentNavs ? product2 : null, Quantity = 3 });
-            var orderLine5 = Add(new TOrderLine { OrderId = order2.AnOrderId, ProductId = product1.ProductId, Order = dependentNavs ? order2 : null, Product = dependentNavs ? product1 : null, Quantity = 4 });
-            var orderLine6 = Add(new TOrderLine { OrderId = order3.AnOrderId, ProductId = product2.ProductId, Order = dependentNavs ? order3 : null, Product = dependentNavs ? product2 : null, Quantity = 5 });
+            var orderLine1 = Add(new TOrderLine { Order = order1, Product = product1, Quantity = 7 });
+            var orderLine2 = Add(new TOrderLine { Order = order1, Product = product2, Quantity = 1 });
+            var orderLine3 = Add(new TOrderLine { Order = order2, Product = product3, Quantity = 2 });
+            var orderLine4 = Add(new TOrderLine { Order = order2, Product = product2, Quantity = 3 });
+            var orderLine5 = Add(new TOrderLine { Order = order2, Product = product1, Quantity = 4 });
+            var orderLine6 = Add(new TOrderLine { Order = order3, Product = product2, Quantity = 5 });
             if (principalNavs)
             {
                 order1.OrderLines.Add(orderLine1);
@@ -919,9 +909,8 @@ namespace Microsoft.Data.Entity.MonsterModel
                 order3.OrderLines.Add(orderLine6);
             }
 
-            // TODO: Dependent PK of identifying relationship should not need to be set
-            var productDetail1 = Add(new TProductDetail { Details = "A Waffle Cart specialty!", ProductId = product1.ProductId, Product = dependentNavs ? product1 : null });
-            var productDetail2 = Add(new TProductDetail { Details = "Eeky Bear's favorite!", ProductId = product2.ProductId, Product = dependentNavs ? product2 : null });
+            var productDetail1 = Add(new TProductDetail { Details = "A Waffle Cart specialty!", Product = product1 });
+            var productDetail2 = Add(new TProductDetail { Details = "Eeky Bear's favorite!", Product = product2 });
             if (principalNavs)
             {
                 product1.Detail = productDetail1;
@@ -998,8 +987,7 @@ namespace Microsoft.Data.Entity.MonsterModel
 
             var computerDetail1 = Add(new TComputerDetail
                 {
-                    ComputerDetailId = computer1.ComputerId, // TODO: Dependent PK of identifying relationship should not need to be set
-                    Computer = dependentNavs ? computer1 : null,
+                    Computer = computer1,
                     Manufacturer = "Dell",
                     Model = "420",
                     PurchaseDate = new DateTime(2008, 4, 1),
@@ -1013,8 +1001,7 @@ namespace Microsoft.Data.Entity.MonsterModel
 
             var computerDetail2 = Add(new TComputerDetail
                 {
-                    ComputerDetailId = computer2.ComputerId, // TODO: Dependent PK of identifying relationship should not need to be set
-                    Computer = dependentNavs ? computer2 : null,
+                    Computer = computer2,
                     Manufacturer = "Not A Dell",
                     Model = "Not 420",
                     PurchaseDate = new DateTime(2012, 4, 1),
@@ -1031,8 +1018,7 @@ namespace Microsoft.Data.Entity.MonsterModel
 
             var license1 = Add(new TLicense
                 {
-                    Name = driver1.Name, // TODO: Dependent PK of identifying relationship should not need to be set
-                    Driver = dependentNavs ? driver1 : null,
+                    Driver = driver1,
                     LicenseClass = "C",
                     LicenseNumber = "10",
                     Restrictions = "None",
@@ -1046,8 +1032,7 @@ namespace Microsoft.Data.Entity.MonsterModel
 
             var license2 = Add(new TLicense
                 {
-                    Name = driver2.Name, // TODO: Dependent PK of identifying relationship should not need to be set
-                    Driver = dependentNavs ? driver2 : null,
+                    Driver = driver2,
                     LicenseClass = "A",
                     LicenseNumber = "11",
                     Restrictions = "None",
@@ -1063,6 +1048,314 @@ namespace Microsoft.Data.Entity.MonsterModel
             {
                 SaveChanges();
             }
+        }
+
+        public override void SeedUsingNavigationsWithDeferredAdd(bool saveChanges = true)
+        {
+            var toAdd = new List<object>[4];
+
+            for (var i = 0; i < toAdd.Length; i++)
+            {
+                toAdd[i] = new List<object>();
+            }
+
+            var customer0 = toAdd[0].AddEx(new TCustomer { Name = "Eeky Bear" });
+            var customer1 = toAdd[0].AddEx(new TCustomer { Name = "Sheila Koalie" });
+            var customer3 = toAdd[0].AddEx(new TCustomer { Name = "Tarquin Tiger" });
+            var customer2 = toAdd[0].AddEx(new TCustomer { Name = "Sue Pandy", Husband = customer0 });
+
+            var product1 = toAdd[0].AddEx(new TProduct { Description = "Mrs Koalie's Famous Waffles", BaseConcurrency = "Pounds Sterling" });
+            var product2 = toAdd[0].AddEx(new TProduct { Description = "Chocolate Donuts", BaseConcurrency = "US Dollars" });
+            var product3 = toAdd[0].AddEx(new TProduct { Description = "Assorted Dog Treats", BaseConcurrency = "Stuffy Money" });
+
+            var barcode1 = toAdd[1].AddEx(new TBarcode { Code = new byte[] { 1, 2, 3, 4 }, Text = "Barcode 1 2 3 4" });
+            var barcode2 = toAdd[1].AddEx(new TBarcode { Code = new byte[] { 2, 2, 3, 4 }, Text = "Barcode 2 2 3 4" });
+            var barcode3 = toAdd[1].AddEx(new TBarcode { Code = new byte[] { 3, 2, 3, 4 }, Text = "Barcode 3 2 3 4" });
+
+            product1.Barcodes.Add(barcode1);
+            product2.Barcodes.Add(barcode2);
+            product3.Barcodes.Add(barcode3);
+
+            var barcodeDetails1 = toAdd[1].AddEx(new TBarcodeDetail { RegisteredTo = "Eeky Bear" });
+            var barcodeDetails2 = toAdd[1].AddEx(new TBarcodeDetail { RegisteredTo = "Trent" });
+
+            barcode1.Detail = barcodeDetails1;
+            barcode2.Detail = barcodeDetails2;
+
+            var incorrectScan1 = toAdd[1].AddEx(
+                new TIncorrectScan
+                    {
+                        ScanDate = new DateTime(2014, 5, 28, 19, 9, 6),
+                        Details = "Treats not Donuts",
+                        ActualBarcode = barcode3
+                    });
+            barcode2.BadScans.Add(incorrectScan1);
+
+            var incorrectScan2 = toAdd[1].AddEx(
+                new TIncorrectScan
+                    {
+                        ScanDate = new DateTime(2014, 5, 28, 19, 15, 31),
+                        Details = "Wot no waffles?",
+                        ActualBarcode = barcode2
+                    });
+            barcode1.BadScans.Add(incorrectScan2);
+
+            var complaint1 = toAdd[1].AddEx(new TComplaint
+                {
+                    Customer = customer2,
+                    Details = "Don't give coffee to Eeky!",
+                    Logged = new DateTime(2014, 5, 27, 19, 22, 26)
+                });
+
+            var complaint2 = toAdd[1].AddEx(new TComplaint
+                {
+                    Customer = customer2,
+                    Details = "Really! Don't give coffee to Eeky!",
+                    Logged = new DateTime(2014, 5, 28, 19, 22, 26)
+                });
+
+            var resolution = toAdd[2].AddEx(new TResolution { Details = "Destroyed all coffee in Redmond area." });
+            complaint2.Resolution = resolution;
+
+            var login1 = toAdd[1].AddEx(new TLogin { Username = "MrsKoalie73" });
+            var login2 = toAdd[1].AddEx(new TLogin { Username = "MrsBossyPants" });
+            var login3 = toAdd[1].AddEx(new TLogin { Username = "TheStripedMenace" });
+
+            customer1.Logins.Add(login1);
+            customer2.Logins.Add(login2);
+            customer3.Logins.Add(login3);
+
+            var suspiciousActivity1 = toAdd[2].AddEx(new TSuspiciousActivity { Activity = "Pig prints on keyboard", Username = login3.Username });
+            var suspiciousActivity2 = toAdd[2].AddEx(new TSuspiciousActivity { Activity = "Crumbs in the cupboard", Username = login3.Username });
+            var suspiciousActivity3 = toAdd[2].AddEx(new TSuspiciousActivity { Activity = "Donuts gone missing", Username = login3.Username });
+
+            var rsaToken1 = toAdd[2].AddEx(new TRsaToken { Issued = DateTime.Now, Serial = "1234", Login = login1 });
+            var rsaToken2 = toAdd[2].AddEx(new TRsaToken { Issued = DateTime.Now, Serial = "2234", Login = login2 });
+
+            var smartCard1 = toAdd[2].AddEx(new TSmartCard { Login = login1, CardSerial = rsaToken1.Serial, Issued = rsaToken1.Issued });
+            var smartCard2 = toAdd[2].AddEx(new TSmartCard { Login = login2, CardSerial = rsaToken2.Serial, Issued = rsaToken2.Issued });
+
+            var reset1 = toAdd[2].AddEx(new TPasswordReset
+                {
+                    EmailedTo = "trent@example.com",
+                    ResetNo = 1,
+                    TempPassword = "Rent-A-Mole",
+                    Login = login3
+                });
+
+            var pageView1 = toAdd[1].AddEx(new TPageView { PageUrl = "somePage1", Login = login1, Viewed = DateTime.Now });
+            var pageView2 = toAdd[1].AddEx(new TPageView { PageUrl = "somePage2", Login = login1, Viewed = DateTime.Now });
+            var pageView3 = toAdd[1].AddEx(new TPageView { PageUrl = "somePage3", Login = login1, Viewed = DateTime.Now });
+
+            var lastLogin1 = toAdd[2].AddEx(new TLastLogin
+                {
+                    LoggedIn = new DateTime(2014, 5, 27, 10, 22, 26),
+                    LoggedOut = new DateTime(2014, 5, 27, 11, 22, 26),
+                });
+
+            login1.LastLogin = lastLogin1;
+            smartCard1.LastLogin = lastLogin1;
+
+            var lastLogin2 = toAdd[2].AddEx(new TLastLogin
+                {
+                    LoggedIn = new DateTime(2014, 5, 27, 12, 22, 26),
+                    LoggedOut = new DateTime(2014, 5, 27, 13, 22, 26),
+                });
+
+            login2.LastLogin = lastLogin2;
+            smartCard2.LastLogin = lastLogin2;
+
+            var message1 = toAdd[2].AddEx(new TMessage
+                {
+                    Subject = "Tea?",
+                    Body = "Fancy a cup of tea?",
+                    Sent = DateTime.Now,
+                });
+
+            login1.SentMessages.Add(message1);
+            login2.ReceivedMessages.Add(message1);
+
+            var message2 = toAdd[2].AddEx(new TMessage
+                {
+                    Subject = "Re: Tea?",
+                    Body = "Love one!",
+                    Sent = DateTime.Now,
+                });
+
+            login2.SentMessages.Add(message2);
+            login1.ReceivedMessages.Add(message2);
+
+            var message3 = toAdd[2].AddEx(new TMessage
+                {
+                    Subject = "Re: Tea?",
+                    Body = "I'll put the kettle on.",
+                    Sent = DateTime.Now,
+                });
+
+            login1.SentMessages.Add(message3);
+            login2.ReceivedMessages.Add(message3);
+
+            var order1 = toAdd[2].AddEx(new TAnOrder { Customer = customer1, Login = login1 });
+            var order2 = toAdd[2].AddEx(new TAnOrder { Customer = customer2, Login = login2 });
+            var order3 = toAdd[2].AddEx(new TAnOrder { Customer = customer3, Login = login3 });
+
+            customer1.Orders.Add(order1);
+            customer2.Orders.Add(order2);
+            customer3.Orders.Add(order3);
+
+            login1.Orders.Add(order1);
+            login2.Orders.Add(order2);
+            login3.Orders.Add(order3);
+
+            var orderNote1 = toAdd[2].AddEx(new TOrderNote { Note = "Must have tea!" });
+            var orderNote2 = toAdd[2].AddEx(new TOrderNote { Note = "And donuts!" });
+            var orderNote3 = toAdd[2].AddEx(new TOrderNote { Note = "But no coffee. :-(" });
+
+            order1.Notes.Add(orderNote1);
+            order1.Notes.Add(orderNote2);
+            order1.Notes.Add(orderNote3);
+
+            var orderQualityCheck1 = toAdd[2].AddEx(new TOrderQualityCheck { Order = order1, CheckedBy = "Eeky Bear" });
+            var orderQualityCheck2 = toAdd[2].AddEx(new TOrderQualityCheck { Order = order2, CheckedBy = "Eeky Bear" });
+            var orderQualityCheck3 = toAdd[2].AddEx(new TOrderQualityCheck { Order = order3, CheckedBy = "Eeky Bear" });
+
+            var orderLine1 = toAdd[3].AddEx(new TOrderLine { Product = product1, Quantity = 7 });
+            var orderLine2 = toAdd[3].AddEx(new TOrderLine { Product = product2, Quantity = 1 });
+            var orderLine3 = toAdd[3].AddEx(new TOrderLine { Product = product3, Quantity = 2 });
+            var orderLine4 = toAdd[3].AddEx(new TOrderLine { Product = product2, Quantity = 3 });
+            var orderLine5 = toAdd[3].AddEx(new TOrderLine { Product = product1, Quantity = 4 });
+            var orderLine6 = toAdd[3].AddEx(new TOrderLine { Product = product2, Quantity = 5 });
+
+            order1.OrderLines.Add(orderLine1);
+            order1.OrderLines.Add(orderLine2);
+            order2.OrderLines.Add(orderLine3);
+            order2.OrderLines.Add(orderLine4);
+            order2.OrderLines.Add(orderLine5);
+            order3.OrderLines.Add(orderLine6);
+
+            var productDetail1 = toAdd[0].AddEx(new TProductDetail { Details = "A Waffle Cart specialty!" });
+            var productDetail2 = toAdd[0].AddEx(new TProductDetail { Details = "Eeky Bear's favorite!" });
+
+            product1.Detail = productDetail1;
+            product2.Detail = productDetail2;
+
+            var productReview1 = toAdd[0].AddEx(new TProductReview { Review = "Better than Tarqies!" });
+            var productReview2 = toAdd[0].AddEx(new TProductReview { Review = "Good with maple syrup." });
+            var productReview3 = toAdd[0].AddEx(new TProductReview { Review = "Eeky says yes!" });
+
+            product1.Reviews.Add(productReview1);
+            product1.Reviews.Add(productReview2);
+            product2.Reviews.Add(productReview3);
+
+            var productPhoto1 = toAdd[0].AddEx(new TProductPhoto { ProductId = product1.ProductId, Photo = new byte[] { 101, 102 } });
+            var productPhoto2 = toAdd[0].AddEx(new TProductPhoto { ProductId = product1.ProductId, Photo = new byte[] { 103, 104 } });
+            var productPhoto3 = toAdd[0].AddEx(new TProductPhoto { ProductId = product3.ProductId, Photo = new byte[] { 105, 106 } });
+
+            product1.Photos.Add(productPhoto1);
+            product1.Photos.Add(productPhoto2);
+            product3.Photos.Add(productPhoto3);
+
+            var productWebFeature1 = toAdd[0].AddEx(new TProductWebFeature
+                {
+                    Heading = "Waffle Style",
+                    ProductId = product1.ProductId,
+                });
+
+            productPhoto1.Features.Add(productWebFeature1);
+            productReview1.Features.Add(productWebFeature1);
+
+            var productWebFeature2 = toAdd[0].AddEx(new TProductWebFeature
+                {
+                    Heading = "What does the waffle say?",
+                    ProductId = product2.ProductId,
+                });
+
+            productReview3.Features.Add(productWebFeature2);
+
+            var supplier1 = toAdd[0].AddEx(new TSupplier { Name = "Trading As Trent" });
+            var supplier2 = toAdd[0].AddEx(new TSupplier { Name = "Ants By Boris" });
+
+            var supplierLogo1 = toAdd[0].AddEx(new TSupplierLogo { Logo = new byte[] { 201, 202 } });
+
+            supplier1.Logo = supplierLogo1;
+
+            var supplierInfo1 = toAdd[0].AddEx(new TSupplierInfo { Supplier = supplier1, Information = "Seems a bit dodgy." });
+            var supplierInfo2 = toAdd[0].AddEx(new TSupplierInfo { Supplier = supplier1, Information = "Orange fur?" });
+            var supplierInfo3 = toAdd[0].AddEx(new TSupplierInfo { Supplier = supplier2, Information = "Very expensive!" });
+
+            var customerInfo1 = toAdd[0].AddEx(new TCustomerInfo { Information = "Really likes tea." });
+            var customerInfo2 = toAdd[0].AddEx(new TCustomerInfo { Information = "Mrs Bossy Pants!" });
+
+            customer1.Info = customerInfo1;
+            customer2.Info = customerInfo2;
+
+            var computer1 = toAdd[0].AddEx(new TComputer { Name = "markash420" });
+            var computer2 = toAdd[0].AddEx(new TComputer { Name = "unicorns420" });
+
+            var computerDetail1 = toAdd[0].AddEx(new TComputerDetail
+                {
+                    Manufacturer = "Dell",
+                    Model = "420",
+                    PurchaseDate = new DateTime(2008, 4, 1),
+                    Serial = "4201",
+                    Specifications = "It's a Dell!"
+                });
+
+            computer1.ComputerDetail = computerDetail1;
+
+            var computerDetail2 = toAdd[0].AddEx(new TComputerDetail
+                {
+                    Manufacturer = "Not A Dell",
+                    Model = "Not 420",
+                    PurchaseDate = new DateTime(2012, 4, 1),
+                    Serial = "4202",
+                    Specifications = "It's not a Dell!"
+                });
+
+            computer2.ComputerDetail = computerDetail2;
+
+            var driver1 = toAdd[0].AddEx(new TDriver { BirthDate = new DateTime(2006, 9, 19), Name = "Eeky Bear" });
+            var driver2 = toAdd[0].AddEx(new TDriver { BirthDate = new DateTime(2007, 9, 19), Name = "Splash Bear" });
+
+            var license1 = toAdd[1].AddEx(new TLicense
+                {
+                    LicenseClass = "C",
+                    LicenseNumber = "10",
+                    Restrictions = "None",
+                    State = LicenseState.Active,
+                    ExpirationDate = new DateTime(2018, 9, 19)
+                });
+
+            driver1.License = license1;
+
+            var license2 = toAdd[1].AddEx(new TLicense
+                {
+                    LicenseClass = "A",
+                    LicenseNumber = "11",
+                    Restrictions = "None",
+                    State = LicenseState.Revoked,
+                    ExpirationDate = new DateTime(2018, 9, 19)
+                });
+            driver2.License = license2;
+
+            foreach (var entity in toAdd.SelectMany(l => l))
+            {
+                Add(entity);
+            }
+
+            if (saveChanges)
+            {
+                SaveChanges();
+            }
+        }
+    }
+
+    internal static class Adder
+    {
+        public static TValue AddEx<TValue>(this List<object> list, TValue value)
+        {
+            list.Add(value);
+            return value;
         }
     }
 }

--- a/test/EntityFramework.InMemory.Tests/InMemoryValueGeneratorTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryValueGeneratorTest.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
 using Moq;
 using Xunit;
@@ -20,18 +20,18 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             var propertyMock = new Mock<IProperty>();
             propertyMock.Setup(m => m.PropertyType).Returns(typeof(int));
 
-            Assert.Equal(1, await generator.NextAsync(Mock.Of<DbContextConfiguration>(), propertyMock.Object));
-            Assert.Equal(2, await generator.NextAsync(Mock.Of<DbContextConfiguration>(), propertyMock.Object));
-            Assert.Equal(3, await generator.NextAsync(Mock.Of<DbContextConfiguration>(), propertyMock.Object));
+            Assert.Equal(1, await generator.NextAsync(Mock.Of<StateEntry>(), propertyMock.Object));
+            Assert.Equal(2, await generator.NextAsync(Mock.Of<StateEntry>(), propertyMock.Object));
+            Assert.Equal(3, await generator.NextAsync(Mock.Of<StateEntry>(), propertyMock.Object));
 
-            Assert.Equal(4, generator.Next(Mock.Of<DbContextConfiguration>(), propertyMock.Object));
-            Assert.Equal(5, generator.Next(Mock.Of<DbContextConfiguration>(), propertyMock.Object));
-            Assert.Equal(6, generator.Next(Mock.Of<DbContextConfiguration>(), propertyMock.Object));
+            Assert.Equal(4, generator.Next(Mock.Of<StateEntry>(), propertyMock.Object));
+            Assert.Equal(5, generator.Next(Mock.Of<StateEntry>(), propertyMock.Object));
+            Assert.Equal(6, generator.Next(Mock.Of<StateEntry>(), propertyMock.Object));
 
             generator = new InMemoryValueGenerator();
 
-            Assert.Equal(1, await generator.NextAsync(Mock.Of<DbContextConfiguration>(), propertyMock.Object));
-            Assert.Equal(2, generator.Next(Mock.Of<DbContextConfiguration>(), propertyMock.Object));
+            Assert.Equal(1, await generator.NextAsync(Mock.Of<StateEntry>(), propertyMock.Object));
+            Assert.Equal(2, generator.Next(Mock.Of<StateEntry>(), propertyMock.Object));
         }
 
         [Fact]
@@ -39,15 +39,15 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         {
             var generator = new InMemoryValueGenerator();
 
-            Assert.Equal(1L, await generator.NextAsync(Mock.Of<DbContextConfiguration>(), CreateProperty(typeof(long))));
-            Assert.Equal(2, await generator.NextAsync(Mock.Of<DbContextConfiguration>(), CreateProperty(typeof(int))));
-            Assert.Equal((short)3, await generator.NextAsync(Mock.Of<DbContextConfiguration>(), CreateProperty(typeof(short))));
-            Assert.Equal((byte)4, await generator.NextAsync(Mock.Of<DbContextConfiguration>(), CreateProperty(typeof(byte))));
+            Assert.Equal(1L, await generator.NextAsync(Mock.Of<StateEntry>(), CreateProperty(typeof(long))));
+            Assert.Equal(2, await generator.NextAsync(Mock.Of<StateEntry>(), CreateProperty(typeof(int))));
+            Assert.Equal((short)3, await generator.NextAsync(Mock.Of<StateEntry>(), CreateProperty(typeof(short))));
+            Assert.Equal((byte)4, await generator.NextAsync(Mock.Of<StateEntry>(), CreateProperty(typeof(byte))));
 
-            Assert.Equal(5L, generator.Next(Mock.Of<DbContextConfiguration>(), CreateProperty(typeof(long))));
-            Assert.Equal(6, generator.Next(Mock.Of<DbContextConfiguration>(), CreateProperty(typeof(int))));
-            Assert.Equal((short)7, generator.Next(Mock.Of<DbContextConfiguration>(), CreateProperty(typeof(short))));
-            Assert.Equal((byte)8, generator.Next(Mock.Of<DbContextConfiguration>(), CreateProperty(typeof(byte))));
+            Assert.Equal(5L, generator.Next(Mock.Of<StateEntry>(), CreateProperty(typeof(long))));
+            Assert.Equal(6, generator.Next(Mock.Of<StateEntry>(), CreateProperty(typeof(int))));
+            Assert.Equal((short)7, generator.Next(Mock.Of<StateEntry>(), CreateProperty(typeof(short))));
+            Assert.Equal((byte)8, generator.Next(Mock.Of<StateEntry>(), CreateProperty(typeof(byte))));
         }
 
         [Fact]
@@ -58,10 +58,10 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 
             for (var i = 1; i < 256; i++)
             {
-                generator.Next(Mock.Of<DbContextConfiguration>(), property);
+                generator.Next(Mock.Of<StateEntry>(), property);
             }
 
-            Assert.Throws<OverflowException>(() => generator.Next(Mock.Of<DbContextConfiguration>(), property));
+            Assert.Throws<OverflowException>(() => generator.Next(Mock.Of<StateEntry>(), property));
         }
 
         private static Property CreateProperty(Type propertyType)

--- a/test/EntityFramework.SqlServer.FunctionalTests/MonsterFixupTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/MonsterFixupTest.cs
@@ -12,6 +12,7 @@ using Microsoft.Data.Entity.MonsterModel;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Fallback;
+using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 {
@@ -37,6 +38,12 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         protected override DbContextOptions CreateOptions(string databaseName)
         {
             return new DbContextOptions().UseSqlServer(CreateConnectionString(databaseName));
+        }
+
+        [Fact]
+        public override void Can_build_monster_model_and_seed_data_using_navigations_with_deferred_add()
+        {
+            base.Can_build_monster_model_and_seed_data_using_navigations_with_deferred_add();
         }
 
         private static string CreateConnectionString(string name)

--- a/test/EntityFramework.SqlServer.Tests/SequentialGuidValueGeneratorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SequentialGuidValueGeneratorTest.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
 using Moq;
 using Xunit;
@@ -33,8 +33,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             for (var i = 0; i < 100; i++)
             {
                 var guid = async
-                    ? await sequentialGuidIdentityGenerator.NextAsync(Mock.Of<DbContextConfiguration>(), Mock.Of<IProperty>())
-                    : sequentialGuidIdentityGenerator.Next(Mock.Of<DbContextConfiguration>(), Mock.Of<IProperty>());
+                    ? await sequentialGuidIdentityGenerator.NextAsync(Mock.Of<StateEntry>(), Mock.Of<IProperty>())
+                    : sequentialGuidIdentityGenerator.Next(Mock.Of<StateEntry>(), Mock.Of<IProperty>());
 
                 values.Add((Guid)guid);
             }

--- a/test/EntityFramework.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
@@ -7,6 +7,7 @@ using System.Data.Common;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational;
@@ -23,27 +24,30 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             var configMock = new Mock<DbContextConfiguration>();
             configMock.Setup(m => m.Connection).Returns(new Mock<RelationalConnection>().Object);
 
+            var entryMock = new Mock<StateEntry>();
+            entryMock.Setup(m => m.Configuration).Returns(configMock.Object);
+
             var executor = new FakeSqlStatementExecutor(10);
             var generator = new SqlServerSequenceValueGenerator(executor, "Foo", 10);
 
             for (var i = 0; i < 15; i++)
             {
-                Assert.Equal((long)i, generator.Next(configMock.Object, CreateProperty(typeof(long))));
+                Assert.Equal((long)i, generator.Next(entryMock.Object, CreateProperty(typeof(long))));
             }
 
             for (var i = 15; i < 30; i++)
             {
-                Assert.Equal(i, generator.Next(configMock.Object, CreateProperty(typeof(int))));
+                Assert.Equal(i, generator.Next(entryMock.Object, CreateProperty(typeof(int))));
             }
 
             for (var i = 30; i < 45; i++)
             {
-                Assert.Equal((short)i, generator.Next(configMock.Object, CreateProperty(typeof(short))));
+                Assert.Equal((short)i, generator.Next(entryMock.Object, CreateProperty(typeof(short))));
             }
 
             for (var i = 45; i < 60; i++)
             {
-                Assert.Equal((byte)i, generator.Next(configMock.Object, CreateProperty(typeof(byte))));
+                Assert.Equal((byte)i, generator.Next(entryMock.Object, CreateProperty(typeof(byte))));
             }
         }
 
@@ -53,27 +57,30 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             var configMock = new Mock<DbContextConfiguration>();
             configMock.Setup(m => m.Connection).Returns(new Mock<RelationalConnection>().Object);
 
+            var entryMock = new Mock<StateEntry>();
+            entryMock.Setup(m => m.Configuration).Returns(configMock.Object);
+
             var executor = new FakeSqlStatementExecutor(10);
             var generator = new SqlServerSequenceValueGenerator(executor, "Foo", 10);
 
             for (var i = 0; i < 15; i++)
             {
-                Assert.Equal((long)i, await generator.NextAsync(configMock.Object, CreateProperty(typeof(long))));
+                Assert.Equal((long)i, await generator.NextAsync(entryMock.Object, CreateProperty(typeof(long))));
             }
 
             for (var i = 15; i < 30; i++)
             {
-                Assert.Equal(i, await generator.NextAsync(configMock.Object, CreateProperty(typeof(int))));
+                Assert.Equal(i, await generator.NextAsync(entryMock.Object, CreateProperty(typeof(int))));
             }
 
             for (var i = 30; i < 45; i++)
             {
-                Assert.Equal((short)i, await generator.NextAsync(configMock.Object, CreateProperty(typeof(short))));
+                Assert.Equal((short)i, await generator.NextAsync(entryMock.Object, CreateProperty(typeof(short))));
             }
 
             for (var i = 45; i < 60; i++)
             {
-                Assert.Equal((byte)i, await generator.NextAsync(configMock.Object, CreateProperty(typeof(byte))));
+                Assert.Equal((byte)i, await generator.NextAsync(entryMock.Object, CreateProperty(typeof(byte))));
             }
         }
 
@@ -82,6 +89,9 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         {
             var configMock = new Mock<DbContextConfiguration>();
             configMock.Setup(m => m.Connection).Returns(new Mock<RelationalConnection>().Object);
+
+            var entryMock = new Mock<StateEntry>();
+            entryMock.Setup(m => m.Configuration).Returns(configMock.Object);
 
             var executor = new FakeSqlStatementExecutor(10);
             var generator = new SqlServerSequenceValueGenerator(executor, "Foo", 10);
@@ -99,7 +109,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                     {
                         for (var j = 0; j < valueCount; j++)
                         {
-                            generatedValues[testNumber].Add((long)generator.Next(configMock.Object, CreateProperty(typeof(long))));
+                            generatedValues[testNumber].Add((long)generator.Next(entryMock.Object, CreateProperty(typeof(long))));
                         }
                     };
             }
@@ -126,6 +136,9 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             var configMock = new Mock<DbContextConfiguration>();
             configMock.Setup(m => m.Connection).Returns(new Mock<RelationalConnection>().Object);
 
+            var entryMock = new Mock<StateEntry>();
+            entryMock.Setup(m => m.Configuration).Returns(configMock.Object);
+
             var executor = new FakeSqlStatementExecutor(10);
             var generator = new SqlServerSequenceValueGenerator(executor, "Foo", 10);
 
@@ -142,7 +155,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
                     {
                         for (var j = 0; j < valueCount; j++)
                         {
-                            generatedValues[testNumber].Add((long)await generator.NextAsync(configMock.Object, CreateProperty(typeof(long))));
+                            generatedValues[testNumber].Add((long)await generator.NextAsync(entryMock.Object, CreateProperty(typeof(long))));
                         }
                     };
             }

--- a/test/EntityFramework.Tests/EntityFramework.Tests.csproj
+++ b/test/EntityFramework.Tests/EntityFramework.Tests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="DefaultModelSourceTest.cs" />
     <Compile Include="DbContextOptionsTest.cs" />
     <Compile Include="EntitySetFinderTest.cs" />
+    <Compile Include="Identity\ForeignKeyValueGeneratorTest.cs" />
     <Compile Include="Identity\GuidValueGeneratorTest.cs" />
     <Compile Include="Identity\SimpleValueGeneratorFactoryTest.cs" />
     <Compile Include="Identity\SimpleValueGeneratorTest.cs" />

--- a/test/EntityFramework.Tests/Identity/ForeignKeyValueGeneratorTest.cs
+++ b/test/EntityFramework.Tests/Identity/ForeignKeyValueGeneratorTest.cs
@@ -1,0 +1,223 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Identity
+{
+    public class ForeignKeyValueGeneratorTest
+    {
+        [Fact]
+        public void Foreign_key_value_is_obtained_from_reference_to_principal()
+        {
+            var model = BuildModel();
+
+            var principal = new Category { Id = 11 };
+            var dependent = new Product { Id = 21, Category = principal };
+
+            var dependentEntry = CreateContextConfiguration(model).StateManager.GetOrCreateEntry(dependent);
+
+            Assert.Equal(11, CreateValueGenerator().Next(dependentEntry, model.GetEntityType(typeof(Product)).GetProperty("CategoryId")));
+        }
+
+        [Fact]
+        public void Foreign_key_value_is_obtained_from_tracked_principal_with_populated_collection()
+        {
+            var model = BuildModel();
+            var manager = CreateContextConfiguration(model).StateManager;
+
+            var principal = new Category { Id = 11 };
+            var dependent = new Product { Id = 21 };
+            principal.Products.Add(dependent);
+
+            manager.StartTracking(manager.GetOrCreateEntry(principal));
+            var dependentEntry = manager.GetOrCreateEntry(dependent);
+
+            Assert.Equal(11, CreateValueGenerator().Next(dependentEntry, model.GetEntityType(typeof(Product)).GetProperty("CategoryId")));
+        }
+
+        [Fact]
+        public void One_to_one_foreign_key_value_is_obtained_from_reference_to_principal()
+        {
+            var model = BuildModel();
+
+            var principal = new Product { Id = 21 };
+            var dependent = new ProductDetail { Product = principal };
+
+            var dependentEntry = CreateContextConfiguration(model).StateManager.GetOrCreateEntry(dependent);
+
+            Assert.Equal(21, CreateValueGenerator().Next(dependentEntry, model.GetEntityType(typeof(ProductDetail)).GetProperty("Id")));
+        }
+
+        [Fact]
+        public void One_to_one_foreign_key_value_is_obtained_from_tracked_principal()
+        {
+            var model = BuildModel();
+            var manager = CreateContextConfiguration(model).StateManager;
+
+            var dependent = new ProductDetail();
+            var principal = new Product { Id = 21, Detail = dependent };
+
+            manager.StartTracking(manager.GetOrCreateEntry(principal));
+            var dependentEntry = manager.GetOrCreateEntry(dependent);
+
+            Assert.Equal(21, CreateValueGenerator().Next(dependentEntry, model.GetEntityType(typeof(ProductDetail)).GetProperty("Id")));
+        }
+
+        [Fact]
+        public void Composite_foreign_key_value_is_obtained_from_reference_to_principal()
+        {
+            var model = BuildModel();
+
+            var principal = new OrderLine { OrderId = 11, ProductId = 21 };
+            var dependent = new OrderLineDetail { OrderLine = principal };
+
+            var dependentEntry = CreateContextConfiguration(model).StateManager.GetOrCreateEntry(dependent);
+
+            Assert.Equal(11, CreateValueGenerator().Next(dependentEntry, model.GetEntityType(typeof(OrderLineDetail)).GetProperty("OrderId")));
+            Assert.Equal(21, CreateValueGenerator().Next(dependentEntry, model.GetEntityType(typeof(OrderLineDetail)).GetProperty("ProductId")));
+        }
+
+        [Fact]
+        public void Composite_foreign_key_value_is_obtained_from_tracked_principal()
+        {
+            var model = BuildModel();
+            var manager = CreateContextConfiguration(model).StateManager;
+
+            var dependent = new OrderLineDetail();
+            var principal = new OrderLine { OrderId = 11, ProductId = 21, Detail = dependent };
+
+            manager.StartTracking(manager.GetOrCreateEntry(principal));
+            var dependentEntry = manager.GetOrCreateEntry(dependent);
+
+            Assert.Equal(11, CreateValueGenerator().Next(dependentEntry, model.GetEntityType(typeof(OrderLineDetail)).GetProperty("OrderId")));
+            Assert.Equal(21, CreateValueGenerator().Next(dependentEntry, model.GetEntityType(typeof(OrderLineDetail)).GetProperty("ProductId")));
+        }
+
+        private static DbContextConfiguration CreateContextConfiguration(IModel model = null)
+        {
+            return TestHelpers.CreateContextConfiguration(model ?? BuildModel());
+        }
+
+        private class Category
+        {
+            private readonly ICollection<Product> _products = new List<Product>();
+
+            public int Id { get; set; }
+
+            public ICollection<Product> Products
+            {
+                get { return _products; }
+            }
+        }
+
+        private class Product
+        {
+            private readonly ICollection<OrderLine> _orderLines = new List<OrderLine>();
+
+            public int Id { get; set; }
+
+            public int CategoryId { get; set; }
+            public Category Category { get; set; }
+
+            public ProductDetail Detail { get; set; }
+
+            public ICollection<OrderLine> OrderLines
+            {
+                get { return _orderLines; }
+            }
+        }
+
+        private class ProductDetail
+        {
+            public int Id { get; set; }
+
+            public Product Product { get; set; }
+        }
+
+        private class Order
+        {
+            private readonly ICollection<OrderLine> _orderLines = new List<OrderLine>();
+
+            public int Id { get; set; }
+
+            public ICollection<OrderLine> OrderLines
+            {
+                get { return _orderLines; }
+            }
+        }
+
+        private class OrderLine
+        {
+            public int OrderId { get; set; }
+            public int ProductId { get; set; }
+
+            public virtual Order Order { get; set; }
+            public virtual Product Product { get; set; }
+
+            public virtual OrderLineDetail Detail { get; set; }
+        }
+
+        private class OrderLineDetail
+        {
+            public int OrderId { get; set; }
+            public int ProductId { get; set; }
+
+            public virtual OrderLine OrderLine { get; set; }
+        }
+
+        private static IModel BuildModel()
+        {
+            var model = new Model();
+            var builder = new ConventionModelBuilder(model);
+
+            builder.Entity<Product>();
+            builder.Entity<Category>();
+            builder.Entity<ProductDetail>();
+            builder.Entity<Order>();
+            builder.Entity<OrderLine>().Key(e => new { e.OrderId, e.ProductId });
+            builder.Entity<OrderLineDetail>().Key(e => new { e.OrderId, e.ProductId });
+
+            var categoryType = model.GetEntityType(typeof(Category));
+            var productType = model.GetEntityType(typeof(Product));
+            var productDetailType = model.GetEntityType(typeof(ProductDetail));
+            var orderType = model.GetEntityType(typeof(Order));
+            var orderLineType = model.GetEntityType(typeof(OrderLine));
+            var orderLineDetailType = model.GetEntityType(typeof(OrderLineDetail));
+
+            var categoryFk = productType.AddForeignKey(categoryType.GetKey(), productType.GetProperty("CategoryId"));
+            var productDetailFk = productDetailType.AddForeignKey(productType.GetKey(), productDetailType.GetProperty("Id"));
+            productDetailFk.IsUnique = true;
+
+            var orderFk = orderLineType.AddForeignKey(orderType.GetKey(), orderLineType.GetProperty("OrderId"));
+            var productFk = orderLineType.AddForeignKey(productType.GetKey(), orderLineType.GetProperty("ProductId"));
+            var orderLineFk = orderLineDetailType.AddForeignKey(orderLineType.GetKey(), orderLineDetailType.GetProperty("OrderId"), orderLineDetailType.GetProperty("ProductId"));
+            orderLineFk.IsUnique = true;
+
+            categoryType.AddNavigation(new Navigation(categoryFk, "Products", pointsToPrincipal: false));
+            productType.AddNavigation(new Navigation(categoryFk, "Category", pointsToPrincipal: true));
+
+            productDetailType.AddNavigation(new Navigation(productDetailFk, "Product", pointsToPrincipal: true));
+            productType.AddNavigation(new Navigation(productDetailFk, "Detail", pointsToPrincipal: false));
+
+            orderType.AddNavigation(new Navigation(orderFk, "OrderLines", pointsToPrincipal: false));
+            orderLineType.AddNavigation(new Navigation(orderFk, "Order", pointsToPrincipal: true));
+
+            productType.AddNavigation(new Navigation(productFk, "OrderLines", pointsToPrincipal: false));
+            orderLineType.AddNavigation(new Navigation(productFk, "Product", pointsToPrincipal: true));
+
+            orderLineType.AddNavigation(new Navigation(orderLineFk, "Detail", pointsToPrincipal: false));
+            orderLineDetailType.AddNavigation(new Navigation(orderLineFk, "OrderLine", pointsToPrincipal: true));
+
+            return model;
+        }
+
+        private static ForeignKeyValueGenerator CreateValueGenerator()
+        {
+            return new ForeignKeyValueGenerator(new ClrPropertyGetterSource(), new ClrCollectionAccessorSource());
+        }
+    }
+}

--- a/test/EntityFramework.Tests/Identity/GuidValueGeneratorTest.cs
+++ b/test/EntityFramework.Tests/Identity/GuidValueGeneratorTest.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
 using Moq;
 using Xunit;
@@ -33,8 +33,8 @@ namespace Microsoft.Data.Entity.Identity
             for (var i = 0; i < 100; i++)
             {
                 var guid = async
-                    ? await sequentialGuidIdentityGenerator.NextAsync(Mock.Of<DbContextConfiguration>(), Mock.Of<IProperty>())
-                    : sequentialGuidIdentityGenerator.Next(Mock.Of<DbContextConfiguration>(), Mock.Of<IProperty>());
+                    ? await sequentialGuidIdentityGenerator.NextAsync(Mock.Of<StateEntry>(), Mock.Of<IProperty>())
+                    : sequentialGuidIdentityGenerator.Next(Mock.Of<StateEntry>(), Mock.Of<IProperty>());
 
                 values.Add((Guid)guid);
             }

--- a/test/EntityFramework.Tests/Identity/SimpleValueGeneratorTest.cs
+++ b/test/EntityFramework.Tests/Identity/SimpleValueGeneratorTest.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
 using Moq;
 using Xunit;
@@ -14,13 +14,13 @@ namespace Microsoft.Data.Entity.Identity
         [Fact]
         public async Task NextAsync_delegates_to_sync_method()
         {
-            var configuration = Mock.Of<DbContextConfiguration>();
+            var stateEntry = Mock.Of<StateEntry>();
             var property = Mock.Of<IProperty>();
 
             var generatorMock = new Mock<SimpleValueGenerator> { CallBase = true };
-            generatorMock.Setup(m => m.Next(configuration, property)).Returns("Boo!");
+            generatorMock.Setup(m => m.Next(stateEntry, property)).Returns("Boo!");
 
-            Assert.Equal("Boo!", await generatorMock.Object.NextAsync(configuration, property));
+            Assert.Equal("Boo!", await generatorMock.Object.NextAsync(stateEntry, property));
         }
     }
 }

--- a/test/EntityFramework.Tests/Identity/TemporaryValueGeneratorTest.cs
+++ b/test/EntityFramework.Tests/Identity/TemporaryValueGeneratorTest.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Threading.Tasks;
-using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
 using Moq;
 using Xunit;
@@ -19,13 +19,13 @@ namespace Microsoft.Data.Entity.Identity
 
             var property = CreateProperty(typeof(int));
 
-            Assert.Equal(-1, await generator.NextAsync(Mock.Of<DbContextConfiguration>(), property));
-            Assert.Equal(-2, await generator.NextAsync(Mock.Of<DbContextConfiguration>(), property));
-            Assert.Equal(-3, await generator.NextAsync(Mock.Of<DbContextConfiguration>(), property));
+            Assert.Equal(-1, await generator.NextAsync(Mock.Of<StateEntry>(), property));
+            Assert.Equal(-2, await generator.NextAsync(Mock.Of<StateEntry>(), property));
+            Assert.Equal(-3, await generator.NextAsync(Mock.Of<StateEntry>(), property));
 
-            Assert.Equal(-4, generator.Next(Mock.Of<DbContextConfiguration>(), property));
-            Assert.Equal(-5, generator.Next(Mock.Of<DbContextConfiguration>(), property));
-            Assert.Equal(-6, generator.Next(Mock.Of<DbContextConfiguration>(), property));
+            Assert.Equal(-4, generator.Next(Mock.Of<StateEntry>(), property));
+            Assert.Equal(-5, generator.Next(Mock.Of<StateEntry>(), property));
+            Assert.Equal(-6, generator.Next(Mock.Of<StateEntry>(), property));
         }
 
         [Fact]
@@ -33,13 +33,13 @@ namespace Microsoft.Data.Entity.Identity
         {
             var generator = new TemporaryValueGenerator();
 
-            Assert.Equal(-1L, await generator.NextAsync(Mock.Of<DbContextConfiguration>(), CreateProperty(typeof(long))));
-            Assert.Equal(-2, await generator.NextAsync(Mock.Of<DbContextConfiguration>(), CreateProperty(typeof(int))));
-            Assert.Equal((short)-3, await generator.NextAsync(Mock.Of<DbContextConfiguration>(), CreateProperty(typeof(short))));
+            Assert.Equal(-1L, await generator.NextAsync(Mock.Of<StateEntry>(), CreateProperty(typeof(long))));
+            Assert.Equal(-2, await generator.NextAsync(Mock.Of<StateEntry>(), CreateProperty(typeof(int))));
+            Assert.Equal((short)-3, await generator.NextAsync(Mock.Of<StateEntry>(), CreateProperty(typeof(short))));
 
-            Assert.Equal(-4L, generator.Next(Mock.Of<DbContextConfiguration>(), CreateProperty(typeof(long))));
-            Assert.Equal(-5, generator.Next(Mock.Of<DbContextConfiguration>(), CreateProperty(typeof(int))));
-            Assert.Equal((short)-6, generator.Next(Mock.Of<DbContextConfiguration>(), CreateProperty(typeof(short))));
+            Assert.Equal(-4L, generator.Next(Mock.Of<StateEntry>(), CreateProperty(typeof(long))));
+            Assert.Equal(-5, generator.Next(Mock.Of<StateEntry>(), CreateProperty(typeof(int))));
+            Assert.Equal((short)-6, generator.Next(Mock.Of<StateEntry>(), CreateProperty(typeof(short))));
         }
 
         [Fact]
@@ -47,7 +47,7 @@ namespace Microsoft.Data.Entity.Identity
         {
             var generator = new TemporaryValueGenerator();
 
-            Assert.Throws<OverflowException>(() => generator.Next(Mock.Of<DbContextConfiguration>(), CreateProperty(typeof(byte))));
+            Assert.Throws<OverflowException>(() => generator.Next(Mock.Of<StateEntry>(), CreateProperty(typeof(byte))));
         }
 
         private static Property CreateProperty(Type propertyType)

--- a/test/EntityFramework.Tests/Identity/ValueGeneratorCacheTest.cs
+++ b/test/EntityFramework.Tests/Identity/ValueGeneratorCacheTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Data.Entity.Identity
         {
             var property = CreateProperty(ValueGenerationOnAdd.None);
             var selector = new ValueGeneratorSelector(new SimpleValueGeneratorFactory<GuidValueGenerator>());
-            var cache = new ValueGeneratorCache(selector);
+            var cache = new ValueGeneratorCache(selector, Mock.Of<ForeignKeyValueGenerator>());
 
             Assert.Null(cache.GetGenerator(property));
         }
@@ -31,7 +31,7 @@ namespace Microsoft.Data.Entity.Identity
             factoryMock.Setup(m => m.GetCacheKey(property)).Returns("TheKeyMaster");
 
             var selector = new ValueGeneratorSelector(factoryMock.Object);
-            var cache = new ValueGeneratorCache(selector);
+            var cache = new ValueGeneratorCache(selector, Mock.Of<ForeignKeyValueGenerator>());
 
             var generator1 = cache.GetGenerator(property);
             Assert.NotNull(generator1);
@@ -56,7 +56,7 @@ namespace Microsoft.Data.Entity.Identity
             factoryMock.Setup(m => m.GetCacheKey(property)).Returns("TheKeyMaster");
 
             var selector = new ValueGeneratorSelector(factoryMock.Object);
-            var cache = new ValueGeneratorCache(selector);
+            var cache = new ValueGeneratorCache(selector, Mock.Of<ForeignKeyValueGenerator>());
 
             var generator1a = cache.GetGenerator(property);
             var generator1b = cache.GetGenerator(property);


### PR DESCRIPTION
The kangaroos are hopping... (Set FK values based on referenced principal on Add)

EF7 requires that all tracked entities have a unique primary key, even if it is temporary. Value generators are often used to obtain this primary key value. However, for identifying relationships (where the PK of an entity is also an FK and is completely or partially defined by the PK at the principal end of the relationship) the value used cannot be generated independently because it must match the principal PK. This change adds a value generator for FKs that uses navigation properties to find the principal and then takes the FK values from that principal. This makes it much easier to add a graph of entities without worrying about setting FK/PK values explicitly.

Note that it is necessary to find the principal in order to get the key for a dependent in an identifying relationship. This means that the principal must be added first so that it gets a valid key, or must at least have a valid key set with a direct reference from the dependent.
