### PR TITLE
Suppressing build warnings until a Profile44 version of StackExchange.Redis is available

### DIFF
--- a/src/EntityFramework.Redis/EntityFramework.Redis.csproj
+++ b/src/EntityFramework.Redis/EntityFramework.Redis.csproj
@@ -25,6 +25,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <NoWarn>1684</NoWarn> <!-- suppressing the warning CS1684 - should remove once StackExchange.Redis is available for Profile44 -->
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
@ajcvickers 1 line fix to suppress build warnings for issue #444 
