### PR TITLE
Update Migrator to expect DataStoreException

### DIFF
--- a/src/EntityFramework.Migrations/Infrastructure/Migrator.cs
+++ b/src/EntityFramework.Migrations/Infrastructure/Migrator.cs
@@ -11,6 +11,7 @@ using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Utilities;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Relational.Model;
+using Microsoft.Data.Entity.Storage;
 
 namespace Microsoft.Data.Entity.Migrations.Infrastructure
 {
@@ -126,7 +127,7 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
                 migrations = HistoryRepository.Migrations;
                 historyRepositoryExists = true;
             }
-            catch (DbException)
+            catch (DataStoreException)
             {
                 // TODO: Log the exception message.
                 migrations = new IMigrationMetadata[0];

--- a/test/EntityFramework.Migrations.Tests/Infrastructure/MigratorTest.cs
+++ b/test/EntityFramework.Migrations.Tests/Infrastructure/MigratorTest.cs
@@ -10,6 +10,7 @@ using Microsoft.Data.Entity.Migrations.Infrastructure;
 using Microsoft.Data.Entity.Migrations.Model;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Relational.Model;
+using Microsoft.Data.Entity.Storage;
 using Moq;
 using Xunit;
 
@@ -607,7 +608,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
 
             var contextConfiguration = new Mock<DbContextConfiguration>().Object;
             var historyRepository = new Mock<HistoryRepository>(contextConfiguration) { CallBase = true };
-            var dbException = new Mock<DbException>();
+            var dbException = new Mock<DataStoreException>();
 
             historyRepository.SetupGet(hr => hr.Migrations).Throws(dbException.Object);
             historyRepository.Setup(hr => hr.GenerateInsertMigrationSql(It.IsAny<IMigrationMetadata>(), It.IsAny<SqlGenerator>()))


### PR DESCRIPTION
Migrator was still expecting a DbException when history table doesn't exist. But this is now a DataStoreException.

Also updating the relevant unit test. Note the unit test didn't catch this change. Catching this change would require adding functional tests that hit the actual data store exception when the table doesn't exist. There aren't any functional tests for migrations as yet.
