### PR TITLE
EDMLib v4?

### DIFF
--- a/src/EntityFramework.AzureTableStorage/Metadata/ETagConvention.cs
+++ b/src/EntityFramework.AzureTableStorage/Metadata/ETagConvention.cs
@@ -10,11 +10,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Metadata
     {
         public virtual void Apply(EntityType entityType)
         {
-            var etag = entityType.TryGetProperty("ETag");
-            if (etag == null)
-            {
-                entityType.AddProperty("ETag", typeof(string), true, true);
-            }
+            entityType.GetOrAddProperty("ETag", typeof(string), shadowProperty: true).IsConcurrencyToken = true;
         }
     }
 }

--- a/src/EntityFramework.AzureTableStorage/Metadata/PartitionKeyAndRowKeyConvention.cs
+++ b/src/EntityFramework.AzureTableStorage/Metadata/PartitionKeyAndRowKeyConvention.cs
@@ -10,14 +10,14 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Metadata
     {
         public virtual void Apply(EntityType entityType)
         {
-            if (entityType.TryGetKey() == null)
+            if (entityType.TryGetPrimaryKey() == null)
             {
                 var pk = entityType.TryGetProperty("PartitionKey");
                 var rk = entityType.TryGetProperty("RowKey");
                 if (pk != null
                     && rk != null)
                 {
-                    entityType.SetKey(pk, rk);
+                    entityType.GetOrSetPrimaryKey(pk, rk);
                 }
             }
         }

--- a/src/EntityFramework.Design/CSharpModelCodeGenerator.cs
+++ b/src/EntityFramework.Design/CSharpModelCodeGenerator.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Data.Entity.Design
                 {
                     GenerateProperties(entityType.Properties, stringBuilder);
 
-                    GenerateKey(entityType.GetKey(), stringBuilder);
+                    GenerateKey(entityType.GetPrimaryKey(), stringBuilder);
 
                     GenerateForeignKeys(entityType.ForeignKeys, stringBuilder);
 

--- a/src/EntityFramework.Redis/RedisDatabase.cs
+++ b/src/EntityFramework.Redis/RedisDatabase.cs
@@ -276,7 +276,7 @@ namespace Microsoft.Data.Entity.Redis
         {
             return string.Join(
                 PropertyValueSeparator,
-                stateEntry.EntityType.GetKey().Properties.Select(p => EncodeKeyValue(propertyValueSelector(stateEntry, p))));
+                stateEntry.EntityType.GetPrimaryKey().Properties.Select(p => EncodeKeyValue(propertyValueSelector(stateEntry, p))));
         }
 
         // returns the object array representing all the properties

--- a/src/EntityFramework.Relational/DatabaseBuilder.cs
+++ b/src/EntityFramework.Relational/DatabaseBuilder.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Data.Entity.Relational
                             mapping.Map(property, BuildColumn(table, property));
                         }
 
-                        var primaryKey = entityType.GetKey();
+                        var primaryKey = entityType.GetPrimaryKey();
                         if (primaryKey != null)
                         {
                             mapping.Map(primaryKey, BuildPrimaryKey(database, primaryKey));
@@ -75,7 +75,7 @@ namespace Microsoft.Data.Entity.Relational
 
         private static IEnumerable<IProperty> OrderProperties(IEntityType entityType)
         {
-            var primaryKey = entityType.GetKey();
+            var primaryKey = entityType.GetPrimaryKey();
 
             var primaryKeyProperties
                 = primaryKey != null

--- a/src/EntityFramework.SQLite/SQLiteValueGeneratorSelector.cs
+++ b/src/EntityFramework.SQLite/SQLiteValueGeneratorSelector.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Data.Entity.SQLite
             if (property.ValueGenerationOnAdd == ValueGenerationOnAdd.Client)
             {
                 // If INTEGER PRIMARY KEY column...
-                var keyProperties = property.EntityType.GetKey().Properties;
+                var keyProperties = property.EntityType.GetPrimaryKey().Properties;
                 if (keyProperties.Count == 1
                     && keyProperties[0] == property)
                 {

--- a/src/EntityFramework/ChangeTracking/PropertyBagExtensions.cs
+++ b/src/EntityFramework/ChangeTracking/PropertyBagExtensions.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             Check.NotNull(propertyBagEntry, "propertyBagEntry");
 
             var entityType = propertyBagEntry.StateEntry.EntityType;
-            return propertyBagEntry.StateEntry.CreateKey(entityType, entityType.GetKey().Properties, propertyBagEntry);
+            return propertyBagEntry.StateEntry.CreateKey(entityType, entityType.GetPrimaryKey().Properties, propertyBagEntry);
         }
     }
 }

--- a/src/EntityFramework/ChangeTracking/RelationshipsSnapshot.cs
+++ b/src/EntityFramework/ChangeTracking/RelationshipsSnapshot.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
         {
             var entityType = stateEntry.EntityType;
 
-            return entityType.GetKey().Properties.Concat(
+            return entityType.GetPrimaryKey().Properties.Concat(
                 entityType.ForeignKeys.SelectMany(fk => fk.Properties)).Distinct()
                 .Concat<IPropertyBase>(entityType.Navigations);
         }

--- a/src/EntityFramework/ChangeTracking/StateEntry.cs
+++ b/src/EntityFramework/ChangeTracking/StateEntry.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
                 _stateData.SetAllPropertiesModified(_entityType.Properties.Count(), isModified: true);
 
                 // Assuming key properties are not modified
-                foreach (var keyProperty in EntityType.GetKey().Properties)
+                foreach (var keyProperty in EntityType.GetPrimaryKey().Properties)
                 {
                     _stateData.SetPropertyModified(keyProperty.Index, isModified: false);
                 }

--- a/src/EntityFramework/ChangeTracking/StateManager.cs
+++ b/src/EntityFramework/ChangeTracking/StateManager.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             Check.NotNull(valueReader, "valueReader");
 
             // TODO: Pre-compute this for speed
-            var keyProperties = entityType.GetKey().Properties;
+            var keyProperties = entityType.GetPrimaryKey().Properties;
             var keyValue = _keyFactorySource.GetKeyFactory(keyProperties).Create(entityType, keyProperties, valueReader);
 
             var existingEntry = TryGetEntry(keyValue);

--- a/src/EntityFramework/Metadata/Compiled/CompiledEntityType.cs
+++ b/src/EntityFramework/Metadata/Compiled/CompiledEntityType.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
             return Empty.Indexes;
         }
 
-        public IKey GetKey()
+        public IKey GetPrimaryKey()
         {
             return LazyInitializer.EnsureInitialized(ref _key, LoadKey);
         }

--- a/src/EntityFramework/Metadata/Compiled/CompiledForeignKey.cs
+++ b/src/EntityFramework/Metadata/Compiled/CompiledForeignKey.cs
@@ -27,6 +27,11 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
             get { return Definition.PrincipalPropertyIndexes.Select(i => ReferencedEntityType.Properties[i]).ToArray(); }
         }
 
+        public IKey ReferencedKey
+        {
+            get { return ReferencedEntityType.GetPrimaryKey(); }
+        }
+
         public IEntityType ReferencedEntityType
         {
             get { return _model.EntityTypes[Definition.PrincipalIndex]; }

--- a/src/EntityFramework/Metadata/Compiled/CompiledSimpleForeignKey.cs
+++ b/src/EntityFramework/Metadata/Compiled/CompiledSimpleForeignKey.cs
@@ -24,7 +24,12 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
 
         public IReadOnlyList<IProperty> ReferencedProperties
         {
-            get { return ReferencedEntityType.GetKey().Properties; }
+            get { return ReferencedEntityType.GetPrimaryKey().Properties; }
+        }
+
+        public IKey ReferencedKey
+        {
+            get { return ReferencedEntityType.GetPrimaryKey(); }
         }
 
         public IEntityType ReferencedEntityType

--- a/src/EntityFramework/Metadata/ForeignKey.cs
+++ b/src/EntityFramework/Metadata/ForeignKey.cs
@@ -22,8 +22,8 @@ namespace Microsoft.Data.Entity.Metadata
         {
         }
 
-        internal ForeignKey([NotNull] Key referencedKey, [NotNull] IReadOnlyList<Property> dependentProperties)
-            : base(Check.NotNull(dependentProperties, "dependentProperties"))
+        public ForeignKey([NotNull] Key referencedKey, [NotNull] IReadOnlyList<Property> dependentProperties)
+            : base(dependentProperties)
         {
             Check.NotNull(referencedKey, "referencedKey");
 
@@ -33,6 +33,11 @@ namespace Microsoft.Data.Entity.Metadata
         public virtual IReadOnlyList<Property> ReferencedProperties
         {
             get { return _referencedKey.Properties; }
+        }
+
+        public virtual Key ReferencedKey
+        {
+            get { return _referencedKey; }
         }
 
         public virtual EntityType ReferencedEntityType
@@ -55,6 +60,11 @@ namespace Microsoft.Data.Entity.Metadata
         IEntityType IForeignKey.ReferencedEntityType
         {
             get { return ReferencedEntityType; }
+        }
+
+        IKey IForeignKey.ReferencedKey
+        {
+            get { return ReferencedKey; }
         }
     }
 }

--- a/src/EntityFramework/Metadata/IEntityType.cs
+++ b/src/EntityFramework/Metadata/IEntityType.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Data.Entity.Metadata
         [CanBeNull]
         Type Type { get; }
 
-        IKey GetKey();
+        IKey GetPrimaryKey();
 
         [CanBeNull]
         IProperty TryGetProperty([NotNull] string name);

--- a/src/EntityFramework/Metadata/IForeignKey.cs
+++ b/src/EntityFramework/Metadata/IForeignKey.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Data.Entity.Metadata
     {
         IReadOnlyList<IProperty> ReferencedProperties { get; }
         IEntityType ReferencedEntityType { get; }
+        IKey ReferencedKey { get; }
         bool IsUnique { get; }
         bool IsRequired { get; }
     }

--- a/src/EntityFramework/Metadata/Index.cs
+++ b/src/EntityFramework/Metadata/Index.cs
@@ -21,16 +21,15 @@ namespace Microsoft.Data.Entity.Metadata
         {
         }
 
-        internal Index([NotNull] IReadOnlyList<Property> properties)
+        public Index([NotNull] IReadOnlyList<Property> properties)
         {
-            Check.NotNull(properties, "properties");
             Check.NotEmpty(properties, "properties");
             MetadataHelper.CheckSameEntityType(properties, "properties");
 
             _properties = properties;
         }
 
-        public bool IsUnique { get; set; }
+        public virtual bool IsUnique { get; set; }
 
         public virtual IReadOnlyList<Property> Properties
         {

--- a/src/EntityFramework/Metadata/Key.cs
+++ b/src/EntityFramework/Metadata/Key.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Data.Entity.Metadata
         {
         }
 
-        internal Key([NotNull] IReadOnlyList<Property> properties)
+        public Key([NotNull] IReadOnlyList<Property> properties)
         {
             Check.NotEmpty(properties, "properties");
             MetadataHelper.CheckSameEntityType(properties, "properties");

--- a/src/EntityFramework/Metadata/ModelConventions/KeyConvention.cs
+++ b/src/EntityFramework/Metadata/ModelConventions/KeyConvention.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
                     ConfigureKeyProperty(property);
                 }
 
-                entityType.SetKey(keyProperties);
+                entityType.GetOrSetPrimaryKey(keyProperties);
             }
         }
 

--- a/src/EntityFramework/Metadata/ModelConventions/PropertiesConvention.cs
+++ b/src/EntityFramework/Metadata/ModelConventions/PropertiesConvention.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
                 var primitiveProperties = entityType.Type.GetRuntimeProperties().Where(IsPrimitiveProperty);
                 foreach (var propertyInfo in primitiveProperties)
                 {
-                    entityType.AddProperty(propertyInfo);
+                    entityType.GetOrAddProperty(propertyInfo);
                 }
             }
         }

--- a/src/EntityFramework/Metadata/Property.cs
+++ b/src/EntityFramework/Metadata/Property.cs
@@ -19,20 +19,14 @@ namespace Microsoft.Data.Entity.Metadata
         private int _originalValueIndex = -1;
         private int _index;
 
-        internal Property([NotNull] string name, [NotNull] Type propertyType)
-            : this(name, propertyType, shadowProperty: false, concurrencyToken: false)
-        {
-        }
-
-        internal Property([NotNull] string name, [NotNull] Type propertyType, bool shadowProperty, bool concurrencyToken)
-            : base(Check.NotEmpty(name, "name"))
+        public Property([NotNull] string name, [NotNull] Type propertyType, bool shadowProperty = false)
+            : base(name)
         {
             Check.NotNull(propertyType, "propertyType");
 
             _propertyType = propertyType;
             _shadowIndex = shadowProperty ? 0 : -1;
             _isNullable = propertyType.IsNullableType();
-            _isConcurrencyToken = concurrencyToken;
         }
 
         public virtual Type PropertyType
@@ -65,7 +59,7 @@ namespace Microsoft.Data.Entity.Metadata
 
                     if (EntityType != null)
                     {
-                        EntityType.UpdateIndexes(this);
+                        EntityType.PropertyMetadataChanged(this);
                     }
                 }
             }
@@ -82,7 +76,7 @@ namespace Microsoft.Data.Entity.Metadata
 
                     if (EntityType != null)
                     {
-                        EntityType.UpdateIndexes(this);
+                        EntityType.PropertyMetadataChanged(this);
                     }
                 }
             }

--- a/src/EntityFramework/Metadata/PropertyExtensions.cs
+++ b/src/EntityFramework/Metadata/PropertyExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Data.Entity.Metadata
             Check.NotNull(property, "property");
 
             // TODO: Perf: make it fast to check if a property is part of the primary key
-            return property.EntityType.GetKey().Properties.Contains(property);
+            return property.EntityType.GetPrimaryKey().Properties.Contains(property);
         }
     }
 }

--- a/src/EntityFramework/Properties/Strings.Designer.cs
+++ b/src/EntityFramework/Properties/Strings.Designer.cs
@@ -730,6 +730,134 @@ namespace Microsoft.Data.Entity
             return GetString("PropertyExtensionInvoked");
         }
 
+        /// <summary>
+        /// The property '{property}' cannot be added to the entity type '{entityType}' because it already belongs to entity type '{existingEntityType}'.
+        /// </summary>
+        internal static string PropertyAlreadyOwned
+        {
+            get { return GetString("PropertyAlreadyOwned"); }
+        }
+
+        /// <summary>
+        /// The property '{property}' cannot be added to the entity type '{entityType}' because it already belongs to entity type '{existingEntityType}'.
+        /// </summary>
+        internal static string FormatPropertyAlreadyOwned(object property, object entityType, object existingEntityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("PropertyAlreadyOwned", "property", "entityType", "existingEntityType"), property, entityType, existingEntityType);
+        }
+
+        /// <summary>
+        /// The property '{property}' cannot be added to the entity type '{entityType}' because an existing property with the same name already exists.
+        /// </summary>
+        internal static string DuplicateProperty
+        {
+            get { return GetString("DuplicateProperty"); }
+        }
+
+        /// <summary>
+        /// The property '{property}' cannot be added to the entity type '{entityType}' because an existing property with the same name already exists.
+        /// </summary>
+        internal static string FormatDuplicateProperty(object property, object entityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("DuplicateProperty", "property", "entityType"), property, entityType);
+        }
+
+        /// <summary>
+        /// The property '{property}' cannot exist on entity type '{entityType}' because the property is not marked as shadow state and no corresponding CLR property exists on the underlying type.
+        /// </summary>
+        internal static string NoClrProperty
+        {
+            get { return GetString("NoClrProperty"); }
+        }
+
+        /// <summary>
+        /// The property '{property}' cannot exist on entity type '{entityType}' because the property is not marked as shadow state and no corresponding CLR property exists on the underlying type.
+        /// </summary>
+        internal static string FormatNoClrProperty(object property, object entityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("NoClrProperty", "property", "entityType"), property, entityType);
+        }
+
+        /// <summary>
+        /// The property '{property}' cannot exist on entity type '{entityType}' because the property is not marked as shadow state and the type of the corresponding CLR property does not match the type specified in the property.
+        /// </summary>
+        internal static string WrongClrPropertyType
+        {
+            get { return GetString("WrongClrPropertyType"); }
+        }
+
+        /// <summary>
+        /// The property '{property}' cannot exist on entity type '{entityType}' because the property is not marked as shadow state and the type of the corresponding CLR property does not match the type specified in the property.
+        /// </summary>
+        internal static string FormatWrongClrPropertyType(object property, object entityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("WrongClrPropertyType", "property", "entityType"), property, entityType);
+        }
+
+        /// <summary>
+        /// The property '{property}' cannot exist on entity type '{entityType}' because the entity type is marked as shadow state while the property is not. Shadow state entity types can only contain shadow state properties.
+        /// </summary>
+        internal static string ClrPropertyOnShadowEntity
+        {
+            get { return GetString("ClrPropertyOnShadowEntity"); }
+        }
+
+        /// <summary>
+        /// The property '{property}' cannot exist on entity type '{entityType}' because the entity type is marked as shadow state while the property is not. Shadow state entity types can only contain shadow state properties.
+        /// </summary>
+        internal static string FormatClrPropertyOnShadowEntity(object property, object entityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ClrPropertyOnShadowEntity", "property", "entityType"), property, entityType);
+        }
+
+        /// <summary>
+        /// The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in an index or key. All indexes and keys must be removed or redefined before the property can be removed.
+        /// </summary>
+        internal static string PropertyInUse
+        {
+            get { return GetString("PropertyInUse"); }
+        }
+
+        /// <summary>
+        /// The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in an index or key. All indexes and keys must be removed or redefined before the property can be removed.
+        /// </summary>
+        internal static string FormatPropertyInUse(object property, object entityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("PropertyInUse", "property", "entityType"), property, entityType);
+        }
+
+        /// <summary>
+        /// Cannot remove key from entity type '{entityType}' because it is referenced by a foreign key in entity type '{dependentType}'. All foreign keys must be removed or redefined before the referenced key can be removed.
+        /// </summary>
+        internal static string KeyInUse
+        {
+            get { return GetString("KeyInUse"); }
+        }
+
+        /// <summary>
+        /// Cannot remove key from entity type '{entityType}' because it is referenced by a foreign key in entity type '{dependentType}'. All foreign keys must be removed or redefined before the referenced key can be removed.
+        /// </summary>
+        internal static string FormatKeyInUse(object entityType, object dependentType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("KeyInUse", "entityType", "dependentType"), entityType, dependentType);
+        }
+
+        /// <summary>
+        /// Cannot remove foreign key from entity type '{entityType}' because it is referenced by navigation property '{navigation}' in entity type '{dependentType}'. All navigations must be removed or redefined before the referenced foreign key can be removed.
+        /// </summary>
+        internal static string ForeignKeyInUse
+        {
+            get { return GetString("ForeignKeyInUse"); }
+        }
+
+        /// <summary>
+        /// Cannot remove foreign key from entity type '{entityType}' because it is referenced by navigation property '{navigation}' in entity type '{dependentType}'. All navigations must be removed or redefined before the referenced foreign key can be removed.
+        /// </summary>
+        internal static string FormatForeignKeyInUse(object entityType, object navigation, object dependentType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("ForeignKeyInUse", "entityType", "navigation", "dependentType"), entityType, navigation, dependentType);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EntityFramework/Properties/Strings.resx
+++ b/src/EntityFramework/Properties/Strings.resx
@@ -252,4 +252,28 @@
   <data name="PropertyExtensionInvoked" xml:space="preserve">
     <value>The Property&amp;lt;T&amp;gt; extension method may only be used within LINQ queries.</value>
   </data>
+  <data name="PropertyAlreadyOwned" xml:space="preserve">
+    <value>The property '{property}' cannot be added to the entity type '{entityType}' because it already belongs to entity type '{existingEntityType}'.</value>
+  </data>
+  <data name="DuplicateProperty" xml:space="preserve">
+    <value>The property '{property}' cannot be added to the entity type '{entityType}' because an existing property with the same name already exists.</value>
+  </data>
+  <data name="NoClrProperty" xml:space="preserve">
+    <value>The property '{property}' cannot exist on entity type '{entityType}' because the property is not marked as shadow state and no corresponding CLR property exists on the underlying type.</value>
+  </data>
+  <data name="WrongClrPropertyType" xml:space="preserve">
+    <value>The property '{property}' cannot exist on entity type '{entityType}' because the property is not marked as shadow state and the type of the corresponding CLR property does not match the type specified in the property.</value>
+  </data>
+  <data name="ClrPropertyOnShadowEntity" xml:space="preserve">
+    <value>The property '{property}' cannot exist on entity type '{entityType}' because the entity type is marked as shadow state while the property is not. Shadow state entity types can only contain shadow state properties.</value>
+  </data>
+  <data name="PropertyInUse" xml:space="preserve">
+    <value>The property '{property}' cannot be removed from entity type '{entityType}' because it is being used in an index or key. All indexes and keys must be removed or redefined before the property can be removed.</value>
+  </data>
+  <data name="KeyInUse" xml:space="preserve">
+    <value>Cannot remove key from entity type '{entityType}' because it is referenced by a foreign key in entity type '{dependentType}'. All foreign keys must be removed or redefined before the referenced key can be removed.</value>
+  </data>
+  <data name="ForeignKeyInUse" xml:space="preserve">
+    <value>Cannot remove foreign key from entity type '{entityType}' because it is referenced by navigation property '{navigation}' in entity type '{dependentType}'. All navigations must be removed or redefined before the referenced foreign key can be removed.</value>
+  </data>
 </root>

--- a/src/EntityFramework/Query/EntityQueryModelVisitor.cs
+++ b/src/EntityFramework/Query/EntityQueryModelVisitor.cs
@@ -58,17 +58,17 @@ namespace Microsoft.Data.Entity.Query
             }
         }
 
-        public QueryCompilationContext QueryCompilationContext
+        public virtual QueryCompilationContext QueryCompilationContext
         {
             get { return _queryCompilationContext; }
         }
 
-        public ILinqOperatorProvider LinqOperatorProvider
+        public virtual ILinqOperatorProvider LinqOperatorProvider
         {
             get { return QueryCompilationContext.LinqOperatorProvider; }
         }
 
-        public StreamedSequenceInfo StreamedSequenceInfo
+        public virtual StreamedSequenceInfo StreamedSequenceInfo
         {
             get { return _streamedSequenceInfo; }
         }
@@ -85,7 +85,7 @@ namespace Microsoft.Data.Entity.Query
             return new DefaultExpressionTreeVisitor(this);
         }
 
-        public Func<QueryContext, IEnumerable<TResult>> CreateQueryExecutor<TResult>([NotNull] QueryModel queryModel)
+        public virtual Func<QueryContext, IEnumerable<TResult>> CreateQueryExecutor<TResult>([NotNull] QueryModel queryModel)
         {
             Check.NotNull(queryModel, "queryModel");
 
@@ -111,7 +111,7 @@ namespace Microsoft.Data.Entity.Query
             return qc => queryExecutor(qc, null);
         }
 
-        public Func<QueryContext, IAsyncEnumerable<TResult>> CreateAsyncQueryExecutor<TResult>([NotNull] QueryModel queryModel)
+        public virtual Func<QueryContext, IAsyncEnumerable<TResult>> CreateAsyncQueryExecutor<TResult>([NotNull] QueryModel queryModel)
         {
             Check.NotNull(queryModel, "queryModel");
 

--- a/test/EntityFramework.AzureTableStorage.Tests/Adapters/TableEntityAdapterFactoryTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Adapters/TableEntityAdapterFactoryTests.cs
@@ -18,9 +18,9 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Adapters
         {
             _factory = new TableEntityAdapterFactory();
             _entityType = new EntityType(typeof(PocoTestType));
-            _entityType.AddProperty("PartitionKey", typeof(string));
-            _entityType.AddProperty("RowKey", typeof(string));
-            _entityType.AddProperty("Timestamp", typeof(DateTime));
+            _entityType.GetOrAddProperty("PartitionKey", typeof(string));
+            _entityType.GetOrAddProperty("RowKey", typeof(string));
+            _entityType.GetOrAddProperty("Timestamp", typeof(DateTimeOffset));
         }
 
         [Fact]

--- a/test/EntityFramework.AzureTableStorage.Tests/Extensions/EntityBuilderExtensionsTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Extensions/EntityBuilderExtensionsTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Extensions
             builder.Entity<PocoTestType>()
                 .PartitionAndRowKey(s => s.BigCount, s => s.IsEnchanted);
 
-            var key = model.EntityTypes.First().GetKey();
+            var key = model.EntityTypes.First().GetPrimaryKey();
             Assert.Equal(2, key.Properties.Count);
             Assert.Equal("BigCount", key.Properties.First(s => s.ColumnName() == "PartitionKey").Name);
             Assert.Equal("IsEnchanted", key.Properties.First(s => s.ColumnName() == "RowKey").Name);

--- a/test/EntityFramework.AzureTableStorage.Tests/Helpers/PocoTestType.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Helpers/PocoTestType.cs
@@ -25,12 +25,13 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Helpers
 
         public static EntityType EntityType()
         {
-            var entityType =
-                new EntityType(typeof(PocoTestType));
+            var entityType = new EntityType(typeof(PocoTestType));
+
             foreach (var property in typeof(PocoTestType).GetProperties())
             {
-                entityType.AddProperty(property);
+                entityType.GetOrAddProperty(property);
             }
+
             return entityType;
         }
 

--- a/test/EntityFramework.AzureTableStorage.Tests/Helpers/SimpleTestTypes.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Helpers/SimpleTestTypes.cs
@@ -15,8 +15,8 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Helpers
         public static EntityType EntityType()
         {
             var entityType = new EntityType(typeof(IntKeysPoco));
-            entityType.AddProperty("PartitionID", typeof(int)).SetColumnName("PartitionKey");
-            entityType.AddProperty("RowID", typeof(int)).SetColumnName("RowKey");
+            entityType.GetOrAddProperty("PartitionID", typeof(int)).SetColumnName("PartitionKey");
+            entityType.GetOrAddProperty("RowID", typeof(int)).SetColumnName("RowKey");
             return entityType;
         }
     }
@@ -29,8 +29,8 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Helpers
         public static EntityType EntityType()
         {
             var entityType = new EntityType(typeof(NullablePoco));
-            entityType.AddProperty("NullInt", typeof(int?));
-            entityType.AddProperty("NullDouble", typeof(double?));
+            entityType.GetOrAddProperty("NullInt", typeof(int?));
+            entityType.GetOrAddProperty("NullDouble", typeof(double?));
             return entityType;
         }
     }

--- a/test/EntityFramework.AzureTableStorage.Tests/Helpers/TestStateEntry.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Helpers/TestStateEntry.cs
@@ -69,10 +69,10 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Helpers
         public TestStateEntry WithType(string name)
         {
             var e = new EntityType(name);
-            e.AddProperty("PartitionKey", typeof(string), true, false);
-            e.AddProperty("RowKey", typeof(string), true, false);
-            e.AddProperty("ETag", typeof(string), true, false);
-            e.AddProperty("Timestamp", typeof(DateTime), true, false);
+            e.GetOrAddProperty("PartitionKey", typeof(string), shadowProperty: true);
+            e.GetOrAddProperty("RowKey", typeof(string), shadowProperty: true);
+            e.GetOrAddProperty("ETag", typeof(string), shadowProperty: true);
+            e.GetOrAddProperty("Timestamp", typeof(DateTime), shadowProperty: true);
             _entityType = e;
             return this;
         }
@@ -80,10 +80,10 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Helpers
         public TestStateEntry WithType(Type type)
         {
             var e = new EntityType(type);
-            e.AddProperty("PartitionKey", typeof(string));
-            e.AddProperty("RowKey", typeof(string));
-            e.AddProperty("ETag", typeof(string));
-            e.AddProperty("Timestamp", typeof(DateTimeOffset));
+            e.GetOrAddProperty("PartitionKey", typeof(string));
+            e.GetOrAddProperty("RowKey", typeof(string));
+            e.GetOrAddProperty("ETag", typeof(string));
+            e.GetOrAddProperty("Timestamp", typeof(DateTimeOffset));
             _entityType = e;
             return this;
         }

--- a/test/EntityFramework.AzureTableStorage.Tests/Metadata/AtsConventionBuilderTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Metadata/AtsConventionBuilderTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Metadata
         public void Adds_composite_key()
         {
             var model = new AtsClrContext().Model;
-            var key = model.GetEntityType(typeof(ClrPoco)).GetKey();
+            var key = model.GetEntityType(typeof(ClrPoco)).GetPrimaryKey();
             Assert.Equal(2, key.Properties.Count);
             Assert.Contains("PartitionKey", key.Properties.Select(p => p.ColumnName()));
             Assert.Contains("RowKey", key.Properties.Select(p => p.ColumnName()));

--- a/test/EntityFramework.AzureTableStorage.Tests/Metadata/ETagConventionTest.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Metadata/ETagConventionTest.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Metadata
 {
     public class ETagConventionTest
     {
-        public ETagConvention _convention = new ETagConvention();
+        private readonly ETagConvention _convention = new ETagConvention();
 
         [Fact]
         public void It_adds_etag()
@@ -26,13 +26,13 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Metadata
         public void It_does_not_overwrite_etag_prop()
         {
             var entityType = new EntityType("TestType");
-            entityType.AddProperty("ETag", typeof(int), false, false);
+            entityType.GetOrAddProperty("ETag", typeof(int), shadowProperty: true);
 
             _convention.Apply(entityType);
             var etagProp = entityType.GetProperty("ETag");
             Assert.NotNull(etagProp);
-            Assert.False(etagProp.IsShadowProperty);
-            Assert.False(etagProp.IsConcurrencyToken);
+            Assert.True(etagProp.IsShadowProperty);
+            Assert.True(etagProp.IsConcurrencyToken);
         }
     }
 }

--- a/test/EntityFramework.AzureTableStorage.Tests/Metadata/PartitionAndRowKeyConventionTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Metadata/PartitionAndRowKeyConventionTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Metadata
             _convention.Apply(entityType);
 
             Assert.Equal(0, entityType.Properties.Count);
-            Assert.Null(entityType.TryGetKey());
+            Assert.Null(entityType.TryGetPrimaryKey());
         }
 
         [Theory]
@@ -29,24 +29,24 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Metadata
         public void It_requires_both_properties(string onlyProp)
         {
             var entityType = new EntityType("John Maynard");
-            entityType.AddProperty(onlyProp, typeof(string));
+            entityType.GetOrAddProperty(onlyProp, typeof(string), shadowProperty: true);
 
             _convention.Apply(entityType);
 
             Assert.Equal(1, entityType.Properties.Count);
-            Assert.Null(entityType.TryGetKey());
+            Assert.Null(entityType.TryGetPrimaryKey());
         }
 
         [Fact]
         public void It_adds_composite_key()
         {
             var entityType = new EntityType("John Maynard");
-            entityType.AddProperty("PartitionKey", typeof(string));
-            entityType.AddProperty("RowKey", typeof(string));
+            entityType.GetOrAddProperty("PartitionKey", typeof(string), shadowProperty: true);
+            entityType.GetOrAddProperty("RowKey", typeof(string), shadowProperty: true);
 
             _convention.Apply(entityType);
 
-            var key = entityType.GetKey();
+            var key = entityType.GetPrimaryKey();
             Assert.Equal(2, key.Properties.Count);
             Assert.Contains("PartitionKey", key.Properties.Select(p => p.ColumnName()));
             Assert.Contains("RowKey", key.Properties.Select(p => p.ColumnName()));

--- a/test/EntityFramework.AzureTableStorage.Tests/Query/AtsObjectArrayValueReaderFactoryTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Query/AtsObjectArrayValueReaderFactoryTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Query
         public void It_gets_value_by_storage_name()
         {
             var entityType = new EntityType("TestType");
-            var property = entityType.AddProperty("ClrName", typeof(object));
+            var property = entityType.GetOrAddProperty("ClrName", typeof(object), shadowProperty: true);
             property.SetColumnName("StorageName");
 
             var data = new Dictionary<string, EntityProperty>
@@ -38,8 +38,8 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Query
         public void Reader_does_not_contain_ignored_properties()
         {
             var entityType = new EntityType("TestType");
-            entityType.AddProperty("Prop1", typeof(string));
-            entityType.AddProperty("Prop2", typeof(int));
+            entityType.GetOrAddProperty("Prop1", typeof(string), shadowProperty: true);
+            entityType.GetOrAddProperty("Prop2", typeof(int), shadowProperty: true);
             var data = new Dictionary<string, EntityProperty>
                 {
                     { "Prop2", new EntityProperty(3) },
@@ -61,8 +61,8 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Query
         public void Reader_contains_nulls_for_unmatched_properties()
         {
             var entityType = new EntityType("TestType");
-            entityType.AddProperty("Prop1", typeof(string));
-            entityType.AddProperty("Prop2", typeof(int));
+            entityType.GetOrAddProperty("Prop1", typeof(string), shadowProperty: true);
+            entityType.GetOrAddProperty("Prop2", typeof(int), shadowProperty: true);
             var buffer = new AtsNamedValueBuffer(new Dictionary<string, EntityProperty>());
             var reader = _factory.Create(entityType, buffer);
 
@@ -76,7 +76,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Query
         public void Reader_uses_default_clr_for_unmapped_properties()
         {
             var entityType = new EntityType("TestType");
-            entityType.AddProperty("BoolProp", typeof(bool));
+            entityType.GetOrAddProperty("BoolProp", typeof(bool), shadowProperty: true);
 
             var buffer = new AtsNamedValueBuffer(new Dictionary<string, EntityProperty>());
             var reader = _factory.Create(entityType, buffer);

--- a/test/EntityFramework.AzureTableStorage.Tests/Utilities/EntityTypeExtensionsTest.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Utilities/EntityTypeExtensionsTest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Utilities
         public void Can_lookup_by_storage_name()
         {
             var entityType = new EntityType("Customer");
-            var property = entityType.AddProperty("Name", typeof(string));
+            var property = entityType.GetOrAddProperty("Name", typeof(string), shadowProperty: true);
             property.SetColumnName("FirstName");
             Assert.Equal(property, entityType.GetPropertyByColumnName("FirstName"));
             Assert.Equal(property, entityType.TryGetPropertyByColumnName("FirstName"));
@@ -24,7 +24,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Utilities
         public void Lookup_by_storage_name_returns_null()
         {
             var entityType = new EntityType("Customer");
-            entityType.AddProperty("Name", typeof(string));
+            entityType.GetOrAddProperty("Name", typeof(string), shadowProperty: true);
 
             Assert.Equal(
                 Strings.FormatPropertyWithStorageNameNotFound("FirstName", "Customer"),

--- a/test/EntityFramework.Design.Tests/CSharpMigrationCodeGeneratorTest.cs
+++ b/test/EntityFramework.Design.Tests/CSharpMigrationCodeGeneratorTest.cs
@@ -379,7 +379,7 @@ namespace MyNamespace
             var model = new Model();
             var entityType = new EntityType("Entity");
 
-            entityType.SetKey(entityType.AddProperty("Id", typeof(int)));
+            entityType.GetOrSetPrimaryKey(entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
             model.AddEntityType(entityType);
 
             var migration
@@ -418,8 +418,7 @@ namespace MyNamespace
                 
                 builder.Entity(""Entity"", b =>
                     {
-                        b.Property<int>(""Id"")
-                            .Shadow(false);
+                        b.Property<int>(""Id"");
                         b.Key(""Id"");
                     });
                 

--- a/test/EntityFramework.Design.Tests/CSharpModelCodeGeneratorTest.cs
+++ b/test/EntityFramework.Design.Tests/CSharpModelCodeGeneratorTest.cs
@@ -603,7 +603,7 @@ return builder.Model;",
             var model = new Model();
             var entityType = new EntityType("Entity");
 
-            entityType.SetKey(entityType.AddProperty("Id", typeof(int)));
+            entityType.GetOrSetPrimaryKey(entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
             model.AddEntityType(entityType);
 
             var stringBuilder = new IndentedStringBuilder();
@@ -626,8 +626,7 @@ namespace MyNamespace
                 
                 builder.Entity(""Entity"", b =>
                     {
-                        b.Property<int>(""Id"")
-                            .Shadow(false);
+                        b.Property<int>(""Id"");
                         b.Key(""Id"");
                     });
                 

--- a/test/EntityFramework.Design.Tests/MigrationScaffolderTest.cs
+++ b/test/EntityFramework.Design.Tests/MigrationScaffolderTest.cs
@@ -224,7 +224,7 @@ namespace MyNamespace
             {
                 var builder = new BasicModelBuilder();
                 
-                builder.Entity(""Entity"", b =>
+                builder.Entity(""Microsoft.Data.Entity.Design.Tests.MigrationScaffolderTest+Entity"", b =>
                     {
                         b.Property<int>(""Id"")
                             .Shadow(false);
@@ -260,7 +260,7 @@ namespace MyNamespace
             {
                 var builder = new BasicModelBuilder();
                 
-                builder.Entity(""Entity"", b =>
+                builder.Entity(""Microsoft.Data.Entity.Design.Tests.MigrationScaffolderTest+Entity"", b =>
                     {
                         b.Property<int>(""Id"")
                             .Shadow(false);
@@ -292,6 +292,13 @@ namespace MyNamespace
     {
         public override void Up(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.CreateTable(""[Ho!use[]]]"",
+                c => new
+                    {
+                        Id = c.Int(nullable: false)
+                    })
+                .PrimaryKey(""PK_Ho!use[]"", t => t.Id);
+            
             migrationBuilder.CreateTable(""dbo.[Cus[\""om.er]]s]"",
                 c => new
                     {
@@ -299,13 +306,6 @@ namespace MyNamespace
                         HouseIdColumn = c.Int(name: ""House[\""Id]Column"", nullable: false)
                     })
                 .PrimaryKey(""My[\""PK]"", t => t.Id);
-            
-            migrationBuilder.CreateTable(""[Ho!use[]]]"",
-                c => new
-                    {
-                        Id = c.Int(nullable: false)
-                    })
-                .PrimaryKey(""PK_Ho!use[]"", t => t.Id);
             
             migrationBuilder.CreateTable(""dbo.[Ord[\""e.r]]s]"",
                 c => new
@@ -326,9 +326,9 @@ namespace MyNamespace
             
             migrationBuilder.DropForeignKey(""dbo.[Ord[\""e.r]]s]"", ""FK_dbo.Ord[\""e.r]s_dbo.Cus[\""om.er]s_CustomerId"");
             
-            migrationBuilder.DropTable(""dbo.[Cus[\""om.er]]s]"");
-            
             migrationBuilder.DropTable(""[Ho!use[]]]"");
+            
+            migrationBuilder.DropTable(""dbo.[Cus[\""om.er]]s]"");
             
             migrationBuilder.DropTable(""dbo.[Ord[\""e.r]]s]"");
         }
@@ -359,7 +359,13 @@ namespace MyNamespace
             {
                 var builder = new BasicModelBuilder();
                 
-                builder.Entity(""Customer"", b =>
+                builder.Entity(""Ho!use[]"", b =>
+                    {
+                        b.Property<int>(""Id"");
+                        b.Key(""Id"");
+                    });
+                
+                builder.Entity(""Microsoft.Data.Entity.Design.Tests.MigrationScaffolderTest+Customer"", b =>
                     {
                         b.Property<int>(""HouseId"")
                             .Shadow(false)
@@ -375,21 +381,14 @@ namespace MyNamespace
                         b.TableName(""Cus[\""om.er]s"", ""dbo"");
                     });
                 
-                builder.Entity(""Ho!use[]"", b =>
-                    {
-                        b.Property<int>(""Id"")
-                            .Shadow(false);
-                        b.Key(""Id"");
-                    });
-                
-                builder.Entity(""Order"", b =>
+                builder.Entity(""Microsoft.Data.Entity.Design.Tests.MigrationScaffolderTest+Order"", b =>
                     {
                         b.Property<int>(""CustomerId"")
                             .Shadow(false);
                         b.Property<int>(""OrderId"")
                             .Shadow(false);
                         b.Key(""OrderId"");
-                        b.ForeignKey(""Customer"", ""CustomerId"");
+                        b.ForeignKey(""Microsoft.Data.Entity.Design.Tests.MigrationScaffolderTest+Customer"", ""CustomerId"");
                         b.TableName(""Ord[\""e.r]s"", ""dbo"");
                         b.Annotation(""Random annotation"", ""42"");
                     });
@@ -421,7 +420,13 @@ namespace MyNamespace
             {
                 var builder = new BasicModelBuilder();
                 
-                builder.Entity(""Customer"", b =>
+                builder.Entity(""Ho!use[]"", b =>
+                    {
+                        b.Property<int>(""Id"");
+                        b.Key(""Id"");
+                    });
+                
+                builder.Entity(""Microsoft.Data.Entity.Design.Tests.MigrationScaffolderTest+Customer"", b =>
                     {
                         b.Property<int>(""HouseId"")
                             .Shadow(false)
@@ -437,21 +442,14 @@ namespace MyNamespace
                         b.TableName(""Cus[\""om.er]s"", ""dbo"");
                     });
                 
-                builder.Entity(""Ho!use[]"", b =>
-                    {
-                        b.Property<int>(""Id"")
-                            .Shadow(false);
-                        b.Key(""Id"");
-                    });
-                
-                builder.Entity(""Order"", b =>
+                builder.Entity(""Microsoft.Data.Entity.Design.Tests.MigrationScaffolderTest+Order"", b =>
                     {
                         b.Property<int>(""CustomerId"")
                             .Shadow(false);
                         b.Property<int>(""OrderId"")
                             .Shadow(false);
                         b.Key(""OrderId"");
-                        b.ForeignKey(""Customer"", ""CustomerId"");
+                        b.ForeignKey(""Microsoft.Data.Entity.Design.Tests.MigrationScaffolderTest+Customer"", ""CustomerId"");
                         b.TableName(""Ord[\""e.r]s"", ""dbo"");
                         b.Annotation(""Random annotation"", ""42"");
                     });
@@ -551,10 +549,8 @@ namespace MyNamespace
                 
                 builder.Entity(""EntityWithNamedKey"", b =>
                     {
-                        b.Property<int>(""Foo"")
-                            .Shadow(false);
-                        b.Property<int>(""Id"")
-                            .Shadow(false);
+                        b.Property<int>(""Foo"");
+                        b.Property<int>(""Id"");
                         b.Key(k => k.Properties(""Id"", ""Foo"")
                             .KeyName(""MyPK2""));
                     });
@@ -562,10 +558,8 @@ namespace MyNamespace
                 builder.Entity(""EntityWithNamedKeyAndAnnotations"", b =>
                     {
                         b.Property<int>(""Foo"")
-                            .Shadow(false)
                             .Annotation(""Foo_Annotation"", ""Foo"");
                         b.Property<int>(""Id"")
-                            .Shadow(false)
                             .Annotation(""Id_Annotation1"", ""Id1"")
                             .Annotation(""Id_Annotation2"", ""Id2"");
                         b.Key(k => k.Properties(""Id"", ""Foo"")
@@ -576,20 +570,16 @@ namespace MyNamespace
                 
                 builder.Entity(""EntityWithUnnamedKey"", b =>
                     {
-                        b.Property<int>(""Foo"")
-                            .Shadow(false);
-                        b.Property<int>(""Id"")
-                            .Shadow(false);
+                        b.Property<int>(""Foo"");
+                        b.Property<int>(""Id"");
                         b.Key(""Id"", ""Foo"");
                     });
                 
                 builder.Entity(""EntityWithUnnamedKeyAndAnnotations"", b =>
                     {
                         b.Property<int>(""Foo"")
-                            .Shadow(false)
                             .Annotation(""Foo_Annotation"", ""Foo"");
                         b.Property<int>(""Id"")
-                            .Shadow(false)
                             .Annotation(""Id_Annotation1"", ""Id1"")
                             .Annotation(""Id_Annotation2"", ""Id2"");
                         b.Key(k => k.Properties(""Id"", ""Foo"")
@@ -626,10 +616,8 @@ namespace MyNamespace
                 
                 builder.Entity(""EntityWithNamedKey"", b =>
                     {
-                        b.Property<int>(""Foo"")
-                            .Shadow(false);
-                        b.Property<int>(""Id"")
-                            .Shadow(false);
+                        b.Property<int>(""Foo"");
+                        b.Property<int>(""Id"");
                         b.Key(k => k.Properties(""Id"", ""Foo"")
                             .KeyName(""MyPK2""));
                     });
@@ -637,10 +625,8 @@ namespace MyNamespace
                 builder.Entity(""EntityWithNamedKeyAndAnnotations"", b =>
                     {
                         b.Property<int>(""Foo"")
-                            .Shadow(false)
                             .Annotation(""Foo_Annotation"", ""Foo"");
                         b.Property<int>(""Id"")
-                            .Shadow(false)
                             .Annotation(""Id_Annotation1"", ""Id1"")
                             .Annotation(""Id_Annotation2"", ""Id2"");
                         b.Key(k => k.Properties(""Id"", ""Foo"")
@@ -651,20 +637,16 @@ namespace MyNamespace
                 
                 builder.Entity(""EntityWithUnnamedKey"", b =>
                     {
-                        b.Property<int>(""Foo"")
-                            .Shadow(false);
-                        b.Property<int>(""Id"")
-                            .Shadow(false);
+                        b.Property<int>(""Foo"");
+                        b.Property<int>(""Id"");
                         b.Key(""Id"", ""Foo"");
                     });
                 
                 builder.Entity(""EntityWithUnnamedKeyAndAnnotations"", b =>
                     {
                         b.Property<int>(""Foo"")
-                            .Shadow(false)
                             .Annotation(""Foo_Annotation"", ""Foo"");
                         b.Property<int>(""Id"")
-                            .Shadow(false)
                             .Annotation(""Id_Annotation1"", ""Id1"")
                             .Annotation(""Id_Annotation2"", ""Id2"");
                         b.Key(k => k.Properties(""Id"", ""Foo"")
@@ -680,8 +662,6 @@ namespace MyNamespace
                 modelSnapshotClass);
         }
 
-        #region Fixture
-
         private static MigrationAssembly MockMigrationAssembly(DbContextConfiguration contextConfiguration)
         {
             var mock = new Mock<MigrationAssembly>(contextConfiguration);
@@ -695,13 +675,13 @@ namespace MyNamespace
         private static IModel CreateModel()
         {
             var model = new Model();
-            var entityType = new EntityType("Entity");
-            var property = entityType.AddProperty("Id", typeof(int));
+            var entityType = new EntityType(typeof(Entity));
+            var property = entityType.GetOrAddProperty("Id", typeof(int));
 
             entityType.SetTableName("MyTable");
             entityType.SetSchema("dbo");
-            entityType.SetKey(property);
-            entityType.GetKey().SetKeyName("MyPK");
+            entityType.GetOrSetPrimaryKey(property);
+            entityType.GetPrimaryKey().SetKeyName("MyPK");
             model.AddEntityType(entityType);
 
             return model;
@@ -712,31 +692,31 @@ namespace MyNamespace
             var model = new Model();
 
             var houseType = new EntityType("Ho!use[]");
-            var houseId = houseType.AddProperty("Id", typeof(int));
-            houseType.SetKey(houseId);
+            var houseId = houseType.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
+            houseType.GetOrSetPrimaryKey(houseId);
             model.AddEntityType(houseType);
 
-            var customerType = new EntityType(@"Customer");
-            var customerId = customerType.AddProperty("Id", typeof(int));
-            var customerFkProperty = customerType.AddProperty("HouseId", typeof(int));
+            var customerType = new EntityType(typeof(Customer));
+            var customerId = customerType.GetOrAddProperty("Id", typeof(int));
+            var customerFkProperty = customerType.GetOrAddProperty("HouseId", typeof(int));
             customerFkProperty.SetColumnName(@"House[""Id]Column");
             customerType.SetSchema("dbo");
             customerType.SetTableName(@"Cus[""om.er]s");
-            customerType.SetKey(customerId);
-            customerType.GetKey().SetKeyName(@"My[""PK]");
-            customerType.GetKey().Annotations.Add(new Annotation(@"My""PK""Annotat!on", @"""Foo"""));
-            var customerFk = customerType.AddForeignKey(houseType.GetKey(), customerFkProperty);
+            customerType.GetOrSetPrimaryKey(customerId);
+            customerType.GetPrimaryKey().SetKeyName(@"My[""PK]");
+            customerType.GetPrimaryKey().Annotations.Add(new Annotation(@"My""PK""Annotat!on", @"""Foo"""));
+            var customerFk = customerType.GetOrAddForeignKey(houseType.GetPrimaryKey(), customerFkProperty);
             customerFk.SetKeyName(@"My_[""FK]");
             customerFk.Annotations.Add(new Annotation(@"My""FK""Annotation", @"""Bar"""));
             model.AddEntityType(customerType);
 
-            var orderType = new EntityType(@"Order");
-            var orderId = orderType.AddProperty(@"OrderId", typeof(int));
-            var orderFK = orderType.AddProperty(@"CustomerId", typeof(int));
+            var orderType = new EntityType(typeof(Order));
+            var orderId = orderType.GetOrAddProperty(@"OrderId", typeof(int));
+            var orderFK = orderType.GetOrAddProperty(@"CustomerId", typeof(int));
             orderType.SetSchema("dbo");
-            orderType.SetKey(orderId);
+            orderType.GetOrSetPrimaryKey(orderId);
             orderType.SetTableName(@"Ord[""e.r]s");
-            orderType.AddForeignKey(customerType.GetKey(), orderFK);
+            orderType.GetOrAddForeignKey(customerType.GetPrimaryKey(), orderFK);
             orderType.Annotations.Add(new Annotation("Random annotation", "42"));
             model.AddEntityType(orderType);
 
@@ -748,45 +728,62 @@ namespace MyNamespace
             var model = new Model();
             var entity1 = new EntityType("EntityWithNamedKeyAndAnnotations");
 
-            var id1 = entity1.AddProperty("Id", typeof(int));
+            var id1 = entity1.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
             id1.Annotations.Add(new Annotation("Id_Annotation1", "Id1"));
             id1.Annotations.Add(new Annotation("Id_Annotation2", "Id2"));
-            var foo1 = entity1.AddProperty("Foo", typeof(int));
+            var foo1 = entity1.GetOrAddProperty("Foo", typeof(int), shadowProperty: true);
             foo1.Annotations.Add(new Annotation("Foo_Annotation", "Foo"));
 
-            entity1.SetKey(id1, foo1);
-            entity1.GetKey().SetKeyName("MyPK1");
-            entity1.GetKey().Annotations.Add(new Annotation("KeyAnnotation1", "Key1"));
-            entity1.GetKey().Annotations.Add(new Annotation("KeyAnnotation2", "Key2"));
+            entity1.GetOrSetPrimaryKey(id1, foo1);
+            entity1.GetPrimaryKey().SetKeyName("MyPK1");
+            entity1.GetPrimaryKey().Annotations.Add(new Annotation("KeyAnnotation1", "Key1"));
+            entity1.GetPrimaryKey().Annotations.Add(new Annotation("KeyAnnotation2", "Key2"));
             model.AddEntityType(entity1);
 
             var entity2 = new EntityType("EntityWithUnnamedKeyAndAnnotations");
 
-            var id2 = entity2.AddProperty("Id", typeof(int));
+            var id2 = entity2.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
             id2.Annotations.Add(new Annotation("Id_Annotation1", "Id1"));
             id2.Annotations.Add(new Annotation("Id_Annotation2", "Id2"));
-            var foo2 = entity2.AddProperty("Foo", typeof(int));
+            var foo2 = entity2.GetOrAddProperty("Foo", typeof(int), shadowProperty: true);
             foo2.Annotations.Add(new Annotation("Foo_Annotation", "Foo"));
 
-            entity2.SetKey(id2, foo2);
-            entity2.GetKey().Annotations.Add(new Annotation("KeyAnnotation1", "Key1"));
-            entity2.GetKey().Annotations.Add(new Annotation("KeyAnnotation2", "Key2"));
+            entity2.GetOrSetPrimaryKey(id2, foo2);
+            entity2.GetPrimaryKey().Annotations.Add(new Annotation("KeyAnnotation1", "Key1"));
+            entity2.GetPrimaryKey().Annotations.Add(new Annotation("KeyAnnotation2", "Key2"));
             model.AddEntityType(entity2);
 
             var entity3 = new EntityType("EntityWithNamedKey");
-            var id3 = entity3.AddProperty("Id", typeof(int));
-            var foo3 = entity3.AddProperty("Foo", typeof(int));
-            entity3.SetKey(id3, foo3);
-            entity3.GetKey().SetKeyName("MyPK2");
+            var id3 = entity3.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
+            var foo3 = entity3.GetOrAddProperty("Foo", typeof(int), shadowProperty: true);
+            entity3.GetOrSetPrimaryKey(id3, foo3);
+            entity3.GetPrimaryKey().SetKeyName("MyPK2");
             model.AddEntityType(entity3);
 
             var entity4 = new EntityType("EntityWithUnnamedKey");
-            var id4 = entity4.AddProperty("Id", typeof(int));
-            var foo4 = entity4.AddProperty("Foo", typeof(int));
-            entity4.SetKey(id4, foo4);
+            var id4 = entity4.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
+            var foo4 = entity4.GetOrAddProperty("Foo", typeof(int), shadowProperty: true);
+            entity4.GetOrSetPrimaryKey(id4, foo4);
             model.AddEntityType(entity4);
 
             return model;
+        }
+
+        private class Entity
+        {
+            public int Id { get; set; }
+        }
+
+        private class Customer
+        {
+            public int Id { get; set; }
+            public int HouseId { get; set; }
+        }
+
+        private class Order
+        {
+            public int OrderId { get; set; }
+            public int CustomerId { get; set; }
         }
 
         public class Context : DbContext
@@ -858,7 +855,5 @@ namespace MyNamespace
                 return scaffoldedMigration;
             }
         }
-
-        #endregion
     }
 }

--- a/test/EntityFramework.FunctionalTests/Metadata/CompiledModelTest.cs
+++ b/test/EntityFramework.FunctionalTests/Metadata/CompiledModelTest.cs
@@ -36,8 +36,8 @@ namespace Microsoft.Data.Entity.FunctionalTests.Metadata
                     .SequenceEqual(builtModel.EntityTypes.Select(a => a.Type)));
 
             Assert.True(
-                compiledModel.EntityTypes.First().GetKey().Properties.Select(p => p.Name)
-                    .SequenceEqual(builtModel.EntityTypes.First().GetKey().Properties.Select(p => p.Name)));
+                compiledModel.EntityTypes.First().GetPrimaryKey().Properties.Select(p => p.Name)
+                    .SequenceEqual(builtModel.EntityTypes.First().GetPrimaryKey().Properties.Select(p => p.Name)));
 
             Assert.True(
                 compiledModel.EntityTypes.First().Properties.Select(p => p.Name)
@@ -324,7 +324,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.Metadata
             var navigations = entities.SelectMany(e => e.Navigations);
             memory.Add(Tuple.Create(navigations.Count(), GetMemory(), "All navigations"));
 
-            var keys = entities.SelectMany(e => e.GetKey().Properties);
+            var keys = entities.SelectMany(e => e.GetPrimaryKey().Properties);
             memory.Add(Tuple.Create(keys.Count(), GetMemory(), "All keys"));
 
             var properties = entities.SelectMany(e => e.Properties).ToList();
@@ -360,20 +360,20 @@ namespace Microsoft.Data.Entity.FunctionalTests.Metadata
             builder.Annotation("ModelAnnotation2", "ModelValue2");
 
             var entityType1 = new EntityType(typeof(KoolEntity1));
-            var property = entityType1.AddProperty("Id1", typeof(int));
-            entityType1.SetKey(property);
-            entityType1.AddProperty("Id2", typeof(Guid));
-            entityType1.AddProperty("KoolEntity2Id", typeof(int));
+            var property = entityType1.GetOrAddProperty("Id1", typeof(int));
+            entityType1.GetOrSetPrimaryKey(property);
+            entityType1.GetOrAddProperty("Id2", typeof(Guid));
+            entityType1.GetOrAddProperty("KoolEntity2Id", typeof(int));
             model.AddEntityType(entityType1);
 
             var entityType2 = new EntityType(typeof(KoolEntity2));
-            entityType2.AddProperty("KoolEntity1Id1", typeof(int));
-            entityType2.AddProperty("KoolEntity1Id2", typeof(Guid));
-            entityType2.AddProperty("KoolEntity3Id", typeof(int));
+            entityType2.GetOrAddProperty("KoolEntity1Id1", typeof(int));
+            entityType2.GetOrAddProperty("KoolEntity1Id2", typeof(Guid));
+            entityType2.GetOrAddProperty("KoolEntity3Id", typeof(int));
             model.AddEntityType(entityType2);
 
             var entityType3 = new EntityType(typeof(KoolEntity3));
-            entityType3.AddProperty("KoolEntity4Id", typeof(int));
+            entityType3.GetOrAddProperty("KoolEntity4Id", typeof(int));
             model.AddEntityType(entityType3);
 
             var entityType4 = new EntityType(typeof(KoolEntity4));
@@ -383,7 +383,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.Metadata
             model.AddEntityType(entityType5);
 
             var entityType6 = new EntityType(typeof(KoolEntity6));
-            entityType6.AddProperty("Kool5Id", typeof(int));
+            entityType6.GetOrAddProperty("Kool5Id", typeof(int));
             model.AddEntityType(entityType6);
 
             for (var i = 7; i <= 20; i++)
@@ -400,8 +400,8 @@ namespace Microsoft.Data.Entity.FunctionalTests.Metadata
                 var type = Type.GetType("Microsoft.Data.Entity.FunctionalTests.Metadata.KoolEntity" + i);
 
                 var entityType = model.GetEntityType(type);
-                var id = entityType.AddProperty(entityType.Type.GetProperty("Id"));
-                entityType.SetKey(id);
+                var id = entityType.GetOrAddProperty(entityType.Type.GetProperty("Id"));
+                entityType.GetOrSetPrimaryKey(id);
             }
 
             for (var i = 1; i <= 20; i++)
@@ -413,19 +413,19 @@ namespace Microsoft.Data.Entity.FunctionalTests.Metadata
                 entityType.Annotations.Add(new Annotation("Annotation1", "Value1"));
                 entityType.Annotations.Add(new Annotation("Annotation2", "Value2"));
 
-                var foo = entityType.AddProperty(entityType.Type.GetProperty("Foo" + i));
+                var foo = entityType.GetOrAddProperty(entityType.Type.GetProperty("Foo" + i));
 
                 foo.Annotations.Add(new Annotation("Foo" + i + "Annotation1", "Foo" + i + "Value1"));
                 foo.Annotations.Add(new Annotation("Foo" + i + "Annotation2", "Foo" + i + "Value2"));
 
-                var goo = entityType.AddProperty(entityType.Type.GetProperty("Goo" + i));
+                var goo = entityType.GetOrAddProperty(entityType.Type.GetProperty("Goo" + i));
             }
 
-            var fk11 = entityType1.AddForeignKey(entityType2.GetKey(), new[] { entityType1.GetProperty("KoolEntity2Id") });
-            var fk21 = entityType2.AddForeignKey(entityType1.GetKey(), new[] { entityType2.GetProperty("KoolEntity1Id1") });
-            var fk22 = entityType2.AddForeignKey(entityType3.GetKey(), new[] { entityType2.GetProperty("KoolEntity3Id") });
-            var fk31 = entityType3.AddForeignKey(entityType4.GetKey(), new[] { entityType3.GetProperty("KoolEntity4Id") });
-            var fk61 = entityType6.AddForeignKey(entityType5.GetKey(), new[] { entityType6.GetProperty("Kool5Id") });
+            var fk11 = entityType1.GetOrAddForeignKey(entityType2.GetPrimaryKey(), new[] { entityType1.GetProperty("KoolEntity2Id") });
+            var fk21 = entityType2.GetOrAddForeignKey(entityType1.GetPrimaryKey(), new[] { entityType2.GetProperty("KoolEntity1Id1") });
+            var fk22 = entityType2.GetOrAddForeignKey(entityType3.GetPrimaryKey(), new[] { entityType2.GetProperty("KoolEntity3Id") });
+            var fk31 = entityType3.GetOrAddForeignKey(entityType4.GetPrimaryKey(), new[] { entityType3.GetProperty("KoolEntity4Id") });
+            var fk61 = entityType6.GetOrAddForeignKey(entityType5.GetPrimaryKey(), new[] { entityType6.GetProperty("Kool5Id") });
 
             entityType1.AddNavigation(new Navigation(fk11, "NavTo2", pointsToPrincipal: true));
             entityType1.AddNavigation(new Navigation(fk21, "NavTo2s", pointsToPrincipal: false));

--- a/test/EntityFramework.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             var model = new Model();
 
             var customerType = new EntityType("Customer");
-            customerType.SetKey(customerType.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
-            customerType.AddProperty("Name", typeof(string), shadowProperty: true, concurrencyToken: false);
+            customerType.GetOrSetPrimaryKey(customerType.AddProperty(new Property("Id", typeof(int), shadowProperty: true)));
+            customerType.GetOrAddProperty("Name", typeof(string), shadowProperty: true);
 
             model.AddEntityType(customerType);
 
@@ -80,8 +80,8 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             var model = new Model();
 
             var customerType = new EntityType(typeof(Customer));
-            customerType.SetKey(customerType.AddProperty("Id", typeof(int), shadowProperty: false, concurrencyToken: false));
-            customerType.AddProperty("Name", typeof(string), shadowProperty: true, concurrencyToken: false);
+            customerType.GetOrSetPrimaryKey(customerType.GetOrAddProperty("Id", typeof(int)));
+            customerType.GetOrAddProperty("Name", typeof(string), shadowProperty: true);
 
             model.AddEntityType(customerType);
 

--- a/test/EntityFramework.InMemory.Tests/InMemoryValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryValueGeneratorSelectorTest.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         private static Property CreateProperty(Type propertyType, ValueGenerationOnAdd valueGeneration)
         {
             var entityType = new EntityType("MyType");
-            var property = entityType.AddProperty("MyProperty", propertyType);
+            var property = entityType.GetOrAddProperty("MyProperty", propertyType, shadowProperty: true);
             property.ValueGenerationOnAdd = valueGeneration;
 
             new Model().AddEntityType(entityType);

--- a/test/EntityFramework.InMemory.Tests/InMemoryValueGeneratorTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryValueGeneratorTest.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         private static Property CreateProperty(Type propertyType)
         {
             var entityType = new EntityType("MyType");
-            return entityType.AddProperty("MyProperty", propertyType);
+            return entityType.GetOrAddProperty("MyProperty", propertyType, shadowProperty: true);
         }
     }
 }

--- a/test/EntityFramework.Redis.Tests/Query/QueryTestType.cs
+++ b/test/EntityFramework.Redis.Tests/Query/QueryTestType.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.Entity.Redis.Tests.Query
                 new EntityType(typeof(QueryTestType));
             foreach (var property in typeof(QueryTestType).GetProperties())
             {
-                entityType.AddProperty(property);
+                entityType.GetOrAddProperty(property);
             }
             return entityType;
         }

--- a/test/EntityFramework.Relational.Tests/DatabaseBuilderTest.cs
+++ b/test/EntityFramework.Relational.Tests/DatabaseBuilderTest.cs
@@ -205,8 +205,8 @@ namespace Microsoft.Data.Entity.Relational.Tests
             principalEntityType.SetSchema("dbo");
             principalEntityType.SetTableName("MyTable1");
 
-            var dependentProperty = dependentEntityType.AddProperty("Id", typeof(int));
-            var principalProperty = principalEntityType.AddProperty("Id", typeof(int));
+            var dependentProperty = dependentEntityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
+            var principalProperty = principalEntityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
             principalProperty.ValueGenerationOnSave = ValueGenerationOnSave.WhenInserting;
 
             model.AddEntityType(principalEntityType);
@@ -217,17 +217,17 @@ namespace Microsoft.Data.Entity.Relational.Tests
             dependentProperty.Annotations.Add(new Annotation(
                 MetadataExtensions.Annotations.StorageTypeName, "int"));
 
-            dependentEntityType.SetKey(dependentProperty);
-            principalEntityType.SetKey(principalProperty);
-            dependentEntityType.GetKey().SetKeyName("MyPK0");
-            principalEntityType.GetKey().SetKeyName("MyPK1");
+            dependentEntityType.GetOrSetPrimaryKey(dependentProperty);
+            principalEntityType.GetOrSetPrimaryKey(principalProperty);
+            dependentEntityType.GetPrimaryKey().SetKeyName("MyPK0");
+            principalEntityType.GetPrimaryKey().SetKeyName("MyPK1");
 
-            var foreignKey = dependentEntityType.AddForeignKey(principalEntityType.GetKey(), dependentProperty);
+            var foreignKey = dependentEntityType.GetOrAddForeignKey(principalEntityType.GetPrimaryKey(), dependentProperty);
             foreignKey.SetKeyName("MyFK");
             foreignKey.Annotations.Add(new Annotation(
                 MetadataExtensions.Annotations.CascadeDelete, "True"));
 
-            var index = dependentEntityType.AddIndex(dependentProperty);
+            var index = dependentEntityType.GetOrAddIndex(dependentProperty);
             index.SetIndexName("MyIndex");
             index.IsUnique = true;
 

--- a/test/EntityFramework.Relational.Tests/MetadataExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/MetadataExtensionsTest.cs
@@ -10,15 +10,6 @@ namespace Microsoft.Data.Entity.Relational.Tests
 {
     public class MetadataExtensionsTest
     {
-        #region Fixture
-
-        public class Customer
-        {
-            public int Id { get; set; }
-        }
-
-        #endregion
-
         [Fact]
         public void ToTable_sets_table_name_on_entity()
         {
@@ -80,6 +71,11 @@ namespace Microsoft.Data.Entity.Relational.Tests
         public void IsClustered_returns_true_by_default()
         {
             Assert.True(new Mock<Key>().Object.IsClustered());
+        }
+
+        private class Customer
+        {
+            public int Id { get; set; }
         }
     }
 }

--- a/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
                 CreateSimpleFKModel().GetEntityType(typeof(FakeEntity)), new FakeEntity { Id = 42, Value = "Test" });
 
             await stateEntry.SetEntityStateAsync(EntityState.Modified);
-            stateEntry.SetPropertyModified(stateEntry.EntityType.GetKey().Properties.Single(), isModified: false);
+            stateEntry.SetPropertyModified(stateEntry.EntityType.GetPrimaryKey().Properties.Single(), isModified: false);
 
             var commandBatches = CreateCommandBatchPreparer().BatchCommands(new[] { stateEntry }).ToArray();
             Assert.Equal(1, commandBatches.Count());
@@ -221,7 +221,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
                 configuration,
                 model.GetEntityType(typeof(FakeEntity)), new FakeEntity { Id = 42, Value = "Test" });
             await stateEntry.SetEntityStateAsync(EntityState.Modified);
-            stateEntry.SetPropertyModified(stateEntry.EntityType.GetKey().Properties.Single(), isModified: true);
+            stateEntry.SetPropertyModified(stateEntry.EntityType.GetPrimaryKey().Properties.Single(), isModified: true);
 
             var relatedStateEntry = new MixedStateEntry(
                 configuration,
@@ -277,7 +277,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
                 model.GetEntityType(typeof(RelatedFakeEntity)), new RelatedFakeEntity { Id = 1, RelatedId = 3 });
             await relatedStateEntry.SetEntityStateAsync(EntityState.Modified);
             relatedStateEntry.OriginalValues[relatedStateEntry.EntityType.GetProperty("RelatedId")] = 42;
-            relatedStateEntry.SetPropertyModified(relatedStateEntry.EntityType.GetKey().Properties.Single(), isModified: false);
+            relatedStateEntry.SetPropertyModified(relatedStateEntry.EntityType.GetPrimaryKey().Properties.Single(), isModified: false);
 
             var commandBatches = CreateCommandBatchPreparer().BatchCommands(new[] { relatedStateEntry, previousParent, newParent }).ToArray();
 

--- a/test/EntityFramework.Relational.Tests/Update/ModificationCommandComparerTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ModificationCommandComparerTest.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             var configuration = new DbContext(new DbContextOptions().UseInMemoryStore(persist: false)).Configuration;
 
             var entityType1 = new EntityType(typeof(object));
-            var key1 = entityType1.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false);
-            entityType1.SetKey(key1);
+            var key1 = entityType1.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
+            entityType1.GetOrSetPrimaryKey(key1);
             var stateEntry1 = new MixedStateEntry(configuration, entityType1, new object());
             stateEntry1[key1] = 0;
             stateEntry1.EntityState = EntityState.Added;
@@ -27,8 +27,8 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             modificationCommandAdded.AddStateEntry(stateEntry1);
 
             var entityType2 = new EntityType(typeof(object));
-            var key2 = entityType2.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false);
-            entityType2.SetKey(key2);
+            var key2 = entityType2.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
+            entityType2.GetOrSetPrimaryKey(key2);
             var stateEntry2 = new MixedStateEntry(configuration, entityType2, new object());
             stateEntry2[key2] = 0;
             stateEntry2.EntityState = EntityState.Modified;
@@ -36,8 +36,8 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             modificationCommandModified.AddStateEntry(stateEntry2);
 
             var entityType3 = new EntityType(typeof(object));
-            var key3 = entityType3.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false);
-            entityType3.SetKey(key3);
+            var key3 = entityType3.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
+            entityType3.GetOrSetPrimaryKey(key3);
             var stateEntry3 = new MixedStateEntry(configuration, entityType3, new object());
             stateEntry3[key3] = 0;
             stateEntry3.EntityState = EntityState.Deleted;

--- a/test/EntityFramework.Relational.Tests/Update/ModificationCommandTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ModificationCommandTest.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         public void ModificationCommand_initialized_correctly_for_modified_entities_with_identity_key()
         {
             var stateEntry = CreateStateEntry(EntityState.Modified, ValueGenerationOnSave.WhenInserting);
-            stateEntry.SetPropertyModified(stateEntry.EntityType.GetKey().Properties[0], isModified: false);
+            stateEntry.SetPropertyModified(stateEntry.EntityType.GetPrimaryKey().Properties[0], isModified: false);
 
             var command = new ModificationCommand(new SchemaQualifiedName("T1"), new ParameterNameGenerator());
             command.AddStateEntry(stateEntry);
@@ -118,7 +118,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         public void ModificationCommand_initialized_correctly_for_modified_entities_with_client_generated_key()
         {
             var stateEntry = CreateStateEntry(EntityState.Modified);
-            stateEntry.SetPropertyModified(stateEntry.EntityType.GetKey().Properties[0], isModified: false);
+            stateEntry.SetPropertyModified(stateEntry.EntityType.GetPrimaryKey().Properties[0], isModified: false);
 
             var command = new ModificationCommand(new SchemaQualifiedName("T1"), new ParameterNameGenerator());
             command.AddStateEntry(stateEntry);
@@ -152,7 +152,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         public void ModificationCommand_initialized_correctly_for_modified_entities_with_concurrency_token()
         {
             var stateEntry = CreateStateEntry(EntityState.Modified, nonKeyStrategy: ValueGenerationOnSave.WhenInsertingAndUpdating);
-            stateEntry.SetPropertyModified(stateEntry.EntityType.GetKey().Properties[0], isModified: false);
+            stateEntry.SetPropertyModified(stateEntry.EntityType.GetPrimaryKey().Properties[0], isModified: false);
 
             var command = new ModificationCommand(new SchemaQualifiedName("T1"), new ParameterNameGenerator());
             command.AddStateEntry(stateEntry);
@@ -332,13 +332,14 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
 
             var entityType = new EntityType(typeof(T1));
 
-            var key = entityType.AddProperty("Id", typeof(int));
+            var key = entityType.GetOrAddProperty("Id", typeof(int));
             key.ValueGenerationOnSave = keyStrategy;
             key.SetColumnName("Col1");
-            entityType.SetKey(key);
+            entityType.GetOrSetPrimaryKey(key);
 
-            var nonKey = entityType.AddProperty("Name",
-                typeof(string), false, nonKeyStrategy == ValueGenerationOnSave.WhenInsertingAndUpdating);
+            var nonKey = entityType.GetOrAddProperty("Name", typeof(string));
+            nonKey.IsConcurrencyToken = nonKeyStrategy == ValueGenerationOnSave.WhenInsertingAndUpdating;
+
             nonKey.SetColumnName("Col2");
             nonKey.ValueGenerationOnSave = nonKeyStrategy;
 

--- a/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -547,12 +547,12 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
 
             var entityType = new EntityType(typeof(T1));
 
-            var key = entityType.AddProperty("Id", typeof(int));
+            var key = entityType.GetOrAddProperty("Id", typeof(int));
             key.ValueGenerationOnSave = keyStrategy;
             key.SetColumnName("Col1");
-            entityType.SetKey(key);
+            entityType.GetOrSetPrimaryKey(key);
 
-            var nonKey = entityType.AddProperty("Name", typeof(string));
+            var nonKey = entityType.GetOrAddProperty("Name", typeof(string));
             nonKey.SetColumnName("Col2");
             nonKey.ValueGenerationOnSave = nonKeyStrategy;
 

--- a/test/EntityFramework.SQLite.FunctionalTests/MonsterFixupTest.cs
+++ b/test/EntityFramework.SQLite.FunctionalTests/MonsterFixupTest.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Data.Entity.SQLite.FunctionalTests
         {
             var keyProperties =
                 from t in builder.Model.EntityTypes
-                let ps = t.GetKey().Properties
+                let ps = t.GetPrimaryKey().Properties
                 where ps.Count == 1
                 let p = ps[0]
                 where p.PropertyType == typeof(int)

--- a/test/EntityFramework.SQLite.Tests/SQLiteValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework.SQLite.Tests/SQLiteValueGeneratorSelectorTest.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Data.Entity.SQLite.Tests
         public void Select_returns_tempFactory_when_single_long_key()
         {
             var entityType = new EntityType("Entity");
-            var property = entityType.AddProperty("Id", typeof(long));
+            var property = entityType.GetOrAddProperty("Id", typeof(long), shadowProperty: true);
             property.ValueGenerationOnAdd = ValueGenerationOnAdd.Client;
-            entityType.SetKey(property);
+            entityType.GetOrSetPrimaryKey(property);
 
             var result = CreateSelector().Select(property);
 
@@ -27,10 +27,10 @@ namespace Microsoft.Data.Entity.SQLite.Tests
         public void Select_returns_tempFactory_when_single_integer_column_key()
         {
             var entityType = new EntityType("Entity");
-            var property = entityType.AddProperty("Id", typeof(int));
+            var property = entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
             property.ValueGenerationOnAdd = ValueGenerationOnAdd.Client;
             property[MetadataExtensions.Annotations.StorageTypeName] = "INTEGER";
-            entityType.SetKey(property);
+            entityType.GetOrSetPrimaryKey(property);
 
             var result = CreateSelector().Select(property);
 
@@ -41,8 +41,8 @@ namespace Microsoft.Data.Entity.SQLite.Tests
         public void Select_returns_null_when_ValueGenerationOnAdd_is_not_Client()
         {
             var entityType = new EntityType("Entity");
-            var property = entityType.AddProperty("Id", typeof(long));
-            entityType.SetKey(property);
+            var property = entityType.GetOrAddProperty("Id", typeof(long), shadowProperty: true);
+            entityType.GetOrSetPrimaryKey(property);
 
             var result = CreateSelector().Select(property);
 
@@ -54,9 +54,9 @@ namespace Microsoft.Data.Entity.SQLite.Tests
         {
             var selector = CreateSelector();
             var entityType = new EntityType("Entity");
-            var property = entityType.AddProperty("Id1", typeof(long));
+            var property = entityType.GetOrAddProperty("Id1", typeof(long), shadowProperty: true);
             property.ValueGenerationOnAdd = ValueGenerationOnAdd.Client;
-            entityType.SetKey(property, entityType.AddProperty("Id2", typeof(long)));
+            entityType.GetOrSetPrimaryKey(property, entityType.GetOrAddProperty("Id2", typeof(long), shadowProperty: true));
 
             Assert.Throws<NotSupportedException>(() => selector.Select(property));
         }
@@ -66,9 +66,9 @@ namespace Microsoft.Data.Entity.SQLite.Tests
         {
             var selector = CreateSelector();
             var entityType = new EntityType("Entity");
-            var property = entityType.AddProperty("Id", typeof(int));
+            var property = entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
             property.ValueGenerationOnAdd = ValueGenerationOnAdd.Client;
-            entityType.SetKey(property);
+            entityType.GetOrSetPrimaryKey(property);
 
             Assert.Throws<NotSupportedException>(() => selector.Select(property));
         }

--- a/test/EntityFramework.SqlServer.Tests/SqlServerSequenceValueGeneratorFactoryTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerSequenceValueGeneratorFactoryTest.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         private static Property CreateProperty()
         {
             var entityType = new EntityType("MyType");
-            var property = entityType.AddProperty("MyProperty", typeof(string));
+            var property = entityType.GetOrAddProperty("MyProperty", typeof(string), shadowProperty: true);
             entityType.SetTableName("MyTable");
 
             new Model().AddEntityType(entityType);

--- a/test/EntityFramework.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         private static Property CreateProperty(Type propertyType)
         {
             var entityType = new EntityType("MyType");
-            return entityType.AddProperty("MyProperty", propertyType);
+            return entityType.GetOrAddProperty("MyProperty", propertyType, shadowProperty: true);
         }
 
         private class FakeSqlStatementExecutor : SqlStatementExecutor

--- a/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         private static Property CreateProperty(Type propertyType, ValueGenerationOnAdd valueGeneration)
         {
             var entityType = new EntityType("MyType");
-            var property = entityType.AddProperty("MyProperty", propertyType);
+            var property = entityType.GetOrAddProperty("MyProperty", propertyType, shadowProperty: true);
             property.ValueGenerationOnAdd = valueGeneration;
             entityType.SetTableName("MyTable");
 

--- a/test/EntityFramework.Tests/ChangeTracking/ChangeDetectorTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/ChangeDetectorTest.cs
@@ -273,7 +273,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             categoryType.GetProperty("Id").ValueGenerationOnAdd = ValueGenerationOnAdd.None;
 
-            productType.AddForeignKey(new Key(new[] { categoryType.GetProperty("PrincipalId") }), productType.GetProperty("DependentId"));
+            productType.GetOrAddForeignKey(new Key(new[] { categoryType.GetProperty("PrincipalId") }), productType.GetProperty("DependentId"));
 
             return model;
         }

--- a/test/EntityFramework.Tests/ChangeTracking/CompositeEntityKeyFactoryTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/CompositeEntityKeyFactoryTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var entry = new ClrStateEntry(TestHelpers.CreateContextConfiguration(model), type, entity);
 
-            var key = (CompositeEntityKey)new CompositeEntityKeyFactory().Create(type, type.GetKey().Properties, entry);
+            var key = (CompositeEntityKey)new CompositeEntityKeyFactory().Create(type, type.GetPrimaryKey().Properties, entry);
 
             Assert.Equal(new object[] { 7, "Ate", random }, key.Value);
         }
@@ -74,7 +74,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var entry = new ClrStateEntry(TestHelpers.CreateContextConfiguration(model), type, entity);
 
-            Assert.Equal(EntityKey.NullEntityKey, new CompositeEntityKeyFactory().Create(type, type.GetKey().Properties, entry));
+            Assert.Equal(EntityKey.NullEntityKey, new CompositeEntityKeyFactory().Create(type, type.GetPrimaryKey().Properties, entry));
         }
 
         [Fact]
@@ -86,7 +86,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var random = new Random();
 
             var key = (CompositeEntityKey)new CompositeEntityKeyFactory().Create(
-                type, type.GetKey().Properties, new ObjectArrayValueReader(new object[] { 7, "Ate", random }));
+                type, type.GetPrimaryKey().Properties, new ObjectArrayValueReader(new object[] { 7, "Ate", random }));
 
             Assert.Equal(new object[] { 7, "Ate", random }, key.Value);
         }
@@ -128,15 +128,15 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var model = new Model();
 
             var entityType = new EntityType(typeof(Banana));
-            var property1 = entityType.AddProperty("P1", typeof(int));
-            var property2 = entityType.AddProperty("P2", typeof(string));
-            var property3 = entityType.AddProperty("P3", typeof(Random));
-            var property4 = entityType.AddProperty("P4", typeof(int));
-            var property5 = entityType.AddProperty("P5", typeof(string));
-            var property6 = entityType.AddProperty("P6", typeof(Random));
+            var property1 = entityType.GetOrAddProperty("P1", typeof(int));
+            var property2 = entityType.GetOrAddProperty("P2", typeof(string));
+            var property3 = entityType.GetOrAddProperty("P3", typeof(Random));
+            var property4 = entityType.GetOrAddProperty("P4", typeof(int));
+            var property5 = entityType.GetOrAddProperty("P5", typeof(string));
+            var property6 = entityType.GetOrAddProperty("P6", typeof(Random));
 
-            entityType.SetKey(property1, property2, property3);
-            entityType.AddForeignKey(entityType.GetKey(), property6, property4, property5);
+            entityType.GetOrSetPrimaryKey(property1, property2, property3);
+            entityType.GetOrAddForeignKey(entityType.GetPrimaryKey(), property6, property4, property5);
 
             model.AddEntityType(entityType);
 

--- a/test/EntityFramework.Tests/ChangeTracking/MixedStateEntryTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/MixedStateEntryTest.cs
@@ -119,40 +119,40 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var entityType1 = new EntityType(typeof(SomeEntity));
             model.AddEntityType(entityType1);
-            var key1 = entityType1.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false);
+            var key1 = entityType1.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
             key1.ValueGenerationOnSave = ValueGenerationOnSave.WhenInserting;
             key1.ValueGenerationOnAdd = ValueGenerationOnAdd.Client;
-            entityType1.SetKey(key1);
-            entityType1.AddProperty("Name", typeof(string));
+            entityType1.GetOrSetPrimaryKey(key1);
+            entityType1.GetOrAddProperty("Name", typeof(string));
 
             var entityType2 = new EntityType(typeof(SomeDependentEntity));
             model.AddEntityType(entityType2);
-            var key2a = entityType2.AddProperty("Id1", typeof(int));
-            var key2b = entityType2.AddProperty("Id2", typeof(string));
-            entityType2.SetKey(key2a, key2b);
-            var fk = entityType2.AddProperty("SomeEntityId", typeof(int), shadowProperty: true, concurrencyToken: false);
-            entityType2.AddForeignKey(entityType1.GetKey(), new[] { fk });
-            var justAProperty = entityType2.AddProperty("JustAProperty", typeof(int));
+            var key2a = entityType2.GetOrAddProperty("Id1", typeof(int));
+            var key2b = entityType2.GetOrAddProperty("Id2", typeof(string));
+            entityType2.GetOrSetPrimaryKey(key2a, key2b);
+            var fk = entityType2.GetOrAddProperty("SomeEntityId", typeof(int), shadowProperty: true);
+            entityType2.GetOrAddForeignKey(entityType1.GetPrimaryKey(), new[] { fk });
+            var justAProperty = entityType2.GetOrAddProperty("JustAProperty", typeof(int));
             justAProperty.ValueGenerationOnSave = ValueGenerationOnSave.WhenInserting;
             justAProperty.ValueGenerationOnAdd = ValueGenerationOnAdd.Client;
 
             var entityType3 = new EntityType(typeof(FullNotificationEntity));
             model.AddEntityType(entityType3);
-            entityType3.SetKey(entityType3.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
-            entityType3.AddProperty("Name", typeof(string), shadowProperty: false, concurrencyToken: true);
+            entityType3.GetOrSetPrimaryKey(entityType3.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityType3.GetOrAddProperty("Name", typeof(string)).IsConcurrencyToken = true;
 
             var entityType4 = new EntityType(typeof(ChangedOnlyEntity));
             model.AddEntityType(entityType4);
-            entityType4.SetKey(entityType4.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
-            entityType4.AddProperty("Name", typeof(string), shadowProperty: false, concurrencyToken: true);
+            entityType4.GetOrSetPrimaryKey(entityType4.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityType4.GetOrAddProperty("Name", typeof(string)).IsConcurrencyToken = true;
 
             var entityType5 = new EntityType(typeof(SomeMoreDependentEntity));
             model.AddEntityType(entityType5);
-            var key5 = entityType5.AddProperty("Id", typeof(int));
-            entityType5.SetKey(key5);
-            var fk5a = entityType5.AddProperty("Fk1", typeof(int));
-            var fk5b = entityType5.AddProperty("Fk2", typeof(string));
-            entityType5.AddForeignKey(entityType2.GetKey(), new[] { fk5a, fk5b });
+            var key5 = entityType5.GetOrAddProperty("Id", typeof(int));
+            entityType5.GetOrSetPrimaryKey(key5);
+            var fk5a = entityType5.GetOrAddProperty("Fk1", typeof(int));
+            var fk5b = entityType5.GetOrAddProperty("Fk2", typeof(string));
+            entityType5.GetOrAddForeignKey(entityType2.GetPrimaryKey(), new[] { fk5a, fk5b });
 
             return model;
         }

--- a/test/EntityFramework.Tests/ChangeTracking/RelationshipsSnapshotTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/RelationshipsSnapshotTest.cs
@@ -295,13 +295,13 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var model = new Model();
 
             var entityType = new EntityType(typeof(Banana));
-            var pkProperty = entityType.AddProperty("Id", typeof(int));
-            var fkProperty = entityType.AddProperty("Fk", typeof(int));
+            var pkProperty = entityType.GetOrAddProperty("Id", typeof(int));
+            var fkProperty = entityType.GetOrAddProperty("Fk", typeof(int));
 
-            entityType.SetKey(pkProperty);
-            var fk = entityType.AddForeignKey(entityType.GetKey(), fkProperty);
+            entityType.GetOrSetPrimaryKey(pkProperty);
+            var fk = entityType.GetOrAddForeignKey(entityType.GetPrimaryKey(), fkProperty);
 
-            entityType.AddProperty("Name", typeof(string));
+            entityType.GetOrAddProperty("Name", typeof(string));
 
             model.AddEntityType(entityType);
 

--- a/test/EntityFramework.Tests/ChangeTracking/ShadowStateEntryTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/ShadowStateEntryTest.cs
@@ -45,40 +45,40 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var entityType1 = new EntityType(typeof(SomeEntity).FullName);
             model.AddEntityType(entityType1);
-            var key1 = entityType1.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false);
+            var key1 = entityType1.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
             key1.ValueGenerationOnSave = ValueGenerationOnSave.WhenInserting;
             key1.ValueGenerationOnAdd = ValueGenerationOnAdd.Client;
-            entityType1.SetKey(key1);
-            entityType1.AddProperty("Name", typeof(string), shadowProperty: true, concurrencyToken: true);
+            entityType1.GetOrSetPrimaryKey(key1);
+            entityType1.GetOrAddProperty("Name", typeof(string), shadowProperty: true).IsConcurrencyToken = true;
 
             var entityType2 = new EntityType(typeof(SomeDependentEntity).FullName);
             model.AddEntityType(entityType2);
-            var key2a = entityType2.AddProperty("Id1", typeof(int), shadowProperty: true, concurrencyToken: false);
-            var key2b = entityType2.AddProperty("Id2", typeof(string), shadowProperty: true, concurrencyToken: false);
-            entityType2.SetKey(key2a, key2b);
-            var fk = entityType2.AddProperty("SomeEntityId", typeof(int), shadowProperty: true, concurrencyToken: false);
-            entityType2.AddForeignKey(entityType1.GetKey(), new[] { fk });
-            var justAProperty = entityType2.AddProperty("JustAProperty", typeof(int), shadowProperty: true, concurrencyToken: false);
+            var key2a = entityType2.GetOrAddProperty("Id1", typeof(int), shadowProperty: true);
+            var key2b = entityType2.GetOrAddProperty("Id2", typeof(string), shadowProperty: true);
+            entityType2.GetOrSetPrimaryKey(key2a, key2b);
+            var fk = entityType2.GetOrAddProperty("SomeEntityId", typeof(int), shadowProperty: true);
+            entityType2.GetOrAddForeignKey(entityType1.GetPrimaryKey(), new[] { fk });
+            var justAProperty = entityType2.GetOrAddProperty("JustAProperty", typeof(int), shadowProperty: true);
             justAProperty.ValueGenerationOnSave = ValueGenerationOnSave.WhenInserting;
             justAProperty.ValueGenerationOnAdd = ValueGenerationOnAdd.Client;
 
             var entityType3 = new EntityType(typeof(FullNotificationEntity));
             model.AddEntityType(entityType3);
-            entityType3.SetKey(entityType3.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
-            entityType3.AddProperty("Name", typeof(string), shadowProperty: true, concurrencyToken: true);
+            entityType3.GetOrSetPrimaryKey(entityType3.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityType3.GetOrAddProperty("Name", typeof(string), shadowProperty: true).IsConcurrencyToken = true;
 
             var entityType4 = new EntityType(typeof(ChangedOnlyEntity));
             model.AddEntityType(entityType4);
-            entityType4.SetKey(entityType4.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
-            entityType4.AddProperty("Name", typeof(string), shadowProperty: true, concurrencyToken: true);
+            entityType4.GetOrSetPrimaryKey(entityType4.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            entityType4.GetOrAddProperty("Name", typeof(string), shadowProperty: true).IsConcurrencyToken = true;
 
             var entityType5 = new EntityType(typeof(SomeMoreDependentEntity).FullName);
             model.AddEntityType(entityType5);
-            var key5 = entityType5.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false);
-            entityType5.SetKey(key5);
-            var fk5a = entityType5.AddProperty("Fk1", typeof(int), shadowProperty: true, concurrencyToken: false);
-            var fk5b = entityType5.AddProperty("Fk2", typeof(string), shadowProperty: true, concurrencyToken: false);
-            entityType5.AddForeignKey(entityType2.GetKey(), new[] { fk5a, fk5b });
+            var key5 = entityType5.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
+            entityType5.GetOrSetPrimaryKey(key5);
+            var fk5a = entityType5.GetOrAddProperty("Fk1", typeof(int), shadowProperty: true);
+            var fk5b = entityType5.GetOrAddProperty("Fk2", typeof(string), shadowProperty: true);
+            entityType5.GetOrAddForeignKey(entityType2.GetPrimaryKey(), new[] { fk5a, fk5b });
 
             return model;
         }

--- a/test/EntityFramework.Tests/ChangeTracking/SidecarTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/SidecarTest.cs
@@ -386,36 +386,38 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var entityType = new EntityType(typeof(Banana));
 
-            var idProperty = entityType.AddProperty("Id", typeof(int), shadowProperty: false, concurrencyToken: true);
+            var idProperty = entityType.GetOrAddProperty("Id", typeof(int));
+            idProperty.IsConcurrencyToken = true;
             idProperty.ValueGenerationOnSave = ValueGenerationOnSave.WhenInserting;
-            entityType.SetKey(idProperty);
+            entityType.GetOrSetPrimaryKey(idProperty);
 
-            entityType.AddProperty("Name", typeof(string));
-            entityType.AddProperty("State", typeof(string), shadowProperty: false, concurrencyToken: true);
+            entityType.GetOrAddProperty("Name", typeof(string));
+            entityType.GetOrAddProperty("State", typeof(string)).IsConcurrencyToken = true;
 
-            var fkProperty = entityType.AddProperty("Fk", typeof(int?), shadowProperty: false, concurrencyToken: true);
-            entityType.AddForeignKey(new Key(new[] { idProperty }), fkProperty);
+            var fkProperty = entityType.GetOrAddProperty("Fk", typeof(int?));
+            fkProperty.IsConcurrencyToken = true;
+            entityType.GetOrAddForeignKey(new Key(new[] { idProperty }), fkProperty);
 
             model.AddEntityType(entityType);
 
             var entityType2 = new EntityType(typeof(SomeDependentEntity));
             model.AddEntityType(entityType2);
-            var key2A = entityType2.AddProperty("Id1", typeof(int));
-            var key2B = entityType2.AddProperty("Id2", typeof(string));
-            entityType2.SetKey(key2A, key2B);
-            var fk = entityType2.AddProperty("SomeEntityId", typeof(int));
-            entityType2.AddForeignKey(entityType.GetKey(), new[] { fk });
-            var justAProperty = entityType2.AddProperty("JustAProperty", typeof(int));
+            var key2A = entityType2.GetOrAddProperty("Id1", typeof(int));
+            var key2B = entityType2.GetOrAddProperty("Id2", typeof(string));
+            entityType2.GetOrSetPrimaryKey(key2A, key2B);
+            var fk = entityType2.GetOrAddProperty("SomeEntityId", typeof(int));
+            entityType2.GetOrAddForeignKey(entityType.GetPrimaryKey(), new[] { fk });
+            var justAProperty = entityType2.GetOrAddProperty("JustAProperty", typeof(int));
             justAProperty.ValueGenerationOnSave = ValueGenerationOnSave.WhenInserting;
             justAProperty.ValueGenerationOnAdd = ValueGenerationOnAdd.Client;
 
             var entityType5 = new EntityType(typeof(SomeMoreDependentEntity));
             model.AddEntityType(entityType5);
-            var key5 = entityType5.AddProperty("Id", typeof(int));
-            entityType5.SetKey(key5);
-            var fk5A = entityType5.AddProperty("Fk1", typeof(int));
-            var fk5B = entityType5.AddProperty("Fk2", typeof(string));
-            entityType5.AddForeignKey(entityType2.GetKey(), new[] { fk5A, fk5B });
+            var key5 = entityType5.GetOrAddProperty("Id", typeof(int));
+            entityType5.GetOrSetPrimaryKey(key5);
+            var fk5A = entityType5.GetOrAddProperty("Fk1", typeof(int));
+            var fk5B = entityType5.GetOrAddProperty("Fk2", typeof(string));
+            entityType5.GetOrAddForeignKey(entityType2.GetPrimaryKey(), new[] { fk5A, fk5B });
 
             return model;
         }

--- a/test/EntityFramework.Tests/ChangeTracking/SimpleEntityKeyFactoryTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/SimpleEntityKeyFactoryTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entity = new Banana { P1 = 7, P2 = "Ate" };
             var entry = new ClrStateEntry(TestHelpers.CreateContextConfiguration(model), type, entity);
 
-            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>().Create(type, type.GetKey().Properties, entry);
+            var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>().Create(type, type.GetPrimaryKey().Properties, entry);
 
             Assert.Equal(7, key.Value);
         }
@@ -57,7 +57,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var type = model.GetEntityType(typeof(Banana));
 
             var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>().Create(
-                type, type.GetKey().Properties, new ObjectArrayValueReader(new object[] { 7, "Ate" }));
+                type, type.GetPrimaryKey().Properties, new ObjectArrayValueReader(new object[] { 7, "Ate" }));
 
             Assert.Equal(7, key.Value);
         }
@@ -114,11 +114,11 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var model = new Model();
 
             var entityType = new EntityType(typeof(Banana));
-            var property1 = entityType.AddProperty("P1", typeof(int));
-            var property2 = entityType.AddProperty("P2", typeof(string));
+            var property1 = entityType.GetOrAddProperty("P1", typeof(int));
+            var property2 = entityType.GetOrAddProperty("P2", typeof(string));
 
-            entityType.SetKey(property1);
-            entityType.AddForeignKey(entityType.GetKey(), property2);
+            entityType.GetOrSetPrimaryKey(property1);
+            entityType.GetOrAddForeignKey(entityType.GetPrimaryKey(), property2);
 
             model.AddEntityType(entityType);
 

--- a/test/EntityFramework.Tests/ChangeTracking/SimpleNullableEntityKeyFactoryTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/SimpleNullableEntityKeyFactoryTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var entity = new Banana { P1 = 7 };
             var entry = new ClrStateEntry(TestHelpers.CreateContextConfiguration(model), type, entity);
 
-            var key = (SimpleEntityKey<int>)new SimpleNullableEntityKeyFactory<int, int?>().Create(type, type.GetKey().Properties, entry);
+            var key = (SimpleEntityKey<int>)new SimpleNullableEntityKeyFactory<int, int?>().Create(type, type.GetPrimaryKey().Properties, entry);
 
             Assert.Equal(7, key.Value);
         }
@@ -97,11 +97,11 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var model = new Model();
 
             var entityType = new EntityType(typeof(Banana));
-            var property1 = entityType.AddProperty("P1", typeof(int));
-            var property2 = entityType.AddProperty("P2", typeof(string));
+            var property1 = entityType.GetOrAddProperty("P1", typeof(int));
+            var property2 = entityType.GetOrAddProperty("P2", typeof(int?));
 
-            entityType.SetKey(property1);
-            entityType.AddForeignKey(entityType.GetKey(), property2);
+            entityType.GetOrSetPrimaryKey(property1);
+            entityType.GetOrAddForeignKey(entityType.GetPrimaryKey(), property2);
 
             model.AddEntityType(entityType);
 

--- a/test/EntityFramework.Tests/ChangeTracking/StateEntryFactoryTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/StateEntryFactoryTest.cs
@@ -16,8 +16,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         public void Creates_shadow_state_only_entry_when_entity_is_fully_shadow_state()
         {
             var entityType = new EntityType("RedHook");
-            entityType.AddProperty("Long", typeof(int), shadowProperty: true, concurrencyToken: false);
-            entityType.AddProperty("Hammer", typeof(string), shadowProperty: true, concurrencyToken: false);
+            entityType.GetOrAddProperty("Long", typeof(int), shadowProperty: true);
+            entityType.GetOrAddProperty("Hammer", typeof(string), shadowProperty: true);
 
             var servicesMock = new Mock<ContextServices>();
             servicesMock.Setup(m => m.ClrPropertyGetterSource).Returns(new ClrPropertyGetterSource());
@@ -39,8 +39,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         public void Creates_CLR_only_entry_when_entity_has_no_shadow_properties()
         {
             var entityType = new EntityType(typeof(RedHook));
-            entityType.AddProperty("Long", typeof(int));
-            entityType.AddProperty("Hammer", typeof(string));
+            entityType.GetOrAddProperty("Long", typeof(int));
+            entityType.GetOrAddProperty("Hammer", typeof(string));
 
             var servicesMock = new Mock<ContextServices>();
             servicesMock.Setup(m => m.ClrPropertyGetterSource).Returns(new ClrPropertyGetterSource());
@@ -63,8 +63,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         public void Creates_mixed_entry_when_entity_CLR_entity_type_and_shadow_properties()
         {
             var entityType = new EntityType(typeof(RedHook));
-            entityType.AddProperty("Long", typeof(int));
-            entityType.AddProperty("Hammer", typeof(string), shadowProperty: true, concurrencyToken: false);
+            entityType.GetOrAddProperty("Long", typeof(int));
+            entityType.GetOrAddProperty("Hammer", typeof(string), shadowProperty: true);
 
             var servicesMock = new Mock<ContextServices>();
             servicesMock.Setup(m => m.ClrPropertyGetterSource).Returns(new ClrPropertyGetterSource());
@@ -87,8 +87,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         public void Creates_shadow_state_only_entry_from_value_buffer_when_entity_is_fully_shadow_state()
         {
             var entityType = new EntityType("RedHook");
-            var property1 = entityType.AddProperty("Long", typeof(int), shadowProperty: true, concurrencyToken: false);
-            var property2 = entityType.AddProperty("Hammer", typeof(string), shadowProperty: true, concurrencyToken: false);
+            var property1 = entityType.GetOrAddProperty("Long", typeof(int), shadowProperty: true);
+            var property2 = entityType.GetOrAddProperty("Hammer", typeof(string), shadowProperty: true);
 
             var servicesMock = new Mock<ContextServices>();
             servicesMock.Setup(m => m.ClrPropertyGetterSource).Returns(new ClrPropertyGetterSource());
@@ -111,8 +111,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         public void Creates_CLR_only_entry_from_value_buffer_when_entity_has_no_shadow_properties()
         {
             var entityType = new EntityType(typeof(RedHook));
-            var property1 = entityType.AddProperty("Long", typeof(int));
-            var property2 = entityType.AddProperty("Hammer", typeof(string));
+            var property1 = entityType.GetOrAddProperty("Long", typeof(int));
+            var property2 = entityType.GetOrAddProperty("Hammer", typeof(string));
 
             var servicesMock = new Mock<ContextServices>();
             servicesMock.Setup(m => m.ClrPropertyGetterSource).Returns(new ClrPropertyGetterSource());
@@ -138,8 +138,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         public void Creates_mixed_entry_from_value_buffer_when_entity_CLR_entity_type_and_shadow_properties()
         {
             var entityType = new EntityType(typeof(RedHook));
-            var property1 = entityType.AddProperty("Long", typeof(int));
-            var property2 = entityType.AddProperty("Hammer", typeof(string), shadowProperty: true, concurrencyToken: false);
+            var property1 = entityType.GetOrAddProperty("Long", typeof(int));
+            var property2 = entityType.GetOrAddProperty("Hammer", typeof(string), shadowProperty: true);
 
             var servicesMock = new Mock<ContextServices>();
             servicesMock.Setup(m => m.ClrPropertyGetterSource).Returns(new ClrPropertyGetterSource());

--- a/test/EntityFramework.Tests/ChangeTracking/StateEntrySubscriberTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/StateEntrySubscriberTest.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         public void Entry_subscribes_to_INotifyPropertyChanging_and_INotifyPropertyChanged()
         {
             var entityType = new EntityType(typeof(FullNotificationEntity));
-            var property = entityType.AddProperty("Name", typeof(string));
+            var property = entityType.GetOrAddProperty("Name", typeof(string));
 
             var entity = new FullNotificationEntity();
 
@@ -74,7 +74,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         public void Subscriptions_to_INotifyPropertyChanging_and_INotifyPropertyChanged_ignore_unmapped_properties()
         {
             var entityType = new EntityType(typeof(FullNotificationEntity));
-            entityType.AddProperty("Name", typeof(string));
+            entityType.GetOrAddProperty("Name", typeof(string));
 
             var entity = new FullNotificationEntity();
 

--- a/test/EntityFramework.Tests/ChangeTracking/StateEntryTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/StateEntryTest.cs
@@ -1011,40 +1011,40 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
             var entityType1 = new EntityType(typeof(SomeEntity));
             model.AddEntityType(entityType1);
-            var key1 = entityType1.AddProperty("Id", typeof(int));
+            var key1 = entityType1.GetOrAddProperty("Id", typeof(int));
             key1.ValueGenerationOnSave = ValueGenerationOnSave.WhenInserting;
             key1.ValueGenerationOnAdd = ValueGenerationOnAdd.Client;
-            entityType1.SetKey(key1);
-            entityType1.AddProperty("Name", typeof(string), shadowProperty: false, concurrencyToken: true);
+            entityType1.GetOrSetPrimaryKey(key1);
+            entityType1.GetOrAddProperty("Name", typeof(string)).IsConcurrencyToken = true;
 
             var entityType2 = new EntityType(typeof(SomeDependentEntity));
             model.AddEntityType(entityType2);
-            var key2a = entityType2.AddProperty("Id1", typeof(int));
-            var key2b = entityType2.AddProperty("Id2", typeof(string));
-            entityType2.SetKey(key2a, key2b);
-            var fk = entityType2.AddProperty("SomeEntityId", typeof(int));
-            entityType2.AddForeignKey(entityType1.GetKey(), new[] { fk });
-            var justAProperty = entityType2.AddProperty("JustAProperty", typeof(int));
+            var key2a = entityType2.GetOrAddProperty("Id1", typeof(int));
+            var key2b = entityType2.GetOrAddProperty("Id2", typeof(string));
+            entityType2.GetOrSetPrimaryKey(key2a, key2b);
+            var fk = entityType2.GetOrAddProperty("SomeEntityId", typeof(int));
+            entityType2.GetOrAddForeignKey(entityType1.GetPrimaryKey(), new[] { fk });
+            var justAProperty = entityType2.GetOrAddProperty("JustAProperty", typeof(int));
             justAProperty.ValueGenerationOnSave = ValueGenerationOnSave.WhenInserting;
             justAProperty.ValueGenerationOnAdd = ValueGenerationOnAdd.Client;
 
             var entityType3 = new EntityType(typeof(FullNotificationEntity));
             model.AddEntityType(entityType3);
-            entityType3.SetKey(entityType3.AddProperty("Id", typeof(int)));
-            entityType3.AddProperty("Name", typeof(string), shadowProperty: false, concurrencyToken: true);
+            entityType3.GetOrSetPrimaryKey(entityType3.GetOrAddProperty("Id", typeof(int)));
+            entityType3.GetOrAddProperty("Name", typeof(string)).IsConcurrencyToken = true;
 
             var entityType4 = new EntityType(typeof(ChangedOnlyEntity));
             model.AddEntityType(entityType4);
-            entityType4.SetKey(entityType4.AddProperty("Id", typeof(int)));
-            entityType4.AddProperty("Name", typeof(string), shadowProperty: false, concurrencyToken: true);
+            entityType4.GetOrSetPrimaryKey(entityType4.GetOrAddProperty("Id", typeof(int)));
+            entityType4.GetOrAddProperty("Name", typeof(string)).IsConcurrencyToken = true;
 
             var entityType5 = new EntityType(typeof(SomeMoreDependentEntity));
             model.AddEntityType(entityType5);
-            var key5 = entityType5.AddProperty("Id", typeof(int));
-            entityType5.SetKey(key5);
-            var fk5a = entityType5.AddProperty("Fk1", typeof(int));
-            var fk5b = entityType5.AddProperty("Fk2", typeof(string));
-            entityType5.AddForeignKey(entityType2.GetKey(), new[] { fk5a, fk5b });
+            var key5 = entityType5.GetOrAddProperty("Id", typeof(int));
+            entityType5.GetOrSetPrimaryKey(key5);
+            var fk5a = entityType5.GetOrAddProperty("Fk1", typeof(int));
+            var fk5b = entityType5.GetOrAddProperty("Fk2", typeof(string));
+            entityType5.GetOrAddForeignKey(entityType2.GetPrimaryKey(), new[] { fk5a, fk5b });
 
             return model;
         }

--- a/test/EntityFramework.Tests/ChangeTracking/StateManagerTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/StateManagerTest.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var stateManager = CreateStateManager(model);
             var entityType = model.GetEntityType("Location");
             var stateEntry = stateManager.CreateNewEntry(entityType);
-            stateEntry[entityType.GetKey().Properties.Single()] = 42;
+            stateEntry[entityType.GetPrimaryKey().Properties.Single()] = 42;
 
             Assert.Equal(EntityState.Unknown, stateEntry.EntityState);
             Assert.Null(stateEntry.Entity);
@@ -437,12 +437,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var productType = model.GetEntityType(typeof(Product));
             var categoryType = model.GetEntityType(typeof(Category));
 
-            productType.AddForeignKey(new Key(new[] { categoryType.GetProperty("PrincipalId") }), productType.GetProperty("DependentId"));
+            productType.GetOrAddForeignKey(new Key(new[] { categoryType.GetProperty("PrincipalId") }), productType.GetProperty("DependentId"));
 
             var locationType = new EntityType("Location");
-            var idProperty = locationType.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false);
-            locationType.AddProperty("Planet", typeof(string), shadowProperty: true, concurrencyToken: false);
-            locationType.SetKey(idProperty);
+            var idProperty = locationType.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
+            locationType.GetOrAddProperty("Planet", typeof(string), shadowProperty: true);
+            locationType.GetOrSetPrimaryKey(idProperty);
             model.AddEntityType(locationType);
 
             return model;

--- a/test/EntityFramework.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Tests/DbContextTest.cs
@@ -333,19 +333,19 @@ namespace Microsoft.Data.Entity.Tests
                     context.Model.EntityTypes.Select(e => e.Name).ToArray());
 
                 var categoryType = context.Model.GetEntityType(typeof(Category));
-                Assert.Equal("Id", categoryType.GetKey().Properties.Single().Name);
+                Assert.Equal("Id", categoryType.GetPrimaryKey().Properties.Single().Name);
                 Assert.Equal(
                     new[] { "Id", "Name" },
                     categoryType.Properties.Select(p => p.Name).ToArray());
 
                 var productType = context.Model.GetEntityType(typeof(Product));
-                Assert.Equal("Id", productType.GetKey().Properties.Single().Name);
+                Assert.Equal("Id", productType.GetPrimaryKey().Properties.Single().Name);
                 Assert.Equal(
                     new[] { "Id", "Name", "Price" },
                     productType.Properties.Select(p => p.Name).ToArray());
 
                 var guType = context.Model.GetEntityType(typeof(TheGu));
-                Assert.Equal("Id", guType.GetKey().Properties.Single().Name);
+                Assert.Equal("Id", guType.GetPrimaryKey().Properties.Single().Name);
                 Assert.Equal(
                     new[] { "Id", "ShirtColor" },
                     guType.Properties.Select(p => p.Name).ToArray());

--- a/test/EntityFramework.Tests/Identity/SimpleValueGeneratorFactoryTest.cs
+++ b/test/EntityFramework.Tests/Identity/SimpleValueGeneratorFactoryTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Data.Entity.Tests.Identity
         private static Property CreateProperty()
         {
             var entityType = new EntityType("Led");
-            return entityType.AddProperty("Zeppelin", typeof(int));
+            return entityType.GetOrAddProperty("Zeppelin", typeof(int), shadowProperty: true);
         }
     }
 }

--- a/test/EntityFramework.Tests/Identity/TemporaryValueGeneratorTest.cs
+++ b/test/EntityFramework.Tests/Identity/TemporaryValueGeneratorTest.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Data.Entity.Tests.Identity
         private static Property CreateProperty(Type propertyType)
         {
             var entityType = new EntityType("MyType");
-            return entityType.AddProperty("MyProperty", propertyType);
+            return entityType.GetOrAddProperty("MyProperty", propertyType, shadowProperty: true);
         }
     }
 }

--- a/test/EntityFramework.Tests/Identity/ValueGeneratorCacheTest.cs
+++ b/test/EntityFramework.Tests/Identity/ValueGeneratorCacheTest.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Data.Entity.Tests.Identity
         private static Property CreateProperty(ValueGenerationOnAdd valueGeneration)
         {
             var entityType = new EntityType("Led");
-            var property = entityType.AddProperty("Zeppelin", typeof(Guid));
+            var property = entityType.GetOrAddProperty("Zeppelin", typeof(Guid), shadowProperty: true);
             property.ValueGenerationOnAdd = valueGeneration;
             return property;
         }

--- a/test/EntityFramework.Tests/Identity/ValueGeneratorPoolTest.cs
+++ b/test/EntityFramework.Tests/Identity/ValueGeneratorPoolTest.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Data.Entity.Tests.Identity
         private static Property CreateProperty()
         {
             var entityType = new EntityType("Led");
-            return entityType.AddProperty("Zeppelin", typeof(int));
+            return entityType.GetOrAddProperty("Zeppelin", typeof(int), shadowProperty: true);
         }
     }
 }

--- a/test/EntityFramework.Tests/Identity/ValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework.Tests/Identity/ValueGeneratorSelectorTest.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Data.Entity.Tests.Identity
         private static Property CreateProperty(Type propertyType, ValueGenerationOnAdd valueGeneration)
         {
             var entityType = new EntityType("MyType");
-            var property = entityType.AddProperty("MyProperty", propertyType);
+            var property = entityType.GetOrAddProperty("MyProperty", propertyType, shadowProperty: true);
             property.ValueGenerationOnAdd = valueGeneration;
 
             new Model().AddEntityType(entityType);

--- a/test/EntityFramework.Tests/Metadata/BasicModelBuilderTest.cs
+++ b/test/EntityFramework.Tests/Metadata/BasicModelBuilderTest.cs
@@ -57,8 +57,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entity = model.GetEntityType(typeof(Customer));
 
-            Assert.Equal(1, entity.GetKey().Properties.Count());
-            Assert.Equal("Id", entity.GetKey().Properties.First().Name);
+            Assert.Equal(1, entity.GetPrimaryKey().Properties.Count());
+            Assert.Equal("Id", entity.GetPrimaryKey().Properties.First().Name);
         }
 
         [Fact]
@@ -75,8 +75,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entity = model.GetEntityType(typeof(Customer));
 
-            Assert.Equal(1, entity.GetKey().Properties.Count());
-            Assert.Equal("Id", entity.GetKey().Properties.First().Name);
+            Assert.Equal(1, entity.GetPrimaryKey().Properties.Count());
+            Assert.Equal("Id", entity.GetPrimaryKey().Properties.First().Name);
         }
 
         [Fact]
@@ -93,8 +93,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entity = model.GetEntityType(typeof(Customer));
 
-            Assert.Equal(1, entity.GetKey().Properties.Count());
-            Assert.Equal("Id", entity.GetKey().Properties.First().Name);
+            Assert.Equal(1, entity.GetPrimaryKey().Properties.Count());
+            Assert.Equal("Id", entity.GetPrimaryKey().Properties.First().Name);
         }
 
         [Fact]
@@ -111,8 +111,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entity = model.GetEntityType(typeof(Customer));
 
-            Assert.Equal(1, entity.GetKey().Properties.Count());
-            Assert.Equal("Id", entity.GetKey().Properties.First().Name);
+            Assert.Equal(1, entity.GetPrimaryKey().Properties.Count());
+            Assert.Equal("Id", entity.GetPrimaryKey().Properties.First().Name);
         }
 
         [Fact]
@@ -129,8 +129,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entity = model.GetEntityType(typeof(Customer));
 
-            Assert.Equal(1, entity.GetKey().Properties.Count());
-            Assert.Equal("Id", entity.GetKey().Properties.First().Name);
+            Assert.Equal(1, entity.GetPrimaryKey().Properties.Count());
+            Assert.Equal("Id", entity.GetPrimaryKey().Properties.First().Name);
         }
 
         [Fact]
@@ -145,9 +145,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entity = model.GetEntityType(typeof(Customer));
 
-            Assert.Equal(2, entity.GetKey().Properties.Count());
-            Assert.Equal("Id", entity.GetKey().Properties.First().Name);
-            Assert.Equal("Name", entity.GetKey().Properties.Last().Name);
+            Assert.Equal(2, entity.GetPrimaryKey().Properties.Count());
+            Assert.Equal("Id", entity.GetPrimaryKey().Properties.First().Name);
+            Assert.Equal("Name", entity.GetPrimaryKey().Properties.Last().Name);
         }
 
         [Fact]
@@ -165,9 +165,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entity = model.GetEntityType(typeof(Customer));
 
-            Assert.Equal(2, entity.GetKey().Properties.Count());
-            Assert.Equal("Id", entity.GetKey().Properties.First().Name);
-            Assert.Equal("Name", entity.GetKey().Properties.Last().Name);
+            Assert.Equal(2, entity.GetPrimaryKey().Properties.Count());
+            Assert.Equal("Id", entity.GetPrimaryKey().Properties.First().Name);
+            Assert.Equal("Name", entity.GetPrimaryKey().Properties.Last().Name);
         }
 
         [Fact]
@@ -185,9 +185,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entity = model.GetEntityType(typeof(Customer));
 
-            Assert.Equal(2, entity.GetKey().Properties.Count());
-            Assert.Equal("Id", entity.GetKey().Properties.First().Name);
-            Assert.Equal("Name", entity.GetKey().Properties.Last().Name);
+            Assert.Equal(2, entity.GetPrimaryKey().Properties.Count());
+            Assert.Equal("Id", entity.GetPrimaryKey().Properties.First().Name);
+            Assert.Equal("Name", entity.GetPrimaryKey().Properties.Last().Name);
         }
 
         [Fact]
@@ -205,9 +205,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entity = model.GetEntityType(typeof(Customer));
 
-            Assert.Equal(2, entity.GetKey().Properties.Count());
-            Assert.Equal("Id", entity.GetKey().Properties.First().Name);
-            Assert.Equal("Name", entity.GetKey().Properties.Last().Name);
+            Assert.Equal(2, entity.GetPrimaryKey().Properties.Count());
+            Assert.Equal("Id", entity.GetPrimaryKey().Properties.First().Name);
+            Assert.Equal("Name", entity.GetPrimaryKey().Properties.Last().Name);
         }
 
         [Fact]
@@ -224,10 +224,10 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entity = model.GetEntityType(typeof(Customer));
 
-            Assert.Equal(2, entity.GetKey().Properties.Count());
-            Assert.Equal(new[] { "Id", "Name" }, entity.GetKey().Properties.Select(p => p.Name));
-            Assert.Equal("V1", entity.GetKey()["A1"]);
-            Assert.Equal("V2", entity.GetKey()["A2"]);
+            Assert.Equal(2, entity.GetPrimaryKey().Properties.Count());
+            Assert.Equal(new[] { "Id", "Name" }, entity.GetPrimaryKey().Properties.Select(p => p.Name));
+            Assert.Equal("V1", entity.GetPrimaryKey()["A1"]);
+            Assert.Equal("V2", entity.GetPrimaryKey()["A2"]);
         }
 
         [Fact]
@@ -247,10 +247,10 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entity = model.GetEntityType(typeof(Customer));
 
-            Assert.Equal(2, entity.GetKey().Properties.Count());
-            Assert.Equal(new[] { "Id", "Name" }, entity.GetKey().Properties.Select(p => p.Name));
-            Assert.Equal("V1", entity.GetKey()["A1"]);
-            Assert.Equal("V2", entity.GetKey()["A2"]);
+            Assert.Equal(2, entity.GetPrimaryKey().Properties.Count());
+            Assert.Equal(new[] { "Id", "Name" }, entity.GetPrimaryKey().Properties.Select(p => p.Name));
+            Assert.Equal("V1", entity.GetPrimaryKey()["A1"]);
+            Assert.Equal("V2", entity.GetPrimaryKey()["A2"]);
         }
 
         [Fact]
@@ -518,8 +518,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                     b.Property(e => e.Up).Shadow();
                     b.Property<int>("Charm").Shadow(false);
                     b.Property(typeof(int), "Top").Shadow(false);
-                    b.Property<string>("Gluon").Shadow(false);
-                    b.Property(typeof(string), "Photon").Shadow(false);
+                    b.Property<string>("Gluon").Shadow();
+                    b.Property(typeof(string), "Photon").Shadow();
                 });
 
             var entityType = model.GetEntityType(typeof(Quarks));
@@ -527,14 +527,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.True(entityType.GetProperty("Up").IsShadowProperty);
             Assert.False(entityType.GetProperty("Charm").IsShadowProperty);
             Assert.False(entityType.GetProperty("Top").IsShadowProperty);
-            Assert.False(entityType.GetProperty("Gluon").IsShadowProperty);
-            Assert.False(entityType.GetProperty("Photon").IsShadowProperty);
+            Assert.True(entityType.GetProperty("Gluon").IsShadowProperty);
+            Assert.True(entityType.GetProperty("Photon").IsShadowProperty);
 
-            Assert.Equal(0, entityType.GetProperty("Up").ShadowIndex);
+            Assert.Equal(2, entityType.GetProperty("Up").ShadowIndex);
             Assert.Equal(-1, entityType.GetProperty("Charm").ShadowIndex);
             Assert.Equal(-1, entityType.GetProperty("Top").ShadowIndex);
-            Assert.Equal(-1, entityType.GetProperty("Gluon").ShadowIndex);
-            Assert.Equal(-1, entityType.GetProperty("Photon").ShadowIndex);
+            Assert.Equal(0, entityType.GetProperty("Gluon").ShadowIndex);
+            Assert.Equal(1, entityType.GetProperty("Photon").ShadowIndex);
         }
 
         [Fact]
@@ -666,7 +666,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(1, entityType.ForeignKeys.Count());
         }
 
-        [Fact]
+        [Fact] 
         public void Can_add_multiple_foreign_keys()
         {
             var model = new Model();
@@ -677,7 +677,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             modelBuilder.Entity<Order>(b =>
                 {
                     b.ForeignKey<Customer>(c => c.CustomerId);
-                    b.ForeignKey<Customer>(c => c.CustomerId).IsUnique();
+                    b.ForeignKey<Customer>(c => c.AnotherCustomerId).IsUnique();
                 });
 
             var entityType = model.GetEntityType(typeof(Order));
@@ -697,8 +697,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             modelBuilder.Entity<Order>(b =>
                 {
                     b.Property<int>("CustomerId");
+                    b.Property<int>("AnotherCustomerId");
                     b.ForeignKey<Customer>(c => c.CustomerId);
-                    b.ForeignKey(typeof(Customer).FullName, "CustomerId").IsUnique();
+                    b.ForeignKey(typeof(Customer).FullName, "AnotherCustomerId").IsUnique();
                 });
 
             var entityType = model.GetEntityType(typeof(Order));
@@ -719,8 +720,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity(typeof(Order).FullName, b =>
                     {
                         b.Property<int>("CustomerId");
+                        b.Property<int>("AnotherCustomerId");
                         b.ForeignKey(typeof(Customer).FullName, "CustomerId");
-                        b.ForeignKey(typeof(Customer).FullName, "CustomerId").IsUnique();
+                        b.ForeignKey(typeof(Customer).FullName, "AnotherCustomerId").IsUnique();
                     });
 
             var entityType = model.GetEntityType(typeof(Order));
@@ -744,8 +746,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             modelBuilder.Entity(typeof(Order).FullName, b =>
                 {
                     b.Property<int>("CustomerId");
+                    b.Property<int>("AnotherCustomerId");
                     b.ForeignKey(typeof(Customer).FullName, "CustomerId");
-                    b.ForeignKey(typeof(Customer).FullName, "CustomerId").IsUnique();
+                    b.ForeignKey(typeof(Customer).FullName, "AnotherCustomerId").IsUnique();
                 });
 
             var entityType = model.GetEntityType(typeof(Order));
@@ -860,6 +863,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             public int OrderId { get; set; }
 
             public int CustomerId { get; set; }
+            public int AnotherCustomerId { get; set; }
             public Customer Customer { get; set; }
 
             public OrderDetails Details { get; set; }

--- a/test/EntityFramework.Tests/Metadata/ClrPropertyGetterSourceTest.cs
+++ b/test/EntityFramework.Tests/Metadata/ClrPropertyGetterSourceTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Delegate_getter_is_returned_for_IProperty_property()
         {
             var entityType = new EntityType(typeof(Customer));
-            var idProperty = entityType.AddProperty("Id", typeof(int));
+            var idProperty = entityType.GetOrAddProperty("Id", typeof(int));
 
             Assert.Equal(7, new ClrPropertyGetterSource().GetAccessor(idProperty).GetClrValue(new Customer { Id = 7 }));
         }
@@ -39,7 +39,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Delegate_getter_is_cached_by_type_and_property_name()
         {
             var entityType = new EntityType(typeof(Customer));
-            var idProperty = entityType.AddProperty("Id", typeof(int));
+            var idProperty = entityType.GetOrAddProperty("Id", typeof(int));
 
             var source = new ClrPropertyGetterSource();
 

--- a/test/EntityFramework.Tests/Metadata/ClrPropertySetterSourceTest.cs
+++ b/test/EntityFramework.Tests/Metadata/ClrPropertySetterSourceTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Delegate_setter_is_returned_for_IProperty_property()
         {
             var entityType = new EntityType(typeof(Customer));
-            var idProperty = entityType.AddProperty("Id", typeof(int));
+            var idProperty = entityType.GetOrAddProperty("Id", typeof(int));
 
             var customer = new Customer { Id = 7 };
 
@@ -47,7 +47,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Delegate_setter_is_cached_by_type_and_property_name()
         {
             var entityType = new EntityType(typeof(Customer));
-            var idProperty = entityType.AddProperty("Id", typeof(int));
+            var idProperty = entityType.GetOrAddProperty("Id", typeof(int));
 
             var source = new ClrPropertySetterSource();
 

--- a/test/EntityFramework.Tests/Metadata/EntityMaterializerSourceTest.cs
+++ b/test/EntityFramework.Tests/Metadata/EntityMaterializerSourceTest.cs
@@ -37,9 +37,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Can_create_materializer_for_entity_with_auto_properties()
         {
             var entityType = new EntityType(typeof(SomeEntity));
-            entityType.AddProperty("Id", typeof(int));
-            entityType.AddProperty("Foo", typeof(string));
-            entityType.AddProperty("Goo", typeof(Guid));
+            entityType.GetOrAddProperty("Id", typeof(int));
+            entityType.GetOrAddProperty("Foo", typeof(string));
+            entityType.GetOrAddProperty("Goo", typeof(Guid?));
 
             var factory = new EntityMaterializerSource(new MemberMapper(new FieldMatcher())).GetMaterializer(entityType);
 
@@ -55,9 +55,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Can_create_materializer_for_entity_with_fields()
         {
             var entityType = new EntityType(typeof(SomeEntityWithFields));
-            entityType.AddProperty("Id", typeof(int));
-            entityType.AddProperty("Foo", typeof(string));
-            entityType.AddProperty("Goo", typeof(Guid));
+            entityType.GetOrAddProperty("Id", typeof(int));
+            entityType.GetOrAddProperty("Foo", typeof(string));
+            entityType.GetOrAddProperty("Goo", typeof(Guid?));
 
             var factory = new EntityMaterializerSource(new MemberMapper(new FieldMatcher())).GetMaterializer(entityType);
 
@@ -81,9 +81,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             valueReaderMock.Setup(m => m.IsNull(1)).Returns(true);
 
             var entityType = new EntityType(typeof(SomeEntity));
-            entityType.AddProperty("Id", typeof(int));
-            entityType.AddProperty("Foo", typeof(string));
-            entityType.AddProperty("Goo", typeof(Guid?));
+            entityType.GetOrAddProperty("Id", typeof(int));
+            entityType.GetOrAddProperty("Foo", typeof(string));
+            entityType.GetOrAddProperty("Goo", typeof(Guid?));
 
             var factory = new EntityMaterializerSource(new MemberMapper(new FieldMatcher())).GetMaterializer(entityType);
 
@@ -98,12 +98,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Can_create_materializer_for_entity_ignoring_shadow_fields()
         {
             var entityType = new EntityType(typeof(SomeEntity));
-            entityType.AddProperty("Id", typeof(int));
-            entityType.AddProperty("IdShadow", typeof(int), shadowProperty: true, concurrencyToken: false);
-            entityType.AddProperty("Foo", typeof(string));
-            entityType.AddProperty("FooShadow", typeof(string), shadowProperty: true, concurrencyToken: false);
-            entityType.AddProperty("Goo", typeof(Guid));
-            entityType.AddProperty("GooShadow", typeof(Guid), shadowProperty: true, concurrencyToken: false);
+            entityType.GetOrAddProperty("Id", typeof(int));
+            entityType.GetOrAddProperty("IdShadow", typeof(int), shadowProperty: true);
+            entityType.GetOrAddProperty("Foo", typeof(string));
+            entityType.GetOrAddProperty("FooShadow", typeof(string), shadowProperty: true);
+            entityType.GetOrAddProperty("Goo", typeof(Guid?));
+            entityType.GetOrAddProperty("GooShadow", typeof(Guid), shadowProperty: true);
 
             var factory = new EntityMaterializerSource(new MemberMapper(new FieldMatcher())).GetMaterializer(entityType);
 

--- a/test/EntityFramework.Tests/Metadata/EntityTypeTest.cs
+++ b/test/EntityFramework.Tests/Metadata/EntityTypeTest.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(
                 "propertyInfo",
                 // ReSharper disable once AssignNullToNotNullAttribute
-                Assert.Throws<ArgumentNullException>(() => entityType.AddProperty(null)).ParamName);
+                Assert.Throws<ArgumentNullException>(() => entityType.GetOrAddProperty(null)).ParamName);
 
             Assert.Equal(
                 "property",
@@ -76,151 +76,314 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         }
 
         [Fact]
-        public void Can_add_and_remove_properties()
+        public void Can_set_reset_and_clear_primary_key_explicitly()
         {
             var entityType = new EntityType(typeof(Customer));
+            var idProperty = entityType.GetOrAddProperty(Customer.IdProperty);
+            var nameProperty = entityType.GetOrAddProperty(Customer.NameProperty);
 
-            var property1 = entityType.AddProperty(Customer.IdProperty);
-            var property2 = entityType.AddProperty(Customer.NameProperty);
+            var key1 = new Key(new[] { idProperty, nameProperty });
 
-            Assert.True(new[] { property1, property2 }.SequenceEqual(entityType.Properties));
+            Assert.Same(key1, entityType.SetPrimaryKey(key1));
+            Assert.Same(key1, entityType.GetPrimaryKey());
+            Assert.Same(key1, entityType.TryGetPrimaryKey());
+            Assert.Same(key1, entityType.Keys.Single());
 
-            entityType.RemoveProperty(property1);
+            var key2 = new Key(new[] { idProperty });
 
-            Assert.True(new[] { property2 }.SequenceEqual(entityType.Properties));
+            Assert.Same(key2, entityType.SetPrimaryKey(key2));
+            Assert.Same(key2, entityType.GetPrimaryKey());
+            Assert.Same(key2, entityType.TryGetPrimaryKey());
+            Assert.Same(key2, entityType.Keys.Single());
+
+            Assert.Null(entityType.SetPrimaryKey(null));
+            Assert.Null(entityType.TryGetPrimaryKey());
+            Assert.Empty(entityType.Keys);
+
+            Assert.Equal(
+                Strings.FormatEntityRequiresKey(typeof(Customer).FullName),
+                Assert.Throws<ModelItemNotFoundException>(() => entityType.GetPrimaryKey()).Message);
         }
 
         [Fact]
-        public void Property_back_pointer_is_fixed_up_as_property_is_added_and_removed()
+        public void Setting_primary_key_throws_if_properties_from_different_type()
         {
             var entityType1 = new EntityType(typeof(Customer));
+            var entityType2 = new EntityType(typeof(Order));
+            var idProperty = entityType2.GetOrAddProperty(Customer.IdProperty);
 
-            var property = entityType1.AddProperty(Customer.IdProperty);
+            var key = new Key(new[] { idProperty });
 
-            Assert.Same(entityType1, property.EntityType);
-
-            entityType1.RemoveProperty(property);
-
-            Assert.Empty(entityType1.Properties);
-            Assert.Null(property.EntityType);
+            Assert.Equal(
+                Strings.FormatKeyPropertiesWrongEntity(typeof(Customer).FullName),
+                Assert.Throws<ArgumentException>(() => entityType1.SetPrimaryKey(key)).Message);
         }
 
         [Fact]
-        public void Properties_are_ordered_by_name()
+        public void Can_set_reset_and_clear_primary_key_using_properties()
         {
             var entityType = new EntityType(typeof(Customer));
+            var idProperty = entityType.GetOrAddProperty(Customer.IdProperty);
+            var nameProperty = entityType.GetOrAddProperty(Customer.NameProperty);
 
-            var property1 = entityType.AddProperty(Customer.IdProperty);
-            var property2 = entityType.AddProperty(Customer.NameProperty);
+            var key1 = entityType.GetOrSetPrimaryKey(idProperty, nameProperty);
 
-            Assert.True(new[] { property1, property2 }.SequenceEqual(entityType.Properties));
+            Assert.Same(key1, entityType.GetPrimaryKey());
+            Assert.Same(key1, entityType.TryGetPrimaryKey());
+            Assert.Same(key1, entityType.GetOrSetPrimaryKey(idProperty, nameProperty));
+
+            var key2 = entityType.GetOrSetPrimaryKey(idProperty);
+
+            Assert.Same(key2, entityType.GetPrimaryKey());
+            Assert.Same(key2, entityType.TryGetPrimaryKey());
+            Assert.NotSame(key1, key2);
+
+            Assert.Null(entityType.GetOrSetPrimaryKey(null));
+            Assert.Null(entityType.TryGetPrimaryKey());
+
+            Assert.Equal(
+                Strings.FormatEntityRequiresKey(typeof(Customer).FullName),
+                Assert.Throws<ModelItemNotFoundException>(() => entityType.GetPrimaryKey()).Message);
         }
 
         [Fact]
-        public void Can_set_and_reset_key()
+        public void Clearing_the_primary_throws_if_it_referenced_from_a_foreign_key_in_the_model()
+        {
+            var customerType = new EntityType(typeof(Customer));
+            var customerPk = customerType.GetOrSetPrimaryKey(customerType.GetOrAddProperty(Customer.IdProperty));
+
+            var orderType = new EntityType(typeof(Order));
+            var customerFk = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+            orderType.GetOrAddForeignKey(customerPk, customerFk);
+
+            var model = new Model();
+            model.AddEntityType(customerType);
+            model.AddEntityType(orderType);
+
+            Assert.Equal(
+                Strings.FormatKeyInUse(typeof(Customer).FullName, typeof(Order).FullName),
+                Assert.Throws<InvalidOperationException>(() => customerType.SetPrimaryKey(null)).Message);
+        }
+
+        [Fact]
+        public void Changing_the_primary_throws_if_it_referenced_from_a_foreign_key_in_the_model()
+        {
+            var customerType = new EntityType(typeof(Customer));
+            var customerPk = customerType.GetOrSetPrimaryKey(customerType.GetOrAddProperty(Customer.IdProperty));
+
+            var orderType = new EntityType(typeof(Order));
+            var customerFk = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+            orderType.GetOrAddForeignKey(customerPk, customerFk);
+
+            var model = new Model();
+            model.AddEntityType(customerType);
+            model.AddEntityType(orderType);
+
+            Assert.Equal(
+                Strings.FormatKeyInUse(typeof(Customer).FullName, typeof(Order).FullName),
+                Assert.Throws<InvalidOperationException>(
+                    () => customerType.GetOrSetPrimaryKey(customerType.GetOrAddProperty(Customer.NameProperty))).Message);
+        }
+
+        [Fact]
+        public void Can_add_a_key_explicitly()
         {
             var entityType = new EntityType(typeof(Customer));
+            var idProperty = entityType.GetOrAddProperty(Customer.IdProperty);
+            var nameProperty = entityType.GetOrAddProperty(Customer.NameProperty);
 
-            var property1 = entityType.AddProperty(Customer.IdProperty);
-            var property2 = entityType.AddProperty(Customer.NameProperty);
+            var key1 = new Key(new[] { idProperty, nameProperty });
 
-            entityType.SetKey(property1, property2);
+            Assert.Same(key1, entityType.AddKey(key1));
+            Assert.Same(key1, entityType.AddKey(key1));
+            Assert.Same(key1, entityType.Keys.Single());
 
-            Assert.True(new[] { property1, property2 }.SequenceEqual(entityType.GetKey().Properties));
-            Assert.True(new[] { property1, property2 }.SequenceEqual(entityType.Properties));
+            var key2 = new Key(new[] { idProperty });
 
-            entityType.RemoveProperty(property1);
-
-            Assert.True(new[] { property2 }.SequenceEqual(entityType.GetKey().Properties));
-            Assert.True(new[] { property2 }.SequenceEqual(entityType.Properties));
-
-            property1 = entityType.AddProperty(Customer.IdProperty);
-
-            entityType.SetKey(property1);
-
-            Assert.True(new[] { property1 }.SequenceEqual(entityType.GetKey().Properties));
-            Assert.True(new[] { property1, property2 }.SequenceEqual(entityType.Properties));
+            Assert.Same(key2, entityType.AddKey(key2));
+            Assert.Same(key2, entityType.AddKey(key2));
+            Assert.Equal(new[] { key1, key2 }, entityType.Keys.ToArray());
         }
 
         [Fact]
-        public void Setting_key_properties_should_update_existing_properties()
+        public void Adding_a_key_throws_if_properties_from_different_type()
+        {
+            var entityType1 = new EntityType(typeof(Customer));
+            var entityType2 = new EntityType(typeof(Order));
+            var idProperty = entityType2.GetOrAddProperty(Customer.IdProperty);
+
+            var key = new Key(new[] { idProperty });
+
+            Assert.Equal(
+                Strings.FormatKeyPropertiesWrongEntity(typeof(Customer).FullName),
+                Assert.Throws<ArgumentException>(() => entityType1.AddKey(key)).Message);
+        }
+
+        [Fact]
+        public void Can_get_or_add_key_using_properties()
         {
             var entityType = new EntityType(typeof(Customer));
+            var idProperty = entityType.GetOrAddProperty(Customer.IdProperty);
+            var nameProperty = entityType.GetOrAddProperty(Customer.NameProperty);
 
-            entityType.AddProperty(Customer.IdProperty);
+            var key1 = entityType.GetOrAddKey(idProperty, nameProperty);
 
-            var newIdProperty = entityType.AddProperty(Customer.IdProperty);
-            var property2 = entityType.AddProperty(Customer.NameProperty);
+            Assert.Same(key1, entityType.Keys.Single());
+            Assert.Same(key1, entityType.GetOrAddKey(idProperty, nameProperty));
+            Assert.Same(key1, entityType.Keys.Single());
 
-            entityType.SetKey(newIdProperty, property2);
+            var key2 = entityType.GetOrAddKey(idProperty);
 
-            Assert.True(new[] { newIdProperty, property2 }.SequenceEqual(entityType.Properties));
+            Assert.Equal(new[] { key1, key2 }, entityType.Keys.ToArray());
+            Assert.Same(key2, entityType.GetOrAddKey(idProperty));
+            Assert.Equal(new[] { key1, key2 }, entityType.Keys.ToArray());
         }
 
         [Fact]
-        public void Can_clear_key()
+        public void Can_remove_keys()
         {
             var entityType = new EntityType(typeof(Customer));
+            var idProperty = entityType.GetOrAddProperty(Customer.IdProperty);
+            var nameProperty = entityType.GetOrAddProperty(Customer.NameProperty);
 
-            var property1 = entityType.AddProperty(Customer.IdProperty);
-            var property2 = entityType.AddProperty(Customer.NameProperty);
+            var key1 = entityType.GetOrSetPrimaryKey(idProperty, nameProperty);
+            var key2 = entityType.GetOrAddKey(idProperty);
 
-            entityType.SetKey(property1, property2);
+            Assert.Equal(new[] { key1, key2 }, entityType.Keys.ToArray());
 
-            Assert.Equal(2, entityType.GetKey().Properties.Count());
+            entityType.RemoveKey(key1);
 
-            entityType.SetKey(null);
+            Assert.Equal(new[] { key2 }, entityType.Keys.ToArray());
 
-            Assert.Null(entityType.TryGetKey());
+            entityType.RemoveKey(key1);
+            entityType.RemoveKey(key2);
+
+            Assert.Empty(entityType.Keys);
         }
 
         [Fact]
-        public void Add_foreign_key()
+        public void Removing_a_key_throws_if_it_referenced_from_a_foreign_key_in_the_model()
         {
-            var entityType = new EntityType(typeof(Order));
-            entityType.SetKey(entityType.AddProperty(Order.IdProperty));
+            var customerType = new EntityType(typeof(Customer));
+            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
 
-            var foreignKey
-                = entityType.AddForeignKey(
-                    entityType.GetKey(),
-                    new[] { entityType.AddProperty(Order.CustomerUniqueProperty) });
+            var orderType = new EntityType(typeof(Order));
+            var customerFk = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+            orderType.GetOrAddForeignKey(customerKey, customerFk);
 
-            Assert.True(entityType.ForeignKeys.Contains(foreignKey));
+            var model = new Model();
+            model.AddEntityType(customerType);
+            model.AddEntityType(orderType);
+
+            Assert.Equal(
+                Strings.FormatKeyInUse(typeof(Customer).FullName, typeof(Order).FullName),
+                Assert.Throws<InvalidOperationException>(() => customerType.RemoveKey(customerKey)).Message);
         }
 
         [Fact]
-        public void Setting_foreign_key_properties_should_update_existing_properties()
+        public void Can_add_a_foreign_key_explicitly()
         {
-            var entityType = new EntityType(typeof(Order));
-            entityType.SetKey(entityType.AddProperty(Order.CustomerIdProperty));
+            var customerType = new EntityType(typeof(Customer));
+            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
+            var orderType = new EntityType(typeof(Order));
+            var customerFk = orderType.GetOrAddProperty(Order.CustomerIdProperty);
 
-            var newIdProperty = entityType.AddProperty(Order.CustomerIdProperty);
-            var property2 = entityType.AddProperty(Order.CustomerUniqueProperty);
+            var fk1 = new ForeignKey(customerKey, new[] { customerFk });
 
-            entityType.AddForeignKey(entityType.GetKey(), new[] { newIdProperty, property2 });
+            Assert.Same(fk1, orderType.AddForeignKey(fk1));
+            Assert.Same(fk1, orderType.AddForeignKey(fk1));
+            Assert.Same(fk1, orderType.ForeignKeys.Single());
 
-            Assert.Equal(new[] { newIdProperty, property2 }, entityType.Properties.ToArray());
+            var fk2 = new ForeignKey(customerKey, new[] { customerFk }) { IsUnique = true };
+
+            Assert.Same(fk2, orderType.AddForeignKey(fk2));
+            Assert.Same(fk2, orderType.AddForeignKey(fk2));
+            Assert.Equal(new[] { fk1, fk2 }, orderType.ForeignKeys.ToArray());
         }
 
         [Fact]
-        public void FK_back_pointer_is_fixed_up_as_FK_is_added()
+        public void Adding_a_foreign_key_throws_if_properties_from_different_type()
         {
-            var entityType = new EntityType(typeof(Customer));
-            var property = entityType.AddProperty(Customer.IdProperty);
-            entityType.SetKey(property);
-            var foreignKey
-                = entityType.AddForeignKey(entityType.GetKey(), property);
+            var entityType1 = new EntityType(typeof(Customer));
+            var entityType2 = new EntityType(typeof(Order));
+            var idProperty = entityType2.GetOrAddProperty(Customer.IdProperty);
 
-            Assert.Same(entityType, foreignKey.EntityType);
-            Assert.Same(entityType, property.EntityType);
+            var fk = new ForeignKey(entityType2.GetOrAddKey(idProperty), new[] { idProperty });
 
-            entityType.RemoveForeignKey(foreignKey);
+            Assert.Equal(
+                Strings.FormatForeignKeyPropertiesWrongEntity(typeof(Customer).FullName),
+                Assert.Throws<ArgumentException>(() => entityType1.AddForeignKey(fk)).Message);
+        }
 
-            // Currently property is not removed when FK is removed
-            Assert.Empty(entityType.ForeignKeys);
-            Assert.Same(property, entityType.Properties.Single());
-            Assert.Same(entityType, foreignKey.EntityType); // TODO: Throw here?
-            Assert.Same(entityType, property.EntityType);
+        [Fact]
+        public void Can_get_or_add_foreign_key_using_properties()
+        {
+            var customerType = new EntityType(typeof(Customer));
+            var customerKey1 = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
+            var customerKey2 = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.NameProperty));
+            var orderType = new EntityType(typeof(Order));
+            var customerFk = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+
+            var fk1 = orderType.GetOrAddForeignKey(customerKey1, new[] { customerFk });
+
+            Assert.Same(fk1, orderType.ForeignKeys.Single());
+            Assert.Same(fk1, orderType.GetOrAddForeignKey(customerKey1, new[] { customerFk }));
+            Assert.Same(fk1, orderType.ForeignKeys.Single());
+
+            var fk2 = orderType.GetOrAddForeignKey(customerKey2, new[] { customerFk });
+
+            Assert.Equal(new[] { fk1, fk2 }, orderType.ForeignKeys.ToArray());
+            Assert.Same(fk2, orderType.GetOrAddForeignKey(customerKey2, new[] { customerFk }));
+            Assert.Equal(new[] { fk1, fk2 }, orderType.ForeignKeys.ToArray());
+        }
+
+        [Fact]
+        public void Can_remove_foreign_keys()
+        {
+            var customerType = new EntityType(typeof(Customer));
+            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
+            var orderType = new EntityType(typeof(Order));
+            var customerFk = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+
+            var fk1 = orderType.GetOrAddForeignKey(customerKey, new[] { customerFk });
+            var fk2 = orderType.AddForeignKey(new ForeignKey(customerKey, new[] { customerFk }));
+
+            Assert.Equal(new[] { fk1, fk2 }, orderType.ForeignKeys.ToArray());
+
+            orderType.RemoveForeignKey(fk1);
+
+            Assert.Equal(new[] { fk2 }, orderType.ForeignKeys.ToArray());
+
+            orderType.RemoveForeignKey(fk1);
+            orderType.RemoveForeignKey(fk2);
+
+            Assert.Empty(orderType.ForeignKeys);
+        }
+
+        [Fact]
+        public void Removing_a_foreign_key_throws_if_it_referenced_from_a_navigation_in_the_model()
+        {
+            var customerType = new EntityType(typeof(Customer));
+            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
+
+            var orderType = new EntityType(typeof(Order));
+            var customerFk = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+            var fk = orderType.GetOrAddForeignKey(customerKey, customerFk);
+
+            orderType.AddNavigation(new Navigation(fk, "Customer", pointsToPrincipal: true));
+            customerType.AddNavigation(new Navigation(fk, "Orders", pointsToPrincipal: false));
+
+            Assert.Equal(
+                Strings.FormatForeignKeyInUse(typeof(Order).FullName, "Customer", typeof(Order).FullName),
+                Assert.Throws<InvalidOperationException>(() => orderType.RemoveForeignKey(fk)).Message);
+
+            var model = new Model();
+            model.AddEntityType(customerType);
+            model.AddEntityType(orderType);
+
+            Assert.Equal(
+                Strings.FormatForeignKeyInUse(typeof(Order).FullName, "Orders", typeof(Customer).FullName),
+                Assert.Throws<InvalidOperationException>(() => orderType.RemoveForeignKey(fk)).Message);
         }
 
         [Fact]
@@ -237,48 +400,20 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         }
 
         [Fact]
-        public void Navigation_back_pointer_is_fixed_up_as_navigation_is_added_and_removed()
-        {
-            var entityType1 = new EntityType(typeof(Customer));
-            entityType1.SetKey(entityType1.AddProperty(Customer.IdProperty));
-            var entityType2 = new EntityType(typeof(Customer));
-
-            var navigation
-                = new Navigation(
-                    new ForeignKey(
-                        entityType1.GetKey(),
-                        new[] { entityType1.AddProperty(Customer.IdProperty) }), "Nav", pointsToPrincipal: true);
-
-            entityType1.AddNavigation(navigation);
-
-            Assert.Same(entityType1, navigation.EntityType);
-
-            entityType2.AddNavigation(navigation);
-
-            Assert.Same(entityType2, navigation.EntityType);
-            Assert.Empty(entityType1.Navigations);
-
-            entityType2.RemoveNavigation(navigation);
-
-            Assert.Empty(entityType2.Navigations);
-            Assert.Null(navigation.EntityType);
-        }
-
-        [Fact]
         public void Can_add_retrieve_and_remove_indexes()
         {
             var entityType = new EntityType(typeof(Order));
-            var property1 = entityType.AddProperty(Order.IdProperty);
-            var property2 = entityType.AddProperty(Order.CustomerIdProperty);
+            var property1 = entityType.GetOrAddProperty(Order.IdProperty);
+            var property2 = entityType.GetOrAddProperty(Order.CustomerIdProperty);
 
             Assert.Equal(0, entityType.Indexes.Count);
 
-            var index1 = entityType.AddIndex(property1);
+            var index1 = entityType.GetOrAddIndex(property1);
 
             Assert.Equal(1, index1.Properties.Count);
             Assert.Same(property1, index1.Properties[0]);
 
-            var index2 = entityType.AddIndex(property1, property2);
+            var index2 = entityType.GetOrAddIndex(property1, property2);
 
             Assert.Equal(2, index2.Properties.Count);
             Assert.Same(property1, index2.Properties[0]);
@@ -306,11 +441,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(
                 "properties",
                 // ReSharper disable once AssignNullToNotNullAttribute
-                Assert.Throws<ArgumentNullException>(() => entityType.AddIndex(null)).ParamName);
+                Assert.Throws<ArgumentNullException>(() => entityType.GetOrAddIndex(null)).ParamName);
 
             Assert.Equal(
                 Strings.FormatCollectionArgumentIsEmpty("properties"),
-                Assert.Throws<ArgumentException>(() => entityType.AddIndex(new Property[0])).Message);
+                Assert.Throws<ArgumentException>(() => entityType.GetOrAddIndex(new Property[0])).Message);
         }
 
         [Fact]
@@ -327,15 +462,136 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         [Fact]
         public void AddIndex_validates_properties_from_same_entity()
         {
-            var entityType1 = new EntityType("E1");
-            var entityType2 = new EntityType("E2");
+            var entityType1 = new EntityType(typeof(Customer));
+            var entityType2 = new EntityType(typeof(Order));
 
-            var property1 = entityType1.AddProperty(Customer.IdProperty);
-            var property2 = entityType1.AddProperty(Customer.NameProperty);
+            var property1 = entityType1.GetOrAddProperty(Customer.IdProperty);
+            var property2 = entityType1.GetOrAddProperty(Customer.NameProperty);
 
             Assert.Equal(Strings.FormatIndexPropertiesWrongEntity(entityType2.Name),
                 Assert.Throws<ArgumentException>(
-                    () => entityType2.AddIndex(property1, property2)).Message);
+                    () => entityType2.GetOrAddIndex(property1, property2)).Message);
+        }
+
+        [Fact]
+        public void Can_add_and_remove_properties()
+        {
+            var entityType = new EntityType(typeof(Customer));
+
+            var property1 = entityType.AddProperty(new Property("Id", typeof(int)));
+
+            Assert.False(property1.IsShadowProperty);
+            Assert.Equal("Id", property1.Name);
+            Assert.Same(typeof(int), property1.PropertyType);
+            Assert.False(property1.IsConcurrencyToken);
+            Assert.Same(entityType, property1.EntityType);
+
+            var property2 = entityType.AddProperty(new Property("Name", typeof(string)));
+
+            Assert.True(new[] { property1, property2 }.SequenceEqual(entityType.Properties));
+
+            entityType.RemoveProperty(property1);
+
+            Assert.Null(property1.EntityType);
+
+            Assert.True(new[] { property2 }.SequenceEqual(entityType.Properties));
+        }
+
+        [Fact]
+        public void Can_add_new_properties_or_get_existing_properties_using_PropertyInfo_or_name()
+        {
+            var entityType = new EntityType(typeof(Customer));
+
+            var idProperty = entityType.GetOrAddProperty("Id", typeof(int));
+
+            Assert.False(idProperty.IsShadowProperty);
+            Assert.Equal("Id", idProperty.Name);
+            Assert.Same(typeof(int), idProperty.PropertyType);
+            Assert.False(idProperty.IsConcurrencyToken);
+            Assert.Same(entityType, idProperty.EntityType);
+
+            Assert.Same(idProperty, entityType.GetOrAddProperty(Customer.IdProperty));
+            Assert.Same(idProperty, entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            Assert.False(idProperty.IsShadowProperty);
+
+            var nameProperty = entityType.GetOrAddProperty("Name", typeof(string), shadowProperty: true);
+
+            Assert.True(nameProperty.IsShadowProperty);
+            Assert.Equal("Name", nameProperty.Name);
+            Assert.Same(typeof(string), nameProperty.PropertyType);
+            Assert.False(nameProperty.IsConcurrencyToken);
+            Assert.Same(entityType, nameProperty.EntityType);
+
+            Assert.Same(nameProperty, entityType.GetOrAddProperty(Customer.NameProperty));
+            Assert.Same(nameProperty, entityType.GetOrAddProperty("Name", typeof(string)));
+            Assert.True(nameProperty.IsShadowProperty);
+
+            Assert.True(new[] { idProperty, nameProperty }.SequenceEqual(entityType.Properties));
+        }
+
+        [Fact]
+        public void Cannot_remove_property_when_used_by_primary_key()
+        {
+            var entityType = new EntityType(typeof(Customer));
+            var property = entityType.GetOrAddProperty(Customer.IdProperty);
+
+            entityType.GetOrSetPrimaryKey(property);
+
+            Assert.Equal(
+                Strings.FormatPropertyInUse("Id", typeof(Customer).FullName),
+                Assert.Throws<InvalidOperationException>(() => entityType.RemoveProperty(property)).Message);
+        }
+
+        [Fact]
+        public void Cannot_remove_property_when_used_by_non_primary_key()
+        {
+            var entityType = new EntityType(typeof(Customer));
+            var property = entityType.GetOrAddProperty(Customer.IdProperty);
+
+            entityType.GetOrAddKey(property);
+
+            Assert.Equal(
+                Strings.FormatPropertyInUse("Id", typeof(Customer).FullName),
+                Assert.Throws<InvalidOperationException>(() => entityType.RemoveProperty(property)).Message);
+        }
+
+        [Fact]
+        public void Cannot_remove_property_when_used_by_foreign_key()
+        {
+            var customerType = new EntityType(typeof(Customer));
+            var customerPk = customerType.GetOrSetPrimaryKey(customerType.GetOrAddProperty(Customer.IdProperty));
+
+            var orderType = new EntityType(typeof(Order));
+            var customerFk = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+            orderType.GetOrAddForeignKey(customerPk, customerFk);
+
+            Assert.Equal(
+                Strings.FormatPropertyInUse("CustomerId", typeof(Order).FullName),
+                Assert.Throws<InvalidOperationException>(() => orderType.RemoveProperty(customerFk)).Message);
+        }
+
+        [Fact]
+        public void Cannot_remove_property_when_used_by_an_index()
+        {
+            var entityType = new EntityType(typeof(Customer));
+            var property = entityType.GetOrAddProperty(Customer.IdProperty);
+
+            entityType.GetOrAddIndex(property);
+
+            Assert.Equal(
+                Strings.FormatPropertyInUse("Id", typeof(Customer).FullName),
+                Assert.Throws<InvalidOperationException>(() => entityType.RemoveProperty(property)).Message);
+        }
+
+        [Fact]
+        public void Properties_are_ordered_by_name()
+        {
+            var entityType = new EntityType(typeof(Customer));
+
+            var property1 = entityType.GetOrAddProperty(Customer.IdProperty);
+            var property2 = entityType.GetOrAddProperty(Customer.NameProperty);
+
+            Assert.True(new[] { property1, property2 }.SequenceEqual(entityType.Properties));
         }
 
         [Fact]
@@ -348,7 +604,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Can_get_property_and_can_try_get_property()
         {
             var entityType = new EntityType(typeof(Customer));
-            entityType.AddProperty(Customer.IdProperty);
+            entityType.GetOrAddProperty(Customer.IdProperty);
 
             Assert.Equal("Id", entityType.TryGetProperty("Id").Name);
             Assert.Equal("Id", entityType.GetProperty("Id").Name);
@@ -365,9 +621,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var entityType = new EntityType(typeof(Customer));
 
-            entityType.AddProperty(Customer.NameProperty);
-            entityType.AddProperty("Id", typeof(int));
-            entityType.AddProperty("Mane", typeof(int), shadowProperty: true, concurrencyToken: false);
+            entityType.GetOrAddProperty(Customer.NameProperty);
+            entityType.GetOrAddProperty("Id", typeof(int));
+            entityType.GetOrAddProperty("Mane", typeof(int), shadowProperty: true);
 
             Assert.False(entityType.GetProperty("Name").IsShadowProperty);
             Assert.False(entityType.GetProperty("Id").IsShadowProperty);
@@ -375,13 +631,85 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         }
 
         [Fact]
+        public void Adding_a_new_property_with_a_name_that_already_exists_throws()
+        {
+            var entityType = new EntityType(typeof(Customer));
+
+            entityType.AddProperty(new Property("Id", typeof(int)));
+
+            Assert.Equal(
+                Strings.FormatDuplicateProperty("Id", typeof(Customer).FullName),
+                Assert.Throws<InvalidOperationException>(() => entityType.AddProperty(new Property("Id", typeof(int)))).Message);
+        }
+
+        [Fact]
+        public void Adding_a_property_that_belongs_to_a_different_type_throws()
+        {
+            var entityType1 = new EntityType(typeof(Customer));
+            var entityType2 = new EntityType(typeof(Order));
+
+            var property1 = entityType1.AddProperty(new Property("Id", typeof(int)));
+
+            Assert.Equal(
+                Strings.FormatPropertyAlreadyOwned("Id", typeof(Order).FullName, typeof(Customer).FullName),
+                Assert.Throws<InvalidOperationException>(() => entityType2.AddProperty(property1)).Message);
+        }
+
+        [Fact]
+        public void Adding_a_CLR_property_to_a_shadow_entity_type_throws()
+        {
+            var entityType = new EntityType("Hello");
+
+            Assert.Equal(
+                Strings.FormatClrPropertyOnShadowEntity("Kitty", "Hello"),
+                Assert.Throws<InvalidOperationException>(() => entityType.AddProperty(new Property("Kitty", typeof(int)))).Message);
+        }
+
+        [Fact]
+        public void Adding_a_CLR_property_that_doesnt_match_a_CLR_property_throws()
+        {
+            var entityType = new EntityType(typeof(Customer));
+
+            Assert.Equal(
+                Strings.FormatNoClrProperty("Snook", typeof(Customer).FullName),
+                Assert.Throws<InvalidOperationException>(() => entityType.AddProperty(new Property("Snook", typeof(int)))).Message);
+        }
+
+        [Fact]
+        public void Adding_a_CLR_property_where_the_type_doesnt_match_the_CLR_type_throws()
+        {
+            var entityType = new EntityType(typeof(Customer));
+
+            Assert.Equal(
+                Strings.FormatWrongClrPropertyType("Id", typeof(Customer).FullName),
+                Assert.Throws<InvalidOperationException>(() => entityType.AddProperty(new Property("Id", typeof(string)))).Message);
+        }
+
+        [Fact]
+        public void Making_a_shadow_property_a_non_shadow_property_throws_if_CLR_property_does_not_match()
+        {
+            var entityType = new EntityType(typeof(Customer));
+
+            var property1 = entityType.AddProperty(new Property("Snook", typeof(int), shadowProperty: true));
+            var property2 = entityType.AddProperty(new Property("Id", typeof(string), shadowProperty: true));
+
+            Assert.Equal(
+                Strings.FormatNoClrProperty("Snook", typeof(Customer).FullName),
+                Assert.Throws<InvalidOperationException>(() => property1.IsShadowProperty = false).Message);
+
+            Assert.Equal(
+                Strings.FormatWrongClrPropertyType("Id", typeof(Customer).FullName),
+                Assert.Throws<InvalidOperationException>(() => property2.IsShadowProperty = false).Message);
+        }
+
+        [Fact]
         public void Can_get_property_indexes()
         {
             var entityType = new EntityType(typeof(Customer));
 
-            entityType.AddProperty(Customer.NameProperty);
-            entityType.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false);
-            entityType.AddProperty("Mane", typeof(int), shadowProperty: true, concurrencyToken: false);
+            entityType.GetOrAddProperty(Customer.NameProperty);
+            entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
+            entityType.GetOrAddProperty("Mane", typeof(int), shadowProperty: true);
 
             Assert.Equal(0, entityType.GetProperty("Id").Index);
             Assert.Equal(1, entityType.GetProperty("Mane").Index);
@@ -395,12 +723,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         }
 
         [Fact]
-        public void Indexes_are_rebuilt_when_more_properties_added()
+        public void Indexes_are_rebuilt_when_more_properties_added_or_relevant_state_changes()
         {
             var entityType = new EntityType(typeof(FullNotificationEntity));
 
-            entityType.AddProperty("Name", typeof(string));
-            entityType.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: true);
+            var nameProperty = entityType.GetOrAddProperty("Name", typeof(string));
+            entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true).IsConcurrencyToken = true;
 
             Assert.Equal(0, entityType.GetProperty("Id").Index);
             Assert.Equal(1, entityType.GetProperty("Name").Index);
@@ -414,8 +742,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(1, entityType.ShadowPropertyCount);
             Assert.Equal(1, entityType.OriginalValueCount);
 
-            entityType.AddProperty("Game", typeof(int), shadowProperty: true, concurrencyToken: true);
-            entityType.AddProperty("Mane", typeof(int), shadowProperty: true, concurrencyToken: true);
+            var gameProperty = entityType.GetOrAddProperty("Game", typeof(int), shadowProperty: true);
+            gameProperty.IsConcurrencyToken = true;
+
+            var maneProperty = entityType.GetOrAddProperty("Mane", typeof(int), shadowProperty: true);
+            maneProperty.IsConcurrencyToken = true;
 
             Assert.Equal(0, entityType.GetProperty("Game").Index);
             Assert.Equal(1, entityType.GetProperty("Id").Index);
@@ -431,6 +762,48 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(1, entityType.GetProperty("Id").OriginalValueIndex);
             Assert.Equal(2, entityType.GetProperty("Mane").OriginalValueIndex);
             Assert.Equal(-1, entityType.GetProperty("Name").OriginalValueIndex);
+
+            Assert.Equal(3, entityType.ShadowPropertyCount);
+            Assert.Equal(3, entityType.OriginalValueCount);
+
+            gameProperty.IsConcurrencyToken = false;
+            nameProperty.IsConcurrencyToken = true;
+
+            Assert.Equal(0, entityType.GetProperty("Game").Index);
+            Assert.Equal(1, entityType.GetProperty("Id").Index);
+            Assert.Equal(2, entityType.GetProperty("Mane").Index);
+            Assert.Equal(3, entityType.GetProperty("Name").Index);
+
+            Assert.Equal(0, entityType.GetProperty("Game").ShadowIndex);
+            Assert.Equal(1, entityType.GetProperty("Id").ShadowIndex);
+            Assert.Equal(2, entityType.GetProperty("Mane").ShadowIndex);
+            Assert.Equal(-1, entityType.GetProperty("Name").ShadowIndex);
+
+            Assert.Equal(-1, entityType.GetProperty("Game").OriginalValueIndex);
+            Assert.Equal(0, entityType.GetProperty("Id").OriginalValueIndex);
+            Assert.Equal(1, entityType.GetProperty("Mane").OriginalValueIndex);
+            Assert.Equal(2, entityType.GetProperty("Name").OriginalValueIndex);
+
+            Assert.Equal(3, entityType.ShadowPropertyCount);
+            Assert.Equal(3, entityType.OriginalValueCount);
+
+            gameProperty.IsShadowProperty = false;
+            nameProperty.IsShadowProperty = true;
+
+            Assert.Equal(0, entityType.GetProperty("Game").Index);
+            Assert.Equal(1, entityType.GetProperty("Id").Index);
+            Assert.Equal(2, entityType.GetProperty("Mane").Index);
+            Assert.Equal(3, entityType.GetProperty("Name").Index);
+
+            Assert.Equal(-1, entityType.GetProperty("Game").ShadowIndex);
+            Assert.Equal(0, entityType.GetProperty("Id").ShadowIndex);
+            Assert.Equal(1, entityType.GetProperty("Mane").ShadowIndex);
+            Assert.Equal(2, entityType.GetProperty("Name").ShadowIndex);
+
+            Assert.Equal(-1, entityType.GetProperty("Game").OriginalValueIndex);
+            Assert.Equal(0, entityType.GetProperty("Id").OriginalValueIndex);
+            Assert.Equal(1, entityType.GetProperty("Mane").OriginalValueIndex);
+            Assert.Equal(2, entityType.GetProperty("Name").OriginalValueIndex);
 
             Assert.Equal(3, entityType.ShadowPropertyCount);
             Assert.Equal(3, entityType.OriginalValueCount);
@@ -483,8 +856,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var entityType = new EntityType(typeof(FullNotificationEntity)) { UseLazyOriginalValues = false };
 
-            entityType.AddProperty("Name", typeof(string));
-            entityType.AddProperty("Id", typeof(int));
+            entityType.GetOrAddProperty("Name", typeof(string));
+            entityType.GetOrAddProperty("Id", typeof(int));
 
             Assert.Equal(0, entityType.GetProperty("Id").OriginalValueIndex);
             Assert.Equal(1, entityType.GetProperty("Name").OriginalValueIndex);
@@ -497,8 +870,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var entityType = new EntityType(typeof(FullNotificationEntity));
 
-            entityType.AddProperty("Name", typeof(string), shadowProperty: false, concurrencyToken: true);
-            entityType.AddProperty("Id", typeof(int));
+            entityType.GetOrAddProperty("Name", typeof(string)).IsConcurrencyToken = true;
+            entityType.GetOrAddProperty("Id", typeof(int));
 
             Assert.Equal(-1, entityType.GetProperty("Id").OriginalValueIndex);
             Assert.Equal(0, entityType.GetProperty("Name").OriginalValueIndex);
@@ -510,16 +883,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void FK_properties_are_marked_as_requiring_original_values()
         {
             var entityType = new EntityType(typeof(FullNotificationEntity));
-            entityType.SetKey(entityType.AddProperty("Id", typeof(int)));
+            entityType.GetOrSetPrimaryKey(entityType.GetOrAddProperty("Id", typeof(int)));
 
             Assert.Equal(-1, entityType.GetProperty("Id").OriginalValueIndex);
 
-            entityType.AddForeignKey(entityType.GetKey(), new[] { entityType.AddProperty("Id", typeof(int)) });
+            entityType.GetOrAddForeignKey(entityType.GetPrimaryKey(), new[] { entityType.GetOrAddProperty("Id", typeof(int)) });
 
             Assert.Equal(0, entityType.GetProperty("Id").OriginalValueIndex);
         }
-
-        #region Fixture
 
         private class Customer
         {
@@ -530,6 +901,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             public Guid Unique { get; set; }
             public string Name { get; set; }
             public string Mane { get; set; }
+            public ICollection<Order> Orders { get; set; }
         }
 
         private class Order
@@ -541,12 +913,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             public int Id { get; set; }
             public int CustomerId { get; set; }
             public Guid CustomerUnique { get; set; }
+            public Customer Customer { get; set; }
         }
 
         private class FullNotificationEntity : INotifyPropertyChanging, INotifyPropertyChanged
         {
             private int _id;
             private string _name;
+            private int _game;
 
             public int Id
             {
@@ -571,6 +945,20 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                     {
                         NotifyChanging();
                         _name = value;
+                        NotifyChanged();
+                    }
+                }
+            }
+
+            public int Game
+            {
+                get { return _game; }
+                set
+                {
+                    if (_game != value)
+                    {
+                        NotifyChanging();
+                        _game = value;
                         NotifyChanged();
                     }
                 }
@@ -637,7 +1025,5 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 }
             }
         }
-
-        #endregion
     }
 }

--- a/test/EntityFramework.Tests/Metadata/FieldMatcherTest.cs
+++ b/test/EntityFramework.Tests/Metadata/FieldMatcherTest.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         private static void FieldMatchTest(string propertyName, string fieldName)
         {
             var entityType = new EntityType(typeof(TheDarkSideOfTheMoon));
-            var property = entityType.AddProperty(propertyName, typeof(int));
+            var property = entityType.GetOrAddProperty(propertyName, typeof(int));
             var propertyInfo = entityType.Type.GetAnyProperty(propertyName);
             var fields = propertyInfo.DeclaringType.GetRuntimeFields().ToDictionary(f => f.Name);
 
@@ -81,7 +81,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void M_underscore_matching_field_is_not_used_if_type_is_not_compatible()
         {
             var entityType = new EntityType(typeof(TheDarkSideOfTheMoon));
-            var property = entityType.AddProperty("SpeakToMe", typeof(int));
+            var property = entityType.GetOrAddProperty("SpeakToMe", typeof(int));
             var propertyInfo = entityType.Type.GetAnyProperty("SpeakToMe");
             var fields = propertyInfo.DeclaringType.GetRuntimeFields().ToDictionary(f => f.Name);
 

--- a/test/EntityFramework.Tests/Metadata/ForeignKeyTest.cs
+++ b/test/EntityFramework.Tests/Metadata/ForeignKeyTest.cs
@@ -13,12 +13,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Can_create_foreign_key()
         {
             var entityType = new EntityType("E");
-            var dependentProp = entityType.AddProperty("P", typeof(int));
-            var principalProp = entityType.AddProperty("Id", typeof(int));
-            entityType.SetKey(principalProp);
+            var dependentProp = entityType.GetOrAddProperty("P", typeof(int), shadowProperty: true);
+            var principalProp = entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
+            entityType.GetOrSetPrimaryKey(principalProp);
 
             var foreignKey
-                = new ForeignKey(entityType.GetKey(), new[] { dependentProp })
+                = new ForeignKey(entityType.GetPrimaryKey(), new[] { dependentProp })
                     {
                         IsUnique = true,
                     };
@@ -27,19 +27,21 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(principalProp, foreignKey.ReferencedProperties.Single());
             Assert.Same(dependentProp, foreignKey.Properties.Single());
             Assert.True(foreignKey.IsUnique);
+            Assert.Same(entityType.GetPrimaryKey(), foreignKey.ReferencedKey);
         }
 
         [Fact]
         public void Can_create_foreign_key_with_non_pk_principal()
         {
             var entityType = new EntityType("E");
-            var keyProp = entityType.AddProperty("Id", typeof(int));
-            var dependentProp = entityType.AddProperty("P", typeof(int));
-            var principalProp = entityType.AddProperty("U", typeof(int));
-            entityType.SetKey(keyProp);
+            var keyProp = entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
+            var dependentProp = entityType.GetOrAddProperty("P", typeof(int), shadowProperty: true);
+            var principalProp = entityType.GetOrAddProperty("U", typeof(int), shadowProperty: true);
+            entityType.GetOrSetPrimaryKey(keyProp);
+            var referencedKey = new Key(new[] { principalProp });
 
             var foreignKey
-                = new ForeignKey(new Key(new[] { principalProp }), new[] { dependentProp })
+                = new ForeignKey(referencedKey, new[] { dependentProp })
                     {
                         IsUnique = true,
                     };
@@ -48,16 +50,17 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(principalProp, foreignKey.ReferencedProperties.Single());
             Assert.Same(dependentProp, foreignKey.Properties.Single());
             Assert.True(foreignKey.IsUnique);
+            Assert.Same(referencedKey, foreignKey.ReferencedKey);
         }
 
         [Fact]
         public void IsRequired_when_dependent_property_not_nullable()
         {
             var entityType = new EntityType("E");
-            entityType.SetKey(entityType.AddProperty("Id", typeof(int)));
-            var dependentProp = entityType.AddProperty("P", typeof(int));
+            entityType.GetOrSetPrimaryKey(entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            var dependentProp = entityType.GetOrAddProperty("P", typeof(int), shadowProperty: true);
 
-            var foreignKey = new ForeignKey(entityType.GetKey(), new[] { dependentProp });
+            var foreignKey = new ForeignKey(entityType.GetPrimaryKey(), new[] { dependentProp });
 
             Assert.True(foreignKey.IsRequired);
         }
@@ -66,10 +69,10 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void IsRequired_when_dependent_property_nullable()
         {
             var entityType = new EntityType("E");
-            entityType.SetKey(entityType.AddProperty("Id", typeof(int)));
-            var dependentProp = entityType.AddProperty("P", typeof(int?));
+            entityType.GetOrSetPrimaryKey(entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
+            var dependentProp = entityType.GetOrAddProperty("P", typeof(int?), shadowProperty: true);
 
-            var foreignKey = new ForeignKey(entityType.GetKey(), new[] { dependentProp });
+            var foreignKey = new ForeignKey(entityType.GetPrimaryKey(), new[] { dependentProp });
 
             Assert.False(foreignKey.IsRequired);
         }

--- a/test/EntityFramework.Tests/Metadata/IndexTest.cs
+++ b/test/EntityFramework.Tests/Metadata/IndexTest.cs
@@ -11,25 +11,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 {
     public class IndexTest
     {
-        #region Fixture
-
-        public class Customer
-        {
-            public static PropertyInfo IdProperty = typeof(Customer).GetProperty("Id");
-            public static PropertyInfo NameProperty = typeof(Customer).GetProperty("Name");
-
-            public int Id { get; set; }
-            public string Name { get; set; }
-        }
-
-        #endregion
-
         [Fact]
         public void Can_create_index_from_properties()
         {
-            var entityType = new EntityType("E");
-            var property1 = entityType.AddProperty(Customer.IdProperty);
-            var property2 = entityType.AddProperty(Customer.NameProperty);
+            var entityType = new EntityType(typeof(Customer));
+            var property1 = entityType.GetOrAddProperty(Customer.IdProperty);
+            var property2 = entityType.GetOrAddProperty(Customer.NameProperty);
 
             var index = new Index(new[] { property1, property2 });
 
@@ -40,9 +27,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         [Fact]
         public void Can_create_unique_index_from_properties()
         {
-            var entityType = new EntityType("E");
-            var property1 = entityType.AddProperty(Customer.IdProperty);
-            var property2 = entityType.AddProperty(Customer.NameProperty);
+            var entityType = new EntityType(typeof(Customer));
+            var property1 = entityType.GetOrAddProperty(Customer.IdProperty);
+            var property2 = entityType.GetOrAddProperty(Customer.NameProperty);
 
             var index = new Index(new[] { property1, property2 }) { IsUnique = true, };
 
@@ -66,16 +53,29 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         [Fact]
         public void Constructor_validates_properties_from_same_entity()
         {
-            var entityType = new EntityType("E");
-            var property1 = entityType.AddProperty(Customer.IdProperty);
-            var property2 = entityType.AddProperty(Customer.NameProperty);
+            var entityType = new EntityType(typeof(Customer));
+            var property1 = entityType.GetOrAddProperty(Customer.IdProperty);
+            var property2 = entityType.GetOrAddProperty(Customer.NameProperty);
 
-            property1.EntityType = new EntityType("E1");
-            property2.EntityType = new EntityType("E2");
+            property1.EntityType = new EntityType(typeof(Customer));
+            property2.EntityType = new EntityType(typeof(Order));
 
             Assert.Equal(Strings.FormatInconsistentEntityType("properties"),
                 Assert.Throws<ArgumentException>(
                     () => new Index(new[] { property1, property2 })).Message);
+        }
+
+        private class Customer
+        {
+            public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty("Id");
+            public static readonly PropertyInfo NameProperty = typeof(Customer).GetProperty("Name");
+
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class Order
+        {
         }
     }
 }

--- a/test/EntityFramework.Tests/Metadata/KeyTest.cs
+++ b/test/EntityFramework.Tests/Metadata/KeyTest.cs
@@ -11,25 +11,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 {
     public class KeyTest
     {
-        #region Fixture
-
-        public class Customer
-        {
-            public static PropertyInfo IdProperty = typeof(Customer).GetProperty("Id");
-            public static PropertyInfo NameProperty = typeof(Customer).GetProperty("Name");
-
-            public int Id { get; set; }
-            public string Name { get; set; }
-        }
-
-        #endregion
-
         [Fact]
         public void Can_create_key_from_properties()
         {
-            var entityType = new EntityType("E");
-            var property1 = entityType.AddProperty(Customer.IdProperty);
-            var property2 = entityType.AddProperty(Customer.NameProperty);
+            var entityType = new EntityType(typeof(Customer));
+            var property1 = entityType.GetOrAddProperty(Customer.IdProperty);
+            var property2 = entityType.GetOrAddProperty(Customer.NameProperty);
 
             var key = new Key(new[] { property1, property2 });
 
@@ -39,16 +26,30 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         [Fact]
         public void Validates_properties_from_same_entity()
         {
-            var entityType = new EntityType("E");
-            var property1 = entityType.AddProperty(Customer.IdProperty);
-            var property2 = entityType.AddProperty(Customer.NameProperty);
-
-            property1.EntityType = new EntityType("E1");
-            property2.EntityType = new EntityType("E2");
+            var entityType1 = new EntityType(typeof(Customer));
+            var entityType2 = new EntityType(typeof(Order));
+            var property1 = entityType1.GetOrAddProperty(Customer.IdProperty);
+            var property2 = entityType2.GetOrAddProperty(Order.NameProperty);
 
             Assert.Equal(Strings.FormatInconsistentEntityType("properties"),
                 Assert.Throws<ArgumentException>(
                     () => new Key(new[] { property1, property2 })).Message);
+        }
+
+        private class Customer
+        {
+            public static readonly PropertyInfo IdProperty = typeof(Customer).GetProperty("Id");
+            public static readonly PropertyInfo NameProperty = typeof(Customer).GetProperty("Name");
+
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class Order
+        {
+            public static readonly PropertyInfo NameProperty = typeof(Order).GetProperty("Name");
+
+            public string Name { get; set; }
         }
     }
 }

--- a/test/EntityFramework.Tests/Metadata/MemberMapperTest.cs
+++ b/test/EntityFramework.Tests/Metadata/MemberMapperTest.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Annotated_field_name_is_used_if_present()
         {
             var entityType = new EntityType(typeof(TheDarkSide));
-            var property = entityType.AddProperty("SpeakToMe", typeof(int));
+            var property = entityType.GetOrAddProperty("SpeakToMe", typeof(int));
             property["BackingField"] = "fieldForSpeak";
 
             var mapping = new MemberMapper(new FieldMatcher()).MapPropertiesToMembers(entityType).Single();
@@ -28,7 +28,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Throws_if_annotated_field_name_is_not_found()
         {
             var entityType = new EntityType(typeof(TheDarkSide));
-            var property = entityType.AddProperty("SpeakToMe", typeof(int));
+            var property = entityType.GetOrAddProperty("SpeakToMe", typeof(int));
             property["BackingField"] = "_speakToMe";
 
             Assert.Equal(
@@ -41,11 +41,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Throws_if_annotated_field_if_types_not_compatible()
         {
             var entityType = new EntityType(typeof(TheDarkSide));
-            var property = entityType.AddProperty("SpeakToMe", typeof(string));
-            property["BackingField"] = "fieldForSpeak";
+            var property = entityType.GetOrAddProperty("SpeakToMe", typeof(int));
+            property["BackingField"] = "_badFieldForSpeak";
 
             Assert.Equal(
-                Strings.FormatBadBackingFieldType("fieldForSpeak", typeof(int?).Name, typeof(TheDarkSide).FullName, "SpeakToMe", typeof(string).Name),
+                Strings.FormatBadBackingFieldType("_badFieldForSpeak", typeof(string).Name, typeof(TheDarkSide).FullName, "SpeakToMe", typeof(int).Name),
                 Assert.Throws<InvalidOperationException>(
                     () => new MemberMapper(new FieldMatcher()).MapPropertiesToMembers(entityType)).Message);
         }
@@ -54,7 +54,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Field_name_match_is_used_in_preference_to_property_setter()
         {
             var entityType = new EntityType(typeof(TheDarkSide));
-            var property = entityType.AddProperty("Breathe", typeof(int));
+            var property = entityType.GetOrAddProperty("Breathe", typeof(int));
 
             var mapping = new MemberMapper(new FieldMatcher()).MapPropertiesToMembers(entityType).Single();
 
@@ -67,7 +67,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Property_setter_is_used_if_no_matching_field_is_found()
         {
             var entityType = new EntityType(typeof(TheDarkSide));
-            var property = entityType.AddProperty("OnTheRun", typeof(int));
+            var property = entityType.GetOrAddProperty("OnTheRun", typeof(int));
 
             var mapping = new MemberMapper(new FieldMatcher()).MapPropertiesToMembers(entityType).Single();
 
@@ -80,7 +80,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Throws_if_no_match_found_and_no_property_setter()
         {
             var entityType = new EntityType(typeof(TheDarkSide));
-            entityType.AddProperty("Time", typeof(string));
+            entityType.GetOrAddProperty("Time", typeof(int));
 
             Assert.Equal(
                 Strings.FormatNoFieldOrSetter(typeof(TheDarkSide).FullName, "Time"),
@@ -92,7 +92,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Property_and_field_in_base_type_is_matched()
         {
             var entityType = new EntityType(typeof(TheDarkSide));
-            var property = entityType.AddProperty("TheGreatGigInTheSky", typeof(int));
+            var property = entityType.GetOrAddProperty("TheGreatGigInTheSky", typeof(int));
 
             var mapping = new MemberMapper(new FieldMatcher()).MapPropertiesToMembers(entityType).Single();
 
@@ -105,7 +105,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Property_and_field_in_base_type_is_matched_even_when_overridden()
         {
             var entityType = new EntityType(typeof(TheDarkSide));
-            var property = entityType.AddProperty("Money", typeof(int));
+            var property = entityType.GetOrAddProperty("Money", typeof(int));
 
             var mapping = new MemberMapper(new FieldMatcher()).MapPropertiesToMembers(entityType).Single();
 
@@ -118,7 +118,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Private_setter_in_base_class_of_overridden_property_is_used()
         {
             var entityType = new EntityType(typeof(TheDarkSide));
-            var property = entityType.AddProperty("UsAndThem", typeof(int));
+            var property = entityType.GetOrAddProperty("UsAndThem", typeof(int));
 
             var mapping = new MemberMapper(new FieldMatcher()).MapPropertiesToMembers(entityType).Single();
 
@@ -130,6 +130,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         private class TheDarkSide : OfTheMoon
         {
             private int? fieldForSpeak;
+#pragma warning disable 169
+            private string _badFieldForSpeak;
+#pragma warning restore 169
 
             public int SpeakToMe
             {

--- a/test/EntityFramework.Tests/Metadata/MetadataBuilderTest.cs
+++ b/test/EntityFramework.Tests/Metadata/MetadataBuilderTest.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.IsType<BasicModelBuilder.EntityBuilder.KeyBuilder>(returnedBuilder);
 
             var model = builder.Model;
-            var key = model.GetEntityType(typeof(Gunter)).GetKey();
+            var key = model.GetEntityType(typeof(Gunter)).GetPrimaryKey();
 
             Assert.Equal("V2.Annotation", key["Annotation"]);
             Assert.Equal("V2.Metadata", key["Metadata"]);
@@ -201,7 +201,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.IsType<ModelBuilder.EntityBuilder.KeyBuilder>(returnedBuilder);
 
             var model = builder.Model;
-            var key = model.GetEntityType(typeof(Gunter)).GetKey();
+            var key = model.GetEntityType(typeof(Gunter)).GetPrimaryKey();
 
             Assert.Equal("V2.Annotation", key["Annotation"]);
             Assert.Equal("V2.Metadata", key["Metadata"]);
@@ -569,7 +569,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.IsType<BasicModelBuilder.EntityBuilder.KeyBuilder>(returnedBuilder);
 
             var model = builder.Model;
-            var key = model.GetEntityType(typeof(Gunter)).GetKey();
+            var key = model.GetEntityType(typeof(Gunter)).GetPrimaryKey();
 
             Assert.Equal("V2.Annotation", key["Annotation"]);
             Assert.Equal("V2.Metadata", key["Metadata"]);
@@ -590,7 +590,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.IsType<ModelBuilder.EntityBuilder.KeyBuilder>(returnedBuilder);
 
             var model = builder.Model;
-            var key = model.GetEntityType(typeof(Gunter)).GetKey();
+            var key = model.GetEntityType(typeof(Gunter)).GetPrimaryKey();
 
             Assert.Equal("V2.Annotation", key["Annotation"]);
             Assert.Equal("V2.Metadata", key["Metadata"]);

--- a/test/EntityFramework.Tests/Metadata/ModelBuilderTest.cs
+++ b/test/EntityFramework.Tests/Metadata/ModelBuilderTest.cs
@@ -57,8 +57,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entity = model.GetEntityType(typeof(Customer));
 
-            Assert.Equal(1, entity.GetKey().Properties.Count());
-            Assert.Equal("Id", entity.GetKey().Properties.First().Name);
+            Assert.Equal(1, entity.GetPrimaryKey().Properties.Count());
+            Assert.Equal("Id", entity.GetPrimaryKey().Properties.First().Name);
         }
 
         [Fact]
@@ -75,8 +75,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entity = model.GetEntityType(typeof(Customer));
 
-            Assert.Equal(1, entity.GetKey().Properties.Count());
-            Assert.Equal("Id", entity.GetKey().Properties.First().Name);
+            Assert.Equal(1, entity.GetPrimaryKey().Properties.Count());
+            Assert.Equal("Id", entity.GetPrimaryKey().Properties.First().Name);
         }
 
         [Fact]
@@ -93,8 +93,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entity = model.GetEntityType(typeof(Customer));
 
-            Assert.Equal(1, entity.GetKey().Properties.Count());
-            Assert.Equal("Id", entity.GetKey().Properties.First().Name);
+            Assert.Equal(1, entity.GetPrimaryKey().Properties.Count());
+            Assert.Equal("Id", entity.GetPrimaryKey().Properties.First().Name);
         }
 
         [Fact]
@@ -111,8 +111,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entity = model.GetEntityType(typeof(Customer));
 
-            Assert.Equal(1, entity.GetKey().Properties.Count());
-            Assert.Equal("Id", entity.GetKey().Properties.First().Name);
+            Assert.Equal(1, entity.GetPrimaryKey().Properties.Count());
+            Assert.Equal("Id", entity.GetPrimaryKey().Properties.First().Name);
         }
 
         [Fact]
@@ -129,8 +129,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entity = model.GetEntityType(typeof(Customer));
 
-            Assert.Equal(1, entity.GetKey().Properties.Count());
-            Assert.Equal("Id", entity.GetKey().Properties.First().Name);
+            Assert.Equal(1, entity.GetPrimaryKey().Properties.Count());
+            Assert.Equal("Id", entity.GetPrimaryKey().Properties.First().Name);
         }
 
         [Fact]
@@ -145,9 +145,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entity = model.GetEntityType(typeof(Customer));
 
-            Assert.Equal(2, entity.GetKey().Properties.Count());
-            Assert.Equal("Id", entity.GetKey().Properties.First().Name);
-            Assert.Equal("Name", entity.GetKey().Properties.Last().Name);
+            Assert.Equal(2, entity.GetPrimaryKey().Properties.Count());
+            Assert.Equal("Id", entity.GetPrimaryKey().Properties.First().Name);
+            Assert.Equal("Name", entity.GetPrimaryKey().Properties.Last().Name);
         }
 
         [Fact]
@@ -165,9 +165,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entity = model.GetEntityType(typeof(Customer));
 
-            Assert.Equal(2, entity.GetKey().Properties.Count());
-            Assert.Equal("Id", entity.GetKey().Properties.First().Name);
-            Assert.Equal("Name", entity.GetKey().Properties.Last().Name);
+            Assert.Equal(2, entity.GetPrimaryKey().Properties.Count());
+            Assert.Equal("Id", entity.GetPrimaryKey().Properties.First().Name);
+            Assert.Equal("Name", entity.GetPrimaryKey().Properties.Last().Name);
         }
 
         [Fact]
@@ -185,9 +185,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entity = model.GetEntityType(typeof(Customer));
 
-            Assert.Equal(2, entity.GetKey().Properties.Count());
-            Assert.Equal("Id", entity.GetKey().Properties.First().Name);
-            Assert.Equal("Name", entity.GetKey().Properties.Last().Name);
+            Assert.Equal(2, entity.GetPrimaryKey().Properties.Count());
+            Assert.Equal("Id", entity.GetPrimaryKey().Properties.First().Name);
+            Assert.Equal("Name", entity.GetPrimaryKey().Properties.Last().Name);
         }
 
         [Fact]
@@ -205,9 +205,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entity = model.GetEntityType(typeof(Customer));
 
-            Assert.Equal(2, entity.GetKey().Properties.Count());
-            Assert.Equal("Id", entity.GetKey().Properties.First().Name);
-            Assert.Equal("Name", entity.GetKey().Properties.Last().Name);
+            Assert.Equal(2, entity.GetPrimaryKey().Properties.Count());
+            Assert.Equal("Id", entity.GetPrimaryKey().Properties.First().Name);
+            Assert.Equal("Name", entity.GetPrimaryKey().Properties.Last().Name);
         }
 
         [Fact]
@@ -224,10 +224,10 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entity = model.GetEntityType(typeof(Customer));
 
-            Assert.Equal(2, entity.GetKey().Properties.Count());
-            Assert.Equal(new[] { "Id", "Name" }, entity.GetKey().Properties.Select(p => p.Name));
-            Assert.Equal("V1", entity.GetKey()["A1"]);
-            Assert.Equal("V2", entity.GetKey()["A2"]);
+            Assert.Equal(2, entity.GetPrimaryKey().Properties.Count());
+            Assert.Equal(new[] { "Id", "Name" }, entity.GetPrimaryKey().Properties.Select(p => p.Name));
+            Assert.Equal("V1", entity.GetPrimaryKey()["A1"]);
+            Assert.Equal("V2", entity.GetPrimaryKey()["A2"]);
         }
 
         [Fact]
@@ -247,10 +247,10 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             var entity = model.GetEntityType(typeof(Customer));
 
-            Assert.Equal(2, entity.GetKey().Properties.Count());
-            Assert.Equal(new[] { "Id", "Name" }, entity.GetKey().Properties.Select(p => p.Name));
-            Assert.Equal("V1", entity.GetKey()["A1"]);
-            Assert.Equal("V2", entity.GetKey()["A2"]);
+            Assert.Equal(2, entity.GetPrimaryKey().Properties.Count());
+            Assert.Equal(new[] { "Id", "Name" }, entity.GetPrimaryKey().Properties.Select(p => p.Name));
+            Assert.Equal("V1", entity.GetPrimaryKey()["A1"]);
+            Assert.Equal("V2", entity.GetPrimaryKey()["A2"]);
         }
 
         [Fact]
@@ -508,8 +508,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                     b.Property(e => e.Up).Shadow();
                     b.Property<int>("Charm").Shadow();
                     b.Property(typeof(int), "Top").Shadow();
-                    b.Property<string>("Gluon").Shadow(false);
-                    b.Property(typeof(string), "Photon").Shadow(false);
+                    b.Property<string>("Gluon").Shadow();
+                    b.Property(typeof(string), "Photon").Shadow();
                 });
 
             var entityType = model.GetEntityType(typeof(Quarks));
@@ -517,14 +517,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.True(entityType.GetProperty("Up").IsShadowProperty);
             Assert.True(entityType.GetProperty("Charm").IsShadowProperty);
             Assert.True(entityType.GetProperty("Top").IsShadowProperty);
-            Assert.False(entityType.GetProperty("Gluon").IsShadowProperty);
-            Assert.False(entityType.GetProperty("Photon").IsShadowProperty);
+            Assert.True(entityType.GetProperty("Gluon").IsShadowProperty);
+            Assert.True(entityType.GetProperty("Photon").IsShadowProperty);
 
-            Assert.Equal(2, entityType.GetProperty("Up").ShadowIndex);
+            Assert.Equal(4, entityType.GetProperty("Up").ShadowIndex);
             Assert.Equal(0, entityType.GetProperty("Charm").ShadowIndex);
-            Assert.Equal(1, entityType.GetProperty("Top").ShadowIndex);
-            Assert.Equal(-1, entityType.GetProperty("Gluon").ShadowIndex);
-            Assert.Equal(-1, entityType.GetProperty("Photon").ShadowIndex);
+            Assert.Equal(3, entityType.GetProperty("Top").ShadowIndex);
+            Assert.Equal(1, entityType.GetProperty("Gluon").ShadowIndex);
+            Assert.Equal(2, entityType.GetProperty("Photon").ShadowIndex);
         }
 
         [Fact]
@@ -666,7 +666,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             modelBuilder.Entity<Order>(b =>
                 {
                     b.ForeignKey<Customer>(c => c.CustomerId);
-                    b.ForeignKey<Customer>(c => c.CustomerId).IsUnique();
+                    b.ForeignKey<Customer>(c => c.AnotherCustomerId).IsUnique();
                 });
 
             var entityType = model.GetEntityType(typeof(Order));
@@ -686,8 +686,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             modelBuilder.Entity<Order>(b =>
                 {
                     b.Property<int>("CustomerId");
+                    b.Property<int>("AnotherCustomerId");
                     b.ForeignKey<Customer>(c => c.CustomerId);
-                    b.ForeignKey(typeof(Customer).FullName, "CustomerId").IsUnique();
+                    b.ForeignKey(typeof(Customer).FullName, "AnotherCustomerId").IsUnique();
                 });
 
             var entityType = model.GetEntityType(typeof(Order));
@@ -708,8 +709,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity(typeof(Order).FullName, b =>
                     {
                         b.Property<int>("CustomerId");
+                        b.Property<int>("AnotherCustomerId");
                         b.ForeignKey(typeof(Customer).FullName, "CustomerId");
-                        b.ForeignKey(typeof(Customer).FullName, "CustomerId").IsUnique();
+                        b.ForeignKey(typeof(Customer).FullName, "AnotherCustomerId").IsUnique();
                     });
 
             var entityType = model.GetEntityType(typeof(Order).FullName);
@@ -733,8 +735,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             modelBuilder.Entity(typeof(Order).FullName, b =>
                 {
                     b.Property<int>("CustomerId");
+                    b.Property<int>("AnotherCustomerId");
                     b.ForeignKey(typeof(Customer).FullName, "CustomerId");
-                    b.ForeignKey(typeof(Customer).FullName, "CustomerId").IsUnique();
+                    b.ForeignKey(typeof(Customer).FullName, "AnotherCustomerId").IsUnique();
                 });
 
             var entityType = model.GetEntityType(typeof(Order));
@@ -5017,6 +5020,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             public int OrderId { get; set; }
 
             public int CustomerId { get; set; }
+            public int AnotherCustomerId { get; set; }
             public Customer Customer { get; set; }
 
             public OrderDetails Details { get; set; }

--- a/test/EntityFramework.Tests/Metadata/ModelConventions/ForeignKeyConventionTest.cs
+++ b/test/EntityFramework.Tests/Metadata/ModelConventions/ForeignKeyConventionTest.cs
@@ -15,13 +15,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         [Fact]
         public void Foreign_key_matching_given_properties_is_found()
         {
-            DependentType.AddProperty("SomeNavID", typeof(int));
-            DependentType.AddProperty("SomeNavPeEKaY", typeof(int));
-            DependentType.AddProperty("PrincipalEntityID", typeof(int));
-            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
-            var fkProperty = DependentType.AddProperty("HeToldMeYouKilledMyFk", typeof(int));
+            DependentType.GetOrAddProperty("SomeNavID", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("SomeNavPeEKaY", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("PrincipalEntityID", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
+            var fkProperty = DependentType.GetOrAddProperty("HeToldMeYouKilledMyFk", typeof(int), shadowProperty: true);
 
-            var fk = DependentType.AddForeignKey(PrincipalType.GetKey(), fkProperty);
+            var fk = DependentType.GetOrAddForeignKey(PrincipalType.GetPrimaryKey(), fkProperty);
 
             Assert.Same(
                 fk,
@@ -32,14 +32,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         [Fact]
         public void Foreign_key_matching_given_property_is_found()
         {
-            DependentType.AddProperty("SomeNavID", typeof(int));
-            DependentType.AddProperty("SomeNavPeEKaY", typeof(int));
-            DependentType.AddProperty("PrincipalEntityID", typeof(int));
-            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
-            var fkProperty1 = DependentType.AddProperty("No", typeof(int));
-            var fkProperty2 = DependentType.AddProperty("IAmYourFk", typeof(int));
+            DependentType.GetOrAddProperty("SomeNavID", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("SomeNavPeEKaY", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("PrincipalEntityID", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
+            var fkProperty1 = DependentType.GetOrAddProperty("No", typeof(int), shadowProperty: true);
+            var fkProperty2 = DependentType.GetOrAddProperty("IAmYourFk", typeof(int), shadowProperty: true);
 
-            var fk = DependentType.AddForeignKey(PrincipalType.GetKey(), fkProperty1, fkProperty2);
+            var fk = DependentType.GetOrAddForeignKey(PrincipalType.GetPrimaryKey(), fkProperty1, fkProperty2);
 
             Assert.Same(
                 fk,
@@ -50,12 +50,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         [Fact]
         public void Foreign_key_matching_navigation_plus_Id_is_found()
         {
-            var fkProperty = DependentType.AddProperty("SomeNavID", typeof(int));
-            DependentType.AddProperty("SomeNavPeEKaY", typeof(int));
-            DependentType.AddProperty("PrincipalEntityID", typeof(int));
-            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
+            var fkProperty = DependentType.GetOrAddProperty("SomeNavID", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("SomeNavPeEKaY", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("PrincipalEntityID", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
 
-            var fk = DependentType.AddForeignKey(PrincipalType.GetKey(), fkProperty);
+            var fk = DependentType.GetOrAddForeignKey(PrincipalType.GetPrimaryKey(), fkProperty);
 
             Assert.Same(fk, new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: false));
         }
@@ -63,11 +63,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         [Fact]
         public void Foreign_key_matching_navigation_plus_PK_name_is_found()
         {
-            var fkProperty = DependentType.AddProperty("SomeNavPeEKaY", typeof(int));
-            DependentType.AddProperty("PrincipalEntityID", typeof(int));
-            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
+            var fkProperty = DependentType.GetOrAddProperty("SomeNavPeEKaY", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("PrincipalEntityID", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
 
-            var fk = DependentType.AddForeignKey(PrincipalType.GetKey(), fkProperty);
+            var fk = DependentType.GetOrAddForeignKey(PrincipalType.GetPrimaryKey(), fkProperty);
 
             Assert.Same(fk, new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: false));
         }
@@ -75,10 +75,10 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         [Fact]
         public void Foreign_key_matching_principal_type_name_plus_Id_is_found()
         {
-            var fkProperty = DependentType.AddProperty("PrincipalEntityID", typeof(int));
-            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
+            var fkProperty = DependentType.GetOrAddProperty("PrincipalEntityID", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
 
-            var fk = DependentType.AddForeignKey(PrincipalType.GetKey(), fkProperty);
+            var fk = DependentType.GetOrAddForeignKey(PrincipalType.GetPrimaryKey(), fkProperty);
 
             Assert.Same(fk, new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: false));
         }
@@ -86,9 +86,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         [Fact]
         public void Foreign_key_matching_principal_type_name_plus_PK_name_is_found()
         {
-            var fkProperty = DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
+            var fkProperty = DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
 
-            var fk = DependentType.AddForeignKey(PrincipalType.GetKey(), fkProperty);
+            var fk = DependentType.GetOrAddForeignKey(PrincipalType.GetPrimaryKey(), fkProperty);
 
             Assert.Same(fk, new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: false));
         }
@@ -96,11 +96,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         [Fact]
         public void Creates_foreign_key_using_given_property()
         {
-            DependentType.AddProperty("SomeNavID", typeof(int));
-            DependentType.AddProperty("SomeNavPeEKaY", typeof(int));
-            DependentType.AddProperty("PrincipalEntityID", typeof(int));
-            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
-            var fkProperty = DependentType.AddProperty("No!No!", typeof(int));
+            DependentType.GetOrAddProperty("SomeNavID", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("SomeNavPeEKaY", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("PrincipalEntityID", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
+            var fkProperty = DependentType.GetOrAddProperty("No!No!", typeof(int), shadowProperty: true);
 
             var fk = new ForeignKeyConvention().FindOrCreateForeignKey(
                 PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { new[] { fkProperty } }, new Property[0], isUnqiue: false);
@@ -114,11 +114,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         [Fact]
         public void Creates_foreign_key_using_given_principal_property()
         {
-            var fkProperty = DependentType.AddProperty("SomeNavID", typeof(int));
-            DependentType.AddProperty("SomeNavPeEKaY", typeof(int));
-            DependentType.AddProperty("PrincipalEntityID", typeof(int));
-            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
-            var principalKeyProperty = PrincipalType.AddProperty("No!No!", typeof(int));
+            var fkProperty = DependentType.GetOrAddProperty("SomeNavID", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("SomeNavPeEKaY", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("PrincipalEntityID", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
+            var principalKeyProperty = PrincipalType.GetOrAddProperty("No!No!", typeof(int), shadowProperty: true);
 
             var fk = new ForeignKeyConvention().FindOrCreateForeignKey(
                 PrincipalType, DependentType, "SomeNav", "SomeInverse", new Property[0][], new[] { principalKeyProperty }, isUnqiue: false);
@@ -132,12 +132,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         [Fact]
         public void Creates_foreign_key_using_given_dependent_and_principal_property()
         {
-            DependentType.AddProperty("SomeNavID", typeof(int));
-            DependentType.AddProperty("SomeNavPeEKaY", typeof(int));
-            DependentType.AddProperty("PrincipalEntityID", typeof(int));
-            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
-            var fkProperty = DependentType.AddProperty("No!", typeof(int));
-            var principalKeyProperty = PrincipalType.AddProperty("No!No!", typeof(int));
+            DependentType.GetOrAddProperty("SomeNavID", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("SomeNavPeEKaY", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("PrincipalEntityID", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
+            var fkProperty = DependentType.GetOrAddProperty("No!", typeof(int), shadowProperty: true);
+            var principalKeyProperty = PrincipalType.GetOrAddProperty("No!No!", typeof(int), shadowProperty: true);
 
             var fk = new ForeignKeyConvention().FindOrCreateForeignKey(
                 PrincipalType,
@@ -157,12 +157,12 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         [Fact]
         public void Creates_foreign_key_using_given_properties()
         {
-            DependentType.AddProperty("SomeNavID", typeof(int));
-            DependentType.AddProperty("SomeNavPeEKaY", typeof(int));
-            DependentType.AddProperty("PrincipalEntityID", typeof(int));
-            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
-            var fkProperty1 = DependentType.AddProperty("ThatsNotTrue!", typeof(int));
-            var fkProperty2 = DependentType.AddProperty("ThatsImpossible!", typeof(int));
+            DependentType.GetOrAddProperty("SomeNavID", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("SomeNavPeEKaY", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("PrincipalEntityID", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
+            var fkProperty1 = DependentType.GetOrAddProperty("ThatsNotTrue!", typeof(int), shadowProperty: true);
+            var fkProperty2 = DependentType.GetOrAddProperty("ThatsImpossible!", typeof(int), shadowProperty: true);
 
             var fk = new ForeignKeyConvention().FindOrCreateForeignKey(
                 PrincipalType,
@@ -183,14 +183,14 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         [Fact]
         public void Creates_foreign_key_using_given_dependent_and_principal_properties()
         {
-            DependentType.AddProperty("SomeNavID", typeof(int));
-            DependentType.AddProperty("SomeNavPeEKaY", typeof(int));
-            DependentType.AddProperty("PrincipalEntityID", typeof(int));
-            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
-            var fkProperty1 = DependentType.AddProperty("ThatsNotTrue!", typeof(int));
-            var fkProperty2 = DependentType.AddProperty("ThatsImpossible!", typeof(int));
-            var principalKeyProperty1 = PrincipalType.AddProperty("SearchYourFeelings", typeof(int));
-            var principalKeyProperty2 = PrincipalType.AddProperty("YouKnowItToBeTrue!", typeof(int));
+            DependentType.GetOrAddProperty("SomeNavID", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("SomeNavPeEKaY", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("PrincipalEntityID", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
+            var fkProperty1 = DependentType.GetOrAddProperty("ThatsNotTrue!", typeof(int), shadowProperty: true);
+            var fkProperty2 = DependentType.GetOrAddProperty("ThatsImpossible!", typeof(int), shadowProperty: true);
+            var principalKeyProperty1 = PrincipalType.GetOrAddProperty("SearchYourFeelings", typeof(int), shadowProperty: true);
+            var principalKeyProperty2 = PrincipalType.GetOrAddProperty("YouKnowItToBeTrue!", typeof(int), shadowProperty: true);
 
             var fk = new ForeignKeyConvention().FindOrCreateForeignKey(
                 PrincipalType,
@@ -212,10 +212,10 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         [Fact]
         public void Creates_foreign_key_matching_navigation_plus_Id()
         {
-            var fkProperty = DependentType.AddProperty("SomeNavID", typeof(int));
-            DependentType.AddProperty("SomeNavPeEKaY", typeof(int));
-            DependentType.AddProperty("PrincipalEntityID", typeof(int));
-            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
+            var fkProperty = DependentType.GetOrAddProperty("SomeNavID", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("SomeNavPeEKaY", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("PrincipalEntityID", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
 
             var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: true);
 
@@ -228,9 +228,9 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         [Fact]
         public void Creates_foreign_key_matching_navigation_plus_PK_name()
         {
-            var fkProperty = DependentType.AddProperty("SomeNavPeEKaY", typeof(int));
-            DependentType.AddProperty("PrincipalEntityID", typeof(int));
-            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
+            var fkProperty = DependentType.GetOrAddProperty("SomeNavPeEKaY", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("PrincipalEntityID", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
 
             var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: false);
 
@@ -243,8 +243,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         [Fact]
         public void Creates_foreign_key_matching_principal_type_name_plus_Id()
         {
-            var fkProperty = DependentType.AddProperty("PrincipalEntityID", typeof(int));
-            DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
+            var fkProperty = DependentType.GetOrAddProperty("PrincipalEntityID", typeof(int), shadowProperty: true);
+            DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
 
             var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: true);
 
@@ -257,7 +257,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         [Fact]
         public void Creates_foreign_key_matching_principal_type_name_plus_PK_name()
         {
-            var fkProperty = DependentType.AddProperty("PrincipalEntityPeEKaY", typeof(int));
+            var fkProperty = DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
 
             var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: false);
 
@@ -298,8 +298,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         [Fact]
         public void Does_not_match_existing_FK_if_FK_already_has_different_navigation_to_principal()
         {
-            var fkProperty = DependentType.AddProperty("SharedFk", typeof(int));
-            var fk = DependentType.AddForeignKey(PrincipalType.GetKey(), fkProperty);
+            var fkProperty = DependentType.GetOrAddProperty("SharedFk", typeof(int), shadowProperty: true);
+            var fk = DependentType.GetOrAddForeignKey(PrincipalType.GetPrimaryKey(), fkProperty);
             DependentType.AddNavigation(new Navigation(fk, "AnotherNav", pointsToPrincipal: true));
 
             var newFk = new ForeignKeyConvention().FindOrCreateForeignKey(
@@ -315,8 +315,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         [Fact]
         public void Does_not_match_existing_FK_if_FK_already_has_different_navigation_to_dependent()
         {
-            var fkProperty = DependentType.AddProperty("SharedFk", typeof(int));
-            var fk = DependentType.AddForeignKey(PrincipalType.GetKey(), fkProperty);
+            var fkProperty = DependentType.GetOrAddProperty("SharedFk", typeof(int), shadowProperty: true);
+            var fk = DependentType.GetOrAddForeignKey(PrincipalType.GetPrimaryKey(), fkProperty);
             PrincipalType.AddNavigation(new Navigation(fk, "AnotherNav", pointsToPrincipal: false));
 
             var newFk = new ForeignKeyConvention().FindOrCreateForeignKey(
@@ -332,8 +332,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         [Fact]
         public void Does_not_match_existing_FK_if_FK_already_has_different_uniqueness()
         {
-            var fkProperty = DependentType.AddProperty("SharedFk", typeof(int));
-            var fk = DependentType.AddForeignKey(PrincipalType.GetKey(), fkProperty);
+            var fkProperty = DependentType.GetOrAddProperty("SharedFk", typeof(int), shadowProperty: true);
+            var fk = DependentType.GetOrAddForeignKey(PrincipalType.GetPrimaryKey(), fkProperty);
             fk.IsUnique = true;
 
             var newFk = new ForeignKeyConvention().FindOrCreateForeignKey(
@@ -351,7 +351,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         {
             var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: true);
 
-            Assert.Same(DependentType.GetKey().Properties.Single(), fk.Properties.Single());
+            Assert.Same(DependentType.GetPrimaryKey().Properties.Single(), fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.ReferencedProperties.Single());
             Assert.True(fk.IsUnique);
             Assert.True(fk.IsRequired);
@@ -362,11 +362,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             var model = new Model();
 
             var principalType = new EntityType(typeof(PrincipalEntity));
-            principalType.SetKey(principalType.AddProperty("PeeKay", typeof(int)));
+            principalType.GetOrSetPrimaryKey(principalType.GetOrAddProperty("PeeKay", typeof(int)));
             model.AddEntityType(principalType);
 
             var dependentType = new EntityType(typeof(DependentEntity));
-            dependentType.SetKey(dependentType.AddProperty("KayPee", typeof(int)));
+            dependentType.GetOrSetPrimaryKey(dependentType.GetOrAddProperty("KayPee", typeof(int), shadowProperty: true));
             model.AddEntityType(dependentType);
 
             return model;
@@ -374,7 +374,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
         private Property PrimaryKey
         {
-            get { return PrincipalType.GetKey().Properties.Single(); }
+            get { return PrincipalType.GetPrimaryKey().Properties.Single(); }
         }
 
         private EntityType DependentType

--- a/test/EntityFramework.Tests/Metadata/ModelConventions/KeyConventionTest.cs
+++ b/test/EntityFramework.Tests/Metadata/ModelConventions/KeyConventionTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             new KeyConvention().Apply(entityType);
 
-            var key = entityType.TryGetKey();
+            var key = entityType.TryGetPrimaryKey();
             Assert.Null(key);
         }
 
@@ -41,7 +41,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             convention.Object.Apply(entityType);
 
-            var key = entityType.TryGetKey();
+            var key = entityType.TryGetPrimaryKey();
             Assert.NotNull(key);
             Assert.Equal(new[] { "ModifiedDate", "Name" }, key.Properties.Select(p => p.Name));
         }
@@ -58,7 +58,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             new KeyConvention().Apply(entityType);
 
-            var key = entityType.TryGetKey();
+            var key = entityType.TryGetPrimaryKey();
             Assert.NotNull(key);
             Assert.Equal(new[] { "Id" }, key.Properties.Select(p => p.Name));
             Assert.Equal(ValueGenerationOnSave.WhenInserting, key.Properties.Single().ValueGenerationOnSave);
@@ -77,7 +77,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             new KeyConvention().Apply(entityType);
 
-            var key = entityType.TryGetKey();
+            var key = entityType.TryGetPrimaryKey();
             Assert.NotNull(key);
             Assert.Equal(new[] { "EntityWithTypeIdId" }, key.Properties.Select(p => p.Name));
             Assert.Equal(ValueGenerationOnSave.WhenInserting, key.Properties.Single().ValueGenerationOnSave);
@@ -97,7 +97,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
 
             new KeyConvention().Apply(entityType);
 
-            var key = entityType.TryGetKey();
+            var key = entityType.TryGetPrimaryKey();
             Assert.NotNull(key);
             Assert.Equal(new[] { "Id" }, key.Properties.Select(p => p.Name));
             Assert.Equal(ValueGenerationOnSave.WhenInserting, key.Properties.Single().ValueGenerationOnSave);

--- a/test/EntityFramework.Tests/Metadata/ModelTest.cs
+++ b/test/EntityFramework.Tests/Metadata/ModelTest.cs
@@ -10,20 +10,6 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 {
     public class ModelTest
     {
-        #region Fixture
-
-        public class Customer
-        {
-            public int Id { get; set; }
-            public string Name { get; set; }
-        }
-
-        public class Order
-        {
-        }
-
-        #endregion
-
         [Fact]
         public void Members_check_arguments()
         {
@@ -117,7 +103,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var entityType2 = new EntityType(typeof(Order));
             var keyProperty = new Property("Id", typeof(Customer)) { EntityType = entityType1 };
             var fkProperty = new Property("CustomerId", typeof(Order)) { EntityType = entityType2 };
-            var foreignKey = entityType2.AddForeignKey(new Key(new[] { keyProperty }), fkProperty);
+            var foreignKey = entityType2.GetOrAddForeignKey(new Key(new[] { keyProperty }), fkProperty);
 
             model.AddEntityType(entityType1);
             model.AddEntityType(entityType2);
@@ -126,6 +112,16 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             Assert.Same(foreignKey, referencingForeignKeys.Single());
             Assert.Same(foreignKey, entityType1.GetReferencingForeignKeys().Single());
+        }
+
+        private class Customer
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class Order
+        {
         }
     }
 }

--- a/test/EntityFramework.Tests/Metadata/NavigationExtensionsTest.cs
+++ b/test/EntityFramework.Tests/Metadata/NavigationExtensionsTest.cs
@@ -102,8 +102,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var categoryType = model.GetEntityType(typeof(Category));
             var productType = model.GetEntityType(typeof(Product));
 
-            var categoryFk = productType.AddForeignKey(categoryType.GetKey(), productType.GetProperty("CategoryId"));
-            var featuredProductFk = categoryType.AddForeignKey(productType.GetKey(), categoryType.GetProperty("FeaturedProductId"));
+            var categoryFk = productType.GetOrAddForeignKey(categoryType.GetPrimaryKey(), productType.GetProperty("CategoryId"));
+            var featuredProductFk = categoryType.GetOrAddForeignKey(productType.GetPrimaryKey(), categoryType.GetProperty("FeaturedProductId"));
             featuredProductFk.IsUnique = true;
 
             if (createProducts)

--- a/test/EntityFramework.Tests/Metadata/PropertyTest.cs
+++ b/test/EntityFramework.Tests/Metadata/PropertyTest.cs
@@ -10,23 +10,6 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 {
     public class PropertyTest
     {
-        #region Fixture
-
-        public class Customer
-        {
-            public static PropertyInfo IdProperty = typeof(Customer).GetProperty("Id");
-            public static PropertyInfo NameProperty = typeof(Customer).GetProperty("Name");
-            public static PropertyInfo AgeProperty = typeof(Customer).GetProperty("Age");
-            public static PropertyInfo HashProperty = typeof(Customer).GetProperty("Hash");
-
-            public int Id { get; set; }
-            public string Name { get; set; }
-            public byte? Age { get; set; }
-            public Guid Hash { get; set; }
-        }
-
-        #endregion
-
         [Fact]
         public void Members_check_arguments()
         {
@@ -71,8 +54,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void HasClrProperty_is_set_appropriately()
         {
             Assert.False(new Property("Kake", typeof(int)).IsShadowProperty);
-            Assert.False(new Property("Kake", typeof(int), shadowProperty: false, concurrencyToken: false).IsShadowProperty);
-            Assert.True(new Property("Kake", typeof(int), shadowProperty: true, concurrencyToken: false).IsShadowProperty);
+            Assert.False(new Property("Kake", typeof(int)).IsShadowProperty);
+            Assert.True(new Property("Kake", typeof(int), shadowProperty: true).IsShadowProperty);
         }
 
         [Fact]
@@ -84,7 +67,11 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         [Fact]
         public void Can_mark_property_as_concurrency_token()
         {
-            Assert.True(new Property("Name", typeof(string), shadowProperty: false, concurrencyToken: true).IsConcurrencyToken);
+            var property = new Property("Name", typeof(string));
+            Assert.False(property.IsConcurrencyToken);
+
+            property.IsConcurrencyToken = true;
+            Assert.True(property.IsConcurrencyToken);
         }
 
         [Fact]
@@ -116,7 +103,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         [Fact]
         public void Can_get_and_set_property_and_shadow_index_for_shadow_property()
         {
-            var property = new Property("Kake", typeof(int), shadowProperty: true, concurrencyToken: false);
+            var property = new Property("Kake", typeof(int), shadowProperty: true);
 
             Assert.Equal(0, property.Index);
             Assert.Equal(0, property.ShadowIndex);

--- a/test/EntityFramework.Tests/Utilities/BidirectionalAdjacencyListGraphTest.cs
+++ b/test/EntityFramework.Tests/Utilities/BidirectionalAdjacencyListGraphTest.cs
@@ -15,22 +15,27 @@ namespace Microsoft.Data.Entity.Tests.Utilities
 
         private class A
         {
+            public int P { get; set; }
         }
 
         private class B
         {
+            public int P { get; set; }
         }
 
         private class C
         {
+            public int P { get; set; }
         }
 
         private class D
         {
+            public int P { get; set; }
         }
 
         private class E
         {
+            public int P { get; set; }
         }
 
         #endregion
@@ -68,17 +73,17 @@ namespace Microsoft.Data.Entity.Tests.Utilities
         public void Sort_simple()
         {
             var entityTypeA = new NamedEntityType(typeof(A));
-            entityTypeA.SetKey(entityTypeA.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeA.GetOrSetPrimaryKey(entityTypeA.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             var entityTypeB = new NamedEntityType(typeof(B));
-            entityTypeB.SetKey(entityTypeB.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeB.GetOrSetPrimaryKey(entityTypeB.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             var entityTypeC = new NamedEntityType(typeof(C));
-            entityTypeC.SetKey(entityTypeC.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             // B -> A -> C
-            entityTypeC.AddForeignKey(entityTypeA.GetKey(), entityTypeC.AddProperty("P", typeof(int)));
-            entityTypeA.AddForeignKey(entityTypeB.GetKey(), entityTypeA.AddProperty("P", typeof(int)));
+            entityTypeC.GetOrAddForeignKey(entityTypeA.GetPrimaryKey(), entityTypeC.GetOrAddProperty("P", typeof(int)));
+            entityTypeA.GetOrAddForeignKey(entityTypeB.GetPrimaryKey(), entityTypeA.GetOrAddProperty("P", typeof(int)));
 
             var model = new EntityTypeGraph();
             model.Populate(entityTypeA, entityTypeB, entityTypeC);
@@ -92,17 +97,17 @@ namespace Microsoft.Data.Entity.Tests.Utilities
         public void Sort_reverse()
         {
             var entityTypeA = new NamedEntityType(typeof(A));
-            entityTypeA.SetKey(entityTypeA.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeA.GetOrSetPrimaryKey(entityTypeA.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             var entityTypeB = new NamedEntityType(typeof(B));
-            entityTypeB.SetKey(entityTypeB.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeB.GetOrSetPrimaryKey(entityTypeB.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             var entityTypeC = new NamedEntityType(typeof(C));
-            entityTypeC.SetKey(entityTypeC.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             // C -> B -> A
-            entityTypeA.AddForeignKey(entityTypeB.GetKey(), entityTypeA.AddProperty("P", typeof(int)));
-            entityTypeB.AddForeignKey(entityTypeC.GetKey(), entityTypeB.AddProperty("P", typeof(int)));
+            entityTypeA.GetOrAddForeignKey(entityTypeB.GetPrimaryKey(), entityTypeA.GetOrAddProperty("P", typeof(int)));
+            entityTypeB.GetOrAddForeignKey(entityTypeC.GetPrimaryKey(), entityTypeB.GetOrAddProperty("P", typeof(int)));
 
             var model = new EntityTypeGraph();
             model.Populate(entityTypeA, entityTypeB, entityTypeC);
@@ -116,17 +121,17 @@ namespace Microsoft.Data.Entity.Tests.Utilities
         public void Sort_preserves_graph()
         {
             var entityTypeA = new NamedEntityType(typeof(A));
-            entityTypeA.SetKey(entityTypeA.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeA.GetOrSetPrimaryKey(entityTypeA.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             var entityTypeB = new NamedEntityType(typeof(B));
-            entityTypeB.SetKey(entityTypeB.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeB.GetOrSetPrimaryKey(entityTypeB.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             var entityTypeC = new NamedEntityType(typeof(C));
-            entityTypeC.SetKey(entityTypeC.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             // B -> A -> C
-            entityTypeC.AddForeignKey(entityTypeA.GetKey(), entityTypeC.AddProperty("P", typeof(int)));
-            entityTypeA.AddForeignKey(entityTypeB.GetKey(), entityTypeA.AddProperty("P", typeof(int)));
+            entityTypeC.GetOrAddForeignKey(entityTypeA.GetPrimaryKey(), entityTypeC.GetOrAddProperty("P", typeof(int)));
+            entityTypeA.GetOrAddForeignKey(entityTypeB.GetPrimaryKey(), entityTypeA.GetOrAddProperty("P", typeof(int)));
 
             var model = new EntityTypeGraph();
             model.Populate(entityTypeA, entityTypeB, entityTypeC);
@@ -156,18 +161,18 @@ namespace Microsoft.Data.Entity.Tests.Utilities
         public void Sort_tree()
         {
             var entityTypeA = new NamedEntityType(typeof(A));
-            entityTypeA.SetKey(entityTypeA.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeA.GetOrSetPrimaryKey(entityTypeA.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             var entityTypeB = new NamedEntityType(typeof(B));
-            entityTypeB.SetKey(entityTypeB.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeB.GetOrSetPrimaryKey(entityTypeB.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             var entityTypeC = new NamedEntityType(typeof(C));
-            entityTypeC.SetKey(entityTypeC.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             // A -> B, A -> C, C -> B
-            entityTypeB.AddForeignKey(entityTypeA.GetKey(), entityTypeB.AddProperty("P", typeof(int)));
-            entityTypeC.AddForeignKey(entityTypeA.GetKey(), entityTypeC.AddProperty("P", typeof(int)));
-            entityTypeB.AddForeignKey(entityTypeC.GetKey(), entityTypeB.AddProperty("P", typeof(int)));
+            entityTypeB.GetOrAddForeignKey(entityTypeA.GetPrimaryKey(), entityTypeB.GetOrAddProperty("P", typeof(int)));
+            entityTypeC.GetOrAddForeignKey(entityTypeA.GetPrimaryKey(), entityTypeC.GetOrAddProperty("P", typeof(int)));
+            entityTypeB.GetOrAddForeignKey(entityTypeC.GetPrimaryKey(), entityTypeB.GetOrAddProperty("P", typeof(int)));
 
             var model = new EntityTypeGraph();
             model.Populate(entityTypeA, entityTypeB, entityTypeC);
@@ -181,13 +186,13 @@ namespace Microsoft.Data.Entity.Tests.Utilities
         public void Sort_no_edges()
         {
             var entityTypeA = new NamedEntityType(typeof(A));
-            entityTypeA.SetKey(entityTypeA.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeA.GetOrSetPrimaryKey(entityTypeA.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             var entityTypeB = new NamedEntityType(typeof(B));
-            entityTypeB.SetKey(entityTypeB.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeB.GetOrSetPrimaryKey(entityTypeB.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             var entityTypeC = new NamedEntityType(typeof(C));
-            entityTypeC.SetKey(entityTypeC.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             // A B C
             var model = new EntityTypeGraph();
@@ -202,10 +207,10 @@ namespace Microsoft.Data.Entity.Tests.Utilities
         public void Sort_self_ref()
         {
             var entityTypeA = new NamedEntityType(typeof(A));
-            entityTypeA.SetKey(entityTypeA.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeA.GetOrSetPrimaryKey(entityTypeA.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             // A -> A
-            entityTypeA.AddForeignKey(entityTypeA.GetKey(), entityTypeA.AddProperty("P", typeof(int)));
+            entityTypeA.GetOrAddForeignKey(entityTypeA.GetPrimaryKey(), entityTypeA.GetOrAddProperty("P", typeof(int)));
 
             var model = new EntityTypeGraph();
             model.Populate(entityTypeA);
@@ -219,17 +224,17 @@ namespace Microsoft.Data.Entity.Tests.Utilities
         public void Sort_circular_direct()
         {
             var entityTypeA = new NamedEntityType(typeof(A));
-            entityTypeA.SetKey(entityTypeA.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeA.GetOrSetPrimaryKey(entityTypeA.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             var entityTypeB = new NamedEntityType(typeof(B));
-            entityTypeB.SetKey(entityTypeB.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeB.GetOrSetPrimaryKey(entityTypeB.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             var entityTypeC = new NamedEntityType(typeof(C));
-            entityTypeC.SetKey(entityTypeC.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             // C, A -> B -> A
-            entityTypeA.AddForeignKey(entityTypeB.GetKey(), entityTypeA.AddProperty("P", typeof(int)));
-            entityTypeB.AddForeignKey(entityTypeA.GetKey(), entityTypeB.AddProperty("P", typeof(int)));
+            entityTypeA.GetOrAddForeignKey(entityTypeB.GetPrimaryKey(), entityTypeA.GetOrAddProperty("P", typeof(int)));
+            entityTypeB.GetOrAddForeignKey(entityTypeA.GetPrimaryKey(), entityTypeB.GetOrAddProperty("P", typeof(int)));
 
             var model = new EntityTypeGraph();
             model.Populate(entityTypeC, entityTypeA, entityTypeB);
@@ -243,18 +248,18 @@ namespace Microsoft.Data.Entity.Tests.Utilities
         public void Sort_circular_transitive()
         {
             var entityTypeA = new NamedEntityType(typeof(A));
-            entityTypeA.SetKey(entityTypeA.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeA.GetOrSetPrimaryKey(entityTypeA.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             var entityTypeB = new NamedEntityType(typeof(B));
-            entityTypeB.SetKey(entityTypeB.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeB.GetOrSetPrimaryKey(entityTypeB.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             var entityTypeC = new NamedEntityType(typeof(C));
-            entityTypeC.SetKey(entityTypeC.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             // A -> C -> B -> A
-            entityTypeA.AddForeignKey(entityTypeB.GetKey(), entityTypeA.AddProperty("P", typeof(int)));
-            entityTypeB.AddForeignKey(entityTypeC.GetKey(), entityTypeB.AddProperty("P", typeof(int)));
-            entityTypeC.AddForeignKey(entityTypeA.GetKey(), entityTypeC.AddProperty("P", typeof(int)));
+            entityTypeA.GetOrAddForeignKey(entityTypeB.GetPrimaryKey(), entityTypeA.GetOrAddProperty("P", typeof(int)));
+            entityTypeB.GetOrAddForeignKey(entityTypeC.GetPrimaryKey(), entityTypeB.GetOrAddProperty("P", typeof(int)));
+            entityTypeC.GetOrAddForeignKey(entityTypeA.GetPrimaryKey(), entityTypeC.GetOrAddProperty("P", typeof(int)));
 
             var model = new EntityTypeGraph();
             model.Populate(entityTypeA, entityTypeB, entityTypeC);
@@ -268,29 +273,29 @@ namespace Microsoft.Data.Entity.Tests.Utilities
         public void Sort_two_cycles()
         {
             var entityTypeA = new NamedEntityType(typeof(A));
-            entityTypeA.SetKey(entityTypeA.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeA.GetOrSetPrimaryKey(entityTypeA.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             var entityTypeB = new NamedEntityType(typeof(B));
-            entityTypeB.SetKey(entityTypeB.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeB.GetOrSetPrimaryKey(entityTypeB.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             var entityTypeC = new NamedEntityType(typeof(C));
-            entityTypeC.SetKey(entityTypeC.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             var entityTypeD = new NamedEntityType(typeof(D));
-            entityTypeD.SetKey(entityTypeD.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeD.GetOrSetPrimaryKey(entityTypeD.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             var entityTypeE = new NamedEntityType(typeof(E));
-            entityTypeE.SetKey(entityTypeE.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeE.GetOrSetPrimaryKey(entityTypeE.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             // A -> C -> B -> A
-            entityTypeA.AddForeignKey(entityTypeB.GetKey(), entityTypeA.AddProperty("P", typeof(int)));
-            entityTypeB.AddForeignKey(entityTypeC.GetKey(), entityTypeB.AddProperty("P", typeof(int)));
-            entityTypeC.AddForeignKey(entityTypeA.GetKey(), entityTypeC.AddProperty("P", typeof(int)));
+            entityTypeA.GetOrAddForeignKey(entityTypeB.GetPrimaryKey(), entityTypeA.GetOrAddProperty("P", typeof(int)));
+            entityTypeB.GetOrAddForeignKey(entityTypeC.GetPrimaryKey(), entityTypeB.GetOrAddProperty("P", typeof(int)));
+            entityTypeC.GetOrAddForeignKey(entityTypeA.GetPrimaryKey(), entityTypeC.GetOrAddProperty("P", typeof(int)));
 
             // A -> E -> D -> A
-            entityTypeA.AddForeignKey(entityTypeD.GetKey(), entityTypeA.AddProperty("P", typeof(int)));
-            entityTypeD.AddForeignKey(entityTypeE.GetKey(), entityTypeD.AddProperty("P", typeof(int)));
-            entityTypeE.AddForeignKey(entityTypeA.GetKey(), entityTypeE.AddProperty("P", typeof(int)));
+            entityTypeA.GetOrAddForeignKey(entityTypeD.GetPrimaryKey(), entityTypeA.GetOrAddProperty("P", typeof(int)));
+            entityTypeD.GetOrAddForeignKey(entityTypeE.GetPrimaryKey(), entityTypeD.GetOrAddProperty("P", typeof(int)));
+            entityTypeE.GetOrAddForeignKey(entityTypeA.GetPrimaryKey(), entityTypeE.GetOrAddProperty("P", typeof(int)));
 
             var model = new EntityTypeGraph();
             model.Populate(entityTypeA, entityTypeB, entityTypeC, entityTypeD, entityTypeE);
@@ -304,18 +309,18 @@ namespace Microsoft.Data.Entity.Tests.Utilities
         public void Sort_leafy_cycle()
         {
             var entityTypeA = new NamedEntityType(typeof(A));
-            entityTypeA.SetKey(entityTypeA.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeA.GetOrSetPrimaryKey(entityTypeA.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             var entityTypeB = new NamedEntityType(typeof(B));
-            entityTypeB.SetKey(entityTypeB.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeB.GetOrSetPrimaryKey(entityTypeB.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             var entityTypeC = new NamedEntityType(typeof(C));
-            entityTypeC.SetKey(entityTypeC.AddProperty("Id", typeof(int), shadowProperty: true, concurrencyToken: false));
+            entityTypeC.GetOrSetPrimaryKey(entityTypeC.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
 
             // C -> B -> C -> A
-            entityTypeB.AddForeignKey(entityTypeC.GetKey(), entityTypeB.AddProperty("P", typeof(int)));
-            entityTypeC.AddForeignKey(entityTypeB.GetKey(), entityTypeC.AddProperty("P", typeof(int)));
-            entityTypeA.AddForeignKey(entityTypeC.GetKey(), entityTypeA.AddProperty("P", typeof(int)));
+            entityTypeB.GetOrAddForeignKey(entityTypeC.GetPrimaryKey(), entityTypeB.GetOrAddProperty("P", typeof(int)));
+            entityTypeC.GetOrAddForeignKey(entityTypeB.GetPrimaryKey(), entityTypeC.GetOrAddProperty("P", typeof(int)));
+            entityTypeA.GetOrAddForeignKey(entityTypeC.GetPrimaryKey(), entityTypeA.GetOrAddProperty("P", typeof(int)));
 
             var model = new EntityTypeGraph();
             model.Populate(entityTypeA, entityTypeB, entityTypeC);

--- a/test/Shared/ApiConsistencyTestBase.cs
+++ b/test/Shared/ApiConsistencyTestBase.cs
@@ -16,6 +16,9 @@ namespace Microsoft.Data.Entity
         protected const BindingFlags PublicInstance
             = BindingFlags.Instance | BindingFlags.Public;
 
+        protected const BindingFlags AnyInstance
+            = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+
         [Fact]
         public void Public_inheritable_apis_should_be_virtual()
         {
@@ -23,7 +26,7 @@ namespace Microsoft.Data.Entity
                 = (from t in GetAllTypes(TargetAssembly.GetTypes())
                     where t.IsVisible
                           && !t.IsSealed
-                          && t.GetConstructors(PublicInstance).Any()
+                          && t.GetConstructors(AnyInstance).Any(c => c.IsPublic || c.IsFamily || c.IsFamilyOrAssembly)
                           && t.Namespace != null
                           && !t.Namespace.EndsWith(".Compiled")
                     from m in t.GetMethods(PublicInstance)


### PR DESCRIPTION
EDMLib v4? (Metadata robustness and non-primary keys)

(This change looks big, but the only really substantive changes are in EntityType.cs)

This change adds non-primary keys as a first-class part of the model as per issue #537. In looking at this it became clear that it was time to add some more robustness to the core metadata to help prevent the model getting into inconsistent state--for example, removing keys that are being referenced by foreign keys. Most of this change is about adding that robustness. Specifically:
- Be explicit and consistent about being able to either find and existing metadata item or create a new one if it doesn't yet exist. This matches the way we tend to use metadata, especially from fluent APIs and conventions. It helps protect against a couple of bugs we have had recently where duplicate items (properties or keys) were added by mistake. The methods are currently called GetOrAddXxx, but we can discuss other ideas.
- Error checking for things like CLR properties actually existing
- Checks to prevent removal of items that are currently still being referenced in the model
