### PR TITLE
Identity theft for dummies...

### DIFF
--- a/src/EntityFramework.Relational/DatabaseBuilder.cs
+++ b/src/EntityFramework.Relational/DatabaseBuilder.cs
@@ -156,6 +156,16 @@ namespace Microsoft.Data.Entity.Relational
                         IsTimestamp = property.PropertyType == typeof(byte[]) && property.IsConcurrencyToken
                     };
 
+            // TODO: This is a workaround to get the value-generation annotations into the relational model
+            // so they can be used for appropriate DDL gen. Hopefully changes can be made to avoid copying all
+            // this stuff, or to do it in a cleaner manner.
+            foreach (var annotation in property.EntityType.Model.Annotations
+                .Concat(property.EntityType.Annotations)
+                .Concat(property.Annotations))
+            {
+                column[annotation.Name] = annotation.Value;
+            }
+
             table.AddColumn(column);
 
             return column;

--- a/src/EntityFramework.Relational/Model/Column.cs
+++ b/src/EntityFramework.Relational/Model/Column.cs
@@ -10,7 +10,9 @@ using Microsoft.Data.Entity.Relational.Utilities;
 namespace Microsoft.Data.Entity.Relational.Model
 {
     // TODO: Consider adding more validation.
-    public class Column
+    // TODO: Inheriting from MetadataBase to get annotations; it is unfortunate that all property information
+    // has to be duplicated in the relational model
+    public class Column : MetadataBase
     {
         private Table _table;
         private bool _isNullable = true;
@@ -105,6 +107,11 @@ namespace Microsoft.Data.Entity.Relational.Model
             Scale = source.Scale;
             IsFixedLength = source.IsFixedLength;
             IsUnicode = source.IsUnicode;
+
+            foreach (var annotation in source.Annotations)
+            {
+                Annotations.Add(annotation);
+            }
         }
 
         public virtual Column Clone([NotNull] CloneContext cloneContext)

--- a/src/EntityFramework.SqlServer/EntityFramework.SqlServer.csproj
+++ b/src/EntityFramework.SqlServer/EntityFramework.SqlServer.csproj
@@ -58,6 +58,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.tt</DependentUpon>
     </Compile>
+    <Compile Include="Extensions\SqlServerMetadataExtensions.cs" />
     <Compile Include="Query\SqlServerQueryCompilationContext.cs" />
     <Compile Include="Query\SqlServerQueryGenerator.cs" />
     <Compile Include="SequentialGuidValueGenerator.cs" />

--- a/src/EntityFramework.SqlServer/Extensions/SqlServerMetadataExtensions.cs
+++ b/src/EntityFramework.SqlServer/Extensions/SqlServerMetadataExtensions.cs
@@ -1,0 +1,223 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.SqlServer;
+using Microsoft.Data.Entity.SqlServer.Utilities;
+
+namespace Microsoft.Data.Entity.Metadata
+{
+    public static class SqlServerMetadataExtensions
+    {
+        public static class Annotations
+        {
+            public const string ValueGeneration = "SqlServerValueGeneration";
+            public const string SequenceBlockSize = "SqlServerSequenceBlockSize";
+            public const string SequenceName = "SqlServerSequenceName";
+            public const string Sequence = "Sequence";
+            public const string Identity = "Identity";
+        }
+
+        public static TPropertyBuilder GenerateValuesUsingSequence<TPropertyBuilder>(
+            [NotNull] this IPropertyBuilder<TPropertyBuilder> propertyBuilder)
+            where TPropertyBuilder : IPropertyBuilder<TPropertyBuilder>
+        {
+            Check.NotNull(propertyBuilder, "propertyBuilder");
+            CheckPropertyTypeForSequence(propertyBuilder);
+
+            SetSequenceAnnotation(propertyBuilder.Metadata);
+            propertyBuilder.Metadata.ValueGeneration = ValueGeneration.OnAdd;
+
+            return (TPropertyBuilder)propertyBuilder;
+        }
+
+        public static TEntityBuilder GenerateValuesUsingSequence<TEntityBuilder>(
+            [NotNull] this IEntityBuilder<TEntityBuilder> entityBuilder)
+            where TEntityBuilder : IEntityBuilder<TEntityBuilder>
+        {
+            Check.NotNull(entityBuilder, "entityBuilder");
+
+            SetSequenceAnnotation(entityBuilder.Metadata);
+
+            return (TEntityBuilder)entityBuilder;
+        }
+
+        public static TEntityBuilder GenerateValuesUsingSequence<TEntity, TEntityBuilder>(
+            [NotNull] this IEntityBuilder<TEntity, TEntityBuilder> entityBuilder)
+            where TEntityBuilder : IEntityBuilder<TEntity, TEntityBuilder>
+        {
+            Check.NotNull(entityBuilder, "entityBuilder");
+
+            SetSequenceAnnotation(entityBuilder.Metadata);
+
+            return (TEntityBuilder)entityBuilder;
+        }
+
+        public static TModelBuilder GenerateValuesUsingSequence<TModelBuilder>(
+            [NotNull] this IModelBuilder<TModelBuilder> modelBuilder)
+            where TModelBuilder : IModelBuilder<TModelBuilder>
+        {
+            Check.NotNull(modelBuilder, "modelBuilder");
+
+            SetSequenceAnnotation(modelBuilder.Metadata);
+
+            return (TModelBuilder)modelBuilder;
+        }
+
+        public static TPropertyBuilder GenerateValuesUsingSequence<TPropertyBuilder>(
+            [NotNull] this IPropertyBuilder<TPropertyBuilder> propertyBuilder,
+            [NotNull] string sequenceName,
+            int blockSize)
+            where TPropertyBuilder : IPropertyBuilder<TPropertyBuilder>
+        {
+            Check.NotNull(propertyBuilder, "propertyBuilder");
+            Check.NotEmpty(sequenceName, "sequenceName");
+            CheckPropertyTypeForSequence(propertyBuilder);
+            CheckBlockSize(blockSize);
+
+            SetSequenceAnnotation(propertyBuilder.Metadata, sequenceName, blockSize);
+            propertyBuilder.Metadata.ValueGeneration = ValueGeneration.OnAdd;
+
+            return (TPropertyBuilder)propertyBuilder;
+        }
+
+        public static TEntityBuilder GenerateValuesUsingSequence<TEntity, TEntityBuilder>(
+            [NotNull] this IEntityBuilder<TEntity, TEntityBuilder> entityBuilder,
+            [NotNull] string sequenceName,
+            int blockSize)
+            where TEntityBuilder : IEntityBuilder<TEntity, TEntityBuilder>
+        {
+            Check.NotNull(entityBuilder, "entityBuilder");
+            Check.NotEmpty(sequenceName, "sequenceName");
+            CheckBlockSize(blockSize);
+
+            SetSequenceAnnotation(entityBuilder.Metadata, sequenceName, blockSize);
+
+            return (TEntityBuilder)entityBuilder;
+        }
+
+        public static TEntityBuilder GenerateValuesUsingSequence<TEntityBuilder>(
+            [NotNull] this IEntityBuilder<TEntityBuilder> entityBuilder,
+            [NotNull] string sequenceName,
+            int blockSize)
+            where TEntityBuilder : IEntityBuilder<TEntityBuilder>
+        {
+            Check.NotNull(entityBuilder, "entityBuilder");
+            Check.NotEmpty(sequenceName, "sequenceName");
+            CheckBlockSize(blockSize);
+
+            SetSequenceAnnotation(entityBuilder.Metadata, sequenceName, blockSize);
+
+            return (TEntityBuilder)entityBuilder;
+        }
+
+        public static TModelBuilder GenerateValuesUsingSequence<TModelBuilder>(
+            [NotNull] this IModelBuilder<TModelBuilder> modelBuilder,
+            [NotNull] string sequenceName,
+            int blockSize)
+            where TModelBuilder : IModelBuilder<TModelBuilder>
+        {
+            Check.NotNull(modelBuilder, "modelBuilder");
+            Check.NotEmpty(sequenceName, "sequenceName");
+            CheckBlockSize(blockSize);
+
+            SetSequenceAnnotation(modelBuilder.Metadata, sequenceName, blockSize);
+
+            return (TModelBuilder)modelBuilder;
+        }
+
+        public static TPropertyBuilder GenerateValuesUsingIdentity<TPropertyBuilder>(
+            [NotNull] this IPropertyBuilder<TPropertyBuilder> propertyBuilder)
+            where TPropertyBuilder : IPropertyBuilder<TPropertyBuilder>
+        {
+            Check.NotNull(propertyBuilder, "propertyBuilder");
+
+            var propertyType = propertyBuilder.Metadata.PropertyType;
+            if (!propertyType.IsInteger()
+                || propertyType == typeof(byte))
+            {
+                throw new ArgumentException(Strings.FormatIdentityBadType(
+                    propertyBuilder.Metadata.Name, propertyBuilder.Metadata.EntityType.Name, propertyType.Name));
+            }
+
+            SetIdentityAnnotation(propertyBuilder.Metadata);
+            propertyBuilder.Metadata.ValueGeneration = ValueGeneration.OnAdd;
+
+            return (TPropertyBuilder)propertyBuilder;
+        }
+
+        public static TEntityBuilder GenerateValuesUsingIdentity<TEntity, TEntityBuilder>(
+            [NotNull] this IEntityBuilder<TEntity, TEntityBuilder> entityBuilder)
+            where TEntityBuilder : IEntityBuilder<TEntity, TEntityBuilder>
+        {
+            Check.NotNull(entityBuilder, "entityBuilder");
+
+            SetIdentityAnnotation(entityBuilder.Metadata);
+
+            return (TEntityBuilder)entityBuilder;
+        }
+
+        public static TEntityBuilder GenerateValuesUsingIdentity<TEntityBuilder>(
+            [NotNull] this IEntityBuilder<TEntityBuilder> entityBuilder)
+            where TEntityBuilder : IEntityBuilder<TEntityBuilder>
+        {
+            Check.NotNull(entityBuilder, "entityBuilder");
+
+            SetIdentityAnnotation(entityBuilder.Metadata);
+
+            return (TEntityBuilder)entityBuilder;
+        }
+
+        public static TModelBuilder GenerateValuesUsingIdentity<TModelBuilder>(
+            [NotNull] this IModelBuilder<TModelBuilder> modelBuilder)
+            where TModelBuilder : IModelBuilder<TModelBuilder>
+        {
+            Check.NotNull(modelBuilder, "modelBuilder");
+
+            SetIdentityAnnotation(modelBuilder.Metadata);
+
+            return (TModelBuilder)modelBuilder;
+        }
+
+        private static void CheckPropertyTypeForSequence<TPropertyBuilder>(IPropertyBuilder<TPropertyBuilder> propertyBuilder)
+            where TPropertyBuilder : IPropertyBuilder<TPropertyBuilder>
+        {
+            if (!propertyBuilder.Metadata.PropertyType.IsInteger())
+            {
+                throw new ArgumentException(Strings.FormatSequenceBadType(
+                    propertyBuilder.Metadata.Name, propertyBuilder.Metadata.EntityType.Name, propertyBuilder.Metadata.PropertyType.Name));
+            }
+        }
+
+        private static void CheckBlockSize(int blockSize)
+        {
+            if (blockSize <= 0)
+            {
+                throw new ArgumentOutOfRangeException("blockSize", Strings.SequenceBadBlockSize);
+            }
+        }
+
+        private static void SetSequenceAnnotation(MetadataBase metadata)
+        {
+            metadata[Annotations.ValueGeneration] = Annotations.Sequence;
+            metadata[Annotations.SequenceName] = null;
+            metadata[Annotations.SequenceBlockSize] = null;
+        }
+
+        private static void SetSequenceAnnotation(MetadataBase metadata, string sequenceName, int blockSize)
+        {
+            metadata[Annotations.ValueGeneration] = Annotations.Sequence;
+            metadata[Annotations.SequenceName] = sequenceName;
+            metadata[Annotations.SequenceBlockSize] = blockSize.ToString(CultureInfo.InvariantCulture);
+        }
+
+        private static void SetIdentityAnnotation(MetadataBase metadata)
+        {
+            metadata[Annotations.ValueGeneration] = Annotations.Identity;
+            metadata[Annotations.SequenceName] = null;
+            metadata[Annotations.SequenceBlockSize] = null;
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.SqlServer/Properties/Strings.Designer.cs
@@ -90,6 +90,54 @@ namespace Microsoft.Data.Entity.SqlServer
             return GetString("MaxBatchSizeMustBePositive");
         }
 
+        /// <summary>
+        /// The value provided for the SQL Server sequence block size must be positive.
+        /// </summary>
+        internal static string SequenceBadBlockSize
+        {
+            get { return GetString("SequenceBadBlockSize"); }
+        }
+
+        /// <summary>
+        /// The value provided for the SQL Server sequence block size must be positive.
+        /// </summary>
+        internal static string FormatSequenceBadBlockSize()
+        {
+            return GetString("SequenceBadBlockSize");
+        }
+
+        /// <summary>
+        /// Identity value generation cannot be used for the property '{property}' on entity type '{entityType}' because the property type is '{propertyType}'. Identity value generation can only be used with signed integer properties.
+        /// </summary>
+        internal static string IdentityBadType
+        {
+            get { return GetString("IdentityBadType"); }
+        }
+
+        /// <summary>
+        /// Identity value generation cannot be used for the property '{property}' on entity type '{entityType}' because the property type is '{propertyType}'. Identity value generation can only be used with signed integer properties.
+        /// </summary>
+        internal static string FormatIdentityBadType(object property, object entityType, object propertyType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("IdentityBadType", "property", "entityType", "propertyType"), property, entityType, propertyType);
+        }
+
+        /// <summary>
+        /// SQL Server sequences cannot be used to generate values for the property '{property}' on entity type '{entityType}' because the property type is '{propertyType}'. Sequences can only be used with integer properties.
+        /// </summary>
+        internal static string SequenceBadType
+        {
+            get { return GetString("SequenceBadType"); }
+        }
+
+        /// <summary>
+        /// SQL Server sequences cannot be used to generate values for the property '{property}' on entity type '{entityType}' because the property type is '{propertyType}'. Sequences can only be used with integer properties.
+        /// </summary>
+        internal static string FormatSequenceBadType(object property, object entityType, object propertyType)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("SequenceBadType", "property", "entityType", "propertyType"), property, entityType, propertyType);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EntityFramework.SqlServer/Properties/Strings.resx
+++ b/src/EntityFramework.SqlServer/Properties/Strings.resx
@@ -132,4 +132,13 @@
   <data name="MaxBatchSizeMustBePositive" xml:space="preserve">
     <value>The value provided for max batch size must be positive.</value>
   </data>
+  <data name="SequenceBadBlockSize" xml:space="preserve">
+    <value>The value provided for the SQL Server sequence block size must be positive.</value>
+  </data>
+  <data name="IdentityBadType" xml:space="preserve">
+    <value>Identity value generation cannot be used for the property '{property}' on entity type '{entityType}' because the property type is '{propertyType}'. Identity value generation can only be used with signed integer properties.</value>
+  </data>
+  <data name="SequenceBadType" xml:space="preserve">
+    <value>SQL Server sequences cannot be used to generate values for the property '{property}' on entity type '{entityType}' because the property type is '{propertyType}'. Sequences can only be used with integer properties.</value>
+  </data>
 </root>

--- a/src/EntityFramework.SqlServer/SqlServerMigrationOperationSqlGenerator.cs
+++ b/src/EntityFramework.SqlServer/SqlServerMigrationOperationSqlGenerator.cs
@@ -145,11 +145,17 @@ namespace Microsoft.Data.Entity.SqlServer
 
         protected override void GenerateColumnTraits(Column column, IndentedStringBuilder stringBuilder)
         {
-            if (column.ValueGenerationStrategy == ValueGeneration.OnAdd
-                && column.ClrType.IsInteger() && column.ClrType != typeof(byte))
+            // TODO: This is essentially duplicated logic from the selector; combine if possible
+            if (column.ValueGenerationStrategy == ValueGeneration.OnAdd)
             {
-                // TODO: Handle other SQL Server strategies
-                stringBuilder.Append(" IDENTITY");
+                var strategy = column[SqlServerMetadataExtensions.Annotations.ValueGeneration];
+
+                if (strategy == SqlServerMetadataExtensions.Annotations.Identity
+                    || (strategy == null
+                        && column.ClrType.IsInteger()))
+                {
+                    stringBuilder.Append(" IDENTITY");
+                }
             }
         }
 

--- a/src/EntityFramework.SqlServer/SqlServerSequenceValueGeneratorFactory.cs
+++ b/src/EntityFramework.SqlServer/SqlServerSequenceValueGeneratorFactory.cs
@@ -29,8 +29,7 @@ namespace Microsoft.Data.Entity.SqlServer
         {
             Check.NotNull(property, "property");
 
-            // TODO: StoreSequenceBlockSize string should be in a constant somewhere--not sure where yet
-            var annotatedIncrement = TryFindAnnotation(property, "StoreSequenceBlockSize");
+            var annotatedIncrement = property.FindAnnotationInHierarchy(SqlServerMetadataExtensions.Annotations.SequenceBlockSize);
 
             // TODO: Allow integer annotations
             return annotatedIncrement != null ? int.Parse(annotatedIncrement) : DefaultBlockSize;
@@ -40,8 +39,7 @@ namespace Microsoft.Data.Entity.SqlServer
         {
             Check.NotNull(property, "property");
 
-            // TODO: StoreSequenceName string should be in a constant somewhere--not sure where yet
-            var sequenceName = TryFindAnnotation(property, "StoreSequenceName");
+            var sequenceName = property.FindAnnotationInHierarchy(SqlServerMetadataExtensions.Annotations.SequenceName);
             if (sequenceName != null)
             {
                 return sequenceName;
@@ -82,11 +80,6 @@ namespace Microsoft.Data.Entity.SqlServer
                 {
                     new DropSequenceOperation(DelimitSequenceName(GetSequenceName(property)))
                 };
-        }
-
-        private static string TryFindAnnotation(IProperty property, string name)
-        {
-            return property[name] ?? property.EntityType[name] ?? property.EntityType.Model[name];
         }
 
         public virtual IValueGenerator Create(IProperty property)

--- a/src/EntityFramework.SqlServer/SqlServerValueGeneratorSelector.cs
+++ b/src/EntityFramework.SqlServer/SqlServerValueGeneratorSelector.cs
@@ -36,16 +36,22 @@ namespace Microsoft.Data.Entity.SqlServer
 
             if (property.ValueGeneration == ValueGeneration.OnAdd)
             {
-                if (property.PropertyType.IsInteger()
-                    && property.PropertyType != typeof(byte))
+                var strategy = property.FindAnnotationInHierarchy(SqlServerMetadataExtensions.Annotations.ValueGeneration);
+
+                if (strategy == SqlServerMetadataExtensions.Annotations.Sequence)
+                {
+                    return _sequenceFactory;
+                }
+
+                if (strategy == SqlServerMetadataExtensions.Annotations.Identity)
                 {
                     return _tempFactory;
                 }
 
-                // TODO: Allow specifying different SQL Server strategies and make sequence the default
-                if (property.PropertyType.IsInteger())
+                if (property.PropertyType.IsInteger()
+                    && property.PropertyType != typeof(byte))
                 {
-                    return _sequenceFactory;
+                    return _tempFactory;
                 }
 
                 if (property.PropertyType == typeof(Guid))

--- a/src/EntityFramework/Metadata/Compiled/NoAnnotations.cs
+++ b/src/EntityFramework/Metadata/Compiled/NoAnnotations.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
     {
         public IEnumerable<IAnnotation> Annotations
         {
-            get { return ImmutableList<Annotation>.Empty; }
+            get { return ImmutableList<IAnnotation>.Empty; }
         }
 
         public string this[[NotNull] string annotationName]

--- a/src/EntityFramework/Metadata/MetadataBase.cs
+++ b/src/EntityFramework/Metadata/MetadataBase.cs
@@ -20,11 +20,10 @@ namespace Microsoft.Data.Entity.Metadata
 
                 return _annotations[annotationName];
             }
-            [param: NotNull]
+            [param: CanBeNull]
             set
             {
                 Check.NotEmpty(annotationName, "annotationName");
-                Check.NotEmpty(value, "value");
 
                 _annotations[annotationName] = value;
             }

--- a/src/EntityFramework/Metadata/PropertyExtensions.cs
+++ b/src/EntityFramework/Metadata/PropertyExtensions.cs
@@ -35,5 +35,27 @@ namespace Microsoft.Data.Entity.Metadata
             return property.EntityType != null
                    && property.EntityType.Keys.SelectMany(e => e.Properties).Contains(property);
         }
+
+        public static string FindAnnotationInHierarchy([NotNull] this IProperty property, [NotNull] string name)
+        {
+            Check.NotNull(property, "property");
+            Check.NotEmpty(name, "name");
+
+            var value = property[name];
+            if (value != null
+                || property.EntityType == null)
+            {
+                return value;
+            }
+
+            value = property.EntityType[name];
+            if (value != null
+                || property.EntityType.Model == null)
+            {
+                return value;
+            }
+
+            return property.EntityType.Model[name];
+        }
     }
 }

--- a/test/EntityFramework.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
@@ -213,15 +213,14 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 modelBuilder.Entity<Pegasus>(b =>
                     {
                         b.Key(e => e.Identifier);
-                        b.Property(e => e.Identifier).GenerateValuesOnAdd();
+                        b.Property(e => e.Identifier).GenerateValuesUsingSequence();
                     });
             }
         }
 
         private class Pegasus
         {
-            // TODO: This is only byte until ability to set specific value generation strategy is enabled
-            public byte Identifier { get; set; }
+            public int Identifier { get; set; }
             public string Name { get; set; }
         }
     }

--- a/test/EntityFramework.SqlServer.Tests/EntityFramework.SqlServer.Tests.csproj
+++ b/test/EntityFramework.SqlServer.Tests/EntityFramework.SqlServer.Tests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="SequentialGuidValueGeneratorTest.cs" />
     <Compile Include="..\EntityFramework.Relational.Tests\SqlGeneratorTestBase.cs" />
     <Compile Include="SqlServerDbContextOptionsExtensionsTest.cs" />
+    <Compile Include="SqlServerMetadataExtensionsTest.cs" />
     <Compile Include="SqlServerMigrationOperationPreProcessorTest.cs" />
     <Compile Include="SqlServerOptionsExtensionTest.cs" />
     <Compile Include="SqlServerConnectionTest.cs" />

--- a/test/EntityFramework.SqlServer.Tests/SqlServerMetadataExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerMetadataExtensionsTest.cs
@@ -1,0 +1,522 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.Metadata;
+using Xunit;
+
+namespace Microsoft.Data.Entity.SqlServer.Tests
+{
+    public class SqlServerMetadataExtensionsTest
+    {
+        [Fact]
+        public void Can_set_sequence_generation_on_property_with_basic_builder()
+        {
+            var builder = new BasicModelBuilder();
+
+            builder.Entity<AnEntity>()
+                .Property(e => e.Id)
+                .GenerateValuesUsingSequence();
+
+            var property = GetProperty(builder.Model, "Id");
+            ValidateSequence(property);
+            Assert.Equal(ValueGeneration.OnAdd, property.ValueGeneration);
+        }
+
+        [Fact]
+        public void Can_set_sequence_generation_on_non_key_property_with_basic_builder()
+        {
+            var builder = new BasicModelBuilder();
+
+            builder.Entity<AnEntity>()
+                .Property(e => e.NotAnId)
+                .GenerateValuesUsingSequence();
+
+            var property = GetProperty(builder.Model, "NotAnId");
+            ValidateSequence(property);
+            Assert.Equal(ValueGeneration.OnAdd, property.ValueGeneration);
+        }
+
+        [Fact]
+        public void Can_set_sequence_generation_on_property_with_convention_builder()
+        {
+            var builder = new ModelBuilder();
+
+            builder.Entity<AnEntity>()
+                .Property(e => e.Id)
+                .GenerateValuesUsingSequence();
+
+            var property = GetProperty(builder.Model, "Id");
+            ValidateSequence(property);
+            Assert.Equal(ValueGeneration.OnAdd, property.ValueGeneration);
+        }
+
+        [Fact]
+        public void Can_set_sequence_generation_on_non_key_property_with_convention_builder()
+        {
+            var builder = new ModelBuilder();
+
+            builder.Entity<AnEntity>()
+                .Property(e => e.NotAnId)
+                .GenerateValuesUsingSequence();
+
+            var property = GetProperty(builder.Model, "NotAnId");
+            ValidateSequence(property);
+            Assert.Equal(ValueGeneration.OnAdd, property.ValueGeneration);
+        }
+
+        [Fact]
+        public void Can_set_sequence_generation_on_entity_type_with_basic_builder()
+        {
+            var builder = new BasicModelBuilder();
+
+            builder.Entity<AnEntity>()
+                .GenerateValuesUsingSequence();
+
+            ValidateSequence(GetEntityType(builder.Model));
+        }
+
+        [Fact]
+        public void Can_set_sequence_generation_on_entity_type_with_convention_builder()
+        {
+            var builder = new ModelBuilder();
+
+            builder.Entity<AnEntity>()
+                .GenerateValuesUsingSequence();
+
+            ValidateSequence(GetEntityType(builder.Model));
+        }
+
+        [Fact]
+        public void Can_set_sequence_generation_on_entity_type_with_non_generic_basic_builder()
+        {
+            var builder = new BasicModelBuilder();
+
+            builder.Entity(typeof(AnEntity))
+                .GenerateValuesUsingSequence();
+
+            ValidateSequence(GetEntityType(builder.Model));
+        }
+
+        [Fact]
+        public void Can_set_sequence_generation_on_entity_type_with_non_generic_convention_builder()
+        {
+            var builder = new ModelBuilder();
+
+            builder.Entity(typeof(AnEntity))
+                .GenerateValuesUsingSequence();
+
+            ValidateSequence(GetEntityType(builder.Model));
+        }
+
+        [Fact]
+        public void Can_set_sequence_generation_on_model_with_basic_builder()
+        {
+            var builder = new BasicModelBuilder();
+            builder.Entity<AnEntity>();
+
+            builder.GenerateValuesUsingSequence();
+
+            ValidateSequence(builder.Model);
+        }
+
+        [Fact]
+        public void Can_set_sequence_generation_on_model_with_convention_builder()
+        {
+            var builder = new ModelBuilder();
+            builder.Entity<AnEntity>();
+
+            builder.GenerateValuesUsingSequence();
+
+            ValidateSequence(builder.Model);
+        }
+
+        [Fact]
+        public void Can_set_sequence_generation_with_options_on_property_with_basic_builder()
+        {
+            var builder = new BasicModelBuilder();
+
+            builder.Entity<AnEntity>()
+                .Property(e => e.Id)
+                .GenerateValuesUsingSequence("SlimShady", 8);
+
+            var property = GetProperty(builder.Model, "Id");
+            ValidateSequenceWithOptions(property);
+            Assert.Equal(ValueGeneration.OnAdd, property.ValueGeneration);
+        }
+
+        [Fact]
+        public void Can_set_sequence_generation_with_options_on_non_key_property_with_basic_builder()
+        {
+            var builder = new BasicModelBuilder();
+
+            builder.Entity<AnEntity>()
+                .Property(e => e.NotAnId)
+                .GenerateValuesUsingSequence("SlimShady", 8);
+
+            var property = GetProperty(builder.Model, "NotAnId");
+            ValidateSequenceWithOptions(property);
+            Assert.Equal(ValueGeneration.OnAdd, property.ValueGeneration);
+        }
+
+        [Fact]
+        public void Can_set_sequence_generation_with_options_on_property_with_convention_builder()
+        {
+            var builder = new ModelBuilder();
+
+            builder.Entity<AnEntity>()
+                .Property(e => e.Id)
+                .GenerateValuesUsingSequence("SlimShady", 8);
+
+            var property = GetProperty(builder.Model, "Id");
+            ValidateSequenceWithOptions(property);
+            Assert.Equal(ValueGeneration.OnAdd, property.ValueGeneration);
+        }
+
+        [Fact]
+        public void Can_set_sequence_generation_with_options_on_non_key_property_with_convention_builder()
+        {
+            var builder = new ModelBuilder();
+
+            builder.Entity<AnEntity>()
+                .Property(e => e.NotAnId)
+                .GenerateValuesUsingSequence("SlimShady", 8);
+
+            var property = GetProperty(builder.Model, "NotAnId");
+            ValidateSequenceWithOptions(property);
+            Assert.Equal(ValueGeneration.OnAdd, property.ValueGeneration);
+        }
+
+        [Fact]
+        public void Can_set_sequence_generation_with_options_on_entity_type_with_basic_builder()
+        {
+            var builder = new BasicModelBuilder();
+
+            builder.Entity<AnEntity>()
+                .GenerateValuesUsingSequence("SlimShady", 8);
+
+            ValidateSequenceWithOptions(GetEntityType(builder.Model));
+        }
+
+        [Fact]
+        public void Can_set_sequence_generation_with_options_on_entity_type_with_convention_builder()
+        {
+            var builder = new ModelBuilder();
+
+            builder.Entity<AnEntity>()
+                .GenerateValuesUsingSequence("SlimShady", 8);
+
+            ValidateSequenceWithOptions(GetEntityType(builder.Model));
+        }
+
+        [Fact]
+        public void Can_set_sequence_generation_with_options_on_entity_type_with_non_generic_basic_builder()
+        {
+            var builder = new BasicModelBuilder();
+
+            builder.Entity(typeof(AnEntity))
+                .GenerateValuesUsingSequence("SlimShady", 8);
+
+            ValidateSequenceWithOptions(GetEntityType(builder.Model));
+        }
+
+        [Fact]
+        public void Can_set_sequence_generation_with_options_on_entity_type_with_non_generic_convention_builder()
+        {
+            var builder = new ModelBuilder();
+
+            builder.Entity(typeof(AnEntity))
+                .GenerateValuesUsingSequence("SlimShady", 8);
+
+            ValidateSequenceWithOptions(GetEntityType(builder.Model));
+        }
+
+        [Fact]
+        public void Can_set_sequence_generation_with_options_on_model_with_basic_builder()
+        {
+            var builder = new BasicModelBuilder();
+            builder.Entity<AnEntity>();
+
+            builder.GenerateValuesUsingSequence("SlimShady", 8);
+
+            ValidateSequenceWithOptions(builder.Model);
+        }
+
+        [Fact]
+        public void Can_set_sequence_generation_with_options_on_model_with_convention_builder()
+        {
+            var builder = new ModelBuilder();
+            builder.Entity<AnEntity>();
+
+            builder.GenerateValuesUsingSequence("SlimShady", 8);
+
+            ValidateSequenceWithOptions(builder.Model);
+        }
+
+        [Fact]
+        public void Can_set_identity_generation_on_property_with_basic_builder()
+        {
+            var builder = new BasicModelBuilder();
+
+            builder.Entity<AnEntity>()
+                .Property(e => e.Id)
+                .GenerateValuesUsingIdentity();
+
+            var property = GetProperty(builder.Model, "Id");
+            ValidateIdentity(property);
+            Assert.Equal(ValueGeneration.OnAdd, property.ValueGeneration);
+        }
+
+        [Fact]
+        public void Can_set_identity_generation_on_non_key_property_with_basic_builder()
+        {
+            var builder = new BasicModelBuilder();
+
+            builder.Entity<AnEntity>()
+                .Property(e => e.NotAnId)
+                .GenerateValuesUsingIdentity();
+
+            var property = GetProperty(builder.Model, "NotAnId");
+            ValidateIdentity(property);
+            Assert.Equal(ValueGeneration.OnAdd, property.ValueGeneration);
+        }
+
+        [Fact]
+        public void Can_set_identity_generation_on_property_with_convention_builder()
+        {
+            var builder = new ModelBuilder();
+
+            builder.Entity<AnEntity>()
+                .Property(e => e.Id)
+                .GenerateValuesUsingIdentity();
+
+            var property = GetProperty(builder.Model, "Id");
+            ValidateIdentity(property);
+            Assert.Equal(ValueGeneration.OnAdd, property.ValueGeneration);
+        }
+
+        [Fact]
+        public void Can_set_identity_generation_on_non_key_property_with_convention_builder()
+        {
+            var builder = new ModelBuilder();
+
+            builder.Entity<AnEntity>()
+                .Property(e => e.NotAnId)
+                .GenerateValuesUsingIdentity();
+
+            var property = GetProperty(builder.Model, "NotAnId");
+            ValidateIdentity(property);
+            Assert.Equal(ValueGeneration.OnAdd, property.ValueGeneration);
+        }
+
+        [Fact]
+        public void Can_set_identity_generation_on_entity_type_with_basic_builder()
+        {
+            var builder = new BasicModelBuilder();
+
+            builder.Entity<AnEntity>()
+                .GenerateValuesUsingIdentity();
+
+            ValidateIdentity(GetEntityType(builder.Model));
+        }
+
+        [Fact]
+        public void Can_set_identity_generation_on_entity_type_with_convention_builder()
+        {
+            var builder = new ModelBuilder();
+
+            builder.Entity<AnEntity>()
+                .GenerateValuesUsingIdentity();
+
+            ValidateIdentity(GetEntityType(builder.Model));
+        }
+
+        [Fact]
+        public void Can_set_identity_generation_on_entity_type_with_non_generic_basic_builder()
+        {
+            var builder = new BasicModelBuilder();
+
+            builder.Entity(typeof(AnEntity))
+                .GenerateValuesUsingIdentity();
+
+            ValidateIdentity(GetEntityType(builder.Model));
+        }
+
+        [Fact]
+        public void Can_set_identity_generation_on_entity_type_with_non_generic_convention_builder()
+        {
+            var builder = new ModelBuilder();
+
+            builder.Entity(typeof(AnEntity))
+                .GenerateValuesUsingIdentity();
+
+            ValidateIdentity(GetEntityType(builder.Model));
+        }
+
+        [Fact]
+        public void Can_set_identity_generation_on_model_with_basic_builder()
+        {
+            var builder = new BasicModelBuilder();
+            builder.Entity<AnEntity>();
+
+            builder.GenerateValuesUsingIdentity();
+
+            ValidateIdentity(builder.Model);
+        }
+
+        [Fact]
+        public void Can_set_identity_generation_on_model_with_convention_builder()
+        {
+            var builder = new ModelBuilder();
+            builder.Entity<AnEntity>();
+
+            builder.GenerateValuesUsingIdentity();
+
+            ValidateIdentity(builder.Model);
+        }
+
+        [Fact]
+        public void Checks_valid_block_size()
+        {
+            var builder = new ModelBuilder();
+
+            Assert.StartsWith(
+                Strings.SequenceBadBlockSize,
+                Assert.Throws<ArgumentOutOfRangeException>(
+                    () => builder.Entity<AnEntity>()
+                        .Property(e => e.Id)
+                        .GenerateValuesUsingSequence("Shady", 0)).Message);
+
+            Assert.StartsWith(
+                Strings.SequenceBadBlockSize,
+                Assert.Throws<ArgumentOutOfRangeException>(
+                    () => builder.Entity<AnEntity>()
+                        .GenerateValuesUsingSequence("Shady", 0)).Message);
+
+            Assert.StartsWith(
+                Strings.SequenceBadBlockSize,
+                Assert.Throws<ArgumentOutOfRangeException>(
+                    () => builder.Entity(typeof(AnEntity))
+                        .GenerateValuesUsingSequence("Shady", 0)).Message);
+
+            Assert.StartsWith(
+                Strings.SequenceBadBlockSize,
+                Assert.Throws<ArgumentOutOfRangeException>(
+                    () => builder.GenerateValuesUsingSequence("Shady", 0)).Message);
+        }
+
+        [Fact]
+        public void Checks_valid_property_type_for_sequence()
+        {
+            var builder = new ModelBuilder();
+            
+            builder.Entity<AnEntity>()
+                .Property(e => e.Long)
+                .GenerateValuesUsingSequence();
+
+            builder.Entity<AnEntity>()
+                .Property(e => e.Short)
+                .GenerateValuesUsingSequence();
+
+            builder.Entity<AnEntity>()
+                .Property(e => e.Byte)
+                .GenerateValuesUsingSequence();
+
+            Assert.StartsWith(
+                Strings.FormatSequenceBadType("String", typeof(AnEntity).FullName, typeof(string).Name),
+                Assert.Throws<ArgumentException>(
+                    () => builder.Entity<AnEntity>()
+                        .Property(e => e.String)
+                        .GenerateValuesUsingSequence()).Message);
+
+            builder.Entity<AnEntity>()
+                .Property(e => e.Long)
+                .GenerateValuesUsingSequence("Shady", 8);
+
+            builder.Entity<AnEntity>()
+                .Property(e => e.Short)
+                .GenerateValuesUsingSequence("Shady", 8);
+
+            builder.Entity<AnEntity>()
+                .Property(e => e.Byte)
+                .GenerateValuesUsingSequence("Shady", 8);
+
+            Assert.StartsWith(
+                Strings.FormatSequenceBadType("String", typeof(AnEntity).FullName, typeof(string).Name),
+                Assert.Throws<ArgumentException>(
+                    () => builder.Entity<AnEntity>()
+                        .Property(e => e.String)
+                        .GenerateValuesUsingSequence("Shady", 8)).Message);
+        }
+
+        [Fact]
+        public void Checks_valid_property_type_for_identity()
+        {
+            var builder = new ModelBuilder();
+
+            builder.Entity<AnEntity>()
+                .Property(e => e.Long)
+                .GenerateValuesUsingIdentity();
+
+            builder.Entity<AnEntity>()
+                .Property(e => e.Short)
+                .GenerateValuesUsingIdentity();
+
+            Assert.StartsWith(
+                Strings.FormatIdentityBadType("Byte", typeof(AnEntity).FullName, typeof(byte).Name),
+                Assert.Throws<ArgumentException>(
+                    () => builder.Entity<AnEntity>()
+                        .Property(e => e.Byte)
+                        .GenerateValuesUsingIdentity()).Message);
+
+            Assert.StartsWith(
+                Strings.FormatIdentityBadType("String", typeof(AnEntity).FullName, typeof(string).Name),
+                Assert.Throws<ArgumentException>(
+                    () => builder.Entity<AnEntity>()
+                        .Property(e => e.String)
+                        .GenerateValuesUsingIdentity()).Message);
+        }
+
+        private static void ValidateSequence(MetadataBase property)
+        {
+            Assert.Equal(SqlServerMetadataExtensions.Annotations.Sequence, property[SqlServerMetadataExtensions.Annotations.ValueGeneration]);
+            Assert.Null(property[SqlServerMetadataExtensions.Annotations.SequenceBlockSize]);
+            Assert.Null(property[SqlServerMetadataExtensions.Annotations.SequenceName]);
+        }
+
+        private static void ValidateSequenceWithOptions(MetadataBase property)
+        {
+            Assert.Equal(SqlServerMetadataExtensions.Annotations.Sequence, property[SqlServerMetadataExtensions.Annotations.ValueGeneration]);
+            Assert.Equal("8", property[SqlServerMetadataExtensions.Annotations.SequenceBlockSize]);
+            Assert.Equal("SlimShady", property[SqlServerMetadataExtensions.Annotations.SequenceName]);
+        }
+
+        private static void ValidateIdentity(MetadataBase property)
+        {
+            Assert.Equal(SqlServerMetadataExtensions.Annotations.Identity, property[SqlServerMetadataExtensions.Annotations.ValueGeneration]);
+            Assert.Null(property[SqlServerMetadataExtensions.Annotations.SequenceBlockSize]);
+            Assert.Null(property[SqlServerMetadataExtensions.Annotations.SequenceName]);
+        }
+
+        private static Property GetProperty(Model model, string propertyName)
+        {
+            return GetEntityType(model).GetProperty(propertyName);
+        }
+
+        private static EntityType GetEntityType(Model model)
+        {
+            return model.GetEntityType(typeof(AnEntity));
+        }
+
+        private class AnEntity
+        {
+            public int Id { get; set; }
+            public int NotAnId { get; set; }
+
+            public long Long { get; set; }
+            public short Short { get; set; }
+            public byte Byte { get; set; }
+            public string String { get; set; }
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.Tests/SqlServerSequenceValueGeneratorFactoryTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerSequenceValueGeneratorFactoryTest.cs
@@ -17,9 +17,9 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Block_size_is_obtained_from_property_annotation()
         {
             var property = CreateProperty();
-            property["StoreSequenceBlockSize"] = "11";
-            property.EntityType["StoreSequenceBlockSize"] = "-1";
-            property.EntityType.Model["StoreSequenceBlockSize"] = "-1";
+            property[SqlServerMetadataExtensions.Annotations.SequenceBlockSize] = "11";
+            property.EntityType[SqlServerMetadataExtensions.Annotations.SequenceBlockSize] = "-1";
+            property.EntityType.Model[SqlServerMetadataExtensions.Annotations.SequenceBlockSize] = "-1";
 
             var factory = new SqlServerSequenceValueGeneratorFactory(new SqlStatementExecutor());
 
@@ -30,8 +30,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Block_size_is_obtained_from_entity_type_annotation_if_not_set_on_property()
         {
             var property = CreateProperty();
-            property.EntityType["StoreSequenceBlockSize"] = "11";
-            property.EntityType.Model["StoreSequenceBlockSize"] = "-1";
+            property.EntityType[SqlServerMetadataExtensions.Annotations.SequenceBlockSize] = "11";
+            property.EntityType.Model[SqlServerMetadataExtensions.Annotations.SequenceBlockSize] = "-1";
 
             var factory = new SqlServerSequenceValueGeneratorFactory(new SqlStatementExecutor());
 
@@ -42,7 +42,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Block_size_is_obtained_from_model_annotation_if_not_set_on_property_or_type()
         {
             var property = CreateProperty();
-            property.EntityType.Model["StoreSequenceBlockSize"] = "11";
+            property.EntityType.Model[SqlServerMetadataExtensions.Annotations.SequenceBlockSize] = "11";
 
             var factory = new SqlServerSequenceValueGeneratorFactory(new SqlStatementExecutor());
 
@@ -63,9 +63,9 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Sequence_name_is_obtained_from_property_annotation()
         {
             var property = CreateProperty();
-            property["StoreSequenceName"] = "Robert";
-            property.EntityType["StoreSequenceName"] = "Jimmy";
-            property.EntityType.Model["StoreSequenceName"] = "Jimmy";
+            property[SqlServerMetadataExtensions.Annotations.SequenceName] = "Robert";
+            property.EntityType[SqlServerMetadataExtensions.Annotations.SequenceName] = "Jimmy";
+            property.EntityType.Model[SqlServerMetadataExtensions.Annotations.SequenceName] = "Jimmy";
 
             var factory = new SqlServerSequenceValueGeneratorFactory(new SqlStatementExecutor());
 
@@ -76,8 +76,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Sequence_name_is_obtained_from_entity_type_annotation_if_not_set_on_property()
         {
             var property = CreateProperty();
-            property.EntityType["StoreSequenceName"] = "Robert";
-            property.EntityType.Model["StoreSequenceName"] = "Jimmy";
+            property.EntityType[SqlServerMetadataExtensions.Annotations.SequenceName] = "Robert";
+            property.EntityType.Model[SqlServerMetadataExtensions.Annotations.SequenceName] = "Jimmy";
 
             var factory = new SqlServerSequenceValueGeneratorFactory(new SqlStatementExecutor());
 
@@ -88,7 +88,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Sequence_name_is_obtained_from_model_annotation_if_not_set_on_property_or_type()
         {
             var property = CreateProperty();
-            property.EntityType.Model["StoreSequenceName"] = "Robert";
+            property.EntityType.Model[SqlServerMetadataExtensions.Annotations.SequenceName] = "Robert";
 
             var factory = new SqlServerSequenceValueGeneratorFactory(new SqlStatementExecutor());
 
@@ -109,8 +109,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Creates_CreateSequenceOperation()
         {
             var property = CreateProperty();
-            property["StoreSequenceBlockSize"] = "11";
-            property["StoreSequenceName"] = "Plant";
+            property[SqlServerMetadataExtensions.Annotations.SequenceBlockSize] = "11";
+            property[SqlServerMetadataExtensions.Annotations.SequenceName] = "Plant";
 
             var factory = new SqlServerSequenceValueGeneratorFactory(new SqlStatementExecutor());
 
@@ -126,7 +126,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Creates_DropSequenceOperation()
         {
             var property = CreateProperty();
-            property["StoreSequenceName"] = "Page";
+            property[SqlServerMetadataExtensions.Annotations.SequenceName] = "Page";
 
             var factory = new SqlServerSequenceValueGeneratorFactory(new SqlStatementExecutor());
 
@@ -139,8 +139,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Creates_the_appropriate_value_generator()
         {
             var property = CreateProperty();
-            property["StoreSequenceBlockSize"] = "11";
-            property["StoreSequenceName"] = "Zeppelin";
+            property[SqlServerMetadataExtensions.Annotations.SequenceBlockSize] = "11";
+            property[SqlServerMetadataExtensions.Annotations.SequenceName] = "Zeppelin";
 
             var factory = new SqlServerSequenceValueGeneratorFactory(new SqlStatementExecutor());
 
@@ -164,7 +164,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Sequence_name_is_the_cache_key()
         {
             var property = CreateProperty();
-            property["StoreSequenceName"] = "Led";
+            property[SqlServerMetadataExtensions.Annotations.SequenceName] = "Led";
 
             var factory = new SqlServerSequenceValueGeneratorFactory(new SqlStatementExecutor());
 

--- a/test/EntityFramework.Tests/EntityFramework.Tests.csproj
+++ b/test/EntityFramework.Tests/EntityFramework.Tests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Identity\ValueGeneratorCacheTest.cs" />
     <Compile Include="Identity\ValueGeneratorPoolTest.cs" />
     <Compile Include="Identity\ValueGeneratorSelectorTest.cs" />
+    <Compile Include="Metadata\AnnotationsTest.cs" />
     <Compile Include="Metadata\BasicModelBuilderTest.cs" />
     <Compile Include="Metadata\CollectionTyoeFactoryTest.cs" />
     <Compile Include="Metadata\EntityTypeExtensionsTest.cs" />
@@ -98,6 +99,7 @@
     <Compile Include="Metadata\ModelConventions\ForeignKeyConventionTest.cs" />
     <Compile Include="Metadata\NavigationExtensionsTest.cs" />
     <Compile Include="Extensions\QueryableExtensionsTest.cs" />
+    <Compile Include="Metadata\PropertyExtensionsTest.cs" />
     <Compile Include="TestHelperExtensions.cs" />
     <Compile Include="ServiceProviderCacheTest.cs" />
     <Compile Include="ChangeTracking\ChangeTrackerTest.cs" />

--- a/test/EntityFramework.Tests/Metadata/AnnotationsTest.cs
+++ b/test/EntityFramework.Tests/Metadata/AnnotationsTest.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.Data.Entity.Metadata;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.Metadata
+{
+    public class AnnotationsTest
+    {
+        [Fact]
+        public void Can_add_annotation()
+        {
+            var annotations = new Annotations { new Annotation("Foo", "Bar") };
+
+            Assert.Equal("Bar", annotations["Foo"]);
+        }
+
+        [Fact]
+        public void Add_duplicate_annotation_replaces_current_annotation()
+        {
+            var annotations = new Annotations { new Annotation("Foo", "Bar") };
+
+            var newAnnotation = new Annotation("Foo", "Bar");
+            annotations.Add(newAnnotation);
+
+            Assert.Same(newAnnotation, annotations.Single());
+        }
+
+        [Fact]
+        public void Can_remove_annotation()
+        {
+            var annotations = new Annotations();
+            var annotation = new Annotation("Foo", "Bar");
+
+            annotations.Add(annotation);
+
+            Assert.Equal("Bar", annotations["Foo"]);
+
+            annotations.Remove(annotation);
+
+            Assert.Null(annotations["Foo"]);
+
+            annotations.Remove(annotation); // no throw
+        }
+
+        [Fact]
+        public void Can_update_existing_annotation()
+        {
+            var annotations = new Annotations();
+            var annotation = new Annotation("Foo", "Bar");
+
+            annotations.Add(annotation);
+
+            Assert.Equal("Bar", annotations["Foo"]);
+
+            annotations["Foo"] = "Baz";
+
+            Assert.Equal("Baz", annotations["Foo"]);
+        }
+
+        [Fact]
+        public void Can_get_set_model_annotations_via_indexer()
+        {
+            var annotations = new Annotations();
+
+            Assert.Null(annotations["foo"]);
+
+            annotations["foo"] = "bar";
+
+            Assert.Equal("bar", annotations["foo"]);
+
+            annotations["foo"] = "horse";
+
+            Assert.Equal("horse", annotations["foo"]);
+
+            annotations["foo"] = null;
+
+            Assert.Null(annotations["foo"]);
+
+            Assert.Empty(annotations);
+        }
+
+        [Fact]
+        public void Annotations_are_ordered_by_name()
+        {
+            var annotations = new Annotations();
+
+            var annotation1 = new Annotation("Z", "Foo");
+            var annotation2 = new Annotation("A", "Bar");
+
+            annotations.Add(annotation1);
+            annotations.Add(annotation2);
+
+            Assert.True(new[] { annotation2, annotation1 }.SequenceEqual(annotations));
+        }
+    }
+}

--- a/test/EntityFramework.Tests/Metadata/MetadataBaseTest.cs
+++ b/test/EntityFramework.Tests/Metadata/MetadataBaseTest.cs
@@ -40,10 +40,6 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Equal(
                 Strings.FormatArgumentIsEmpty("annotationName"),
                 Assert.Throws<ArgumentException>(() => metadataBase[""] = "The kake is a lie").Message);
-
-            Assert.Equal(
-                "value",
-                Assert.Throws<ArgumentNullException>(() => metadataBase["X"] = null).ParamName);
         }
 
         [Fact]
@@ -106,9 +102,21 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var metadataBase = new ConcreteMetadata();
 
+            Assert.Null(metadataBase["foo"]);
+
             metadataBase["foo"] = "bar";
 
             Assert.Equal("bar", metadataBase["foo"]);
+
+            metadataBase["foo"] = "horse";
+
+            Assert.Equal("horse", metadataBase["foo"]);
+
+            metadataBase["foo"] = null;
+
+            Assert.Null(metadataBase["foo"]);
+
+            Assert.Empty(metadataBase.Annotations);
         }
 
         [Fact]

--- a/test/EntityFramework.Tests/Metadata/PropertyExtensionsTest.cs
+++ b/test/EntityFramework.Tests/Metadata/PropertyExtensionsTest.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Metadata;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.Metadata
+{
+    public class PropertyExtensionsTest
+    {
+        [Fact]
+        public void Annotation_found_on_property_first()
+        {
+            var property = CreateProperty();
+            property["ArnieTheAnnotation"] = "P";
+            property.EntityType["ArnieTheAnnotation"] = "E";
+            property.EntityType.Model["ArnieTheAnnotation"] = "M";
+
+            Assert.Equal("P", property.FindAnnotationInHierarchy("ArnieTheAnnotation"));
+        }
+
+        [Fact]
+        public void Annotation_found_on_entity_type_second()
+        {
+            var property = CreateProperty();
+            property.EntityType["ArnieTheAnnotation"] = "E";
+            property.EntityType.Model["ArnieTheAnnotation"] = "M";
+
+            Assert.Equal("E", property.FindAnnotationInHierarchy("ArnieTheAnnotation"));
+        }
+
+        [Fact]
+        public void Annotation_found_on_model_last()
+        {
+            var property = CreateProperty();
+            property.EntityType.Model["ArnieTheAnnotation"] = "M";
+
+            Assert.Equal("M", property.FindAnnotationInHierarchy("ArnieTheAnnotation"));
+        }
+
+        [Fact]
+        public void Null_returned_if_annotation_not_found()
+        {
+            Assert.Null(CreateProperty().FindAnnotationInHierarchy("ArnieTheAnnotation"));
+        }
+
+        [Fact]
+        public void Null_returned_if_annotation_not_found_with_no_model()
+        {
+            var entityType = new EntityType("MyType");
+            var property = entityType.GetOrAddProperty("MyProperty", typeof(string), shadowProperty: true);
+
+            Assert.Null(property.FindAnnotationInHierarchy("ArnieTheAnnotation"));
+        }
+
+        [Fact]
+        public void Null_returned_if_annotation_not_found_with_no_model_entity_type()
+        {
+            Assert.Null(new Property("MyProperty", typeof(string)).FindAnnotationInHierarchy("ArnieTheAnnotation"));
+        }
+
+        private static Property CreateProperty()
+        {
+            var entityType = new EntityType("MyType");
+            var property = entityType.GetOrAddProperty("MyProperty", typeof(string), shadowProperty: true);
+
+            new Model().AddEntityType(entityType);
+
+            return property;
+        }
+    }
+}

--- a/test/EntityFramework.Tests/Metadata/PropertyTest.cs
+++ b/test/EntityFramework.Tests/Metadata/PropertyTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Reflection;
 using Microsoft.Data.Entity.Metadata;
 using Xunit;
 


### PR DESCRIPTION
Allow SQL Server-specific value generation strategies to be used.

This change adds fluent API for setting Identity or Sequence value generation for integer properties when using SQL Server. Note that Migrations support is still missing--this change only includes a hack to stop Identity columns being generated when sequences are being used.

Currently the default is still Identity. It will be switched to Sequence once Migrations support is added.
