### PR TITLE
Workaround ANI issue in .csproj files

### DIFF
--- a/src/EntityFramework.AzureTableStorage/EntityFramework.AzureTableStorage.csproj
+++ b/src/EntityFramework.AzureTableStorage/EntityFramework.AzureTableStorage.csproj
@@ -56,9 +56,8 @@
     <PackageReference Include="Microsoft.Framework.DependencyInjection">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>
-    <PackageReference Include="Microsoft.Framework.Logging">
-      <TargetFramework>net45</TargetFramework>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Framework.Logging" />
+    <PackageReference Include="Microsoft.Framework.Logging.Interfaces" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\packages\KoreBuild\build\Resources.cs">

--- a/src/EntityFramework.InMemory/EntityFramework.InMemory.csproj
+++ b/src/EntityFramework.InMemory/EntityFramework.InMemory.csproj
@@ -47,6 +47,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Framework.DependencyInjection" />
     <PackageReference Include="Microsoft.Framework.Logging" />
+    <PackageReference Include="Microsoft.Framework.Logging.Interfaces" />
     <PackageReference Include="Remotion.Linq">
       <TargetFramework>portable-net45+wp80+win</TargetFramework>
     </PackageReference>

--- a/src/EntityFramework.Redis/EntityFramework.Redis.csproj
+++ b/src/EntityFramework.Redis/EntityFramework.Redis.csproj
@@ -48,6 +48,7 @@
     <PackageReference Include="Microsoft.Framework.ConfigurationModel" />
     <PackageReference Include="Microsoft.Framework.DependencyInjection" />
     <PackageReference Include="Microsoft.Framework.Logging" />
+    <PackageReference Include="Microsoft.Framework.Logging.Interfaces" />
     <PackageReference Include="Remotion.Linq">
       <TargetFramework>portable-net45+wp80+win</TargetFramework>
     </PackageReference>

--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -49,6 +49,7 @@
     <PackageReference Include="Microsoft.Framework.ConfigurationModel" />
     <PackageReference Include="Microsoft.Framework.DependencyInjection" />
     <PackageReference Include="Microsoft.Framework.Logging" />
+    <PackageReference Include="Microsoft.Framework.Logging.Interfaces" />
     <PackageReference Include="Remotion.Linq">
       <TargetFramework>portable-net45+wp80+win</TargetFramework>
     </PackageReference>

--- a/src/EntityFramework/EntityFramework.csproj
+++ b/src/EntityFramework/EntityFramework.csproj
@@ -47,6 +47,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Framework.DependencyInjection" />
     <PackageReference Include="Microsoft.Framework.Logging" />
+    <PackageReference Include="Microsoft.Framework.Logging.Interfaces" />
     <PackageReference Include="Remotion.Linq">
       <TargetFramework>portable-net45+wp80+win</TargetFramework>
     </PackageReference>

--- a/test/EntityFramework.AzureTableStorage.FunctionalTests/EntityFramework.AzureTableStorage.FunctionalTests.csproj
+++ b/test/EntityFramework.AzureTableStorage.FunctionalTests/EntityFramework.AzureTableStorage.FunctionalTests.csproj
@@ -48,9 +48,8 @@
     <PackageReference Include="Microsoft.Framework.DependencyInjection">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>
-    <PackageReference Include="Microsoft.Framework.Logging">
-      <TargetFramework>net45</TargetFramework>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Framework.Logging" />
+    <PackageReference Include="Microsoft.Framework.Logging.Interfaces" />
     <PackageReference Include="Moq">
       <TargetFramework>net40</TargetFramework>
     </PackageReference>

--- a/test/EntityFramework.AzureTableStorage.Tests/EntityFramework.AzureTableStorage.Tests.csproj
+++ b/test/EntityFramework.AzureTableStorage.Tests/EntityFramework.AzureTableStorage.Tests.csproj
@@ -45,9 +45,8 @@
     <PackageReference Include="Microsoft.Framework.DependencyInjection">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>
-    <PackageReference Include="Microsoft.Framework.Logging">
-      <TargetFramework>net45</TargetFramework>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Framework.Logging" />
+    <PackageReference Include="Microsoft.Framework.Logging.Interfaces" />
     <PackageReference Include="xunit.abstractions">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>

--- a/test/EntityFramework.FunctionalTests/EntityFramework.FunctionalTests.csproj
+++ b/test/EntityFramework.FunctionalTests/EntityFramework.FunctionalTests.csproj
@@ -46,9 +46,8 @@
     <PackageReference Include="Microsoft.Framework.DependencyInjection">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>
-    <PackageReference Include="Microsoft.Framework.Logging">
-      <TargetFramework>net45</TargetFramework>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Framework.Logging" />
+    <PackageReference Include="Microsoft.Framework.Logging.Interfaces" />
     <PackageReference Include="xunit.abstractions">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>

--- a/test/EntityFramework.InMemory.FunctionalTests/EntityFramework.InMemory.FunctionalTests.csproj
+++ b/test/EntityFramework.InMemory.FunctionalTests/EntityFramework.InMemory.FunctionalTests.csproj
@@ -43,9 +43,8 @@
     <PackageReference Include="Microsoft.Framework.DependencyInjection">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>
-    <PackageReference Include="Microsoft.Framework.Logging">
-      <TargetFramework>net45</TargetFramework>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Framework.Logging" />
+    <PackageReference Include="Microsoft.Framework.Logging.Interfaces" />
     <PackageReference Include="xunit.abstractions">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>

--- a/test/EntityFramework.InMemory.Tests/EntityFramework.InMemory.Tests.csproj
+++ b/test/EntityFramework.InMemory.Tests/EntityFramework.InMemory.Tests.csproj
@@ -37,9 +37,8 @@
     <PackageReference Include="Microsoft.Framework.DependencyInjection">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>
-    <PackageReference Include="Microsoft.Framework.Logging">
-      <TargetFramework>net45</TargetFramework>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Framework.Logging" />
+    <PackageReference Include="Microsoft.Framework.Logging.Interfaces" />
     <PackageReference Include="xunit.abstractions">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>

--- a/test/EntityFramework.Redis.FunctionalTests/EntityFramework.Redis.FunctionalTests.csproj
+++ b/test/EntityFramework.Redis.FunctionalTests/EntityFramework.Redis.FunctionalTests.csproj
@@ -60,9 +60,8 @@
     <PackageReference Include="Microsoft.Framework.DependencyInjection">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>
-    <PackageReference Include="Microsoft.Framework.Logging">
-      <TargetFramework>net45</TargetFramework>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Framework.Logging" />
+    <PackageReference Include="Microsoft.Framework.Logging.Interfaces" />
     <PackageReference Include="StackExchange.Redis">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>

--- a/test/EntityFramework.Redis.Tests/EntityFramework.Redis.Tests.csproj
+++ b/test/EntityFramework.Redis.Tests/EntityFramework.Redis.Tests.csproj
@@ -56,6 +56,7 @@
       <TargetFramework>net40</TargetFramework>
     </PackageReference>
     <PackageReference Include="Microsoft.Framework.Logging" />
+    <PackageReference Include="Microsoft.Framework.Logging.Interfaces" />
     <PackageReference Include="Remotion.Linq">
       <TargetFramework>portable-net45+wp80+win</TargetFramework>
     </PackageReference>

--- a/test/EntityFramework.Relational.FunctionalTests/EntityFramework.Relational.FunctionalTests.csproj
+++ b/test/EntityFramework.Relational.FunctionalTests/EntityFramework.Relational.FunctionalTests.csproj
@@ -47,9 +47,8 @@
     <PackageReference Include="Microsoft.Framework.DependencyInjection">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>
-    <PackageReference Include="Microsoft.Framework.Logging">
-      <TargetFramework>net45</TargetFramework>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Framework.Logging" />
+    <PackageReference Include="Microsoft.Framework.Logging.Interfaces" />
     <PackageReference Include="xunit.abstractions">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>

--- a/test/EntityFramework.Relational.Tests/EntityFramework.Relational.Tests.csproj
+++ b/test/EntityFramework.Relational.Tests/EntityFramework.Relational.Tests.csproj
@@ -42,9 +42,8 @@
     <PackageReference Include="Microsoft.Framework.DependencyInjection">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>
-    <PackageReference Include="Microsoft.Framework.Logging">
-      <TargetFramework>net45</TargetFramework>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Framework.Logging" />
+    <PackageReference Include="Microsoft.Framework.Logging.Interfaces" />
     <PackageReference Include="xunit.abstractions">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>

--- a/test/EntityFramework.SQLite.FunctionalTests/EntityFramework.SQLite.FunctionalTests.csproj
+++ b/test/EntityFramework.SQLite.FunctionalTests/EntityFramework.SQLite.FunctionalTests.csproj
@@ -34,9 +34,8 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Data" />
-    <PackageReference Include="Microsoft.Framework.Logging">
-      <TargetFramework>net45</TargetFramework>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Framework.Logging" />
+    <PackageReference Include="Microsoft.Framework.Logging.Interfaces" />
     <PackageReference Include="Ix-Async">
       <TargetFramework>net45</TargetFramework>
       <Assemblies>System.Interactive.Async</Assemblies>

--- a/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
@@ -50,9 +50,8 @@
     <PackageReference Include="Microsoft.Framework.DependencyInjection">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>
-    <PackageReference Include="Microsoft.Framework.Logging">
-      <TargetFramework>net45</TargetFramework>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Framework.Logging" />
+    <PackageReference Include="Microsoft.Framework.Logging.Interfaces" />
     <PackageReference Include="xunit.abstractions">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>

--- a/test/EntityFramework.Tests/EntityFramework.Tests.csproj
+++ b/test/EntityFramework.Tests/EntityFramework.Tests.csproj
@@ -42,9 +42,8 @@
     <PackageReference Include="Microsoft.Framework.DependencyInjection">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>
-    <PackageReference Include="Microsoft.Framework.Logging">
-      <TargetFramework>net45</TargetFramework>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Framework.Logging" />
+    <PackageReference Include="Microsoft.Framework.Logging.Interfaces" />
     <PackageReference Include="xunit.abstractions">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>


### PR DESCRIPTION
This avoids referencing the net45 version of Logging from the .csproj files. This should enable us to run unit tests in VS again while #553 is being resolved.
