### PR TITLE
Fix for #455 - Updated CancellationToken usage in Redis

### DIFF
--- a/src/EntityFramework.Redis/RedisDatabase.cs
+++ b/src/EntityFramework.Redis/RedisDatabase.cs
@@ -118,10 +118,7 @@ namespace Microsoft.Data.Entity.Redis
         {
             Check.NotNull(stateEntries, "stateEntries");
 
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return 0;
-            }
+            cancellationToken.ThrowIfCancellationRequested();
 
             var transaction = PrepareTransactionForSaveChanges(stateEntries);
 
@@ -218,10 +215,7 @@ namespace Microsoft.Data.Entity.Redis
         public virtual async Task FlushDatabaseAsync(
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (cancellationToken.IsCancellationRequested)
-            {
-                return;
-            }
+            cancellationToken.ThrowIfCancellationRequested();
 
             var connection = (RedisConnection)Configuration.Connection;
 
@@ -375,6 +369,8 @@ namespace Microsoft.Data.Entity.Redis
         /// <returns>The next generated value</returns>
         public virtual long GetNextGeneratedValue([NotNull] IProperty property, long incrementBy, [CanBeNull] string sequenceName)
         {
+            Check.NotNull(property, "property");
+
             if (sequenceName == null)
             {
                 sequenceName = ConstructRedisValueGeneratorKeyName(property);

--- a/src/EntityFramework.Redis/RedisSequenceValueGenerator.cs
+++ b/src/EntityFramework.Redis/RedisSequenceValueGenerator.cs
@@ -34,6 +34,11 @@ namespace Microsoft.Data.Entity.Redis
         public override async Task<long> GetNewCurrentValueAsync(
             StateEntry stateEntry, IProperty property, CancellationToken cancellationToken)
         {
+            Check.NotNull(stateEntry, "stateEntry");
+            Check.NotNull(property, "property");
+
+            cancellationToken.ThrowIfCancellationRequested();
+
             return await
                 Task.FromResult<long>(_redisDatabase.GetNextGeneratedValue(property, BlockSize, SequenceName))
                 .WithCurrentCulture();


### PR DESCRIPTION
Now calls ThrowIfCancellationRequested() instead of just returning.

(Issue mentions Azure Table Storage as well but that has already been updated).
