### PR TITLE
new[] { 1, 2, 1 }

### DIFF
--- a/src/EntityFramework/Metadata/Navigation.cs
+++ b/src/EntityFramework/Metadata/Navigation.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Data.Entity.Metadata
     public class Navigation : NamedMetadataBase, INavigation
     {
         private ForeignKey _foreignKey;
-        private readonly bool _pointsToPrincipal;
+        private bool _pointsToPrincipal;
 
         public Navigation([NotNull] ForeignKey foreignKey, [NotNull] string name, bool pointsToPrincipal)
             : base(Check.NotEmpty(name, "name"))
@@ -37,6 +37,13 @@ namespace Microsoft.Data.Entity.Metadata
         public virtual bool PointsToPrincipal
         {
             get { return _pointsToPrincipal; }
+            [param: NotNull]
+            set
+            {
+                Check.NotNull(value, "value");
+
+                _pointsToPrincipal = value;
+            }
         }
 
         IEntityType IPropertyBase.EntityType

--- a/test/EntityFramework.FunctionalTests/TestModels/ConcurrencyModel/F1Context.cs
+++ b/test/EntityFramework.FunctionalTests/TestModels/ConcurrencyModel/F1Context.cs
@@ -110,6 +110,7 @@ namespace ConcurrencyModel
                     b.Property(t => t.Tire);
                     b.Property(t => t.Victories);
                     b.OneToMany(e => e.Drivers, e => e.Team);
+                    b.OneToOne(e => e.Gearbox).ForeignKey<Team>(e => e.GearboxId);
                 });
 
             modelBuilder.Entity<TestDriver>(b => b.Key(t => t.Id));
@@ -125,14 +126,7 @@ namespace ConcurrencyModel
             var teamType = model.GetEntityType(typeof(Team));
             var sponsorType = model.GetEntityType(typeof(Sponsor));
 
-            // TODO: Use FAPIS when available
             // TODO: Sponsor * <-> * Team
-
-            {
-                // Team -> 1? Gearbox
-                var teamGearboxIdFk = teamType.AddForeignKey(gearboxType.GetKey(), teamType.GetProperty("GearboxId"));
-                teamType.AddNavigation(new Navigation(teamGearboxIdFk, "Gearbox", pointsToPrincipal: true));
-            }
 
             // TODO: Remove once temporary keys can be overridden
             teamType.GetProperty("Id").ValueGenerationOnAdd = ValueGenerationOnAdd.None;

--- a/test/EntityFramework.FunctionalTests/TestModels/MonsterModel.cs
+++ b/test/EntityFramework.FunctionalTests/TestModels/MonsterModel.cs
@@ -251,29 +251,12 @@ namespace Microsoft.Data.Entity.MonsterModel
         IComplaint Complaint { get; set; }
     }
 
-    public class Resolution : IResolution
-    {
-        public int ResolutionId { get; set; }
-        public string Details { get; set; }
-
-        public virtual IComplaint Complaint { get; set; }
-    }
-
     public interface IRsaToken
     {
         string Serial { get; set; }
         DateTime Issued { get; set; }
         string Username { get; set; }
         ILogin Login { get; set; }
-    }
-
-    public class RsaToken : IRsaToken
-    {
-        public string Serial { get; set; }
-        public DateTime Issued { get; set; }
-
-        public string Username { get; set; }
-        public virtual ILogin Login { get; set; }
     }
 
     public interface ISmartCard
@@ -285,16 +268,6 @@ namespace Microsoft.Data.Entity.MonsterModel
         ILastLogin LastLogin { get; set; }
     }
 
-    public class SmartCard : ISmartCard
-    {
-        public string Username { get; set; }
-        public string CardSerial { get; set; }
-        public DateTime Issued { get; set; }
-
-        public virtual ILogin Login { get; set; }
-        public virtual ILastLogin LastLogin { get; set; }
-    }
-
     public interface ISupplierInfo
     {
         int SupplierInfoId { get; set; }
@@ -303,25 +276,10 @@ namespace Microsoft.Data.Entity.MonsterModel
         ISupplier Supplier { get; set; }
     }
 
-    public class SupplierInfo : ISupplierInfo
-    {
-        public int SupplierInfoId { get; set; }
-        public string Information { get; set; }
-
-        public int SupplierId { get; set; }
-        public virtual ISupplier Supplier { get; set; }
-    }
-
     public interface ISupplierLogo
     {
         int SupplierId { get; set; }
         byte[] Logo { get; set; }
-    }
-
-    public class SupplierLogo : ISupplierLogo
-    {
-        public int SupplierId { get; set; }
-        public byte[] Logo { get; set; }
     }
 
     public interface ISupplier

--- a/test/EntityFramework.Relational.FunctionalTests/OptimisticConcurrencyRelationalTestBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/OptimisticConcurrencyRelationalTestBase.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Linq;
 using ConcurrencyModel;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.Metadata;
@@ -17,11 +16,8 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
         {
             var model = modelBuilder.Model;
 
-            var chassisType = model.GetEntityType(typeof(Chassis));
-            var teamType = model.GetEntityType(typeof(Team));
-
-            chassisType.SetTableName("Chassis");
-            teamType.SetTableName("Team");
+            model.GetEntityType(typeof(Chassis)).SetTableName("Chassis");
+            model.GetEntityType(typeof(Team)).SetTableName("Team");
             model.GetEntityType(typeof(Driver)).SetTableName("Drivers");
             model.GetEntityType(typeof(Engine)).SetTableName("Engines");
             model.GetEntityType(typeof(EngineSupplier)).SetTableName("EngineSuppliers");
@@ -30,16 +26,7 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
             model.GetEntityType(typeof(TestDriver)).SetTableName("TestDrivers");
             model.GetEntityType(typeof(TitleSponsor)).SetTableName("TitleSponsors");
 
-            {
-                // Chasis 1 <-> 1 Team
-                modelBuilder
-                    .Entity<Chassis>()
-                    .ForeignKeys(fks => fks.ForeignKey<Team>(c => c.TeamId, isUnique: true).CascadeDelete(cascadeDelete: true));
-
-                var chassisTeamIdFk = chassisType.ForeignKeys.Single(fk => fk.Properties.Single().Name == "TeamId");
-                chassisType.AddNavigation(new Navigation(chassisTeamIdFk, "Team", pointsToPrincipal: true));
-                teamType.AddNavigation(new Navigation(chassisTeamIdFk, "Chassis", pointsToPrincipal: false));
-            }
+            modelBuilder.Entity<Team>().OneToOne(e => e.Chassis, e => e.Team);
 
             return model;
         }

--- a/test/EntityFramework.Tests/ChangeTracking/NavigationFixerTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/NavigationFixerTest.cs
@@ -954,36 +954,33 @@ namespace Microsoft.Data.Entity.ChangeTracking
             var model = new Model();
             var builder = new ConventionModelBuilder(model);
 
-            builder.Entity<Product>();
+            builder.Entity<Product>(b =>
+                {
+                    b.OneToOne(e => e.OriginalProduct, e => e.AlternateProduct)
+                        .ForeignKey<Product>(e => e.AlternateProductId);
+
+                    b.OneToOne(e => e.Detail, e => e.Product);
+                });
+
             builder.Entity<Category>().OneToMany(e => e.Products, e => e.Category);
+
             builder.Entity<ProductDetail>();
+
             builder.Entity<ProductPhoto>(b =>
                 {
                     b.Key(e => new { e.ProductId, e.PhotoId });
                     b.OneToMany(e => e.ProductTags, e => e.Photo)
                         .ForeignKey(e => new { e.ProductId, e.PhotoId });
                 });
+
             builder.Entity<ProductReview>(b =>
                 {
                     b.Key(e => new { e.ProductId, e.ReviewId });
                     b.OneToMany(e => e.ProductTags, e => e.Review)
                         .ForeignKey(e => new { e.ProductId, e.ReviewId });
                 });
+
             builder.Entity<ProductTag>();
-
-            var productType = model.GetEntityType(typeof(Product));
-            var productDetailType = model.GetEntityType(typeof(ProductDetail));
-
-            var alternateProductFk = productType.AddForeignKey(productType.GetKey(), productType.GetProperty("AlternateProductId"));
-            alternateProductFk.IsUnique = true;
-            var productDetailFk = productDetailType.AddForeignKey(productType.GetKey(), productDetailType.GetProperty("Id"));
-            productDetailFk.IsUnique = true;
-
-            productType.AddNavigation(new Navigation(alternateProductFk, "AlternateProduct", pointsToPrincipal: true));
-            productType.AddNavigation(new Navigation(alternateProductFk, "OriginalProduct", pointsToPrincipal: false));
-
-            productDetailType.AddNavigation(new Navigation(productDetailFk, "Product", pointsToPrincipal: true));
-            productType.AddNavigation(new Navigation(productDetailFk, "Detail", pointsToPrincipal: false));
 
             return model;
         }

--- a/test/EntityFramework.Tests/Identity/ForeignKeyValueGeneratorTest.cs
+++ b/test/EntityFramework.Tests/Identity/ForeignKeyValueGeneratorTest.cs
@@ -174,29 +174,25 @@ namespace Microsoft.Data.Entity.Identity
             var model = new Model();
             var builder = new ConventionModelBuilder(model);
 
-            builder.Entity<Product>().OneToMany(e => e.OrderLines, e => e.Product);
+            builder.Entity<Product>(b =>
+                {
+                    b.OneToMany(e => e.OrderLines, e => e.Product);
+                    b.OneToOne(e => e.Detail, e => e.Product);
+                });
+
             builder.Entity<Category>().OneToMany(e => e.Products, e => e.Category);
+
             builder.Entity<ProductDetail>();
+
             builder.Entity<Order>().OneToMany(e => e.OrderLines, e => e.Order);
-            builder.Entity<OrderLine>().Key(e => new { e.OrderId, e.ProductId });
+
             builder.Entity<OrderLineDetail>().Key(e => new { e.OrderId, e.ProductId });
 
-            var productType = model.GetEntityType(typeof(Product));
-            var productDetailType = model.GetEntityType(typeof(ProductDetail));
-            var orderLineType = model.GetEntityType(typeof(OrderLine));
-            var orderLineDetailType = model.GetEntityType(typeof(OrderLineDetail));
-
-            var productDetailFk = productDetailType.AddForeignKey(productType.GetKey(), productDetailType.GetProperty("Id"));
-            productDetailFk.IsUnique = true;
-
-            var orderLineFk = orderLineDetailType.AddForeignKey(orderLineType.GetKey(), orderLineDetailType.GetProperty("OrderId"), orderLineDetailType.GetProperty("ProductId"));
-            orderLineFk.IsUnique = true;
-
-            productDetailType.AddNavigation(new Navigation(productDetailFk, "Product", pointsToPrincipal: true));
-            productType.AddNavigation(new Navigation(productDetailFk, "Detail", pointsToPrincipal: false));
-
-            orderLineType.AddNavigation(new Navigation(orderLineFk, "Detail", pointsToPrincipal: false));
-            orderLineDetailType.AddNavigation(new Navigation(orderLineFk, "OrderLine", pointsToPrincipal: true));
+            builder.Entity<OrderLine>(b =>
+                {
+                    b.Key(e => new { e.OrderId, e.ProductId });
+                    b.OneToOne(e => e.Detail, e => e.OrderLine);
+                });
 
             return model;
         }

--- a/test/EntityFramework.Tests/Metadata/ModelConventions/ForeignKeyConventionTest.cs
+++ b/test/EntityFramework.Tests/Metadata/ModelConventions/ForeignKeyConventionTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             Assert.Same(
                 fk,
                 new ForeignKeyConvention().FindOrCreateForeignKey(
-                    PrincipalType, DependentType, "SomeNav", new[] { new[] { fkProperty } }));
+                    PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { new[] { fkProperty } }, isUnqiue: false));
         }
 
         [Fact]
@@ -42,7 +42,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             Assert.Same(
                 fk,
                 new ForeignKeyConvention().FindOrCreateForeignKey(
-                    PrincipalType, DependentType, "SomeNav", new[] { new[] { fkProperty1, fkProperty2 } }));
+                    PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { new[] { fkProperty1, fkProperty2 } }, isUnqiue: false));
         }
 
         [Fact]
@@ -55,7 +55,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
 
             var fk = DependentType.AddForeignKey(PrincipalType.GetKey(), fkProperty);
 
-            Assert.Same(fk, new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav"));
+            Assert.Same(fk, new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: false));
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
 
             var fk = DependentType.AddForeignKey(PrincipalType.GetKey(), fkProperty);
 
-            Assert.Same(fk, new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav"));
+            Assert.Same(fk, new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: false));
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
 
             var fk = DependentType.AddForeignKey(PrincipalType.GetKey(), fkProperty);
 
-            Assert.Same(fk, new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav"));
+            Assert.Same(fk, new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: false));
         }
 
         [Fact]
@@ -88,7 +88,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
 
             var fk = DependentType.AddForeignKey(PrincipalType.GetKey(), fkProperty);
 
-            Assert.Same(fk, new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav"));
+            Assert.Same(fk, new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: false));
         }
 
         [Fact]
@@ -101,7 +101,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             var fkProperty = DependentType.AddProperty("No!No!", typeof(int));
 
             var fk = new ForeignKeyConvention().FindOrCreateForeignKey(
-                PrincipalType, DependentType, "SomeNav", new[] { new[] { fkProperty } });
+                PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { new[] { fkProperty } }, isUnqiue: false);
 
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.ReferencedProperties.Single());
@@ -120,7 +120,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             var fkProperty2 = DependentType.AddProperty("ThatsImpossible!", typeof(int));
 
             var fk = new ForeignKeyConvention().FindOrCreateForeignKey(
-                PrincipalType, DependentType, "SomeNav", new[] { new[] { fkProperty1, fkProperty2 } });
+                PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { new[] { fkProperty1, fkProperty2 } }, isUnqiue: false);
 
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
@@ -137,11 +137,11 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             DependentType.AddProperty("PrincipalEntityID", typeof(int));
             DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
 
-            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav");
+            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: true);
 
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.ReferencedProperties.Single());
-            Assert.False(fk.IsUnique);
+            Assert.True(fk.IsUnique);
             Assert.True(fk.IsRequired);
         }
 
@@ -152,7 +152,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             DependentType.AddProperty("PrincipalEntityID", typeof(int));
             DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
 
-            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav");
+            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: false);
 
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.ReferencedProperties.Single());
@@ -166,11 +166,11 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             var fkProperty = DependentType.AddProperty("PrincipalEntityID", typeof(int));
             DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
 
-            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav");
+            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: true);
 
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.ReferencedProperties.Single());
-            Assert.False(fk.IsUnique);
+            Assert.True(fk.IsUnique);
             Assert.True(fk.IsRequired);
         }
 
@@ -179,7 +179,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
         {
             var fkProperty = DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
 
-            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav");
+            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: false);
 
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.ReferencedProperties.Single());
@@ -190,7 +190,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
         [Fact]
         public void Creates_foreign_key_based_on_nav_name_if_no_appropriate_property_is_found()
         {
-            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav");
+            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: false);
 
             Assert.Equal("SomeNavId", fk.Properties.Single().Name);
             Assert.Equal(typeof(int), fk.Properties.Single().PropertyType);
@@ -204,7 +204,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
         [Fact]
         public void Creates_foreign_key_based_on_type_name_if_no_appropriate_property_is_found()
         {
-            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, null);
+            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, null, null, isUnqiue: false);
 
             Assert.Equal("PrincipalEntityId", fk.Properties.Single().Name);
             Assert.Equal(typeof(int), fk.Properties.Single().PropertyType);
@@ -215,15 +215,79 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             Assert.True(fk.IsRequired);
         }
 
+        [Fact]
+        public void Does_not_match_existing_FK_if_FK_already_has_different_navigation_to_principal()
+        {
+            var fkProperty = DependentType.AddProperty("SharedFk", typeof(int));
+            var fk = DependentType.AddForeignKey(PrincipalType.GetKey(), fkProperty);
+            DependentType.AddNavigation(new Navigation(fk, "AnotherNav", pointsToPrincipal: true));
+
+            var newFk = new ForeignKeyConvention().FindOrCreateForeignKey(
+                PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { new[] { fkProperty } }, isUnqiue: false);
+
+            Assert.NotSame(fk, newFk);
+            Assert.Same(fkProperty, newFk.Properties.Single());
+            Assert.Same(PrimaryKey, newFk.ReferencedProperties.Single());
+            Assert.False(newFk.IsUnique);
+            Assert.True(newFk.IsRequired);
+        }
+
+        [Fact]
+        public void Does_not_match_existing_FK_if_FK_already_has_different_navigation_to_dependent()
+        {
+            var fkProperty = DependentType.AddProperty("SharedFk", typeof(int));
+            var fk = DependentType.AddForeignKey(PrincipalType.GetKey(), fkProperty);
+            PrincipalType.AddNavigation(new Navigation(fk, "AnotherNav", pointsToPrincipal: false));
+
+            var newFk = new ForeignKeyConvention().FindOrCreateForeignKey(
+                PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { new[] { fkProperty } }, isUnqiue: false);
+
+            Assert.NotSame(fk, newFk);
+            Assert.Same(fkProperty, newFk.Properties.Single());
+            Assert.Same(PrimaryKey, newFk.ReferencedProperties.Single());
+            Assert.False(newFk.IsUnique);
+            Assert.True(newFk.IsRequired);
+        }
+
+        [Fact]
+        public void Does_not_match_existing_FK_if_FK_already_has_different_uniqueness()
+        {
+            var fkProperty = DependentType.AddProperty("SharedFk", typeof(int));
+            var fk = DependentType.AddForeignKey(PrincipalType.GetKey(), fkProperty);
+            fk.IsUnique = true;
+
+            var newFk = new ForeignKeyConvention().FindOrCreateForeignKey(
+                PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { new[] { fkProperty } }, isUnqiue: false);
+
+            Assert.NotSame(fk, newFk);
+            Assert.Same(fkProperty, newFk.Properties.Single());
+            Assert.Same(PrimaryKey, newFk.ReferencedProperties.Single());
+            Assert.False(newFk.IsUnique);
+            Assert.True(newFk.IsRequired);
+        }
+
+        [Fact]
+        public void Creates_unique_foreign_key_using_dependent_PK_if_no_matching_FK_property_found()
+        {
+            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: true);
+
+            Assert.Same(DependentType.GetKey().Properties.Single(), fk.Properties.Single());
+            Assert.Same(PrimaryKey, fk.ReferencedProperties.Single());
+            Assert.True(fk.IsUnique);
+            Assert.True(fk.IsRequired);
+        }
+
         private static Model BuildModel()
         {
             var model = new Model();
 
             var principalType = new EntityType(typeof(PrincipalEntity));
             principalType.SetKey(principalType.AddProperty("PeeKay", typeof(int)));
-
             model.AddEntityType(principalType);
-            model.AddEntityType(new EntityType(typeof(DependentEntity)));
+
+            var dependentType = new EntityType(typeof(DependentEntity));
+            dependentType.SetKey(dependentType.AddProperty("KayPee", typeof(int)));
+            model.AddEntityType(dependentType);
 
             return model;
         }


### PR DESCRIPTION
new[] { 1, 2, 1 } (Implementation of OneToOne for 1:1 relationships in Code First)

This is mostly refactoring and tweaking of the existing OneToMany code to make it also work for OneToOne. One functional difference is in the convention for finding an FK where for 1:1 relationships the PK is used if no other property matches the FK convention.
