### PR TITLE
Exception to the rule - Introducing DataStoreOperationException

### DIFF
--- a/src/EntityFramework.Relational/RelationalEntityServicesBuilderExtensions.cs
+++ b/src/EntityFramework.Relational/RelationalEntityServicesBuilderExtensions.cs
@@ -23,9 +23,9 @@ namespace Microsoft.Data.Entity.Relational
                 .AddSingleton<RelationalObjectArrayValueReaderFactory>()
                 .AddSingleton<RelationalTypedValueReaderFactory>()
                 .AddSingleton<ParameterNameGeneratorFactory>()
-                .AddSingleton<CommandBatchPreparer>()
                 .AddSingleton<ModificationCommandComparer>()
                 .AddSingleton<GraphFactory, BidirectionalAdjacencyListGraphFactory>()
+                .AddScoped<CommandBatchPreparer>()
                 .AddScoped<RelationalDatabase>()
                 // TODO: Is singleton correct here? What is IConfiguration scoped as?
                 .AddSingleton<ConnectionStringResolver>();

--- a/src/EntityFramework.Relational/Update/ModificationCommandBatchFactory.cs
+++ b/src/EntityFramework.Relational/Update/ModificationCommandBatchFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Relational.Utilities;
 
 namespace Microsoft.Data.Entity.Relational.Update
@@ -10,6 +11,7 @@ namespace Microsoft.Data.Entity.Relational.Update
     public class ModificationCommandBatchFactory
     {
         private readonly SqlGenerator _sqlGenerator;
+        private readonly DbContextConfiguration _contextConfiguration;
 
         /// <summary>
         ///     This constructor is intended only for use when creating test doubles that will override members
@@ -21,16 +23,19 @@ namespace Microsoft.Data.Entity.Relational.Update
         }
 
         public ModificationCommandBatchFactory(
-            [NotNull] SqlGenerator sqlGenerator)
+            [NotNull] SqlGenerator sqlGenerator,
+            [NotNull] DbContextConfiguration contextConfiguration)
         {
             Check.NotNull(sqlGenerator, "sqlGenerator");
+            Check.NotNull(contextConfiguration, "contextConfiguration");
 
             _sqlGenerator = sqlGenerator;
+            _contextConfiguration = contextConfiguration;
         }
 
         public virtual ModificationCommandBatch Create()
         {
-            return new ModificationCommandBatch();
+            return new ModificationCommandBatch(_contextConfiguration);
         }
 
         public virtual bool AddCommand(

--- a/src/EntityFramework.SQLite/Extensions/SQLiteEntityServicesBuilderExtensions.cs
+++ b/src/EntityFramework.SQLite/Extensions/SQLiteEntityServicesBuilderExtensions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddSingleton<SqlStatementExecutor>()
                 .AddSingleton<SQLiteTypeMapper>()
                 .AddSingleton<SQLiteBatchExecutor>()
-                .AddSingleton<ModificationCommandBatchFactory, SQLiteModificationCommandBatchFactory>()
+                .AddScoped<ModificationCommandBatchFactory, SQLiteModificationCommandBatchFactory>()
                 .AddScoped<DataStoreSource, SQLiteDataStoreSource>()
                 .AddScoped<SQLiteDataStoreServices>()
                 .AddScoped<SQLiteDataStore>()

--- a/src/EntityFramework.SQLite/SQLiteModificationCommandBatchFactory.cs
+++ b/src/EntityFramework.SQLite/SQLiteModificationCommandBatchFactory.cs
@@ -2,14 +2,17 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Relational.Update;
 
 namespace Microsoft.Data.Entity.SQLite
 {
     public class SQLiteModificationCommandBatchFactory : ModificationCommandBatchFactory
     {
-        public SQLiteModificationCommandBatchFactory([NotNull] SQLiteSqlGenerator sqlGenerator)
-            : base(sqlGenerator)
+        public SQLiteModificationCommandBatchFactory(
+            [NotNull] SQLiteSqlGenerator sqlGenerator, 
+            [NotNull] DbContextConfiguration contextConfiguration)
+            : base(sqlGenerator, contextConfiguration)
         {
         }
     }

--- a/src/EntityFramework.SqlServer/Extensions/SqlServerEntityServicesBuilderExtensions.cs
+++ b/src/EntityFramework.SqlServer/Extensions/SqlServerEntityServicesBuilderExtensions.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddSingleton<SqlStatementExecutor>()
                 .AddSingleton<SqlServerTypeMapper>()
                 .AddSingleton<SqlServerBatchExecutor>()
-                .AddSingleton<ModificationCommandBatchFactory, SqlServerModificationCommandBatchFactory>()
+                .AddScoped<ModificationCommandBatchFactory, SqlServerModificationCommandBatchFactory>()
                 .AddScoped<DataStoreSource, SqlServerDataStoreSource>()
                 .AddScoped<SqlServerDataStoreServices>()
                 .AddScoped<SqlServerDataStore>()

--- a/src/EntityFramework.SqlServer/SqlServerModificationCommandBatchFactory.cs
+++ b/src/EntityFramework.SqlServer/SqlServerModificationCommandBatchFactory.cs
@@ -2,14 +2,17 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Relational.Update;
 
 namespace Microsoft.Data.Entity.SqlServer
 {
     public class SqlServerModificationCommandBatchFactory : ModificationCommandBatchFactory
     {
-        public SqlServerModificationCommandBatchFactory([NotNull] SqlServerSqlGenerator sqlGenerator)
-            : base(sqlGenerator)
+        public SqlServerModificationCommandBatchFactory(
+            [NotNull] SqlServerSqlGenerator sqlGenerator, 
+            [NotNull] DbContextConfiguration contextConfiguration)
+            : base(sqlGenerator, contextConfiguration)
         {
         }
     }

--- a/src/EntityFramework/EntityFramework.csproj
+++ b/src/EntityFramework/EntityFramework.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Identity\ValueGeneratorCache.cs" />
     <Compile Include="Identity\ValueGeneratorPool.cs" />
     <Compile Include="Identity\ValueGeneratorSelector.cs" />
+    <Compile Include="Storage\DataStoreException.cs" />
     <Compile Include="Infrastructure\IDbContextOptionsExtensions.cs" />
     <Compile Include="INotifyPropertyChanging.cs" />
     <Compile Include="Metadata\Compiled\CompiledIndex.cs" />

--- a/src/EntityFramework/Properties/Strings.Designer.cs
+++ b/src/EntityFramework/Properties/Strings.Designer.cs
@@ -618,6 +618,102 @@ namespace Microsoft.Data.Entity
             return GetString("CurrentValuesAlwaysInSync");
         }
 
+        /// <summary>
+        /// An error occured while running a data store operation. See InnerException for details.
+        /// </summary>
+        internal static string DataStoreException
+        {
+            get { return GetString("DataStoreException"); }
+        }
+
+        /// <summary>
+        /// An error occured while running a data store operation. See InnerException for details.
+        /// </summary>
+        internal static string FormatDataStoreException()
+        {
+            return GetString("DataStoreException");
+        }
+
+        /// <summary>
+        /// {0} The exception is already a DataStoreException (or derives from DataStoreException). Re-throwing the original exception.
+        /// </summary>
+        internal static string LogDataStoreExceptionRethrow
+        {
+            get { return GetString("LogDataStoreExceptionRethrow"); }
+        }
+
+        /// <summary>
+        /// {0} The exception is already a DataStoreException (or derives from DataStoreException). Re-throwing the original exception.
+        /// </summary>
+        internal static string FormatLogDataStoreExceptionRethrow(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("LogDataStoreExceptionRethrow"), p0);
+        }
+
+        /// <summary>
+        /// {0} Throwing a new DataStoreException with InnerException set to the original exception.
+        /// </summary>
+        internal static string LogDataStoreExceptionWrap
+        {
+            get { return GetString("LogDataStoreExceptionWrap"); }
+        }
+
+        /// <summary>
+        /// {0} Throwing a new DataStoreException with InnerException set to the original exception.
+        /// </summary>
+        internal static string FormatLogDataStoreExceptionWrap(object p0)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("LogDataStoreExceptionWrap"), p0);
+        }
+
+        /// <summary>
+        /// An exception occurred while executing a query.
+        /// </summary>
+        internal static string LogExceptionDuringQueryExecution
+        {
+            get { return GetString("LogExceptionDuringQueryExecution"); }
+        }
+
+        /// <summary>
+        /// An exception occurred while executing a query.
+        /// </summary>
+        internal static string FormatLogExceptionDuringQueryExecution()
+        {
+            return GetString("LogExceptionDuringQueryExecution");
+        }
+
+        /// <summary>
+        /// An exception occurred while iterating results of a query.
+        /// </summary>
+        internal static string LogExceptionDuringQueryIteration
+        {
+            get { return GetString("LogExceptionDuringQueryIteration"); }
+        }
+
+        /// <summary>
+        /// An exception occurred while iterating results of a query.
+        /// </summary>
+        internal static string FormatLogExceptionDuringQueryIteration()
+        {
+            return GetString("LogExceptionDuringQueryIteration");
+        }
+
+        /// <summary>
+        /// An exception occurred while saving changes.
+        /// </summary>
+        internal static string LogExceptionDuringSaveChanges
+        {
+            get { return GetString("LogExceptionDuringSaveChanges"); }
+        }
+
+        /// <summary>
+        /// An exception occurred while saving changes.
+        /// </summary>
+        internal static string FormatLogExceptionDuringSaveChanges()
+        {
+            return GetString("LogExceptionDuringSaveChanges");
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EntityFramework/Properties/Strings.resx
+++ b/src/EntityFramework/Properties/Strings.resx
@@ -231,4 +231,22 @@
   <data name="CurrentValuesAlwaysInSync" xml:space="preserve">
     <value>CurrentValues are always in sync with the entity state.</value>
   </data>
+  <data name="DataStoreException" xml:space="preserve">
+    <value>An error occured while running a data store operation. See InnerException for details.</value>
+  </data>
+  <data name="LogDataStoreExceptionRethrow" xml:space="preserve">
+    <value>{0} The exception is already a DataStoreException (or derives from DataStoreException). Re-throwing the original exception.</value>
+  </data>
+  <data name="LogDataStoreExceptionWrap" xml:space="preserve">
+    <value>{0} Throwing a new DataStoreException with InnerException set to the original exception.</value>
+  </data>
+  <data name="LogExceptionDuringQueryExecution" xml:space="preserve">
+    <value>An exception occurred while executing a query.</value>
+  </data>
+  <data name="LogExceptionDuringQueryIteration" xml:space="preserve">
+    <value>An exception occurred while iterating results of a query.</value>
+  </data>
+  <data name="LogExceptionDuringSaveChanges" xml:space="preserve">
+    <value>An exception occurred while saving changes.</value>
+  </data>
 </root>

--- a/src/EntityFramework/Storage/DataStoreException.cs
+++ b/src/EntityFramework/Storage/DataStoreException.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+using System;
+
+namespace Microsoft.Data.Entity.Storage
+{
+    public class DataStoreException : Exception
+    {
+        private readonly DbContext _context;
+
+        public DataStoreException()
+        { }
+
+        public DataStoreException([NotNull] string message, [NotNull] DbContext context)
+            : this(message, context, null)
+        { }
+
+        public DataStoreException([NotNull] string message, [NotNull] DbContext context, [CanBeNull] Exception innerException)
+            : base(message, innerException)
+        {
+            Check.NotNull(context, "contextType");
+
+            _context = context;
+        }
+
+        public virtual DbContext Context
+        {
+            get { return _context; }
+        }
+
+        public static bool ContainsDataStoreException([CanBeNull] Exception ex)
+        {
+            while (ex != null)
+            {
+                if (ex is DataStoreException)
+                {
+                    return true;
+                }
+                ex = ex.InnerException;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/EntityFramework/Update/DbUpdateConcurrencyException.cs
+++ b/src/EntityFramework/Update/DbUpdateConcurrencyException.cs
@@ -15,28 +15,32 @@ namespace Microsoft.Data.Entity.Update
         {
         }
 
-        public DbUpdateConcurrencyException([NotNull] string message)
-            : base(message)
+        public DbUpdateConcurrencyException([NotNull] string message, [NotNull] DbContext context)
+            : base(message, context)
         {
             Check.NotEmpty(message, "message");
+            Check.NotNull(context, "context");
         }
 
-        public DbUpdateConcurrencyException([NotNull] string message, [CanBeNull] Exception innerException)
-            : base(message, innerException)
+        public DbUpdateConcurrencyException([NotNull] string message, [NotNull] DbContext context, [CanBeNull] Exception innerException)
+            : base(message, context, innerException)
         {
             Check.NotEmpty(message, "message");
+            Check.NotNull(context, "context");
         }
 
-        public DbUpdateConcurrencyException([NotNull] string message, [NotNull] IReadOnlyList<StateEntry> stateEntries)
-            : base(message, stateEntries)
+        public DbUpdateConcurrencyException([NotNull] string message, [NotNull] DbContext context, [NotNull] IReadOnlyList<StateEntry> stateEntries)
+            : base(message, context, stateEntries)
         {
             Check.NotEmpty(message, "message");
+            Check.NotNull(context, "context");
         }
 
-        public DbUpdateConcurrencyException([NotNull] string message, [CanBeNull] Exception innerException, [NotNull] IReadOnlyList<StateEntry> stateEntries)
-            : base(message, innerException, stateEntries)
+        public DbUpdateConcurrencyException([NotNull] string message, [NotNull] DbContext context, [CanBeNull] Exception innerException, [NotNull] IReadOnlyList<StateEntry> stateEntries)
+            : base(message, context, innerException, stateEntries)
         {
             Check.NotEmpty(message, "message");
+            Check.NotNull(context, "context");
         }
     }
 }

--- a/src/EntityFramework/Update/DbUpdateException.cs
+++ b/src/EntityFramework/Update/DbUpdateException.cs
@@ -6,10 +6,12 @@ using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Utilities;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Storage;
 
 namespace Microsoft.Data.Entity.Update
 {
-    public class DbUpdateException : InvalidOperationException
+    public class DbUpdateException : DataStoreException
     {
         private readonly IReadOnlyList<StateEntry> _stateEntries;
 
@@ -18,35 +20,39 @@ namespace Microsoft.Data.Entity.Update
             _stateEntries = new List<StateEntry>();
         }
 
-        public DbUpdateException([NotNull] string message)
-            : base(message)
+        public DbUpdateException([NotNull] string message, [NotNull] DbContext context)
+            : base(message, context)
         {
             Check.NotEmpty(message, "message");
+            Check.NotNull(context, "context");
 
             _stateEntries = new List<StateEntry>();
         }
 
-        public DbUpdateException([NotNull] string message, [CanBeNull] Exception innerException)
-            : base(message, innerException)
+        public DbUpdateException([NotNull] string message, [NotNull] DbContext context, [CanBeNull] Exception innerException)
+            : base(message, context, innerException)
         {
             Check.NotEmpty(message, "message");
+            Check.NotNull(context, "context");
 
             _stateEntries = new List<StateEntry>();
         }
 
-        public DbUpdateException([NotNull] string message, [NotNull] IReadOnlyList<StateEntry> stateEntries)
-            : base(message)
+        public DbUpdateException([NotNull] string message, [NotNull] DbContext context, [NotNull] IReadOnlyList<StateEntry> stateEntries)
+            : base(message, context)
         {
             Check.NotEmpty(message, "message");
+            Check.NotNull(context, "context");
             Check.NotEmpty(stateEntries, "stateEntries");
 
             _stateEntries = stateEntries;
         }
 
-        public DbUpdateException([NotNull] string message, [CanBeNull] Exception innerException, [NotNull] IReadOnlyList<StateEntry> stateEntries)
-            : base(message, innerException)
+        public DbUpdateException([NotNull] string message, [NotNull] DbContext context, [CanBeNull] Exception innerException, [NotNull] IReadOnlyList<StateEntry> stateEntries)
+            : base(message, context, innerException)
         {
             Check.NotEmpty(message, "message");
+            Check.NotNull(context, "context");
             Check.NotEmpty(stateEntries, "stateEntries");
 
             _stateEntries = stateEntries;

--- a/test/EntityFramework.AzureTableStorage.Tests/AtsDataStoreTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/AtsDataStoreTests.cs
@@ -8,9 +8,11 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.AzureTableStorage.Adapters;
+using Microsoft.Data.Entity.AzureTableStorage.Query;
 using Microsoft.Data.Entity.AzureTableStorage.Requests;
 using Microsoft.Data.Entity.AzureTableStorage.Tests.Helpers;
 using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Update;
 using Microsoft.Framework.Logging;
 using Microsoft.WindowsAzure.Storage;
@@ -26,9 +28,16 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests
         private Queue<TableResult> _queue;
 
         public AtsDataStoreTests(Mock<AtsConnection> connection)
-            : base(connection.Object, new TableEntityAdapterFactory())
+            : base(BuildConfig(), connection.Object, new TableEntityAdapterFactory())
         {
             _connection = connection;
+        }
+
+        private static DbContextConfiguration BuildConfig()
+        {
+            var config = new Mock<DbContextConfiguration>();
+            config.Setup(c => c.Context).Returns(new Mock<DbContext>().Object);
+            return config.Object;
         }
 
         private void QueueResult(params TableResult[] results)

--- a/test/EntityFramework.FunctionalTests/EntityFramework.FunctionalTests.csproj
+++ b/test/EntityFramework.FunctionalTests/EntityFramework.FunctionalTests.csproj
@@ -33,11 +33,17 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
+    <PackageReference Include="Remotion.Linq">
+      <TargetFramework>portable-net45+wp80+win</TargetFramework>
+    </PackageReference>
     <PackageReference Include="Ix-Async">
       <TargetFramework>net45</TargetFramework>
       <Assemblies>System.Interactive.Async</Assemblies>
     </PackageReference>
     <PackageReference Include="Microsoft.Framework.ConfigurationModel">
+      <TargetFramework>net45</TargetFramework>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Framework.DependencyInjection">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>
     <PackageReference Include="Microsoft.Framework.Logging">
@@ -58,6 +64,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ExceptionInterceptionTest.cs" />
     <Compile Include="FixupTest.cs" />
     <Compile Include="Metadata\CompiledModelTest.cs" />
     <Compile Include="Metadata\KoolModel.cs" />

--- a/test/EntityFramework.FunctionalTests/ExceptionInterceptionTest.cs
+++ b/test/EntityFramework.FunctionalTests/ExceptionInterceptionTest.cs
@@ -1,0 +1,212 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.InMemory;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Storage;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
+using Xunit;
+using System.Threading.Tasks;
+using Remotion.Linq;
+
+namespace Microsoft.Data.Entity.FunctionalTests
+{
+    public class ExceptionInterceptionTest
+    {
+        [Fact]
+        public async Task SaveChanges_throws_DataStoreOperationException_for_store_exception_nonasync()
+        {
+            await SaveChanges_throws_DataStoreOperationException_for_store_exception(async: false);
+        }
+
+        [Fact]
+        public async Task SaveChanges_throws_DataStoreOperationException_for_store_exception_async()
+        {
+            await SaveChanges_throws_DataStoreOperationException_for_store_exception(async: true);
+        }
+
+        public async Task SaveChanges_throws_DataStoreOperationException_for_store_exception(bool async)
+        {
+            using (var context = new BloggingContext())
+            {
+                context.Blogs.Add(new BloggingContext.Blog(jimSaysThrow: false) { Url = "http://sample.com" });
+                context.SaveChanges();
+                context.ChangeTracker.Entries().Single().State = EntityState.Added;
+
+                Exception ex;
+                if (async)
+                {
+                    ex = await Assert.ThrowsAsync<DataStoreException>(() => context.SaveChangesAsync());
+                }
+                else
+                {
+                    ex = Assert.Throws<DataStoreException>(() => context.SaveChanges());
+                }
+
+                Assert.IsType<DataStoreException>(ex);
+                Assert.Equal(context, ((DataStoreException)ex).Context);
+                // Original exception from DataStore is nested within an AggregateException
+                Assert.IsType<ArgumentException>(ex.InnerException);
+            }
+        }
+
+        [Fact]
+        public async Task Query_throws_DatabaseOperationException_when_DataStore_query_throws_nonasync()
+        {
+            await Query_throws_DatabaseOperationException_when_DataStore_query_throws(async: false);
+        }
+
+        [Fact]
+        public async Task Query_throws_DatabaseOperationException_when_DataStore_query_throws_async()
+        {
+            await Query_throws_DatabaseOperationException_when_DataStore_query_throws(async: true);
+        }
+
+        public async Task Query_throws_DatabaseOperationException_when_DataStore_query_throws(bool async)
+        {
+            var services = new ServiceCollection();
+            services.AddEntityFramework()
+                .AddInMemoryStore()
+                .ServiceCollection
+                .AddScoped<InMemoryDataStore, FaultedDataStore>();
+
+            using (var context = new BloggingContext(services.BuildServiceProvider()))
+            {
+                Exception ex;
+                if (async)
+                {
+                    ex = await Assert.ThrowsAsync<DataStoreException>(() => context.Blogs.FirstOrDefaultAsync());
+                }
+                else
+                {
+                    ex = Assert.Throws<DataStoreException>(() => context.Blogs.FirstOrDefault());
+                }
+                Assert.IsType<DataStoreException>(ex);
+                Assert.Equal(context, ((DataStoreException)ex).Context);
+                Assert.IsType<ArgumentException>(ex.InnerException);
+                Assert.Equal(
+                    async
+                        ? "Jim said to throw from AsyncQuery!"
+                        : "Jim said to throw from Query!",
+                    ex.InnerException.Message);
+            }
+        }
+
+        public class FaultedDataStore : InMemoryDataStore
+        {
+            public override IEnumerable<TResult> Query<TResult>(QueryModel queryModel, StateManager stateManager)
+            {
+                throw new ArgumentException("Jim said to throw from Query!");
+            }
+
+            public override IAsyncEnumerable<TResult> AsyncQuery<TResult>(QueryModel queryModel, StateManager stateManager)
+            {
+                throw new ArgumentException("Jim said to throw from AsyncQuery!");
+            }
+        }
+
+        [Fact]
+        public void Query_throws_DatabaseOperationException_for_store_exception_during_DbSet_enumeration()
+        {
+            Query_throws_DatabaseOperationException_for_store_exception(c => c.Blogs.ToList(), asyncOperation: false);
+        }
+
+        [Fact]
+        public void Query_throws_DatabaseOperationException_for_store_exception_during_DbSet_enumeration_async()
+        {
+            Query_throws_DatabaseOperationException_for_store_exception(c => c.Blogs.ToListAsync().Wait(), asyncOperation: true);
+        }
+
+        [Fact]
+        public void Query_throws_DatabaseOperationException_for_store_exception_during_LINQ_enumeration()
+        {
+            Query_throws_DatabaseOperationException_for_store_exception(c =>
+                c.Blogs
+                 .OrderBy(b => b.Name)
+                 .Where(b => b.Url.StartsWith("http://"))
+                 .ToList(),
+                asyncOperation: false);
+        }
+
+        [Fact]
+        public void Query_throws_DatabaseOperationException_for_store_exception_during_LINQ_enumeration_async()
+        {
+            Query_throws_DatabaseOperationException_for_store_exception(c =>
+                c.Blogs
+                 .OrderBy(b => b.Name)
+                 .Where(b => b.Url.StartsWith("http://"))
+                 .ToListAsync()
+                 .Wait(),
+                asyncOperation: true);
+        }
+
+        public void Query_throws_DatabaseOperationException_for_store_exception(Action<BloggingContext> test, bool asyncOperation)
+        {
+            using (var context = new BloggingContext())
+            {
+                context.Blogs.Add(new BloggingContext.Blog(false) { Url = "http://sample.com" });
+                context.SaveChanges();
+                var entry = context.ChangeTracker.StateManager.StateEntries.Single();
+                context.ChangeTracker.StateManager.StopTracking(entry);
+
+
+                var ex = Assert.ThrowsAny<Exception>(() => test(context));
+                if (asyncOperation)
+                {
+                    // Get rid of AggregateExceptions from async operation
+                    ex = ex.InnerException.InnerException;
+                }
+
+                Assert.IsType<DataStoreException>(ex);
+                Assert.Equal(context, ((DataStoreException)ex).Context);
+                Assert.IsType<ArgumentException>(ex.InnerException);
+                Assert.Equal("Jim said to throw from ctor!", ex.InnerException.Message);
+            }
+        }
+
+        public class BloggingContext : DbContext
+        {
+            public BloggingContext()
+            { }
+
+            public BloggingContext(IServiceProvider provider)
+                : base(provider)
+            { }
+
+            public DbSet<Blog> Blogs { get; set; }
+
+            public class Blog
+            {
+                public Blog()
+                    : this(true)
+                { }
+
+                public Blog(bool jimSaysThrow)
+                {
+                    if (jimSaysThrow)
+                    {
+                        throw new ArgumentException("Jim said to throw from ctor!");
+                    }
+                }
+
+                public string Url { get; set; }
+                public string Name { get; set; }
+            }
+
+            protected override void OnConfiguring(DbContextOptions options)
+            {
+                options.UseInMemoryStore(persist: false);
+            }
+
+            protected override void OnModelCreating(ModelBuilder builder)
+            {
+                builder.Entity<Blog>().Key(b => b.Url);
+            }
+        }
+    }
+}

--- a/test/EntityFramework.FunctionalTests/MonsterFixupTestBase.cs
+++ b/test/EntityFramework.FunctionalTests/MonsterFixupTestBase.cs
@@ -6,9 +6,11 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.MonsterModel;
 using Xunit;
+using Microsoft.Data.Entity.Storage;
 
 namespace Microsoft.Data.Entity.FunctionalTests
 {
@@ -238,7 +240,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                 Assert.Equal(
                     "Aborting.",
-                    (await Assert.ThrowsAsync<Exception>(async () => await context.SaveChangesAsync())).Message);
+                    (await Assert.ThrowsAsync<DataStoreException>(async () => await context.SaveChangesAsync()))
+                    .InnerException.Message);
 
                 var afterSnapshot = stateManager.StateEntries.SelectMany(e => e.EntityType.Properties.Select(p => e[p])).ToList();
 

--- a/test/EntityFramework.FunctionalTests/project.json
+++ b/test/EntityFramework.FunctionalTests/project.json
@@ -1,6 +1,7 @@
 {
   "dependencies": {
     "EntityFramework.InMemory" : "",
+    "Remotion.Linq": "1.15.13.0",
     "Xunit.KRunner": "1.0.0-*"
   },
   "commands": {

--- a/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -325,7 +325,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         private static CommandBatchPreparer CreateCommandBatchPreparer(ModificationCommandBatchFactory modificationCommandBatchFactory = null)
         {
             return new CommandBatchPreparer(
-                modificationCommandBatchFactory ?? new ModificationCommandBatchFactory(new Mock<SqlGenerator> { CallBase = true }.Object),
+                modificationCommandBatchFactory ?? new ModificationCommandBatchFactory(new Mock<SqlGenerator> { CallBase = true }.Object, new Mock<DbContextConfiguration>().Object),
                 new ParameterNameGeneratorFactory(),
                 new BidirectionalAdjacencyListGraphFactory(),
                 new ModificationCommandComparer());

--- a/test/EntityFramework.Relational.Tests/Update/ModificationCommandBatchFactoryTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ModificationCommandBatchFactoryTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Data.Entity.Infrastructure;
 using Moq;
 using Xunit;
 
@@ -16,13 +17,21 @@ namespace Microsoft.Data.Entity.Relational.Update
                 "sqlGenerator",
                 // ReSharper disable once AssignNullToNotNullAttribute
                 Assert.Throws<ArgumentNullException>(() =>
-                    new ModificationCommandBatchFactory(null)).ParamName);
+                    new ModificationCommandBatchFactory(null, null)).ParamName);
+
+            Assert.Equal(
+                "contextConfiguration",
+                // ReSharper disable once AssignNullToNotNullAttribute
+                Assert.Throws<ArgumentNullException>(() =>
+                    new ModificationCommandBatchFactory(new Mock<SqlGenerator>().Object, null)).ParamName);
         }
 
         [Fact]
         public void Create_returns_new_instances()
         {
-            var factory = new ModificationCommandBatchFactory(new Mock<SqlGenerator>().Object);
+            var factory = new ModificationCommandBatchFactory(
+                new Mock<SqlGenerator>().Object, 
+                new Mock<DbContextConfiguration>().Object);
 
             var firstBatch = factory.Create();
             var secondBatch = factory.Create();
@@ -35,7 +44,9 @@ namespace Microsoft.Data.Entity.Relational.Update
         [Fact]
         public void AddCommand_checks_arguments()
         {
-            var factory = new ModificationCommandBatchFactory(new Mock<SqlGenerator>().Object);
+            var factory = new ModificationCommandBatchFactory(
+                new Mock<SqlGenerator>().Object,
+                new Mock<DbContextConfiguration>().Object);
 
             Assert.Equal(
                 "modificationCommandBatch",
@@ -54,7 +65,9 @@ namespace Microsoft.Data.Entity.Relational.Update
         public void AddCommand_delegates()
         {
             var sqlGenerator = new Mock<SqlGenerator>().Object;
-            var factory = new ModificationCommandBatchFactory(sqlGenerator);
+            var factory = new ModificationCommandBatchFactory(
+                sqlGenerator,
+                new Mock<DbContextConfiguration>().Object);
 
             var modificationCommandBatchMock = new Mock<ModificationCommandBatch>();
             var mockModificationCommand = new Mock<ModificationCommand>().Object;

--- a/test/EntityFramework.Relational.Tests/Update/ModificationCommandBatchTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ModificationCommandBatchTest.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             Assert.Equal(1, stateEntry[stateEntry.EntityType.GetProperty("Id")]);
             Assert.Equal("FortyTwo", stateEntry[stateEntry.EntityType.GetProperty("Name")]);
         }
-        
+
         [Fact]
         public async Task Exception_not_thrown_for_more_than_one_row_returned_for_single_command()
         {
@@ -162,7 +162,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             batch.AddCommand(command, new Mock<SqlGenerator> { CallBase = true }.Object);
 
             await batch.ExecuteAsync(new Mock<RelationalTransaction>().Object, new RelationalTypeMapper());
-            
+
             Assert.Equal(42, stateEntry[stateEntry.EntityType.GetProperty("Id")]);
         }
 
@@ -390,12 +390,21 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             private readonly DbDataReader _reader;
 
             public ModificationCommandBatchFake()
+                : base(BuildConfig())
             {
             }
 
             public ModificationCommandBatchFake(DbDataReader reader)
+                : base(BuildConfig())
             {
                 _reader = reader;
+            }
+
+            private static DbContextConfiguration BuildConfig()
+            {
+                var config = new Mock<DbContextConfiguration>();
+                config.Setup(c => c.Context).Returns(new Mock<DbContext>().Object);
+                return config.Object;
             }
 
             protected override string GenerateCommandText(SqlGenerator sqlGenerator)

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerConfigPatternsTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerConfigPatternsTest.cs
@@ -5,7 +5,9 @@ using System;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Storage;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Fallback;
 using Xunit;
@@ -164,13 +166,13 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                     Assert.Equal(
                         GetString("FormatNoDataStoreConfigured"),
-                        Assert.Throws<InvalidOperationException>(() =>
+                        Assert.Throws<DataStoreException>(() =>
                             {
                                 using (var context = new NorthwindContext(serviceProvider))
                                 {
                                     Assert.Equal(91, context.Customers.Count());
                                 }
-                            }).Message);
+                            }).InnerException.Message);
                 }
             }
 
@@ -199,13 +201,13 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 {
                     Assert.Equal(
                         GetString("FormatNoDataStoreConfigured"),
-                        Assert.Throws<InvalidOperationException>(() =>
+                        Assert.Throws<DataStoreException>(() =>
                             {
                                 using (var context = new NorthwindContext())
                                 {
                                     Assert.Equal(91, context.Customers.Count());
                                 }
-                            }).Message);
+                            }).InnerException.Message);
                 }
             }
 
@@ -233,13 +235,13 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                     Assert.Equal(
                         GetString("FormatNoDataStoreService"),
-                        Assert.Throws<InvalidOperationException>(() =>
+                        Assert.Throws<DataStoreException>(() =>
                             {
                                 using (var context = new NorthwindContext(serviceProvider))
                                 {
                                     Assert.Equal(91, context.Customers.Count());
                                 }
-                            }).Message);
+                            }).InnerException.Message);
                 }
             }
 

--- a/test/EntityFramework.SqlServer.Tests/SqlServerEntityServicesBuilderExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerEntityServicesBuilderExtensionsTest.cs
@@ -120,7 +120,6 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             Assert.Same(databaseBuilder, scopedProvider.GetService<DatabaseBuilder>());
             Assert.Same(arrayReaderFactory, scopedProvider.GetService<RelationalObjectArrayValueReaderFactory>());
             Assert.Same(typedReaderFactory, scopedProvider.GetService<RelationalTypedValueReaderFactory>());
-            Assert.Same(batchPreparer, scopedProvider.GetService<CommandBatchPreparer>());
             Assert.Same(modificationCommandComparer, scopedProvider.GetService<ModificationCommandComparer>());
             Assert.Same(graphFactory, scopedProvider.GetService<GraphFactory>());
 
@@ -128,9 +127,10 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             Assert.Same(sqlStatementExecutor, scopedProvider.GetService<SqlStatementExecutor>());
             Assert.Same(sqlTypeMapper, scopedProvider.GetService<SqlServerTypeMapper>());
             Assert.Same(sqlServerBatchExecutor, scopedProvider.GetService<SqlServerBatchExecutor>());
-            Assert.Same(sqlServerModificationCommandBatchFactory, scopedProvider.GetService<ModificationCommandBatchFactory>());
 
             // Scoped
+            Assert.NotSame(batchPreparer, scopedProvider.GetService<CommandBatchPreparer>());
+            Assert.NotSame(sqlServerModificationCommandBatchFactory, scopedProvider.GetService<ModificationCommandBatchFactory>());
             Assert.NotSame(sqlServerDataStoreSource, scopedProvider.GetService<DataStoreSource>());
             Assert.NotSame(sqlServerDataStore, scopedProvider.GetService<SqlServerDataStore>());
             Assert.NotSame(sqlServerConnection, scopedProvider.GetService<SqlServerConnection>());


### PR DESCRIPTION
Introducing a DataStoreOperationException to identify when a data store
related exception occurs during save/query from a DbContext. This allows
tooling, framework, etc. to handle issues related to database
operations.

Also updating the existing DbUpdateException to inherit from the new exception
type so that the existing cases where this is thrown don't need to be wrapped
in a new exception.
