### PR TITLE
Issue 484 - Fix for build warning

### DIFF
--- a/test/EntityFramework.Redis.FunctionalTests/EntityFramework.Redis.FunctionalTests.csproj
+++ b/test/EntityFramework.Redis.FunctionalTests/EntityFramework.Redis.FunctionalTests.csproj
@@ -63,9 +63,6 @@
     <PackageReference Include="Microsoft.Framework.Logging">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>
-    <PackageReference Include="Redis-64">
-      <TargetFramework>net45</TargetFramework>
-    </PackageReference>
     <PackageReference Include="StackExchange.Redis">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>

--- a/test/EntityFramework.Redis.FunctionalTests/project.json
+++ b/test/EntityFramework.Redis.FunctionalTests/project.json
@@ -12,7 +12,7 @@
     "Xunit.KRunner": "1.0.0-*"
   },
   "commands": {
-    "test": "Xunit.KRunner"
+    "do_not_test_using_k": "Xunit.KRunner"
   },
   "frameworks": {
     "net45": {


### PR DESCRIPTION
@anpete Removing Redis FunctionalTests .csproj dependency on Redis-64 as it expects to find Redis-64.dll which does not exist. However do still want the Redis-64 package installed so that redis-server.exe can be found - so put the project.json file back but rename the test tool within it so that tests will contine not to run under K.
