### PR TITLE
Making 125 people less mad...

### DIFF
--- a/src/EntityFramework/ChangeTracking/StateEntry.cs
+++ b/src/EntityFramework/ChangeTracking/StateEntry.cs
@@ -542,6 +542,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             Check.NotNull(property, "property");
 
             return HasTemporaryValue(property)
+                   || (property.UseStoreDefault && HasDefaultValue(property))
                    || (property.ValueGeneration == ValueGeneration.OnAddAndUpdate
                        && (EntityState == EntityState.Modified || EntityState == EntityState.Added)
                        && !IsPropertyModified(property));

--- a/src/EntityFramework/Metadata/BasicModelBuilder.cs
+++ b/src/EntityFramework/Metadata/BasicModelBuilder.cs
@@ -294,6 +294,13 @@ namespace Microsoft.Data.Entity.Metadata
 
                     return this;
                 }
+
+                public virtual PropertyBuilder UseStoreDefault(bool useDefault = true)
+                {
+                    Builder.UseStoreDefault(useDefault);
+
+                    return this;
+                }
             }
 
             public class ForeignKeyBuilder : IForeignKeyBuilder<ForeignKeyBuilder>

--- a/src/EntityFramework/Metadata/Compiled/CompiledProperty.cs
+++ b/src/EntityFramework/Metadata/Compiled/CompiledProperty.cs
@@ -40,6 +40,11 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
             get { return false; }
         }
 
+        public bool UseStoreDefault
+        {
+            get { return false; }
+        }
+
         public IEntityType EntityType
         {
             get { return _entityType; }

--- a/src/EntityFramework/Metadata/Compiled/CompiledPropertyNoAnnotations.cs
+++ b/src/EntityFramework/Metadata/Compiled/CompiledPropertyNoAnnotations.cs
@@ -40,6 +40,11 @@ namespace Microsoft.Data.Entity.Metadata.Compiled
             get { return false; }
         }
 
+        public bool UseStoreDefault
+        {
+            get { return false; }
+        }
+
         public IEntityType EntityType
         {
             get { return _entityType; }

--- a/src/EntityFramework/Metadata/IProperty.cs
+++ b/src/EntityFramework/Metadata/IProperty.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Data.Entity.Metadata
         Type UnderlyingType { get; }
         bool IsNullable { get; }
         bool IsReadOnly { get; }
+        bool UseStoreDefault { get; }
         ValueGeneration ValueGeneration { get; }
         int Index { get; }
         int ShadowIndex { get; }

--- a/src/EntityFramework/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/EntityFramework/Metadata/Internal/InternalPropertyBuilder.cs
@@ -36,5 +36,10 @@ namespace Microsoft.Data.Entity.Metadata.Internal
         {
             Metadata.ValueGeneration = computed ? ValueGeneration.OnAddAndUpdate : ValueGeneration.None;
         }
+
+        public virtual void UseStoreDefault(bool useDefault = true)
+        {
+            Metadata.UseStoreDefault = useDefault;
+        }
     }
 }

--- a/src/EntityFramework/Metadata/ModelBuilder.cs
+++ b/src/EntityFramework/Metadata/ModelBuilder.cs
@@ -336,6 +336,13 @@ namespace Microsoft.Data.Entity.Metadata
 
                     return this;
                 }
+
+                public virtual PropertyBuilder UseStoreDefault(bool useDefault = true)
+                {
+                    Builder.UseStoreDefault(useDefault);
+
+                    return this;
+                }
             }
 
             public class ForeignKeyBuilder : IForeignKeyBuilder<ForeignKeyBuilder>

--- a/test/EntityFramework.SqlServer.FunctionalTests/DefaultValuesTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/DefaultValuesTest.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
+using Xunit;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public class DefaultValuesTest
+    {
+        [Fact]
+        public void Can_use_SQL_Server_default_values()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFramework()
+                .AddSqlServer()
+                .ServiceCollection
+                .BuildServiceProvider();
+
+            using (var context = new ChipsContext(serviceProvider, "KettleChips"))
+            {
+                context.Database.EnsureDeleted();
+                context.Database.EnsureCreated();
+
+                // TODO: Integrate default values into Migrations
+                var storeConnection = context.Database.AsRelational().Connection;
+                new SqlStatementExecutor().ExecuteNonQuery(storeConnection.DbConnection, storeConnection.DbTransaction,
+                    new[]
+                        {
+                            new SqlStatement(
+                                "ALTER TABLE dbo.KettleChips ADD CONSTRAINT DF_KettleChips_BestBuyDate DEFAULT '20350925' FOR BestBuyDate")
+                        });
+
+                var honeyDijon = context.Add(new KettleChips { Name = "Honey Dijon" });
+
+                context.SaveChanges();
+
+                Assert.Equal(new DateTime(2035, 9, 25), honeyDijon.BestBuyDate);
+
+                var buffaloBleu = context.Add(new KettleChips { Name = "Buffalo Bleu", BestBuyDate = new DateTime(2111, 1, 11) });
+
+                context.SaveChanges();
+
+                Assert.Equal(new DateTime(2111, 1, 11), buffaloBleu.BestBuyDate);
+            }
+
+            using (var context = new ChipsContext(serviceProvider, "KettleChips"))
+            {
+                Assert.Equal(new DateTime(2035, 9, 25), context.Chips.Single(c => c.Name == "Honey Dijon").BestBuyDate);
+                Assert.Equal(new DateTime(2111, 1, 11), context.Chips.Single(c => c.Name == "Buffalo Bleu").BestBuyDate);
+            }
+        }
+
+        private class ChipsContext : DbContext
+        {
+            private readonly string _databaseName;
+
+            public ChipsContext(IServiceProvider serviceProvider, string databaseName)
+                : base(serviceProvider)
+            {
+                _databaseName = databaseName;
+            }
+
+            public DbSet<KettleChips> Chips { get; set; }
+
+            protected override void OnConfiguring(DbContextOptions options)
+            {
+                options.UseSqlServer(SqlServerTestDatabase.CreateConnectionString(_databaseName));
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<KettleChips>()
+                    .Property(e => e.BestBuyDate)
+                    .UseStoreDefault();
+            }
+        }
+
+        private class KettleChips
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public DateTime BestBuyDate { get; set; }
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
@@ -77,6 +77,7 @@
     <Compile Include="ConnectionStringTest.cs" />
     <Compile Include="CompositeKeyEndToEndTest.cs" />
     <Compile Include="DeadlockTest.cs" />
+    <Compile Include="DefaultValuesTest.cs" />
     <Compile Include="ExistingConnectionTest.cs" />
     <Compile Include="NorthwindQueryFixture.cs" />
     <Compile Include="NorthwindAsyncQueryTest.cs" />

--- a/test/EntityFramework.Tests/Metadata/BasicModelBuilderTest.cs
+++ b/test/EntityFramework.Tests/Metadata/BasicModelBuilderTest.cs
@@ -596,6 +596,34 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         }
 
         [Fact]
+        public void Properties_can_be_set_to_use_store_default_values()
+        {
+            var model = new Model();
+            var modelBuilder = new BasicModelBuilder(model);
+
+            modelBuilder.Entity<Quarks>(b =>
+            {
+                b.Property(e => e.Id);
+                b.Property(e => e.Up).UseStoreDefault();
+                b.Property(e => e.Down).UseStoreDefault(false);
+                b.Property<int>("Charm").UseStoreDefault();
+                b.Property<string>("Strange").UseStoreDefault(false);
+                b.Property(typeof(int), "Top").UseStoreDefault();
+                b.Property(typeof(string), "Bottom").UseStoreDefault(false);
+            });
+
+            var entityType = model.GetEntityType(typeof(Quarks));
+
+            Assert.False(entityType.GetProperty("Id").UseStoreDefault);
+            Assert.True(entityType.GetProperty("Up").UseStoreDefault);
+            Assert.False(entityType.GetProperty("Down").UseStoreDefault);
+            Assert.True(entityType.GetProperty("Charm").UseStoreDefault);
+            Assert.False(entityType.GetProperty("Strange").UseStoreDefault);
+            Assert.True(entityType.GetProperty("Top").UseStoreDefault);
+            Assert.False(entityType.GetProperty("Bottom").UseStoreDefault);
+        }
+
+        [Fact]
         public void PropertyBuilder_methods_can_be_chained()
         {
             new BasicModelBuilder()
@@ -607,6 +635,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Shadow()
                 .StoreComputed()
                 .GenerateValuesOnAdd()
+                .UseStoreDefault()
                 .Required();
         }
 

--- a/test/EntityFramework.Tests/Metadata/ModelBuilderTest.cs
+++ b/test/EntityFramework.Tests/Metadata/ModelBuilderTest.cs
@@ -585,6 +585,34 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         }
 
         [Fact]
+        public void Properties_can_be_set_to_use_store_default_values()
+        {
+            var model = new Model();
+            var modelBuilder = new ModelBuilder(model);
+
+            modelBuilder.Entity<Quarks>(b =>
+            {
+                b.Property(e => e.Id);
+                b.Property(e => e.Up).UseStoreDefault();
+                b.Property(e => e.Down).UseStoreDefault(false);
+                b.Property<int>("Charm").UseStoreDefault();
+                b.Property<string>("Strange").UseStoreDefault(false);
+                b.Property(typeof(int), "Top").UseStoreDefault();
+                b.Property(typeof(string), "Bottom").UseStoreDefault(false);
+            });
+
+            var entityType = model.GetEntityType(typeof(Quarks));
+
+            Assert.False(entityType.GetProperty("Id").UseStoreDefault);
+            Assert.True(entityType.GetProperty("Up").UseStoreDefault);
+            Assert.False(entityType.GetProperty("Down").UseStoreDefault);
+            Assert.True(entityType.GetProperty("Charm").UseStoreDefault);
+            Assert.False(entityType.GetProperty("Strange").UseStoreDefault);
+            Assert.True(entityType.GetProperty("Top").UseStoreDefault);
+            Assert.False(entityType.GetProperty("Bottom").UseStoreDefault);
+        }
+
+        [Fact]
         public void PropertyBuilder_methods_can_be_chained()
         {
             new ModelBuilder()
@@ -596,6 +624,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Shadow()
                 .StoreComputed()
                 .GenerateValuesOnAdd()
+                .UseStoreDefault()
                 .Required();
         }
 


### PR DESCRIPTION
Support store-generated default values

This change allows a property to be marked as using store-generated default values. If no value has been set for the property when the update pipeline inserts the entity the update pipeline will read the value generated from the store. If a value is specified explicitly it will be inserted. This is essentially the same behavior has used for generating keys except that it doesn't involve value generation on Add.

Note that the generation of default constraints in the database by Migrations is not yet implemented so these will need to be setup manually for now.

Also not supported yet is the ability to use this in updates where the semantics are a bit more nuanced.
