### PR TITLE
FixupSpeedup episode one - the slowdown menace

### DIFF
--- a/src/EntityFramework/ChangeTracking/ChangeDetector.cs
+++ b/src/EntityFramework/ChangeTracking/ChangeDetector.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             Check.NotNull(stateManager, "stateManager");
 
             var foundChanges = false;
-            foreach (var entry in stateManager.StateEntries.ToArray())
+            foreach (var entry in stateManager.StateEntries.ToList())
             {
                 if (DetectChanges(entry))
                 {
@@ -244,9 +244,9 @@ namespace Microsoft.Data.Entity.ChangeTracking
             var isPrimaryKey = property.IsPrimaryKey();
 
             // TODO: Perf: make it faster to check if the property is at the principal end or not
-            var foreignKeys = _configuration.Model.GetReferencingForeignKeys(property).ToArray();
+            var foreignKeys = _configuration.Model.GetReferencingForeignKeys(property).ToList();
 
-            if (isPrimaryKey || foreignKeys.Length > 0)
+            if (isPrimaryKey || foreignKeys.Count > 0)
             {
                 var snapshotValue = entry.RelationshipsSnapshot[property];
                 var currentValue = entry[property];

--- a/src/EntityFramework/ChangeTracking/StateEntry.cs
+++ b/src/EntityFramework/ChangeTracking/StateEntry.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Data.Entity.ChangeTracking
         private StateData _stateData;
         private Sidecar[] _sidecars;
 
+        private readonly Dictionary<IForeignKey, EntityKey> _principalKeys = new Dictionary<IForeignKey, EntityKey>();
+
         /// <summary>
         ///     This constructor is intended only for use when creating test doubles that will override members
         ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
@@ -464,6 +466,20 @@ namespace Microsoft.Data.Entity.ChangeTracking
             return _configuration.Services.EntityKeyFactorySource
                 .GetKeyFactory(foreignKey.Properties)
                 .Create(foreignKey.ReferencedEntityType, foreignKey.Properties, RelationshipsSnapshot);
+        }
+
+        public EntityKey GetPrincipalKey([NotNull] IForeignKey foreignKey, IEntityType referencedEntityType, IReadOnlyList<IProperty> referencedProperties)
+        {
+            Check.NotNull(foreignKey, "foreignKey");
+
+            EntityKey result;
+            if (!_principalKeys.TryGetValue(foreignKey, out result))
+            {
+                _principalKeys.Add(foreignKey, 
+                    result = CreateKey(referencedEntityType, referencedProperties, this));
+            }
+
+            return result;
         }
 
         public virtual object[] GetValueBuffer()

--- a/src/EntityFramework/ChangeTracking/StateManager.cs
+++ b/src/EntityFramework/ChangeTracking/StateManager.cs
@@ -212,12 +212,17 @@ namespace Microsoft.Data.Entity.ChangeTracking
                 return null;
             }
 
+            var referencedEntityType = foreignKey.ReferencedEntityType;
+            var referencedProperties = foreignKey.ReferencedProperties;
+
+
             // TODO: Perf: Add additional indexes so that this isn't a linear lookup
             var principals = StateEntries.Where(
-                e => e.EntityType == foreignKey.ReferencedEntityType
-                     && dependentKeyValue.Equals(e.GetPrincipalKeyValue(foreignKey))).ToArray();
+                e => e.EntityType == referencedEntityType
+                && dependentKeyValue.Equals(
+                    e.GetPrincipalKey(foreignKey, referencedEntityType, referencedProperties))).ToList();
 
-            if (principals.Length > 1)
+            if (principals.Count > 1)
             {
                 // TODO: Better exception message
                 // Issue #739


### PR DESCRIPTION
Entity fixup is still costly but this changeset is making it 10x faster by getting some low hanging fruit:
- Reduction of allocations by changing .ToArray() by .ToList() when the collection is temporary.
- Caching of values that are used constantly.
- Accessing the same property repeatedly inside loops avoided.

The caching will probably have to be revisited in a future iteration. Here are some of the numbers I obtained:

RelationshipFixup before the change
1153252ms total (100 iterations)
17920ms 95th percentile
20988ms 99th percentile
20988ms 99.9th percentile

RelationshipFixup after the change
138670ms total (100 iterations)
1652ms 95th percentile
1944ms 99th percentile
1944ms 99.9th percentile

The closest EF6 test we have is objectctx-fixup-fk-poco
13339ms total (100 iterations)
171.74ms 95th percentile
287.71ms 99th percentile
287.71ms 99.9th percentile
