### PR TITLE
Fixing Redis Functional Test Flakiness

### DIFF
--- a/test/EntityFramework.Redis.FunctionalTests/BaseClassFixture.cs
+++ b/test/EntityFramework.Redis.FunctionalTests/BaseClassFixture.cs
@@ -12,8 +12,6 @@ namespace Microsoft.Data.Entity.Redis
 
         public DbContext GetOrCreateContext()
         {
-            RedisTestConfig.GetOrStartServer();
-
             if (_context == null)
             {
                 var options = new DbContextOptions()

--- a/test/EntityFramework.Redis.FunctionalTests/EntityFramework.Redis.FunctionalTests.csproj
+++ b/test/EntityFramework.Redis.FunctionalTests/EntityFramework.Redis.FunctionalTests.csproj
@@ -69,8 +69,10 @@
   <ItemGroup>
     <Compile Include="BaseClassFixture.cs" />
     <Compile Include="RedisTestConfig.cs" />
+    <Compile Include="RedisXunitTestFramework.cs" />
     <Compile Include="SimpleFixture.cs" />
     <Compile Include="SimpleTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\EntityFramework.Redis\EntityFramework.Redis.csproj">
@@ -88,9 +90,6 @@
   <ItemGroup>
     <None Include="project.json" />
     <None Include="README.md" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Properties\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/test/EntityFramework.Redis.FunctionalTests/Properties/AssemblyInfo.cs
+++ b/test/EntityFramework.Redis.FunctionalTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+[assembly: TestFramework("Microsoft.Data.Entity.Redis.RedisXunitTestFramework", "EntityFramework.Redis.FunctionalTests")]

--- a/test/EntityFramework.Redis.FunctionalTests/RedisTestConfig.cs
+++ b/test/EntityFramework.Redis.FunctionalTests/RedisTestConfig.cs
@@ -6,7 +6,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
-using StackExchange.Redis;
 
 namespace Microsoft.Data.Entity.Redis
 {
@@ -95,37 +94,6 @@ namespace Microsoft.Data.Entity.Redis
             return true;
         }
 
-        private static bool CanConnectToExistingRedisServer(int numRetries, int sleepMillisecsBetweenRetries = 0)
-        {
-            var canConnectToServer = false;
-            for (var retryCount = 0; retryCount < numRetries; retryCount++)
-            {
-                try
-                {
-                    using (var connectionMultiplexer =
-                        ConnectionMultiplexer.Connect("127.0.0.1:" + RedisPort))
-                    {
-                        if (connectionMultiplexer.IsConnected)
-                        {
-                            canConnectToServer = true;
-                            break;
-                        }
-                    }
-                }
-                catch (RedisConnectionException)
-                {
-                    // exception connecting to server - try again
-                }
-
-                if (sleepMillisecsBetweenRetries > 0)
-                {
-                    Thread.Sleep(sleepMillisecsBetweenRetries);
-                }
-            }
-
-            return canConnectToServer;
-        }
-
         private static bool TryStartRedisServer()
         {
             var serverPath = GetUserProfileServerPath();
@@ -207,10 +175,6 @@ namespace Microsoft.Data.Entity.Redis
                         {
                             throw new Exception("Got null process trying to  start Redis Server at path "
                                                 + tempRedisServerFullPath + " with Arguments '" + serverArgs + "', working dir = " + tempPath);
-                        }
-                        else if (!CanConnectToExistingRedisServer(5, 2000))
-                        {
-                            throw new Exception("Cannot connect to started Redis server process PID " + _redisServerProcess.Id);
                         }
                     }
                 }

--- a/test/EntityFramework.Redis.FunctionalTests/RedisXunitTestFramework.cs
+++ b/test/EntityFramework.Redis.FunctionalTests/RedisXunitTestFramework.cs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Microsoft.Data.Entity.Redis
+{
+    public class RedisXunitTestFramework : XunitTestFramework
+    {
+        protected override ITestFrameworkExecutor CreateExecutor(AssemblyName assemblyName)
+        {
+            return new RedisXunitTestExecutor(assemblyName, SourceInformationProvider);
+        }
+    }
+
+    public class RedisXunitTestExecutor : XunitTestFrameworkExecutor, IDisposable
+    {
+        private bool _isDisposed;
+
+        public RedisXunitTestExecutor(
+            AssemblyName assemblyName, ISourceInformationProvider sourceInformationProvider)
+            : base(assemblyName, sourceInformationProvider)
+        {
+            try
+            {
+                RedisTestConfig.GetOrStartServer();
+            }
+            catch (Exception)
+            {
+                // do not let exceptions starting server prevent XunitTestExecutor from being created
+            }
+        }
+
+        ~RedisXunitTestExecutor()
+        {
+            Dispose(false);
+        }
+
+        void IDisposable.Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_isDisposed)
+            {
+                try
+                {
+                    RedisTestConfig.StopRedisServer();
+                }
+                catch (Exception)
+                {
+                    // do not let exceptions stopping server prevent XunitTestExecutor from being disposed
+                }
+
+                _isDisposed = true;
+            }
+        }
+    }
+}

--- a/test/EntityFramework.Redis.FunctionalTests/SimpleFixture.cs
+++ b/test/EntityFramework.Redis.FunctionalTests/SimpleFixture.cs
@@ -6,7 +6,7 @@ using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.Redis
 {
-    public class SimpleFixture : BaseClassFixture, IDisposable
+    public class SimpleFixture : BaseClassFixture
     {
         public override IModel CreateModel()
         {
@@ -20,11 +20,6 @@ namespace Microsoft.Data.Entity.Redis
                 });
 
             return model;
-        }
-
-        void IDisposable.Dispose()
-        {
-            RedisTestConfig.StopRedisServer();
         }
     }
 

--- a/test/EntityFramework.Redis.FunctionalTests/project.json
+++ b/test/EntityFramework.Redis.FunctionalTests/project.json
@@ -12,7 +12,7 @@
     "Xunit.KRunner": "1.0.0-*"
   },
   "commands": {
-    "do_not_test_using_k": "Xunit.KRunner"
+    "test": "Xunit.KRunner"
   },
   "frameworks": {
     "net45": {


### PR DESCRIPTION
@anpete @bricelam. Addresses #572 and #487 

A CollectionFixture seems the right way to start and stop the redis server for the tests, but they are not working in Xunit at the moment so this is the next best thing. Have added a RedisXunitTestExecutor which starts the server in its constructor and stops it in the destructor (unfortunately had to use that because Dispose() wasn't always called).

Also found that you _must_ have only one ConnectionMultiplexer per set of
config options - more causes multi-threading issues which means the tests
sometimes work but more often fail. So set up a Dictionary of
config options to ConnectionMultiplexer in RedisDatabase and only create
the ConnectionMultiplexer as needed.

The Simple Tests are now running with server starting and stopping as
expected both under VS and for 'k test' - so re-enabling the latter.
