### PR TITLE
Issue 653 - added support for DateTimeOffset properties in Redis + Data Types Tests

### DIFF
--- a/src/EntityFramework.Redis/RedisDatabase.cs
+++ b/src/EntityFramework.Redis/RedisDatabase.cs
@@ -401,6 +401,10 @@ namespace Microsoft.Data.Entity.Redis
             {
                 return MaybeNullable(DateTime.Parse(value), property);
             }
+            if (typeof(DateTimeOffset) == underlyingType)
+            {
+                return MaybeNullable(DateTimeOffset.Parse(value), property);
+            }
             if (typeof(Single) == underlyingType)
             {
                 return MaybeNullable(Convert.ToSingle(value), property);

--- a/test/EntityFramework.FunctionalTests/BuiltInDataTypesFixtureBase.cs
+++ b/test/EntityFramework.FunctionalTests/BuiltInDataTypesFixtureBase.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.FunctionalTests
+{
+    /// <summary>
+    /// See also <see cref="SupplementalBuiltInDataTypesFixtureBase" />.
+    /// Not all built-in data types are supported on all providers yet.
+    /// At the same time, not all conventions (e.g. Ignore) are available yet.
+    /// So this class provides a base fixture for those data types which are
+    /// supported on all current providers.
+    /// Over time, the aim is to transfer as many data types as possible into
+    /// this class and ultimately to delete <see cref="SupplementalBuiltInDataTypesFixtureBase" />.
+    /// </summary>
+    public abstract class BuiltInDataTypesFixtureBase
+    {
+        public abstract DbContext CreateContext();
+
+        public virtual IModel CreateModel()
+        {
+            var model = new Model();
+            var builder = new BasicModelBuilder(model);
+            builder.Entity<BuiltInNonNullableDataTypes>(b =>
+                {
+                    b.Key(dt => dt.Id);
+                    b.Property(dt => dt.Id);
+                    b.Property(dt => dt.TestInt32);
+                    b.Property(dt => dt.TestInt64);
+                    b.Property(dt => dt.TestDouble);
+                    b.Property(dt => dt.TestDecimal);
+                    b.Property(dt => dt.TestDateTime);
+                    b.Property(dt => dt.TestDateTimeOffset);
+                    b.Property(dt => dt.TestSingle);
+                    b.Property(dt => dt.TestBoolean);
+                    b.Property(dt => dt.TestByte);
+                    b.Property(dt => dt.TestInt16);
+                });
+
+            builder.Entity<BuiltInNullableDataTypes>(b =>
+            {
+                b.Key(dt => dt.Id);
+                b.Property(dt => dt.Id);
+                b.Property(dt => dt.TestNullableInt32);
+                b.Property(dt => dt.TestString);
+                b.Property(dt => dt.TestNullableInt64);
+                b.Property(dt => dt.TestNullableDouble);
+                b.Property(dt => dt.TestNullableDecimal);
+                b.Property(dt => dt.TestNullableDateTime);
+                b.Property(dt => dt.TestNullableDateTimeOffset);
+                b.Property(dt => dt.TestNullableSingle);
+                b.Property(dt => dt.TestNullableBoolean);
+                b.Property(dt => dt.TestNullableByte);
+                b.Property(dt => dt.TestNullableInt16);
+            });
+
+            return model;
+        }
+    }
+
+    public class BuiltInNonNullableDataTypes
+    {
+        public int Id { get; set; }
+        public int TestInt32 { get; set; }
+        public long TestInt64 { get; set; }
+        public double TestDouble { get; set; }
+        public decimal TestDecimal { get; set; }
+        public DateTime TestDateTime { get; set; }
+        public DateTimeOffset TestDateTimeOffset { get; set; }
+        public float TestSingle { get; set; }
+        public bool TestBoolean { get; set; }
+        public byte TestByte { get; set; }
+        public uint TestUnsignedInt32 { get; set; }
+        public ulong TestUnsignedInt64 { get; set; }
+        public short TestInt16 { get; set; }
+    }
+
+    public class BuiltInNullableDataTypes
+    {
+        public int Id { get; set; }
+        public int? TestNullableInt32 { get; set; }
+        public string TestString { get; set; }
+        public long? TestNullableInt64 { get; set; }
+        public double? TestNullableDouble { get; set; }
+        public decimal? TestNullableDecimal { get; set; }
+        public DateTime? TestNullableDateTime { get; set; }
+        public DateTimeOffset? TestNullableDateTimeOffset { get; set; }
+        public float? TestNullableSingle { get; set; }
+        public bool? TestNullableBoolean { get; set; }
+        public byte? TestNullableByte { get; set; }
+        public short? TestNullableInt16 { get; set; }
+    }
+}

--- a/test/EntityFramework.FunctionalTests/BuiltInDataTypesTestBase.cs
+++ b/test/EntityFramework.FunctionalTests/BuiltInDataTypesTestBase.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Data.Entity.FunctionalTests
+{
+    /// <summary>
+    /// See also <see cref="SupplementalBuiltInDataTypesTestBase" />.
+    /// Not all built-in data types are supported on all providers yet.
+    /// At the same time, not all conventions (e.g. Ignore) are available yet.
+    /// So this class provides a base test class for those data types which are
+    /// supported on all current providers.
+    /// Over time, the aim is to transfer as many tests as possible into
+    /// this class and ultimately to delete <see cref="SupplementalBuiltInDataTypesTestBase" />.
+    /// </summary>
+    public abstract class BuiltInDataTypesTestBase
+    {
+        protected DbContext _context;
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_non_nullable_data_types()
+        {
+            var allDataTypes = _context.Set<BuiltInNonNullableDataTypes>().Add(
+                new BuiltInNonNullableDataTypes
+                {
+                    Id = 0,
+                    TestInt32 = -123456789,
+                    TestInt64 = -1234567890123456789L,
+                    TestDouble = -1.23456789,
+                    // TODO: SQL Server default precision is 18 (use max precision, 38, 
+                    // when available but no way to define that in the model at the moment)
+                    TestDecimal = -1234567890.012345678M,
+                    TestDateTime = new DateTime(123456789L),
+                    TestDateTimeOffset = new DateTimeOffset(987654321L, TimeSpan.FromHours(-8.0)),
+                    TestSingle = -1.234F,
+                    TestBoolean = true,
+                    TestByte = 255,
+                    TestUnsignedInt32 = 1234565789U,
+                    TestUnsignedInt64 = 1234565789UL,
+                    TestInt16 = -1234,
+                });
+
+            var changes = _context.SaveChanges();
+            Assert.Equal(1, changes);
+
+            var dt = _context.Set<BuiltInNonNullableDataTypes>().Where(nndt => nndt.Id == 0).Single();
+
+            Assert.Equal(-123456789, dt.TestInt32);
+            Assert.Equal(-1234567890123456789L, dt.TestInt64);
+            Assert.Equal(-1.23456789, dt.TestDouble);
+            Assert.Equal(-1234567890.012345678M, dt.TestDecimal);
+            Assert.Equal(new DateTime(123456789L), dt.TestDateTime);
+            Assert.Equal(new DateTimeOffset(987654321L, TimeSpan.FromHours(-8.0)), dt.TestDateTimeOffset);
+            Assert.Equal(-1.234F, dt.TestSingle);
+            Assert.Equal(true, dt.TestBoolean);
+            Assert.Equal(255, dt.TestByte);
+            Assert.Equal(1234565789U, dt.TestUnsignedInt32);
+            Assert.Equal(1234565789UL, dt.TestUnsignedInt64);
+            Assert.Equal(-1234, dt.TestInt16);
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_nullable_data_types_with_values_set_to_null()
+        {
+            var allDataTypes = _context.Set<BuiltInNullableDataTypes>().Add(
+                new BuiltInNullableDataTypes
+                {
+                    Id = 0,
+                    TestNullableInt32 = null,
+                    TestString = null,
+                    TestNullableInt64 = null,
+                    TestNullableDouble = null,
+                    TestNullableDecimal = null,
+                    TestNullableDateTime = null,
+                    TestNullableDateTimeOffset = null,
+                    TestNullableSingle = null,
+                    TestNullableBoolean = null,
+                    TestNullableByte = null,
+                    TestNullableInt16 = null,
+                });
+
+            var changes = _context.SaveChanges();
+            Assert.Equal(1, changes);
+
+            var dt = _context.Set<BuiltInNullableDataTypes>().Where(ndt => ndt.Id == 0).Single();
+
+            Assert.Null(dt.TestNullableInt32);
+            Assert.Null(dt.TestNullableInt64);
+            Assert.Null(dt.TestNullableDouble);
+            Assert.Null(dt.TestNullableDecimal);
+            Assert.Null(dt.TestNullableDateTime);
+            Assert.Null(dt.TestNullableDateTimeOffset);
+            Assert.Null(dt.TestNullableSingle);
+            Assert.Null(dt.TestNullableBoolean);
+            Assert.Null(dt.TestNullableByte);
+            Assert.Null(dt.TestNullableInt16);
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_nullable_data_types_with_values_set_to_non_null()
+        {
+            var allDataTypes = _context.Set<BuiltInNullableDataTypes>().Add(
+                new BuiltInNullableDataTypes
+                {
+                    Id = 1,
+                    TestNullableInt32 = -123456789,
+                    TestString = "TestString",
+                    TestNullableInt64 = -1234567890123456789L,
+                    TestNullableDouble = -1.23456789,
+                    // TODO: SQL Server default precision is 18 (use max precision, 38, 
+                    // when available but no way to define that in the model at the moment)
+                    TestNullableDecimal = -1234567890.012345678M,
+                    TestNullableDateTime = new DateTime(123456789L),
+                    TestNullableDateTimeOffset = new DateTimeOffset(987654321L, TimeSpan.FromHours(-8.0)),
+                    TestNullableSingle = -1.234F,
+                    TestNullableBoolean = false,
+                    TestNullableByte = 255,
+                    TestNullableInt16 = -1234,
+                });
+
+            var changes = _context.SaveChanges();
+            Assert.Equal(1, changes);
+
+            var dt = _context.Set<BuiltInNullableDataTypes>().Where(ndt => ndt.Id == 1).Single();
+
+            Assert.Equal(-123456789, dt.TestNullableInt32);
+            Assert.Equal("TestString", dt.TestString);
+            Assert.Equal(-1234567890123456789L, dt.TestNullableInt64);
+            Assert.Equal(-1.23456789, dt.TestNullableDouble);
+            Assert.Equal(-1234567890.012345678M, dt.TestNullableDecimal);
+            Assert.Equal(new DateTime(123456789L), dt.TestNullableDateTime);
+            Assert.Equal(new DateTimeOffset(987654321L, TimeSpan.FromHours(-8.0)), dt.TestNullableDateTimeOffset);
+            Assert.Equal(-1.234F, dt.TestNullableSingle);
+            Assert.Equal(false, dt.TestNullableBoolean);
+            Assert.Equal((byte)255, dt.TestNullableByte);
+            Assert.Equal((short)-1234, dt.TestNullableInt16);
+        }
+    }
+}
+

--- a/test/EntityFramework.FunctionalTests/EntityFramework.FunctionalTests.csproj
+++ b/test/EntityFramework.FunctionalTests/EntityFramework.FunctionalTests.csproj
@@ -68,6 +68,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AsNoTrackingTestBase.cs" />
+    <Compile Include="BuiltInDataTypesFixtureBase.cs" />
+    <Compile Include="BuiltInDataTypesTestBase.cs" />
     <Compile Include="ExceptionInterceptionTest.cs" />
     <Compile Include="FixupTest.cs" />
     <Compile Include="Metadata\CompiledModelTest.cs" />
@@ -77,6 +79,8 @@
     <Compile Include="NorthwindAsyncQueryTestBase.cs" />
     <Compile Include="NorthwindQueryTestBase.cs" />
     <Compile Include="OptimisticConcurrencyTestBase.cs" />
+    <Compile Include="SupplementalBuiltInDataTypesFixtureBase.cs" />
+    <Compile Include="SupplementalBuiltInDataTypesTestBase.cs" />
     <Compile Include="TestStore.cs" />
     <Compile Include="TestFileLogger.cs" />
     <Compile Include="TestModels\ChangedChangingMonsterContext.cs" />

--- a/test/EntityFramework.FunctionalTests/SupplementalBuiltInDataTypesFixtureBase.cs
+++ b/test/EntityFramework.FunctionalTests/SupplementalBuiltInDataTypesFixtureBase.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.FunctionalTests
+{
+    /// <summary>
+    /// See also <see cref="BuiltInDataTypesFixtureBase" />.
+    /// Not all built-in data types are supported on all providers yet.
+    /// At the same time, not all conventions (e.g. Ignore) are available yet.
+    /// So this class provides a base fixture for those data types which are
+    /// only supported on some providers.
+    /// Over time, the aim is to transfer as many data types as possible into
+    /// BuiltInDataTypesFixtureBase and ultimately to delete this class.
+    /// </summary>
+    public abstract class SupplementalBuiltInDataTypesFixtureBase
+    {
+        public abstract DbContext CreateContext();
+
+        public virtual IModel CreateModel()
+        {
+            var model = new Model();
+            var builder = new BasicModelBuilder(model);
+            builder.Entity<SupplementalBuiltInNonNullableDataTypes>(b =>
+                {
+                    b.Key(dt => dt.Id);
+                    b.Property(dt => dt.TestUnsignedInt32);
+                    b.Property(dt => dt.TestUnsignedInt64);
+                    b.Property(dt => dt.TestUnsignedInt16);
+                    b.Property(dt => dt.TestCharacter);
+                    b.Property(dt => dt.TestSignedByte);
+                });
+
+            builder.Entity<SupplementalBuiltInNullableDataTypes>(b =>
+            {
+                b.Key(dt => dt.Id);
+                b.Property(dt => dt.TestNullableUnsignedInt32);
+                b.Property(dt => dt.TestNullableUnsignedInt64);
+                b.Property(dt => dt.TestNullableInt16);
+                b.Property(dt => dt.TestNullableUnsignedInt16);
+                b.Property(dt => dt.TestNullableCharacter);
+                b.Property(dt => dt.TestNullableSignedByte);
+            });
+
+            return model;
+        }
+    }
+
+    public class SupplementalBuiltInNonNullableDataTypes
+    {
+        public int Id { get; set; }
+        public uint TestUnsignedInt32 { get; set; }
+        public ulong TestUnsignedInt64 { get; set; }
+        public ushort TestUnsignedInt16 { get; set; }
+        public char TestCharacter { get; set; }
+        public sbyte TestSignedByte { get; set; }
+    }
+
+    public class SupplementalBuiltInNullableDataTypes
+    {
+        public int Id { get; set; }
+        public uint? TestNullableUnsignedInt32 { get; set; }
+        public ulong? TestNullableUnsignedInt64 { get; set; }
+        public short? TestNullableInt16 { get; set; }
+        public ushort? TestNullableUnsignedInt16 { get; set; }
+        public char? TestNullableCharacter { get; set; }
+        public sbyte? TestNullableSignedByte { get; set; }
+    }
+}

--- a/test/EntityFramework.FunctionalTests/SupplementalBuiltInDataTypesTestBase.cs
+++ b/test/EntityFramework.FunctionalTests/SupplementalBuiltInDataTypesTestBase.cs
@@ -1,0 +1,106 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Data.Entity.FunctionalTests
+{
+    /// <summary>
+    /// See also <see cref="BuiltInDataTypesTestBase" />.
+    /// Not all built-in data types are supported on all providers yet.
+    /// At the same time, not all conventions (e.g. Ignore) are available yet.
+    /// So this class provides a base test class for those data types which are
+    /// only supported on some providers.
+    /// Over time, the aim is to transfer as many tests as possible into
+    /// BuiltInDataTypesTestBase and ultimately to delete this class.
+    /// </summary>
+    public abstract class SupplementalBuiltInDataTypesTestBase
+    {
+        protected DbContext _context;
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_supplemental_non_nullable_data_types()
+        {
+            var allDataTypes = _context.Set<SupplementalBuiltInNonNullableDataTypes>().Add(
+                new SupplementalBuiltInNonNullableDataTypes
+                {
+                    Id = 0,
+                    TestUnsignedInt32 = 1234565789U,
+                    TestUnsignedInt64 = 1234567890123456789UL,
+                    TestUnsignedInt16 = 1234,
+                    TestCharacter = 'a',
+                    TestSignedByte = -128,
+                });
+
+            var changes = _context.SaveChanges();
+            Assert.Equal(1, changes);
+
+            var dt = _context.Set<SupplementalBuiltInNonNullableDataTypes>().Where(nndt => nndt.Id == 0).Single();
+
+            Assert.Equal(1234565789U, dt.TestUnsignedInt32);
+            Assert.Equal(1234567890123456789UL, dt.TestUnsignedInt64);
+            Assert.Equal(1234, dt.TestUnsignedInt16);
+            Assert.Equal('a', dt.TestCharacter);
+            Assert.Equal(-128, dt.TestSignedByte);
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_supplemental_nullable_data_types_with_values_set_to_null()
+        {
+            var allDataTypes = _context.Set<SupplementalBuiltInNullableDataTypes>().Add(
+                new SupplementalBuiltInNullableDataTypes
+                {
+                    Id = 0,
+                    TestNullableUnsignedInt32 = null,
+                    TestNullableUnsignedInt64 = null,
+                    TestNullableInt16 = null,
+                    TestNullableUnsignedInt16 = null,
+                    TestNullableCharacter = null,
+                    TestNullableSignedByte = null,
+                });
+
+            var changes = _context.SaveChanges();
+            Assert.Equal(1, changes);
+
+            var dt = _context.Set<SupplementalBuiltInNullableDataTypes>().Where(ndt => ndt.Id == 0).Single();
+
+            Assert.Null(dt.TestNullableUnsignedInt32);
+            Assert.Null(dt.TestNullableUnsignedInt64);
+            Assert.Null(dt.TestNullableInt16);
+            Assert.Null(dt.TestNullableUnsignedInt16);
+            Assert.Null(dt.TestNullableCharacter);
+            Assert.Null(dt.TestNullableSignedByte);
+        }
+
+        [Fact]
+        public virtual void Can_insert_and_read_back_all_supplemental_nullable_data_types_with_values_set_to_non_null()
+        {
+            var allDataTypes = _context.Set<SupplementalBuiltInNullableDataTypes>().Add(
+                new SupplementalBuiltInNullableDataTypes
+                {
+                    Id = 1,
+                    TestNullableUnsignedInt32 = 1234565789U,
+                    TestNullableUnsignedInt64 = 1234567890123456789UL,
+                    TestNullableInt16 = -1234,
+                    TestNullableUnsignedInt16 = 1234,
+                    TestNullableCharacter = 'a',
+                    TestNullableSignedByte = -128,
+                });
+
+            var changes = _context.SaveChanges();
+            Assert.Equal(1, changes);
+
+            var dt = _context.Set<SupplementalBuiltInNullableDataTypes>().Where(ndt => ndt.Id == 1).Single();
+
+            Assert.Equal(1234565789U, dt.TestNullableUnsignedInt32);
+            Assert.Equal(1234567890123456789UL, dt.TestNullableUnsignedInt64);
+            Assert.Equal((short)-1234, dt.TestNullableInt16);
+            Assert.Equal((ushort)1234, dt.TestNullableUnsignedInt16);
+            Assert.Equal('a', dt.TestNullableCharacter);
+            Assert.Equal((sbyte)-128, dt.TestNullableSignedByte);
+        }
+    }
+}
+

--- a/test/EntityFramework.InMemory.FunctionalTests/BuiltInDataTypesFixture.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/BuiltInDataTypesFixture.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.FunctionalTests;
+
+namespace Microsoft.Data.Entity.InMemory.FunctionalTests
+{
+    public class BuiltInDataTypesFixture : BuiltInDataTypesFixtureBase
+    {
+        public override DbContext CreateContext()
+        {
+            var options = new DbContextOptions()
+                .UseModel(CreateModel())
+                .UseInMemoryStore();
+
+            return new DbContext(options);
+        }
+    }
+}

--- a/test/EntityFramework.InMemory.FunctionalTests/BuiltInDataTypesTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/BuiltInDataTypesTest.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+using Microsoft.Data.Entity.FunctionalTests;
+
+namespace Microsoft.Data.Entity.InMemory.FunctionalTests
+{
+    public class BuiltInDataTypesTest : BuiltInDataTypesTestBase, IClassFixture<BuiltInDataTypesFixture>
+    {
+        public BuiltInDataTypesTest(BuiltInDataTypesFixture fixture)
+        {
+            _context = fixture.CreateContext();
+        }
+    }
+}

--- a/test/EntityFramework.InMemory.FunctionalTests/EntityFramework.InMemory.FunctionalTests.csproj
+++ b/test/EntityFramework.InMemory.FunctionalTests/EntityFramework.InMemory.FunctionalTests.csproj
@@ -65,6 +65,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AsNoTrackingTest.cs" />
+    <Compile Include="BuiltInDataTypesFixture.cs" />
+    <Compile Include="BuiltInDataTypesTest.cs" />
     <Compile Include="MusicStoreQueryTests.cs" />
     <Compile Include="CompositeKeyEndToEndTest.cs" />
     <Compile Include="GuidValueGeneratorEndToEndTest.cs" />
@@ -76,6 +78,8 @@
     <Compile Include="NorthwindAsyncQueryTest.cs" />
     <Compile Include="NorthwindQueryTest.cs" />
     <Compile Include="ShadowStateUpdateTest.cs" />
+    <Compile Include="SupplementalBuiltInDataTypesFixture.cs" />
+    <Compile Include="SupplementalBuiltInDataTypesTest.cs" />
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>

--- a/test/EntityFramework.InMemory.FunctionalTests/SupplementalBuiltInDataTypesFixture.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/SupplementalBuiltInDataTypesFixture.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.FunctionalTests;
+
+namespace Microsoft.Data.Entity.InMemory.FunctionalTests
+{
+    public class SupplementalBuiltInDataTypesFixture : SupplementalBuiltInDataTypesFixtureBase
+    {
+        public override DbContext CreateContext()
+        {
+            var options = new DbContextOptions()
+                .UseModel(CreateModel())
+                .UseInMemoryStore();
+
+            return new DbContext(options);
+        }
+    }
+}

--- a/test/EntityFramework.InMemory.FunctionalTests/SupplementalBuiltInDataTypesTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/SupplementalBuiltInDataTypesTest.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+using Microsoft.Data.Entity.FunctionalTests;
+
+namespace Microsoft.Data.Entity.InMemory.FunctionalTests
+{
+    public class SupplementalBuiltInDataTypesTest :
+        SupplementalBuiltInDataTypesTestBase, IClassFixture<SupplementalBuiltInDataTypesFixture>
+    {
+        public SupplementalBuiltInDataTypesTest(SupplementalBuiltInDataTypesFixture fixture)
+        {
+            _context = fixture.CreateContext();
+        }
+    }
+}

--- a/test/EntityFramework.Redis.FunctionalTests/BuiltInDataTypesFixture.cs
+++ b/test/EntityFramework.Redis.FunctionalTests/BuiltInDataTypesFixture.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.Redis.Extensions;
+
+namespace Microsoft.Data.Entity.Redis.FunctionalTests
+{
+    public class BuiltInDataTypesFixture : BuiltInDataTypesFixtureBase
+    {
+        public override DbContext CreateContext()
+        {
+            var options = new DbContextOptions()
+                .UseModel(CreateModel())
+                .UseRedis("127.0.0.1", RedisTestConfig.RedisPort);
+
+            return new DbContext(options);
+        }
+    }
+}

--- a/test/EntityFramework.Redis.FunctionalTests/BuiltInDataTypesTest.cs
+++ b/test/EntityFramework.Redis.FunctionalTests/BuiltInDataTypesTest.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+using Microsoft.Data.Entity.FunctionalTests;
+
+namespace Microsoft.Data.Entity.Redis.FunctionalTests
+{
+    public class BuiltInDataTypesTest : BuiltInDataTypesTestBase, IClassFixture<BuiltInDataTypesFixture>
+    {
+        public BuiltInDataTypesTest(BuiltInDataTypesFixture fixture)
+        {
+            _context = fixture.CreateContext();
+        }
+    }
+}

--- a/test/EntityFramework.Redis.FunctionalTests/EntityFramework.Redis.FunctionalTests.csproj
+++ b/test/EntityFramework.Redis.FunctionalTests/EntityFramework.Redis.FunctionalTests.csproj
@@ -72,6 +72,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AsNoTrackingTest.cs" />
+    <Compile Include="BuiltInDataTypesFixture.cs" />
+    <Compile Include="BuiltInDataTypesTest.cs" />
     <Compile Include="NorthwindQueryFixture.cs" />
     <Compile Include="NorthwindQueryTest.cs" />
     <Compile Include="RedisTestConfig.cs" />
@@ -79,6 +81,8 @@
     <Compile Include="SimpleFixture.cs" />
     <Compile Include="SimpleTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SupplementalBuiltInDataTypesFixture.cs" />
+    <Compile Include="SupplementalBuiltInDataTypesTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\EntityFramework.Redis\EntityFramework.Redis.csproj">

--- a/test/EntityFramework.Redis.FunctionalTests/SupplementalBuiltInDataTypesFixture.cs
+++ b/test/EntityFramework.Redis.FunctionalTests/SupplementalBuiltInDataTypesFixture.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.Redis.Extensions;
+
+namespace Microsoft.Data.Entity.Redis.FunctionalTests
+{
+    public class SupplementalBuiltInDataTypesFixture : SupplementalBuiltInDataTypesFixtureBase
+    {
+        public override DbContext CreateContext()
+        {
+            var options = new DbContextOptions()
+                .UseModel(CreateModel())
+                .UseRedis("127.0.0.1", RedisTestConfig.RedisPort);
+
+            return new DbContext(options);
+        }
+    }
+}

--- a/test/EntityFramework.Redis.FunctionalTests/SupplementalBuiltInDataTypesTest.cs
+++ b/test/EntityFramework.Redis.FunctionalTests/SupplementalBuiltInDataTypesTest.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+using Microsoft.Data.Entity.FunctionalTests;
+
+namespace Microsoft.Data.Entity.Redis.FunctionalTests
+{
+    public class SupplementalBuiltInDataTypesTest : 
+        SupplementalBuiltInDataTypesTestBase, IClassFixture<SupplementalBuiltInDataTypesFixture>
+    {
+        public SupplementalBuiltInDataTypesTest(SupplementalBuiltInDataTypesFixture fixture)
+        {
+            _context = fixture.CreateContext();
+        }
+    }
+}

--- a/test/EntityFramework.SQLite.FunctionalTests/BuiltInDataTypesFixture.cs
+++ b/test/EntityFramework.SQLite.FunctionalTests/BuiltInDataTypesFixture.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
+
+
+namespace Microsoft.Data.Entity.SQLite.FunctionalTests
+{
+    public class BuiltInDataTypesFixture : BuiltInDataTypesFixtureBase, IDisposable
+    {
+        private DbContext _context;
+
+        public override DbContext CreateContext()
+        {
+            var testDatabase = SQLiteTestDatabase.Scratch().Result;
+
+            var options = new DbContextOptions()
+                .UseModel(CreateModel())
+                .UseSQLite(testDatabase.Connection.ConnectionString);
+
+            _context = new DbContext(options);
+            _context.Database.EnsureCreated();
+            return _context;
+        }
+
+        void IDisposable.Dispose()
+        {
+            if (_context != null)
+            {
+                _context.Dispose();
+            }
+        }
+    }
+}

--- a/test/EntityFramework.SQLite.FunctionalTests/BuiltInDataTypesTest.cs
+++ b/test/EntityFramework.SQLite.FunctionalTests/BuiltInDataTypesTest.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+using Microsoft.Data.Entity.FunctionalTests;
+
+namespace Microsoft.Data.Entity.SQLite.FunctionalTests
+{
+    public class BuiltInDataTypesTest : BuiltInDataTypesTestBase, IClassFixture<BuiltInDataTypesFixture>
+    {
+        public BuiltInDataTypesTest(BuiltInDataTypesFixture fixture)
+        {
+            _context = fixture.CreateContext();
+        }
+    }
+}
+

--- a/test/EntityFramework.SQLite.FunctionalTests/EntityFramework.SQLite.FunctionalTests.csproj
+++ b/test/EntityFramework.SQLite.FunctionalTests/EntityFramework.SQLite.FunctionalTests.csproj
@@ -69,6 +69,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AsNoTrackingTest.cs" />
+    <Compile Include="BuiltInDataTypesFixture.cs" />
+    <Compile Include="BuiltInDataTypesTest.cs" />
     <Compile Include="MonsterFixupTest.cs" />
     <Compile Include="NorthwindAsyncQueryTest.cs" />
     <Compile Include="NorthwindQueryFixture.cs" />

--- a/test/EntityFramework.SqlServer.FunctionalTests/BuiltInDataTypesFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/BuiltInDataTypesFixture.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public class BuiltInDataTypesFixture : BuiltInDataTypesFixtureBase, IDisposable
+    {
+        private DbContext _context;
+
+        public override DbContext CreateContext()
+        {
+            var testDatabase = SqlServerTestDatabase.Scratch().Result;
+
+            var options
+                = new DbContextOptions()
+                    .UseModel(CreateModel())
+                    .UseSqlServer(testDatabase.Connection.ConnectionString);
+
+            _context = new DbContext(options);
+            _context.Database.EnsureCreated();
+            return _context;
+        }
+
+        void IDisposable.Dispose()
+        {
+            if (_context != null)
+            {
+                _context.Dispose();
+            }
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.FunctionalTests/BuiltInDataTypesTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/BuiltInDataTypesTest.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+using Microsoft.Data.Entity.FunctionalTests;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public class BuiltInDataTypesTest : BuiltInDataTypesTestBase, IClassFixture<BuiltInDataTypesFixture>
+    {
+        public BuiltInDataTypesTest(BuiltInDataTypesFixture fixture)
+        {
+            _context = fixture.CreateContext();
+        }
+    }
+}
+

--- a/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
@@ -72,6 +72,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AsNoTrackingTest.cs" />
+    <Compile Include="BuiltInDataTypesFixture.cs" />
+    <Compile Include="BuiltInDataTypesTest.cs" />
     <Compile Include="ConnectionStringTest.cs" />
     <Compile Include="CompositeKeyEndToEndTest.cs" />
     <Compile Include="ExistingConnectionTest.cs" />


### PR DESCRIPTION
Added support for DateTimeOffset properties in Redis.
Added tests for all built-in data types for all providers except Azure - which needs special treatment (PartitionKeys etc).
As noted several of the data types are not yet supported on all providers - so these have been moved to a Supplemental set of tests which are implemented only on the providers that support them. As SQL Server and  SQLite start supporting these we should move those data types into the BuiltInDataTypes\* classes and remove them from the Supplemental ones.
