### PR TITLE
Adding a ValueGenerator to the Redis provider

### DIFF
--- a/src/EntityFramework.Redis/EntityFramework.Redis.csproj
+++ b/src/EntityFramework.Redis/EntityFramework.Redis.csproj
@@ -89,7 +89,12 @@
     <Compile Include="RedisDataStoreServices.cs" />
     <Compile Include="RedisDataStoreSource.cs" />
     <Compile Include="RedisOptionsExtension.cs" />
+    <Compile Include="RedisSequenceValueGenerator.cs" />
+    <Compile Include="RedisValueGeneratorCache.cs" />
+    <Compile Include="RedisValueGeneratorFactory.cs" />
+    <Compile Include="RedisValueGeneratorSelector.cs" />
     <Compile Include="Utilities\Check.cs" />
+    <Compile Include="..\Shared\SharedTypeExtensions.cs" />
     <EmbeddedResource Include="Properties\Strings.resx">
       <LogicalName>EntityFramework.Redis.Strings.resources</LogicalName>
     </EmbeddedResource>

--- a/src/EntityFramework.Redis/Extensions/RedisEntityServicesBuilderExtensions.cs
+++ b/src/EntityFramework.Redis/Extensions/RedisEntityServicesBuilderExtensions.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Framework.DependencyInjection
             Check.NotNull(builder, "builder");
 
             builder.ServiceCollection
+                .AddSingleton<RedisValueGeneratorSelector>()
+                .AddSingleton<RedisValueGeneratorCache>()
                 .AddScoped<DataStoreSource, RedisDataStoreSource>()
                 .AddScoped<RedisOptionsExtension>()
                 .AddScoped<RedisDataStore>()
@@ -24,7 +26,7 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddScoped<RedisConnection>()
                 .AddScoped<RedisDataStoreCreator>()
                 .AddScoped<RedisDatabase>()
-                .AddScoped<ValueGeneratorCache>();
+                .AddScoped<RedisValueGeneratorFactory>();
 
             return builder;
         }

--- a/src/EntityFramework.Redis/RedisDataStoreServices.cs
+++ b/src/EntityFramework.Redis/RedisDataStoreServices.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Data.Entity.Redis
         private readonly RedisDataStore _store;
         private readonly RedisDataStoreCreator _creator;
         private readonly RedisConnection _connection;
-        private readonly ValueGeneratorCache _valueGeneratorCache;
+        private readonly RedisValueGeneratorCache _valueGeneratorCache;
         private readonly RedisDatabase _database;
         private readonly ModelBuilderFactory _modelBuilderFactory;
 
@@ -23,7 +23,7 @@ namespace Microsoft.Data.Entity.Redis
             [NotNull] RedisDataStore store,
             [NotNull] RedisDataStoreCreator creator,
             [NotNull] RedisConnection connection,
-            [NotNull] ValueGeneratorCache valueGeneratorCache,
+            [NotNull] RedisValueGeneratorCache valueGeneratorCache,
             [NotNull] RedisDatabase database,
             [NotNull] ModelBuilderFactory modelBuilderFactory)
         {

--- a/src/EntityFramework.Redis/RedisDatabase.cs
+++ b/src/EntityFramework.Redis/RedisDatabase.cs
@@ -43,6 +43,12 @@ namespace Microsoft.Data.Entity.Redis
         private const string DataHashNameFormat = // 1st arg is EntityType, 2nd is value of the PK
             DataPrefix + "{0}" + KeyNameSeparator + "{1}";
 
+        private const string ValueGeneratorPrefix =
+            EntityFrameworkPrefix + "ValueGenerator" + KeyNameSeparator;
+
+        private const string ValueGenertorKeyNameFormat = // 1st arg is EntityType, 2nd is name of the property
+            ValueGeneratorPrefix + "{0}" + KeyNameSeparator + "{1}";
+
         private static readonly ConcurrentDictionary<string, ConnectionMultiplexer> _connectionMultiplexers 
             = new ConcurrentDictionary<string, ConnectionMultiplexer>(); // key = ConfigurationOptions.ToString()
 
@@ -288,6 +294,14 @@ namespace Microsoft.Data.Entity.Redis
                 DataHashNameFormat, Escape(entityType.SimpleName), compositePrimaryKeyValues);
         }
 
+        public static string ConstructRedisValueGeneratorKeyName([NotNull] IProperty property)
+        {
+            Check.NotNull(property, "property");
+
+            return string.Format(CultureInfo.InvariantCulture,
+                ValueGenertorKeyNameFormat, Escape(property.EntityType.SimpleName), Escape(property.Name));
+        }
+
         private static string ConstructKeyValue(
             StateEntry stateEntry, Func<StateEntry, IProperty, object> propertyValueSelector)
         {
@@ -352,9 +366,28 @@ namespace Microsoft.Data.Entity.Redis
             return results;
         }
 
+        /// <summary>
+        ///     Get the next generated value for the given property
+        /// </summary>
+        /// <param name="property">the property for which to get the next generated value</param>
+        /// <param name="incrementBy">when getting blocks of values, set this to the block size, otherwise use 1</param>
+        /// <param name="sequenceName">the name under which the generated sequence is kept on the underlying database, can be null to use default name</param>
+        /// <returns>The next generated value</returns>
+        public virtual long GetNextGeneratedValue([NotNull] IProperty property, long incrementBy, [CanBeNull] string sequenceName)
+        {
+            if (sequenceName == null)
+            {
+                sequenceName = ConstructRedisValueGeneratorKeyName(property);
+            }
+
+            // INCRBY
+            return GetUnderlyingDatabase().StringIncrement(sequenceName, incrementBy);
+        }
+
         private static string EncodeKeyValue([NotNull] object propertyValue)
         {
             Check.NotNull(propertyValue, "propertyValue");
+
             return Escape(Convert.ToString(propertyValue));
         }
 

--- a/src/EntityFramework.Redis/RedisSequenceValueGenerator.cs
+++ b/src/EntityFramework.Redis/RedisSequenceValueGenerator.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Identity;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Redis.Utilities;
+
+namespace Microsoft.Data.Entity.Redis
+{
+    public class RedisSequenceValueGenerator : BlockOfSequentialValuesGenerator
+    {
+        private RedisDatabase _redisDatabase;
+
+        public RedisSequenceValueGenerator(
+            [NotNull] RedisDatabase redisDatabase,
+            [NotNull] string sequenceName,
+            int blockSize)
+            : base(sequenceName, blockSize)
+        {
+            Check.NotNull(redisDatabase, "redisDatabase");
+
+            _redisDatabase = redisDatabase;
+        }
+
+        public override long GetNewCurrentValue(StateEntry stateEntry, IProperty property)
+        {
+            return _redisDatabase.GetNextGeneratedValue(property, BlockSize, SequenceName);
+        }
+
+        public override async Task<long> GetNewCurrentValueAsync(
+            StateEntry stateEntry, IProperty property, CancellationToken cancellationToken)
+        {
+            return await 
+                Task.FromResult<long>(_redisDatabase.GetNextGeneratedValue(property, BlockSize, SequenceName))
+                .ConfigureAwait(continueOnCapturedContext: false);
+        }
+    }
+}

--- a/src/EntityFramework.Redis/RedisValueGeneratorCache.cs
+++ b/src/EntityFramework.Redis/RedisValueGeneratorCache.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Identity;
+
+namespace Microsoft.Data.Entity.Redis
+{
+    public class RedisValueGeneratorCache : ValueGeneratorCache
+    {
+        public RedisValueGeneratorCache(
+            [NotNull] RedisValueGeneratorSelector selector,
+            [NotNull] ForeignKeyValueGenerator foreignKeyValueGenerator)
+            : base(selector, foreignKeyValueGenerator)
+        {
+        }
+    }
+}

--- a/src/EntityFramework.Redis/RedisValueGeneratorFactory.cs
+++ b/src/EntityFramework.Redis/RedisValueGeneratorFactory.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Identity;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Redis.Utilities;
+
+namespace Microsoft.Data.Entity.Redis
+{
+    public class RedisValueGeneratorFactory : IValueGeneratorFactory
+    {
+        public const int DefaultBlockSize = 10;
+
+        private RedisDatabase _redisDatabase;
+
+        public RedisValueGeneratorFactory([NotNull] RedisDatabase redisDatabase)
+        {
+            Check.NotNull(redisDatabase, "redisDatabase");
+
+            _redisDatabase = redisDatabase;
+        }
+
+        IValueGenerator IValueGeneratorFactory.Create(IProperty property)
+        {
+            return new RedisSequenceValueGenerator(_redisDatabase, GetSequenceName(property), GetBlockSize(property));
+        }
+
+        // TODO: investigate how to make pool size configurable
+        int IValueGeneratorFactory.GetPoolSize(IProperty property)
+        {
+            Check.NotNull(property, "property");
+
+            return 1;
+        }
+
+        string IValueGeneratorFactory.GetCacheKey(IProperty property)
+        {
+            Check.NotNull(property, "property");
+
+            return GetSequenceName(property);
+        }
+
+        // TODO: investigate how to make block size configurable
+        public virtual int GetBlockSize([NotNull] IProperty property)
+        {
+            Check.NotNull(property, "property");
+
+            return DefaultBlockSize;
+        }
+
+        public virtual string GetSequenceName([NotNull] IProperty property)
+        {
+            Check.NotNull(property, "property");
+
+            return RedisDatabase.ConstructRedisValueGeneratorKeyName(property);
+        }
+
+    }
+}

--- a/src/EntityFramework.Redis/RedisValueGeneratorSelector.cs
+++ b/src/EntityFramework.Redis/RedisValueGeneratorSelector.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Identity;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Redis.Utilities;
+
+namespace Microsoft.Data.Entity.Redis
+{
+    public class RedisValueGeneratorSelector : ValueGeneratorSelector
+    {
+        private readonly RedisValueGeneratorFactory _redisValueGeneratorFactory;
+
+        public RedisValueGeneratorSelector(
+            [NotNull] SimpleValueGeneratorFactory<GuidValueGenerator> guidFactory,
+            [NotNull] RedisValueGeneratorFactory redisValueGeneratorFactory)
+            : base(guidFactory)
+        {
+            Check.NotNull(redisValueGeneratorFactory, "redisValueGeneratorFactory");
+
+            _redisValueGeneratorFactory = redisValueGeneratorFactory;
+        }
+
+        public override IValueGeneratorFactory Select(IProperty property)
+        {
+            Check.NotNull(property, "property");
+
+            if (ValueGeneration.OnAdd == property.ValueGeneration
+                && (property.PropertyType.IsInteger()
+                    || typeof(uint) == property.PropertyType
+                    || typeof(ulong) == property.PropertyType
+                    || typeof(ushort) == property.PropertyType
+                    || typeof(sbyte) == property.PropertyType))
+            {
+                return _redisValueGeneratorFactory;
+            }
+
+            return base.Select(property);
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/SqlServerSequenceValueGenerator.cs
+++ b/src/EntityFramework.SqlServer/SqlServerSequenceValueGenerator.cs
@@ -7,128 +7,47 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking;
-using Microsoft.Data.Entity.Identity;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Identity;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.SqlServer.Utilities;
-using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.SqlServer
 {
-    public class SqlServerSequenceValueGenerator : IValueGenerator
+    public class SqlServerSequenceValueGenerator : BlockOfSequentialValuesGenerator
     {
-        private readonly AsyncLock _lock = new AsyncLock();
         private readonly SqlStatementExecutor _executor;
-        private readonly string _sequenceName;
-        private readonly int _blockSize;
-        private SequenceValue _currentValue = new SequenceValue(-1, 0);
 
         public SqlServerSequenceValueGenerator(
             [NotNull] SqlStatementExecutor executor,
             [NotNull] string sequenceName,
             int blockSize)
+            : base(sequenceName, blockSize)
         {
             Check.NotNull(executor, "executor");
-            Check.NotEmpty(sequenceName, "sequenceName");
 
             _executor = executor;
-            _sequenceName = sequenceName;
-            _blockSize = blockSize;
         }
 
-        public virtual string SequenceName
-        {
-            get { return _sequenceName; }
-        }
-
-        public virtual int BlockSize
-        {
-            get { return _blockSize; }
-        }
-
-        public virtual void Next(StateEntry stateEntry, IProperty property)
+        public override long GetNewCurrentValue(StateEntry stateEntry, IProperty property)
         {
             Check.NotNull(stateEntry, "stateEntry");
             Check.NotNull(property, "property");
 
-            var newValue = GetNextValue();
-
-            // If the chosen value is outside of the current block then we need a new block.
-            // It is possible that other threads will use all of the new block before this thread
-            // gets a chance to use the new new value, so use a while here to do it all again.
-            while (newValue.Current >= newValue.Max)
-            {
-                using (_lock.Lock())
-                {
-                    // Once inside the lock check to see if another thread already got a new block, in which
-                    // case just get a value out of the new block instead of requesting one.
-                    if (newValue.Max == _currentValue.Max)
-                    {
-                        var commandInfo = PrepareCommand(stateEntry.Configuration);
-
-                        var newCurrent = (long)_executor.ExecuteScalar(commandInfo.Item1.DbConnection, commandInfo.Item1.DbTransaction, commandInfo.Item2);
-                        newValue = new SequenceValue(newCurrent, newCurrent + _blockSize);
-                        _currentValue = newValue;
-                    }
-                    else
-                    {
-                        newValue = GetNextValue();
-                    }
-                }
-            }
-
-            stateEntry[property] = Convert.ChangeType(newValue.Current, property.PropertyType);
+            var commandInfo = PrepareCommand(stateEntry.Configuration);
+            return (long)_executor.ExecuteScalar(commandInfo.Item1.DbConnection, commandInfo.Item1.DbTransaction, commandInfo.Item2);
         }
 
-        public virtual async Task NextAsync(StateEntry stateEntry, IProperty property, CancellationToken cancellationToken = default(CancellationToken))
+        public override async Task<long> GetNewCurrentValueAsync(StateEntry stateEntry, IProperty property, CancellationToken cancellationToken)
         {
             Check.NotNull(stateEntry, "stateEntry");
             Check.NotNull(property, "property");
-
-            var newValue = GetNextValue();
-
-            // If the chosen value is outside of the current block then we need a new block.
-            // It is possible that other threads will use all of the new block before this thread
-            // gets a chance to use the new new value, so use a while here to do it all again.
-            while (newValue.Current >= newValue.Max)
-            {
-                // Once inside the lock check to see if another thread already got a new block, in which
-                // case just get a value out of the new block instead of requesting one.
-                using (await _lock.LockAsync(cancellationToken).WithCurrentCulture())
-                {
-                    if (newValue.Max == _currentValue.Max)
-                    {
-                        var commandInfo = PrepareCommand(stateEntry.Configuration);
-
-                        var newCurrent = (long)await _executor
-                            .ExecuteScalarAsync(commandInfo.Item1.DbConnection, commandInfo.Item1.DbTransaction, commandInfo.Item2, cancellationToken)
-                            .WithCurrentCulture();
-                        newValue = new SequenceValue(newCurrent, newCurrent + _blockSize);
-                        _currentValue = newValue;
-                    }
-                    else
-                    {
-                        newValue = GetNextValue();
-                    }
-                }
-            }
-
-            stateEntry[property] = Convert.ChangeType(newValue.Current, property.PropertyType);
-        }
-
-        private SequenceValue GetNextValue()
-        {
-            SequenceValue originalValue;
-            SequenceValue newValue;
-            do
-            {
-                originalValue = _currentValue;
-                newValue = originalValue.NextValue();
-            }
-            while (Interlocked.CompareExchange(ref _currentValue, newValue, originalValue) != originalValue);
-
-            return newValue;
+            
+            var commandInfo = PrepareCommand(stateEntry.Configuration);
+            return (long)await _executor
+                .ExecuteScalarAsync(commandInfo.Item1.DbConnection, commandInfo.Item1.DbTransaction, commandInfo.Item2, cancellationToken)
+                .WithCurrentCulture();
         }
 
         private Tuple<RelationalConnection, SqlStatement> PrepareCommand(DbContextConfiguration contextConfiguration)
@@ -136,39 +55,12 @@ namespace Microsoft.Data.Entity.SqlServer
             // TODO: Parameterize query and/or delimit identifier without using SqlServerMigrationOperationSqlGenerator
             var sql = new SqlStatement(string.Format(
                 CultureInfo.InvariantCulture,
-                "SELECT NEXT VALUE FOR {0}", _sequenceName));
+                "SELECT NEXT VALUE FOR {0}", SequenceName));
 
             // TODO: Should be able to get relational connection without cast
             var connection = (RelationalConnection)contextConfiguration.Connection;
 
             return Tuple.Create(connection, sql);
-        }
-
-        private class SequenceValue
-        {
-            private readonly long _current;
-            private readonly long _max;
-
-            public SequenceValue(long current, long max)
-            {
-                _current = current;
-                _max = max;
-            }
-
-            public long Current
-            {
-                get { return _current; }
-            }
-
-            public long Max
-            {
-                get { return _max; }
-            }
-
-            public SequenceValue NextValue()
-            {
-                return new SequenceValue(_current + 1, _max);
-            }
         }
     }
 }

--- a/src/EntityFramework/EntityFramework.csproj
+++ b/src/EntityFramework/EntityFramework.csproj
@@ -74,6 +74,7 @@
     <Compile Include="EntityStateExtensions.cs" />
     <Compile Include="ChangeTracking\PropertyBagExtensions.cs" />
     <Compile Include="Extensions\TaskExtensions.cs" />
+    <Compile Include="Identity\BlockOfSequentialValuesGenerator.cs" />
     <Compile Include="Identity\ForeignKeyValueGenerator.cs" />
     <Compile Include="Identity\GuidValueGenerator.cs" />
     <Compile Include="Identity\IValueGenerator.cs" />

--- a/src/EntityFramework/Identity/BlockOfSequentialValuesGenerator.cs
+++ b/src/EntityFramework/Identity/BlockOfSequentialValuesGenerator.cs
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Identity
+{
+    /// <summary>
+    /// Acts as a <see cref="IValueGenerator"> by requesting a block of values from the
+    /// underlying data store and returning them one by one. Will ask the underlying
+    /// data store for another block when the current block is exhausted.
+    /// </summary>
+    public abstract class BlockOfSequentialValuesGenerator : IValueGenerator
+    {
+        private readonly AsyncLock _lock = new AsyncLock();
+        private readonly string _sequenceName;
+        private readonly int _blockSize;
+        private SequenceValue _currentValue = new SequenceValue(-1, 0);
+
+        public BlockOfSequentialValuesGenerator(
+            [NotNull] string sequenceName,
+            int blockSize)
+        {
+            Check.NotEmpty(sequenceName, "sequenceName");
+
+            _sequenceName = sequenceName;
+            _blockSize = blockSize;
+        }
+
+        public string SequenceName
+        {
+            get { return _sequenceName; }
+        }
+
+        public int BlockSize
+        {
+            get { return _blockSize; }
+        }
+
+        public void Next(StateEntry stateEntry, IProperty property)
+        {
+            Check.NotNull(stateEntry, "stateEntry");
+            Check.NotNull(property, "property");
+
+            var newValue = GetNextValue();
+
+            // If the chosen value is outside of the current block then we need a new block.
+            // It is possible that other threads will use all of the new block before this thread
+            // gets a chance to use the new new value, so use a while here to do it all again.
+            while (newValue.Current >= newValue.Max)
+            {
+                using (_lock.Lock())
+                {
+                    // Once inside the lock check to see if another thread already got a new block, in which
+                    // case just get a value out of the new block instead of requesting one.
+                    if (newValue.Max == _currentValue.Max)
+                    {
+                        var newCurrent = GetNewCurrentValue(stateEntry, property);
+                        newValue = new SequenceValue(newCurrent, newCurrent + _blockSize);
+                        _currentValue = newValue;
+                    }
+                    else
+                    {
+                        newValue = GetNextValue();
+                    }
+                }
+            }
+
+            stateEntry[property] = Convert.ChangeType(newValue.Current, property.PropertyType);
+        }
+
+        public async Task NextAsync(StateEntry stateEntry, IProperty property, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Check.NotNull(stateEntry, "stateEntry");
+            Check.NotNull(property, "property");
+
+            var newValue = GetNextValue();
+
+            // If the chosen value is outside of the current block then we need a new block.
+            // It is possible that other threads will use all of the new block before this thread
+            // gets a chance to use the new new value, so use a while here to do it all again.
+            while (newValue.Current >= newValue.Max)
+            {
+                // Once inside the lock check to see if another thread already got a new block, in which
+                // case just get a value out of the new block instead of requesting one.
+                using (await _lock.LockAsync(cancellationToken).WithCurrentCulture())
+                {
+                    if (newValue.Max == _currentValue.Max)
+                    {
+                        var newCurrent = await GetNewCurrentValueAsync(stateEntry, property, cancellationToken);
+                        newValue = new SequenceValue(newCurrent, newCurrent + _blockSize);
+                        _currentValue = newValue;
+                    }
+                    else
+                    {
+                        newValue = GetNextValue();
+                    }
+                }
+            }
+
+            stateEntry[property] = Convert.ChangeType(newValue.Current, property.PropertyType);
+        }
+
+        public abstract long GetNewCurrentValue([NotNull] StateEntry stateEntry, [NotNull] IProperty property);
+
+        public abstract Task<long> GetNewCurrentValueAsync(
+            [NotNull] StateEntry stateEntry, [NotNull] IProperty property, CancellationToken cancellationToken);
+
+        private SequenceValue GetNextValue()
+        {
+            SequenceValue originalValue;
+            SequenceValue newValue;
+            do
+            {
+                originalValue = _currentValue;
+                newValue = originalValue.NextValue();
+            }
+            while (Interlocked.CompareExchange(ref _currentValue, newValue, originalValue) != originalValue);
+
+            return newValue;
+        }
+
+        private class SequenceValue
+        {
+            private readonly long _current;
+            private readonly long _max;
+
+            public SequenceValue(long current, long max)
+            {
+                _current = current;
+                _max = max;
+            }
+
+            public long Current
+            {
+                get { return _current; }
+            }
+
+            public long Max
+            {
+                get { return _max; }
+            }
+
+            public SequenceValue NextValue()
+            {
+                return new SequenceValue(_current + 1, _max);
+            }
+        }
+    }
+}

--- a/test/EntityFramework.Redis.Tests/EntityFramework.Redis.Tests.csproj
+++ b/test/EntityFramework.Redis.Tests/EntityFramework.Redis.Tests.csproj
@@ -55,10 +55,16 @@
     <PackageReference Include="Moq">
       <TargetFramework>net40</TargetFramework>
     </PackageReference>
+    <PackageReference Include="Microsoft.Framework.ConfigurationModel">
+      <TargetFramework>net45</TargetFramework>
+    </PackageReference>
     <PackageReference Include="Microsoft.Framework.Logging">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>
     <PackageReference Include="Microsoft.Framework.Logging.Interfaces">
+      <TargetFramework>net45</TargetFramework>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Framework.DependencyInjection">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>
     <PackageReference Include="Remotion.Linq">
@@ -69,6 +75,7 @@
     <Compile Include="..\Shared\ApiConsistencyTestBase.cs">
       <Link>ApiConsistencyTestBase.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\TestHelpers.cs" />
     <Compile Include="Query\QueryTestType.cs" />
     <Compile Include="Query\RedisQueryCompilationContextTests.cs" />
     <Compile Include="Query\RedisQueryModelVisitorTests.cs" />
@@ -77,6 +84,12 @@
     <Compile Include="RedisDatabaseTests.cs" />
     <Compile Include="RedisDataStoreCreatorTests.cs" />
     <Compile Include="RedisDataStoreSourceTests.cs" />
+    <Compile Include="RedisSequenceValueGeneratorTest.cs" />
+    <Compile Include="RedisValueGeneratorSelectorTest.cs" />
+    <Compile Include="TestHelperExtensions.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\EntityFramework.Redis\EntityFramework.Redis.csproj">

--- a/test/EntityFramework.Redis.Tests/RedisSequenceValueGeneratorTest.cs
+++ b/test/EntityFramework.Redis.Tests/RedisSequenceValueGeneratorTest.cs
@@ -1,0 +1,389 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Tests;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Redis.Tests
+{
+    public class RedisSequenceValueGeneratorTest
+    {
+        private static readonly Model _model = TestHelpers.BuildModelFor<AnEntity>();
+
+        [Fact]
+        public void Generates_sequential_values()
+        {
+            var stateEntry = TestHelpers.CreateStateEntry<AnEntity>(_model);
+            var property = stateEntry.EntityType.GetProperty("Id");
+            var sequenceName = RedisDatabase.ConstructRedisValueGeneratorKeyName(property);
+            var blockSize = 1;
+            var incrementingValue = 0L;
+            var dbConfigurationMock = new Mock<DbContextConfiguration>();
+            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object);
+            redisDatabaseMock
+                .Setup(db => db.GetNextGeneratedValue(It.IsAny<IProperty>(), It.IsAny<long>(), It.IsAny<string>()))
+                .Returns<IProperty, long, string>((p, l, s) =>
+                {
+                    var originalValue = incrementingValue;
+                    incrementingValue += l;
+                    return originalValue;
+                });
+
+            var intProperty = stateEntry.EntityType.GetProperty("Id");
+            var longProperty = stateEntry.EntityType.GetProperty("Long");
+            var shortProperty = stateEntry.EntityType.GetProperty("Short");
+            var byteProperty = stateEntry.EntityType.GetProperty("Byte");
+            var uintProperty = stateEntry.EntityType.GetProperty("UnsignedInt");
+            var ulongProperty = stateEntry.EntityType.GetProperty("UnsignedLong");
+            var ushortProperty = stateEntry.EntityType.GetProperty("UnsignedShort");
+            var sbyteProperty = stateEntry.EntityType.GetProperty("SignedByte");
+
+            var generator = new RedisSequenceValueGenerator(redisDatabaseMock.Object, sequenceName, blockSize);
+
+            for (var i = 0; i < 15; i++)
+            {
+                generator.Next(stateEntry, intProperty);
+
+                Assert.Equal(i, stateEntry[intProperty]);
+                Assert.False(stateEntry.HasTemporaryValue(intProperty));
+            }
+
+            for (var i = 15; i < 30; i++)
+            {
+                generator.Next(stateEntry, longProperty);
+
+                Assert.Equal((long)i, stateEntry[longProperty]);
+                Assert.False(stateEntry.HasTemporaryValue(longProperty));
+            }
+
+            for (var i = 30; i < 45; i++)
+            {
+                generator.Next(stateEntry, shortProperty);
+
+                Assert.Equal((short)i, stateEntry[shortProperty]);
+                Assert.False(stateEntry.HasTemporaryValue(shortProperty));
+            }
+
+            for (var i = 45; i < 60; i++)
+            {
+                generator.Next(stateEntry, byteProperty);
+
+                Assert.Equal((byte)i, stateEntry[byteProperty]);
+                Assert.False(stateEntry.HasTemporaryValue(byteProperty));
+            }
+
+            for (var i = 60; i < 75; i++)
+            {
+                generator.Next(stateEntry, uintProperty);
+
+                Assert.Equal((uint)i, stateEntry[uintProperty]);
+                Assert.False(stateEntry.HasTemporaryValue(uintProperty));
+            }
+
+            for (var i = 75; i < 90; i++)
+            {
+                generator.Next(stateEntry, ulongProperty);
+
+                Assert.Equal((ulong)i, stateEntry[ulongProperty]);
+                Assert.False(stateEntry.HasTemporaryValue(ulongProperty));
+            }
+
+            for (var i = 90; i < 105; i++)
+            {
+                generator.Next(stateEntry, ushortProperty);
+
+                Assert.Equal((ushort)i, stateEntry[ushortProperty]);
+                Assert.False(stateEntry.HasTemporaryValue(ushortProperty));
+            }
+
+            for (var i = 105; i < 120; i++)
+            {
+                generator.Next(stateEntry, sbyteProperty);
+
+                Assert.Equal((sbyte)i, stateEntry[sbyteProperty]);
+                Assert.False(stateEntry.HasTemporaryValue(sbyteProperty));
+            }
+        }
+
+        [Fact]
+        public async Task Generates_sequential_values_async()
+        {
+            var stateEntry = TestHelpers.CreateStateEntry<AnEntity>(_model);
+            var property = stateEntry.EntityType.GetProperty("Id");
+            var sequenceName = RedisDatabase.ConstructRedisValueGeneratorKeyName(property);
+            var blockSize = 1;
+            var incrementingValue = 0L;
+            var dbConfigurationMock = new Mock<DbContextConfiguration>();
+            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object);
+            redisDatabaseMock
+                .Setup(db => db.GetNextGeneratedValue(It.IsAny<IProperty>(), It.IsAny<long>(), It.IsAny<string>()))
+                .Returns<IProperty, long, string>((p, l, s) =>
+                {
+                    var originalValue = incrementingValue;
+                    incrementingValue += l;
+                    return originalValue;
+                });
+
+            var intProperty = stateEntry.EntityType.GetProperty("Id");
+            var longProperty = stateEntry.EntityType.GetProperty("Long");
+            var shortProperty = stateEntry.EntityType.GetProperty("Short");
+            var byteProperty = stateEntry.EntityType.GetProperty("Byte");
+            var uintProperty = stateEntry.EntityType.GetProperty("UnsignedInt");
+            var ulongProperty = stateEntry.EntityType.GetProperty("UnsignedLong");
+            var ushortProperty = stateEntry.EntityType.GetProperty("UnsignedShort");
+            var sbyteProperty = stateEntry.EntityType.GetProperty("SignedByte");
+
+            var generator = new RedisSequenceValueGenerator(redisDatabaseMock.Object, sequenceName, blockSize);
+
+            for (var i = 0; i < 15; i++)
+            {
+                await generator.NextAsync(stateEntry, intProperty);
+
+                Assert.Equal(i, stateEntry[intProperty]);
+                Assert.False(stateEntry.HasTemporaryValue(intProperty));
+            }
+
+            for (var i = 15; i < 30; i++)
+            {
+                await generator.NextAsync(stateEntry, longProperty);
+
+                Assert.Equal((long)i, stateEntry[longProperty]);
+                Assert.False(stateEntry.HasTemporaryValue(longProperty));
+            }
+
+            for (var i = 30; i < 45; i++)
+            {
+                await generator.NextAsync(stateEntry, shortProperty);
+
+                Assert.Equal((short)i, stateEntry[shortProperty]);
+                Assert.False(stateEntry.HasTemporaryValue(shortProperty));
+            }
+
+            for (var i = 45; i < 60; i++)
+            {
+                await generator.NextAsync(stateEntry, byteProperty);
+
+                Assert.Equal((byte)i, stateEntry[byteProperty]);
+                Assert.False(stateEntry.HasTemporaryValue(byteProperty));
+            }
+
+            for (var i = 60; i < 75; i++)
+            {
+                await generator.NextAsync(stateEntry, uintProperty);
+
+                Assert.Equal((uint)i, stateEntry[uintProperty]);
+                Assert.False(stateEntry.HasTemporaryValue(uintProperty));
+            }
+
+            for (var i = 75; i < 90; i++)
+            {
+                await generator.NextAsync(stateEntry, ulongProperty);
+
+                Assert.Equal((ulong)i, stateEntry[ulongProperty]);
+                Assert.False(stateEntry.HasTemporaryValue(ulongProperty));
+            }
+
+            for (var i = 90; i < 105; i++)
+            {
+                await generator.NextAsync(stateEntry, ushortProperty);
+
+                Assert.Equal((ushort)i, stateEntry[ushortProperty]);
+                Assert.False(stateEntry.HasTemporaryValue(ushortProperty));
+            }
+
+            for (var i = 105; i < 120; i++)
+            {
+                await generator.NextAsync(stateEntry, sbyteProperty);
+
+                Assert.Equal((sbyte)i, stateEntry[sbyteProperty]);
+                Assert.False(stateEntry.HasTemporaryValue(sbyteProperty));
+            }
+        }
+
+        [Fact]
+        public void Multiple_threads_can_use_the_same_generator()
+        {
+            var incrementingValue = 0L;
+            var dbConfigurationMock = new Mock<DbContextConfiguration>();
+            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object);
+            redisDatabaseMock
+                .Setup(db => db.GetNextGeneratedValue(It.IsAny<IProperty>(), It.IsAny<long>(), It.IsAny<string>()))
+                .Returns<IProperty, long, string>((p, l, s) =>
+                {
+                    var originalValue = incrementingValue;
+                    incrementingValue += l;
+                    return originalValue;
+                });
+
+            var generator = new RedisSequenceValueGenerator(redisDatabaseMock.Object, "TestSequenceName", 1);
+
+            var property = _model.GetEntityType(typeof(AnEntity)).GetProperty("Long");
+
+            const int threadCount = 50;
+            const int valueCount = 35;
+
+            var tests = new Action[threadCount];
+            var generatedValues = new List<long>[threadCount];
+            for (var i = 0; i < tests.Length; i++)
+            {
+                var testNumber = i;
+                generatedValues[testNumber] = new List<long>();
+                tests[testNumber] = () =>
+                {
+                    var stateEntry = TestHelpers.CreateStateEntry<AnEntity>(_model);
+
+                    for (var j = 0; j < valueCount; j++)
+                    {
+                        generator.Next(stateEntry, property);
+
+                        generatedValues[testNumber].Add((long)stateEntry[property]);
+                    }
+                };
+            }
+
+            Parallel.Invoke(tests);
+
+            // Check that each value was generated once and only once
+            var checks = new bool[threadCount * valueCount];
+            foreach (var values in generatedValues)
+            {
+                Assert.Equal(valueCount, values.Count);
+                foreach (var value in values)
+                {
+                    checks[value] = true;
+                }
+            }
+
+            Assert.True(checks.All(c => c));
+        }
+
+        [Fact]
+        public async Task Multiple_threads_can_use_the_same_generator_async()
+        {
+            var incrementingValue = 0L;
+            var dbConfigurationMock = new Mock<DbContextConfiguration>();
+            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object);
+            redisDatabaseMock
+                .Setup(db => db.GetNextGeneratedValue(It.IsAny<IProperty>(), It.IsAny<long>(), It.IsAny<string>()))
+                .Returns<IProperty, long, string>((p, l, s) =>
+                {
+                    var originalValue = incrementingValue;
+                    incrementingValue += l;
+                    return originalValue;
+                });
+
+            var generator = new RedisSequenceValueGenerator(redisDatabaseMock.Object, "TestSequenceName", 1);
+
+            var property = _model.GetEntityType(typeof(AnEntity)).GetProperty("Long");
+
+            const int threadCount = 50;
+            const int valueCount = 35;
+
+            var tests = new Func<Task>[threadCount];
+            var generatedValues = new List<long>[threadCount];
+            for (var i = 0; i < tests.Length; i++)
+            {
+                var testNumber = i;
+                generatedValues[testNumber] = new List<long>();
+                tests[testNumber] = async () =>
+                {
+                    var stateEntry = TestHelpers.CreateStateEntry<AnEntity>(_model);
+
+                    for (var j = 0; j < valueCount; j++)
+                    {
+                        await generator.NextAsync(stateEntry, property);
+
+                        generatedValues[testNumber].Add((long)stateEntry[property]);
+                    }
+                };
+            }
+
+            var tasks = tests.Select(Task.Run).ToArray();
+
+            foreach (var t in tasks)
+            {
+                await t;
+            }
+
+            // Check that each value was generated once and only once
+            var checks = new bool[threadCount * valueCount];
+            foreach (var values in generatedValues)
+            {
+                Assert.Equal(valueCount, values.Count);
+                foreach (var value in values)
+                {
+                    checks[value] = true;
+                }
+            }
+
+            Assert.True(checks.All(c => c));
+        }
+
+        [Fact]
+        public void Generates_sequential_values_with_larger_block_size()
+        {
+            var blockSize = 10;
+            var incrementingValue = 0L;
+            var dbConfigurationMock = new Mock<DbContextConfiguration>();
+            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object);
+            redisDatabaseMock
+                .Setup(db => db.GetNextGeneratedValue(It.IsAny<IProperty>(), It.IsAny<long>(), It.IsAny<string>()))
+                .Returns<IProperty, long, string>((p, l, s) =>
+                {
+                    var originalValue = incrementingValue;
+                    incrementingValue += l;
+                    return originalValue;
+                });
+
+            var generator = new RedisSequenceValueGenerator(redisDatabaseMock.Object, "TestSequenceName", blockSize);
+            var stateEntry = TestHelpers.CreateStateEntry<AnEntity>(_model);
+
+            var property = _model.GetEntityType(typeof(AnEntity)).GetProperty("Long");
+
+            for (var l = 0L; l < 100L; l++)
+            {
+                generator.Next(stateEntry, property);
+
+                Assert.Equal(l, stateEntry[property]);
+                Assert.False(stateEntry.HasTemporaryValue(property));
+            }
+        }
+
+        [Fact]
+        public void Throws_when_type_conversion_would_overflow()
+        {
+            var incrementingValue = 256L;
+            var dbConfigurationMock = new Mock<DbContextConfiguration>();
+            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object);
+            redisDatabaseMock
+                .Setup(db => db.GetNextGeneratedValue(It.IsAny<IProperty>(), It.IsAny<long>(), It.IsAny<string>()))
+                .Returns<IProperty, long, string>((p, l, s) => incrementingValue);
+
+            var generator = new RedisSequenceValueGenerator(redisDatabaseMock.Object, "MyTestSequenceName", 1);
+
+            var stateEntry = TestHelpers.CreateStateEntry<AnEntity>(_model);
+            var byteProperty = stateEntry.EntityType.GetProperty("Byte");
+
+            Assert.Throws<OverflowException>(() => generator.Next(stateEntry, byteProperty));
+        }
+
+        private class AnEntity
+        {
+            public int Id { get; set; }
+            public long Long { get; set; }
+            public short Short { get; set; }
+            public byte Byte { get; set; }
+            public uint UnsignedInt { get; set; }
+            public ulong UnsignedLong { get; set; }
+            public ushort UnsignedShort { get; set; }
+            public sbyte SignedByte { get; set; }
+        }
+    }
+}

--- a/test/EntityFramework.Redis.Tests/RedisValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework.Redis.Tests/RedisValueGeneratorSelectorTest.cs
@@ -1,0 +1,123 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Data.Entity.Identity;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Moq;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Redis.Tests
+{
+    public class RedisValueGeneratorSelectorTest
+    {
+        [Fact]
+        public void Select_returns_RedisValueGeneratorFactory_for_all_integer_types_with_ValueGeneration_set_to_OnAdd()
+        {
+            var dbConfigurationMock = new Mock<DbContextConfiguration>();
+            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object);
+            var guidValueGenerator = new SimpleValueGeneratorFactory<GuidValueGenerator>();
+            var redisValueGeneratorFactory = new RedisValueGeneratorFactory(redisDatabaseMock.Object);
+
+            var selector = new RedisValueGeneratorSelector(guidValueGenerator, redisValueGeneratorFactory);
+
+            Assert.Same(redisValueGeneratorFactory, selector.Select(CreateProperty(typeof(long), ValueGeneration.OnAdd)));
+            Assert.Same(redisValueGeneratorFactory, selector.Select(CreateProperty(typeof(int), ValueGeneration.OnAdd)));
+            Assert.Same(redisValueGeneratorFactory, selector.Select(CreateProperty(typeof(short), ValueGeneration.OnAdd)));
+            Assert.Same(redisValueGeneratorFactory, selector.Select(CreateProperty(typeof(byte), ValueGeneration.OnAdd)));
+            Assert.Same(redisValueGeneratorFactory, selector.Select(CreateProperty(typeof(ulong), ValueGeneration.OnAdd)));
+            Assert.Same(redisValueGeneratorFactory, selector.Select(CreateProperty(typeof(uint), ValueGeneration.OnAdd)));
+            Assert.Same(redisValueGeneratorFactory, selector.Select(CreateProperty(typeof(ushort), ValueGeneration.OnAdd)));
+            Assert.Same(redisValueGeneratorFactory, selector.Select(CreateProperty(typeof(sbyte), ValueGeneration.OnAdd)));
+        }
+
+        [Fact]
+        public void Select_returns_GuidValueGenerator_for_Guid_type_with_ValueGeneration_set_to_OnAdd()
+        {
+            var dbConfigurationMock = new Mock<DbContextConfiguration>();
+            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object);
+            var guidValueGenerator = new SimpleValueGeneratorFactory<GuidValueGenerator>();
+            var redisValueGeneratorFactory = new RedisValueGeneratorFactory(redisDatabaseMock.Object);
+
+            var selector = new RedisValueGeneratorSelector(guidValueGenerator, redisValueGeneratorFactory);
+
+            Assert.Same(guidValueGenerator, selector.Select(CreateProperty(typeof(Guid), ValueGeneration.OnAdd)));
+        }
+
+        [Fact]
+        public void Select_returns_null_for_all_types_with_ValueGeneration_set_to_None()
+        {
+            var dbConfigurationMock = new Mock<DbContextConfiguration>();
+            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object);
+            var guidValueGenerator = new SimpleValueGeneratorFactory<GuidValueGenerator>();
+            var redisValueGeneratorFactory = new RedisValueGeneratorFactory(redisDatabaseMock.Object);
+
+            var selector = new RedisValueGeneratorSelector(guidValueGenerator, redisValueGeneratorFactory);
+
+            Assert.Null(selector.Select(CreateProperty(typeof(long), ValueGeneration.None)));
+            Assert.Null(selector.Select(CreateProperty(typeof(int), ValueGeneration.None)));
+            Assert.Null(selector.Select(CreateProperty(typeof(short), ValueGeneration.None)));
+            Assert.Null(selector.Select(CreateProperty(typeof(byte), ValueGeneration.None)));
+            Assert.Null(selector.Select(CreateProperty(typeof(ulong), ValueGeneration.None)));
+            Assert.Null(selector.Select(CreateProperty(typeof(uint), ValueGeneration.None)));
+            Assert.Null(selector.Select(CreateProperty(typeof(ushort), ValueGeneration.None)));
+            Assert.Null(selector.Select(CreateProperty(typeof(sbyte), ValueGeneration.None)));
+            Assert.Null(selector.Select(CreateProperty(typeof(string), ValueGeneration.None)));
+            Assert.Null(selector.Select(CreateProperty(typeof(float), ValueGeneration.None)));
+            Assert.Null(selector.Select(CreateProperty(typeof(double), ValueGeneration.None)));
+            Assert.Null(selector.Select(CreateProperty(typeof(Guid), ValueGeneration.None)));
+            Assert.Null(selector.Select(CreateProperty(typeof(DateTime), ValueGeneration.None)));
+            Assert.Null(selector.Select(CreateProperty(typeof(DateTimeOffset), ValueGeneration.None)));
+        }
+
+        [Fact]
+        public void Select_throws_for_unsupported_combinations()
+        {
+            var dbConfigurationMock = new Mock<DbContextConfiguration>();
+            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object);
+            var guidValueGenerator = new SimpleValueGeneratorFactory<GuidValueGenerator>();
+            var redisValueGeneratorFactory = new RedisValueGeneratorFactory(redisDatabaseMock.Object);
+
+            var selector = new RedisValueGeneratorSelector(guidValueGenerator, redisValueGeneratorFactory);
+
+            var typeMock = new Mock<IEntityType>();
+            typeMock.Setup(m => m.Name).Returns("AnEntity");
+
+            Assert.Equal(
+                GetString("FormatNoValueGenerator", "MyProperty", "MyType", "String"),
+                Assert.Throws<NotSupportedException>(() => selector.Select(CreateProperty(typeof(string), ValueGeneration.OnAdd))).Message);
+            Assert.Equal(
+                GetString("FormatNoValueGenerator", "MyProperty", "MyType", "Single"),
+                Assert.Throws<NotSupportedException>(() => selector.Select(CreateProperty(typeof(float), ValueGeneration.OnAdd))).Message);
+            Assert.Equal(
+                GetString("FormatNoValueGenerator", "MyProperty", "MyType", "Double"),
+                Assert.Throws<NotSupportedException>(() => selector.Select(CreateProperty(typeof(double), ValueGeneration.OnAdd))).Message);
+            Assert.Equal(
+                GetString("FormatNoValueGenerator", "MyProperty", "MyType", "DateTime"),
+                Assert.Throws<NotSupportedException>(() => selector.Select(CreateProperty(typeof(DateTime), ValueGeneration.OnAdd))).Message);
+            Assert.Equal(
+                GetString("FormatNoValueGenerator", "MyProperty", "MyType", "DateTimeOffset"),
+                Assert.Throws<NotSupportedException>(() => selector.Select(CreateProperty(typeof(DateTimeOffset), ValueGeneration.OnAdd))).Message);
+        }
+
+        private static Property CreateProperty(Type propertyType, ValueGeneration valueGeneration)
+        {
+            var entityType = new EntityType("MyType");
+            var property = entityType.GetOrAddProperty("MyProperty", propertyType, shadowProperty: true);
+            property.ValueGeneration = valueGeneration;
+
+            new Model().AddEntityType(entityType);
+
+            return property;
+        }
+
+        private static string GetString(string stringName, params object[] parameters)
+        {
+            var strings = typeof(DbContext).GetTypeInfo().Assembly.GetType(typeof(DbContext).Namespace + ".Strings");
+            return (string)strings.GetTypeInfo().GetDeclaredMethods(stringName).Single().Invoke(null, parameters);
+        }
+    }
+}

--- a/test/EntityFramework.Redis.Tests/TestHelperExtensions.cs
+++ b/test/EntityFramework.Redis.Tests/TestHelperExtensions.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Data.Entity.Redis.Extensions;
+
+namespace Microsoft.Data.Entity.Tests
+{
+    public static class TestHelperExtensions
+    {
+        public static EntityServicesBuilder AddProviderServices(this EntityServicesBuilder entityServicesBuilder)
+        {
+            return entityServicesBuilder.AddRedis();
+        }
+
+        public static DbContextOptions UseProviderOptions(this DbContextOptions options)
+        {
+            return options.UseRedis("127.0.0.1", 6375);
+        }
+    }
+}

--- a/test/EntityFramework.Redis.Tests/project.json
+++ b/test/EntityFramework.Redis.Tests/project.json
@@ -7,7 +7,7 @@
     "commands": {
         "test": "Xunit.KRunner"
     },
-    "code": [ "**\\*.cs", "..\\Shared\\ApiConsistencyTestBase.cs" ],
+    "code": [ "**\\*.cs", "..\\Shared\\ApiConsistencyTestBase.cs", "..\\Shared\\TestHelpers.cs" ],
     "frameworks": {
         "aspnet50": { }
     }


### PR DESCRIPTION
Fix for #651 
Moved the common parts of SqlServerSequenceValueGenerator out into BlockOfSequentialValuesGenerator and have both SqlServerSquenceValueGenerator and RedisSequenceValueGenerator inherit from that.
