### PR TITLE
Update SQLite tests to create and dispose the test database correctly

### DIFF
--- a/test/EntityFramework.FunctionalTests/BuiltInDataTypesTestBase.cs
+++ b/test/EntityFramework.FunctionalTests/BuiltInDataTypesTestBase.cs
@@ -25,45 +25,50 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = _fixture.CreateContext())
             {
-                var allDataTypes = context.Set<BuiltInNonNullableDataTypes>().Add(
-                    new BuiltInNonNullableDataTypes
-                        {
-                            Id0 = 0,
-                            Id1 = 0,
-                            TestInt32 = -123456789,
-                            TestInt64 = -1234567890123456789L,
-                            TestDouble = -1.23456789,
-                            // TODO: SQL Server default precision is 18 (use max precision, 38, 
-                            // when available but no way to define that in the model at the moment)
-                            TestDecimal = -1234567890.012345678M,
-                            TestDateTime = DateTime.Parse("01/01/2000 12:34:56"),
-                            TestDateTimeOffset = new DateTimeOffset(DateTime.Parse("01/01/2000 12:34:56"), TimeSpan.FromHours(-8.0)),
-                            TestSingle = -1.234F,
-                            TestBoolean = true,
-                            TestByte = 255,
-                            TestUnsignedInt32 = 1234565789U,
-                            TestUnsignedInt64 = 1234565789UL,
-                            TestInt16 = -1234,
-                        });
-
-                var changes = context.SaveChanges();
-                Assert.Equal(1, changes);
-
-                var dt = context.Set<BuiltInNonNullableDataTypes>().Where(nndt => nndt.Id0 == 0).Single();
-
-                Assert.Equal(-123456789, dt.TestInt32);
-                Assert.Equal(-1234567890123456789L, dt.TestInt64);
-                Assert.Equal(-1.23456789, dt.TestDouble);
-                Assert.Equal(-1234567890.012345678M, dt.TestDecimal);
-                Assert.Equal(DateTime.Parse("01/01/2000 12:34:56"), dt.TestDateTime);
-                Assert.Equal(new DateTimeOffset(DateTime.Parse("01/01/2000 12:34:56"), TimeSpan.FromHours(-8.0)), dt.TestDateTimeOffset);
-                Assert.Equal(-1.234F, dt.TestSingle);
-                Assert.Equal(true, dt.TestBoolean);
-                Assert.Equal(255, dt.TestByte);
-                Assert.Equal(1234565789U, dt.TestUnsignedInt32);
-                Assert.Equal(1234565789UL, dt.TestUnsignedInt64);
-                Assert.Equal(-1234, dt.TestInt16);
+                Test_insert_and_read_back_all_non_nullable_data_types(context);
             }
+        }
+
+        public void Test_insert_and_read_back_all_non_nullable_data_types(DbContext context)
+        {
+            var allDataTypes = context.Set<BuiltInNonNullableDataTypes>().Add(
+                new BuiltInNonNullableDataTypes
+                    {
+                        Id0 = 0,
+                        Id1 = 0,
+                        TestInt32 = -123456789,
+                        TestInt64 = -1234567890123456789L,
+                        TestDouble = -1.23456789,
+                        // TODO: SQL Server default precision is 18 (use max precision, 38,
+                        // when available but no way to define that in the model at the moment)
+                        TestDecimal = -1234567890.012345678M,
+                        TestDateTime = DateTime.Parse("01/01/2000 12:34:56"),
+                        TestDateTimeOffset = new DateTimeOffset(DateTime.Parse("01/01/2000 12:34:56"), TimeSpan.FromHours(-8.0)),
+                        TestSingle = -1.234F,
+                        TestBoolean = true,
+                        TestByte = 255,
+                        TestUnsignedInt32 = 1234565789U,
+                        TestUnsignedInt64 = 1234565789UL,
+                        TestInt16 = -1234,
+                    });
+
+            var changes = context.SaveChanges();
+            Assert.Equal(1, changes);
+
+            var dt = context.Set<BuiltInNonNullableDataTypes>().Where(nndt => nndt.Id0 == 0).Single();
+
+            Assert.Equal(-123456789, dt.TestInt32);
+            Assert.Equal(-1234567890123456789L, dt.TestInt64);
+            Assert.Equal(-1.23456789, dt.TestDouble);
+            Assert.Equal(-1234567890.012345678M, dt.TestDecimal);
+            Assert.Equal(DateTime.Parse("01/01/2000 12:34:56"), dt.TestDateTime);
+            Assert.Equal(new DateTimeOffset(DateTime.Parse("01/01/2000 12:34:56"), TimeSpan.FromHours(-8.0)), dt.TestDateTimeOffset);
+            Assert.Equal(-1.234F, dt.TestSingle);
+            Assert.Equal(true, dt.TestBoolean);
+            Assert.Equal(255, dt.TestByte);
+            Assert.Equal(1234565789U, dt.TestUnsignedInt32);
+            Assert.Equal(1234565789UL, dt.TestUnsignedInt64);
+            Assert.Equal(-1234, dt.TestInt16);
         }
 
         [Fact]
@@ -71,41 +76,46 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = _fixture.CreateContext())
             {
-                var allDataTypes = context.Set<BuiltInNullableDataTypes>().Add(
-                    new BuiltInNullableDataTypes
-                        {
-                            Id0 = 100,
-                            Id1 = 100,
-                            TestNullableInt32 = null,
-                            TestString = null,
-                            TestNullableInt64 = null,
-                            TestNullableDouble = null,
-                            TestNullableDecimal = null,
-                            TestNullableDateTime = null,
-                            TestNullableDateTimeOffset = null,
-                            TestNullableSingle = null,
-                            TestNullableBoolean = null,
-                            TestNullableByte = null,
-                            TestNullableInt16 = null,
-                        });
-
-                var changes = context.SaveChanges();
-                Assert.Equal(1, changes);
-
-                var dt = context.Set<BuiltInNullableDataTypes>().Where(ndt => ndt.Id0 == 100).Single();
-
-                Assert.Null(dt.TestNullableInt32);
-                Assert.Null(dt.TestString);
-                Assert.Null(dt.TestNullableInt64);
-                Assert.Null(dt.TestNullableDouble);
-                Assert.Null(dt.TestNullableDecimal);
-                Assert.Null(dt.TestNullableDateTime);
-                Assert.Null(dt.TestNullableDateTimeOffset);
-                Assert.Null(dt.TestNullableSingle);
-                Assert.Null(dt.TestNullableBoolean);
-                Assert.Null(dt.TestNullableByte);
-                Assert.Null(dt.TestNullableInt16);
+                Test_insert_and_read_back_all_nullable_data_types_with_values_set_to_null(context);
             }
+        }
+
+        public void Test_insert_and_read_back_all_nullable_data_types_with_values_set_to_null(DbContext context)
+        {
+            var allDataTypes = context.Set<BuiltInNullableDataTypes>().Add(
+                new BuiltInNullableDataTypes
+                    {
+                        Id0 = 100,
+                        Id1 = 100,
+                        TestNullableInt32 = null,
+                        TestString = null,
+                        TestNullableInt64 = null,
+                        TestNullableDouble = null,
+                        TestNullableDecimal = null,
+                        TestNullableDateTime = null,
+                        TestNullableDateTimeOffset = null,
+                        TestNullableSingle = null,
+                        TestNullableBoolean = null,
+                        TestNullableByte = null,
+                        TestNullableInt16 = null,
+                    });
+
+            var changes = context.SaveChanges();
+            Assert.Equal(1, changes);
+
+            var dt = context.Set<BuiltInNullableDataTypes>().Where(ndt => ndt.Id0 == 100).Single();
+
+            Assert.Null(dt.TestNullableInt32);
+            Assert.Null(dt.TestString);
+            Assert.Null(dt.TestNullableInt64);
+            Assert.Null(dt.TestNullableDouble);
+            Assert.Null(dt.TestNullableDecimal);
+            Assert.Null(dt.TestNullableDateTime);
+            Assert.Null(dt.TestNullableDateTimeOffset);
+            Assert.Null(dt.TestNullableSingle);
+            Assert.Null(dt.TestNullableBoolean);
+            Assert.Null(dt.TestNullableByte);
+            Assert.Null(dt.TestNullableInt16);
         }
 
         [Fact]
@@ -113,43 +123,48 @@ namespace Microsoft.Data.Entity.FunctionalTests
         {
             using (var context = _fixture.CreateContext())
             {
-                var allDataTypes = context.Set<BuiltInNullableDataTypes>().Add(
-                    new BuiltInNullableDataTypes
-                        {
-                            Id0 = 101,
-                            Id1 = 101,
-                            TestNullableInt32 = -123456789,
-                            TestString = "TestString",
-                            TestNullableInt64 = -1234567890123456789L,
-                            TestNullableDouble = -1.23456789,
-                            // TODO: SQL Server default precision is 18 (use max precision, 38, 
-                            // when available but no way to define that in the model at the moment)
-                            TestNullableDecimal = -1234567890.012345678M,
-                            TestNullableDateTime = DateTime.Parse("01/01/2000 12:34:56"),
-                            TestNullableDateTimeOffset = new DateTimeOffset(DateTime.Parse("01/01/2000 12:34:56"), TimeSpan.FromHours(-8.0)),
-                            TestNullableSingle = -1.234F,
-                            TestNullableBoolean = false,
-                            TestNullableByte = 255,
-                            TestNullableInt16 = -1234,
-                        });
-
-                var changes = context.SaveChanges();
-                Assert.Equal(1, changes);
-
-                var dt = context.Set<BuiltInNullableDataTypes>().Where(ndt => ndt.Id0 == 101).Single();
-
-                Assert.Equal(-123456789, dt.TestNullableInt32);
-                Assert.Equal("TestString", dt.TestString);
-                Assert.Equal(-1234567890123456789L, dt.TestNullableInt64);
-                Assert.Equal(-1.23456789, dt.TestNullableDouble);
-                Assert.Equal(-1234567890.012345678M, dt.TestNullableDecimal);
-                Assert.Equal(DateTime.Parse("01/01/2000 12:34:56"), dt.TestNullableDateTime);
-                Assert.Equal(new DateTimeOffset(DateTime.Parse("01/01/2000 12:34:56"), TimeSpan.FromHours(-8.0)), dt.TestNullableDateTimeOffset);
-                Assert.Equal(-1.234F, dt.TestNullableSingle);
-                Assert.Equal(false, dt.TestNullableBoolean);
-                Assert.Equal((byte)255, dt.TestNullableByte);
-                Assert.Equal((short)-1234, dt.TestNullableInt16);
+                Test_insert_and_read_back_all_nullable_data_types_with_values_set_to_non_null(context);
             }
+        }
+
+        public void Test_insert_and_read_back_all_nullable_data_types_with_values_set_to_non_null(DbContext context)
+        {
+            var allDataTypes = context.Set<BuiltInNullableDataTypes>().Add(
+                new BuiltInNullableDataTypes
+                    {
+                        Id0 = 101,
+                        Id1 = 101,
+                        TestNullableInt32 = -123456789,
+                        TestString = "TestString",
+                        TestNullableInt64 = -1234567890123456789L,
+                        TestNullableDouble = -1.23456789,
+                        // TODO: SQL Server default precision is 18 (use max precision, 38, 
+                        // when available but no way to define that in the model at the moment)
+                        TestNullableDecimal = -1234567890.012345678M,
+                        TestNullableDateTime = DateTime.Parse("01/01/2000 12:34:56"),
+                        TestNullableDateTimeOffset = new DateTimeOffset(DateTime.Parse("01/01/2000 12:34:56"), TimeSpan.FromHours(-8.0)),
+                        TestNullableSingle = -1.234F,
+                        TestNullableBoolean = false,
+                        TestNullableByte = 255,
+                        TestNullableInt16 = -1234,
+                    });
+
+            var changes = context.SaveChanges();
+            Assert.Equal(1, changes);
+
+            var dt = context.Set<BuiltInNullableDataTypes>().Where(ndt => ndt.Id0 == 101).Single();
+
+            Assert.Equal(-123456789, dt.TestNullableInt32);
+            Assert.Equal("TestString", dt.TestString);
+            Assert.Equal(-1234567890123456789L, dt.TestNullableInt64);
+            Assert.Equal(-1.23456789, dt.TestNullableDouble);
+            Assert.Equal(-1234567890.012345678M, dt.TestNullableDecimal);
+            Assert.Equal(DateTime.Parse("01/01/2000 12:34:56"), dt.TestNullableDateTime);
+            Assert.Equal(new DateTimeOffset(DateTime.Parse("01/01/2000 12:34:56"), TimeSpan.FromHours(-8.0)), dt.TestNullableDateTimeOffset);
+            Assert.Equal(-1.234F, dt.TestNullableSingle);
+            Assert.Equal(false, dt.TestNullableBoolean);
+            Assert.Equal((byte)255, dt.TestNullableByte);
+            Assert.Equal((short)-1234, dt.TestNullableInt16);
         }
     }
 }

--- a/test/EntityFramework.SQLite.FunctionalTests/BuiltInDataTypesFixture.cs
+++ b/test/EntityFramework.SQLite.FunctionalTests/BuiltInDataTypesFixture.cs
@@ -10,17 +10,44 @@ namespace Microsoft.Data.Entity.SQLite.FunctionalTests
 {
     public class BuiltInDataTypesFixture : BuiltInDataTypesFixtureBase
     {
+        private readonly IServiceProvider _serviceProvider;
+
+        public BuiltInDataTypesFixture()
+        {
+            _serviceProvider
+                = new ServiceCollection()
+                    .AddEntityFramework()
+                    .AddSQLite()
+                    .ServiceCollection
+                    .BuildServiceProvider();
+        }
+
+
         public override DbContext CreateContext()
         {
-            var testDatabase = SQLiteTestDatabase.Scratch().Result;
+            // do not use this method for SQLite tests
+            throw new NotImplementedException();
+        }
 
-            var options = new DbContextOptions()
-                .UseModel(CreateModel())
-                .UseSQLite(testDatabase.Connection.ConnectionString);
+        public SQLiteTestDatabase CreateSQLiteTestDatabase()
+        {
+            var db = SQLiteTestDatabase.Scratch().Result;
+            using (var context = CreateSQLiteContext(db))
+            {
+                context.Database.EnsureCreated();
+            }
 
-            var context = new DbContext(options);
-            context.Database.EnsureCreated();
-            return context;
+            return db;
+        }
+
+        public DbContext CreateSQLiteContext(SQLiteTestDatabase testDatabase)
+        {
+            var options
+                = new DbContextOptions()
+                    .UseModel(CreateModel())
+                    .UseSQLite(testDatabase.Connection.ConnectionString);
+
+            return new DbContext(_serviceProvider, options);
         }
     }
 }

--- a/test/EntityFramework.SQLite.FunctionalTests/BuiltInDataTypesTest.cs
+++ b/test/EntityFramework.SQLite.FunctionalTests/BuiltInDataTypesTest.cs
@@ -12,5 +12,41 @@ namespace Microsoft.Data.Entity.SQLite.FunctionalTests
         {
             _fixture = fixture;
         }
+
+        [Fact]
+        public override void Can_insert_and_read_back_all_non_nullable_data_types()
+        {
+            using (var testDatabase = ((BuiltInDataTypesFixture)_fixture).CreateSQLiteTestDatabase())
+            {
+                using (var context = ((BuiltInDataTypesFixture)_fixture).CreateSQLiteContext(testDatabase))
+                {
+                    Test_insert_and_read_back_all_non_nullable_data_types(context);
+                }
+            }
+        }
+
+        [Fact]
+        public override void Can_insert_and_read_back_all_nullable_data_types_with_values_set_to_null()
+        {
+            using (var testDatabase = ((BuiltInDataTypesFixture)_fixture).CreateSQLiteTestDatabase())
+            {
+                using (var context = ((BuiltInDataTypesFixture)_fixture).CreateSQLiteContext(testDatabase))
+                {
+                    Test_insert_and_read_back_all_nullable_data_types_with_values_set_to_null(context);
+                }
+            }
+        }
+
+        [Fact]
+        public override void Can_insert_and_read_back_all_nullable_data_types_with_values_set_to_non_null()
+        {
+            using (var testDatabase = ((BuiltInDataTypesFixture)_fixture).CreateSQLiteTestDatabase())
+            {
+                using (var context = ((BuiltInDataTypesFixture)_fixture).CreateSQLiteContext(testDatabase))
+                {
+                    Test_insert_and_read_back_all_nullable_data_types_with_values_set_to_non_null(context);
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
@ajcvickers Hey Arthur - could you take a look at this please? I was able to repro the intermittent test failure of the SQLite BuiltInDataTypes tests using TestDriven.NET and this seems to fix it (I've repeated the tests 20 times and no failures so far).
