### PR TITLE
Magically not-vanishing angle brackets...

### DIFF
--- a/src/EntityFramework/Metadata/ModelBuilder.cs
+++ b/src/EntityFramework/Metadata/ModelBuilder.cs
@@ -827,6 +827,33 @@ namespace Microsoft.Data.Entity.Metadata
 
                     return new OneToManyBuilder<TRelatedEntity>(Builder.ReferencedKey(keyExpression.GetPropertyAccessList()));
                 }
+
+                public virtual new OneToManyBuilder<TRelatedEntity> Annotation([NotNull] string annotation, [NotNull] string value)
+                {
+                    Check.NotEmpty(annotation, "annotation");
+                    Check.NotEmpty(value, "value");
+
+                    return (OneToManyBuilder<TRelatedEntity>)base.Annotation(annotation, value);
+                }
+
+                public virtual new OneToManyBuilder<TRelatedEntity> ForeignKey([NotNull] params string[] foreignKeyPropertyNames)
+                {
+                    Check.NotNull(foreignKeyPropertyNames, "foreignKeyPropertyNames");
+
+                    return new OneToManyBuilder<TRelatedEntity>(Builder.ForeignKey(foreignKeyPropertyNames));
+                }
+
+                public virtual new OneToManyBuilder<TRelatedEntity> ReferencedKey([NotNull] params string[] keyPropertyNames)
+                {
+                    Check.NotNull(keyPropertyNames, "keyPropertyNames");
+
+                    return new OneToManyBuilder<TRelatedEntity>(Builder.ReferencedKey(keyPropertyNames));
+                }
+
+                public virtual new OneToManyBuilder<TRelatedEntity> Required(bool required = true)
+                {
+                    return (OneToManyBuilder<TRelatedEntity>)base.Required(required);
+                }
             }
 
             public class ManyToOneBuilder<TRelatedEntity> : ManyToOneBuilder
@@ -850,6 +877,33 @@ namespace Microsoft.Data.Entity.Metadata
                     Check.NotNull(keyExpression, "keyExpression");
 
                     return new ManyToOneBuilder<TRelatedEntity>(Builder.ReferencedKey(keyExpression.GetPropertyAccessList()));
+                }
+
+                public virtual new ManyToOneBuilder<TRelatedEntity> Annotation([NotNull] string annotation, [NotNull] string value)
+                {
+                    Check.NotEmpty(annotation, "annotation");
+                    Check.NotEmpty(value, "value");
+
+                    return (ManyToOneBuilder<TRelatedEntity>)base.Annotation(annotation, value);
+                }
+
+                public virtual new ManyToOneBuilder<TRelatedEntity> ForeignKey([NotNull] params string[] foreignKeyPropertyNames)
+                {
+                    Check.NotNull(foreignKeyPropertyNames, "foreignKeyPropertyNames");
+
+                    return new ManyToOneBuilder<TRelatedEntity>(Builder.ForeignKey(foreignKeyPropertyNames));
+                }
+
+                public virtual new ManyToOneBuilder<TRelatedEntity> ReferencedKey([NotNull] params string[] keyPropertyNames)
+                {
+                    Check.NotNull(keyPropertyNames, "keyPropertyNames");
+
+                    return new ManyToOneBuilder<TRelatedEntity>(Builder.ReferencedKey(keyPropertyNames));
+                }
+
+                public virtual new ManyToOneBuilder<TRelatedEntity> Required(bool required = true)
+                {
+                    return (ManyToOneBuilder<TRelatedEntity>)base.Required(required);
                 }
             }
         }

--- a/test/EntityFramework.Tests/Metadata/ModelBuilderTest.cs
+++ b/test/EntityFramework.Tests/Metadata/ModelBuilderTest.cs
@@ -6145,5 +6145,125 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
             return builder;
         }
+
+        [Fact]
+        public void Generic_OneToMany_is_preserved_when_chaining_from_Annotation()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            AssertIsGenericOneToMany(modelBuilder
+                .Entity<Customer>()
+                .OneToMany(e => e.Orders, e => e.Customer)
+                .Annotation("X", "Y"));
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Order));
+            Assert.Equal("Y", entityType.ForeignKeys.Single()["X"]);
+        }
+
+        [Fact]
+        public void Generic_OneToMany_is_preserved_when_chaining_from_ForeignKey()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            AssertIsGenericOneToMany(modelBuilder
+                .Entity<Customer>()
+                .OneToMany(e => e.Orders, e => e.Customer)
+                .ForeignKey("AnotherCustomerId"));
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Order));
+            Assert.Equal("AnotherCustomerId", entityType.ForeignKeys.Single().Properties.Single().Name);
+        }
+
+        [Fact]
+        public void Generic_OneToMany_is_preserved_when_chaining_from_ReferencedKey()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            AssertIsGenericOneToMany(modelBuilder
+                .Entity<Customer>()
+                .OneToMany(e => e.Orders, e => e.Customer)
+                .ReferencedKey("AlternateKey"));
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Order));
+            Assert.Equal("AlternateKey", entityType.ForeignKeys.Single().ReferencedProperties.Single().Name);
+        }
+
+        [Fact]
+        public void Generic_OneToMany_is_preserved_when_chaining_from_Required()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            AssertIsGenericOneToMany(modelBuilder
+                .Entity<Customer>()
+                .OneToMany(e => e.Orders, e => e.Customer)
+                .Required(false));
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Order));
+            Assert.False(entityType.ForeignKeys.Single().IsRequired);
+        }
+
+        private static void AssertIsGenericOneToMany(ModelBuilder.EntityBuilder<Customer>.OneToManyBuilder<Order> _)
+        {
+        }
+
+        [Fact]
+        public void Generic_ManyToOne_is_preserved_when_chaining_from_Annotation()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            AssertIsGenericManyToOne(modelBuilder
+                .Entity<Order>()
+                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Annotation("X", "Y"));
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Order));
+            Assert.Equal("Y", entityType.ForeignKeys.Single()["X"]);
+        }
+
+        [Fact]
+        public void Generic_ManyToOne_is_preserved_when_chaining_from_ForeignKey()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            AssertIsGenericManyToOne(modelBuilder
+                .Entity<Order>()
+                .ManyToOne(e => e.Customer, e => e.Orders)
+                .ForeignKey("AnotherCustomerId"));
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Order));
+            Assert.Equal("AnotherCustomerId", entityType.ForeignKeys.Single().Properties.Single().Name);
+        }
+
+        [Fact]
+        public void Generic_ManyToOne_is_preserved_when_chaining_from_ReferencedKey()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            AssertIsGenericManyToOne(modelBuilder
+                .Entity<Order>()
+                .ManyToOne(e => e.Customer, e => e.Orders)
+                .ReferencedKey("AlternateKey"));
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Order));
+            Assert.Equal("AlternateKey", entityType.ForeignKeys.Single().ReferencedProperties.Single().Name);
+        }
+
+        [Fact]
+        public void Generic_ManyToOne_is_preserved_when_chaining_from_Required()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            AssertIsGenericManyToOne(modelBuilder
+                .Entity<Order>()
+                .ManyToOne(e => e.Customer, e => e.Orders)
+                .Required(false));
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Order));
+            Assert.False(entityType.ForeignKeys.Single().IsRequired);
+        }
+
+        private static void AssertIsGenericManyToOne(ModelBuilder.EntityBuilder<Order>.ManyToOneBuilder<Customer> _)
+        {
+        }
     }
 }


### PR DESCRIPTION
Add "new" methods to generic OneToMany and ManyToOne builders so that the returned builder for chaining is still generic.
