### PR TITLE
Fix to more reliably kill redis-server

### DIFF
--- a/test/EntityFramework.Redis.FunctionalTests/SimpleFixture.cs
+++ b/test/EntityFramework.Redis.FunctionalTests/SimpleFixture.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.Redis
 {
-    public class SimpleFixture : BaseClassFixture
+    public class SimpleFixture : BaseClassFixture, IDisposable
     {
 
         public override IModel CreateModel()
@@ -20,6 +21,11 @@ namespace Microsoft.Data.Entity.Redis
                 });
 
             return model;
+        }
+
+        void IDisposable.Dispose()
+        {
+            RedisTestConfig.StopRedisServer();
         }
     }
 


### PR DESCRIPTION
@pranavkm @anpete  Have been having problems where the redis server started by the tests is not killed and then interferes with other builds because it is still holding onto a file which TeamCity wants to clean up.

Here I'm updating to find the process by name and ensure any such outstanding process is killed at the end of the tests.

For the moment am doing this in the ClassFixture.Dispose() method which works reliably for both VS and "k test". Overriding the XunitFramework and killing the server there worked for running the tests in VS but not for running "k test". Will look into why this is happening but since at the moment we only have 1 test class this works fine for now.
