### PR TITLE
[SMALL] We should be using 'default(CancellationToken)'

### DIFF
--- a/src/EntityFramework.AzureTableStorage/AtsDataStore.cs
+++ b/src/EntityFramework.AzureTableStorage/AtsDataStore.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage
             return ExecuteChanges(stateEntries);
         }
 
-        public override Task<int> SaveChangesAsync(IReadOnlyList<StateEntry> stateEntries, CancellationToken cancellationToken = new CancellationToken())
+        public override Task<int> SaveChangesAsync(IReadOnlyList<StateEntry> stateEntries, CancellationToken cancellationToken = default(CancellationToken))
         {
             Check.NotNull(stateEntries, "stateEntries");
 
@@ -226,7 +226,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage
         }
 
         private async Task<int> ExecuteBatchedChangesAsync(IReadOnlyList<StateEntry> stateEntries,
-            CancellationToken cancellationToken = new CancellationToken())
+            CancellationToken cancellationToken = default(CancellationToken))
         {
             var tableGroups = stateEntries.GroupBy(s => s.EntityType.TableName());
             var allBatchTasks = new List<Task<IList<TableResult>>>();

--- a/src/EntityFramework.AzureTableStorage/AtsDataStoreCreator.cs
+++ b/src/EntityFramework.AzureTableStorage/AtsDataStoreCreator.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage
             return created;
         }
 
-        public override async Task<bool> EnsureCreatedAsync(IModel model, CancellationToken cancellationToken = new CancellationToken())
+        public override async Task<bool> EnsureCreatedAsync(IModel model, CancellationToken cancellationToken = default(CancellationToken))
         {
             Check.NotNull(model, "model");
 

--- a/src/EntityFramework.SQLite/SQLiteDataStoreCreator.cs
+++ b/src/EntityFramework.SQLite/SQLiteDataStoreCreator.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Data.Entity.SQLite
             return (long)_executor.ExecuteScalar(_connection.DbConnection, _connection.DbTransaction, CreateHasTablesCommand()) != 0;
         }
 
-        public override async Task<bool> HasTablesAsync(CancellationToken cancellationToken = new CancellationToken())
+        public override async Task<bool> HasTablesAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return (long)(await _executor
                 .ExecuteScalarAsync(_connection.DbConnection, _connection.DbTransaction, CreateHasTablesCommand(), cancellationToken)

--- a/src/EntityFramework.SqlServer/SqlServerDataStoreCreator.cs
+++ b/src/EntityFramework.SqlServer/SqlServerDataStoreCreator.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Data.Entity.SqlServer
             return (int)_statementExecutor.ExecuteScalar(_connection.DbConnection, _connection.DbTransaction, CreateHasTablesCommand()) != 0;
         }
 
-        public override async Task<bool> HasTablesAsync(CancellationToken cancellationToken = new CancellationToken())
+        public override async Task<bool> HasTablesAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             return (int)(await _statementExecutor
                 .ExecuteScalarAsync(_connection.DbConnection, _connection.DbTransaction, CreateHasTablesCommand(), cancellationToken)


### PR DESCRIPTION
... rather than 'new CancellationToken()' throughout the product code. Fixed in a couple of places.
