### PR TITLE
That name no longer has any meaning for me...

### DIFF
--- a/src/EntityFramework/Metadata/ModelBuilder.cs
+++ b/src/EntityFramework/Metadata/ModelBuilder.cs
@@ -555,36 +555,28 @@ namespace Microsoft.Data.Entity.Metadata
                 }
 
                 public OneToOneBuilder ForeignKey<TDependentEntity>(
-                    [CanBeNull] Expression<Func<TDependentEntity, object>> foreignKeyExpression = null)
+                    [NotNull] Expression<Func<TDependentEntity, object>> foreignKeyExpression)
                 {
-                    var inverting = ModelBuilder.Entity<TDependentEntity>().Metadata != _builder.DependentType;
-                    if (inverting)
+                    Check.NotNull(foreignKeyExpression, "foreignKeyExpression");
+
+                    if (ModelBuilder.Entity<TDependentEntity>().Metadata != _builder.DependentType)
                     {
                         _builder.Invert();
                     }
 
-                    if (foreignKeyExpression == null)
-                    {
-                        return new OneToOneBuilder(inverting
-                            ? _builder.ForeignKey(new PropertyInfo[0])
-                            : _builder);
-                    }
-
-                    return new OneToOneBuilder(
-                        _builder.ForeignKey(foreignKeyExpression.GetPropertyAccessList()));
+                    return new OneToOneBuilder(_builder.ForeignKey(foreignKeyExpression.GetPropertyAccessList()));
                 }
 
                 public OneToOneBuilder ReferencedKey<TPrincipalEntity>(
-                    [CanBeNull] Expression<Func<TPrincipalEntity, object>> keyExpression = null)
+                    [NotNull] Expression<Func<TPrincipalEntity, object>> keyExpression)
                 {
+                    Check.NotNull(keyExpression, "keyExpression");
+
                     var builder = ModelBuilder.Entity<TPrincipalEntity>().Metadata == _builder.PrincipalType
                         ? _builder
                         : _builder.Invert().ForeignKey(new PropertyInfo[0]);
 
-                    return new OneToOneBuilder(
-                        builder.ReferencedKey(keyExpression != null
-                            ? keyExpression.GetPropertyAccessList()
-                            : new PropertyInfo[0]));
+                    return new OneToOneBuilder(builder.ReferencedKey(keyExpression.GetPropertyAccessList()));
                 }
             }
 
@@ -669,11 +661,9 @@ namespace Microsoft.Data.Entity.Metadata
 
                 public RelationshipBuilder ReferencedKey(IList<PropertyInfo> propertyAccessList)
                 {
-                    var principalProperties = propertyAccessList.Any()
-                        ? propertyAccessList
-                            .Select(pi => _principalType.TryGetProperty(pi.Name) ?? _principalType.AddProperty(pi))
-                            .ToArray()
-                        : _principalType.GetKey().Properties;
+                    var principalProperties = propertyAccessList
+                        .Select(pi => _principalType.TryGetProperty(pi.Name) ?? _principalType.AddProperty(pi))
+                        .ToArray();
 
                     if (Metadata.ReferencedProperties.SequenceEqual(principalProperties))
                     {

--- a/test/EntityFramework.FunctionalTests/TestModels/ConcurrencyModel/F1Context.cs
+++ b/test/EntityFramework.FunctionalTests/TestModels/ConcurrencyModel/F1Context.cs
@@ -110,7 +110,7 @@ namespace ConcurrencyModel
                     b.Property(t => t.Tire);
                     b.Property(t => t.Victories);
                     b.OneToMany(e => e.Drivers, e => e.Team);
-                    b.OneToOne(e => e.Gearbox).ForeignKey<Team>();
+                    b.OneToOne(e => e.Gearbox).ForeignKey<Team>(e => e.GearboxId);
                 });
 
             modelBuilder.Entity<TestDriver>(b => b.Key(t => t.Id));

--- a/test/EntityFramework.FunctionalTests/TestModels/MonsterContext`.cs
+++ b/test/EntityFramework.FunctionalTests/TestModels/MonsterContext`.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Data.Entity.MonsterModel
                     b.OneToOne(e => (TCustomerInfo)e.Info);
 
                     b.OneToOne(e => (TCustomer)e.Wife, e => (TCustomer)e.Husband)
-                        .ForeignKey<TCustomer>();
+                        .ForeignKey<TCustomer>(e => e.HusbandId);
                 });
 
             builder.Entity<TComplaint>(b =>
@@ -391,7 +391,7 @@ namespace Microsoft.Data.Entity.MonsterModel
                     b.Key(e => e.Username);
 
                     b.OneToOne(e => (TLogin)e.Login)
-                        .ForeignKey<TSmartCard>();
+                        .ForeignKey<TSmartCard>(e => e.Username);
 
                     b.OneToOne(e => (TLastLogin)e.LastLogin)
                         .ForeignKey<TLastLogin>(e => e.SmartcardUsername);

--- a/test/EntityFramework.Tests/ChangeTracking/NavigationFixerTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/NavigationFixerTest.cs
@@ -957,7 +957,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             builder.Entity<Product>(b =>
                 {
                     b.OneToOne(e => e.OriginalProduct, e => e.AlternateProduct)
-                        .ForeignKey<Product>();
+                        .ForeignKey<Product>(e => e.AlternateProductId);
 
                     b.OneToOne(e => e.Detail, e => e.Product);
                 });

--- a/test/EntityFramework.Tests/Metadata/ModelBuilderTest.cs
+++ b/test/EntityFramework.Tests/Metadata/ModelBuilderTest.cs
@@ -3124,7 +3124,7 @@ namespace Microsoft.Data.Entity.Metadata
             modelBuilder
                 .Entity<OrderDetails>()
                 .OneToOne(e => e.Order, e => e.Details)
-                .ForeignKey<OrderDetails>();
+                .ForeignKey<OrderDetails>(e => e.Id);
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Equal("Order", dependentType.Navigations.Single().Name);
@@ -3159,7 +3159,7 @@ namespace Microsoft.Data.Entity.Metadata
             modelBuilder
                 .Entity<OrderDetails>()
                 .OneToOne(e => e.Order, e => e.Details)
-                .ForeignKey<OrderDetails>();
+                .ForeignKey<OrderDetails>(e => e.OrderId);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -3192,7 +3192,7 @@ namespace Microsoft.Data.Entity.Metadata
             modelBuilder
                 .Entity<CustomerDetails>()
                 .OneToOne<Customer>(e => e.Customer)
-                .ForeignKey<CustomerDetails>();
+                .ForeignKey<CustomerDetails>(e => e.Id);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -3224,7 +3224,7 @@ namespace Microsoft.Data.Entity.Metadata
             modelBuilder
                 .Entity<CustomerDetails>()
                 .OneToOne<Customer>(null, e => e.Details)
-                .ForeignKey<CustomerDetails>();
+                .ForeignKey<CustomerDetails>(e => e.Id);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -3256,7 +3256,7 @@ namespace Microsoft.Data.Entity.Metadata
             modelBuilder
                 .Entity<CustomerDetails>()
                 .OneToOne<Customer>()
-                .ForeignKey<CustomerDetails>();
+                .ForeignKey<CustomerDetails>(e => e.Id);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -3287,7 +3287,7 @@ namespace Microsoft.Data.Entity.Metadata
             modelBuilder
                 .Entity<CustomerDetails>()
                 .OneToOne(e => e.Customer, e => e.Details)
-                .ForeignKey<CustomerDetails>();
+                .ForeignKey<CustomerDetails>(e => e.Id);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -3557,7 +3557,7 @@ namespace Microsoft.Data.Entity.Metadata
             modelBuilder
                 .Entity<OrderDetails>()
                 .OneToOne(e => e.Order, e => e.Details)
-                .ReferencedKey<Order>();
+                .ReferencedKey<Order>(e => e.OrderId);
 
             Assert.Same(fk, dependentType.ForeignKeys.Single());
             Assert.Equal("Order", dependentType.Navigations.Single().Name);
@@ -3592,7 +3592,7 @@ namespace Microsoft.Data.Entity.Metadata
             modelBuilder
                 .Entity<OrderDetails>()
                 .OneToOne(e => e.Order, e => e.Details)
-                .ReferencedKey<Order>();
+                .ReferencedKey<Order>(e => e.OrderId);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -3629,8 +3629,8 @@ namespace Microsoft.Data.Entity.Metadata
             modelBuilder
                 .Entity<OrderDetails>()
                 .OneToOne(e => e.Order, e => e.Details)
-                .ForeignKey<OrderDetails>()
-                .ReferencedKey<Order>();
+                .ForeignKey<OrderDetails>(e => e.OrderId)
+                .ReferencedKey<Order>(e => e.OrderId);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -3667,8 +3667,8 @@ namespace Microsoft.Data.Entity.Metadata
             modelBuilder
                 .Entity<OrderDetails>()
                 .OneToOne(e => e.Order, e => e.Details)
-                .ReferencedKey<Order>()
-                .ForeignKey<OrderDetails>();
+                .ReferencedKey<Order>(e => e.OrderId)
+                .ForeignKey<OrderDetails>(e => e.OrderId);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -3701,7 +3701,7 @@ namespace Microsoft.Data.Entity.Metadata
             modelBuilder
                 .Entity<CustomerDetails>()
                 .OneToOne<Customer>(e => e.Customer)
-                .ReferencedKey<Customer>();
+                .ReferencedKey<Customer>(e => e.Id);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -3733,7 +3733,7 @@ namespace Microsoft.Data.Entity.Metadata
             modelBuilder
                 .Entity<CustomerDetails>()
                 .OneToOne<Customer>(null, e => e.Details)
-                .ReferencedKey<Customer>();
+                .ReferencedKey<Customer>(e => e.Id);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -3765,7 +3765,7 @@ namespace Microsoft.Data.Entity.Metadata
             modelBuilder
                 .Entity<CustomerDetails>()
                 .OneToOne<Customer>()
-                .ReferencedKey<Customer>();
+                .ReferencedKey<Customer>(e => e.Id);
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -4591,7 +4591,7 @@ namespace Microsoft.Data.Entity.Metadata
             modelBuilder
                 .Entity<Moostard>()
                 .OneToOne(e => e.Whoopper, e => e.Moostard)
-                .ForeignKey<Moostard>();
+                .ForeignKey<Moostard>(e => new { e.Id1, e.Id2 });
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty1, fk.Properties[0]);
@@ -4626,7 +4626,7 @@ namespace Microsoft.Data.Entity.Metadata
             modelBuilder
                 .Entity<Moostard>()
                 .OneToOne(e => e.Whoopper, e => e.Moostard)
-                .ReferencedKey<Whoopper>();
+                .ReferencedKey<Whoopper>(e => new { e.Id1, e.Id2 });
 
             var fk = dependentType.ForeignKeys.Single();
             Assert.Same(fkProperty1, fk.Properties[0]);


### PR DESCRIPTION
That name no longer has any meaning for me... (Remove parameterless overloads of ForeignKey and ReferencedKey)

After discussion of this API we decided that the semantics of these overloads were ambiguous as to whether they were for just specifying the end or indicating that the FK should be created explicitly in shadow state. Also, it was not super-clear which was the principal/dependent when no property was supplied. Given that the only real value is to avoid having to be explicit about either the FK or PK in cases where the principal/dependent need to be flipped, we decided it was better to remove these overloads.
