### PR TITLE
I really hope all this negativity is short lived...

### DIFF
--- a/src/EntityFramework.InMemory/InMemoryValueGenerator.cs
+++ b/src/EntityFramework.InMemory/InMemoryValueGenerator.cs
@@ -14,12 +14,12 @@ namespace Microsoft.Data.Entity.InMemory
     {
         private long _current;
 
-        public override object Next(StateEntry entry, IProperty property)
+        public override void Next(StateEntry stateEntry, IProperty property)
         {
-            Check.NotNull(entry, "entry");
+            Check.NotNull(stateEntry, "stateEntry");
             Check.NotNull(property, "property");
 
-            return Convert.ChangeType(Interlocked.Increment(ref _current), property.PropertyType);
+            stateEntry[property] = Convert.ChangeType(Interlocked.Increment(ref _current), property.PropertyType);
         }
     }
 }

--- a/src/EntityFramework.SqlServer/SequentialGuidValueGenerator.cs
+++ b/src/EntityFramework.SqlServer/SequentialGuidValueGenerator.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Data.Entity.SqlServer
     {
         private long _counter = DateTime.UtcNow.Ticks;
 
-        public override object Next(StateEntry entry, IProperty property)
+        public override void Next(StateEntry stateEntry, IProperty property)
         {
-            Check.NotNull(entry, "entry");
+            Check.NotNull(stateEntry, "stateEntry");
             Check.NotNull(property, "property");
 
             var guidBytes = Guid.NewGuid().ToByteArray();
@@ -36,7 +36,7 @@ namespace Microsoft.Data.Entity.SqlServer
             guidBytes[14] = counterBytes[3];
             guidBytes[15] = counterBytes[2];
 
-            return new Guid(guidBytes);
+            stateEntry[property] = new Guid(guidBytes);
         }
     }
 }

--- a/src/EntityFramework.SqlServer/SqlServerSequenceValueGenerator.cs
+++ b/src/EntityFramework.SqlServer/SqlServerSequenceValueGenerator.cs
@@ -47,9 +47,9 @@ namespace Microsoft.Data.Entity.SqlServer
             get { return _blockSize; }
         }
 
-        public virtual object Next(StateEntry entry, IProperty property)
+        public virtual void Next(StateEntry stateEntry, IProperty property)
         {
-            Check.NotNull(entry, "entry");
+            Check.NotNull(stateEntry, "stateEntry");
             Check.NotNull(property, "property");
 
             var newValue = GetNextValue();
@@ -65,7 +65,7 @@ namespace Microsoft.Data.Entity.SqlServer
                     // case just get a value out of the new block instead of requesting one.
                     if (newValue.Max == _currentValue.Max)
                     {
-                        var commandInfo = PrepareCommand(entry.Configuration);
+                        var commandInfo = PrepareCommand(stateEntry.Configuration);
 
                         var newCurrent = (long)_executor.ExecuteScalar(commandInfo.Item1.DbConnection, commandInfo.Item1.DbTransaction, commandInfo.Item2);
                         newValue = new SequenceValue(newCurrent, newCurrent + _blockSize);
@@ -78,10 +78,10 @@ namespace Microsoft.Data.Entity.SqlServer
                 }
             }
 
-            return Convert.ChangeType(newValue.Current, property.PropertyType);
+            stateEntry[property] = Convert.ChangeType(newValue.Current, property.PropertyType);
         }
 
-        public virtual async Task<object> NextAsync(StateEntry stateEntry, IProperty property, CancellationToken cancellationToken = default(CancellationToken))
+        public virtual async Task NextAsync(StateEntry stateEntry, IProperty property, CancellationToken cancellationToken = default(CancellationToken))
         {
             Check.NotNull(stateEntry, "stateEntry");
             Check.NotNull(property, "property");
@@ -114,7 +114,7 @@ namespace Microsoft.Data.Entity.SqlServer
                 }
             }
 
-            return Convert.ChangeType(newValue.Current, property.PropertyType);
+            stateEntry[property] = Convert.ChangeType(newValue.Current, property.PropertyType);
         }
 
         private SequenceValue GetNextValue()

--- a/src/EntityFramework/Identity/ForeignKeyValueGenerator.cs
+++ b/src/EntityFramework/Identity/ForeignKeyValueGenerator.cs
@@ -36,14 +36,14 @@ namespace Microsoft.Data.Entity.Identity
             _collectionAccessorSource = collectionAccessorSource;
         }
 
-        public override object Next(StateEntry entry, IProperty property)
+        public override void Next(StateEntry stateEntry, IProperty property)
         {
             Check.NotNull(property, "property");
 
             Contract.Assert(property.IsForeignKey());
 
             var entityType = property.EntityType;
-            var stateManager = entry.Configuration.StateManager;
+            var stateManager = stateEntry.Configuration.StateManager;
 
             foreach (var foreignKey in entityType.ForeignKeys)
             {
@@ -56,20 +56,18 @@ namespace Microsoft.Data.Entity.Identity
                             .Where(n => n.ForeignKey == foreignKey)
                             .Distinct())
                         {
-                            var principal = TryFindPrincipal(stateManager, navigation, entry.Entity);
+                            var principal = TryFindPrincipal(stateManager, navigation, stateEntry.Entity);
 
                             if (principal != null)
                             {
                                 var principalEntry = stateManager.GetOrCreateEntry(principal);
 
-                                return principalEntry[foreignKey.ReferencedProperties[propertyIndex]];
+                                stateEntry[property] = principalEntry[foreignKey.ReferencedProperties[propertyIndex]];
                             }
                         }
                     }
                 }
             }
-
-            return null;
         }
 
         private object TryFindPrincipal(StateManager stateManager, INavigation navigation, object dependentEntity)

--- a/src/EntityFramework/Identity/GuidValueGenerator.cs
+++ b/src/EntityFramework/Identity/GuidValueGenerator.cs
@@ -10,12 +10,12 @@ namespace Microsoft.Data.Entity.Identity
 {
     public class GuidValueGenerator : SimpleValueGenerator
     {
-        public override object Next(StateEntry entry, IProperty property)
+        public override void Next(StateEntry stateEntry, IProperty property)
         {
-            Check.NotNull(entry, "entry");
+            Check.NotNull(stateEntry, "stateEntry");
             Check.NotNull(property, "property");
 
-            return Guid.NewGuid();
+            stateEntry[property] = Guid.NewGuid();
         }
     }
 }

--- a/src/EntityFramework/Identity/IValueGenerator.cs
+++ b/src/EntityFramework/Identity/IValueGenerator.cs
@@ -11,9 +11,9 @@ namespace Microsoft.Data.Entity.Identity
 {
     public interface IValueGenerator
     {
-        object Next([NotNull] StateEntry entry, [NotNull] IProperty property);
+        void Next([NotNull] StateEntry stateEntry, [NotNull] IProperty property);
 
-        Task<object> NextAsync(
+        Task NextAsync(
             [NotNull] StateEntry stateEntry,
             [NotNull] IProperty property,
             CancellationToken cancellationToken = default(CancellationToken));

--- a/src/EntityFramework/Identity/SimpleValueGenerator.cs
+++ b/src/EntityFramework/Identity/SimpleValueGenerator.cs
@@ -11,9 +11,9 @@ namespace Microsoft.Data.Entity.Identity
 {
     public abstract class SimpleValueGenerator : IValueGenerator
     {
-        public abstract object Next(StateEntry entry, IProperty property);
+        public abstract void Next(StateEntry stateEntry, IProperty property);
 
-        public virtual Task<object> NextAsync(
+        public virtual Task NextAsync(
             StateEntry stateEntry,
             IProperty property,
             CancellationToken cancellationToken = default(CancellationToken))
@@ -21,7 +21,9 @@ namespace Microsoft.Data.Entity.Identity
             Check.NotNull(stateEntry, "stateEntry");
             Check.NotNull(property, "property");
 
-            return Task.FromResult(Next(stateEntry, property));
+            Next(stateEntry, property);
+
+            return Task.FromResult(true);
         }
     }
 }

--- a/src/EntityFramework/Identity/TemporaryValueGenerator.cs
+++ b/src/EntityFramework/Identity/TemporaryValueGenerator.cs
@@ -13,12 +13,13 @@ namespace Microsoft.Data.Entity.Identity
     {
         private long _current;
 
-        public override object Next(StateEntry entry, IProperty property)
+        public override void Next(StateEntry stateEntry, IProperty property)
         {
-            Check.NotNull(entry, "entry");
+            Check.NotNull(stateEntry, "stateEntry");
             Check.NotNull(property, "property");
 
-            return Convert.ChangeType(Interlocked.Decrement(ref _current), property.PropertyType);
+            stateEntry[property] = Convert.ChangeType(Interlocked.Decrement(ref _current), property.PropertyType);
+            stateEntry.MarkAsTemporary(property);
         }
     }
 }

--- a/test/EntityFramework.AzureTableStorage.FunctionalTests/AtsOptimisticConcurrencyTests.cs
+++ b/test/EntityFramework.AzureTableStorage.FunctionalTests/AtsOptimisticConcurrencyTests.cs
@@ -72,84 +72,84 @@ namespace Microsoft.Data.Entity.AzureTableStorage.FunctionalTests
         {
             builder.Entity<Chassis>(
                 b =>
-                    {
-                        b.PartitionAndRowKey(c => c.Name, c => c.TeamId);
-                        b.Key(c => c.TeamId);
-                        b.Property<string>("ETag");
-                        b.TableName("Chassis" + tableSuffix);
-                    });
+                {
+                    b.PartitionAndRowKey(c => c.Name, c => c.TeamId);
+                    b.Key(c => c.TeamId);
+                    b.Property<string>("ETag");
+                    b.TableName("Chassis" + tableSuffix);
+                });
 
             builder.Entity<Team>(
                 b =>
-                    {
-                        b.PartitionAndRowKey(c => c.Name, c => c.Id);
-                        b.Key(c => c.Id);
-                        b.Property<string>("ETag");
-                        b.TableName("Teams" + tableSuffix);
-                    });
+                {
+                    b.PartitionAndRowKey(c => c.Name, c => c.Id);
+                    b.Key(c => c.Id);
+                    b.Property<string>("ETag");
+                    b.TableName("Teams" + tableSuffix);
+                });
 
             builder.Entity<Driver>(
                 b =>
-                    {
-                        b.PartitionAndRowKey(c => c.Name, c => c.Id);
-                        b.Key(c => c.Id);
-                        b.Property<string>("ETag");
-                        b.TableName("Drivers" + tableSuffix);
-                    });
+                {
+                    b.PartitionAndRowKey(c => c.Name, c => c.Id);
+                    b.Key(c => c.Id);
+                    b.Property<string>("ETag");
+                    b.TableName("Drivers" + tableSuffix);
+                });
 
             builder.Entity<Engine>(
                 b =>
-                    {
-                        b.PartitionAndRowKey(c => c.Name, c => c.Id);
-                        b.Key(c => c.Id);
-                        b.Property<string>("ETag");
-                        b.TableName("Engines" + tableSuffix);
-                    });
+                {
+                    b.PartitionAndRowKey(c => c.Name, c => c.Id);
+                    b.Key(c => c.Id);
+                    b.Property<string>("ETag");
+                    b.TableName("Engines" + tableSuffix);
+                });
 
             builder.Entity<EngineSupplier>(
                 b =>
-                    {
-                        b.PartitionAndRowKey(c => c.Name, c => c.Id);
-                        b.Key(c => c.Id);
-                        b.Property<string>("ETag");
-                        b.TableName("EngineSuppliers" + tableSuffix);
-                    });
+                {
+                    b.PartitionAndRowKey(c => c.Name, c => c.Id);
+                    b.Key(c => c.Id);
+                    b.Property<string>("ETag");
+                    b.TableName("EngineSuppliers" + tableSuffix);
+                });
 
             builder.Entity<Gearbox>(
                 b =>
-                    {
-                        b.PartitionAndRowKey(c => c.Name, c => c.Id);
-                        b.Key(c => c.Id);
-                        b.Property<string>("ETag");
-                        b.TableName("Gearboxes" + tableSuffix);
-                    });
+                {
+                    b.PartitionAndRowKey(c => c.Name, c => c.Id);
+                    b.Key(c => c.Id);
+                    b.Property<string>("ETag");
+                    b.TableName("Gearboxes" + tableSuffix);
+                });
 
             builder.Entity<Sponsor>(
                 b =>
-                    {
-                        b.PartitionAndRowKey(c => c.Name, c => c.Id);
-                        b.Key(c => c.Id);
-                        b.Property<string>("ETag");
-                        b.TableName("Sponsors" + tableSuffix);
-                    });
+                {
+                    b.PartitionAndRowKey(c => c.Name, c => c.Id);
+                    b.Key(c => c.Id);
+                    b.Property<string>("ETag");
+                    b.TableName("Sponsors" + tableSuffix);
+                });
 
             builder.Entity<TestDriver>(
                 b =>
-                    {
-                        b.PartitionAndRowKey(c => c.Name, c => c.Id);
-                        b.Key(c => c.Id);
-                        b.Property<string>("ETag");
-                        b.TableName("TestDrivers" + tableSuffix);
-                    });
+                {
+                    b.PartitionAndRowKey(c => c.Name, c => c.Id);
+                    b.Key(c => c.Id);
+                    b.Property<string>("ETag");
+                    b.TableName("TestDrivers" + tableSuffix);
+                });
 
             builder.Entity<TitleSponsor>(
                 b =>
-                    {
-                        b.PartitionAndRowKey(c => c.Name, c => c.Id);
-                        b.Key(c => c.Id);
-                        b.Property<string>("ETag");
-                        b.TableName("TitleSponsors" + tableSuffix);
-                    });
+                {
+                    b.PartitionAndRowKey(c => c.Name, c => c.Id);
+                    b.Key(c => c.Id);
+                    b.Property<string>("ETag");
+                    b.TableName("TitleSponsors" + tableSuffix);
+                });
         }
 
         public class AtsTestStore : TestStore
@@ -174,9 +174,9 @@ namespace Microsoft.Data.Entity.AzureTableStorage.FunctionalTests
         {
             private class IntGenerator : SimpleValueGenerator
             {
-                public override object Next(StateEntry entry, IProperty property)
+                public override void Next(StateEntry stateEntry, IProperty property)
                 {
-                    return Guid.NewGuid().GetHashCode();
+                    stateEntry[property] = Guid.NewGuid().GetHashCode();
                 }
             }
 

--- a/test/EntityFramework.InMemory.Tests/EntityFramework.InMemory.Tests.csproj
+++ b/test/EntityFramework.InMemory.Tests/EntityFramework.InMemory.Tests.csproj
@@ -69,8 +69,10 @@
     <Compile Include="InMemoryDataStoreTest.cs" />
     <Compile Include="InMemoryEntityServicesBuilderExtensionsTest.cs" />
     <Compile Include="..\Shared\ApiConsistencyTestBase.cs" />
+    <Compile Include="..\Shared\TestHelpers.cs" />
     <Compile Include="InMemoryValueGeneratorSelectorTest.cs" />
     <Compile Include="InMemoryValueGeneratorTest.cs" />
+    <Compile Include="TestHelperExtensions.cs" />
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
@@ -88,6 +90,9 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="System" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/test/EntityFramework.InMemory.Tests/InMemoryValueGeneratorTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryValueGeneratorTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Tests;
 using Moq;
 using Xunit;
 
@@ -12,26 +13,57 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 {
     public class InMemoryValueGeneratorTest
     {
+        private static readonly Model _model = TestHelpers.BuildModelFor<AnEntity>();
+
         [Fact]
         public async Task Creates_values()
         {
             var generator = new InMemoryValueGenerator();
 
-            var propertyMock = new Mock<IProperty>();
-            propertyMock.Setup(m => m.PropertyType).Returns(typeof(int));
+            var stateEntry = TestHelpers.CreateStateEntry<AnEntity>(_model, EntityState.Added);
+            var property = stateEntry.EntityType.GetProperty("Id");
 
-            Assert.Equal(1, await generator.NextAsync(Mock.Of<StateEntry>(), propertyMock.Object));
-            Assert.Equal(2, await generator.NextAsync(Mock.Of<StateEntry>(), propertyMock.Object));
-            Assert.Equal(3, await generator.NextAsync(Mock.Of<StateEntry>(), propertyMock.Object));
+            await generator.NextAsync(stateEntry, property);
 
-            Assert.Equal(4, generator.Next(Mock.Of<StateEntry>(), propertyMock.Object));
-            Assert.Equal(5, generator.Next(Mock.Of<StateEntry>(), propertyMock.Object));
-            Assert.Equal(6, generator.Next(Mock.Of<StateEntry>(), propertyMock.Object));
+            Assert.Equal(1, stateEntry[property]);
+            Assert.False(stateEntry.HasTemporaryValue(property));
+
+            await generator.NextAsync(stateEntry, property);
+
+            Assert.Equal(2, stateEntry[property]);
+            Assert.False(stateEntry.HasTemporaryValue(property));
+
+            await generator.NextAsync(stateEntry, property);
+
+            Assert.Equal(3, stateEntry[property]);
+            Assert.False(stateEntry.HasTemporaryValue(property));
+
+            generator.Next(stateEntry, property);
+
+            Assert.Equal(4, stateEntry[property]);
+            Assert.False(stateEntry.HasTemporaryValue(property));
+
+            generator.Next(stateEntry, property);
+
+            Assert.Equal(5, stateEntry[property]);
+            Assert.False(stateEntry.HasTemporaryValue(property));
+
+            generator.Next(stateEntry, property);
+
+            Assert.Equal(6, stateEntry[property]);
+            Assert.False(stateEntry.HasTemporaryValue(property));
 
             generator = new InMemoryValueGenerator();
 
-            Assert.Equal(1, await generator.NextAsync(Mock.Of<StateEntry>(), propertyMock.Object));
-            Assert.Equal(2, generator.Next(Mock.Of<StateEntry>(), propertyMock.Object));
+            await generator.NextAsync(stateEntry, property);
+
+            Assert.Equal(1, stateEntry[property]);
+            Assert.False(stateEntry.HasTemporaryValue(property));
+
+            await generator.NextAsync(stateEntry, property);
+
+            Assert.Equal(2, stateEntry[property]);
+            Assert.False(stateEntry.HasTemporaryValue(property));
         }
 
         [Fact]
@@ -39,15 +71,95 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         {
             var generator = new InMemoryValueGenerator();
 
-            Assert.Equal(1L, await generator.NextAsync(Mock.Of<StateEntry>(), CreateProperty(typeof(long))));
-            Assert.Equal(2, await generator.NextAsync(Mock.Of<StateEntry>(), CreateProperty(typeof(int))));
-            Assert.Equal((short)3, await generator.NextAsync(Mock.Of<StateEntry>(), CreateProperty(typeof(short))));
-            Assert.Equal((byte)4, await generator.NextAsync(Mock.Of<StateEntry>(), CreateProperty(typeof(byte))));
+            var stateEntry = TestHelpers.CreateStateEntry<AnEntity>(_model, EntityState.Added);
+            var intProperty = stateEntry.EntityType.GetProperty("Id");
+            var longProperty = stateEntry.EntityType.GetProperty("Long");
+            var shortProperty = stateEntry.EntityType.GetProperty("Short");
+            var byteProperty = stateEntry.EntityType.GetProperty("Byte");
+            var uintProperty = stateEntry.EntityType.GetProperty("UnsignedInt");
+            var ulongProperty = stateEntry.EntityType.GetProperty("UnsignedLong");
+            var ushortProperty = stateEntry.EntityType.GetProperty("UnsignedShort");
+            var sbyteProperty = stateEntry.EntityType.GetProperty("SignedByte");
 
-            Assert.Equal(5L, generator.Next(Mock.Of<StateEntry>(), CreateProperty(typeof(long))));
-            Assert.Equal(6, generator.Next(Mock.Of<StateEntry>(), CreateProperty(typeof(int))));
-            Assert.Equal((short)7, generator.Next(Mock.Of<StateEntry>(), CreateProperty(typeof(short))));
-            Assert.Equal((byte)8, generator.Next(Mock.Of<StateEntry>(), CreateProperty(typeof(byte))));
+            await generator.NextAsync(stateEntry, longProperty);
+
+            Assert.Equal(1L, stateEntry[longProperty]);
+            Assert.False(stateEntry.HasTemporaryValue(longProperty));
+
+            await generator.NextAsync(stateEntry, intProperty);
+
+            Assert.Equal(2, stateEntry[intProperty]);
+            Assert.False(stateEntry.HasTemporaryValue(intProperty));
+
+            await generator.NextAsync(stateEntry, shortProperty);
+
+            Assert.Equal((short)3, stateEntry[shortProperty]);
+            Assert.False(stateEntry.HasTemporaryValue(shortProperty));
+
+            await generator.NextAsync(stateEntry, byteProperty);
+
+            Assert.Equal((byte)4, stateEntry[byteProperty]);
+            Assert.False(stateEntry.HasTemporaryValue(byteProperty));
+
+            await generator.NextAsync(stateEntry, ulongProperty);
+
+            Assert.Equal((ulong)5, stateEntry[ulongProperty]);
+            Assert.False(stateEntry.HasTemporaryValue(ulongProperty));
+
+            await generator.NextAsync(stateEntry, uintProperty);
+
+            Assert.Equal((uint)6, stateEntry[uintProperty]);
+            Assert.False(stateEntry.HasTemporaryValue(uintProperty));
+
+            await generator.NextAsync(stateEntry, ushortProperty);
+
+            Assert.Equal((ushort)7, stateEntry[ushortProperty]);
+            Assert.False(stateEntry.HasTemporaryValue(ushortProperty));
+
+            await generator.NextAsync(stateEntry, sbyteProperty);
+
+            Assert.Equal((sbyte)8, stateEntry[sbyteProperty]);
+            Assert.False(stateEntry.HasTemporaryValue(sbyteProperty));
+
+            generator.Next(stateEntry, longProperty);
+
+            Assert.Equal(9L, stateEntry[longProperty]);
+            Assert.False(stateEntry.HasTemporaryValue(longProperty));
+
+            generator.Next(stateEntry, intProperty);
+
+            Assert.Equal(10, stateEntry[intProperty]);
+            Assert.False(stateEntry.HasTemporaryValue(intProperty));
+
+            generator.Next(stateEntry, shortProperty);
+
+            Assert.Equal((short)11, stateEntry[shortProperty]);
+            Assert.False(stateEntry.HasTemporaryValue(shortProperty));
+
+            generator.Next(stateEntry, byteProperty);
+
+            Assert.Equal((byte)12, stateEntry[byteProperty]);
+            Assert.False(stateEntry.HasTemporaryValue(byteProperty));
+
+            generator.Next(stateEntry, ulongProperty);
+
+            Assert.Equal((ulong)13, stateEntry[ulongProperty]);
+            Assert.False(stateEntry.HasTemporaryValue(ulongProperty));
+
+            generator.Next(stateEntry, uintProperty);
+
+            Assert.Equal((uint)14, stateEntry[uintProperty]);
+            Assert.False(stateEntry.HasTemporaryValue(uintProperty));
+
+            generator.Next(stateEntry, ushortProperty);
+
+            Assert.Equal((ushort)15, stateEntry[ushortProperty]);
+            Assert.False(stateEntry.HasTemporaryValue(ushortProperty));
+
+            generator.Next(stateEntry, sbyteProperty);
+
+            Assert.Equal((sbyte)16, stateEntry[sbyteProperty]);
+            Assert.False(stateEntry.HasTemporaryValue(sbyteProperty));
         }
 
         [Fact]
@@ -68,6 +180,18 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         {
             var entityType = new EntityType("MyType");
             return entityType.GetOrAddProperty("MyProperty", propertyType, shadowProperty: true);
+        }
+
+        private class AnEntity
+        {
+            public int Id { get; set; }
+            public long Long { get; set; }
+            public short Short { get; set; }
+            public byte Byte { get; set; }
+            public uint UnsignedInt { get; set; }
+            public ulong UnsignedLong { get; set; }
+            public ushort UnsignedShort { get; set; }
+            public sbyte SignedByte { get; set; }
         }
     }
 }

--- a/test/EntityFramework.InMemory.Tests/TestHelperExtensions.cs
+++ b/test/EntityFramework.InMemory.Tests/TestHelperExtensions.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Framework.DependencyInjection;
+
+namespace Microsoft.Data.Entity.Tests
+{
+    public static class TestHelperExtensions
+    {
+        public static EntityServicesBuilder AddProviderServices(this EntityServicesBuilder entityServicesBuilder)
+        {
+            return entityServicesBuilder.AddInMemoryStore();
+        }
+
+        public static DbContextOptions UseProviderOptions(this DbContextOptions options)
+        {
+            return options;
+        }
+    }
+}

--- a/test/EntityFramework.InMemory.Tests/project.json
+++ b/test/EntityFramework.InMemory.Tests/project.json
@@ -4,7 +4,7 @@
         "Moq": "4.2.1312.1622",
         "Xunit.KRunner": "1.0.0-*"
     },
-    "code": [ "**\\*.cs", "..\\Shared\\ApiConsistencyTestBase.cs" ],
+    "code": [ "**\\*.cs", "..\\Shared\\ApiConsistencyTestBase.cs", "..\\Shared\\TestHelpers.cs" ],
     "commands": {
         "test": "Xunit.KRunner"
     },

--- a/test/EntityFramework.SqlServer.Tests/EntityFramework.SqlServer.Tests.csproj
+++ b/test/EntityFramework.SqlServer.Tests/EntityFramework.SqlServer.Tests.csproj
@@ -65,6 +65,7 @@
   <ItemGroup>
     <Compile Include="ApiConsistencyTest.cs" />
     <Compile Include="..\Shared\ApiConsistencyTestBase.cs" />
+    <Compile Include="..\Shared\TestHelpers.cs" />
     <Compile Include="SequentialGuidValueGeneratorTest.cs" />
     <Compile Include="..\EntityFramework.Relational.Tests\SqlGeneratorTestBase.cs" />
     <Compile Include="SqlServerDbContextOptionsExtensionsTest.cs" />
@@ -79,6 +80,7 @@
     <Compile Include="SqlServerSqlGeneratorTest.cs" />
     <Compile Include="SqlServerTypeMapperTest.cs" />
     <Compile Include="SqlServerValueGeneratorSelectorTest.cs" />
+    <Compile Include="TestHelperExtensions.cs" />
     <Compile Include="Update\SqlServerModificationCommandBatchFactoryTest.cs" />
     <Compile Include="Update\SqlServerModificationCommandBatchTest.cs" />
     <None Include="project.json" />

--- a/test/EntityFramework.SqlServer.Tests/SequentialGuidValueGeneratorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SequentialGuidValueGeneratorTest.cs
@@ -4,15 +4,16 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
-using Moq;
+using Microsoft.Data.Entity.Tests;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.Tests
 {
     public class SequentialGuidValueGeneratorTest
     {
+        private static readonly Model _model = TestHelpers.BuildModelFor<WithGuid>();
+
         [Fact]
         public async Task Can_get_next_values()
         {
@@ -29,18 +30,33 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         {
             var sequentialGuidIdentityGenerator = new SequentialGuidValueGenerator();
 
+            var stateEntry = TestHelpers.CreateStateEntry<WithGuid>(_model, EntityState.Added);
+            var property = stateEntry.EntityType.GetProperty("Id");
+
             var values = new HashSet<Guid>();
             for (var i = 0; i < 100; i++)
             {
-                var guid = async
-                    ? await sequentialGuidIdentityGenerator.NextAsync(Mock.Of<StateEntry>(), Mock.Of<IProperty>())
-                    : sequentialGuidIdentityGenerator.Next(Mock.Of<StateEntry>(), Mock.Of<IProperty>());
+                if (async)
+                {
+                    await sequentialGuidIdentityGenerator.NextAsync(stateEntry, property);
+                }
+                else
+                {
+                    sequentialGuidIdentityGenerator.Next(stateEntry, property);
+                }
 
-                values.Add((Guid)guid);
+                Assert.False(stateEntry.HasTemporaryValue(property));
+
+                values.Add((Guid)stateEntry[property]);
             }
 
             // Check all generated values are different--functional test checks ordering on SQL Server
             Assert.Equal(100, values.Count);
+        }
+
+        private class WithGuid
+        {
+            public Guid Id { get; set; }
         }
     }
 }

--- a/test/EntityFramework.SqlServer.Tests/TestHelperExtensions.cs
+++ b/test/EntityFramework.SqlServer.Tests/TestHelperExtensions.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Data.SqlClient;
+using Microsoft.Framework.DependencyInjection;
+
+namespace Microsoft.Data.Entity.Tests
+{
+    public static class TestHelperExtensions
+    {
+        public static EntityServicesBuilder AddProviderServices(this EntityServicesBuilder entityServicesBuilder)
+        {
+            return entityServicesBuilder.AddSqlServer();
+        }
+
+        public static DbContextOptions UseProviderOptions(this DbContextOptions options)
+        {
+            return options.UseSqlServer(new SqlConnection());
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.Tests/project.json
+++ b/test/EntityFramework.SqlServer.Tests/project.json
@@ -7,7 +7,8 @@
     "code": [
         "**\\*.cs",
         "..\\Shared\\ApiConsistencyTestBase.cs",
-        "..\\EntityFramework.Relational.Tests\\SqlGeneratorTestBase.cs"
+        "..\\EntityFramework.Relational.Tests\\SqlGeneratorTestBase.cs",
+        "..\\Shared\\TestHelpers.cs"
     ],
     "commands": {
         "test": "Xunit.KRunner"

--- a/test/EntityFramework.Tests/EntityFramework.Tests.csproj
+++ b/test/EntityFramework.Tests/EntityFramework.Tests.csproj
@@ -96,9 +96,9 @@
     <Compile Include="Metadata\MetadataBuilderTest.cs" />
     <Compile Include="Metadata\ModelConventions\ForeignKeyConventionTest.cs" />
     <Compile Include="Metadata\NavigationExtensionsTest.cs" />
+    <Compile Include="TestHelperExtensions.cs" />
     <Compile Include="QueryableExtensionsTest.cs" />
     <Compile Include="ServiceProviderCacheTest.cs" />
-    <Compile Include="TestHelpers.cs" />
     <Compile Include="ChangeTracking\ChangeTrackerTest.cs" />
     <Compile Include="ChangeTracking\ClrStateEntryTest.cs" />
     <Compile Include="ChangeTracking\CompositeEntityKeyFactoryTest.cs" />
@@ -154,6 +154,7 @@
     <Compile Include="Utilities\ThreadSafeLazyRefTest.cs" />
     <Compile Include="Utilities\TypeExtensionsTest.cs" />
     <Compile Include="..\Shared\ApiConsistencyTestBase.cs" />
+    <Compile Include="..\Shared\TestHelpers.cs" />
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>

--- a/test/EntityFramework.Tests/Identity/ForeignKeyValueGeneratorTest.cs
+++ b/test/EntityFramework.Tests/Identity/ForeignKeyValueGeneratorTest.cs
@@ -20,8 +20,11 @@ namespace Microsoft.Data.Entity.Tests.Identity
             var dependent = new Product { Id = 21, Category = principal };
 
             var dependentEntry = CreateContextConfiguration(model).StateManager.GetOrCreateEntry(dependent);
+            var property = model.GetEntityType(typeof(Product)).GetProperty("CategoryId");
 
-            Assert.Equal(11, CreateValueGenerator().Next(dependentEntry, model.GetEntityType(typeof(Product)).GetProperty("CategoryId")));
+            CreateValueGenerator().Next(dependentEntry, property);
+
+            Assert.Equal(11, dependentEntry[property]);
         }
 
         [Fact]
@@ -36,8 +39,11 @@ namespace Microsoft.Data.Entity.Tests.Identity
 
             manager.StartTracking(manager.GetOrCreateEntry(principal));
             var dependentEntry = manager.GetOrCreateEntry(dependent);
+            var property = model.GetEntityType(typeof(Product)).GetProperty("CategoryId");
 
-            Assert.Equal(11, CreateValueGenerator().Next(dependentEntry, model.GetEntityType(typeof(Product)).GetProperty("CategoryId")));
+            CreateValueGenerator().Next(dependentEntry, property);
+
+            Assert.Equal(11, dependentEntry[property]);
         }
 
         [Fact]
@@ -49,8 +55,11 @@ namespace Microsoft.Data.Entity.Tests.Identity
             var dependent = new ProductDetail { Product = principal };
 
             var dependentEntry = CreateContextConfiguration(model).StateManager.GetOrCreateEntry(dependent);
+            var property = model.GetEntityType(typeof(ProductDetail)).GetProperty("Id");
 
-            Assert.Equal(21, CreateValueGenerator().Next(dependentEntry, model.GetEntityType(typeof(ProductDetail)).GetProperty("Id")));
+            CreateValueGenerator().Next(dependentEntry, property);
+
+            Assert.Equal(21, dependentEntry[property]);
         }
 
         [Fact]
@@ -64,8 +73,11 @@ namespace Microsoft.Data.Entity.Tests.Identity
 
             manager.StartTracking(manager.GetOrCreateEntry(principal));
             var dependentEntry = manager.GetOrCreateEntry(dependent);
+            var property = model.GetEntityType(typeof(ProductDetail)).GetProperty("Id");
 
-            Assert.Equal(21, CreateValueGenerator().Next(dependentEntry, model.GetEntityType(typeof(ProductDetail)).GetProperty("Id")));
+            CreateValueGenerator().Next(dependentEntry, property);
+
+            Assert.Equal(21, dependentEntry[property]);
         }
 
         [Fact]
@@ -77,9 +89,14 @@ namespace Microsoft.Data.Entity.Tests.Identity
             var dependent = new OrderLineDetail { OrderLine = principal };
 
             var dependentEntry = CreateContextConfiguration(model).StateManager.GetOrCreateEntry(dependent);
+            var property1 = model.GetEntityType(typeof(OrderLineDetail)).GetProperty("OrderId");
+            var property2 = model.GetEntityType(typeof(OrderLineDetail)).GetProperty("ProductId");
 
-            Assert.Equal(11, CreateValueGenerator().Next(dependentEntry, model.GetEntityType(typeof(OrderLineDetail)).GetProperty("OrderId")));
-            Assert.Equal(21, CreateValueGenerator().Next(dependentEntry, model.GetEntityType(typeof(OrderLineDetail)).GetProperty("ProductId")));
+            CreateValueGenerator().Next(dependentEntry, property1);
+            CreateValueGenerator().Next(dependentEntry, property2);
+
+            Assert.Equal(11, dependentEntry[property1]);
+            Assert.Equal(21, dependentEntry[property2]);
         }
 
         [Fact]
@@ -93,9 +110,14 @@ namespace Microsoft.Data.Entity.Tests.Identity
 
             manager.StartTracking(manager.GetOrCreateEntry(principal));
             var dependentEntry = manager.GetOrCreateEntry(dependent);
+            var property1 = model.GetEntityType(typeof(OrderLineDetail)).GetProperty("OrderId");
+            var property2 = model.GetEntityType(typeof(OrderLineDetail)).GetProperty("ProductId");
 
-            Assert.Equal(11, CreateValueGenerator().Next(dependentEntry, model.GetEntityType(typeof(OrderLineDetail)).GetProperty("OrderId")));
-            Assert.Equal(21, CreateValueGenerator().Next(dependentEntry, model.GetEntityType(typeof(OrderLineDetail)).GetProperty("ProductId")));
+            CreateValueGenerator().Next(dependentEntry, property1);
+            CreateValueGenerator().Next(dependentEntry, property2);
+
+            Assert.Equal(11, dependentEntry[property1]);
+            Assert.Equal(21, dependentEntry[property2]);
         }
 
         private static DbContextConfiguration CreateContextConfiguration(IModel model = null)
@@ -176,10 +198,10 @@ namespace Microsoft.Data.Entity.Tests.Identity
             var builder = new ModelBuilder(model);
 
             builder.Entity<Product>(b =>
-                {
-                    b.OneToMany(e => e.OrderLines, e => e.Product);
-                    b.OneToOne(e => e.Detail, e => e.Product);
-                });
+            {
+                b.OneToMany(e => e.OrderLines, e => e.Product);
+                b.OneToOne(e => e.Detail, e => e.Product);
+            });
 
             builder.Entity<Category>().OneToMany(e => e.Products, e => e.Category);
 
@@ -190,10 +212,10 @@ namespace Microsoft.Data.Entity.Tests.Identity
             builder.Entity<OrderLineDetail>().Key(e => new { e.OrderId, e.ProductId });
 
             builder.Entity<OrderLine>(b =>
-                {
-                    b.Key(e => new { e.OrderId, e.ProductId });
-                    b.OneToOne(e => e.Detail, e => e.OrderLine);
-                });
+            {
+                b.Key(e => new { e.OrderId, e.ProductId });
+                b.OneToOne(e => e.Detail, e => e.OrderLine);
+            });
 
             return model;
         }

--- a/test/EntityFramework.Tests/Identity/GuidValueGeneratorTest.cs
+++ b/test/EntityFramework.Tests/Identity/GuidValueGeneratorTest.cs
@@ -4,16 +4,16 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Identity;
 using Microsoft.Data.Entity.Metadata;
-using Moq;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.Identity
 {
     public class GuidValueGeneratorTest
     {
+        private static readonly Model _model = TestHelpers.BuildModelFor<WithGuid>();
+
         [Fact]
         public async Task Creates_GUIDs()
         {
@@ -30,17 +30,32 @@ namespace Microsoft.Data.Entity.Tests.Identity
         {
             var sequentialGuidIdentityGenerator = new GuidValueGenerator();
 
+            var stateEntry = TestHelpers.CreateStateEntry<WithGuid>(_model, EntityState.Added);
+            var property = stateEntry.EntityType.GetProperty("Id");
+
             var values = new HashSet<Guid>();
             for (var i = 0; i < 100; i++)
             {
-                var guid = async
-                    ? await sequentialGuidIdentityGenerator.NextAsync(Mock.Of<StateEntry>(), Mock.Of<IProperty>())
-                    : sequentialGuidIdentityGenerator.Next(Mock.Of<StateEntry>(), Mock.Of<IProperty>());
+                if (async)
+                {
+                    await sequentialGuidIdentityGenerator.NextAsync(stateEntry, property);
+                }
+                else
+                {
+                    sequentialGuidIdentityGenerator.Next(stateEntry, property);
+                }
 
-                values.Add((Guid)guid);
+                Assert.False(stateEntry.HasTemporaryValue(property));
+
+                values.Add((Guid)stateEntry[property]);
             }
 
             Assert.Equal(100, values.Count);
+        }
+
+        private class WithGuid
+        {
+            public Guid Id { get; set; }
         }
     }
 }

--- a/test/EntityFramework.Tests/Identity/SimpleValueGeneratorTest.cs
+++ b/test/EntityFramework.Tests/Identity/SimpleValueGeneratorTest.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Identity;
 using Microsoft.Data.Entity.Metadata;
-using Moq;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.Identity
@@ -15,13 +14,32 @@ namespace Microsoft.Data.Entity.Tests.Identity
         [Fact]
         public async Task NextAsync_delegates_to_sync_method()
         {
-            var stateEntry = Mock.Of<StateEntry>();
-            var property = Mock.Of<IProperty>();
+            var stateEntry = TestHelpers.CreateStateEntry<AnEntity>(TestHelpers.BuildModelFor<AnEntity>());
+            var property = stateEntry.EntityType.GetProperty("Id");
 
-            var generatorMock = new Mock<SimpleValueGenerator> { CallBase = true };
-            generatorMock.Setup(m => m.Next(stateEntry, property)).Returns("Boo!");
+            var generator = new TestValueGenerator();
 
-            Assert.Equal("Boo!", await generatorMock.Object.NextAsync(stateEntry, property));
+            await generator.NextAsync(stateEntry, property);
+
+            Assert.Same(generator.StateEntry, stateEntry);
+            Assert.Same(generator.Property, property);
+        }
+
+        private class TestValueGenerator : SimpleValueGenerator
+        {
+            public StateEntry StateEntry { get; set; }
+            public IProperty Property { get; set; }
+
+            public override void Next(StateEntry stateEntry, IProperty property)
+            {
+                StateEntry = stateEntry;
+                Property = property;
+            }
+        }
+
+        private class AnEntity
+        {
+            public int Id { get; set; }
         }
     }
 }

--- a/test/EntityFramework.Tests/TestHelperExtensions.cs
+++ b/test/EntityFramework.Tests/TestHelperExtensions.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Framework.DependencyInjection;
+
+namespace Microsoft.Data.Entity.Tests
+{
+    public static class TestHelperExtensions
+    {
+        public static EntityServicesBuilder AddProviderServices(this EntityServicesBuilder entityServicesBuilder)
+        {
+            return entityServicesBuilder.AddInMemoryStore();
+        }
+
+        public static DbContextOptions UseProviderOptions(this DbContextOptions options)
+        {
+            return options;
+        }
+    }
+}

--- a/test/EntityFramework.Tests/project.json
+++ b/test/EntityFramework.Tests/project.json
@@ -4,7 +4,7 @@
         "Moq": "4.2.1312.1622",
         "Xunit.KRunner": "1.0.0-*"
     },
-    "code": [ "**\\*.cs", "..\\Shared\\ApiConsistencyTestBase.cs" ],
+    "code": [ "**\\*.cs", "..\\Shared\\ApiConsistencyTestBase.cs", "..\\Shared\\TestHelpers.cs" ],
     "commands": {
         "test": "Xunit.KRunner"
     },

--- a/test/Shared/TestHelpers.cs
+++ b/test/Shared/TestHelpers.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Framework.DependencyInjection;
@@ -13,7 +14,7 @@ namespace Microsoft.Data.Entity.Tests
     {
         public static DbContextOptions CreateOptions(IModel model)
         {
-            return new DbContextOptions().UseModel(model);
+            return new DbContextOptions().UseModel(model).UseProviderOptions();
         }
 
         public static DbContextOptions CreateOptions()
@@ -24,7 +25,7 @@ namespace Microsoft.Data.Entity.Tests
         public static IServiceProvider CreateServiceProvider()
         {
             var services = new ServiceCollection();
-            services.AddEntityFramework().AddInMemoryStore();
+            services.AddEntityFramework().AddProviderServices();
             return services.BuildServiceProvider();
         }
 
@@ -46,6 +47,26 @@ namespace Microsoft.Data.Entity.Tests
         public static DbContextConfiguration CreateContextConfiguration()
         {
             return new DbContext(CreateServiceProvider(), CreateOptions()).Configuration;
+        }
+
+        public static Model BuildModelFor<TEntity>()
+        {
+            var builder = new ModelBuilder();
+            builder.Entity<TEntity>();
+            return builder.Model;
+        }
+
+        public static StateEntry CreateStateEntry<TEntity>(IModel model, EntityState entityState = EntityState.Unknown)
+            where TEntity : new()
+        {
+            var entry = CreateContextConfiguration(model)
+                .Services
+                .StateEntryFactory
+                .Create(model.GetEntityType(typeof(TEntity)), new TEntity());
+
+            entry.EntityState = entityState;
+
+            return entry;
         }
     }
 }


### PR DESCRIPTION
Update value generators to be able to mark generated values as temporary

This change allows value generators to mark generated values as temporary, which in turn will allow the update pipeline to make a decision as to whether a store-generated value is expected.
