### PR TITLE
U Can't Touch This...

### DIFF
--- a/src/EntityFramework/Utilities/TypeExtensions.cs
+++ b/src/EntityFramework/Utilities/TypeExtensions.cs
@@ -102,5 +102,40 @@ namespace System
             }
             while (type != null);
         }
+
+        private static readonly Dictionary<Type, object> _commonTypeDictionary = new Dictionary<Type, object>
+            {
+                { typeof(int), default(int) },
+                { typeof(Guid), default(Guid) },
+                { typeof(DateTime), default(DateTime) },
+                { typeof(DateTimeOffset), default(DateTimeOffset) },
+                { typeof(long), default(long) },
+                { typeof(bool), default(bool) },
+                { typeof(double), default(double) },
+                { typeof(short), default(short) },
+                { typeof(float), default(float) },
+                { typeof(byte), default(byte) },
+                { typeof(char), default(char) },
+                { typeof(uint), default(uint) },
+                { typeof(ushort), default(ushort) },
+                { typeof(ulong), default(ulong) },
+                { typeof(sbyte), default(sbyte) }
+            };
+
+        public static object GetDefaultValue(this Type type)
+        {
+            if (!type.GetTypeInfo().IsValueType)
+            {
+                return null;
+            }
+
+            // A bit of perf code to avoid calling Activator.CreateInstance for common types and
+            // to avoid boxing on every call. This is about 50% faster than just calling CreateInstance
+            // for all value types.
+            object value;
+            return _commonTypeDictionary.TryGetValue(type, out value)
+                ? value
+                : Activator.CreateInstance(type);
+        }
     }
 }

--- a/test/EntityFramework.Redis.FunctionalTests/project.json
+++ b/test/EntityFramework.Redis.FunctionalTests/project.json
@@ -3,7 +3,7 @@
         "EntityFramework.Redis": "",
         "EntityFramework.FunctionalTests": "",
         "Microsoft.Framework.ConfigurationModel.Xml": "1.0.0-*",
-        "Redis-64": "2.8.9"
+        "redis-64": "2.8.9"
     },
     "commands": {
         "test": "Xunit.KRunner"

--- a/test/EntityFramework.SqlServer.FunctionalTests/SequentialGuidEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SequentialGuidEndToEndTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Framework.DependencyInjection;
@@ -45,6 +46,42 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             }
         }
 
+        [Fact]
+        public async Task Can_use_explicit_values()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFramework()
+                .AddSqlServer()
+                .ServiceCollection
+                .BuildServiceProvider();
+
+            var guids = new List<Guid>();
+
+            using (var context = new BronieContext(serviceProvider, "GooieExplicitBronies"))
+            {
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
+
+                for (var i = 0; i < 50; i++)
+                {
+                    guids.Add((await context.AddAsync(new Pegasus { Name = "Rainbow Dash " + i, Index = i, Id = Guid.NewGuid() })).Id);
+                }
+
+                await context.SaveChangesAsync();
+            }
+
+            using (var context = new BronieContext(serviceProvider, "GooieExplicitBronies"))
+            {
+                var pegasuses = await context.Pegasuses.OrderBy(e => e.Index).ToListAsync();
+
+                for (var i = 0; i < 50; i++)
+                {
+                    Assert.Equal("Rainbow Dash " + i, pegasuses[i].Name);
+                    Assert.Equal(guids[i], pegasuses[i].Id);
+                }
+            }
+        }
+
         private class BronieContext : DbContext
         {
             private readonly string _databaseName;
@@ -67,6 +104,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             public Guid Id { get; set; }
             public string Name { get; set; }
+            public int Index { get; set; }
         }
     }
 }

--- a/test/EntityFramework.Tests/ChangeTracking/SidecarTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/SidecarTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
-        public void Can_check_if_property_value_can_be_stored()
+        public virtual void Can_check_if_property_value_can_be_stored()
         {
             var sidecar = CreateSidecar();
 
@@ -29,7 +29,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
-        public void Can_check_if_value_is_stored()
+        public virtual void Can_check_if_value_is_stored()
         {
             var sidecar = CreateSidecar();
 
@@ -46,7 +46,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
-        public void Can_read_and_write_values()
+        public virtual void Can_read_and_write_values()
         {
             var entity = new Banana { Name = "Stand", Fk = 88 };
             var sidecar = CreateSidecar(CreateStateEntry(entity));
@@ -65,7 +65,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
-        public void Can_read_and_write_null()
+        public virtual void Can_read_and_write_null()
         {
             var entity = new Banana { Name = "Stand", Fk = 88 };
             var sidecar = CreateSidecar(CreateStateEntry(entity));
@@ -79,7 +79,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
-        public void Can_commit_values_into_state_entry()
+        public virtual void Can_commit_values_into_state_entry()
         {
             var entity = new Banana { Name = "Stand", Fk = 88 };
             var sidecar = CreateSidecar(CreateStateEntry(entity));
@@ -92,7 +92,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
-        public void Committing_detaches_sidecar()
+        public virtual void Committing_detaches_sidecar()
         {
             var entity = new Banana { Name = "Stand", Fk = 88 };
             var stateEntry = CreateStateEntry(entity);
@@ -105,7 +105,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
-        public void Rolling_back_detaches_sidecar_without_committing_values()
+        public virtual void Rolling_back_detaches_sidecar_without_committing_values()
         {
             var entity = new Banana { Name = "Stand", Fk = 88 };
             var stateEntry = CreateStateEntry(entity);
@@ -122,7 +122,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
-        public void Can_snapshot_values()
+        public virtual void Can_snapshot_values()
         {
             var entity = new Banana { Name = "Stand", Fk = 88 };
             var sidecar = CreateSidecar(CreateStateEntry(entity));
@@ -157,7 +157,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
-        public void Can_snapshot_individual_values()
+        public virtual void Can_snapshot_individual_values()
         {
             var entity = new Banana { Name = "Stand", Fk = 88 };
             var sidecar = CreateSidecar(CreateStateEntry(entity));
@@ -191,7 +191,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
-        public void Can_snapshot_null_values()
+        public virtual void Can_snapshot_null_values()
         {
             var entity = new Banana { Name = "Stand", State = null };
             var sidecar = CreateSidecar(CreateStateEntry(entity));
@@ -217,7 +217,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
-        public void Can_update_already_saved_values()
+        public virtual void Can_update_already_saved_values()
         {
             var entity = new Banana { Name = "Stand", Fk = 88 };
             var sidecar = CreateSidecar(CreateStateEntry(entity));
@@ -242,7 +242,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
-        public void Can_ensure_value_is_snapshotted_but_not_overwrite_existing_snapshot_value()
+        public virtual void Can_ensure_value_is_snapshotted_but_not_overwrite_existing_snapshot_value()
         {
             var entity = new Banana { Name = "Stand", Fk = 88 };
             var sidecar = CreateSidecar(CreateStateEntry(entity));
@@ -261,7 +261,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
-        public void Can_ensure_null_value_is_snapshotted_but_not_overwrite_existing_snapshot_value()
+        public virtual void Can_ensure_null_value_is_snapshotted_but_not_overwrite_existing_snapshot_value()
         {
             var entity = new Banana { Name = "Stand", State = null };
             var sidecar = CreateSidecar(CreateStateEntry(entity));
@@ -280,7 +280,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
-        public void Ensuring_snapshot_does_nothing_for_property_that_cannot_be_stored()
+        public virtual void Ensuring_snapshot_does_nothing_for_property_that_cannot_be_stored()
         {
             var entity = new Banana { Name = "Stand", Fk = 88 };
             var sidecar = CreateSidecar(CreateStateEntry(entity));
@@ -291,7 +291,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
-        public void Can_create_foreign_key_value_based_on_dependent_values()
+        public virtual void Can_create_foreign_key_value_based_on_dependent_values()
         {
             var entityType = _model.GetEntityType(typeof(Banana).FullName);
             var foreignKey = entityType.ForeignKeys.Single();
@@ -306,7 +306,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
-        public void Can_create_foreign_key_value_based_on_principal_end_values()
+        public virtual void Can_create_foreign_key_value_based_on_principal_end_values()
         {
             var entityType = _model.GetEntityType(typeof(Banana).FullName);
             var foreignKey = entityType.ForeignKeys.Single();
@@ -321,7 +321,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
-        public void Can_create_primary_key()
+        public virtual void Can_create_primary_key()
         {
             var entry = CreateStateEntry();
             var sidecar = CreateSidecar(entry);
@@ -333,7 +333,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
-        public void Can_create_composite_foreign_key_value_based_on_dependent_values()
+        public virtual void Can_create_composite_foreign_key_value_based_on_dependent_values()
         {
             var entityType = _model.GetEntityType(typeof(SomeMoreDependentEntity).FullName);
             var foreignKey = entityType.ForeignKeys.Single();
@@ -349,7 +349,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
-        public void Can_create_composite_foreign_key_value_based_on_principal_end_values()
+        public virtual void Can_create_composite_foreign_key_value_based_on_principal_end_values()
         {
             var dependentType = _model.GetEntityType(typeof(SomeMoreDependentEntity).FullName);
             var foreignKey = dependentType.ForeignKeys.Single();

--- a/test/EntityFramework.Tests/ChangeTracking/StateEntryTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/StateEntryTest.cs
@@ -243,6 +243,44 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
+        public void Value_generation_does_not_happen_if_property_has_non_default_value()
+        {
+            var model = BuildModel();
+            var entityType = model.GetEntityType(typeof(SomeEntity).FullName);
+            var keyProperty = entityType.GetProperty("Id");
+            var configuration = TestHelpers.CreateContextConfiguration(model);
+
+            var entry = CreateStateEntry(configuration, entityType, new SomeEntity());
+
+            entry[keyProperty] = 31143;
+
+            entry.EntityState = EntityState.Added;
+
+            Assert.Equal(31143, entry[keyProperty]);
+        }
+
+        [Fact]
+        public void Temporary_values_are_reset_when_entity_is_detached()
+        {
+            var model = BuildModel();
+            var entityType = model.GetEntityType(typeof(SomeEntity).FullName);
+            var keyProperty = entityType.GetProperty("Id");
+            var configuration = TestHelpers.CreateContextConfiguration(model);
+
+            var entry = CreateStateEntry(configuration, entityType, new SomeEntity());
+
+            entry.EntityState = EntityState.Added;
+            entry.MarkAsTemporary(keyProperty);
+
+            Assert.NotNull(entry[keyProperty]);
+            Assert.NotEqual(0, entry[keyProperty]);
+
+            entry.EntityState = EntityState.Unknown;
+
+            Assert.Equal(0, entry[keyProperty]);
+        }
+
+        [Fact]
         public void Changing_state_to_Added_triggers_value_generation_for_any_property()
         {
             var model = BuildModel();

--- a/test/EntityFramework.Tests/Utilities/TypeExtensionsTest.cs
+++ b/test/EntityFramework.Tests/Utilities/TypeExtensionsTest.cs
@@ -375,5 +375,48 @@ namespace Microsoft.Data.Entity.Tests.Utilities
         }
 
         // ReSharper restore InconsistentNaming
+
+        public void Can_get_default_value_for_type()
+        {
+            Assert.Equal(false, typeof(bool).GetDefaultValue());
+            Assert.Equal((sbyte)0, typeof(sbyte).GetDefaultValue());
+            Assert.Equal((short)0, typeof(short).GetDefaultValue());
+            Assert.Equal(0, typeof(int).GetDefaultValue());
+            Assert.Equal((long)0, typeof(long).GetDefaultValue());
+            Assert.Equal((byte)0, typeof(byte).GetDefaultValue());
+            Assert.Equal((ushort)0, typeof(ushort).GetDefaultValue());
+            Assert.Equal((uint)0, typeof(uint).GetDefaultValue());
+            Assert.Equal((ulong)0, typeof(ulong).GetDefaultValue());
+            Assert.Equal((float)0.0, typeof(float).GetDefaultValue());
+            Assert.Equal(0.0, typeof(double).GetDefaultValue());
+            Assert.Equal((char)0, typeof(char).GetDefaultValue());
+            Assert.Equal(default(Guid), typeof(Guid).GetDefaultValue());
+            Assert.Equal(default(DateTime), typeof(DateTime).GetDefaultValue());
+            Assert.Equal(default(DateTimeOffset), typeof(DateTimeOffset).GetDefaultValue());
+            Assert.Equal(default(SomeStruct), typeof(SomeStruct).GetDefaultValue());
+            Assert.Equal(null, typeof(string).GetDefaultValue());
+            Assert.Equal(null, typeof(bool?).GetDefaultValue());
+            Assert.Equal(null, typeof(sbyte?).GetDefaultValue());
+            Assert.Equal(null, typeof(short?).GetDefaultValue());
+            Assert.Equal(null, typeof(int?).GetDefaultValue());
+            Assert.Equal(null, typeof(long?).GetDefaultValue());
+            Assert.Equal(null, typeof(byte?).GetDefaultValue());
+            Assert.Equal(null, typeof(ushort?).GetDefaultValue());
+            Assert.Equal(null, typeof(uint?).GetDefaultValue());
+            Assert.Equal(null, typeof(ulong?).GetDefaultValue());
+            Assert.Equal(null, typeof(float?).GetDefaultValue());
+            Assert.Equal(null, typeof(double?).GetDefaultValue());
+            Assert.Equal(null, typeof(char?).GetDefaultValue());
+            Assert.Equal(null, typeof(Guid?).GetDefaultValue());
+            Assert.Equal(null, typeof(DateTime?).GetDefaultValue());
+            Assert.Equal(null, typeof(DateTimeOffset?).GetDefaultValue());
+            Assert.Equal(null, typeof(SomeStruct?).GetDefaultValue());
+        }
+
+        private struct SomeStruct
+        {
+            public int Value1 { get; set; }
+            public long Value2 { get; set; }
+        }
     }
 }


### PR DESCRIPTION
Stop generating values for properties for which a value has been set.

We currently check against the default value for the property type; I will file an issue for allowing this check to be specified, which would then also allow it to be disregarded entirely such that this behavior is switched off.
