### PR TITLE
Let me newgle that for you...

### DIFF
--- a/src/EntityFramework/ChangeTracking/ChangeDetector.cs
+++ b/src/EntityFramework/ChangeTracking/ChangeDetector.cs
@@ -199,16 +199,22 @@ namespace Microsoft.Data.Entity.ChangeTracking
                 var added = new HashSet<object>(ReferenceEqualityComparer.Instance);
 
                 var removed = new HashSet<object>(ReferenceEqualityComparer.Instance);
-                foreach (var entity in snapshotCollection)
+                if (snapshotCollection != null)
                 {
-                    removed.Add(entity);
+                    foreach (var entity in snapshotCollection)
+                    {
+                        removed.Add(entity);
+                    }
                 }
 
-                foreach (var entity in currentCollection)
+                if (currentCollection != null)
                 {
-                    if (!removed.Remove(entity))
+                    foreach (var entity in currentCollection)
                     {
-                        added.Add(entity);
+                        if (!removed.Remove(entity))
+                        {
+                            added.Add(entity);
+                        }
                     }
                 }
 

--- a/src/EntityFramework/EntityFramework.csproj
+++ b/src/EntityFramework/EntityFramework.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Identity\ValueGeneratorPool.cs" />
     <Compile Include="Identity\ValueGeneratorSelector.cs" />
     <Compile Include="Metadata\BasicModelBuilder.cs" />
+    <Compile Include="Metadata\CollectionTypeFactory.cs" />
     <Compile Include="Metadata\IEntityBuilder.cs" />
     <Compile Include="Metadata\IEntityBuilder`.cs" />
     <Compile Include="Metadata\IForeignKeyBuilder.cs" />

--- a/src/EntityFramework/Metadata/ClrCollectionAccessorSource.cs
+++ b/src/EntityFramework/Metadata/ClrCollectionAccessorSource.cs
@@ -15,6 +15,9 @@ namespace Microsoft.Data.Entity.Metadata
         private static readonly MethodInfo _genericCreate
             = typeof(ClrCollectionAccessorSource).GetTypeInfo().GetDeclaredMethods("CreateGeneric").Single();
 
+        private static readonly MethodInfo _createAndSet
+            = typeof(ClrCollectionAccessorSource).GetTypeInfo().GetDeclaredMethods("CreateAndSet").Single();
+
         private readonly ThreadSafeDictionaryCache<Tuple<Type, string>, IClrCollectionAccessor> _cache
             = new ThreadSafeDictionaryCache<Tuple<Type, string>, IClrCollectionAccessor>();
 
@@ -29,28 +32,79 @@ namespace Microsoft.Data.Entity.Metadata
                 return accessor;
             }
 
-            // TODO: Currently assumes ICollection navigation property
-
             return _cache.GetOrAdd(
                 Tuple.Create(navigation.EntityType.Type, navigation.Name),
-                k => Create(k.Item1.GetAnyProperty(k.Item2)));
+                k => Create(navigation));
         }
 
-        private IClrCollectionAccessor Create(PropertyInfo property)
+        private static IClrCollectionAccessor Create(INavigation navigation)
         {
+            var property = navigation.EntityType.Type.GetAnyProperty(navigation.Name);
+            var elementType = property.PropertyType.TryGetElementType(typeof(ICollection<>));
+
+            // TODO: Only ICollections supported; add support for enumerables with add/remove methods
+            if (elementType == null)
+            {
+                throw new NotSupportedException(
+                    Strings.FormatNavigationBadType(
+                        navigation.Name, navigation.EntityType.Name, property.PropertyType.FullName, navigation.GetTargetType().Name));
+            }
+
+            if (property.PropertyType.IsArray)
+            {
+                throw new NotSupportedException(
+                    Strings.FormatNavigationArray(navigation.Name, navigation.EntityType.Name, property.PropertyType.FullName));
+            }
+
+            if (property.GetMethod == null)
+            {
+                throw new NotSupportedException(Strings.FormatNavigationNoGetter(navigation.Name, navigation.EntityType.Name));
+            }
+
             var boundMethod = _genericCreate.MakeGenericMethod(
-                property.DeclaringType, property.PropertyType, property.PropertyType.TryGetElementType(typeof(ICollection<>)));
+                property.DeclaringType, property.PropertyType, elementType);
 
             return (IClrCollectionAccessor)boundMethod.Invoke(null, new object[] { property });
         }
 
         // ReSharper disable once UnusedMember.Local
         private static IClrCollectionAccessor CreateGeneric<TEntity, TCollection, TElement>(PropertyInfo property)
-            where TCollection : ICollection<TElement>
+            where TCollection : class, ICollection<TElement>
         {
             var getterDelegate = (Func<TEntity, TCollection>)property.GetMethod.CreateDelegate(typeof(Func<TEntity, TCollection>));
 
-            return new ClrICollectionAccessor<TEntity, TCollection, TElement>(getterDelegate);
+            Action<TEntity, TCollection> setterDelegate = null;
+            Func<TEntity, Action<TEntity, TCollection>, TCollection> createAndSetDelegate = null;
+
+            var setter = property.SetMethod;
+            if (setter != null)
+            {
+                setterDelegate = (Action<TEntity, TCollection>)setter.CreateDelegate(typeof(Action<TEntity, TCollection>));
+
+                var concreteType = new CollectionTypeFactory().TryFindTypeToInstantiate(typeof(TCollection));
+
+                if (concreteType != null)
+                {
+                    createAndSetDelegate = (Func<TEntity, Action<TEntity, TCollection>, TCollection>)_createAndSet
+                        .MakeGenericMethod(typeof(TEntity), typeof(TCollection), concreteType)
+                        .CreateDelegate(typeof(Func<TEntity, Action<TEntity, TCollection>, TCollection>));
+                }
+            }
+
+            return new ClrICollectionAccessor<TEntity, TCollection, TElement>(
+                property.Name, getterDelegate, setterDelegate, createAndSetDelegate);
+        }
+
+        // ReSharper disable once UnusedMember.Local
+        private static TCollection CreateAndSet<TEntity, TCollection, TConcreteCollection>(
+            TEntity entity,
+            Action<TEntity, TCollection> setterDelegate)
+            where TCollection : class
+            where TConcreteCollection : TCollection, new()
+        {
+            var collection = new TConcreteCollection();
+            setterDelegate(entity, collection);
+            return collection;
         }
     }
 }

--- a/src/EntityFramework/Metadata/CollectionTypeFactory.cs
+++ b/src/EntityFramework/Metadata/CollectionTypeFactory.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Metadata
+{
+    public class CollectionTypeFactory
+    {
+        public virtual Type TryFindTypeToInstantiate([NotNull] Type collectionType)
+        {
+            Check.NotNull(collectionType, "collectionType");
+
+            // Code taken from EF6. The rules are:
+            // If the collection is defined as a concrete type with a public parameterless constructor, then create an instance of that type
+            // Else, if HashSet{T} can be assigned to the type, then use HashSet{T}
+            // Else, if List{T} can be assigned to the type, then use List{T}
+            // Else, return null.
+
+            var elementType = collectionType.TryGetElementType(typeof(ICollection<>));
+
+            if (elementType == null)
+            {
+                return null;
+            }
+
+            if (!collectionType.GetTypeInfo().IsAbstract)
+            {
+                var constructor = collectionType.GetDeclaredConstructor(null);
+                if (constructor != null && constructor.IsPublic)
+                {
+                    return collectionType;
+                }
+            }
+
+            var hashSetOfT = typeof(HashSet<>).MakeGenericType(elementType);
+            if (collectionType.GetTypeInfo().IsAssignableFrom(hashSetOfT.GetTypeInfo()))
+            {
+                return hashSetOfT;
+            }
+
+            var listOfT = typeof(List<>).MakeGenericType(elementType);
+            if (collectionType.GetTypeInfo().IsAssignableFrom(listOfT.GetTypeInfo()))
+            {
+                return listOfT;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/EntityFramework/Properties/Strings.Designer.cs
+++ b/src/EntityFramework/Properties/Strings.Designer.cs
@@ -1018,6 +1018,86 @@ namespace Microsoft.Data.Entity
             return string.Format(CultureInfo.CurrentCulture, GetString("ForeignKeyTypeMismatch", "dependentType", "principalType"), dependentType, principalType);
         }
 
+        /// <summary>
+        /// The type of navigation property '{navigation}' on entity type '{entityType}' is '{foundType}' which does not implement ICollection&lt;{targetType}&gt;. Collection navigation properties must implement ICollection&lt;&gt; of the target type.
+        /// </summary>
+        internal static string NavigationBadType
+        {
+            get { return GetString("NavigationBadType"); }
+        }
+
+        /// <summary>
+        /// The type of navigation property '{navigation}' on entity type '{entityType}' is '{foundType}' which does not implement ICollection&lt;{targetType}&gt;. Collection navigation properties must implement ICollection&lt;&gt; of the target type.
+        /// </summary>
+        internal static string FormatNavigationBadType(object navigation, object entityType, object foundType, object targetType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("NavigationBadType", "navigation", "entityType", "foundType", "targetType"), navigation, entityType, foundType, targetType);
+        }
+
+        /// <summary>
+        /// The type of navigation property '{navigation}' on entity type '{entityType}' is '{foundType}' which is an array type.. Collection navigation properties cannot be arrays.
+        /// </summary>
+        internal static string NavigationArray
+        {
+            get { return GetString("NavigationArray"); }
+        }
+
+        /// <summary>
+        /// The type of navigation property '{navigation}' on entity type '{entityType}' is '{foundType}' which is an array type.. Collection navigation properties cannot be arrays.
+        /// </summary>
+        internal static string FormatNavigationArray(object navigation, object entityType, object foundType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("NavigationArray", "navigation", "entityType", "foundType"), navigation, entityType, foundType);
+        }
+
+        /// <summary>
+        /// The navigation property '{navigation}' on entity type '{entityType}' does not have a getter.
+        /// </summary>
+        internal static string NavigationNoGetter
+        {
+            get { return GetString("NavigationNoGetter"); }
+        }
+
+        /// <summary>
+        /// The navigation property '{navigation}' on entity type '{entityType}' does not have a getter.
+        /// </summary>
+        internal static string FormatNavigationNoGetter(object navigation, object entityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("NavigationNoGetter", "navigation", "entityType"), navigation, entityType);
+        }
+
+        /// <summary>
+        /// The navigation property '{navigation}' on entity type '{entityType}' does not have a setter. Read-only collection navigation properties must be initialized before use.
+        /// </summary>
+        internal static string NavigationNoSetter
+        {
+            get { return GetString("NavigationNoSetter"); }
+        }
+
+        /// <summary>
+        /// The navigation property '{navigation}' on entity type '{entityType}' does not have a setter. Read-only collection navigation properties must be initialized before use.
+        /// </summary>
+        internal static string FormatNavigationNoSetter(object navigation, object entityType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("NavigationNoSetter", "navigation", "entityType"), navigation, entityType);
+        }
+
+        /// <summary>
+        /// The type of navigation property '{navigation}' on entity type '{entityType}' is '{foundType}' for which it was not possible to create a concrete instance. Either initialize the property before use, add a public parameterless constructor to the type, or use a type which can be assigned a HashSet&lt;&gt; or List&lt;&gt;.
+        /// </summary>
+        internal static string NavigationCannotCreateType
+        {
+            get { return GetString("NavigationCannotCreateType"); }
+        }
+
+        /// <summary>
+        /// The type of navigation property '{navigation}' on entity type '{entityType}' is '{foundType}' for which it was not possible to create a concrete instance. Either initialize the property before use, add a public parameterless constructor to the type, or use a type which can be assigned a HashSet&lt;&gt; or List&lt;&gt;.
+        /// </summary>
+        internal static string FormatNavigationCannotCreateType(object navigation, object entityType, object foundType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("NavigationCannotCreateType", "navigation", "entityType", "foundType"), navigation, entityType, foundType);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EntityFramework/Properties/Strings.resx
+++ b/src/EntityFramework/Properties/Strings.resx
@@ -306,4 +306,19 @@
   <data name="ForeignKeyTypeMismatch" xml:space="preserve">
     <value>The types of the properties specified for the foreign key on entity type '{dependentType}' do not match the types of the properties in the referenced key on entity type '{principalType}'.</value>
   </data>
+  <data name="NavigationBadType" xml:space="preserve">
+    <value>The type of navigation property '{navigation}' on entity type '{entityType}' is '{foundType}' which does not implement ICollection&lt;{targetType}&gt;. Collection navigation properties must implement ICollection&lt;&gt; of the target type.</value>
+  </data>
+  <data name="NavigationArray" xml:space="preserve">
+    <value>The type of navigation property '{navigation}' on entity type '{entityType}' is '{foundType}' which is an array type.. Collection navigation properties cannot be arrays.</value>
+  </data>
+  <data name="NavigationNoGetter" xml:space="preserve">
+    <value>The navigation property '{navigation}' on entity type '{entityType}' does not have a getter.</value>
+  </data>
+  <data name="NavigationNoSetter" xml:space="preserve">
+    <value>The navigation property '{navigation}' on entity type '{entityType}' does not have a setter. Read-only collection navigation properties must be initialized before use.</value>
+  </data>
+  <data name="NavigationCannotCreateType" xml:space="preserve">
+    <value>The type of navigation property '{navigation}' on entity type '{entityType}' is '{foundType}' for which it was not possible to create a concrete instance. Either initialize the property before use, add a public parameterless constructor to the type, or use a type which can be assigned a HashSet&lt;&gt; or List&lt;&gt;.</value>
+  </data>
 </root>

--- a/test/EntityFramework.FunctionalTests/MonsterFixupTestBase.cs
+++ b/test/EntityFramework.FunctionalTests/MonsterFixupTestBase.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.FunctionalTests.TestModels;
+using Microsoft.Data.Entity.FunctionalTests.TestUtilities;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
 using Xunit;
@@ -1478,7 +1479,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 Assert.Same(barcode1, incorrectScan2.ExpectedBarcode);
                 Assert.Same(incorrectScan2, barcode1.BadScans.Single());
 
-                Assert.Empty(barcode3.BadScans);
+                Assert.Null(barcode3.BadScans);
 
                 var complaint1 = context.Complaints.Single(e => e.Details.StartsWith("Don't"));
                 var complaint2 = context.Complaints.Single(e => e.Details.StartsWith("Really"));
@@ -1506,7 +1507,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 Assert.Same(customer3, login3.Customer);
                 Assert.Same(login3, customer3.Logins.Single());
 
-                Assert.Empty(customer0.Logins);
+                Assert.Null(customer0.Logins);
 
                 var rsaToken1 = context.RsaTokens.Single(e => e.Serial == "1234");
                 var rsaToken2 = context.RsaTokens.Single(e => e.Serial == "2234");
@@ -1626,7 +1627,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 Assert.Same(product2, productReview3.Product);
                 Assert.Same(productReview3, product2.Reviews.Single());
 
-                Assert.Empty(product3.Reviews);
+                Assert.Null(product3.Reviews);
 
                 var productPhoto1 = context.ProductPhotos.Single(e => e.Photo[0] == 101);
                 var productPhoto2 = context.ProductPhotos.Single(e => e.Photo[0] == 103);
@@ -1637,7 +1638,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     product1.Photos.OrderBy(r => r.Photo.First()).ToArray());
 
                 Assert.Same(productPhoto3, product3.Photos.Single());
-                Assert.Empty(product2.Photos);
+                Assert.Null(product2.Photos);
 
                 var productWebFeature1 = context.ProductWebFeatures.Single(e => e.Heading.StartsWith("Waffle"));
                 var productWebFeature2 = context.ProductWebFeatures.Single(e => e.Heading.StartsWith("What"));
@@ -1649,13 +1650,13 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 Assert.Same(productWebFeature1, productReview1.Features.Single());
 
                 Assert.Null(productWebFeature2.Photo);
-                Assert.Empty(productPhoto2.Features);
+                Assert.Null(productPhoto2.Features);
 
                 Assert.Same(productReview3, productWebFeature2.Review);
                 Assert.Same(productWebFeature2, productReview3.Features.Single());
 
-                Assert.Empty(productPhoto3.Features);
-                Assert.Empty(productReview2.Features);
+                Assert.Null(productPhoto3.Features);
+                Assert.Null(productReview2.Features);
 
                 var supplier1 = context.Suppliers.Single(e => e.Name.StartsWith("Trading"));
                 var supplier2 = context.Suppliers.Single(e => e.Name.StartsWith("Ants"));
@@ -1747,7 +1748,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             AssertConsistent(
                 expectedPrincipal,
                 expectedDependents,
-                e => e.BadScans.OrderBy(m => m.Details),
+                e => e.BadScans.NullChecked().OrderBy(m => m.Details),
                 e => e.ExpectedBarcode,
                 e => e.Code,
                 e => e.ExpectedCode);
@@ -1769,7 +1770,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             AssertConsistent(
                 expectedPrincipal,
                 expectedDependents,
-                e => e.Features.OrderBy(f => f.Heading),
+                e => e.Features.NullChecked().OrderBy(f => f.Heading),
                 e => e.Photo,
                 e => Tuple.Create(e.PhotoId, e.ProductId),
                 e => e.ProductId == null || e.PhotoId == null ? null : Tuple.Create(e.ReviewId, e.ProductId));
@@ -1780,7 +1781,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             AssertConsistent(
                 expectedPrincipal,
                 expectedDependents,
-                e => e.Features.OrderBy(f => f.Heading),
+                e => e.Features.NullChecked().OrderBy(f => f.Heading),
                 e => e.Review,
                 e => Tuple.Create(e.ReviewId, e.ProductId),
                 e => e.ProductId == null ? null : Tuple.Create(e.ReviewId, e.ProductId));
@@ -1791,7 +1792,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             AssertConsistent(
                 expectedPrincipal,
                 expectedDependents,
-                e => e.ReceivedMessages.OrderBy(m => m.Body),
+                e => e.ReceivedMessages.NullChecked().OrderBy(m => m.Body),
                 e => e.Recipient,
                 e => e.Username,
                 e => e.ToUsername);
@@ -1802,7 +1803,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             AssertConsistent(
                 expectedPrincipal,
                 expectedDependents,
-                e => e.SentMessages.OrderBy(m => m.Body),
+                e => e.SentMessages.NullChecked().OrderBy(m => m.Body),
                 e => e.Sender,
                 e => e.Username,
                 e => e.FromUsername);

--- a/test/EntityFramework.FunctionalTests/TestModels/ChangedChangingMonsterContext.cs
+++ b/test/EntityFramework.FunctionalTests/TestModels/ChangedChangingMonsterContext.cs
@@ -100,9 +100,9 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
             private ICollection<IIncorrectScan> _badScans;
             private IBarcodeDetail _detail;
 
-            public Barcode()
+            public void InitializeCollections()
             {
-                BadScans = new HashSet<IIncorrectScan>();
+                BadScans = BadScans ?? new HashSet<IIncorrectScan>();
             }
 
             public byte[] Code
@@ -619,9 +619,13 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
 
             public AnOrder()
             {
-                OrderLines = new HashSet<IOrderLine>();
-                Notes = new HashSet<IOrderNote>();
                 Concurrency = new ConcurrencyInfo();
+            }
+
+            public void InitializeCollections()
+            {
+                OrderLines = OrderLines ?? new HashSet<IOrderLine>();
+                Notes = Notes ?? new HashSet<IOrderNote>();
             }
 
             public int AnOrderId
@@ -862,14 +866,18 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
 
             public Product()
             {
-                Suppliers = new HashSet<ISupplier>();
-                //Replaces = new HashSet<DiscontinuedProduct>();
-                Reviews = new HashSet<IProductReview>();
-                Photos = new HashSet<IProductPhoto>();
-                Barcodes = new HashSet<IBarcode>();
                 Dimensions = new Dimensions();
                 ComplexConcurrency = new ConcurrencyInfo();
                 NestedComplexConcurrency = new AuditInfo();
+            }
+
+            public void InitializeCollections()
+            {
+                Suppliers = Suppliers ?? new HashSet<ISupplier>();
+                //Replaces = new HashSet<DiscontinuedProduct>();
+                Reviews = Reviews ?? new HashSet<IProductReview>();
+                Photos = Photos ?? new HashSet<IProductPhoto>();
+                Barcodes = Barcodes ?? new HashSet<IBarcode>();
             }
 
             public int ProductId
@@ -956,9 +964,9 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
             private byte[] _photo;
             private ICollection<IProductWebFeature> _features;
 
-            public ProductPhoto()
+            public void InitializeCollections()
             {
-                Features = new HashSet<IProductWebFeature>();
+                Features = Features ?? new HashSet<IProductWebFeature>();
             }
 
             public int ProductId
@@ -994,9 +1002,9 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
             private IProduct _product;
             private ICollection<IProductWebFeature> _features;
 
-            public ProductReview()
+            public void InitializeCollections()
             {
-                Features = new HashSet<IProductWebFeature>();
+                Features = Features ?? new HashSet<IProductWebFeature>();
             }
 
             public int ProductId
@@ -1236,9 +1244,9 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
             private ICollection<IProduct> _products;
             private ISupplierLogo _logo;
 
-            public Supplier()
+            public void InitializeCollections()
             {
-                Products = new HashSet<IProduct>();
+                Products = Products ?? new HashSet<IProduct>();
                 //BackOrderLines = new HashSet<BackOrderLine>();
             }
 
@@ -1309,10 +1317,14 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
 
             public Customer()
             {
-                Orders = new HashSet<IAnOrder>();
-                Logins = new HashSet<ILogin>();
                 ContactInfo = new ContactDetails();
                 Auditing = new AuditInfo();
+            }
+
+            public void InitializeCollections()
+            {
+                Orders = Orders ?? new HashSet<IAnOrder>();
+                Logins = Logins ?? new HashSet<ILogin>();
             }
 
             public int CustomerId
@@ -1387,11 +1399,11 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
             private ICollection<IMessage> _receivedMessages;
             private ICollection<IAnOrder> _orders;
 
-            public Login()
+            public void InitializeCollections()
             {
-                SentMessages = new HashSet<IMessage>();
-                ReceivedMessages = new HashSet<IMessage>();
-                Orders = new HashSet<IAnOrder>();
+                SentMessages = SentMessages ?? new HashSet<IMessage>();
+                ReceivedMessages = ReceivedMessages ?? new HashSet<IMessage>();
+                Orders = Orders ?? new HashSet<IAnOrder>();
             }
 
             public string Username

--- a/test/EntityFramework.FunctionalTests/TestModels/ChangedOnlyMonsterContext.cs
+++ b/test/EntityFramework.FunctionalTests/TestModels/ChangedOnlyMonsterContext.cs
@@ -90,9 +90,9 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
             private ICollection<IIncorrectScan> _badScans;
             private IBarcodeDetail _detail;
 
-            public Barcode()
+            public void InitializeCollections()
             {
-                BadScans = new HashSet<IIncorrectScan>();
+                BadScans = BadScans ?? new HashSet<IIncorrectScan>();
             }
 
             public byte[] Code
@@ -609,9 +609,13 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
 
             public AnOrder()
             {
-                OrderLines = new HashSet<IOrderLine>();
-                Notes = new HashSet<IOrderNote>();
                 Concurrency = new ConcurrencyInfo();
+            }
+
+            public void InitializeCollections()
+            {
+                OrderLines = OrderLines ?? new HashSet<IOrderLine>();
+                Notes = Notes ?? new HashSet<IOrderNote>();
             }
 
             public int AnOrderId
@@ -852,14 +856,18 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
 
             public Product()
             {
-                Suppliers = new HashSet<ISupplier>();
-                //Replaces = new HashSet<DiscontinuedProduct>();
-                Reviews = new HashSet<IProductReview>();
-                Photos = new HashSet<IProductPhoto>();
-                Barcodes = new HashSet<IBarcode>();
-                Dimensions = new Dimensions();
                 ComplexConcurrency = new ConcurrencyInfo();
                 NestedComplexConcurrency = new AuditInfo();
+            }
+
+            public void InitializeCollections()
+            {
+                Suppliers = Suppliers ?? new HashSet<ISupplier>();
+                //Replaces = new HashSet<DiscontinuedProduct>();
+                Reviews = Reviews ?? new HashSet<IProductReview>();
+                Photos = Photos ?? new HashSet<IProductPhoto>();
+                Barcodes = Barcodes ?? new HashSet<IBarcode>();
+                Dimensions = Dimensions ?? new Dimensions();
             }
 
             public int ProductId
@@ -946,9 +954,9 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
             private byte[] _photo;
             private ICollection<IProductWebFeature> _features;
 
-            public ProductPhoto()
+            public void InitializeCollections()
             {
-                Features = new HashSet<IProductWebFeature>();
+                Features = Features ?? new HashSet<IProductWebFeature>();
             }
 
             public int ProductId
@@ -984,9 +992,9 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
             private IProduct _product;
             private ICollection<IProductWebFeature> _features;
 
-            public ProductReview()
+            public void InitializeCollections()
             {
-                Features = new HashSet<IProductWebFeature>();
+                Features = Features ?? new HashSet<IProductWebFeature>();
             }
 
             public int ProductId
@@ -1226,9 +1234,9 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
             private ICollection<IProduct> _products;
             private ISupplierLogo _logo;
 
-            public Supplier()
+            public void InitializeCollections()
             {
-                Products = new HashSet<IProduct>();
+                Products = Products ?? new HashSet<IProduct>();
                 //BackOrderLines = new HashSet<BackOrderLine>();
             }
 
@@ -1299,10 +1307,14 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
 
             public Customer()
             {
-                Orders = new HashSet<IAnOrder>();
-                Logins = new HashSet<ILogin>();
                 ContactInfo = new ContactDetails();
                 Auditing = new AuditInfo();
+            }
+
+            public void InitializeCollections()
+            {
+                Orders = Orders ?? new HashSet<IAnOrder>();
+                Logins = Logins ?? new HashSet<ILogin>();
             }
 
             public int CustomerId
@@ -1377,11 +1389,11 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
             private ICollection<IMessage> _receivedMessages;
             private ICollection<IAnOrder> _orders;
 
-            public Login()
+            public void InitializeCollections()
             {
-                SentMessages = new HashSet<IMessage>();
-                ReceivedMessages = new HashSet<IMessage>();
-                Orders = new HashSet<IAnOrder>();
+                SentMessages = SentMessages ?? new HashSet<IMessage>();
+                ReceivedMessages = ReceivedMessages ?? new HashSet<IMessage>();
+                Orders = Orders ?? new HashSet<IAnOrder>();
             }
 
             public string Username

--- a/test/EntityFramework.FunctionalTests/TestModels/MonsterContext`.cs
+++ b/test/EntityFramework.FunctionalTests/TestModels/MonsterContext`.cs
@@ -709,8 +709,11 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
             var barcode3 = Add(new TBarcode { Code = new byte[] { 3, 2, 3, 4 }, Product = dependentNavs ? product3 : null, Text = "Barcode 3 2 3 4" });
             if (principalNavs)
             {
+                product1.InitializeCollections();
                 product1.Barcodes.Add(barcode1);
+                product2.InitializeCollections();
                 product2.Barcodes.Add(barcode2);
+                product3.InitializeCollections();
                 product3.Barcodes.Add(barcode3);
             }
 
@@ -732,6 +735,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                     });
             if (principalNavs)
             {
+                barcode2.InitializeCollections(); 
                 barcode2.BadScans.Add(incorrectScan1);
             }
 
@@ -745,6 +749,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                     });
             if (principalNavs)
             {
+                barcode1.InitializeCollections();
                 barcode1.BadScans.Add(incorrectScan2);
             }
 
@@ -775,8 +780,11 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
             var login3 = Add(new TLogin { Customer = dependentNavs ? customer3 : null, Username = "TheStripedMenace", AlternateUsername = "Tarquin" });
             if (principalNavs)
             {
+                customer1.InitializeCollections();
                 customer1.Logins.Add(login1);
+                customer2.InitializeCollections();
                 customer2.Logins.Add(login2);
+                customer3.InitializeCollections();
                 customer3.Logins.Add(login3);
             }
 
@@ -838,7 +846,9 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                 });
             if (principalNavs)
             {
+                login1.InitializeCollections();
                 login1.SentMessages.Add(message1);
+                login2.InitializeCollections();
                 login2.ReceivedMessages.Add(message1);
             }
 
@@ -880,6 +890,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                 customer3.Orders.Add(order3);
                 login1.Orders.Add(order1);
                 login2.Orders.Add(order2);
+                login3.InitializeCollections();
                 login3.Orders.Add(order3);
             }
 
@@ -888,6 +899,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
             var orderNote3 = Add(new TOrderNote { Note = "But no coffee. :-(", Order = dependentNavs ? order1 : null });
             if (principalNavs)
             {
+                order1.InitializeCollections();
                 order1.Notes.Add(orderNote1);
                 order1.Notes.Add(orderNote2);
                 order1.Notes.Add(orderNote3);
@@ -907,9 +919,11 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
             {
                 order1.OrderLines.Add(orderLine1);
                 order1.OrderLines.Add(orderLine2);
+                order2.InitializeCollections();
                 order2.OrderLines.Add(orderLine3);
                 order2.OrderLines.Add(orderLine4);
                 order2.OrderLines.Add(orderLine5);
+                order3.InitializeCollections();
                 order3.OrderLines.Add(orderLine6);
             }
 
@@ -950,7 +964,9 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                 });
             if (principalNavs)
             {
+                productPhoto1.InitializeCollections();
                 productPhoto1.Features.Add(productWebFeature1);
+                productReview1.InitializeCollections();
                 productReview1.Features.Add(productWebFeature1);
             }
 
@@ -962,6 +978,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                 });
             if (principalNavs)
             {
+                productReview3.InitializeCollections();
                 productReview3.Features.Add(productWebFeature2);
             }
 
@@ -1076,8 +1093,11 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
             var barcode2 = toAdd[1].AddEx(new TBarcode { Code = new byte[] { 2, 2, 3, 4 }, Text = "Barcode 2 2 3 4" });
             var barcode3 = toAdd[1].AddEx(new TBarcode { Code = new byte[] { 3, 2, 3, 4 }, Text = "Barcode 3 2 3 4" });
 
+            product1.InitializeCollections();
             product1.Barcodes.Add(barcode1);
+            product2.InitializeCollections();
             product2.Barcodes.Add(barcode2);
+            product3.InitializeCollections();
             product3.Barcodes.Add(barcode3);
 
             var barcodeDetails1 = toAdd[1].AddEx(new TBarcodeDetail { RegisteredTo = "Eeky Bear" });
@@ -1093,6 +1113,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                         Details = "Treats not Donuts",
                         ActualBarcode = barcode3
                     });
+            barcode2.InitializeCollections();
             barcode2.BadScans.Add(incorrectScan1);
 
             var incorrectScan2 = toAdd[1].AddEx(
@@ -1102,6 +1123,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                         Details = "Wot no waffles?",
                         ActualBarcode = barcode2
                     });
+            barcode1.InitializeCollections();
             barcode1.BadScans.Add(incorrectScan2);
 
             var complaint1 = toAdd[1].AddEx(new TComplaint
@@ -1127,8 +1149,11 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
             var login2 = toAdd[1].AddEx(new TLogin { Username = "MrsBossyPants", AlternateUsername = "Sue" });
             var login3 = toAdd[1].AddEx(new TLogin { Username = "TheStripedMenace", AlternateUsername = "Tarquin" });
 
+            customer1.InitializeCollections();
             customer1.Logins.Add(login1);
+            customer2.InitializeCollections();
             customer2.Logins.Add(login2);
+            customer3.InitializeCollections();
             customer3.Logins.Add(login3);
 
             var suspiciousActivity1 = toAdd[2].AddEx(new TSuspiciousActivity { Activity = "Pig prints on keyboard", Username = login3.Username });
@@ -1178,7 +1203,9 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                     Sent = DateTime.Now,
                 });
 
+            login1.InitializeCollections();
             login1.SentMessages.Add(message1);
+            login2.InitializeCollections();
             login2.ReceivedMessages.Add(message1);
 
             var message2 = toAdd[2].AddEx(new TMessage
@@ -1211,12 +1238,14 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
 
             login1.Orders.Add(order1);
             login2.Orders.Add(order2);
+            login3.InitializeCollections();
             login3.Orders.Add(order3);
 
             var orderNote1 = toAdd[2].AddEx(new TOrderNote { Note = "Must have tea!" });
             var orderNote2 = toAdd[2].AddEx(new TOrderNote { Note = "And donuts!" });
             var orderNote3 = toAdd[2].AddEx(new TOrderNote { Note = "But no coffee. :-(" });
 
+            order1.InitializeCollections();
             order1.Notes.Add(orderNote1);
             order1.Notes.Add(orderNote2);
             order1.Notes.Add(orderNote3);
@@ -1234,9 +1263,11 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
 
             order1.OrderLines.Add(orderLine1);
             order1.OrderLines.Add(orderLine2);
+            order2.InitializeCollections();
             order2.OrderLines.Add(orderLine3);
             order2.OrderLines.Add(orderLine4);
             order2.OrderLines.Add(orderLine5);
+            order3.InitializeCollections();
             order3.OrderLines.Add(orderLine6);
 
             var productDetail1 = toAdd[0].AddEx(new TProductDetail { Details = "A Waffle Cart specialty!" });
@@ -1267,7 +1298,9 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                     ProductId = product1.ProductId,
                 });
 
+            productPhoto1.InitializeCollections();
             productPhoto1.Features.Add(productWebFeature1);
+            productReview1.InitializeCollections();
             productReview1.Features.Add(productWebFeature1);
 
             var productWebFeature2 = toAdd[0].AddEx(new TProductWebFeature
@@ -1276,6 +1309,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
                     ProductId = product2.ProductId,
                 });
 
+            productReview3.InitializeCollections();
             productReview3.Features.Add(productWebFeature2);
 
             var supplier1 = toAdd[0].AddEx(new TSupplier { Name = "Trading As Trent" });

--- a/test/EntityFramework.FunctionalTests/TestModels/MonsterModel.cs
+++ b/test/EntityFramework.FunctionalTests/TestModels/MonsterModel.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
         IProduct Product { get; set; }
         ICollection<IIncorrectScan> BadScans { get; set; }
         IBarcodeDetail Detail { get; set; }
+        void InitializeCollections();
     }
 
     public interface IComplaint
@@ -159,6 +160,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
         ICollection<IOrderNote> Notes { get; set; }
         string Username { get; set; }
         ILogin Login { get; set; }
+        void InitializeCollections();
     }
 
     public interface IOrderNote
@@ -216,6 +218,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
         ICollection<IProductReview> Reviews { get; set; }
         ICollection<IProductPhoto> Photos { get; set; }
         ICollection<IBarcode> Barcodes { get; set; }
+        void InitializeCollections();
     }
 
     public interface IProductPhoto
@@ -224,6 +227,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
         int PhotoId { get; set; }
         byte[] Photo { get; set; }
         ICollection<IProductWebFeature> Features { get; set; }
+        void InitializeCollections();
     }
 
     public interface IProductReview
@@ -233,6 +237,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
         string Review { get; set; }
         IProduct Product { get; set; }
         ICollection<IProductWebFeature> Features { get; set; }
+        void InitializeCollections();
     }
 
     public interface IProductWebFeature
@@ -291,6 +296,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
         ICollection<IProduct> Products { get; set; }
         //ICollection<BackOrderLine> BackOrderLines { get; set; }
         ISupplierLogo Logo { get; set; }
+        void InitializeCollections();
     }
 
     public interface ISuspiciousActivity
@@ -325,6 +331,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
         ICustomer Husband { get; set; }
         ICustomer Wife { get; set; }
         ICustomerInfo Info { get; set; }
+        void InitializeCollections();
     }
 
     public enum LicenseState
@@ -344,6 +351,7 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
         ICollection<IMessage> SentMessages { get; set; }
         ICollection<IMessage> ReceivedMessages { get; set; }
         ICollection<IAnOrder> Orders { get; set; }
+        void InitializeCollections();
     }
 
     public class Phone

--- a/test/EntityFramework.FunctionalTests/TestModels/SnapshotMonsterContext.cs
+++ b/test/EntityFramework.FunctionalTests/TestModels/SnapshotMonsterContext.cs
@@ -46,9 +46,9 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
 
         public class Barcode : IBarcode
         {
-            public Barcode()
+            public void InitializeCollections()
             {
-                BadScans = new HashSet<IIncorrectScan>();
+                BadScans = BadScans ?? new HashSet<IIncorrectScan>();
             }
 
             public byte[] Code { get; set; }
@@ -195,9 +195,13 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
         {
             public AnOrder()
             {
-                OrderLines = new HashSet<IOrderLine>();
-                Notes = new HashSet<IOrderNote>();
                 Concurrency = new ConcurrencyInfo();
+            }
+
+            public void InitializeCollections()
+            {
+                OrderLines = OrderLines ?? new HashSet<IOrderLine>();
+                Notes = Notes ?? new HashSet<IOrderNote>();
             }
 
             public int AnOrderId { get; set; }
@@ -264,14 +268,18 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
         {
             public Product()
             {
-                Suppliers = new HashSet<ISupplier>();
-                Replaces = new HashSet<DiscontinuedProduct>();
-                Reviews = new HashSet<IProductReview>();
-                Photos = new HashSet<IProductPhoto>();
-                Barcodes = new HashSet<IBarcode>();
                 Dimensions = new Dimensions();
                 ComplexConcurrency = new ConcurrencyInfo();
                 NestedComplexConcurrency = new AuditInfo();
+            }
+
+            public void InitializeCollections()
+            {
+                Suppliers = Suppliers ?? new HashSet<ISupplier>();
+                Replaces = Replaces ?? new HashSet<DiscontinuedProduct>();
+                Reviews = Reviews ?? new HashSet<IProductReview>();
+                Photos = Photos ?? new HashSet<IProductPhoto>();
+                Barcodes = Barcodes ?? new HashSet<IBarcode>();
             }
 
             public int ProductId { get; set; }
@@ -299,9 +307,9 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
 
         public class ProductPhoto : IProductPhoto
         {
-            public ProductPhoto()
+            public void InitializeCollections()
             {
-                Features = new HashSet<IProductWebFeature>();
+                Features = Features ?? new HashSet<IProductWebFeature>();
             }
 
             public int ProductId { get; set; }
@@ -313,9 +321,9 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
 
         public class ProductReview : IProductReview
         {
-            public ProductReview()
+            public void InitializeCollections()
             {
-                Features = new HashSet<IProductWebFeature>();
+                Features = Features ?? new HashSet<IProductWebFeature>();
             }
 
             public int ProductId { get; set; }
@@ -382,9 +390,9 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
 
         public class Supplier : ISupplier
         {
-            public Supplier()
+            public void InitializeCollections()
             {
-                Products = new HashSet<IProduct>();
+                Products = Products ?? new HashSet<IProduct>();
                 //BackOrderLines = new HashSet<BackOrderLine>();
             }
 
@@ -408,10 +416,14 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
         {
             public Customer()
             {
-                Orders = new HashSet<IAnOrder>();
-                Logins = new HashSet<ILogin>();
                 ContactInfo = new ContactDetails();
                 Auditing = new AuditInfo();
+            }
+
+            public void InitializeCollections()
+            {
+                Orders = Orders ?? new HashSet<IAnOrder>();
+                Logins = Logins ?? new HashSet<ILogin>();
             }
 
             public int CustomerId { get; set; }
@@ -430,11 +442,11 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestModels
 
         public class Login : ILogin
         {
-            public Login()
+            public void InitializeCollections()
             {
-                SentMessages = new HashSet<IMessage>();
-                ReceivedMessages = new HashSet<IMessage>();
-                Orders = new HashSet<IAnOrder>();
+                SentMessages = SentMessages ?? new HashSet<IMessage>();
+                ReceivedMessages = ReceivedMessages ?? new HashSet<IMessage>();
+                Orders = Orders ?? new HashSet<IAnOrder>();
             }
 
             public string Username { get; set; }

--- a/test/EntityFramework.FunctionalTests/TestUtilities/Extensions.cs
+++ b/test/EntityFramework.FunctionalTests/TestUtilities/Extensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using Xunit;
@@ -19,6 +20,11 @@ namespace Microsoft.Data.Entity.FunctionalTests.TestUtilities
             var strings = resourceAssemblyType.GetTypeInfo().Assembly.GetType(resourceAssemblyType.Namespace + ".Strings");
             var expectedMessage = (string)strings.GetTypeInfo().GetDeclaredMethods(expectedResourceMethod).Single().Invoke(null, parameters);
             Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        public static IEnumerable<T> NullChecked<T>(this IEnumerable<T> enumerable)
+        {
+            return enumerable ?? Enumerable.Empty<T>();
         }
     }
 }

--- a/test/EntityFramework.Tests/EntityFramework.Tests.csproj
+++ b/test/EntityFramework.Tests/EntityFramework.Tests.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Identity\ValueGeneratorPoolTest.cs" />
     <Compile Include="Identity\ValueGeneratorSelectorTest.cs" />
     <Compile Include="Metadata\BasicModelBuilderTest.cs" />
+    <Compile Include="Metadata\CollectionTyoeFactoryTest.cs" />
     <Compile Include="Metadata\EntityTypeExtensionsTest.cs" />
     <Compile Include="Metadata\IndexTest.cs" />
     <Compile Include="Metadata\MetadataBuilderTest.cs" />

--- a/test/EntityFramework.Tests/Metadata/ClrCollectionAccessorSourceTest.cs
+++ b/test/EntityFramework.Tests/Metadata/ClrCollectionAccessorSourceTest.cs
@@ -47,20 +47,66 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             AccessorTest("AsMyCollection", e => e.AsMyCollection);
         }
 
-        private static void AccessorTest(string navigationName, Func<MyEntity, IEnumerable<MyOtherEntity>> reader)
+        [Fact]
+        public void Delegate_accessor_is_returned_when_no_setter()
         {
-            var entityType = new EntityType(typeof(MyEntity));
-            var otherType = new EntityType(typeof(MyOtherEntity));
-            var foreignKey = otherType.GetOrAddForeignKey(
-                entityType.GetOrSetPrimaryKey(entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true)),
-                otherType.GetOrAddProperty("MyEntityId", typeof(int), shadowProperty: true));
+            AccessorTest("WithNoSetter", e => e.WithNoSetter);
+        }
 
-            var navigation = entityType.AddNavigation(new Navigation(foreignKey, navigationName, pointsToPrincipal: false));
+        [Fact]
+        public void Delegate_accessor_is_returned_when_no_public_constructor()
+        {
+            AccessorTest("AsMyPrivateCollection", e => e.AsMyPrivateCollection);
+        }
 
-            var accessor = new ClrCollectionAccessorSource().GetAccessor(navigation);
+        [Fact]
+        public void Delegate_accessor_is_returned_when_no_internal_constructor()
+        {
+            AccessorTest("AsMyInternalCollection", e => e.AsMyInternalCollection);
+        }
+
+        [Fact]
+        public void Delegate_accessor_is_returned_when_no_parameterless_constructor()
+        {
+            AccessorTest("AsMyUnavailableCollection", e => e.AsMyUnavailableCollection);
+        }
+
+        [Fact]
+        public void Delegate_accessor_handles_uninitialized_collections()
+        {
+            AccessorTest("AsICollection", e => e.AsICollection, initializeCollections: false);
+        }
+
+        [Fact]
+        public void Delegate_accessor_handles_uninitialized_collections_for_interface_navigation_derived_from_ICollection()
+        {
+            AccessorTest("AsIList", e => e.AsIList, initializeCollections: false);
+        }
+
+        [Fact]
+        public void Delegate_accessor_handles_uninitialized_collections_for_concrete_generic_type_navigation()
+        {
+            AccessorTest("AsList", e => e.AsList, initializeCollections: false);
+        }
+
+        [Fact]
+        public void Delegate_accessor_handles_uninitialized_collections_for_concrete_non_generic_type_navigation()
+        {
+            AccessorTest("AsMyCollection", e => e.AsMyCollection, initializeCollections: false);
+        }
+
+        private static void AccessorTest(
+            string navigationName, Func<MyEntity, IEnumerable<MyOtherEntity>> reader, bool initializeCollections = true)
+        {
+            var accessor = new ClrCollectionAccessorSource().GetAccessor(CreateNavigation(navigationName));
 
             var entity = new MyEntity();
             var value = new MyOtherEntity();
+
+            if (initializeCollections)
+            {
+                entity.InitializeCollections();
+            }
 
             Assert.False(accessor.Contains(entity, value));
             Assert.DoesNotThrow(() => accessor.Remove(entity, value));
@@ -92,33 +138,179 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(source.GetAccessor(navigation), source.GetAccessor(navigation));
         }
 
-        #region Fixture
+        [Fact]
+        public void Creating_accessor_for_navigation_without_getter_throws()
+        {
+            var navigation = CreateNavigation("WithNoGetter");
+
+            Assert.Equal(
+                Strings.FormatNavigationNoGetter("WithNoGetter", typeof(MyEntity).FullName),
+                Assert.Throws<NotSupportedException>(() => new ClrCollectionAccessorSource().GetAccessor(navigation)).Message);
+        }
+
+        [Fact]
+        public void Creating_accessor_for_enumerable_navigation_throws()
+        {
+            var navigation = CreateNavigation("AsIEnumerable");
+
+            Assert.Equal(
+                Strings.FormatNavigationBadType(
+                    "AsIEnumerable", typeof(MyEntity).FullName, typeof(IEnumerable<MyOtherEntity>).FullName, typeof(MyOtherEntity).FullName),
+                Assert.Throws<NotSupportedException>(() => new ClrCollectionAccessorSource().GetAccessor(navigation)).Message);
+        }
+
+        [Fact]
+        public void Creating_accessor_for_array_navigation_throws()
+        {
+            var navigation = CreateNavigation("AsArray");
+
+            Assert.Equal(
+                Strings.FormatNavigationArray("AsArray", typeof(MyEntity).FullName, typeof(MyOtherEntity[]).FullName),
+                Assert.Throws<NotSupportedException>(() => new ClrCollectionAccessorSource().GetAccessor(navigation)).Message);
+        }
+
+        [Fact]
+        public void Initialization_for_navigation_without_setter_throws()
+        {
+            var accessor = new ClrCollectionAccessorSource().GetAccessor(CreateNavigation("WithNoSetter"));
+
+            Assert.Equal(
+                Strings.FormatNavigationNoSetter("WithNoSetter", typeof(MyEntity).FullName),
+                Assert.Throws<InvalidOperationException>(() => accessor.Add(new MyEntity(), new MyOtherEntity())).Message);
+        }
+
+        [Fact]
+        public void Initialization_for_navigation_with_private_constructor_throws()
+        {
+            var accessor = new ClrCollectionAccessorSource().GetAccessor(CreateNavigation("AsMyPrivateCollection"));
+
+            Assert.Equal(
+                Strings.FormatNavigationCannotCreateType("AsMyPrivateCollection", typeof(MyEntity).FullName, typeof(MyPrivateCollection).FullName),
+                Assert.Throws<InvalidOperationException>(() => accessor.Add(new MyEntity(), new MyOtherEntity())).Message);
+        }
+
+        [Fact]
+        public void Initialization_for_navigation_with_internal_constructor_throws()
+        {
+            var accessor = new ClrCollectionAccessorSource().GetAccessor(CreateNavigation("AsMyInternalCollection"));
+
+            Assert.Equal(
+                Strings.FormatNavigationCannotCreateType("AsMyInternalCollection", typeof(MyEntity).FullName, typeof(MyInternalCollection).FullName),
+                Assert.Throws<InvalidOperationException>(() => accessor.Add(new MyEntity(), new MyOtherEntity())).Message);
+        }
+
+        [Fact]
+        public void Initialization_for_navigation_without_parameterless_constructor_throws()
+        {
+            var accessor = new ClrCollectionAccessorSource().GetAccessor(CreateNavigation("AsMyUnavailableCollection"));
+
+            Assert.Equal(
+                Strings.FormatNavigationCannotCreateType("AsMyUnavailableCollection", typeof(MyEntity).FullName, typeof(MyUnavailableCollection).FullName),
+                Assert.Throws<InvalidOperationException>(() => accessor.Add(new MyEntity(), new MyOtherEntity())).Message);
+        }
+
+        private static Navigation CreateNavigation(string navigationName)
+        {
+            var entityType = new EntityType(typeof(MyEntity));
+            var otherType = new EntityType(typeof(MyOtherEntity));
+            var foreignKey = otherType.GetOrAddForeignKey(
+                entityType.GetOrSetPrimaryKey(entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true)),
+                otherType.GetOrAddProperty("MyEntityId", typeof(int), shadowProperty: true));
+
+            return entityType.AddNavigation(new Navigation(foreignKey, navigationName, pointsToPrincipal: false));
+        }
 
         private class MyEntity
         {
-            private readonly ICollection<MyOtherEntity> _asICollection = new HashSet<MyOtherEntity>();
-            private readonly IList<MyOtherEntity> _asIList = new List<MyOtherEntity>();
-            private readonly List<MyOtherEntity> _asList = new List<MyOtherEntity>();
-            private readonly MyCollection _myCollection = new MyCollection();
+            private ICollection<MyOtherEntity> _asICollection;
+            private IList<MyOtherEntity> _asIList;
+            private List<MyOtherEntity> _asList;
+            private MyCollection _myCollection;
+            private ICollection<MyOtherEntity> _withNoSetter;
+            private ICollection<MyOtherEntity> _withNoGetter;
+            private IEnumerable<MyOtherEntity> _enumerable;
+            private MyOtherEntity[] _array;
+            private MyPrivateCollection _privateCollection;
+            private MyInternalCollection _internalCollection;
+            private MyUnavailableCollection _unavailableCollection;
+
+            public void InitializeCollections()
+            {
+                _asICollection = new HashSet<MyOtherEntity>();
+                _asIList = new List<MyOtherEntity>();
+                _asList = new List<MyOtherEntity>();
+                _myCollection = new MyCollection();
+                _withNoSetter = new HashSet<MyOtherEntity>();
+                _withNoGetter = new HashSet<MyOtherEntity>();
+                _enumerable = new HashSet<MyOtherEntity>();
+                _array = new MyOtherEntity[0];
+                _privateCollection = MyPrivateCollection.Create();
+                _internalCollection = new MyInternalCollection();
+                _unavailableCollection = new MyUnavailableCollection(true);
+            }
 
             internal ICollection<MyOtherEntity> AsICollection
             {
                 get { return _asICollection; }
+                set { _asICollection = value; }
             }
 
             internal IList<MyOtherEntity> AsIList
             {
                 get { return _asIList; }
+                set { _asIList = value; }
             }
 
             internal List<MyOtherEntity> AsList
             {
                 get { return _asList; }
+                set { _asList = value; }
             }
 
-            internal List<MyOtherEntity> AsMyCollection
+            internal MyCollection AsMyCollection
             {
                 get { return _myCollection; }
+                set { _myCollection = value; }
+            }
+
+            internal ICollection<MyOtherEntity> WithNoSetter
+            {
+                get { return _withNoSetter; }
+            }
+
+            internal ICollection<MyOtherEntity> WithNoGetter
+            {
+                set { _withNoGetter = value; }
+            }
+
+            internal IEnumerable<MyOtherEntity> AsIEnumerable
+            {
+                get { return _enumerable; }
+                set { _enumerable = value; }
+            }
+
+            internal MyOtherEntity[] AsArray
+            {
+                get { return _array; }
+                set { _array = value; }
+            }
+
+            internal MyPrivateCollection AsMyPrivateCollection
+            {
+                get { return _privateCollection; }
+                set { _privateCollection = value; }
+            }
+
+            internal MyInternalCollection AsMyInternalCollection
+            {
+                get { return _internalCollection; }
+                set { _internalCollection = value; }
+            }
+
+            internal MyUnavailableCollection AsMyUnavailableCollection
+            {
+                get { return _unavailableCollection; }
+                set { _unavailableCollection = value; }
             }
         }
 
@@ -130,6 +322,31 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
         }
 
-        #endregion
+        private class MyPrivateCollection : List<MyOtherEntity>
+        {
+            private MyPrivateCollection()
+            {
+            }
+
+            public static MyPrivateCollection Create()
+            {
+                return new MyPrivateCollection();
+            }
+        }
+
+        private class MyInternalCollection : List<MyOtherEntity>
+        {
+            // ReSharper disable once EmptyConstructor
+            internal MyInternalCollection()
+            {
+            }
+        }
+
+        private class MyUnavailableCollection : List<MyOtherEntity>
+        {
+            public MyUnavailableCollection(bool _)
+            {
+            }
+        }
     }
 }

--- a/test/EntityFramework.Tests/Metadata/CollectionTyoeFactoryTest.cs
+++ b/test/EntityFramework.Tests/Metadata/CollectionTyoeFactoryTest.cs
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Microsoft.Data.Entity.Metadata;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.Metadata
+{
+    public class CollectionTypeFactoryTest
+    {
+        [Fact]
+        public void Returns_given_type_if_public_parameterless_constructor_available()
+        {
+            var factory = new CollectionTypeFactory();
+
+            Assert.Same(typeof(CustomHashSet), factory.TryFindTypeToInstantiate(typeof(CustomHashSet)));
+            Assert.Same(typeof(CustomList), factory.TryFindTypeToInstantiate(typeof(CustomList)));
+            Assert.Same(typeof(HashSet<Random>), factory.TryFindTypeToInstantiate(typeof(HashSet<Random>)));
+            Assert.Same(typeof(List<Random>), factory.TryFindTypeToInstantiate(typeof(List<Random>)));
+            Assert.Same(typeof(ObservableCollection<Random>), factory.TryFindTypeToInstantiate(typeof(ObservableCollection<Random>)));
+        }
+
+        [Fact]
+        public void Returns_HashSet_if_assignable()
+        {
+            var factory = new CollectionTypeFactory();
+
+            Assert.Same(typeof(HashSet<Random>), factory.TryFindTypeToInstantiate(typeof(ICollection<Random>)));
+
+            Assert.Same(typeof(HashSet<Random>), factory.TryFindTypeToInstantiate(typeof(ISet<Random>)));
+        }
+
+        [Fact]
+        public void Returns_List_if_assignable()
+        {
+            Assert.Same(typeof(List<Random>), new CollectionTypeFactory().TryFindTypeToInstantiate(typeof(IList<Random>)));
+        }
+
+        [Fact]
+        public void Returns_null_when_no_usable_concrete_type_found()
+        {
+            var factory = new CollectionTypeFactory();
+
+            Assert.Null(factory.TryFindTypeToInstantiate(typeof(PrivateConstructor)));
+            Assert.Null(factory.TryFindTypeToInstantiate(typeof(InternalConstructor)));
+            Assert.Null(factory.TryFindTypeToInstantiate(typeof(ProtectedConstructor)));
+            Assert.Null(factory.TryFindTypeToInstantiate(typeof(NoParameterlessConstructor)));
+            Assert.Null(factory.TryFindTypeToInstantiate(typeof(Abstract)));
+            Assert.Null(factory.TryFindTypeToInstantiate(typeof(object)));
+            Assert.Null(factory.TryFindTypeToInstantiate(typeof(Random)));
+            Assert.Null(factory.TryFindTypeToInstantiate(typeof(IEnumerable<Random>)));
+        }
+
+        private class CustomHashSet : HashSet<Random>
+        {
+        }
+
+        private class CustomList : List<Random>
+        {
+        }
+
+        private class PrivateConstructor : List<Random>
+        {
+            private PrivateConstructor()
+            {
+            }
+        }
+
+        private class InternalConstructor : List<Random>
+        {
+            // ReSharper disable once EmptyConstructor
+            internal InternalConstructor()
+            {
+            }
+        }
+
+        private class ProtectedConstructor : List<Random>
+        {
+            protected ProtectedConstructor()
+            {
+            }
+        }
+
+        private class NoParameterlessConstructor : List<Random>
+        {
+            public NoParameterlessConstructor(bool _)
+            {
+            }
+        }
+
+        private abstract class Abstract : List<Random>
+        {
+        }
+    }
+}


### PR DESCRIPTION
Support uninitialized collection navigation properties

Issues #451, #152

Specifically:
- Collection can be null for Contains and Remove calls
- Collection is initialized if possible if null when Add is called. Same rules used for the type to instantiate as in EF6.
- Error checking for when we can't use/initialize the collection
