### PR TITLE
Hiring a temp...

### DIFF
--- a/src/EntityFramework/ChangeTracking/ChangeDetector.cs
+++ b/src/EntityFramework/ChangeTracking/ChangeDetector.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
 
             if (property != null)
             {
-                entry.SetPropertyModified(property, true);
+                entry.SetPropertyModified(property);
 
                 // Note: Make sure DetectPrincipalKeyChange is called even if DetectForeignKeyChange has returned true
                 var foreignKeyChange = DetectForeignKeyChange(entry, property);
@@ -140,7 +140,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
                 // TODO: Perf: don't lookup accessor twice
                 if (!Equals(entry[property], originalValues[property]))
                 {
-                    entry.SetPropertyModified(property, true);
+                    entry.SetPropertyModified(property);
                     foundChanges = true;
                 }
 

--- a/src/EntityFramework/ChangeTracking/StateData.cs
+++ b/src/EntityFramework/ChangeTracking/StateData.cs
@@ -24,11 +24,11 @@ namespace Microsoft.Data.Entity.ChangeTracking
                 _bits = new int[(propertyCount + BitsForAdditionalState - 1) / BitsPerInt + 1];
             }
 
-            public void SetAllPropertiesModified(int propertyCount, bool isModified)
+            public void FlagAllProperties(int propertyCount, bool isFlagged)
             {
                 for (var i = 0; i < _bits.Length; i++)
                 {
-                    if (isModified)
+                    if (isFlagged)
                     {
                         _bits[i] |= CreateMaskForWrite(i, propertyCount);
                     }
@@ -51,18 +51,18 @@ namespace Microsoft.Data.Entity.ChangeTracking
                 set { _bits[0] = (_bits[0] & ~TransparentSidecarMask) | (value ? TransparentSidecarMask : 0); }
             }
 
-            public bool IsPropertyModified(int propertyIndex)
+            public bool IsPropertyFlagged(int propertyIndex)
             {
                 propertyIndex += BitsForAdditionalState;
 
                 return (_bits[propertyIndex / BitsPerInt] & (1 << propertyIndex % BitsPerInt)) != 0;
             }
 
-            public void SetPropertyModified(int propertyIndex, bool isModified)
+            public void FlagProperty(int propertyIndex, bool isFlagged)
             {
                 propertyIndex += BitsForAdditionalState;
 
-                if (isModified)
+                if (isFlagged)
                 {
                     _bits[propertyIndex / BitsPerInt] |= 1 << propertyIndex % BitsPerInt;
                 }
@@ -72,7 +72,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
                 }
             }
 
-            public bool AnyPropertiesModified()
+            public bool AnyPropertiesFlagged()
             {
                 return _bits.Where((t, i) => (t & CreateMaskForRead(i)) != 0).Any();
             }

--- a/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
                 configuration,
                 model.GetEntityType(typeof(FakeEntity)), new FakeEntity { Id = 42, Value = "Test" });
             await stateEntry.SetEntityStateAsync(EntityState.Modified);
-            stateEntry.SetPropertyModified(stateEntry.EntityType.GetPrimaryKey().Properties.Single(), isModified: true);
+            stateEntry.SetPropertyModified(stateEntry.EntityType.GetPrimaryKey().Properties.Single());
 
             var relatedStateEntry = new MixedStateEntry(
                 configuration,

--- a/test/EntityFramework.Tests/ChangeTracking/StateDataTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/StateDataTest.cs
@@ -21,53 +21,53 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var data = new StateEntry.StateData(propertyCount);
 
-            Assert.False(data.AnyPropertiesModified());
+            Assert.False(data.AnyPropertiesFlagged());
 
             for (var i = 0; i < propertyCount; i++)
             {
-                data.SetPropertyModified(i, true);
+                data.FlagProperty(i, true);
 
                 for (var j = 0; j < propertyCount; j++)
                 {
-                    Assert.Equal(j <= i, data.IsPropertyModified(j));
+                    Assert.Equal(j <= i, data.IsPropertyFlagged(j));
                 }
 
-                Assert.True(data.AnyPropertiesModified());
+                Assert.True(data.AnyPropertiesFlagged());
             }
 
             for (var i = 0; i < propertyCount; i++)
             {
-                data.SetPropertyModified(i, false);
+                data.FlagProperty(i, false);
 
                 for (var j = 0; j < propertyCount; j++)
                 {
-                    Assert.Equal(j > i, data.IsPropertyModified(j));
+                    Assert.Equal(j > i, data.IsPropertyFlagged(j));
                 }
 
-                Assert.Equal(i < propertyCount - 1, data.AnyPropertiesModified());
+                Assert.Equal(i < propertyCount - 1, data.AnyPropertiesFlagged());
             }
 
             for (var i = 0; i < propertyCount; i++)
             {
-                Assert.False(data.IsPropertyModified(i));
+                Assert.False(data.IsPropertyFlagged(i));
             }
 
-            data.SetAllPropertiesModified(propertyCount, isModified: true);
+            data.FlagAllProperties(propertyCount, isFlagged: true);
 
-            Assert.Equal(propertyCount > 0, data.AnyPropertiesModified());
+            Assert.Equal(propertyCount > 0, data.AnyPropertiesFlagged());
 
             for (var i = 0; i < propertyCount; i++)
             {
-                Assert.True(data.IsPropertyModified(i));
+                Assert.True(data.IsPropertyFlagged(i));
             }
 
-            data.SetAllPropertiesModified(propertyCount, isModified: false);
+            data.FlagAllProperties(propertyCount, isFlagged: false);
 
-            Assert.False(data.AnyPropertiesModified());
+            Assert.False(data.AnyPropertiesFlagged());
 
             for (var i = 0; i < propertyCount; i++)
             {
-                Assert.False(data.IsPropertyModified(i));
+                Assert.False(data.IsPropertyFlagged(i));
             }
         }
 
@@ -90,7 +90,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             data.EntityState = EntityState.Deleted;
             Assert.Equal(EntityState.Deleted, data.EntityState);
 
-            data.SetAllPropertiesModified(70, isModified: true);
+            data.FlagAllProperties(70, isFlagged: true);
 
             Assert.Equal(EntityState.Deleted, data.EntityState);
 
@@ -120,7 +120,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             data.TransparentSidecarInUse = false;
             Assert.False(data.TransparentSidecarInUse);
 
-            data.SetAllPropertiesModified(70, isModified: true);
+            data.FlagAllProperties(70, isFlagged: true);
 
             Assert.False(data.TransparentSidecarInUse);
 

--- a/test/EntityFramework.Tests/ChangeTracking/StateEntryTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/StateEntryTest.cs
@@ -98,10 +98,72 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.False(entry.IsPropertyModified(keyProperty));
             Assert.False(entry.IsPropertyModified(nonKeyProperty));
 
-            entry.SetPropertyModified(keyProperty, isModified: true);
+            entry.SetPropertyModified(keyProperty);
 
             Assert.Equal(EntityState.Modified, entry.EntityState);
             Assert.True(entry.IsPropertyModified(keyProperty));
+            Assert.False(entry.IsPropertyModified(nonKeyProperty));
+        }
+
+        [Fact]
+        public void Added_entities_can_have_temporary_values()
+        {
+            var model = BuildModel();
+            var entityType = model.GetEntityType(typeof(SomeEntity).FullName);
+            var keyProperty = entityType.GetProperty("Id");
+            var nonKeyProperty = entityType.GetProperty("Name");
+            var configuration = TestHelpers.CreateContextConfiguration(model);
+
+            var entry = CreateStateEntry(configuration, entityType, new SomeEntity());
+            entry[keyProperty] = 1;
+
+            Assert.False(entry.HasTemporaryValue(keyProperty));
+            Assert.False(entry.HasTemporaryValue(nonKeyProperty));
+            Assert.False(entry.IsPropertyModified(keyProperty));
+            Assert.False(entry.IsPropertyModified(nonKeyProperty));
+
+            entry.EntityState = EntityState.Added;
+
+            Assert.False(entry.HasTemporaryValue(keyProperty));
+            Assert.False(entry.HasTemporaryValue(nonKeyProperty));
+            Assert.False(entry.IsPropertyModified(keyProperty));
+            Assert.False(entry.IsPropertyModified(nonKeyProperty));
+
+            entry.MarkAsTemporary(keyProperty);
+
+            Assert.True(entry.HasTemporaryValue(keyProperty));
+            Assert.False(entry.HasTemporaryValue(nonKeyProperty));
+            Assert.False(entry.IsPropertyModified(keyProperty));
+            Assert.False(entry.IsPropertyModified(nonKeyProperty));
+
+            entry.MarkAsTemporary(nonKeyProperty);
+            entry.MarkAsTemporary(keyProperty, isTemporary: false);
+
+            Assert.False(entry.HasTemporaryValue(keyProperty));
+            Assert.True(entry.HasTemporaryValue(nonKeyProperty));
+            Assert.False(entry.IsPropertyModified(keyProperty));
+            Assert.False(entry.IsPropertyModified(nonKeyProperty));
+
+            entry.EntityState = EntityState.Unchanged;
+
+            Assert.False(entry.HasTemporaryValue(keyProperty));
+            Assert.False(entry.HasTemporaryValue(nonKeyProperty));
+            Assert.False(entry.IsPropertyModified(keyProperty));
+            Assert.False(entry.IsPropertyModified(nonKeyProperty));
+
+            entry.MarkAsTemporary(keyProperty);
+            entry.MarkAsTemporary(nonKeyProperty);
+
+            Assert.False(entry.HasTemporaryValue(keyProperty));
+            Assert.False(entry.HasTemporaryValue(nonKeyProperty));
+            Assert.False(entry.IsPropertyModified(keyProperty));
+            Assert.False(entry.IsPropertyModified(nonKeyProperty));
+
+            entry.EntityState = EntityState.Added;
+
+            Assert.False(entry.HasTemporaryValue(keyProperty));
+            Assert.False(entry.HasTemporaryValue(nonKeyProperty));
+            Assert.False(entry.IsPropertyModified(keyProperty));
             Assert.False(entry.IsPropertyModified(nonKeyProperty));
         }
 


### PR DESCRIPTION
(Allow property values to be marked a temporary

This is a small change to allow property values in Added entities to be marked as temporary. The code reuses generalized IsModified storage since that flag is only used in Modified entities while this flag is only used in Added entities. See https://github.com/aspnet/EntityFramework/wiki/Entity-Framework-Design-Meeting-Notes---July-10,-2014#value-generation
