### PR TITLE
"He told me you killed my PK!" "No, I am your PK"

### DIFF
--- a/src/EntityFramework/Metadata/ModelConventions/ForeignKeyConvention.cs
+++ b/src/EntityFramework/Metadata/ModelConventions/ForeignKeyConvention.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
                 navigationToPrincipal,
                 navigationToDependent,
                 GetCandidateForeignKeyProperties(principalType, dependentType, navigationToPrincipal, isUnqiue),
+                new Property[0],
                 isUnqiue);
         }
 
@@ -38,7 +39,8 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             [NotNull] EntityType dependentType,
             [CanBeNull] string navigationToPrincipal,
             [CanBeNull] string navigationToDependent,
-            [NotNull] IReadOnlyList<Property[]> foreignKeyProperties,
+            [NotNull] IReadOnlyList<IReadOnlyList<Property>> foreignKeyProperties,
+            [NotNull] IReadOnlyList<Property> referencedProperties,
             bool isUnqiue)
         {
             Check.NotNull(principalType, "principalType");
@@ -77,13 +79,14 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
                                          concurrencyToken: false)
                                  };
 
-            var newForeignKey = dependentType.AddForeignKey(principalType.GetKey(), fkProperty);
+            var principalKey = referencedProperties.Any() ? new Key(referencedProperties) : principalType.GetKey();
+            var newForeignKey = dependentType.AddForeignKey(principalKey, fkProperty.ToArray());
             newForeignKey.IsUnique = isUnqiue;
             
             return newForeignKey;
         }
 
-        private IReadOnlyList<Property[]> GetCandidateForeignKeyProperties(
+        private IReadOnlyList<IReadOnlyList<Property>> GetCandidateForeignKeyProperties(
             EntityType principalType, EntityType dependentType, string navigationToPrincipal, bool isUnqiue)
         {
             var pk = principalType.TryGetKey();

--- a/test/EntityFramework.FunctionalTests/MonsterFixupTestBase.cs
+++ b/test/EntityFramework.FunctionalTests/MonsterFixupTestBase.cs
@@ -1259,7 +1259,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                 var resolution = context.Resolutions.Single(e => e.Details.StartsWith("Destroyed"));
 
-                Assert.Equal(complaint2.ComplaintId, resolution.ResolutionId);
+                Assert.Equal(SupportsCandidateKeys ? complaint2.AlternateId : complaint2.ComplaintId, resolution.ResolutionId);
 
                 var login1 = context.Logins.Single(e => e.Username == "MrsKoalie73");
                 var login2 = context.Logins.Single(e => e.Username == "MrsBossyPants");
@@ -1293,7 +1293,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                 var reset1 = context.PasswordResets.Single(e => e.EmailedTo == "trent@example.com");
 
-                Assert.Equal(login3.Username, reset1.Username);
+                Assert.Equal(SupportsCandidateKeys ? login3.AlternateUsername : login3.Username, reset1.Username);
 
                 var pageView1 = context.PageViews.Single(e => e.PageUrl == "somePage1");
                 var pageView2 = context.PageViews.Single(e => e.PageUrl == "somePage1");
@@ -1711,19 +1711,31 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
         protected abstract Task CreateAndSeedDatabase(string databaseName, Func<MonsterContext> createContext);
 
+        // TODO: Temporary means to disable use of candidate keys on SQL Server. See GitHub #537
+        protected abstract bool SupportsCandidateKeys { get; }
+
         private SnapshotMonsterContext CreateSnapshotMonsterContext(IServiceProvider serviceProvider, string databaseName = SnapshotDatabaseName)
         {
-            return new SnapshotMonsterContext(serviceProvider, CreateOptions(databaseName), OnModelCreating);
+            return new SnapshotMonsterContext(serviceProvider, CreateOptions(databaseName), OnModelCreating)
+                {
+                    SupportsCandidateKeys = SupportsCandidateKeys
+                };
         }
 
         private ChangedChangingMonsterContext CreateChangedChangingMonsterContext(IServiceProvider serviceProvider, string databaseName = FullNotifyDatabaseName)
         {
-            return new ChangedChangingMonsterContext(serviceProvider, CreateOptions(databaseName), OnModelCreating);
+            return new ChangedChangingMonsterContext(serviceProvider, CreateOptions(databaseName), OnModelCreating)
+            {
+                SupportsCandidateKeys = SupportsCandidateKeys
+            };
         }
 
         private ChangedOnlyMonsterContext CreateChangedOnlyMonsterContext(IServiceProvider serviceProvider, string databaseName = ChangedOnlyDatabaseName)
         {
-            return new ChangedOnlyMonsterContext(serviceProvider, CreateOptions(databaseName), OnModelCreating);
+            return new ChangedOnlyMonsterContext(serviceProvider, CreateOptions(databaseName), OnModelCreating)
+            {
+                SupportsCandidateKeys = SupportsCandidateKeys
+            };
         }
 
         protected virtual void OnModelCreating(ModelBuilder builder)

--- a/test/EntityFramework.FunctionalTests/TestModels/ChangedChangingMonsterContext.cs
+++ b/test/EntityFramework.FunctionalTests/TestModels/ChangedChangingMonsterContext.cs
@@ -147,6 +147,7 @@ namespace Microsoft.Data.Entity.MonsterModel
             private ICustomer _customer;
             private IResolution _resolution;
             private int _complaintId;
+            private int _alternateId;
             private int? _customerId;
             private DateTime _logged;
             private string _details;
@@ -155,6 +156,12 @@ namespace Microsoft.Data.Entity.MonsterModel
             {
                 get { return _complaintId; }
                 set { SetWithNotify(value, ref _complaintId); }
+            }
+
+            public int AlternateId
+            {
+                get { return _alternateId; }
+                set { SetWithNotify(value, ref _alternateId); }
             }
 
             public int? CustomerId
@@ -601,6 +608,7 @@ namespace Microsoft.Data.Entity.MonsterModel
         public class AnOrder : NotificationEntity, IAnOrder
         {
             private int _anOrderId;
+            private int _alternateId;
             private int? _customerId;
             private ConcurrencyInfo _concurrency;
             private ICustomer _customer;
@@ -620,6 +628,12 @@ namespace Microsoft.Data.Entity.MonsterModel
             {
                 get { return _anOrderId; }
                 set { SetWithNotify(value, ref _anOrderId); }
+            }
+
+            public int AlternateId
+            {
+                get { return _alternateId; }
+                set { SetWithNotify(value, ref _alternateId); }
             }
 
             public int? CustomerId
@@ -1365,6 +1379,7 @@ namespace Microsoft.Data.Entity.MonsterModel
         public class Login : NotificationEntity, ILogin
         {
             private string _username;
+            private string _alternateUsername;
             private int _customerId;
             private ICustomer _customer;
             private ILastLogin _lastLogin;
@@ -1383,6 +1398,12 @@ namespace Microsoft.Data.Entity.MonsterModel
             {
                 get { return _username; }
                 set { SetWithNotify(value, ref _username); }
+            }
+
+            public string AlternateUsername
+            {
+                get { return _alternateUsername; }
+                set { SetWithNotify(value, ref _alternateUsername); }
             }
 
             public int CustomerId

--- a/test/EntityFramework.FunctionalTests/TestModels/ChangedOnlyMonsterContext.cs
+++ b/test/EntityFramework.FunctionalTests/TestModels/ChangedOnlyMonsterContext.cs
@@ -137,6 +137,7 @@ namespace Microsoft.Data.Entity.MonsterModel
             private ICustomer _customer;
             private IResolution _resolution;
             private int _complaintId;
+            private int _alternateId;
             private int? _customerId;
             private DateTime _logged;
             private string _details;
@@ -145,6 +146,12 @@ namespace Microsoft.Data.Entity.MonsterModel
             {
                 get { return _complaintId; }
                 set { SetWithNotify(value, ref _complaintId); }
+            }
+
+            public int AlternateId
+            {
+                get { return _alternateId; }
+                set { SetWithNotify(value, ref _alternateId); }
             }
 
             public int? CustomerId
@@ -591,6 +598,7 @@ namespace Microsoft.Data.Entity.MonsterModel
         public class AnOrder : NotificationEntity, IAnOrder
         {
             private int _anOrderId;
+            private int _alternateId;
             private int? _customerId;
             private ConcurrencyInfo _concurrency;
             private ICustomer _customer;
@@ -610,6 +618,12 @@ namespace Microsoft.Data.Entity.MonsterModel
             {
                 get { return _anOrderId; }
                 set { SetWithNotify(value, ref _anOrderId); }
+            }
+
+            public int AlternateId
+            {
+                get { return _alternateId; }
+                set { SetWithNotify(value, ref _alternateId); }
             }
 
             public int? CustomerId
@@ -1355,6 +1369,7 @@ namespace Microsoft.Data.Entity.MonsterModel
         public class Login : NotificationEntity, ILogin
         {
             private string _username;
+            private string _alternateUsername;
             private int _customerId;
             private ICustomer _customer;
             private ILastLogin _lastLogin;
@@ -1373,6 +1388,12 @@ namespace Microsoft.Data.Entity.MonsterModel
             {
                 get { return _username; }
                 set { SetWithNotify(value, ref _username); }
+            }
+
+            public string AlternateUsername
+            {
+                get { return _alternateUsername; }
+                set { SetWithNotify(value, ref _alternateUsername); }
             }
 
             public int CustomerId

--- a/test/EntityFramework.FunctionalTests/TestModels/MonsterModel.cs
+++ b/test/EntityFramework.FunctionalTests/TestModels/MonsterModel.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Data.Entity.MonsterModel
     public interface IComplaint
     {
         int ComplaintId { get; set; }
+        int AlternateId { get; set; }
         int? CustomerId { get; set; }
         DateTime Logged { get; set; }
         string Details { get; set; }
@@ -150,6 +151,7 @@ namespace Microsoft.Data.Entity.MonsterModel
     public interface IAnOrder
     {
         int AnOrderId { get; set; }
+        int AlternateId { get; set; }
         int? CustomerId { get; set; }
         ConcurrencyInfo Concurrency { get; set; }
         ICustomer Customer { get; set; }
@@ -335,6 +337,7 @@ namespace Microsoft.Data.Entity.MonsterModel
     public interface ILogin
     {
         string Username { get; set; }
+        string AlternateUsername { get; set; }
         int CustomerId { get; set; }
         ICustomer Customer { get; set; }
         ILastLogin LastLogin { get; set; }

--- a/test/EntityFramework.FunctionalTests/TestModels/SnapshotMonsterContext.cs
+++ b/test/EntityFramework.FunctionalTests/TestModels/SnapshotMonsterContext.cs
@@ -63,6 +63,7 @@ namespace Microsoft.Data.Entity.MonsterModel
         public class Complaint : IComplaint
         {
             public int ComplaintId { get; set; }
+            public int AlternateId { get; set; }
             public int? CustomerId { get; set; }
             public DateTime Logged { get; set; }
             public string Details { get; set; }
@@ -200,6 +201,7 @@ namespace Microsoft.Data.Entity.MonsterModel
             }
 
             public int AnOrderId { get; set; }
+            public int AlternateId { get; set; }
             public int? CustomerId { get; set; }
 
             public ConcurrencyInfo Concurrency { get; set; }
@@ -436,6 +438,7 @@ namespace Microsoft.Data.Entity.MonsterModel
             }
 
             public string Username { get; set; }
+            public string AlternateUsername { get; set; }
             public int CustomerId { get; set; }
 
             public virtual ICustomer Customer { get; set; }

--- a/test/EntityFramework.InMemory.FunctionalTests/MonsterFixupTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/MonsterFixupTest.cs
@@ -8,6 +8,7 @@ using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.MonsterModel;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Fallback;
+using Xunit;
 
 namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 {
@@ -40,6 +41,12 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             }
 
             return Task.FromResult(0);
+        }
+
+        // TODO: Temporary means to disable use of candidate keys on SQL Server. See GitHub #537
+        protected override bool SupportsCandidateKeys
+        {
+            get { return true; }
         }
     }
 }

--- a/test/EntityFramework.SqlServer.FunctionalTests/MonsterFixupTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/MonsterFixupTest.cs
@@ -69,5 +69,11 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 }
             }
         }
+
+        // TODO: Temporary means to disable use of candidate keys on SQL Server. See GitHub #537
+        protected override bool SupportsCandidateKeys
+        {
+            get { return false; }
+        }
     }
 }

--- a/test/EntityFramework.Tests/Metadata/ModelBuilderTest.cs
+++ b/test/EntityFramework.Tests/Metadata/ModelBuilderTest.cs
@@ -1261,6 +1261,320 @@ namespace Microsoft.Data.Entity.Metadata
         }
 
         [Fact]
+        public void OneToMany_can_use_explicitly_specified_PK()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Customer>().Key(c => c.Id);
+            modelBuilder.Entity<Order>().Property(e => e.CustomerId);
+
+            var dependentType = model.GetEntityType(typeof(Order));
+            var principalType = model.GetEntityType(typeof(Customer));
+
+            var fkProperty = dependentType.GetProperty("CustomerId");
+            var principalProperty = principalType.GetProperty("Id");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Customer>()
+                .OneToMany(e => e.Orders, e => e.Customer)
+                .ReferencedKey(e => e.Id);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+            Assert.Same(principalProperty, fk.ReferencedProperties.Single());
+
+            Assert.Equal("Customer", dependentType.Navigations.Single().Name);
+            Assert.Equal("Orders", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void OneToMany_can_use_non_PK_principal()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Customer>(b =>
+                {
+                    b.Key(c => c.Id);
+                    b.Property(e => e.AlternateKey);
+                });
+            modelBuilder.Entity<Order>().Property(e => e.CustomerId);
+
+            var dependentType = model.GetEntityType(typeof(Order));
+            var principalType = model.GetEntityType(typeof(Customer));
+
+            var fkProperty = dependentType.GetProperty("CustomerId");
+            var principalProperty = principalType.GetProperty("AlternateKey");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Customer>()
+                .OneToMany(e => e.Orders, e => e.Customer)
+                .ReferencedKey(e => e.AlternateKey);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+            Assert.Same(principalProperty, fk.ReferencedProperties.Single());
+
+            Assert.Equal("Customer", dependentType.Navigations.Single().Name);
+            Assert.Equal("Orders", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void OneToMany_can_have_both_convention_properties_specified()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.Key(c => c.Id);
+                b.Property(e => e.AlternateKey);
+            });
+            modelBuilder.Entity<Order>().Property(e => e.CustomerId);
+
+            var dependentType = model.GetEntityType(typeof(Order));
+            var principalType = model.GetEntityType(typeof(Customer));
+
+            var fkProperty = dependentType.GetProperty("CustomerId");
+            var principalProperty = principalType.GetProperty("Id");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Customer>()
+                .OneToMany(e => e.Orders, e => e.Customer)
+                .ForeignKey(e => e.CustomerId)
+                .ReferencedKey(e => e.Id);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+            Assert.Same(principalProperty, fk.ReferencedProperties.Single());
+
+            Assert.Equal("Customer", dependentType.Navigations.Single().Name);
+            Assert.Equal("Orders", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void OneToMany_can_have_both_convention_properties_specified_in_any_order()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.Key(c => c.Id);
+                b.Property(e => e.AlternateKey);
+            });
+            modelBuilder.Entity<Order>().Property(e => e.CustomerId);
+
+            var dependentType = model.GetEntityType(typeof(Order));
+            var principalType = model.GetEntityType(typeof(Customer));
+
+            var fkProperty = dependentType.GetProperty("CustomerId");
+            var principalProperty = principalType.GetProperty("Id");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Customer>()
+                .OneToMany(e => e.Orders, e => e.Customer)
+                .ReferencedKey(e => e.Id)
+                .ForeignKey(e => e.CustomerId);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+            Assert.Same(principalProperty, fk.ReferencedProperties.Single());
+
+            Assert.Equal("Customer", dependentType.Navigations.Single().Name);
+            Assert.Equal("Orders", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void OneToMany_can_have_FK_by_convention_specified_with_explicit_principal_key()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.Key(c => c.Id);
+                b.Property(e => e.AlternateKey);
+            });
+            modelBuilder.Entity<Order>().Property(e => e.CustomerId);
+
+            var dependentType = model.GetEntityType(typeof(Order));
+            var principalType = model.GetEntityType(typeof(Customer));
+
+            var fkProperty = dependentType.GetProperty("CustomerId");
+            var principalProperty = principalType.GetProperty("AlternateKey");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Customer>()
+                .OneToMany(e => e.Orders, e => e.Customer)
+                .ForeignKey(e => e.CustomerId)
+                .ReferencedKey(e => e.AlternateKey);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+            Assert.Same(principalProperty, fk.ReferencedProperties.Single());
+
+            Assert.Equal("Customer", dependentType.Navigations.Single().Name);
+            Assert.Equal("Orders", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void OneToMany_can_have_FK_by_convention_specified_with_explicit_principal_key_in_any_order()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.Key(c => c.Id);
+                b.Property(e => e.AlternateKey);
+            });
+            modelBuilder.Entity<Order>().Property(e => e.CustomerId);
+
+            var dependentType = model.GetEntityType(typeof(Order));
+            var principalType = model.GetEntityType(typeof(Customer));
+
+            var fkProperty = dependentType.GetProperty("CustomerId");
+            var principalProperty = principalType.GetProperty("AlternateKey");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Customer>()
+                .OneToMany(e => e.Orders, e => e.Customer)
+                .ReferencedKey(e => e.AlternateKey)
+                .ForeignKey(e => e.CustomerId);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+            Assert.Same(principalProperty, fk.ReferencedProperties.Single());
+
+            Assert.Equal("Customer", dependentType.Navigations.Single().Name);
+            Assert.Equal("Orders", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void OneToMany_can_have_principal_key_by_convention_specified_with_explicit_PK()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<BigMak>(b =>
+                {
+                    b.Key(c => c.Id);
+                    b.Property(e => e.AlternateKey);
+                });
+            modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
+
+            var dependentType = model.GetEntityType(typeof(Pickle));
+            var principalType = model.GetEntityType(typeof(BigMak));
+
+            var fkProperty = dependentType.GetProperty("BurgerId");
+            var principalProperty = principalType.GetProperty("AlternateKey");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<BigMak>()
+                .OneToMany(e => e.Pickles, e => e.BigMak)
+                .ForeignKey(e => e.BurgerId)
+                .ReferencedKey(e => e.AlternateKey);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+            Assert.Same(principalProperty, fk.ReferencedProperties.Single());
+
+            Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
+            Assert.Equal("Pickles", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void OneToMany_can_have_principal_key_by_convention_specified_with_explicit_PK_in_any_order()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<BigMak>(b =>
+            {
+                b.Key(c => c.Id);
+                b.Property(e => e.AlternateKey);
+            });
+            modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
+
+            var dependentType = model.GetEntityType(typeof(Pickle));
+            var principalType = model.GetEntityType(typeof(BigMak));
+
+            var fkProperty = dependentType.GetProperty("BurgerId");
+            var principalProperty = principalType.GetProperty("AlternateKey");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<BigMak>()
+                .OneToMany(e => e.Pickles, e => e.BigMak)
+                .ReferencedKey(e => e.AlternateKey)
+                .ForeignKey(e => e.BurgerId);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+            Assert.Same(principalProperty, fk.ReferencedProperties.Single());
+
+            Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
+            Assert.Equal("Pickles", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
         public void ManyToOne_finds_existing_navs_and_uses_associated_FK()
         {
             var model = new Model();
@@ -1887,6 +2201,320 @@ namespace Microsoft.Data.Entity.Metadata
             Assert.Equal("Pickles", principalType.Navigations.Single().Name);
             Assert.Same(newFk, dependentType.Navigations.Single().ForeignKey);
             Assert.Same(newFk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void ManyToOne_can_use_explicitly_specified_PK()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Customer>().Key(c => c.Id);
+            modelBuilder.Entity<Order>().Property(e => e.CustomerId);
+
+            var dependentType = model.GetEntityType(typeof(Order));
+            var principalType = model.GetEntityType(typeof(Customer));
+
+            var fkProperty = dependentType.GetProperty("CustomerId");
+            var principalProperty = principalType.GetProperty("Id");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Order>()
+                .ManyToOne(e => e.Customer, e => e.Orders)
+                .ReferencedKey(e => e.Id);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+            Assert.Same(principalProperty, fk.ReferencedProperties.Single());
+
+            Assert.Equal("Customer", dependentType.Navigations.Single().Name);
+            Assert.Equal("Orders", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void ManyToOne_can_use_non_PK_principal()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.Key(c => c.Id);
+                b.Property(e => e.AlternateKey);
+            });
+            modelBuilder.Entity<Order>().Property(e => e.CustomerId);
+
+            var dependentType = model.GetEntityType(typeof(Order));
+            var principalType = model.GetEntityType(typeof(Customer));
+
+            var fkProperty = dependentType.GetProperty("CustomerId");
+            var principalProperty = principalType.GetProperty("AlternateKey");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Order>()
+                .ManyToOne(e => e.Customer, e => e.Orders)
+                .ReferencedKey(e => e.AlternateKey);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+            Assert.Same(principalProperty, fk.ReferencedProperties.Single());
+
+            Assert.Equal("Customer", dependentType.Navigations.Single().Name);
+            Assert.Equal("Orders", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void ManyToOne_can_have_both_convention_properties_specified()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.Key(c => c.Id);
+                b.Property(e => e.AlternateKey);
+            });
+            modelBuilder.Entity<Order>().Property(e => e.CustomerId);
+
+            var dependentType = model.GetEntityType(typeof(Order));
+            var principalType = model.GetEntityType(typeof(Customer));
+
+            var fkProperty = dependentType.GetProperty("CustomerId");
+            var principalProperty = principalType.GetProperty("Id");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Order>()
+                .ManyToOne(e => e.Customer, e => e.Orders)
+                .ForeignKey(e => e.CustomerId)
+                .ReferencedKey(e => e.Id);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+            Assert.Same(principalProperty, fk.ReferencedProperties.Single());
+
+            Assert.Equal("Customer", dependentType.Navigations.Single().Name);
+            Assert.Equal("Orders", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void ManyToOne_can_have_both_convention_properties_specified_in_any_order()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.Key(c => c.Id);
+                b.Property(e => e.AlternateKey);
+            });
+            modelBuilder.Entity<Order>().Property(e => e.CustomerId);
+
+            var dependentType = model.GetEntityType(typeof(Order));
+            var principalType = model.GetEntityType(typeof(Customer));
+
+            var fkProperty = dependentType.GetProperty("CustomerId");
+            var principalProperty = principalType.GetProperty("Id");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Order>()
+                .ManyToOne(e => e.Customer, e => e.Orders)
+                .ReferencedKey(e => e.Id)
+                .ForeignKey(e => e.CustomerId);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+            Assert.Same(principalProperty, fk.ReferencedProperties.Single());
+
+            Assert.Equal("Customer", dependentType.Navigations.Single().Name);
+            Assert.Equal("Orders", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void ManyToOne_can_have_FK_by_convention_specified_with_explicit_principal_key()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.Key(c => c.Id);
+                b.Property(e => e.AlternateKey);
+            });
+            modelBuilder.Entity<Order>().Property(e => e.CustomerId);
+
+            var dependentType = model.GetEntityType(typeof(Order));
+            var principalType = model.GetEntityType(typeof(Customer));
+
+            var fkProperty = dependentType.GetProperty("CustomerId");
+            var principalProperty = principalType.GetProperty("AlternateKey");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Order>()
+                .ManyToOne(e => e.Customer, e => e.Orders)
+                .ForeignKey(e => e.CustomerId)
+                .ReferencedKey(e => e.AlternateKey);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+            Assert.Same(principalProperty, fk.ReferencedProperties.Single());
+
+            Assert.Equal("Customer", dependentType.Navigations.Single().Name);
+            Assert.Equal("Orders", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void ManyToOne_can_have_FK_by_convention_specified_with_explicit_principal_key_in_any_order()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Customer>(b =>
+            {
+                b.Key(c => c.Id);
+                b.Property(e => e.AlternateKey);
+            });
+            modelBuilder.Entity<Order>().Property(e => e.CustomerId);
+
+            var dependentType = model.GetEntityType(typeof(Order));
+            var principalType = model.GetEntityType(typeof(Customer));
+
+            var fkProperty = dependentType.GetProperty("CustomerId");
+            var principalProperty = principalType.GetProperty("AlternateKey");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Order>()
+                .ManyToOne(e => e.Customer, e => e.Orders)
+                .ReferencedKey(e => e.AlternateKey)
+                .ForeignKey(e => e.CustomerId);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+            Assert.Same(principalProperty, fk.ReferencedProperties.Single());
+
+            Assert.Equal("Customer", dependentType.Navigations.Single().Name);
+            Assert.Equal("Orders", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void ManyToOne_can_have_principal_key_by_convention_specified_with_explicit_PK()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<BigMak>(b =>
+            {
+                b.Key(c => c.Id);
+                b.Property(e => e.AlternateKey);
+            });
+            modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
+
+            var dependentType = model.GetEntityType(typeof(Pickle));
+            var principalType = model.GetEntityType(typeof(BigMak));
+
+            var fkProperty = dependentType.GetProperty("BurgerId");
+            var principalProperty = principalType.GetProperty("AlternateKey");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Pickle>()
+                .ManyToOne(e => e.BigMak, e => e.Pickles)
+                .ForeignKey(e => e.BurgerId)
+                .ReferencedKey(e => e.AlternateKey);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+            Assert.Same(principalProperty, fk.ReferencedProperties.Single());
+
+            Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
+            Assert.Equal("Pickles", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void ManyToOne_can_have_principal_key_by_convention_specified_with_explicit_PK_in_any_order()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<BigMak>(b =>
+            {
+                b.Key(c => c.Id);
+                b.Property(e => e.AlternateKey);
+            });
+            modelBuilder.Entity<Pickle>().Property(e => e.BurgerId);
+
+            var dependentType = model.GetEntityType(typeof(Pickle));
+            var principalType = model.GetEntityType(typeof(BigMak));
+
+            var fkProperty = dependentType.GetProperty("BurgerId");
+            var principalProperty = principalType.GetProperty("AlternateKey");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Pickle>()
+                .ManyToOne(e => e.BigMak, e => e.Pickles)
+                .ReferencedKey(e => e.AlternateKey)
+                .ForeignKey(e => e.BurgerId);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+            Assert.Same(principalProperty, fk.ReferencedProperties.Single());
+
+            Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
+            Assert.Equal("Pickles", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
             Assert.Equal(principalPropertyCount, principalType.Properties.Count);
             Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
             Assert.Empty(principalType.ForeignKeys);
@@ -2673,9 +3301,486 @@ namespace Microsoft.Data.Entity.Metadata
             Assert.Empty(principalType.ForeignKeys);
         }
 
+        [Fact]
+        public void OneToOne_can_have_PK_explicitly_specified()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Customer>().Key(c => c.Id);
+            modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
+
+            var dependentType = model.GetEntityType(typeof(CustomerDetails));
+            var principalType = model.GetEntityType(typeof(Customer));
+
+            var fkProperty = dependentType.GetProperty("Id");
+            var principalProperty = principalType.GetProperty("Id");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Customer>()
+                .OneToOne(e => e.Details, e => e.Customer)
+                .ReferencedKey<Customer>(e => e.Id);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+            Assert.Same(principalProperty, fk.ReferencedProperties.Single());
+
+            Assert.Equal("Customer", dependentType.Navigations.Single().Name);
+            Assert.Equal("Details", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void OneToOne_can_use_alternate_principal_key()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Customer>(b =>
+                {
+                    b.Key(c => c.Id);
+                    b.Property(e => e.AlternateKey);
+                });
+            modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
+
+            var dependentType = model.GetEntityType(typeof(CustomerDetails));
+            var principalType = model.GetEntityType(typeof(Customer));
+
+            var fkProperty = dependentType.GetProperty("Id");
+            var principalProperty = principalType.GetProperty("AlternateKey");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Customer>()
+                .OneToOne(e => e.Details, e => e.Customer)
+                .ReferencedKey<Customer>(e => e.AlternateKey);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+            Assert.Same(principalProperty, fk.ReferencedProperties.Single());
+
+            Assert.Equal("Customer", dependentType.Navigations.Single().Name);
+            Assert.Equal("Details", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void OneToOne_can_have_both_convention_keys_specified_explicitly()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Order>().Key(c => c.OrderId);
+            modelBuilder.Entity<OrderDetails>(b =>
+            {
+                b.Key(e => e.Id);
+                b.Property(e => e.OrderId);
+            });
+
+            var dependentType = model.GetEntityType(typeof(OrderDetails));
+            var principalType = model.GetEntityType(typeof(Order));
+
+            var fkProperty = dependentType.GetProperty("OrderId");
+            var principalProperty = principalType.GetProperty("OrderId");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Order>()
+                .OneToOne(e => e.Details, e => e.Order)
+                .ForeignKey<OrderDetails>(e => e.OrderId)
+                .ReferencedKey<Order>(e => e.OrderId);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+            Assert.Same(principalProperty, fk.ReferencedProperties.Single());
+
+            Assert.Equal("Order", dependentType.Navigations.Single().Name);
+            Assert.Equal("Details", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void OneToOne_can_have_both_convention_keys_specified_explicitly_in_any_order()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Order>().Key(c => c.OrderId);
+            modelBuilder.Entity<OrderDetails>(b =>
+            {
+                b.Key(e => e.Id);
+                b.Property(e => e.OrderId);
+            });
+
+            var dependentType = model.GetEntityType(typeof(OrderDetails));
+            var principalType = model.GetEntityType(typeof(Order));
+
+            var fkProperty = dependentType.GetProperty("OrderId");
+            var principalProperty = principalType.GetProperty("OrderId");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Order>()
+                .OneToOne(e => e.Details, e => e.Order)
+                .ReferencedKey<Order>(e => e.OrderId)
+                .ForeignKey<OrderDetails>(e => e.OrderId);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+            Assert.Same(principalProperty, fk.ReferencedProperties.Single());
+
+            Assert.Equal("Order", dependentType.Navigations.Single().Name);
+            Assert.Equal("Details", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void OneToOne_can_have_both_keys_specified_explicitly()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<BigMak>(b =>
+                {
+                    b.Key(c => c.Id);
+                    b.Property(e => e.AlternateKey);
+                });
+            modelBuilder.Entity<Bun>().Property(e => e.BurgerId);
+
+            var dependentType = model.GetEntityType(typeof(Bun));
+            var principalType = model.GetEntityType(typeof(BigMak));
+
+            var fkProperty = dependentType.GetProperty("BurgerId");
+            var principalProperty = principalType.GetProperty("AlternateKey");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<BigMak>()
+                .OneToOne(e => e.Bun, e => e.BigMak)
+                .ForeignKey<Bun>(e => e.BurgerId)
+                .ReferencedKey<BigMak>(e => e.AlternateKey);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+            Assert.Same(principalProperty, fk.ReferencedProperties.Single());
+
+            Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
+            Assert.Equal("Bun", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void OneToOne_can_have_both_keys_specified_explicitly_in_any_order()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<BigMak>(b =>
+            {
+                b.Key(c => c.Id);
+                b.Property(e => e.AlternateKey);
+            });
+            modelBuilder.Entity<Bun>().Property(e => e.BurgerId);
+
+            var dependentType = model.GetEntityType(typeof(Bun));
+            var principalType = model.GetEntityType(typeof(BigMak));
+
+            var fkProperty = dependentType.GetProperty("BurgerId");
+            var principalProperty = principalType.GetProperty("AlternateKey");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<BigMak>()
+                .OneToOne(e => e.Bun, e => e.BigMak)
+                .ReferencedKey<BigMak>(e => e.AlternateKey)
+                .ForeignKey<Bun>(e => e.BurgerId);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+            Assert.Same(principalProperty, fk.ReferencedProperties.Single());
+
+            Assert.Equal("BigMak", dependentType.Navigations.Single().Name);
+            Assert.Equal("Bun", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void OneToOne_principal_and_dependent_can_be_flipped_using_principal_with_existing_FK_still_used()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Order>().Key(c => c.OrderId);
+            modelBuilder.Entity<OrderDetails>().Key(e => e.Id);
+            modelBuilder
+                .Entity<OrderDetails>()
+                .ForeignKeys(fks => fks.ForeignKey<Order>(c => c.Id));
+
+            var dependentType = model.GetEntityType(typeof(OrderDetails));
+            var principalType = model.GetEntityType(typeof(Order));
+            var fk = dependentType.ForeignKeys.Single();
+            fk.IsUnique = true;
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<OrderDetails>()
+                .OneToOne(e => e.Order, e => e.Details)
+                .ReferencedKey<Order>();
+
+            Assert.Same(fk, dependentType.ForeignKeys.Single());
+            Assert.Equal("Order", dependentType.Navigations.Single().Name);
+            Assert.Equal("Details", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void OneToOne_principal_and_dependent_can_be_flipped_using_principal_with_FK_still_found_by_convention()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Order>().Key(c => c.OrderId);
+            modelBuilder.Entity<OrderDetails>(b =>
+            {
+                b.Key(e => e.Id);
+                b.Property(e => e.OrderId);
+            });
+
+            var dependentType = model.GetEntityType(typeof(OrderDetails));
+            var principalType = model.GetEntityType(typeof(Order));
+
+            var fkProperty = dependentType.GetProperty("OrderId");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<OrderDetails>()
+                .OneToOne(e => e.Order, e => e.Details)
+                .ReferencedKey<Order>();
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+
+            Assert.Equal("Order", dependentType.Navigations.Single().Name);
+            Assert.Equal("Details", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void OneToOne_principal_and_dependent_can_be_flipped_in_both_ways()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Order>().Key(c => c.OrderId);
+            modelBuilder.Entity<OrderDetails>(b =>
+            {
+                b.Key(e => e.Id);
+                b.Property(e => e.OrderId);
+            });
+
+            var dependentType = model.GetEntityType(typeof(OrderDetails));
+            var principalType = model.GetEntityType(typeof(Order));
+
+            var fkProperty = dependentType.GetProperty("OrderId");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<OrderDetails>()
+                .OneToOne(e => e.Order, e => e.Details)
+                .ForeignKey<OrderDetails>()
+                .ReferencedKey<Order>();
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+
+            Assert.Equal("Order", dependentType.Navigations.Single().Name);
+            Assert.Equal("Details", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void OneToOne_principal_and_dependent_can_be_flipped_in_both_ways_in_any_order()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Order>().Key(c => c.OrderId);
+            modelBuilder.Entity<OrderDetails>(b =>
+            {
+                b.Key(e => e.Id);
+                b.Property(e => e.OrderId);
+            });
+
+            var dependentType = model.GetEntityType(typeof(OrderDetails));
+            var principalType = model.GetEntityType(typeof(Order));
+
+            var fkProperty = dependentType.GetProperty("OrderId");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<OrderDetails>()
+                .OneToOne(e => e.Order, e => e.Details)
+                .ReferencedKey<Order>()
+                .ForeignKey<OrderDetails>();
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+
+            Assert.Equal("Order", dependentType.Navigations.Single().Name);
+            Assert.Equal("Details", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void Unidirectional_from_other_end_OneToOne_principal_and_dependent_can_be_flipped_using_principal()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Customer>().Key(c => c.Id);
+            modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
+
+            var dependentType = model.GetEntityType(typeof(CustomerDetails));
+            var principalType = model.GetEntityType(typeof(Customer));
+
+            var fkProperty = dependentType.GetProperty("Id");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<CustomerDetails>()
+                .OneToOne<Customer>(e => e.Customer)
+                .ReferencedKey<Customer>();
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+
+            Assert.Equal("Customer", dependentType.Navigations.Single().Name);
+            Assert.Empty(principalType.Navigations);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void Unidirectional_OneToOne_principal_and_dependent_can_be_flipped_using_principal()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Customer>().Key(c => c.Id);
+            modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
+
+            var dependentType = model.GetEntityType(typeof(CustomerDetails));
+            var principalType = model.GetEntityType(typeof(Customer));
+
+            var fkProperty = dependentType.GetProperty("Id");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<CustomerDetails>()
+                .OneToOne<Customer>(null, e => e.Details)
+                .ReferencedKey<Customer>();
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+
+            Assert.Empty(dependentType.Navigations);
+            Assert.Equal("Details", principalType.Navigations.Single().Name);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void No_navigation_OneToOne_principal_and_dependent_can_be_flipped_using_principal()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Customer>().Key(c => c.Id);
+            modelBuilder.Entity<CustomerDetails>().Key(e => e.Id);
+
+            var dependentType = model.GetEntityType(typeof(CustomerDetails));
+            var principalType = model.GetEntityType(typeof(Customer));
+
+            var fkProperty = dependentType.GetProperty("Id");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<CustomerDetails>()
+                .OneToOne<Customer>()
+                .ReferencedKey<Customer>();
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty, fk.Properties.Single());
+
+            Assert.Empty(dependentType.Navigations);
+            Assert.Empty(principalType.Navigations);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
         private class BigMak
         {
             public int Id { get; set; }
+            public int AlternateKey { get; set; }
 
             public IEnumerable<Pickle> Pickles { get; set; }
 
@@ -2759,6 +3864,104 @@ namespace Microsoft.Data.Entity.Metadata
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
+
+            Assert.Equal("Whoopper", dependentType.Navigations.Single().Name);
+            Assert.Equal("Tomatoes", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void OneToMany_can_use_alternate_composite_key()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Whoopper>(b =>
+                {
+                    b.Key(c => new { c.Id1, c.Id2 });
+                    b.Property(e => e.AlternateKey1);
+                    b.Property(e => e.AlternateKey2);
+                });
+            modelBuilder.Entity<Tomato>(b =>
+            {
+                b.Property(e => e.BurgerId1);
+                b.Property(e => e.BurgerId2);
+            });
+
+            var dependentType = model.GetEntityType(typeof(Tomato));
+            var principalType = model.GetEntityType(typeof(Whoopper));
+
+            var fkProperty1 = dependentType.GetProperty("BurgerId1");
+            var fkProperty2 = dependentType.GetProperty("BurgerId2");
+            var principalProperty1 = principalType.GetProperty("AlternateKey1");
+            var principalProperty2 = principalType.GetProperty("AlternateKey2");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Whoopper>()
+                .OneToMany(e => e.Tomatoes, e => e.Whoopper)
+                .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 })
+                .ReferencedKey(e => new { e.AlternateKey1, e.AlternateKey2 });
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty1, fk.Properties[0]);
+            Assert.Same(fkProperty2, fk.Properties[1]);
+            Assert.Same(principalProperty1, fk.ReferencedProperties[0]);
+            Assert.Same(principalProperty2, fk.ReferencedProperties[1]);
+
+            Assert.Equal("Whoopper", dependentType.Navigations.Single().Name);
+            Assert.Equal("Tomatoes", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void OneToMany_can_use_alternate_composite_key_in_any_order()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Whoopper>(b =>
+            {
+                b.Key(c => new { c.Id1, c.Id2 });
+                b.Property(e => e.AlternateKey1);
+                b.Property(e => e.AlternateKey2);
+            });
+            modelBuilder.Entity<Tomato>(b =>
+            {
+                b.Property(e => e.BurgerId1);
+                b.Property(e => e.BurgerId2);
+            });
+
+            var dependentType = model.GetEntityType(typeof(Tomato));
+            var principalType = model.GetEntityType(typeof(Whoopper));
+
+            var fkProperty1 = dependentType.GetProperty("BurgerId1");
+            var fkProperty2 = dependentType.GetProperty("BurgerId2");
+            var principalProperty1 = principalType.GetProperty("AlternateKey1");
+            var principalProperty2 = principalType.GetProperty("AlternateKey2");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Whoopper>()
+                .OneToMany(e => e.Tomatoes, e => e.Whoopper)
+                .ReferencedKey(e => new { e.AlternateKey1, e.AlternateKey2 })
+                .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty1, fk.Properties[0]);
+            Assert.Same(fkProperty2, fk.Properties[1]);
+            Assert.Same(principalProperty1, fk.ReferencedProperties[0]);
+            Assert.Same(principalProperty2, fk.ReferencedProperties[1]);
 
             Assert.Equal("Whoopper", dependentType.Navigations.Single().Name);
             Assert.Equal("Tomatoes", principalType.Navigations.Single().Name);
@@ -2943,6 +4146,104 @@ namespace Microsoft.Data.Entity.Metadata
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
+
+            Assert.Equal("Whoopper", dependentType.Navigations.Single().Name);
+            Assert.Equal("Tomatoes", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void ManyToOne_can_use_alternate_composite_key()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Whoopper>(b =>
+            {
+                b.Key(c => new { c.Id1, c.Id2 });
+                b.Property(e => e.AlternateKey1);
+                b.Property(e => e.AlternateKey2);
+            });
+            modelBuilder.Entity<Tomato>(b =>
+            {
+                b.Property(e => e.BurgerId1);
+                b.Property(e => e.BurgerId2);
+            });
+
+            var dependentType = model.GetEntityType(typeof(Tomato));
+            var principalType = model.GetEntityType(typeof(Whoopper));
+
+            var fkProperty1 = dependentType.GetProperty("BurgerId1");
+            var fkProperty2 = dependentType.GetProperty("BurgerId2");
+            var principalProperty1 = principalType.GetProperty("AlternateKey1");
+            var principalProperty2 = principalType.GetProperty("AlternateKey2");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Tomato>()
+                .ManyToOne(e => e.Whoopper, e => e.Tomatoes)
+                .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 })
+                .ReferencedKey(e => new { e.AlternateKey1, e.AlternateKey2 });
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty1, fk.Properties[0]);
+            Assert.Same(fkProperty2, fk.Properties[1]);
+            Assert.Same(principalProperty1, fk.ReferencedProperties[0]);
+            Assert.Same(principalProperty2, fk.ReferencedProperties[1]);
+
+            Assert.Equal("Whoopper", dependentType.Navigations.Single().Name);
+            Assert.Equal("Tomatoes", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void ManyToOne_can_use_alternate_composite_key_in_any_order()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Whoopper>(b =>
+            {
+                b.Key(c => new { c.Id1, c.Id2 });
+                b.Property(e => e.AlternateKey1);
+                b.Property(e => e.AlternateKey2);
+            });
+            modelBuilder.Entity<Tomato>(b =>
+            {
+                b.Property(e => e.BurgerId1);
+                b.Property(e => e.BurgerId2);
+            });
+
+            var dependentType = model.GetEntityType(typeof(Tomato));
+            var principalType = model.GetEntityType(typeof(Whoopper));
+
+            var fkProperty1 = dependentType.GetProperty("BurgerId1");
+            var fkProperty2 = dependentType.GetProperty("BurgerId2");
+            var principalProperty1 = principalType.GetProperty("AlternateKey1");
+            var principalProperty2 = principalType.GetProperty("AlternateKey2");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Tomato>()
+                .ManyToOne(e => e.Whoopper, e => e.Tomatoes)
+                .ReferencedKey(e => new { e.AlternateKey1, e.AlternateKey2 })
+                .ForeignKey(e => new { e.BurgerId1, e.BurgerId2 });
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty1, fk.Properties[0]);
+            Assert.Same(fkProperty2, fk.Properties[1]);
+            Assert.Same(principalProperty1, fk.ReferencedProperties[0]);
+            Assert.Same(principalProperty2, fk.ReferencedProperties[1]);
 
             Assert.Equal("Whoopper", dependentType.Navigations.Single().Name);
             Assert.Equal("Tomatoes", principalType.Navigations.Single().Name);
@@ -3139,7 +4440,105 @@ namespace Microsoft.Data.Entity.Metadata
         }
 
         [Fact]
-        public void OneToOne_uses_composite_PK_for_FK_by_conventions()
+        public void OneToOne_can_use_alternate_composite_key()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Whoopper>(b =>
+            {
+                b.Key(c => new { c.Id1, c.Id2 });
+                b.Property(e => e.AlternateKey1);
+                b.Property(e => e.AlternateKey2);
+            });
+            modelBuilder.Entity<ToastedBun>(b =>
+            {
+                b.Property(e => e.BurgerId1);
+                b.Property(e => e.BurgerId2);
+            });
+
+            var dependentType = model.GetEntityType(typeof(ToastedBun));
+            var principalType = model.GetEntityType(typeof(Whoopper));
+            var principalProperty1 = principalType.GetProperty("AlternateKey1");
+            var principalProperty2 = principalType.GetProperty("AlternateKey2");
+
+            var fkProperty1 = dependentType.GetProperty("BurgerId1");
+            var fkProperty2 = dependentType.GetProperty("BurgerId2");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Whoopper>()
+                .OneToOne(e => e.ToastedBun, e => e.Whoopper)
+                .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 })
+                .ReferencedKey<Whoopper>(e => new { e.AlternateKey1, e.AlternateKey2 });
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty1, fk.Properties[0]);
+            Assert.Same(fkProperty2, fk.Properties[1]);
+            Assert.Same(principalProperty1, fk.ReferencedProperties[0]);
+            Assert.Same(principalProperty2, fk.ReferencedProperties[1]);
+
+            Assert.Equal("Whoopper", dependentType.Navigations.Single().Name);
+            Assert.Equal("ToastedBun", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void OneToOne_can_use_alternate_composite_key_in_any_order()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Whoopper>(b =>
+            {
+                b.Key(c => new { c.Id1, c.Id2 });
+                b.Property(e => e.AlternateKey1);
+                b.Property(e => e.AlternateKey2);
+            });
+            modelBuilder.Entity<ToastedBun>(b =>
+            {
+                b.Property(e => e.BurgerId1);
+                b.Property(e => e.BurgerId2);
+            });
+
+            var dependentType = model.GetEntityType(typeof(ToastedBun));
+            var principalType = model.GetEntityType(typeof(Whoopper));
+            var principalProperty1 = principalType.GetProperty("AlternateKey1");
+            var principalProperty2 = principalType.GetProperty("AlternateKey2");
+
+            var fkProperty1 = dependentType.GetProperty("BurgerId1");
+            var fkProperty2 = dependentType.GetProperty("BurgerId2");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Whoopper>()
+                .OneToOne(e => e.ToastedBun, e => e.Whoopper)
+                .ReferencedKey<Whoopper>(e => new { e.AlternateKey1, e.AlternateKey2 })
+                .ForeignKey<ToastedBun>(e => new { e.BurgerId1, e.BurgerId2 });
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty1, fk.Properties[0]);
+            Assert.Same(fkProperty2, fk.Properties[1]);
+            Assert.Same(principalProperty1, fk.ReferencedProperties[0]);
+            Assert.Same(principalProperty2, fk.ReferencedProperties[1]);
+
+            Assert.Equal("Whoopper", dependentType.Navigations.Single().Name);
+            Assert.Equal("ToastedBun", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void OneToOne_uses_composite_PK_for_FK_by_convention()
         {
             var model = new Model();
             var modelBuilder = new ModelBuilder(model);
@@ -3158,6 +4557,76 @@ namespace Microsoft.Data.Entity.Metadata
             modelBuilder
                 .Entity<Whoopper>()
                 .OneToOne(e => e.Moostard, e => e.Whoopper);
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty1, fk.Properties[0]);
+            Assert.Same(fkProperty2, fk.Properties[1]);
+
+            Assert.Equal("Whoopper", dependentType.Navigations.Single().Name);
+            Assert.Equal("Moostard", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void OneToOne_can_be_flipped_and_composite_PK_is_still_used_by_convention()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
+            modelBuilder.Entity<Moostard>().Key(c => new { c.Id1, c.Id2 });
+
+            var dependentType = model.GetEntityType(typeof(Moostard));
+            var principalType = model.GetEntityType(typeof(Whoopper));
+
+            var fkProperty1 = dependentType.GetProperty("Id1");
+            var fkProperty2 = dependentType.GetProperty("Id2");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Moostard>()
+                .OneToOne(e => e.Whoopper, e => e.Moostard)
+                .ForeignKey<Moostard>();
+
+            var fk = dependentType.ForeignKeys.Single();
+            Assert.Same(fkProperty1, fk.Properties[0]);
+            Assert.Same(fkProperty2, fk.Properties[1]);
+
+            Assert.Equal("Whoopper", dependentType.Navigations.Single().Name);
+            Assert.Equal("Moostard", principalType.Navigations.Single().Name);
+            Assert.Same(fk, dependentType.Navigations.Single().ForeignKey);
+            Assert.Same(fk, principalType.Navigations.Single().ForeignKey);
+            Assert.Equal(principalPropertyCount, principalType.Properties.Count);
+            Assert.Equal(dependentPropertyCount, dependentType.Properties.Count);
+            Assert.Empty(principalType.ForeignKeys);
+        }
+
+        [Fact]
+        public void OneToOne_can_be_flipped_using_principal_and_composite_PK_is_still_used_by_convention()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+            modelBuilder.Entity<Whoopper>().Key(c => new { c.Id1, c.Id2 });
+            modelBuilder.Entity<Moostard>().Key(c => new { c.Id1, c.Id2 });
+
+            var dependentType = model.GetEntityType(typeof(Moostard));
+            var principalType = model.GetEntityType(typeof(Whoopper));
+
+            var fkProperty1 = dependentType.GetProperty("Id1");
+            var fkProperty2 = dependentType.GetProperty("Id2");
+
+            var principalPropertyCount = principalType.Properties.Count;
+            var dependentPropertyCount = dependentType.Properties.Count;
+
+            modelBuilder
+                .Entity<Moostard>()
+                .OneToOne(e => e.Whoopper, e => e.Moostard)
+                .ReferencedKey<Whoopper>();
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
@@ -3289,6 +4758,8 @@ namespace Microsoft.Data.Entity.Metadata
         {
             public int Id1 { get; set; }
             public int Id2 { get; set; }
+            public int AlternateKey1 { get; set; }
+            public int AlternateKey2 { get; set; }
 
             public IEnumerable<Tomato> Tomatoes { get; set; }
 
@@ -3326,6 +4797,7 @@ namespace Microsoft.Data.Entity.Metadata
         private class Customer
         {
             public int Id { get; set; }
+            public int AlternateKey { get; set; }
             public string Name { get; set; }
 
             public IEnumerable<Order> Orders { get; set; }

--- a/test/EntityFramework.Tests/Metadata/ModelConventions/ForeignKeyConventionTest.cs
+++ b/test/EntityFramework.Tests/Metadata/ModelConventions/ForeignKeyConventionTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             Assert.Same(
                 fk,
                 new ForeignKeyConvention().FindOrCreateForeignKey(
-                    PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { new[] { fkProperty } }, isUnqiue: false));
+                    PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { new[] { fkProperty } }, new Property[0], isUnqiue: false));
         }
 
         [Fact]
@@ -42,7 +42,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             Assert.Same(
                 fk,
                 new ForeignKeyConvention().FindOrCreateForeignKey(
-                    PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { new[] { fkProperty1, fkProperty2 } }, isUnqiue: false));
+                    PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { new[] { fkProperty1, fkProperty2 } }, new Property[0], isUnqiue: false));
         }
 
         [Fact]
@@ -101,10 +101,53 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             var fkProperty = DependentType.AddProperty("No!No!", typeof(int));
 
             var fk = new ForeignKeyConvention().FindOrCreateForeignKey(
-                PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { new[] { fkProperty } }, isUnqiue: false);
+                PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { new[] { fkProperty } }, new Property[0], isUnqiue: false);
 
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.ReferencedProperties.Single());
+            Assert.False(fk.IsUnique);
+            Assert.True(fk.IsRequired);
+        }
+
+        [Fact]
+        public void Creates_foreign_key_using_given_principal_property()
+        {
+            var fkProperty = DependentType.AddProperty("SomeNavID", typeof(int));
+            DependentType.AddProperty("SomeNavPeEKaY", typeof(int));
+            DependentType.AddProperty("PrincipalEntityID", typeof(int));
+            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
+            var principalKeyProperty = PrincipalType.AddProperty("No!No!", typeof(int));
+
+            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(
+                PrincipalType, DependentType, "SomeNav", "SomeInverse", new Property[0][], new[] { principalKeyProperty }, isUnqiue: false);
+
+            Assert.Same(fkProperty, fk.Properties.Single());
+            Assert.Same(principalKeyProperty, fk.ReferencedProperties.Single());
+            Assert.False(fk.IsUnique);
+            Assert.True(fk.IsRequired);
+        }
+
+        [Fact]
+        public void Creates_foreign_key_using_given_dependent_and_principal_property()
+        {
+            DependentType.AddProperty("SomeNavID", typeof(int));
+            DependentType.AddProperty("SomeNavPeEKaY", typeof(int));
+            DependentType.AddProperty("PrincipalEntityID", typeof(int));
+            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
+            var fkProperty = DependentType.AddProperty("No!", typeof(int));
+            var principalKeyProperty = PrincipalType.AddProperty("No!No!", typeof(int));
+
+            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(
+                PrincipalType, 
+                DependentType, 
+                "SomeNav", 
+                "SomeInverse", 
+                new[] { new[] { fkProperty } }, 
+                new[] { principalKeyProperty }, 
+                isUnqiue: false);
+
+            Assert.Same(fkProperty, fk.Properties.Single());
+            Assert.Same(principalKeyProperty, fk.ReferencedProperties.Single());
             Assert.False(fk.IsUnique);
             Assert.True(fk.IsRequired);
         }
@@ -120,11 +163,46 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             var fkProperty2 = DependentType.AddProperty("ThatsImpossible!", typeof(int));
 
             var fk = new ForeignKeyConvention().FindOrCreateForeignKey(
-                PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { new[] { fkProperty1, fkProperty2 } }, isUnqiue: false);
+                PrincipalType, 
+                DependentType, 
+                "SomeNav", 
+                "SomeInverse", 
+                new[] { new[] { fkProperty1, fkProperty2 } }, 
+                new Property[0], 
+                isUnqiue: false);
 
             Assert.Same(fkProperty1, fk.Properties[0]);
             Assert.Same(fkProperty2, fk.Properties[1]);
             Assert.Same(PrimaryKey, fk.ReferencedProperties.Single());
+            Assert.False(fk.IsUnique);
+            Assert.True(fk.IsRequired);
+        }
+
+        [Fact]
+        public void Creates_foreign_key_using_given_dependent_and_principal_properties()
+        {
+            DependentType.AddProperty("SomeNavID", typeof(int));
+            DependentType.AddProperty("SomeNavPeEKaY", typeof(int));
+            DependentType.AddProperty("PrincipalEntityID", typeof(int));
+            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
+            var fkProperty1 = DependentType.AddProperty("ThatsNotTrue!", typeof(int));
+            var fkProperty2 = DependentType.AddProperty("ThatsImpossible!", typeof(int));
+            var principalKeyProperty1 = PrincipalType.AddProperty("SearchYourFeelings", typeof(int));
+            var principalKeyProperty2 = PrincipalType.AddProperty("YouKnowItToBeTrue!", typeof(int));
+
+            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(
+                PrincipalType, 
+                DependentType, 
+                "SomeNav", 
+                "SomeInverse", 
+                new[] { new[] { fkProperty1, fkProperty2 } },
+                new[] { principalKeyProperty1, principalKeyProperty2 }, 
+                isUnqiue: false);
+
+            Assert.Same(fkProperty1, fk.Properties[0]);
+            Assert.Same(fkProperty2, fk.Properties[1]);
+            Assert.Same(principalKeyProperty1, fk.ReferencedProperties[0]);
+            Assert.Same(principalKeyProperty2, fk.ReferencedProperties[1]);
             Assert.False(fk.IsUnique);
             Assert.True(fk.IsRequired);
         }
@@ -223,7 +301,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             DependentType.AddNavigation(new Navigation(fk, "AnotherNav", pointsToPrincipal: true));
 
             var newFk = new ForeignKeyConvention().FindOrCreateForeignKey(
-                PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { new[] { fkProperty } }, isUnqiue: false);
+                PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { new[] { fkProperty } }, new Property[0], isUnqiue: false);
 
             Assert.NotSame(fk, newFk);
             Assert.Same(fkProperty, newFk.Properties.Single());
@@ -240,7 +318,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             PrincipalType.AddNavigation(new Navigation(fk, "AnotherNav", pointsToPrincipal: false));
 
             var newFk = new ForeignKeyConvention().FindOrCreateForeignKey(
-                PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { new[] { fkProperty } }, isUnqiue: false);
+                PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { new[] { fkProperty } }, new Property[0], isUnqiue: false);
 
             Assert.NotSame(fk, newFk);
             Assert.Same(fkProperty, newFk.Properties.Single());
@@ -257,7 +335,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             fk.IsUnique = true;
 
             var newFk = new ForeignKeyConvention().FindOrCreateForeignKey(
-                PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { new[] { fkProperty } }, isUnqiue: false);
+                PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { new[] { fkProperty } }, new Property[0], isUnqiue: false);
 
             Assert.NotSame(fk, newFk);
             Assert.Same(fkProperty, newFk.Properties.Single());


### PR DESCRIPTION
"He told me you killed my PK!" "No, I am your PK" (Added ReferencedKey API to allow specification of non-primary principal key)

This is the counterpoint to the ForeignKey API and is used to specify the key properties at the principal end of the relationship.

Note that Migrations doesn't support yet creating the required candidate keys so functional testing is limited to in-memory. Also, we decided this morning to remove the parameterless overloads of ForeignKey amd ReferencedKey, but I will do that as a separate change.
