### PR TITLE
4SqlServer()

### DIFF
--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <Import Project="..\..\tools\EntityFramework.props" />
@@ -65,6 +65,27 @@
     <Compile Include="ConnectionStringResolver.cs" />
     <Compile Include="DatabaseBuilder.cs" />
     <Compile Include="IDbCommandExecutor.cs" />
+    <Compile Include="Metadata\IRelationalEntityTypeExtensions.cs" />
+    <Compile Include="Metadata\IRelationalForeignKeyExtensions.cs" />
+    <Compile Include="Metadata\IRelationalIndexExtensions.cs" />
+    <Compile Include="Metadata\IRelationalKeyExtensions.cs" />
+    <Compile Include="Metadata\IRelationalPropertyExtensions.cs" />
+    <Compile Include="Metadata\ReadOnlyRelationalEntityTypeExtensions.cs" />
+    <Compile Include="Metadata\ReadOnlyRelationalForeignKeyExtensions.cs" />
+    <Compile Include="Metadata\ReadOnlyRelationalIndexExtensions.cs" />
+    <Compile Include="Metadata\ReadOnlyRelationalKeyExtensions.cs" />
+    <Compile Include="Metadata\ReadOnlyRelationalPropertyExtensions.cs" />
+    <Compile Include="Metadata\RelationalAnnotationNames.cs" />
+    <Compile Include="Metadata\RelationalEntityBuilder.cs" />
+    <Compile Include="Metadata\RelationalEntityTypeExtensions.cs" />
+    <Compile Include="Metadata\RelationalForeignKeyExtensions.cs" />
+    <Compile Include="Metadata\RelationalForeignKeyBuilder.cs" />
+    <Compile Include="Metadata\RelationalIndexExtensions.cs" />
+    <Compile Include="Metadata\RelationalIndexBuilder.cs" />
+    <Compile Include="Metadata\RelationalKeyExtensions.cs" />
+    <Compile Include="Metadata\RelationalKeyBuilder.cs" />
+    <Compile Include="Metadata\RelationalPropertyExtensions.cs" />
+    <Compile Include="Metadata\RelationalPropertyBuilder.cs" />
     <Compile Include="ModelDatabaseMapping.cs" />
     <Compile Include="Query\AsyncQueryMethodProvider.cs" />
     <Compile Include="Query\CommandBuilder.cs" />
@@ -99,9 +120,11 @@
     <Compile Include="Query\RelationalResultOperatorHandler.cs" />
     <Compile Include="Query\Sql\ISqlQueryGenerator.cs" />
     <Compile Include="Query\Sql\DefaultSqlQueryGenerator.cs" />
+    <Compile Include="RelationalBuilderExtensions.cs" />
     <Compile Include="RelationalDatabase.cs" />
     <Compile Include="RelationalDatabaseExtensions.cs" />
     <Compile Include="RelationalDataStoreCreator.cs" />
+    <Compile Include="RelationalMetadataExtensions.cs" />
     <Compile Include="RelationalOptionsExtension.cs" />
     <Compile Include="RelationalConnection.cs" />
     <Compile Include="RelationalDataStore.cs" />

--- a/src/EntityFramework.Relational/Metadata/IRelationalEntityTypeExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/IRelationalEntityTypeExtensions.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace Microsoft.Data.Entity.Relational.Metadata
+{
+    public interface IRelationalEntityTypeExtensions
+    {
+        string Table { get; }
+
+        [CanBeNull]
+        string Schema { get; }
+    }
+}

--- a/src/EntityFramework.Relational/Metadata/IRelationalForeignKeyExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/IRelationalForeignKeyExtensions.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace Microsoft.Data.Entity.Relational.Metadata
+{
+    public interface IRelationalForeignKeyExtensions
+    {
+        [CanBeNull]
+        string Name { get; }
+    }
+}

--- a/src/EntityFramework.Relational/Metadata/IRelationalIndexExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/IRelationalIndexExtensions.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace Microsoft.Data.Entity.Relational.Metadata
+{
+    public interface IRelationalIndexExtensions
+    {
+        [CanBeNull]
+        string Name { get; }
+    }
+}

--- a/src/EntityFramework.Relational/Metadata/IRelationalKeyExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/IRelationalKeyExtensions.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace Microsoft.Data.Entity.Relational.Metadata
+{
+    public interface IRelationalKeyExtensions
+    {
+        [CanBeNull]
+        string Name { get; }
+    }
+}

--- a/src/EntityFramework.Relational/Metadata/IRelationalPropertyExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/IRelationalPropertyExtensions.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace Microsoft.Data.Entity.Relational.Metadata
+{
+    public interface IRelationalPropertyExtensions
+    {
+        string Column { get; }
+        
+        [CanBeNull]
+        string ColumnType { get; }
+
+        [CanBeNull]
+        string DefaultExpression { get; }
+    }
+}

--- a/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalEntityTypeExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalEntityTypeExtensions.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Metadata
+{
+    public class ReadOnlyRelationalEntityTypeExtensions : IRelationalEntityTypeExtensions
+    {
+        protected const string RelationalTableAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.TableName;
+        protected const string RelationalSchemaAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.Schema;
+
+        private readonly IEntityType _entityType;
+
+        public ReadOnlyRelationalEntityTypeExtensions([NotNull] IEntityType entityType)
+        {
+            Check.NotNull(entityType, "entityType");
+
+            _entityType = entityType;
+        }
+
+        public virtual string Table
+        {
+            get { return _entityType[RelationalTableAnnotation] ?? _entityType.SimpleName; }
+        }
+
+        public virtual string Schema
+        {
+            get { return _entityType[RelationalSchemaAnnotation]; }
+        }
+
+        protected virtual IEntityType EntityType
+        {
+            get { return _entityType; }
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalForeignKeyExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalForeignKeyExtensions.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Metadata
+{
+    public class ReadOnlyRelationalForeignKeyExtensions : IRelationalForeignKeyExtensions
+    {
+        protected const string NameAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.Name;
+
+        private readonly IForeignKey _foreignKey;
+
+        public ReadOnlyRelationalForeignKeyExtensions([NotNull] IForeignKey foreignKey)
+        {
+            Check.NotNull(foreignKey, "foreignKey");
+
+            _foreignKey = foreignKey;
+        }
+
+        public virtual string Name
+        {
+            get { return _foreignKey[NameAnnotation]; }
+        }
+
+        protected virtual IForeignKey ForeignKey
+        {
+            get { return _foreignKey; }
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalIndexExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalIndexExtensions.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Metadata
+{
+    public class ReadOnlyRelationalIndexExtensions : IRelationalIndexExtensions
+    {
+        protected const string NameAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.Name;
+
+        private readonly IIndex _index;
+
+        public ReadOnlyRelationalIndexExtensions([NotNull] IIndex index)
+        {
+            Check.NotNull(index, "index");
+
+            _index = index;
+        }
+
+        public virtual string Name
+        {
+            get { return _index[NameAnnotation]; }
+        }
+
+        protected virtual IIndex Index
+        {
+            get { return _index; }
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalKeyExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalKeyExtensions.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Metadata
+{
+    public class ReadOnlyRelationalKeyExtensions : IRelationalKeyExtensions
+    {
+        protected const string NameAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.Name;
+
+        private readonly IKey _key;
+
+        public ReadOnlyRelationalKeyExtensions([NotNull] IKey key)
+        {
+            Check.NotNull(key, "key");
+
+            _key = key;
+        }
+
+        public virtual string Name
+        {
+            get { return _key[NameAnnotation]; }
+        }
+
+        protected virtual IKey Key
+        {
+            get { return _key; }
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalPropertyExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalPropertyExtensions.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Metadata
+{
+    public class ReadOnlyRelationalPropertyExtensions : IRelationalPropertyExtensions
+    {
+        protected const string NameAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.ColumnName;
+        protected const string ColumnTypeAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.ColumnType;
+        protected const string DefaultExpressionAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.ColumnDefaultExpression;
+
+        private readonly IProperty _property;
+
+        public ReadOnlyRelationalPropertyExtensions([NotNull] IProperty property)
+        {
+            Check.NotNull(property, "property");
+
+            _property = property;
+        }
+
+        public virtual string Column
+        {
+            get { return _property[NameAnnotation] ?? _property.Name; }
+        }
+
+        public virtual string ColumnType
+        {
+            get { return _property[ColumnTypeAnnotation]; }
+        }
+
+        public virtual string DefaultExpression
+        {
+            get { return _property[DefaultExpressionAnnotation]; }
+        }
+
+        protected virtual IProperty Property
+        {
+            get { return _property; }
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Metadata/RelationalAnnotationNames.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalAnnotationNames.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.Relational.Metadata
+{
+    public static class RelationalAnnotationNames
+    {
+        public const string Prefix = "Relational:";
+        public const string ColumnName = "ColumnName";
+        public const string ColumnType = "ColumnName";
+        public const string ColumnDefaultExpression = "ColumnName";
+        public const string TableName = "TableName";
+        public const string Schema = "Schema";
+        public const string Name = "Name";
+    }
+}

--- a/src/EntityFramework.Relational/Metadata/RelationalEntityBuilder.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalEntityBuilder.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Metadata
+{
+    public class RelationalEntityBuilder
+    {
+        private readonly EntityType _entityType;
+
+        public RelationalEntityBuilder([NotNull] EntityType entityType)
+        {
+            Check.NotNull(entityType, "entityType");
+
+            _entityType = entityType;
+        }
+
+        public virtual RelationalEntityBuilder Table([CanBeNull] string tableName)
+        {
+            Check.NullButNotEmpty(tableName, "tableName");
+
+            _entityType.Relational().Table = tableName;
+
+            return this;
+        }
+
+        public virtual RelationalEntityBuilder Table([CanBeNull] string tableName, [CanBeNull] string schemaName)
+        {
+            Check.NullButNotEmpty(tableName, "tableName");
+            Check.NullButNotEmpty(schemaName, "schemaName");
+
+            _entityType.Relational().Table = tableName;
+            _entityType.Relational().Schema = schemaName;
+
+            return this;
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Metadata/RelationalEntityTypeExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalEntityTypeExtensions.cs
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Metadata
+{
+    public class RelationalEntityTypeExtensions : ReadOnlyRelationalEntityTypeExtensions
+    {
+        public RelationalEntityTypeExtensions([NotNull] EntityType entityType)
+            : base(entityType)
+        {
+        }
+
+        public new virtual string Table
+        {
+            get { return base.Table; }
+            [param: CanBeNull]
+            set
+            {
+                Check.NullButNotEmpty(value, "value");
+
+                ((EntityType)EntityType)[RelationalTableAnnotation] = value;
+            }
+        }
+
+        [CanBeNull]
+        public new virtual string Schema
+        {
+            get { return base.Schema; }
+            [param: CanBeNull]
+            set
+            {
+                Check.NullButNotEmpty(value, "value");
+
+                ((EntityType)EntityType)[RelationalSchemaAnnotation] = value;
+            }
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Metadata/RelationalForeignKeyBuilder.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalForeignKeyBuilder.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Metadata
+{
+    public class RelationalForeignKeyBuilder
+    {
+        private readonly ForeignKey _foreignKey;
+
+        public RelationalForeignKeyBuilder([NotNull] ForeignKey foreignKey)
+        {
+            Check.NotNull(foreignKey, "foreignKey");
+
+            _foreignKey = foreignKey;
+        }
+
+        public virtual RelationalForeignKeyBuilder Name([CanBeNull] string name)
+        {
+            Check.NullButNotEmpty(name, "name");
+
+            _foreignKey.Relational().Name = name;
+
+            return this;
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Metadata/RelationalForeignKeyExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalForeignKeyExtensions.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Metadata
+{
+    public class RelationalForeignKeyExtensions : ReadOnlyRelationalForeignKeyExtensions
+    {
+        public RelationalForeignKeyExtensions([NotNull] ForeignKey foreignKey)
+            : base(foreignKey)
+        {
+        }
+
+        public new virtual string Name
+        {
+            get { return base.Name; }
+            [param: CanBeNull]
+            set
+            {
+                Check.NullButNotEmpty(value, "value");
+
+                ((ForeignKey)ForeignKey)[NameAnnotation] = value;
+            }
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Metadata/RelationalIndexBuilder.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalIndexBuilder.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Metadata
+{
+    public class RelationalIndexBuilder
+    {
+        private readonly Index _index;
+
+        public RelationalIndexBuilder([NotNull] Index index)
+        {
+            Check.NotNull(index, "index");
+
+            _index = index;
+        }
+
+        public virtual RelationalIndexBuilder Name([CanBeNull] string name)
+        {
+            Check.NullButNotEmpty(name, "name");
+
+            _index.Relational().Name = name;
+
+            return this;
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Metadata/RelationalIndexExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalIndexExtensions.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Metadata
+{
+    public class RelationalIndexExtensions : ReadOnlyRelationalIndexExtensions
+    {
+        public RelationalIndexExtensions([NotNull] Index index)
+            : base(index)
+        {
+        }
+
+        public new virtual string Name
+        {
+            get { return base.Name; }
+            [param: CanBeNull]
+            set
+            {
+                Check.NullButNotEmpty(value, "value");
+
+                ((Index)Index)[NameAnnotation] = value;
+            }
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Metadata/RelationalKeyBuilder.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalKeyBuilder.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Metadata
+{
+    public class RelationalKeyBuilder
+    {
+        private readonly Key _key;
+
+        public RelationalKeyBuilder([NotNull] Key key)
+        {
+            Check.NotNull(key, "key");
+
+            _key = key;
+        }
+
+        public virtual RelationalKeyBuilder Name([CanBeNull] string name)
+        {
+            Check.NullButNotEmpty(name, "name");
+
+            _key.Relational().Name = name;
+
+            return this;
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Metadata/RelationalKeyExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalKeyExtensions.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Metadata
+{
+    public class RelationalKeyExtensions : ReadOnlyRelationalKeyExtensions
+    {
+        public RelationalKeyExtensions([NotNull] Key key)
+            : base(key)
+        {
+        }
+
+        public new virtual string Name
+        {
+            get { return base.Name; }
+            [param: CanBeNull]
+            set
+            {
+                Check.NullButNotEmpty(value, "value");
+
+                ((Key)Key)[NameAnnotation] = value;
+            }
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Metadata/RelationalPropertyBuilder.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalPropertyBuilder.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Metadata
+{
+    public class RelationalPropertyBuilder
+    {
+        private readonly Property _property;
+
+        public RelationalPropertyBuilder([NotNull] Property property)
+        {
+            Check.NotNull(property, "property");
+
+            _property = property;
+        }
+
+        public virtual RelationalPropertyBuilder Column([CanBeNull] string columnName)
+        {
+            Check.NullButNotEmpty(columnName, "columnName");
+
+            _property.Relational().Column = columnName;
+
+            return this;
+        }
+
+        public virtual RelationalPropertyBuilder ColumnType([CanBeNull] string columnType)
+        {
+            Check.NullButNotEmpty(columnType, "columnType");
+
+            _property.Relational().ColumnType = columnType;
+
+            return this;
+        }
+
+        public virtual RelationalPropertyBuilder DefaultExpression([CanBeNull] string expression)
+        {
+            Check.NullButNotEmpty(expression, "expression");
+
+            _property.Relational().DefaultExpression = expression;
+
+            return this;
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Metadata/RelationalPropertyExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalPropertyExtensions.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Utilities;
+
+namespace Microsoft.Data.Entity.Relational.Metadata
+{
+    public class RelationalPropertyExtensions : ReadOnlyRelationalPropertyExtensions
+    {
+        public RelationalPropertyExtensions([NotNull] Property property)
+            : base(property)
+        {
+        }
+
+        public new virtual string Column
+        {
+            get { return base.Column; }
+            [param: CanBeNull]
+            set
+            {
+                Check.NullButNotEmpty(value, "value");
+
+                ((Property)Property)[NameAnnotation] = value;
+            }
+        }
+
+        public new virtual string ColumnType
+        {
+            get { return base.ColumnType; }
+            [param: CanBeNull]
+            set
+            {
+                Check.NullButNotEmpty(value, "value");
+
+                ((Property)Property)[ColumnTypeAnnotation] = value;
+            }
+        }
+
+        public new virtual string DefaultExpression
+        {
+            get { return base.DefaultExpression; }
+            [param: CanBeNull]
+            set
+            {
+                Check.NullButNotEmpty(value, "value");
+
+                ((Property)Property)[DefaultExpressionAnnotation] = value;
+            }
+        }
+    }
+}

--- a/src/EntityFramework.Relational/RelationalBuilderExtensions.cs
+++ b/src/EntityFramework.Relational/RelationalBuilderExtensions.cs
@@ -1,0 +1,212 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Metadata;
+using Microsoft.Data.Entity.Relational.Utilities;
+
+// ReSharper disable once CheckNamespace
+
+namespace Microsoft.Data.Entity
+{
+    public static class RelationalBuilderExtensions
+    {
+        public static RelationalPropertyBuilder ForRelational<TPropertyBuilder>(
+            [NotNull] this IPropertyBuilder<TPropertyBuilder> propertyBuilder)
+            where TPropertyBuilder : IPropertyBuilder<TPropertyBuilder>
+        {
+            Check.NotNull(propertyBuilder, "propertyBuilder");
+
+            return new RelationalPropertyBuilder(propertyBuilder.Metadata);
+        }
+
+        public static TPropertyBuilder ForRelational<TPropertyBuilder>(
+            [NotNull] this IPropertyBuilder<TPropertyBuilder> propertyBuilder,
+            [NotNull] Action<RelationalPropertyBuilder> relationalPropertyBuilder)
+            where TPropertyBuilder : IPropertyBuilder<TPropertyBuilder>
+        {
+            Check.NotNull(propertyBuilder, "propertyBuilder");
+            Check.NotNull(relationalPropertyBuilder, "relationalPropertyBuilder");
+
+            relationalPropertyBuilder(ForRelational(propertyBuilder));
+
+            return (TPropertyBuilder)propertyBuilder;
+        }
+
+        public static RelationalEntityBuilder ForRelational<TEntityBuilder>(
+            [NotNull] this IEntityBuilder<TEntityBuilder> entityBuilder)
+            where TEntityBuilder : IEntityBuilder<TEntityBuilder>
+        {
+            Check.NotNull(entityBuilder, "entityBuilder");
+
+            return new RelationalEntityBuilder(entityBuilder.Metadata);
+        }
+
+        public static TEntityBuilder ForRelational<TEntityBuilder>(
+            [NotNull] this IEntityBuilder<TEntityBuilder> entityBuilder,
+            [NotNull] Action<RelationalEntityBuilder> relationalEntityBuilder)
+            where TEntityBuilder : IEntityBuilder<TEntityBuilder>
+        {
+            Check.NotNull(entityBuilder, "entityBuilder");
+
+            relationalEntityBuilder(ForRelational(entityBuilder));
+
+            return (TEntityBuilder)entityBuilder;
+        }
+
+        public static RelationalEntityBuilder ForRelational<TEntity, TEntityBuilder>(
+            [NotNull] this IEntityBuilder<TEntity, TEntityBuilder> entityBuilder)
+            where TEntityBuilder : IEntityBuilder<TEntity, TEntityBuilder>
+        {
+            Check.NotNull(entityBuilder, "entityBuilder");
+
+            return new RelationalEntityBuilder(entityBuilder.Metadata);
+        }
+
+        public static TEntityBuilder ForRelational<TEntity, TEntityBuilder>(
+            [NotNull] this IEntityBuilder<TEntity, TEntityBuilder> entityBuilder,
+            [NotNull] Action<RelationalEntityBuilder> relationalEntityBuilder)
+            where TEntityBuilder : IEntityBuilder<TEntity, TEntityBuilder>
+        {
+            Check.NotNull(entityBuilder, "entityBuilder");
+
+            relationalEntityBuilder(ForRelational(entityBuilder));
+
+            return (TEntityBuilder)entityBuilder;
+        }
+
+        public static RelationalKeyBuilder ForRelational<TKeyBuilder>(
+        [NotNull] this IKeyBuilder<TKeyBuilder> keyBuilder)
+        where TKeyBuilder : IKeyBuilder<TKeyBuilder>
+        {
+            Check.NotNull(keyBuilder, "keyBuilder");
+
+            return new RelationalKeyBuilder(keyBuilder.Metadata);
+        }
+
+        public static TKeyBuilder ForRelational<TKeyBuilder>(
+            [NotNull] this IKeyBuilder<TKeyBuilder> keyBuilder,
+            [NotNull] Action<RelationalKeyBuilder> relationalKeyBuilder)
+            where TKeyBuilder : IKeyBuilder<TKeyBuilder>
+        {
+            Check.NotNull(keyBuilder, "keyBuilder");
+            Check.NotNull(relationalKeyBuilder, "relationalKeyBuilder");
+
+            relationalKeyBuilder(ForRelational(keyBuilder));
+
+            return (TKeyBuilder)keyBuilder;
+        }
+
+        public static RelationalForeignKeyBuilder ForRelational<TForeignKeyBuilder>(
+        [NotNull] this IForeignKeyBuilder<TForeignKeyBuilder> foreignKeyBuilder)
+        where TForeignKeyBuilder : IForeignKeyBuilder<TForeignKeyBuilder>
+        {
+            Check.NotNull(foreignKeyBuilder, "foreignKeyBuilder");
+
+            return new RelationalForeignKeyBuilder(foreignKeyBuilder.Metadata);
+        }
+
+        public static TForeignKeyBuilder ForRelational<TForeignKeyBuilder>(
+            [NotNull] this IForeignKeyBuilder<TForeignKeyBuilder> foreignKeyBuilder,
+            [NotNull] Action<RelationalForeignKeyBuilder> relationalForeignKeyBuilder)
+            where TForeignKeyBuilder : IForeignKeyBuilder<TForeignKeyBuilder>
+        {
+            Check.NotNull(foreignKeyBuilder, "foreignKeyBuilder");
+            Check.NotNull(relationalForeignKeyBuilder, "relationalForeignKeyBuilder");
+
+            relationalForeignKeyBuilder(ForRelational(foreignKeyBuilder));
+
+            return (TForeignKeyBuilder)foreignKeyBuilder;
+        }
+
+        public static RelationalIndexBuilder ForRelational<TIndexBuilder>(
+        [NotNull] this IIndexBuilder<TIndexBuilder> indexBuilder)
+        where TIndexBuilder : IIndexBuilder<TIndexBuilder>
+        {
+            Check.NotNull(indexBuilder, "indexBuilder");
+
+            return new RelationalIndexBuilder(indexBuilder.Metadata);
+        }
+
+        public static TIndexBuilder ForRelational<TIndexBuilder>(
+            [NotNull] this IIndexBuilder<TIndexBuilder> indexBuilder,
+            [NotNull] Action<RelationalIndexBuilder> relationalIndexBuilder)
+            where TIndexBuilder : IIndexBuilder<TIndexBuilder>
+        {
+            Check.NotNull(indexBuilder, "indexBuilder");
+            Check.NotNull(relationalIndexBuilder, "relationalIndexBuilder");
+
+            relationalIndexBuilder(ForRelational(indexBuilder));
+
+            return (TIndexBuilder)indexBuilder;
+        }
+
+        public static RelationalForeignKeyBuilder ForRelational<TOneToManyBuilder>(
+        [NotNull] this IOneToManyBuilder<TOneToManyBuilder> foreignKeyBuilder)
+        where TOneToManyBuilder : IOneToManyBuilder<TOneToManyBuilder>
+        {
+            Check.NotNull(foreignKeyBuilder, "foreignKeyBuilder");
+
+            return new RelationalForeignKeyBuilder(foreignKeyBuilder.Metadata);
+        }
+
+        public static TOneToManyBuilder ForRelational<TOneToManyBuilder>(
+            [NotNull] this IOneToManyBuilder<TOneToManyBuilder> foreignKeyBuilder,
+            [NotNull] Action<RelationalForeignKeyBuilder> relationalOneToManyBuilder)
+            where TOneToManyBuilder : IOneToManyBuilder<TOneToManyBuilder>
+        {
+            Check.NotNull(foreignKeyBuilder, "foreignKeyBuilder");
+            Check.NotNull(relationalOneToManyBuilder, "relationalOneToManyBuilder");
+
+            relationalOneToManyBuilder(ForRelational(foreignKeyBuilder));
+
+            return (TOneToManyBuilder)foreignKeyBuilder;
+        }
+
+        public static RelationalForeignKeyBuilder ForRelational<TManyToOneBuilder>(
+        [NotNull] this IManyToOneBuilder<TManyToOneBuilder> foreignKeyBuilder)
+        where TManyToOneBuilder : IManyToOneBuilder<TManyToOneBuilder>
+        {
+            Check.NotNull(foreignKeyBuilder, "foreignKeyBuilder");
+
+            return new RelationalForeignKeyBuilder(foreignKeyBuilder.Metadata);
+        }
+
+        public static TManyToOneBuilder ForRelational<TManyToOneBuilder>(
+            [NotNull] this IManyToOneBuilder<TManyToOneBuilder> foreignKeyBuilder,
+            [NotNull] Action<RelationalForeignKeyBuilder> relationalManyToOneBuilder)
+            where TManyToOneBuilder : IManyToOneBuilder<TManyToOneBuilder>
+        {
+            Check.NotNull(foreignKeyBuilder, "foreignKeyBuilder");
+            Check.NotNull(relationalManyToOneBuilder, "relationalManyToOneBuilder");
+
+            relationalManyToOneBuilder(ForRelational(foreignKeyBuilder));
+
+            return (TManyToOneBuilder)foreignKeyBuilder;
+        }
+
+        public static RelationalForeignKeyBuilder ForRelational<TOneToOneBuilder>(
+        [NotNull] this IOneToOneBuilder<TOneToOneBuilder> foreignKeyBuilder)
+        where TOneToOneBuilder : IOneToOneBuilder<TOneToOneBuilder>
+        {
+            Check.NotNull(foreignKeyBuilder, "foreignKeyBuilder");
+
+            return new RelationalForeignKeyBuilder(foreignKeyBuilder.Metadata);
+        }
+
+        public static TOneToOneBuilder ForRelational<TOneToOneBuilder>(
+            [NotNull] this IOneToOneBuilder<TOneToOneBuilder> foreignKeyBuilder,
+            [NotNull] Action<RelationalForeignKeyBuilder> relationalOneToOneBuilder)
+            where TOneToOneBuilder : IOneToOneBuilder<TOneToOneBuilder>
+        {
+            Check.NotNull(foreignKeyBuilder, "foreignKeyBuilder");
+            Check.NotNull(relationalOneToOneBuilder, "relationalOneToOneBuilder");
+
+            relationalOneToOneBuilder(ForRelational(foreignKeyBuilder));
+
+            return (TOneToOneBuilder)foreignKeyBuilder;
+        }
+    }
+}

--- a/src/EntityFramework.Relational/RelationalMetadataExtensions.cs
+++ b/src/EntityFramework.Relational/RelationalMetadataExtensions.cs
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Metadata;
+using Microsoft.Data.Entity.Relational.Utilities;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.Data.Entity
+{
+    public static class RelationalMetadataExtensions
+    {
+        public static RelationalPropertyExtensions Relational([NotNull] this Property property)
+        {
+            Check.NotNull(property, "property");
+
+            return new RelationalPropertyExtensions(property);
+        }
+
+        public static IRelationalPropertyExtensions Relational([NotNull] this IProperty property)
+        {
+            Check.NotNull(property, "property");
+
+            return new ReadOnlyRelationalPropertyExtensions(property);
+        }
+
+        public static RelationalEntityTypeExtensions Relational([NotNull] this EntityType entityType)
+        {
+            Check.NotNull(entityType, "entityType");
+
+            return new RelationalEntityTypeExtensions(entityType);
+        }
+
+        public static IRelationalEntityTypeExtensions Relational([NotNull] this IEntityType entityType)
+        {
+            Check.NotNull(entityType, "entityType");
+
+            return new ReadOnlyRelationalEntityTypeExtensions(entityType);
+        }
+
+        public static RelationalKeyExtensions Relational([NotNull] this Key key)
+        {
+            Check.NotNull(key, "key");
+
+            return new RelationalKeyExtensions(key);
+        }
+
+        public static IRelationalKeyExtensions Relational([NotNull] this IKey key)
+        {
+            Check.NotNull(key, "key");
+
+            return new ReadOnlyRelationalKeyExtensions(key);
+        }
+
+        public static RelationalIndexExtensions Relational([NotNull] this Index index)
+        {
+            Check.NotNull(index, "index");
+
+            return new RelationalIndexExtensions(index);
+        }
+
+        public static IRelationalIndexExtensions Relational([NotNull] this IIndex index)
+        {
+            Check.NotNull(index, "index");
+
+            return new ReadOnlyRelationalIndexExtensions(index);
+        }
+
+        public static RelationalForeignKeyExtensions Relational([NotNull] this ForeignKey foreignKey)
+        {
+            Check.NotNull(foreignKey, "foreignKey");
+
+            return new RelationalForeignKeyExtensions(foreignKey);
+        }
+
+        public static IRelationalForeignKeyExtensions Relational([NotNull] this IForeignKey foreignKey)
+        {
+            Check.NotNull(foreignKey, "foreignKey");
+
+            return new ReadOnlyRelationalForeignKeyExtensions(foreignKey);
+        }
+    }
+}

--- a/src/EntityFramework.Relational/Utilities/Check.cs
+++ b/src/EntityFramework.Relational/Utilities/Check.cs
@@ -81,6 +81,27 @@ namespace Microsoft.Data.Entity.Relational.Utilities
             return value;
         }
 
+        public static string NullButNotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
+        {
+            if (ReferenceEquals(parameterName, null))
+            {
+                throw new ArgumentNullException("parameterName");
+            }
+
+            if (parameterName.Length == 0)
+            {
+                throw new ArgumentException(Strings.FormatArgumentIsEmpty("parameterName"));
+            }
+
+            if (!ReferenceEquals(value, null)
+                && value.Length == 0)
+            {
+                throw new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+            }
+
+            return value;
+        }
+
         public static T IsDefined<T>(T value, [InvokerParameterName] [NotNull] string parameterName)
             where T : struct
         {

--- a/src/EntityFramework.SqlServer/EntityFramework.SqlServer.csproj
+++ b/src/EntityFramework.SqlServer/EntityFramework.SqlServer.csproj
@@ -60,9 +60,32 @@
       <DependentUpon>Resources.tt</DependentUpon>
     </Compile>
     <Compile Include="Extensions\SqlServerMetadataExtensions.cs" />
+    <Compile Include="Metadata\ISqlServerEntityTypeExtensions.cs" />
+    <Compile Include="Metadata\ISqlServerForeignKeyExtensions.cs" />
+    <Compile Include="Metadata\ISqlServerIndexExtensions.cs" />
+    <Compile Include="Metadata\ISqlServerKeyExtensions.cs" />
+    <Compile Include="Metadata\ISqlServerPropertyExtensions.cs" />
+    <Compile Include="Metadata\ReadOnlySqlServerEntityTypeExtensions.cs" />
+    <Compile Include="Metadata\ReadOnlySqlServerForeignKeyExtensions.cs" />
+    <Compile Include="Metadata\ReadOnlySqlServerIndexExtensions.cs" />
+    <Compile Include="Metadata\ReadOnlySqlServerKeyExtensions.cs" />
+    <Compile Include="Metadata\ReadOnlySqlServerPropertyExtensions.cs" />
+    <Compile Include="Metadata\SqlServerAnnotationNames.cs" />
+    <Compile Include="Metadata\SqlServerEntityBuilder.cs" />
+    <Compile Include="Metadata\SqlServerEntityTypeExtensions.cs" />
+    <Compile Include="Metadata\SqlServerForeignKeyBuilder.cs" />
+    <Compile Include="Metadata\SqlServerForeignKeyExtensions.cs" />
+    <Compile Include="Metadata\SqlServerIndexBuilder.cs" />
+    <Compile Include="Metadata\SqlServerIndexExtensions.cs" />
+    <Compile Include="Metadata\SqlServerKeyBuilder.cs" />
+    <Compile Include="Metadata\SqlServerKeyExtensions.cs" />
+    <Compile Include="Metadata\SqlServerPropertyExtensions.cs" />
+    <Compile Include="Metadata\SqlServerPropertyBuilder.cs" />
     <Compile Include="Query\SqlServerQueryCompilationContext.cs" />
     <Compile Include="Query\SqlServerQueryGenerator.cs" />
     <Compile Include="SequentialGuidValueGenerator.cs" />
+    <Compile Include="SqlServerBuilderExtensions.cs" />
+    <Compile Include="SqlServerMetadataExtensions.cs" />
     <Compile Include="Update\SqlServerBatchExecutor.cs" />
     <Compile Include="SqlServerDataStoreServices.cs" />
     <Compile Include="SqlServerMigrationOperationPreProcessor.cs" />

--- a/src/EntityFramework.SqlServer/Metadata/ISqlServerEntityTypeExtensions.cs
+++ b/src/EntityFramework.SqlServer/Metadata/ISqlServerEntityTypeExtensions.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational.Metadata;
+
+namespace Microsoft.Data.Entity.SqlServer.Metadata
+{
+    public interface ISqlServerEntityTypeExtensions : IRelationalEntityTypeExtensions
+    {
+    }
+}

--- a/src/EntityFramework.SqlServer/Metadata/ISqlServerForeignKeyExtensions.cs
+++ b/src/EntityFramework.SqlServer/Metadata/ISqlServerForeignKeyExtensions.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational.Metadata;
+
+namespace Microsoft.Data.Entity.SqlServer.Metadata
+{
+    public interface ISqlServerForeignKeyExtensions : IRelationalForeignKeyExtensions
+    {
+    }
+}

--- a/src/EntityFramework.SqlServer/Metadata/ISqlServerIndexExtensions.cs
+++ b/src/EntityFramework.SqlServer/Metadata/ISqlServerIndexExtensions.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational.Metadata;
+
+namespace Microsoft.Data.Entity.SqlServer.Metadata
+{
+    public interface ISqlServerIndexExtensions : IRelationalIndexExtensions
+    {
+    }
+}

--- a/src/EntityFramework.SqlServer/Metadata/ISqlServerKeyExtensions.cs
+++ b/src/EntityFramework.SqlServer/Metadata/ISqlServerKeyExtensions.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational.Metadata;
+
+namespace Microsoft.Data.Entity.SqlServer.Metadata
+{
+    public interface ISqlServerKeyExtensions : IRelationalKeyExtensions
+    {
+    }
+}

--- a/src/EntityFramework.SqlServer/Metadata/ISqlServerPropertyExtensions.cs
+++ b/src/EntityFramework.SqlServer/Metadata/ISqlServerPropertyExtensions.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational.Metadata;
+
+namespace Microsoft.Data.Entity.SqlServer.Metadata
+{
+    public interface ISqlServerPropertyExtensions : IRelationalPropertyExtensions
+    {
+    }
+}

--- a/src/EntityFramework.SqlServer/Metadata/ReadOnlySqlServerEntityTypeExtensions.cs
+++ b/src/EntityFramework.SqlServer/Metadata/ReadOnlySqlServerEntityTypeExtensions.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Metadata;
+
+namespace Microsoft.Data.Entity.SqlServer.Metadata
+{
+    public class ReadOnlySqlServerEntityTypeExtensions : ReadOnlyRelationalEntityTypeExtensions, ISqlServerEntityTypeExtensions
+    {
+        protected const string SqlServerTableAnnotation = SqlServerAnnotationNames.Prefix + RelationalAnnotationNames.TableName;
+        protected const string SqlServerSchemaAnnotation = SqlServerAnnotationNames.Prefix + RelationalAnnotationNames.Schema;
+
+        public ReadOnlySqlServerEntityTypeExtensions([NotNull] IEntityType entityType)
+            : base(entityType)
+        {
+        }
+
+        public override string Table
+        {
+            get { return EntityType[SqlServerTableAnnotation] ?? base.Table; }
+        }
+
+        public override string Schema
+        {
+            get { return EntityType[SqlServerSchemaAnnotation] ?? base.Schema; }
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/Metadata/ReadOnlySqlServerForeignKeyExtensions.cs
+++ b/src/EntityFramework.SqlServer/Metadata/ReadOnlySqlServerForeignKeyExtensions.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Metadata;
+
+namespace Microsoft.Data.Entity.SqlServer.Metadata
+{
+    public class ReadOnlySqlServerForeignKeyExtensions : ReadOnlyRelationalForeignKeyExtensions, ISqlServerForeignKeyExtensions
+    {
+        protected const string SqlServerNameAnnotation = SqlServerAnnotationNames.Prefix + RelationalAnnotationNames.Name;
+
+        public ReadOnlySqlServerForeignKeyExtensions([NotNull] IForeignKey foreignKey)
+            : base(foreignKey)
+        {
+        }
+
+        public override string Name
+        {
+            get { return ForeignKey[SqlServerNameAnnotation] ?? base.Name; }
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/Metadata/ReadOnlySqlServerIndexExtensions.cs
+++ b/src/EntityFramework.SqlServer/Metadata/ReadOnlySqlServerIndexExtensions.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Metadata;
+
+namespace Microsoft.Data.Entity.SqlServer.Metadata
+{
+    public class ReadOnlySqlServerIndexExtensions : ReadOnlyRelationalIndexExtensions, ISqlServerIndexExtensions
+    {
+        protected const string SqlServerNameAnnotation = SqlServerAnnotationNames.Prefix + RelationalAnnotationNames.Name;
+
+        public ReadOnlySqlServerIndexExtensions([NotNull] IIndex index)
+            : base(index)
+        {
+        }
+
+        public override string Name
+        {
+            get { return Index[SqlServerNameAnnotation] ?? base.Name; }
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/Metadata/ReadOnlySqlServerKeyExtensions.cs
+++ b/src/EntityFramework.SqlServer/Metadata/ReadOnlySqlServerKeyExtensions.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Metadata;
+
+namespace Microsoft.Data.Entity.SqlServer.Metadata
+{
+    public class ReadOnlySqlServerKeyExtensions : ReadOnlyRelationalKeyExtensions, ISqlServerKeyExtensions
+    {
+        protected const string SqlServerNameAnnotation = SqlServerAnnotationNames.Prefix + RelationalAnnotationNames.Name;
+
+        public ReadOnlySqlServerKeyExtensions([NotNull] IKey key)
+            : base(key)
+        {
+        }
+
+        public override string Name
+        {
+            get { return Key[SqlServerNameAnnotation] ?? base.Name; }
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/Metadata/ReadOnlySqlServerPropertyExtensions.cs
+++ b/src/EntityFramework.SqlServer/Metadata/ReadOnlySqlServerPropertyExtensions.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Metadata;
+
+namespace Microsoft.Data.Entity.SqlServer.Metadata
+{
+    public class ReadOnlySqlServerPropertyExtensions : ReadOnlyRelationalPropertyExtensions, ISqlServerPropertyExtensions
+    {
+        protected const string SqlServerNameAnnotation = SqlServerAnnotationNames.Prefix + RelationalAnnotationNames.ColumnName;
+        protected const string SqlServerColumnTypeAnnotation = SqlServerAnnotationNames.Prefix + RelationalAnnotationNames.ColumnType;
+        protected const string SqlServerDefaultExpressionAnnotation = SqlServerAnnotationNames.Prefix + RelationalAnnotationNames.ColumnDefaultExpression;
+
+        public ReadOnlySqlServerPropertyExtensions([NotNull] IProperty property)
+            : base(property)
+        {
+        }
+
+        public override string Column
+        {
+            get { return Property[SqlServerNameAnnotation] ?? base.Column; }
+        }
+
+        public override string ColumnType
+        {
+            get { return Property[SqlServerNameAnnotation] ?? base.ColumnType; }
+        }
+
+        public override string DefaultExpression
+        {
+            get { return Property[SqlServerDefaultExpressionAnnotation] ?? base.DefaultExpression; }
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/Metadata/SqlServerAnnotationNames.cs
+++ b/src/EntityFramework.SqlServer/Metadata/SqlServerAnnotationNames.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.SqlServer.Metadata
+{
+    public static class SqlServerAnnotationNames
+    {
+        public const string Prefix = "SqlServer:";
+    }
+}

--- a/src/EntityFramework.SqlServer/Metadata/SqlServerEntityBuilder.cs
+++ b/src/EntityFramework.SqlServer/Metadata/SqlServerEntityBuilder.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.SqlServer.Utilities;
+
+namespace Microsoft.Data.Entity.SqlServer.Metadata
+{
+    public class SqlServerEntityBuilder
+    {
+        private readonly EntityType _entityType;
+
+        public SqlServerEntityBuilder([NotNull] EntityType entityType)
+        {
+            Check.NotNull(entityType, "entityType");
+
+            _entityType = entityType;
+        }
+
+        public virtual SqlServerEntityBuilder Table([CanBeNull] string tableName)
+        {
+            Check.NullButNotEmpty(tableName, "tableName");
+
+            _entityType.SqlServer().Table = tableName;
+
+            return this;
+        }
+
+        public virtual SqlServerEntityBuilder Table([CanBeNull] string tableName, [CanBeNull] string schemaName)
+        {
+            Check.NullButNotEmpty(tableName, "tableName");
+            Check.NullButNotEmpty(schemaName, "schemaName");
+
+            _entityType.SqlServer().Table = tableName;
+            _entityType.SqlServer().Schema = schemaName;
+
+            return this;
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/Metadata/SqlServerEntityTypeExtensions.cs
+++ b/src/EntityFramework.SqlServer/Metadata/SqlServerEntityTypeExtensions.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.SqlServer.Utilities;
+
+namespace Microsoft.Data.Entity.SqlServer.Metadata
+{
+    public class SqlServerEntityTypeExtensions : ReadOnlySqlServerEntityTypeExtensions
+    {
+        public SqlServerEntityTypeExtensions([NotNull] EntityType entityType)
+            : base(entityType)
+        {
+        }
+
+        public new virtual string Table
+        {
+            get { return base.Table; }
+            [param: CanBeNull]
+            set
+            {
+                Check.NullButNotEmpty(value, "value");
+
+                ((EntityType)EntityType)[SqlServerTableAnnotation] = value;
+            }
+        }
+
+        [CanBeNull]
+        public new virtual string Schema
+        {
+            get { return base.Schema; }
+            [param: CanBeNull]
+            set
+            {
+                Check.NullButNotEmpty(value, "value");
+                
+                ((EntityType)EntityType)[SqlServerSchemaAnnotation] = value;
+            }
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/Metadata/SqlServerForeignKeyBuilder.cs
+++ b/src/EntityFramework.SqlServer/Metadata/SqlServerForeignKeyBuilder.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.SqlServer.Utilities;
+
+namespace Microsoft.Data.Entity.SqlServer.Metadata
+{
+    public class SqlServerForeignKeyBuilder
+    {
+        private readonly ForeignKey _foreignKey;
+
+        public SqlServerForeignKeyBuilder([NotNull] ForeignKey foreignKey)
+        {
+            Check.NotNull(foreignKey, "foreignKey");
+
+            _foreignKey = foreignKey;
+        }
+
+        public virtual SqlServerForeignKeyBuilder Name([CanBeNull] string name)
+        {
+            Check.NullButNotEmpty(name, "name");
+
+            _foreignKey.SqlServer().Name = name;
+
+            return this;
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/Metadata/SqlServerForeignKeyExtensions.cs
+++ b/src/EntityFramework.SqlServer/Metadata/SqlServerForeignKeyExtensions.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.SqlServer.Utilities;
+
+namespace Microsoft.Data.Entity.SqlServer.Metadata
+{
+    public class SqlServerForeignKeyExtensions : ReadOnlySqlServerForeignKeyExtensions
+    {
+        public SqlServerForeignKeyExtensions([NotNull] ForeignKey foreignKey)
+            : base(foreignKey)
+        {
+        }
+
+        [CanBeNull]
+        public new virtual string Name
+        {
+            get { return base.Name; }
+            [param: CanBeNull]
+            set
+            {
+                Check.NullButNotEmpty(value, "value");
+
+                ((ForeignKey)ForeignKey)[SqlServerNameAnnotation] = value;
+            }
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/Metadata/SqlServerIndexBuilder.cs
+++ b/src/EntityFramework.SqlServer/Metadata/SqlServerIndexBuilder.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.SqlServer.Utilities;
+
+namespace Microsoft.Data.Entity.SqlServer.Metadata
+{
+    public class SqlServerIndexBuilder
+    {
+        private readonly Index _index;
+
+        public SqlServerIndexBuilder([NotNull] Index index)
+        {
+            Check.NotNull(index, "index");
+
+            _index = index;
+        }
+
+        public virtual SqlServerIndexBuilder Name([CanBeNull] string name)
+        {
+            Check.NullButNotEmpty(name, "name");
+
+            _index.SqlServer().Name = name;
+
+            return this;
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/Metadata/SqlServerIndexExtensions.cs
+++ b/src/EntityFramework.SqlServer/Metadata/SqlServerIndexExtensions.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.SqlServer.Utilities;
+
+namespace Microsoft.Data.Entity.SqlServer.Metadata
+{
+    public class SqlServerIndexExtensions : ReadOnlySqlServerIndexExtensions
+    {
+        public SqlServerIndexExtensions([NotNull] Index index)
+            : base(index)
+        {
+        }
+
+        [CanBeNull]
+        public new virtual string Name
+        {
+            get { return base.Name; }
+            [param: CanBeNull]
+            set
+            {
+                Check.NullButNotEmpty(value, "value");
+
+                ((Index)Index)[SqlServerNameAnnotation] = value;
+            }
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/Metadata/SqlServerKeyBuilder.cs
+++ b/src/EntityFramework.SqlServer/Metadata/SqlServerKeyBuilder.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.SqlServer.Utilities;
+
+namespace Microsoft.Data.Entity.SqlServer.Metadata
+{
+    public class SqlServerKeyBuilder
+    {
+        private readonly Key _key;
+
+        public SqlServerKeyBuilder([NotNull] Key key)
+        {
+            Check.NotNull(key, "key");
+
+            _key = key;
+        }
+
+        public virtual SqlServerKeyBuilder Name([CanBeNull] string name)
+        {
+            Check.NullButNotEmpty(name, "name");
+
+            _key.SqlServer().Name = name;
+
+            return this;
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/Metadata/SqlServerKeyExtensions.cs
+++ b/src/EntityFramework.SqlServer/Metadata/SqlServerKeyExtensions.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.SqlServer.Utilities;
+
+namespace Microsoft.Data.Entity.SqlServer.Metadata
+{
+    public class SqlServerKeyExtensions : ReadOnlySqlServerKeyExtensions
+    {
+        public SqlServerKeyExtensions([NotNull] Key key)
+            : base(key)
+        {
+        }
+
+        [CanBeNull]
+        public new virtual string Name
+        {
+            get { return base.Name; }
+            [param: CanBeNull]
+            set
+            {
+                Check.NullButNotEmpty(value, "value");
+
+                ((Key)Key)[SqlServerNameAnnotation] = value;
+            }
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/Metadata/SqlServerPropertyBuilder.cs
+++ b/src/EntityFramework.SqlServer/Metadata/SqlServerPropertyBuilder.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.SqlServer.Utilities;
+
+namespace Microsoft.Data.Entity.SqlServer.Metadata
+{
+    public class SqlServerPropertyBuilder
+    {
+        private readonly Property _property;
+
+        public SqlServerPropertyBuilder([NotNull] Property property)
+        {
+            Check.NotNull(property, "property");
+
+            _property = property;
+        }
+
+        public virtual SqlServerPropertyBuilder Column([CanBeNull] string columnName)
+        {
+            Check.NullButNotEmpty(columnName, "columnName");
+
+            _property.SqlServer().Column = columnName;
+
+            return this;
+        }
+
+        public virtual SqlServerPropertyBuilder ColumnType([CanBeNull] string columnType)
+        {
+            Check.NullButNotEmpty(columnType, "columnType");
+
+            _property.SqlServer().ColumnType = columnType;
+
+            return this;
+        }
+
+        public virtual SqlServerPropertyBuilder DefaultExpression([CanBeNull] string expression)
+        {
+            Check.NullButNotEmpty(expression, "expression");
+
+            _property.SqlServer().DefaultExpression = expression;
+
+            return this;
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/Metadata/SqlServerPropertyExtensions.cs
+++ b/src/EntityFramework.SqlServer/Metadata/SqlServerPropertyExtensions.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.SqlServer.Utilities;
+
+namespace Microsoft.Data.Entity.SqlServer.Metadata
+{
+    public class SqlServerPropertyExtensions : ReadOnlySqlServerPropertyExtensions
+    {
+        public SqlServerPropertyExtensions([NotNull] Property property)
+            : base(property)
+        {
+        }
+
+        public new virtual string Column
+        {
+            get { return base.Column; }
+            [param: CanBeNull]
+            set
+            {
+                Check.NullButNotEmpty(value, "value");
+
+                ((Property)Property)[SqlServerNameAnnotation] = value;
+            }
+        }
+
+        [CanBeNull]
+        public new virtual string ColumnType
+        {
+            get { return base.ColumnType; }
+            [param: CanBeNull]
+            set
+            {
+                Check.NullButNotEmpty(value, "value");
+
+                ((Property)Property)[SqlServerColumnTypeAnnotation] = value;
+            }
+        }
+
+        [CanBeNull]
+        public new virtual string DefaultExpression
+        {
+            get { return base.DefaultExpression; }
+            [param: CanBeNull]
+            set
+            {
+                Check.NullButNotEmpty(value, "value");
+
+                ((Property)Property)[SqlServerDefaultExpressionAnnotation] = value;
+            }
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/SqlServerBuilderExtensions.cs
+++ b/src/EntityFramework.SqlServer/SqlServerBuilderExtensions.cs
@@ -1,0 +1,212 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.SqlServer.Metadata;
+using Microsoft.Data.Entity.SqlServer.Utilities;
+
+// ReSharper disable once CheckNamespace
+
+namespace Microsoft.Data.Entity
+{
+    public static class SqlServerBuilderExtensions
+    {
+        public static SqlServerPropertyBuilder ForSqlServer<TPropertyBuilder>(
+            [NotNull] this IPropertyBuilder<TPropertyBuilder> propertyBuilder)
+            where TPropertyBuilder : IPropertyBuilder<TPropertyBuilder>
+        {
+            Check.NotNull(propertyBuilder, "propertyBuilder");
+
+            return new SqlServerPropertyBuilder(propertyBuilder.Metadata);
+        }
+
+        public static TPropertyBuilder ForSqlServer<TPropertyBuilder>(
+            [NotNull] this IPropertyBuilder<TPropertyBuilder> propertyBuilder,
+            [NotNull] Action<SqlServerPropertyBuilder> sqlServerPropertyBuilder)
+            where TPropertyBuilder : IPropertyBuilder<TPropertyBuilder>
+        {
+            Check.NotNull(propertyBuilder, "propertyBuilder");
+            Check.NotNull(sqlServerPropertyBuilder, "sqlServerPropertyBuilder");
+
+            sqlServerPropertyBuilder(ForSqlServer(propertyBuilder));
+
+            return (TPropertyBuilder)propertyBuilder;
+        }
+
+        public static SqlServerEntityBuilder ForSqlServer<TEntityBuilder>(
+            [NotNull] this IEntityBuilder<TEntityBuilder> entityBuilder)
+            where TEntityBuilder : IEntityBuilder<TEntityBuilder>
+        {
+            Check.NotNull(entityBuilder, "entityBuilder");
+
+            return new SqlServerEntityBuilder(entityBuilder.Metadata);
+        }
+
+        public static TEntityBuilder ForSqlServer<TEntityBuilder>(
+            [NotNull] this IEntityBuilder<TEntityBuilder> entityBuilder,
+            [NotNull] Action<SqlServerEntityBuilder> relationalEntityBuilder)
+            where TEntityBuilder : IEntityBuilder<TEntityBuilder>
+        {
+            Check.NotNull(entityBuilder, "entityBuilder");
+
+            relationalEntityBuilder(ForSqlServer(entityBuilder));
+
+            return (TEntityBuilder)entityBuilder;
+        }
+
+        public static SqlServerEntityBuilder ForSqlServer<TEntity, TEntityBuilder>(
+            [NotNull] this IEntityBuilder<TEntity, TEntityBuilder> entityBuilder)
+            where TEntityBuilder : IEntityBuilder<TEntity, TEntityBuilder>
+        {
+            Check.NotNull(entityBuilder, "entityBuilder");
+
+            return new SqlServerEntityBuilder(entityBuilder.Metadata);
+        }
+
+        public static TEntityBuilder ForSqlServer<TEntity, TEntityBuilder>(
+            [NotNull] this IEntityBuilder<TEntity, TEntityBuilder> entityBuilder,
+            [NotNull] Action<SqlServerEntityBuilder> relationalEntityBuilder)
+            where TEntityBuilder : IEntityBuilder<TEntity, TEntityBuilder>
+        {
+            Check.NotNull(entityBuilder, "entityBuilder");
+
+            relationalEntityBuilder(ForSqlServer(entityBuilder));
+
+            return (TEntityBuilder)entityBuilder;
+        }
+
+        public static SqlServerKeyBuilder ForSqlServer<TKeyBuilder>(
+            [NotNull] this IKeyBuilder<TKeyBuilder> keyBuilder)
+            where TKeyBuilder : IKeyBuilder<TKeyBuilder>
+        {
+            Check.NotNull(keyBuilder, "keyBuilder");
+
+            return new SqlServerKeyBuilder(keyBuilder.Metadata);
+        }
+
+        public static TKeyBuilder ForSqlServer<TKeyBuilder>(
+            [NotNull] this IKeyBuilder<TKeyBuilder> keyBuilder,
+            [NotNull] Action<SqlServerKeyBuilder> relationalKeyBuilder)
+            where TKeyBuilder : IKeyBuilder<TKeyBuilder>
+        {
+            Check.NotNull(keyBuilder, "keyBuilder");
+            Check.NotNull(relationalKeyBuilder, "relationalKeyBuilder");
+
+            relationalKeyBuilder(ForSqlServer(keyBuilder));
+
+            return (TKeyBuilder)keyBuilder;
+        }
+
+        public static SqlServerForeignKeyBuilder ForSqlServer<TForeignKeyBuilder>(
+            [NotNull] this IForeignKeyBuilder<TForeignKeyBuilder> foreignKeyBuilder)
+            where TForeignKeyBuilder : IForeignKeyBuilder<TForeignKeyBuilder>
+        {
+            Check.NotNull(foreignKeyBuilder, "foreignKeyBuilder");
+
+            return new SqlServerForeignKeyBuilder(foreignKeyBuilder.Metadata);
+        }
+
+        public static TForeignKeyBuilder ForSqlServer<TForeignKeyBuilder>(
+            [NotNull] this IForeignKeyBuilder<TForeignKeyBuilder> foreignKeyBuilder,
+            [NotNull] Action<SqlServerForeignKeyBuilder> relationalForeignKeyBuilder)
+            where TForeignKeyBuilder : IForeignKeyBuilder<TForeignKeyBuilder>
+        {
+            Check.NotNull(foreignKeyBuilder, "foreignKeyBuilder");
+            Check.NotNull(relationalForeignKeyBuilder, "relationalForeignKeyBuilder");
+
+            relationalForeignKeyBuilder(ForSqlServer(foreignKeyBuilder));
+
+            return (TForeignKeyBuilder)foreignKeyBuilder;
+        }
+
+        public static SqlServerIndexBuilder ForSqlServer<TIndexBuilder>(
+            [NotNull] this IIndexBuilder<TIndexBuilder> indexBuilder)
+            where TIndexBuilder : IIndexBuilder<TIndexBuilder>
+        {
+            Check.NotNull(indexBuilder, "indexBuilder");
+
+            return new SqlServerIndexBuilder(indexBuilder.Metadata);
+        }
+
+        public static TIndexBuilder ForSqlServer<TIndexBuilder>(
+            [NotNull] this IIndexBuilder<TIndexBuilder> indexBuilder,
+            [NotNull] Action<SqlServerIndexBuilder> relationalIndexBuilder)
+            where TIndexBuilder : IIndexBuilder<TIndexBuilder>
+        {
+            Check.NotNull(indexBuilder, "indexBuilder");
+            Check.NotNull(relationalIndexBuilder, "relationalIndexBuilder");
+
+            relationalIndexBuilder(ForSqlServer(indexBuilder));
+
+            return (TIndexBuilder)indexBuilder;
+        }
+
+        public static SqlServerForeignKeyBuilder ForSqlServer<TOneToManyBuilder>(
+            [NotNull] this IOneToManyBuilder<TOneToManyBuilder> foreignKeyBuilder)
+            where TOneToManyBuilder : IOneToManyBuilder<TOneToManyBuilder>
+        {
+            Check.NotNull(foreignKeyBuilder, "foreignKeyBuilder");
+
+            return new SqlServerForeignKeyBuilder(foreignKeyBuilder.Metadata);
+        }
+
+        public static TOneToManyBuilder ForSqlServer<TOneToManyBuilder>(
+            [NotNull] this IOneToManyBuilder<TOneToManyBuilder> foreignKeyBuilder,
+            [NotNull] Action<SqlServerForeignKeyBuilder> relationalOneToManyBuilder)
+            where TOneToManyBuilder : IOneToManyBuilder<TOneToManyBuilder>
+        {
+            Check.NotNull(foreignKeyBuilder, "foreignKeyBuilder");
+            Check.NotNull(relationalOneToManyBuilder, "relationalOneToManyBuilder");
+
+            relationalOneToManyBuilder(ForSqlServer(foreignKeyBuilder));
+
+            return (TOneToManyBuilder)foreignKeyBuilder;
+        }
+
+        public static SqlServerForeignKeyBuilder ForSqlServer<TManyToOneBuilder>(
+            [NotNull] this IManyToOneBuilder<TManyToOneBuilder> foreignKeyBuilder)
+            where TManyToOneBuilder : IManyToOneBuilder<TManyToOneBuilder>
+        {
+            Check.NotNull(foreignKeyBuilder, "foreignKeyBuilder");
+
+            return new SqlServerForeignKeyBuilder(foreignKeyBuilder.Metadata);
+        }
+
+        public static TManyToOneBuilder ForSqlServer<TManyToOneBuilder>(
+            [NotNull] this IManyToOneBuilder<TManyToOneBuilder> foreignKeyBuilder,
+            [NotNull] Action<SqlServerForeignKeyBuilder> relationalManyToOneBuilder)
+            where TManyToOneBuilder : IManyToOneBuilder<TManyToOneBuilder>
+        {
+            Check.NotNull(foreignKeyBuilder, "foreignKeyBuilder");
+            Check.NotNull(relationalManyToOneBuilder, "relationalManyToOneBuilder");
+
+            relationalManyToOneBuilder(ForSqlServer(foreignKeyBuilder));
+
+            return (TManyToOneBuilder)foreignKeyBuilder;
+        }
+
+        public static SqlServerForeignKeyBuilder ForSqlServer<TOneToOneBuilder>(
+            [NotNull] this IOneToOneBuilder<TOneToOneBuilder> foreignKeyBuilder)
+            where TOneToOneBuilder : IOneToOneBuilder<TOneToOneBuilder>
+        {
+            Check.NotNull(foreignKeyBuilder, "foreignKeyBuilder");
+
+            return new SqlServerForeignKeyBuilder(foreignKeyBuilder.Metadata);
+        }
+
+        public static TOneToOneBuilder ForSqlServer<TOneToOneBuilder>(
+            [NotNull] this IOneToOneBuilder<TOneToOneBuilder> foreignKeyBuilder,
+            [NotNull] Action<SqlServerForeignKeyBuilder> relationalOneToOneBuilder)
+            where TOneToOneBuilder : IOneToOneBuilder<TOneToOneBuilder>
+        {
+            Check.NotNull(foreignKeyBuilder, "foreignKeyBuilder");
+            Check.NotNull(relationalOneToOneBuilder, "relationalOneToOneBuilder");
+
+            relationalOneToOneBuilder(ForSqlServer(foreignKeyBuilder));
+
+            return (TOneToOneBuilder)foreignKeyBuilder;
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/SqlServerMetadataExtensions.cs
+++ b/src/EntityFramework.SqlServer/SqlServerMetadataExtensions.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.SqlServer.Metadata;
+using Microsoft.Data.Entity.SqlServer.Utilities;
+
+// ReSharper disable once CheckNamespace
+
+namespace Microsoft.Data.Entity
+{
+    public static class SqlServerMetadataExtensions
+    {
+        public static SqlServerPropertyExtensions SqlServer([NotNull] this Property property)
+        {
+            Check.NotNull(property, "property");
+
+            return new SqlServerPropertyExtensions(property);
+        }
+
+        public static ISqlServerPropertyExtensions SqlServer([NotNull] this IProperty property)
+        {
+            Check.NotNull(property, "property");
+
+            return new ReadOnlySqlServerPropertyExtensions(property);
+        }
+
+        public static SqlServerEntityTypeExtensions SqlServer([NotNull] this EntityType entityType)
+        {
+            Check.NotNull(entityType, "entityType");
+
+            return new SqlServerEntityTypeExtensions(entityType);
+        }
+
+        public static ISqlServerEntityTypeExtensions SqlServer([NotNull] this IEntityType entityType)
+        {
+            Check.NotNull(entityType, "entityType");
+
+            return new ReadOnlySqlServerEntityTypeExtensions(entityType);
+        }
+
+        public static SqlServerKeyExtensions SqlServer([NotNull] this Key key)
+        {
+            Check.NotNull(key, "key");
+
+            return new SqlServerKeyExtensions(key);
+        }
+
+        public static ISqlServerKeyExtensions SqlServer([NotNull] this IKey key)
+        {
+            Check.NotNull(key, "key");
+
+            return new ReadOnlySqlServerKeyExtensions(key);
+        }
+
+        public static SqlServerIndexExtensions SqlServer([NotNull] this Index index)
+        {
+            Check.NotNull(index, "index");
+
+            return new SqlServerIndexExtensions(index);
+        }
+
+        public static ISqlServerIndexExtensions SqlServer([NotNull] this IIndex index)
+        {
+            Check.NotNull(index, "index");
+
+            return new ReadOnlySqlServerIndexExtensions(index);
+        }
+
+        public static SqlServerForeignKeyExtensions SqlServer([NotNull] this ForeignKey foreignKey)
+        {
+            Check.NotNull(foreignKey, "foreignKey");
+
+            return new SqlServerForeignKeyExtensions(foreignKey);
+        }
+
+        public static ISqlServerForeignKeyExtensions SqlServer([NotNull] this IForeignKey foreignKey)
+        {
+            Check.NotNull(foreignKey, "foreignKey");
+
+            return new ReadOnlySqlServerForeignKeyExtensions(foreignKey);
+        }
+    }
+}

--- a/src/EntityFramework.SqlServer/SqlServerMigrationOperationSqlGenerator.cs
+++ b/src/EntityFramework.SqlServer/SqlServerMigrationOperationSqlGenerator.cs
@@ -148,9 +148,9 @@ namespace Microsoft.Data.Entity.SqlServer
             // TODO: This is essentially duplicated logic from the selector; combine if possible
             if (column.ValueGenerationStrategy == ValueGeneration.OnAdd)
             {
-                var strategy = column[SqlServerMetadataExtensions.Annotations.ValueGeneration];
+                var strategy = column[Entity.Metadata.SqlServerMetadataExtensions.Annotations.ValueGeneration];
 
-                if (strategy == SqlServerMetadataExtensions.Annotations.Identity
+                if (strategy == Entity.Metadata.SqlServerMetadataExtensions.Annotations.Identity
                     || (strategy == null
                         && column.ClrType.IsInteger()))
                 {

--- a/src/EntityFramework.SqlServer/SqlServerSequenceValueGeneratorFactory.cs
+++ b/src/EntityFramework.SqlServer/SqlServerSequenceValueGeneratorFactory.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Data.Entity.SqlServer
         {
             Check.NotNull(property, "property");
 
-            var annotatedIncrement = property.FindAnnotationInHierarchy(SqlServerMetadataExtensions.Annotations.SequenceBlockSize);
+            var annotatedIncrement = property.FindAnnotationInHierarchy(Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceBlockSize);
 
             // TODO: Allow integer annotations
             // Issue #777
@@ -40,7 +40,7 @@ namespace Microsoft.Data.Entity.SqlServer
         {
             Check.NotNull(property, "property");
 
-            var sequenceName = property.FindAnnotationInHierarchy(SqlServerMetadataExtensions.Annotations.SequenceName);
+            var sequenceName = property.FindAnnotationInHierarchy(Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceName);
             if (sequenceName != null)
             {
                 return sequenceName;

--- a/src/EntityFramework.SqlServer/SqlServerValueGeneratorSelector.cs
+++ b/src/EntityFramework.SqlServer/SqlServerValueGeneratorSelector.cs
@@ -36,14 +36,14 @@ namespace Microsoft.Data.Entity.SqlServer
 
             if (property.ValueGeneration == ValueGeneration.OnAdd)
             {
-                var strategy = property.FindAnnotationInHierarchy(SqlServerMetadataExtensions.Annotations.ValueGeneration);
+                var strategy = property.FindAnnotationInHierarchy(Entity.Metadata.SqlServerMetadataExtensions.Annotations.ValueGeneration);
 
-                if (strategy == SqlServerMetadataExtensions.Annotations.Sequence)
+                if (strategy == Entity.Metadata.SqlServerMetadataExtensions.Annotations.Sequence)
                 {
                     return _sequenceFactory;
                 }
 
-                if (strategy == SqlServerMetadataExtensions.Annotations.Identity)
+                if (strategy == Entity.Metadata.SqlServerMetadataExtensions.Annotations.Identity)
                 {
                     return _tempFactory;
                 }

--- a/src/EntityFramework.SqlServer/Utilities/Check.cs
+++ b/src/EntityFramework.SqlServer/Utilities/Check.cs
@@ -64,6 +64,27 @@ namespace Microsoft.Data.Entity.SqlServer.Utilities
             return value;
         }
 
+        public static string NullButNotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
+        {
+            if (ReferenceEquals(parameterName, null))
+            {
+                throw new ArgumentNullException("parameterName");
+            }
+
+            if (parameterName.Length == 0)
+            {
+                throw new ArgumentException(Strings.FormatArgumentIsEmpty("parameterName"));
+            }
+
+            if (!ReferenceEquals(value, null)
+                && value.Length == 0)
+            {
+                throw new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+            }
+
+            return value;
+        }
+
         public static T IsDefined<T>(T value, [InvokerParameterName] [NotNull] string parameterName)
             where T : struct
         {

--- a/test/EntityFramework.Migrations.Tests/Infrastructure/MigrationMetadataTest.cs
+++ b/test/EntityFramework.Migrations.Tests/Infrastructure/MigrationMetadataTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
         [Fact]
         public void Create_migration_metadata()
         {
-            var targetModel = new Metadata.Model();
+            var targetModel = new Entity.Metadata.Model();
             var upgradeOperations = new MigrationOperation[0];
             var downgradeOperations = new MigrationOperation[0];
 
@@ -34,7 +34,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
         [Fact]
         public void Create_migration_metadata_with_product_version()
         {
-            var targetModel = new Metadata.Model();
+            var targetModel = new Entity.Metadata.Model();
             var upgradeOperations = new MigrationOperation[0];
             var downgradeOperations = new MigrationOperation[0];
 

--- a/test/EntityFramework.Migrations.Tests/Infrastructure/MigratorTest.cs
+++ b/test/EntityFramework.Migrations.Tests/Infrastructure/MigratorTest.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                     {
                         new MigrationMetadata("000000000000001_Migration1")
                             {
-                                TargetModel = new Metadata.Model(),
+                                TargetModel = new Entity.Metadata.Model(),
                                 UpgradeOperations
                                     = new MigrationOperation[]
                                         {
@@ -134,7 +134,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                     {
                         new MigrationMetadata("000000000000001_Migration1")
                             {
-                                TargetModel = new Metadata.Model(),
+                                TargetModel = new Entity.Metadata.Model(),
                                 UpgradeOperations
                                     = new MigrationOperation[]
                                         {
@@ -143,7 +143,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                             },
                         new MigrationMetadata("000000000000002_Migration2")
                             {
-                                TargetModel = new Metadata.Model(),
+                                TargetModel = new Entity.Metadata.Model(),
                                 UpgradeOperations
                                     = new MigrationOperation[]
                                         {
@@ -176,11 +176,11 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                     {
                         new MigrationMetadata("000000000000001_Migration1")
                             {
-                                TargetModel = new Metadata.Model()
+                                TargetModel = new Entity.Metadata.Model()
                             },
                         new MigrationMetadata("000000000000002_Migration2")
                             {
-                                TargetModel = new Metadata.Model(),
+                                TargetModel = new Entity.Metadata.Model(),
                                 UpgradeOperations
                                     = new MigrationOperation[]
                                         {
@@ -212,15 +212,15 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                     {
                         new MigrationMetadata("000000000000001_Migration1")
                             {
-                                TargetModel = new Metadata.Model()
+                                TargetModel = new Entity.Metadata.Model()
                             },
                         new MigrationMetadata("000000000000002_Migration2")
                             {
-                                TargetModel = new Metadata.Model()
+                                TargetModel = new Entity.Metadata.Model()
                             },
                         new MigrationMetadata("000000000000003_Migration3")
                             {
-                                TargetModel = new Metadata.Model(),
+                                TargetModel = new Entity.Metadata.Model(),
                                 UpgradeOperations
                                     = new MigrationOperation[]
                                         {
@@ -230,7 +230,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                             },
                         new MigrationMetadata("000000000000004_Migration4")
                             {
-                                TargetModel = new Metadata.Model(),
+                                TargetModel = new Entity.Metadata.Model(),
                                 UpgradeOperations
                                     = new MigrationOperation[]
                                         {
@@ -263,15 +263,15 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                     {
                         new MigrationMetadata("000000000000001_Migration1")
                             {
-                                TargetModel = new Metadata.Model()
+                                TargetModel = new Entity.Metadata.Model()
                             },
                         new MigrationMetadata("000000000000002_Migration2")
                             {
-                                TargetModel = new Metadata.Model()
+                                TargetModel = new Entity.Metadata.Model()
                             },
                         new MigrationMetadata("000000000000003_Migration3")
                             {
-                                TargetModel = new Metadata.Model(),
+                                TargetModel = new Entity.Metadata.Model(),
                                 UpgradeOperations
                                     = new MigrationOperation[]
                                         {
@@ -281,7 +281,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                             },
                         new MigrationMetadata("000000000000004_Migration4")
                             {
-                                TargetModel = new Metadata.Model(),
+                                TargetModel = new Entity.Metadata.Model(),
                                 UpgradeOperations
                                     = new MigrationOperation[]
                                         {
@@ -314,15 +314,15 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                     {
                         new MigrationMetadata("000000000000001_Migration1")
                             {
-                                TargetModel = new Metadata.Model()
+                                TargetModel = new Entity.Metadata.Model()
                             },
                         new MigrationMetadata("000000000000002_Migration2")
                             {
-                                TargetModel = new Metadata.Model()
+                                TargetModel = new Entity.Metadata.Model()
                             },
                         new MigrationMetadata("000000000000003_Migration3")
                             {
-                                TargetModel = new Metadata.Model(),
+                                TargetModel = new Entity.Metadata.Model(),
                                 UpgradeOperations
                                     = new MigrationOperation[]
                                         {
@@ -332,7 +332,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                             },
                         new MigrationMetadata("000000000000004_Migration4")
                             {
-                                TargetModel = new Metadata.Model(),
+                                TargetModel = new Entity.Metadata.Model(),
                                 UpgradeOperations
                                     = new MigrationOperation[]
                                         {
@@ -389,15 +389,15 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                     {
                         new MigrationMetadata("000000000000001_Migration1")
                             {
-                                TargetModel = new Metadata.Model()
+                                TargetModel = new Entity.Metadata.Model()
                             },
                         new MigrationMetadata("000000000000002_Migration2")
                             {
-                                TargetModel = new Metadata.Model()
+                                TargetModel = new Entity.Metadata.Model()
                             },
                         new MigrationMetadata("000000000000003_Migration3")
                             {
-                                TargetModel = new Metadata.Model(),
+                                TargetModel = new Entity.Metadata.Model(),
                                 DowngradeOperations
                                     = new MigrationOperation[]
                                         {
@@ -407,7 +407,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                             },
                         new MigrationMetadata("000000000000004_Migration4")
                             {
-                                TargetModel = new Metadata.Model(),
+                                TargetModel = new Entity.Metadata.Model(),
                                 DowngradeOperations
                                     = new MigrationOperation[]
                                         {
@@ -442,15 +442,15 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                     {
                         new MigrationMetadata("000000000000001_Migration1")
                             {
-                                TargetModel = new Metadata.Model()
+                                TargetModel = new Entity.Metadata.Model()
                             },
                         new MigrationMetadata("000000000000002_Migration2")
                             {
-                                TargetModel = new Metadata.Model()
+                                TargetModel = new Entity.Metadata.Model()
                             },
                         new MigrationMetadata("000000000000003_Migration3")
                             {
-                                TargetModel = new Metadata.Model(),
+                                TargetModel = new Entity.Metadata.Model(),
                                 UpgradeOperations
                                     = new MigrationOperation[]
                                         {
@@ -484,15 +484,15 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                     {
                         new MigrationMetadata("000000000000001_Migration1")
                             {
-                                TargetModel = new Metadata.Model()
+                                TargetModel = new Entity.Metadata.Model()
                             },
                         new MigrationMetadata("000000000000002_Migration2")
                             {
-                                TargetModel = new Metadata.Model()
+                                TargetModel = new Entity.Metadata.Model()
                             },
                         new MigrationMetadata("000000000000003_Migration3")
                             {
-                                TargetModel = new Metadata.Model(),
+                                TargetModel = new Entity.Metadata.Model(),
                                 UpgradeOperations
                                     = new MigrationOperation[]
                                         {
@@ -502,7 +502,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                             },
                         new MigrationMetadata("000000000000004_Migration4")
                             {
-                                TargetModel = new Metadata.Model(),
+                                TargetModel = new Entity.Metadata.Model(),
                                 DowngradeOperations
                                     = new MigrationOperation[]
                                         {
@@ -536,7 +536,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                     {
                         new MigrationMetadata("000000000000001_Migration1")
                             {
-                                TargetModel = new Metadata.Model(),
+                                TargetModel = new Entity.Metadata.Model(),
                                 DowngradeOperations
                                     = new MigrationOperation[]
                                         {
@@ -545,7 +545,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                             },
                         new MigrationMetadata("000000000000002_Migration2")
                             {
-                                TargetModel = new Metadata.Model(),
+                                TargetModel = new Entity.Metadata.Model(),
                                 DowngradeOperations
                                     = new MigrationOperation[]
                                         {
@@ -577,7 +577,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                     {
                         new MigrationMetadata("000000000000001_Migration1")
                             {
-                                TargetModel = new Metadata.Model(),
+                                TargetModel = new Entity.Metadata.Model(),
                                 UpgradeOperations
                                     = new MigrationOperation[]
                                         {

--- a/test/EntityFramework.Relational.FunctionalTests/NorthwindQueryFixtureRelationalBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/NorthwindQueryFixtureRelationalBase.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
 {
     public abstract class NorthwindQueryFixtureRelationalBase : NorthwindQueryFixtureBase
     {
-        public Metadata.Model SetTableNames(Metadata.Model model)
+        public Entity.Metadata.Model SetTableNames(Entity.Metadata.Model model)
         {
             model.GetEntityType(typeof(Customer)).SetTableName("Customers");
             model.GetEntityType(typeof(Employee)).SetTableName("Employees");

--- a/test/EntityFramework.Relational.FunctionalTests/TransactionTestBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/TransactionTestBase.cs
@@ -322,9 +322,9 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
 
         #region Helpers
 
-        protected Metadata.Model CreateModel()
+        protected Entity.Metadata.Model CreateModel()
         {
-            var model = new Metadata.Model();
+            var model = new Entity.Metadata.Model();
             var modelBuilder = new BasicModelBuilder(model);
 
             // TODO: Uncomment when complex types are supported

--- a/test/EntityFramework.Relational.Tests/ApiExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/ApiExtensionsTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
         [Fact]
         public void Can_set_entity_table_name()
         {
-            var model = new Metadata.Model();
+            var model = new Entity.Metadata.Model();
             var modelBuilder = new BasicModelBuilder(model);
 
             modelBuilder
@@ -25,7 +25,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
         [Fact]
         public void Can_set_entity_table_name_with_dot()
         {
-            var model = new Metadata.Model();
+            var model = new Entity.Metadata.Model();
             var modelBuilder = new BasicModelBuilder(model);
 
             modelBuilder
@@ -37,7 +37,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
         [Fact]
         public void Can_set_entity_table_name_and_schema()
         {
-            var model = new Metadata.Model();
+            var model = new Entity.Metadata.Model();
             var modelBuilder = new BasicModelBuilder(model);
 
             modelBuilder
@@ -50,7 +50,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
         [Fact]
         public void Can_set_entity_table_name_when_no_clr_type()
         {
-            var model = new Metadata.Model();
+            var model = new Entity.Metadata.Model();
             var modelBuilder = new BasicModelBuilder(model);
 
             modelBuilder
@@ -63,7 +63,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
         [Fact]
         public void Can_set_entity_table_name_and_schema_when_no_clr_type()
         {
-            var model = new Metadata.Model();
+            var model = new Entity.Metadata.Model();
             var modelBuilder = new BasicModelBuilder(model);
 
             modelBuilder
@@ -77,7 +77,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
         [Fact]
         public void Can_set_property_column_name()
         {
-            var model = new Metadata.Model();
+            var model = new Entity.Metadata.Model();
             var modelBuilder = new BasicModelBuilder(model);
 
             modelBuilder
@@ -90,7 +90,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
         [Fact]
         public void Can_set_property_column_name_when_no_clr_property()
         {
-            var model = new Metadata.Model();
+            var model = new Entity.Metadata.Model();
             var modelBuilder = new BasicModelBuilder(model);
 
             modelBuilder
@@ -103,7 +103,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
         [Fact]
         public void Can_set_property_column_name_when_no_clr_type()
         {
-            var model = new Metadata.Model();
+            var model = new Entity.Metadata.Model();
             var modelBuilder = new BasicModelBuilder(model);
 
             modelBuilder
@@ -116,7 +116,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
         [Fact]
         public void Can_set_foreign_key_name()
         {
-            var model = new Metadata.Model();
+            var model = new Entity.Metadata.Model();
             var modelBuilder = new BasicModelBuilder(model);
 
             modelBuilder.Entity(typeof(Customer).FullName, b =>
@@ -154,7 +154,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
         [Fact]
         public void Property_column_name_defaults_to_name()
         {
-            var model = new Metadata.Model();
+            var model = new Entity.Metadata.Model();
             var modelBuilder = new BasicModelBuilder(model);
 
             modelBuilder
@@ -167,7 +167,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
         [Fact]
         public void Property_column_name_can_be_different_from_name()
         {
-            var model = new Metadata.Model();
+            var model = new Entity.Metadata.Model();
             var modelBuilder = new BasicModelBuilder(model);
 
             modelBuilder

--- a/test/EntityFramework.Relational.Tests/DatabaseBuilderTest.cs
+++ b/test/EntityFramework.Relational.Tests/DatabaseBuilderTest.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
 
         private static IModel CreateModel()
         {
-            var model = new Metadata.Model { StorageName = "MyDatabase" };
+            var model = new Entity.Metadata.Model { StorageName = "MyDatabase" };
 
             var dependentEntityType = new EntityType("Dependent");
             dependentEntityType.SetSchema("dbo");

--- a/test/EntityFramework.Relational.Tests/EntityFramework.Relational.Tests.csproj
+++ b/test/EntityFramework.Relational.Tests/EntityFramework.Relational.Tests.csproj
@@ -71,7 +71,9 @@
     <Compile Include="ConnectionStringResolverTest.cs" />
     <Compile Include="DatabaseBuilderTest.cs" />
     <Compile Include="MetadataExtensionsTest.cs" />
+    <Compile Include="Metadata\RelationalMetadataExtensionsTest.cs" />
     <Compile Include="Model\RelationalTypeMappingTest.cs" />
+    <Compile Include="Metadata\RelationalBuilderExtensionsTest.cs" />
     <Compile Include="RelationalConnectionTest.cs" />
     <Compile Include="RelationalDatabaseExtensionsTest.cs" />
     <Compile Include="RelationalDatabaseTest.cs" />

--- a/test/EntityFramework.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
@@ -1,0 +1,927 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Data.Entity.Metadata;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Relational.Metadata.Tests
+{
+    public class RelationalBuilderExtensionsTest
+    {
+        [Fact]
+        public void Can_set_column_name_with_basic_builder()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational()
+                .Column("Eman");
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal("Name", property.Name);
+            Assert.Equal("Eman", property.Relational().Column);
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational()
+                .Column(null);
+
+            Assert.Equal("Name", property.Relational().Column);
+        }
+
+        [Fact]
+        public void Can_set_column_name_with_basic_builder_using_nested_closure()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational(b => { b.Column("Eman"); });
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal("Name", property.Name);
+            Assert.Equal("Eman", property.Relational().Column);
+        }
+
+        [Fact]
+        public void Can_set_column_name_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational()
+                .Column("Eman");
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal("Name", property.Name);
+            Assert.Equal("Eman", property.Relational().Column);
+        }
+
+        [Fact]
+        public void Can_set_column_name_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational(b => { b.Column("Eman"); });
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal("Name", property.Name);
+            Assert.Equal("Eman", property.Relational().Column);
+        }
+
+        [Fact]
+        public void Can_set_column_type_with_basic_builder()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational()
+                .ColumnType("nvarchar(42)");
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal("nvarchar(42)", property.Relational().ColumnType);
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational()
+                .ColumnType(null);
+
+            Assert.Null(property.Relational().ColumnType);
+        }
+
+        [Fact]
+        public void Can_set_column_type_with_basic_builder_using_nested_closure()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational(b => { b.ColumnType("nvarchar(42)"); });
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal("nvarchar(42)", property.Relational().ColumnType);
+        }
+
+        [Fact]
+        public void Can_set_column_type_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational()
+                .ColumnType("nvarchar(42)");
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal("nvarchar(42)", property.Relational().ColumnType);
+        }
+
+        [Fact]
+        public void Can_set_column_type_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational(b => { b.ColumnType("nvarchar(42)"); });
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal("nvarchar(42)", property.Relational().ColumnType);
+        }
+
+        [Fact]
+        public void Can_set_column_default_expression_with_basic_builder()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational()
+                .DefaultExpression("CherryCoke");
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal("CherryCoke", property.Relational().DefaultExpression);
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational()
+                .DefaultExpression(null);
+
+            Assert.Null(property.Relational().DefaultExpression);
+        }
+
+        [Fact]
+        public void Can_set_column_default_expression_with_basic_builder_using_nested_closure()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational(b => { b.DefaultExpression("CherryCoke"); });
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal("CherryCoke", property.Relational().DefaultExpression);
+        }
+
+        [Fact]
+        public void Can_set_column_default_expression_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational()
+                .DefaultExpression("CherryCoke");
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal("CherryCoke", property.Relational().DefaultExpression);
+        }
+
+        [Fact]
+        public void Can_set_column_default_expression_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational(b => { b.DefaultExpression("CherryCoke"); });
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal("CherryCoke", property.Relational().DefaultExpression);
+        }
+
+        [Fact]
+        public void Can_set_key_name_with_basic_builder()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Key(e => e.Id)
+                .ForRelational()
+                .Name("KeyLimePie");
+
+            var key = modelBuilder.Model.GetEntityType(typeof(Customer)).GetPrimaryKey();
+
+            Assert.Equal("KeyLimePie", key.Relational().Name);
+
+            modelBuilder
+                .Entity<Customer>()
+                .Key(e => e.Id)
+                .ForRelational()
+                .Name(null);
+
+            Assert.Null(key.Relational().Name);
+        }
+
+        [Fact]
+        public void Can_set_key_name_with_basic_builder_using_nested_closure()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Key(e => e.Id)
+                .ForRelational(b => { b.Name("KeyLimePie"); });
+
+            var key = modelBuilder.Model.GetEntityType(typeof(Customer)).GetPrimaryKey();
+
+            Assert.Equal("KeyLimePie", key.Relational().Name);
+        }
+
+        [Fact]
+        public void Can_set_key_name_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Key(e => e.Id)
+                .ForRelational()
+                .Name("KeyLimePie");
+
+            var key = modelBuilder.Model.GetEntityType(typeof(Customer)).GetPrimaryKey();
+
+            Assert.Equal("KeyLimePie", key.Relational().Name);
+        }
+
+        [Fact]
+        public void Can_set_key_name_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Key(e => e.Id)
+                .ForRelational(b => { b.Name("KeyLimePie"); });
+
+            var key = modelBuilder.Model.GetEntityType(typeof(Customer)).GetPrimaryKey();
+
+            Assert.Equal("KeyLimePie", key.Relational().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_with_basic_builder()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Key(e => e.Id);
+
+            modelBuilder
+                .Entity<Order>()
+                .ForeignKey<Customer>(e => e.CustomerId)
+                .ForRelational()
+                .Name("LemonSupreme");
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+
+            modelBuilder
+                .Entity<Order>()
+                .ForeignKey<Customer>(e => e.CustomerId)
+                .ForRelational()
+                .Name(null);
+
+            Assert.Null(foreignKey.Relational().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_with_basic_builder_using_nested_closure()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Key(e => e.Id);
+
+            modelBuilder
+                .Entity<Order>()
+                .ForeignKey<Customer>(e => e.CustomerId)
+                .ForRelational(b => { b.Name("LemonSupreme"); });
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_for_one_to_many_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .OneToMany(e => e.Orders, e => e.Customer)
+                .ForRelational()
+                .Name("LemonSupreme");
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+
+            modelBuilder
+                .Entity<Customer>()
+                .OneToMany(e => e.Orders, e => e.Customer)
+                .ForRelational()
+                .Name(null);
+
+            Assert.Null(foreignKey.Relational().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_for_one_to_many_with_FK_specified_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .OneToMany(e => e.Orders, e => e.Customer)
+                .ForeignKey(e => e.CustomerId)
+                .ForRelational()
+                .Name("LemonSupreme");
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_for_one_to_many_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .OneToMany(e => e.Orders, e => e.Customer)
+                .ForRelational(b => { b.Name("LemonSupreme"); });
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_for_one_to_many_with_FK_specified_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .OneToMany(e => e.Orders, e => e.Customer)
+                .ForeignKey(e => e.CustomerId)
+                .ForRelational(b => { b.Name("LemonSupreme"); });
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_for_many_to_one_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Order>()
+                .ManyToOne(e => e.Customer, e => e.Orders)
+                .ForRelational()
+                .Name("LemonSupreme");
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+
+            modelBuilder
+                .Entity<Order>()
+                .ManyToOne(e => e.Customer, e => e.Orders)
+                .ForRelational()
+                .Name(null);
+
+            Assert.Null(foreignKey.Relational().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_for_many_to_one_with_FK_specified_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Order>()
+                .ManyToOne(e => e.Customer, e => e.Orders)
+                .ForeignKey(e => e.CustomerId)
+                .ForRelational()
+                .Name("LemonSupreme");
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_for_many_to_one_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Order>()
+                .ManyToOne(e => e.Customer, e => e.Orders)
+                .ForRelational(b => { b.Name("LemonSupreme"); });
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_for_many_to_one_with_FK_specified_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Order>()
+                .ManyToOne(e => e.Customer, e => e.Orders)
+                .ForeignKey(e => e.CustomerId)
+                .ForRelational(b => { b.Name("LemonSupreme"); });
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_for_one_to_one_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Order>()
+                .OneToOne(e => e.Details, e => e.Order)
+                .ForRelational()
+                .Name("LemonSupreme");
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+
+            modelBuilder
+                .Entity<Order>()
+                .OneToOne(e => e.Details, e => e.Order)
+                .ForRelational()
+                .Name(null);
+
+            Assert.Null(foreignKey.Relational().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_for_one_to_one_with_FK_specified_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Order>()
+                .OneToOne(e => e.Details, e => e.Order)
+                .ForeignKey<OrderDetails>(e => e.Id)
+                .ForRelational()
+                .Name("LemonSupreme");
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_for_one_to_one_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Order>()
+                .OneToOne(e => e.Details, e => e.Order)
+                .ForRelational(b => { b.Name("LemonSupreme"); });
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_for_one_to_one_with_FK_specified_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Order>()
+                .OneToOne(e => e.Details, e => e.Order)
+                .ForeignKey<OrderDetails>(e => e.Id)
+                .ForRelational(b => { b.Name("LemonSupreme"); });
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+        }
+
+        [Fact]
+        public void Can_set_index_name_with_basic_builder()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Index(e => e.Id)
+                .ForRelational()
+                .Name("Eeeendeeex");
+
+            var index = modelBuilder.Model.GetEntityType(typeof(Customer)).Indexes.Single();
+
+            Assert.Equal("Eeeendeeex", index.Relational().Name);
+
+            modelBuilder
+                .Entity<Customer>()
+                .Index(e => e.Id)
+                .ForRelational()
+                .Name(null);
+
+            Assert.Null(index.Relational().Name);
+        }
+
+        [Fact]
+        public void Can_set_index_name_with_basic_builder_using_nested_closure()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Index(e => e.Id)
+                .ForRelational(b => { b.Name("Eeeendeeex"); });
+
+            var index = modelBuilder.Model.GetEntityType(typeof(Customer)).Indexes.Single();
+
+            Assert.Equal("Eeeendeeex", index.Relational().Name);
+        }
+
+        [Fact]
+        public void Can_set_index_name_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Index(e => e.Id)
+                .ForRelational()
+                .Name("Eeeendeeex");
+
+            var index = modelBuilder.Model.GetEntityType(typeof(Customer)).Indexes.Single();
+
+            Assert.Equal("Eeeendeeex", index.Relational().Name);
+        }
+
+        [Fact]
+        public void Can_set_index_name_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Index(e => e.Id)
+                .ForRelational(b => { b.Name("Eeeendeeex"); });
+
+            var index = modelBuilder.Model.GetEntityType(typeof(Customer)).Indexes.Single();
+
+            Assert.Equal("Eeeendeeex", index.Relational().Name);
+        }
+
+        [Fact]
+        public void Can_set_table_name_with_basic_builder()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForRelational()
+                .Table("Customizer");
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForRelational()
+                .Table(null);
+
+            Assert.Equal("Customer", entityType.Relational().Table);
+        }
+
+        [Fact]
+        public void Can_set_table_name_with_basic_builder_using_nested_closure()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForRelational(b => { b.Table("Customizer"); });
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+        }
+
+        [Fact]
+        public void Can_set_table_name_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForRelational()
+                .Table("Customizer");
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+        }
+
+        [Fact]
+        public void Can_set_table_name_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForRelational(b => { b.Table("Customizer"); });
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+        }
+
+        [Fact]
+        public void Can_set_table_name_with_basic_builder_non_generic()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity(typeof(Customer))
+                .ForRelational()
+                .Table("Customizer");
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+        }
+
+        [Fact]
+        public void Can_set_table_name_with_basic_builder_using_nested_closure_non_generic()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity(typeof(Customer))
+                .ForRelational(b => { b.Table("Customizer"); });
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+        }
+
+        [Fact]
+        public void Can_set_table_name_with_convention_builder_non_generic()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity(typeof(Customer))
+                .ForRelational()
+                .Table("Customizer");
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+        }
+
+        [Fact]
+        public void Can_set_table_name_with_convention_builder_using_nested_closure_non_generic()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity(typeof(Customer))
+                .ForRelational(b => { b.Table("Customizer"); });
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+        }
+
+        [Fact]
+        public void Can_set_table_and_schema_name_with_basic_builder()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForRelational()
+                .Table("Customizer", "db0");
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("db0", entityType.Relational().Schema);
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForRelational()
+                .Table(null, null);
+
+            Assert.Equal("Customer", entityType.Relational().Table);
+            Assert.Null(entityType.Relational().Schema);
+        }
+
+        [Fact]
+        public void Can_set_table_and_schema_name_with_basic_builder_using_nested_closure()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForRelational(b => { b.Table("Customizer", "db0"); });
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("db0", entityType.Relational().Schema);
+        }
+
+        [Fact]
+        public void Can_set_table_and_schema_name_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForRelational()
+                .Table("Customizer", "db0");
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("db0", entityType.Relational().Schema);
+        }
+
+        [Fact]
+        public void Can_set_table_and_schema_name_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForRelational(b => { b.Table("Customizer", "db0"); });
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("db0", entityType.Relational().Schema);
+        }
+
+        [Fact]
+        public void Can_set_table_and_schema_name_with_basic_builder_non_generic()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity(typeof(Customer))
+                .ForRelational()
+                .Table("Customizer", "db0");
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("db0", entityType.Relational().Schema);
+        }
+
+        [Fact]
+        public void Can_set_table_and_schema_name_with_basic_builder_using_nested_closure_non_generic()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity(typeof(Customer))
+                .ForRelational(b => { b.Table("Customizer", "db0"); });
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("db0", entityType.Relational().Schema);
+        }
+
+        [Fact]
+        public void Can_set_table_and_schema_name_with_convention_builder_non_generic()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity(typeof(Customer))
+                .ForRelational()
+                .Table("Customizer", "db0");
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("db0", entityType.Relational().Schema);
+        }
+
+        [Fact]
+        public void Can_set_table_and_schema_name_with_convention_builder_using_nested_closure_non_generic()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity(typeof(Customer))
+                .ForRelational(b => { b.Table("Customizer", "db0"); });
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("db0", entityType.Relational().Schema);
+        }
+
+        private class Customer
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+
+            public IEnumerable<Order> Orders { get; set; }
+        }
+
+        private class Order
+        {
+            public int OrderId { get; set; }
+
+            public int CustomerId { get; set; }
+            public Customer Customer { get; set; }
+
+            public OrderDetails Details { get; set; }
+        }
+
+        private class OrderDetails
+        {
+            public int Id { get; set; }
+
+            public int OrderId { get; set; }
+            public Order Order { get; set; }
+        }
+    }
+}

--- a/test/EntityFramework.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
@@ -1,0 +1,222 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Data.Entity.Metadata;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Relational.Metadata.Tests
+{
+    public class RelationalMetadataExtensionsTest
+    {
+        [Fact]
+        public void Can_get_and_set_column_name()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            var property = modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .Metadata;
+
+            Assert.Equal("Name", property.Relational().Column);
+            Assert.Equal("Name", ((IProperty)property).Relational().Column);
+
+            property.Relational().Column = "Eman";
+
+            Assert.Equal("Name", property.Name);
+            Assert.Equal("Name", ((IProperty)property).Name);
+            Assert.Equal("Eman", property.Relational().Column);
+            Assert.Equal("Eman", ((IProperty)property).Relational().Column);
+
+            property.Relational().Column = null;
+
+            Assert.Equal("Name", property.Relational().Column);
+            Assert.Equal("Name", ((IProperty)property).Relational().Column);
+        }
+
+        [Fact]
+        public void Can_get_and_set_table_name()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            var entityType = modelBuilder
+                .Entity<Customer>()
+                .Metadata;
+
+            Assert.Equal("Customer", entityType.Relational().Table);
+            Assert.Equal("Customer", ((IEntityType)entityType).Relational().Table);
+
+            entityType.Relational().Table = "Customizer";
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customer", ((IEntityType)entityType).SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("Customizer", ((IEntityType)entityType).Relational().Table);
+
+            entityType.Relational().Table = null;
+
+            Assert.Equal("Customer", entityType.Relational().Table);
+            Assert.Equal("Customer", ((IEntityType)entityType).Relational().Table);
+        }
+
+        [Fact]
+        public void Can_get_and_set_schema_name()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            var entityType = modelBuilder
+                .Entity<Customer>()
+                .Metadata;
+
+            Assert.Null(entityType.Relational().Schema);
+            Assert.Null(((IEntityType)entityType).Relational().Schema);
+
+            entityType.Relational().Schema = "db0";
+
+            Assert.Equal("db0", entityType.Relational().Schema);
+            Assert.Equal("db0", ((IEntityType)entityType).Relational().Schema);
+
+            entityType.Relational().Schema = null;
+
+            Assert.Null(entityType.Relational().Schema);
+            Assert.Null(((IEntityType)entityType).Relational().Schema);
+        }
+
+        [Fact]
+        public void Can_get_and_set_column_type()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            var property = modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .Metadata;
+
+            Assert.Null(property.Relational().ColumnType);
+            Assert.Null(((IProperty)property).Relational().ColumnType);
+
+            property.Relational().ColumnType = "nvarchar(max)";
+
+            Assert.Equal("nvarchar(max)", property.Relational().ColumnType);
+            Assert.Equal("nvarchar(max)", ((IProperty)property).Relational().ColumnType);
+
+            property.Relational().ColumnType = null;
+
+            Assert.Null(property.Relational().ColumnType);
+            Assert.Null(((IProperty)property).Relational().ColumnType);
+        }
+
+        [Fact]
+        public void Can_get_and_set_column_default_expression()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            var property = modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .Metadata;
+
+            Assert.Null(property.Relational().DefaultExpression);
+            Assert.Null(((IProperty)property).Relational().DefaultExpression);
+
+            property.Relational().DefaultExpression = "newsequentialid()";
+
+            Assert.Equal("newsequentialid()", property.Relational().DefaultExpression);
+            Assert.Equal("newsequentialid()", ((IProperty)property).Relational().DefaultExpression);
+
+            property.Relational().DefaultExpression = null;
+
+            Assert.Null(property.Relational().DefaultExpression);
+            Assert.Null(((IProperty)property).Relational().DefaultExpression);
+        }
+
+        [Fact]
+        public void Can_get_and_set_column_key_name()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            var key = modelBuilder
+                .Entity<Customer>()
+                .Key(e => e.Id)
+                .Metadata;
+
+            Assert.Null(key.Relational().Name);
+            Assert.Null(((IKey)key).Relational().Name);
+
+            key.Relational().Name = "PrimaryKey";
+
+            Assert.Equal("PrimaryKey", key.Relational().Name);
+            Assert.Equal("PrimaryKey", ((IKey)key).Relational().Name);
+
+            key.Relational().Name = null;
+
+            Assert.Null(key.Relational().Name);
+            Assert.Null(((IKey)key).Relational().Name);
+        }
+
+        [Fact]
+        public void Can_get_and_set_column_foreign_key_name()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Key(e => e.Id);
+
+            var foreignKey = modelBuilder
+                .Entity<Order>()
+                .ForeignKey<Customer>(e => e.CustomerId)
+                .Metadata;
+
+            Assert.Null(foreignKey.Relational().Name);
+            Assert.Null(((IForeignKey)foreignKey).Relational().Name);
+
+            foreignKey.Relational().Name = "FK";
+
+            Assert.Equal("FK", foreignKey.Relational().Name);
+            Assert.Equal("FK", ((IForeignKey)foreignKey).Relational().Name);
+
+            foreignKey.Relational().Name = null;
+
+            Assert.Null(foreignKey.Relational().Name);
+            Assert.Null(((IForeignKey)foreignKey).Relational().Name);
+        }
+
+        [Fact]
+        public void Can_get_and_set_index_name()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            var index = modelBuilder
+                .Entity<Customer>()
+                .Index(e => e.Id)
+                .Metadata;
+
+            Assert.Null(index.Relational().Name);
+            Assert.Null(((IIndex)index).Relational().Name);
+
+            index.Relational().Name = "MyIndex";
+
+            Assert.Equal("MyIndex", index.Relational().Name);
+            Assert.Equal("MyIndex", ((IIndex)index).Relational().Name);
+
+            index.Relational().Name = null;
+
+            Assert.Null(index.Relational().Name);
+            Assert.Null(((IIndex)index).Relational().Name);
+        }
+
+        private class Customer
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class Order
+        {
+            public int OrderId { get; set; }
+            public int CustomerId { get; set; }
+        }
+    }
+}

--- a/test/EntityFramework.Relational.Tests/MetadataExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/MetadataExtensionsTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
         [Fact]
         public void ToTable_sets_table_name_on_entity()
         {
-            var model = new Metadata.Model();
+            var model = new Entity.Metadata.Model();
             var modelBuilder = new BasicModelBuilder(model);
 
             modelBuilder.Entity<Customer>().ToTable("customers");
@@ -40,7 +40,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
         [Fact]
         public void ColumnName_sets_storage_name_on_entity_property()
         {
-            var model = new Metadata.Model();
+            var model = new Entity.Metadata.Model();
             var modelBuilder = new BasicModelBuilder(model);
 
             modelBuilder.Entity<Customer>().Property(c => c.Id).ColumnName("id");
@@ -55,7 +55,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
         [Fact]
         public void ColumnType_sets_annotation_on_entity_property()
         {
-            var model = new Metadata.Model();
+            var model = new Entity.Metadata.Model();
             var modelBuilder = new BasicModelBuilder(model);
 
             modelBuilder.Entity<Customer>().Property(c => c.Id).ColumnType("bigint");

--- a/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -313,7 +313,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
 
         private static IModel CreateSimpleFKModel()
         {
-            var model = new Metadata.Model();
+            var model = new Entity.Metadata.Model();
             var modelBuilder = new BasicModelBuilder(model);
 
             modelBuilder.Entity<FakeEntity>(b =>
@@ -333,7 +333,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
 
         private static IModel CreateCyclicFKModel()
         {
-            var model = new Metadata.Model();
+            var model = new Entity.Metadata.Model();
             var modelBuilder = new BasicModelBuilder(model);
 
             modelBuilder.Entity<FakeEntity>(b =>

--- a/test/EntityFramework.Relational.Tests/Update/ModificationCommandTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ModificationCommandTest.cs
@@ -360,7 +360,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
 
         private static IModel BuildModel(ValueGeneration keyStrategy, ValueGeneration nonKeyStrategy)
         {
-            var model = new Metadata.Model();
+            var model = new Entity.Metadata.Model();
 
             var entityType = new EntityType(typeof(T1));
 

--- a/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -556,7 +556,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
 
         private static IModel BuildModel(ValueGeneration keyStrategy, ValueGeneration nonKeyStrategy)
         {
-            var model = new Metadata.Model();
+            var model = new Entity.Metadata.Model();
 
             var entityType = new EntityType(typeof(T1));
 

--- a/test/EntityFramework.SqlServer.Tests/EntityFramework.SqlServer.Tests.csproj
+++ b/test/EntityFramework.SqlServer.Tests/EntityFramework.SqlServer.Tests.csproj
@@ -67,6 +67,8 @@
     <Compile Include="ApiConsistencyTest.cs" />
     <Compile Include="..\Shared\ApiConsistencyTestBase.cs" />
     <Compile Include="..\Shared\TestHelpers.cs" />
+    <Compile Include="Metadata\SqlServerBuilderExtensionsTest.cs" />
+    <Compile Include="Metadata\SqlServerMetadataExtensionsTest.cs" />
     <Compile Include="SequentialGuidValueGeneratorTest.cs" />
     <Compile Include="..\EntityFramework.Relational.Tests\SqlGeneratorTestBase.cs" />
     <Compile Include="SqlServerDbContextOptionsExtensionsTest.cs" />

--- a/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
@@ -1,0 +1,1191 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Data.Entity.Metadata;
+using Xunit;
+
+namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
+{
+    public class SqlServerBuilderExtensionsTest
+    {
+        [Fact]
+        public void Can_set_column_name_with_basic_builder()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational()
+                .Column("Eman");
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForSqlServer()
+                .Column("MyNameIs");
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal("Name", property.Name);
+            Assert.Equal("Eman", property.Relational().Column);
+            Assert.Equal("MyNameIs", property.SqlServer().Column);
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForSqlServer()
+                .Column(null);
+
+            Assert.Equal("Name", property.Name);
+            Assert.Equal("Eman", property.Relational().Column);
+            Assert.Equal("Eman", property.SqlServer().Column);
+        }
+
+        [Fact]
+        public void Can_set_column_name_with_basic_builder_using_nested_closure()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational(b => { b.Column("Eman"); })
+                .ForSqlServer(b => { b.Column("MyNameIs"); });
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal("Name", property.Name);
+            Assert.Equal("Eman", property.Relational().Column);
+            Assert.Equal("MyNameIs", property.SqlServer().Column);
+        }
+
+        [Fact]
+        public void Can_set_column_name_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational()
+                .Column("Eman");
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForSqlServer()
+                .Column("MyNameIs");
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal("Name", property.Name);
+            Assert.Equal("Eman", property.Relational().Column);
+            Assert.Equal("MyNameIs", property.SqlServer().Column);
+        }
+
+        [Fact]
+        public void Can_set_column_name_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational(b => { b.Column("Eman"); })
+                .ForSqlServer(b => { b.Column("MyNameIs"); });
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal("Name", property.Name);
+            Assert.Equal("Eman", property.Relational().Column);
+            Assert.Equal("MyNameIs", property.SqlServer().Column);
+        }
+
+        [Fact]
+        public void Can_set_column_type_with_basic_builder()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational()
+                .ColumnType("nvarchar(42)");
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForSqlServer()
+                .ColumnType("nvarchar(DA)");
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal("nvarchar(42)", property.Relational().ColumnType);
+            Assert.Equal("nvarchar(DA)", property.SqlServer().ColumnType);
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForSqlServer()
+                .ColumnType(null);
+
+            Assert.Equal("nvarchar(42)", property.Relational().ColumnType);
+            Assert.Equal("nvarchar(42)", property.SqlServer().ColumnType);
+        }
+
+        [Fact]
+        public void Can_set_column_type_with_basic_builder_using_nested_closure()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational(b => { b.ColumnType("nvarchar(42)"); })
+                .ForSqlServer(b => { b.ColumnType("nvarchar(DA)"); });
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal("nvarchar(42)", property.Relational().ColumnType);
+            Assert.Equal("nvarchar(DA)", property.SqlServer().ColumnType);
+        }
+
+        [Fact]
+        public void Can_set_column_type_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational()
+                .ColumnType("nvarchar(42)");
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForSqlServer()
+                .ColumnType("nvarchar(DA)");
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal("nvarchar(42)", property.Relational().ColumnType);
+            Assert.Equal("nvarchar(DA)", property.SqlServer().ColumnType);
+        }
+
+        [Fact]
+        public void Can_set_column_type_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational(b => { b.ColumnType("nvarchar(42)"); })
+                .ForSqlServer(b => { b.ColumnType("nvarchar(DA)"); });
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal("nvarchar(42)", property.Relational().ColumnType);
+            Assert.Equal("nvarchar(DA)", property.SqlServer().ColumnType);
+        }
+
+        [Fact]
+        public void Can_set_column_default_expression_with_basic_builder()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational()
+                .DefaultExpression("CherryCoke");
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForSqlServer()
+                .DefaultExpression("VanillaCoke");
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal("CherryCoke", property.Relational().DefaultExpression);
+            Assert.Equal("VanillaCoke", property.SqlServer().DefaultExpression);
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForSqlServer()
+                .DefaultExpression(null);
+
+            Assert.Equal("CherryCoke", property.Relational().DefaultExpression);
+            Assert.Equal("CherryCoke", property.SqlServer().DefaultExpression);
+        }
+
+        [Fact]
+        public void Can_set_column_default_expression_with_basic_builder_using_nested_closure()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational(b => { b.DefaultExpression("CherryCoke"); })
+                .ForSqlServer(b => { b.DefaultExpression("VanillaCoke"); });
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal("CherryCoke", property.Relational().DefaultExpression);
+            Assert.Equal("VanillaCoke", property.SqlServer().DefaultExpression);
+        }
+
+        [Fact]
+        public void Can_set_column_default_expression_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational()
+                .DefaultExpression("CherryCoke");
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForSqlServer()
+                .DefaultExpression("VanillaCoke");
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal("CherryCoke", property.Relational().DefaultExpression);
+            Assert.Equal("VanillaCoke", property.SqlServer().DefaultExpression);
+        }
+
+        [Fact]
+        public void Can_set_column_default_expression_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational(b => { b.DefaultExpression("CherryCoke"); })
+                .ForSqlServer(b => { b.DefaultExpression("VanillaCoke"); });
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal("CherryCoke", property.Relational().DefaultExpression);
+            Assert.Equal("VanillaCoke", property.SqlServer().DefaultExpression);
+        }
+
+        [Fact]
+        public void Can_set_key_name_with_basic_builder()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Key(e => e.Id)
+                .ForRelational()
+                .Name("KeyLimePie");
+
+            modelBuilder
+                .Entity<Customer>()
+                .Key(e => e.Id)
+                .ForSqlServer()
+                .Name("LemonSupreme");
+
+            var key = modelBuilder.Model.GetEntityType(typeof(Customer)).GetPrimaryKey();
+
+            Assert.Equal("KeyLimePie", key.Relational().Name);
+            Assert.Equal("LemonSupreme", key.SqlServer().Name);
+
+            modelBuilder
+                .Entity<Customer>()
+                .Key(e => e.Id)
+                .ForSqlServer()
+                .Name(null);
+
+            Assert.Equal("KeyLimePie", key.Relational().Name);
+            Assert.Equal("KeyLimePie", key.SqlServer().Name);
+        }
+
+        [Fact]
+        public void Can_set_key_name_with_basic_builder_using_nested_closure()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Key(e => e.Id)
+                .ForRelational(b => { b.Name("KeyLimePie"); })
+                .ForSqlServer(b => { b.Name("LemonSupreme"); });
+
+            var key = modelBuilder.Model.GetEntityType(typeof(Customer)).GetPrimaryKey();
+
+            Assert.Equal("KeyLimePie", key.Relational().Name);
+            Assert.Equal("LemonSupreme", key.SqlServer().Name);
+        }
+
+        [Fact]
+        public void Can_set_key_name_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Key(e => e.Id)
+                .ForRelational()
+                .Name("KeyLimePie");
+
+            modelBuilder
+                .Entity<Customer>()
+                .Key(e => e.Id)
+                .ForSqlServer()
+                .Name("LemonSupreme");
+
+            var key = modelBuilder.Model.GetEntityType(typeof(Customer)).GetPrimaryKey();
+
+            Assert.Equal("KeyLimePie", key.Relational().Name);
+            Assert.Equal("LemonSupreme", key.SqlServer().Name);
+        }
+
+        [Fact]
+        public void Can_set_key_name_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Key(e => e.Id)
+                .ForRelational(b => { b.Name("KeyLimePie"); })
+                .ForSqlServer(b => { b.Name("LemonSupreme"); });
+
+            var key = modelBuilder.Model.GetEntityType(typeof(Customer)).GetPrimaryKey();
+
+            Assert.Equal("KeyLimePie", key.Relational().Name);
+            Assert.Equal("LemonSupreme", key.SqlServer().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_with_basic_builder()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Key(e => e.Id);
+
+            modelBuilder
+                .Entity<Order>()
+                .ForeignKey<Customer>(e => e.CustomerId)
+                .ForRelational()
+                .Name("LemonSupreme");
+
+            modelBuilder
+                .Entity<Order>()
+                .ForeignKey<Customer>(e => e.CustomerId)
+                .ForSqlServer()
+                .Name("ChocolateLimes");
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+            Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
+
+            modelBuilder
+                .Entity<Order>()
+                .ForeignKey<Customer>(e => e.CustomerId)
+                .ForSqlServer()
+                .Name(null);
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+            Assert.Equal("LemonSupreme", foreignKey.SqlServer().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_with_basic_builder_using_nested_closure()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Key(e => e.Id);
+
+            modelBuilder
+                .Entity<Order>()
+                .ForeignKey<Customer>(e => e.CustomerId)
+                .ForRelational(b => { b.Name("LemonSupreme"); })
+                .ForSqlServer(b => { b.Name("ChocolateLimes"); });
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+            Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_for_one_to_many_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .OneToMany(e => e.Orders, e => e.Customer)
+                .ForRelational()
+                .Name("LemonSupreme");
+
+            modelBuilder
+                .Entity<Customer>()
+                .OneToMany(e => e.Orders, e => e.Customer)
+                .ForSqlServer()
+                .Name("ChocolateLimes");
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+            Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
+
+            modelBuilder
+                .Entity<Customer>()
+                .OneToMany(e => e.Orders, e => e.Customer)
+                .ForSqlServer()
+                .Name(null);
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+            Assert.Equal("LemonSupreme", foreignKey.SqlServer().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_for_one_to_many_with_FK_specified_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .OneToMany(e => e.Orders, e => e.Customer)
+                .ForeignKey(e => e.CustomerId)
+                .ForRelational()
+                .Name("LemonSupreme");
+
+            modelBuilder
+                .Entity<Customer>()
+                .OneToMany(e => e.Orders, e => e.Customer)
+                .ForeignKey(e => e.CustomerId)
+                .ForSqlServer()
+                .Name("ChocolateLimes");
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+            Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_for_one_to_many_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .OneToMany(e => e.Orders, e => e.Customer)
+                .ForRelational(b => { b.Name("LemonSupreme"); })
+                .ForSqlServer(b => { b.Name("ChocolateLimes"); });
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+            Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_for_one_to_many_with_FK_specified_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .OneToMany(e => e.Orders, e => e.Customer)
+                .ForeignKey(e => e.CustomerId)
+                .ForRelational(b => { b.Name("LemonSupreme"); })
+                .ForSqlServer(b => { b.Name("ChocolateLimes"); });
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+            Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_for_many_to_one_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Order>()
+                .ManyToOne(e => e.Customer, e => e.Orders)
+                .ForRelational()
+                .Name("LemonSupreme");
+
+            modelBuilder
+                .Entity<Order>()
+                .ManyToOne(e => e.Customer, e => e.Orders)
+                .ForSqlServer()
+                .Name("ChocolateLimes");
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+            Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
+
+            modelBuilder
+                .Entity<Order>()
+                .ManyToOne(e => e.Customer, e => e.Orders)
+                .ForSqlServer()
+                .Name(null);
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+            Assert.Equal("LemonSupreme", foreignKey.SqlServer().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_for_many_to_one_with_FK_specified_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Order>()
+                .ManyToOne(e => e.Customer, e => e.Orders)
+                .ForeignKey(e => e.CustomerId)
+                .ForRelational()
+                .Name("LemonSupreme");
+
+            modelBuilder
+                .Entity<Order>()
+                .ManyToOne(e => e.Customer, e => e.Orders)
+                .ForeignKey(e => e.CustomerId)
+                .ForSqlServer()
+                .Name("ChocolateLimes");
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+            Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_for_many_to_one_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Order>()
+                .ManyToOne(e => e.Customer, e => e.Orders)
+                .ForRelational(b => { b.Name("LemonSupreme"); })
+                .ForSqlServer(b => { b.Name("ChocolateLimes"); });
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+            Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_for_many_to_one_with_FK_specified_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Order>()
+                .ManyToOne(e => e.Customer, e => e.Orders)
+                .ForeignKey(e => e.CustomerId)
+                .ForRelational(b => { b.Name("LemonSupreme"); })
+                .ForSqlServer(b => { b.Name("ChocolateLimes"); });
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(Order)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+            Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_for_one_to_one_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Order>()
+                .OneToOne(e => e.Details, e => e.Order)
+                .ForRelational()
+                .Name("LemonSupreme");
+
+            modelBuilder
+                .Entity<Order>()
+                .OneToOne(e => e.Details, e => e.Order)
+                .ForSqlServer()
+                .Name("ChocolateLimes");
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+            Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
+
+            modelBuilder
+                .Entity<Order>()
+                .OneToOne(e => e.Details, e => e.Order)
+                .ForSqlServer()
+                .Name(null);
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+            Assert.Equal("LemonSupreme", foreignKey.SqlServer().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_for_one_to_one_with_FK_specified_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Order>()
+                .OneToOne(e => e.Details, e => e.Order)
+                .ForeignKey<OrderDetails>(e => e.Id)
+                .ForRelational()
+                .Name("LemonSupreme");
+
+            modelBuilder
+                .Entity<Order>()
+                .OneToOne(e => e.Details, e => e.Order)
+                .ForeignKey<OrderDetails>(e => e.Id)
+                .ForSqlServer()
+                .Name("ChocolateLimes");
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+            Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_for_one_to_one_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Order>()
+                .OneToOne(e => e.Details, e => e.Order)
+                .ForRelational(b => { b.Name("LemonSupreme"); })
+                .ForSqlServer(b => { b.Name("ChocolateLimes"); });
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+            Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
+        }
+
+        [Fact]
+        public void Can_set_foreign_key_name_for_one_to_one_with_FK_specified_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Order>()
+                .OneToOne(e => e.Details, e => e.Order)
+                .ForeignKey<OrderDetails>(e => e.Id)
+                .ForRelational(b => { b.Name("LemonSupreme"); })
+                .ForSqlServer(b => { b.Name("ChocolateLimes"); });
+
+            var foreignKey = modelBuilder.Model.GetEntityType(typeof(OrderDetails)).ForeignKeys.Single();
+
+            Assert.Equal("LemonSupreme", foreignKey.Relational().Name);
+            Assert.Equal("ChocolateLimes", foreignKey.SqlServer().Name);
+        }
+
+        [Fact]
+        public void Can_set_index_name_with_basic_builder()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Index(e => e.Id)
+                .ForRelational()
+                .Name("Eeeendeeex");
+
+            modelBuilder
+                .Entity<Customer>()
+                .Index(e => e.Id)
+                .ForSqlServer()
+                .Name("Dexter");
+
+            var index = modelBuilder.Model.GetEntityType(typeof(Customer)).Indexes.Single();
+
+            Assert.Equal("Eeeendeeex", index.Relational().Name);
+            Assert.Equal("Dexter", index.SqlServer().Name);
+
+            modelBuilder
+                .Entity<Customer>()
+                .Index(e => e.Id)
+                .ForSqlServer()
+                .Name(null);
+
+            Assert.Equal("Eeeendeeex", index.Relational().Name);
+            Assert.Equal("Eeeendeeex", index.SqlServer().Name);
+        }
+
+        [Fact]
+        public void Can_set_index_name_with_basic_builder_using_nested_closure()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Index(e => e.Id)
+                .ForRelational(b => { b.Name("Eeeendeeex"); })
+                .ForSqlServer(b => { b.Name("Dexter"); });
+
+            var index = modelBuilder.Model.GetEntityType(typeof(Customer)).Indexes.Single();
+
+            Assert.Equal("Eeeendeeex", index.Relational().Name);
+            Assert.Equal("Dexter", index.SqlServer().Name);
+        }
+
+        [Fact]
+        public void Can_set_index_name_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Index(e => e.Id)
+                .ForRelational()
+                .Name("Eeeendeeex");
+
+            modelBuilder
+                .Entity<Customer>()
+                .Index(e => e.Id)
+                .ForSqlServer()
+                .Name("Dexter");
+
+            var index = modelBuilder.Model.GetEntityType(typeof(Customer)).Indexes.Single();
+
+            Assert.Equal("Eeeendeeex", index.Relational().Name);
+            Assert.Equal("Dexter", index.SqlServer().Name);
+        }
+
+        [Fact]
+        public void Can_set_index_name_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Index(e => e.Id)
+                .ForRelational(b => { b.Name("Eeeendeeex"); })
+                .ForSqlServer(b => { b.Name("Dexter"); });
+
+            var index = modelBuilder.Model.GetEntityType(typeof(Customer)).Indexes.Single();
+
+            Assert.Equal("Eeeendeeex", index.Relational().Name);
+            Assert.Equal("Dexter", index.SqlServer().Name);
+        }
+
+        [Fact]
+        public void Can_set_table_name_with_basic_builder()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForRelational()
+                .Table("Customizer");
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForSqlServer()
+                .Table("Custardizer");
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("Custardizer", entityType.SqlServer().Table);
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForSqlServer()
+                .Table(null);
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("Customizer", entityType.SqlServer().Table);
+        }
+
+        [Fact]
+        public void Can_set_table_name_with_basic_builder_using_nested_closure()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForRelational(b => { b.Table("Customizer"); })
+                .ForSqlServer(b => { b.Table("Custardizer"); });
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("Custardizer", entityType.SqlServer().Table);
+        }
+
+        [Fact]
+        public void Can_set_table_name_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForRelational()
+                .Table("Customizer");
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForSqlServer()
+                .Table("Custardizer");
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("Custardizer", entityType.SqlServer().Table);
+        }
+
+        [Fact]
+        public void Can_set_table_name_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForRelational(b => { b.Table("Customizer"); })
+                .ForSqlServer(b => { b.Table("Custardizer"); });
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("Custardizer", entityType.SqlServer().Table);
+        }
+
+        [Fact]
+        public void Can_set_table_name_with_basic_builder_non_generic()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity(typeof(Customer))
+                .ForRelational()
+                .Table("Customizer");
+
+            modelBuilder
+                .Entity(typeof(Customer))
+                .ForSqlServer()
+                .Table("Custardizer");
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("Custardizer", entityType.SqlServer().Table);
+
+            modelBuilder
+                .Entity(typeof(Customer))
+                .ForSqlServer()
+                .Table(null);
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("Customizer", entityType.SqlServer().Table);
+        }
+
+        [Fact]
+        public void Can_set_table_name_with_basic_builder_using_nested_closure_non_generic()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity(typeof(Customer))
+                .ForRelational(b => { b.Table("Customizer"); })
+                .ForSqlServer(b => { b.Table("Custardizer"); });
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("Custardizer", entityType.SqlServer().Table);
+        }
+
+        [Fact]
+        public void Can_set_table_name_with_convention_builder_non_generic()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity(typeof(Customer))
+                .ForRelational()
+                .Table("Customizer");
+
+            modelBuilder
+                .Entity(typeof(Customer))
+                .ForSqlServer()
+                .Table("Custardizer");
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("Custardizer", entityType.SqlServer().Table);
+        }
+
+        [Fact]
+        public void Can_set_table_name_with_convention_builder_using_nested_closure_non_generic()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity(typeof(Customer))
+                .ForRelational(b => { b.Table("Customizer"); })
+                .ForSqlServer(b => { b.Table("Custardizer"); });
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("Custardizer", entityType.SqlServer().Table);
+        }
+
+
+        [Fact]
+        public void Can_set_table_and_schema_name_with_basic_builder()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForRelational()
+                .Table("Customizer", "db0");
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForSqlServer()
+                .Table("Custardizer", "dbOh");
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("Custardizer", entityType.SqlServer().Table);
+            Assert.Equal("db0", entityType.Relational().Schema);
+            Assert.Equal("dbOh", entityType.SqlServer().Schema);
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForSqlServer()
+                .Table(null, null);
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("Customizer", entityType.SqlServer().Table);
+            Assert.Equal("db0", entityType.Relational().Schema);
+            Assert.Equal("db0", entityType.SqlServer().Schema);
+        }
+
+        [Fact]
+        public void Can_set_table_and_schema_name_with_basic_builder_using_nested_closure()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForRelational(b => { b.Table("Customizer", "db0"); })
+                .ForSqlServer(b => { b.Table("Custardizer", "dbOh"); });
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("Custardizer", entityType.SqlServer().Table);
+            Assert.Equal("db0", entityType.Relational().Schema);
+            Assert.Equal("dbOh", entityType.SqlServer().Schema);
+        }
+
+        [Fact]
+        public void Can_set_table_and_schema_name_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForRelational()
+                .Table("Customizer", "db0");
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForSqlServer()
+                .Table("Custardizer", "dbOh");
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("Custardizer", entityType.SqlServer().Table);
+            Assert.Equal("db0", entityType.Relational().Schema);
+            Assert.Equal("dbOh", entityType.SqlServer().Schema);
+        }
+
+        [Fact]
+        public void Can_set_table_and_schema_name_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForRelational(b => { b.Table("Customizer", "db0"); })
+                .ForSqlServer(b => { b.Table("Custardizer", "dbOh"); });
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("Custardizer", entityType.SqlServer().Table);
+            Assert.Equal("db0", entityType.Relational().Schema);
+            Assert.Equal("dbOh", entityType.SqlServer().Schema);
+        }
+
+        [Fact]
+        public void Can_set_table_and_schema_name_with_basic_builder_non_generic()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity(typeof(Customer))
+                .ForRelational()
+                .Table("Customizer", "db0");
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForSqlServer()
+                .Table("Custardizer", "dbOh");
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("Custardizer", entityType.SqlServer().Table);
+            Assert.Equal("db0", entityType.Relational().Schema);
+            Assert.Equal("dbOh", entityType.SqlServer().Schema);
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForSqlServer()
+                .Table(null, null);
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("Customizer", entityType.SqlServer().Table);
+            Assert.Equal("db0", entityType.Relational().Schema);
+            Assert.Equal("db0", entityType.SqlServer().Schema);
+        }
+
+        [Fact]
+        public void Can_set_table_and_schema_name_with_basic_builder_using_nested_closure_non_generic()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity(typeof(Customer))
+                .ForRelational(b => { b.Table("Customizer", "db0"); })
+                .ForSqlServer(b => { b.Table("Custardizer", "dbOh"); });
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("Custardizer", entityType.SqlServer().Table);
+            Assert.Equal("db0", entityType.Relational().Schema);
+            Assert.Equal("dbOh", entityType.SqlServer().Schema);
+        }
+
+        [Fact]
+        public void Can_set_table_and_schema_name_with_convention_builder_non_generic()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity(typeof(Customer))
+                .ForRelational()
+                .Table("Customizer", "db0");
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForSqlServer()
+                .Table("Custardizer", "dbOh");
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("Custardizer", entityType.SqlServer().Table);
+            Assert.Equal("db0", entityType.Relational().Schema);
+            Assert.Equal("dbOh", entityType.SqlServer().Schema);
+        }
+
+        [Fact]
+        public void Can_set_table_and_schema_name_with_convention_builder_using_nested_closure_non_generic()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity(typeof(Customer))
+                .ForRelational(b => { b.Table("Customizer", "db0"); })
+                .ForSqlServer(b => { b.Table("Custardizer", "dbOh"); });
+
+            var entityType = modelBuilder.Model.GetEntityType(typeof(Customer));
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("Custardizer", entityType.SqlServer().Table);
+            Assert.Equal("db0", entityType.Relational().Schema);
+            Assert.Equal("dbOh", entityType.SqlServer().Schema);
+        }
+
+        private class Customer
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+
+            public IEnumerable<Order> Orders { get; set; }
+        }
+
+        private class Order
+        {
+            public int OrderId { get; set; }
+
+            public int CustomerId { get; set; }
+            public Customer Customer { get; set; }
+
+            public OrderDetails Details { get; set; }
+        }
+
+        private class OrderDetails
+        {
+            public int Id { get; set; }
+
+            public int OrderId { get; set; }
+            public Order Order { get; set; }
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
@@ -1,0 +1,330 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.Data.Entity.Metadata;
+using Xunit;
+
+namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
+{
+    public class SqlServerMetadataExtensionsTest
+    {
+        [Fact]
+        public void Can_get_and_set_column_name()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            var property = modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .Metadata;
+
+            Assert.Equal("Name", property.SqlServer().Column);
+            Assert.Equal("Name", ((IProperty)property).SqlServer().Column);
+
+            property.Relational().Column = "Eman";
+
+            Assert.Equal("Name", property.Name);
+            Assert.Equal("Name", ((IProperty)property).Name);
+            Assert.Equal("Eman", property.Relational().Column);
+            Assert.Equal("Eman", ((IProperty)property).Relational().Column);
+            Assert.Equal("Eman", property.SqlServer().Column);
+            Assert.Equal("Eman", ((IProperty)property).SqlServer().Column);
+
+            property.SqlServer().Column = "MyNameIs";
+
+            Assert.Equal("Name", property.Name);
+            Assert.Equal("Name", ((IProperty)property).Name);
+            Assert.Equal("Eman", property.Relational().Column);
+            Assert.Equal("Eman", ((IProperty)property).Relational().Column);
+            Assert.Equal("MyNameIs", property.SqlServer().Column);
+            Assert.Equal("MyNameIs", ((IProperty)property).SqlServer().Column);
+
+            property.SqlServer().Column = null;
+
+            Assert.Equal("Name", property.Name);
+            Assert.Equal("Name", ((IProperty)property).Name);
+            Assert.Equal("Eman", property.Relational().Column);
+            Assert.Equal("Eman", ((IProperty)property).Relational().Column);
+            Assert.Equal("Eman", property.SqlServer().Column);
+            Assert.Equal("Eman", ((IProperty)property).SqlServer().Column);
+        }
+
+        [Fact]
+        public void Can_get_and_set_table_name()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            var entityType = modelBuilder
+                .Entity<Customer>()
+                .Metadata;
+
+            Assert.Equal("Customer", entityType.SqlServer().Table);
+            Assert.Equal("Customer", ((IEntityType)entityType).SqlServer().Table);
+
+            entityType.Relational().Table = "Customizer";
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customer", ((IEntityType)entityType).SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("Customizer", ((IEntityType)entityType).Relational().Table);
+            Assert.Equal("Customizer", entityType.SqlServer().Table);
+            Assert.Equal("Customizer", ((IEntityType)entityType).SqlServer().Table);
+
+            entityType.SqlServer().Table = "Custardizer";
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customer", ((IEntityType)entityType).SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("Customizer", ((IEntityType)entityType).Relational().Table);
+            Assert.Equal("Custardizer", entityType.SqlServer().Table);
+            Assert.Equal("Custardizer", ((IEntityType)entityType).SqlServer().Table);
+
+            entityType.SqlServer().Table = null;
+
+            Assert.Equal("Customer", entityType.SimpleName);
+            Assert.Equal("Customer", ((IEntityType)entityType).SimpleName);
+            Assert.Equal("Customizer", entityType.Relational().Table);
+            Assert.Equal("Customizer", ((IEntityType)entityType).Relational().Table);
+            Assert.Equal("Customizer", entityType.SqlServer().Table);
+            Assert.Equal("Customizer", ((IEntityType)entityType).SqlServer().Table);
+        }
+
+        [Fact]
+        public void Can_get_and_set_schema_name()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            var entityType = modelBuilder
+                .Entity<Customer>()
+                .Metadata;
+
+            Assert.Null(entityType.Relational().Schema);
+            Assert.Null(((IEntityType)entityType).Relational().Schema);
+            Assert.Null(entityType.SqlServer().Schema);
+            Assert.Null(((IEntityType)entityType).SqlServer().Schema);
+
+            entityType.Relational().Schema = "db0";
+
+            Assert.Equal("db0", entityType.Relational().Schema);
+            Assert.Equal("db0", ((IEntityType)entityType).Relational().Schema);
+            Assert.Equal("db0", entityType.SqlServer().Schema);
+            Assert.Equal("db0", ((IEntityType)entityType).SqlServer().Schema);
+
+            entityType.SqlServer().Schema = "dbOh";
+
+            Assert.Equal("db0", entityType.Relational().Schema);
+            Assert.Equal("db0", ((IEntityType)entityType).Relational().Schema);
+            Assert.Equal("dbOh", entityType.SqlServer().Schema);
+            Assert.Equal("dbOh", ((IEntityType)entityType).SqlServer().Schema);
+
+            entityType.SqlServer().Schema = null;
+
+            Assert.Equal("db0", entityType.Relational().Schema);
+            Assert.Equal("db0", ((IEntityType)entityType).Relational().Schema);
+            Assert.Equal("db0", entityType.SqlServer().Schema);
+            Assert.Equal("db0", ((IEntityType)entityType).SqlServer().Schema);
+        }
+
+        [Fact]
+        public void Can_get_and_set_column_type()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            var property = modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .Metadata;
+
+            Assert.Null(property.Relational().ColumnType);
+            Assert.Null(((IProperty)property).Relational().ColumnType);
+            Assert.Null(property.SqlServer().ColumnType);
+            Assert.Null(((IProperty)property).SqlServer().ColumnType);
+
+            property.Relational().ColumnType = "nvarchar(max)";
+
+            Assert.Equal("nvarchar(max)", property.Relational().ColumnType);
+            Assert.Equal("nvarchar(max)", ((IProperty)property).Relational().ColumnType);
+            Assert.Equal("nvarchar(max)", property.SqlServer().ColumnType);
+            Assert.Equal("nvarchar(max)", ((IProperty)property).SqlServer().ColumnType);
+
+            property.SqlServer().ColumnType = "nvarchar(verstappen)";
+
+            Assert.Equal("nvarchar(max)", property.Relational().ColumnType);
+            Assert.Equal("nvarchar(max)", ((IProperty)property).Relational().ColumnType);
+            Assert.Equal("nvarchar(verstappen)", property.SqlServer().ColumnType);
+            Assert.Equal("nvarchar(verstappen)", ((IProperty)property).SqlServer().ColumnType);
+
+            property.SqlServer().ColumnType = null;
+
+            Assert.Equal("nvarchar(max)", property.Relational().ColumnType);
+            Assert.Equal("nvarchar(max)", ((IProperty)property).Relational().ColumnType);
+            Assert.Equal("nvarchar(max)", property.SqlServer().ColumnType);
+            Assert.Equal("nvarchar(max)", ((IProperty)property).SqlServer().ColumnType);
+        }
+
+        [Fact]
+        public void Can_get_and_set_column_default_expression()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            var property = modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .Metadata;
+
+            Assert.Null(property.Relational().DefaultExpression);
+            Assert.Null(((IProperty)property).Relational().DefaultExpression);
+            Assert.Null(property.SqlServer().DefaultExpression);
+            Assert.Null(((IProperty)property).SqlServer().DefaultExpression);
+
+            property.Relational().DefaultExpression = "newsequentialid()";
+
+            Assert.Equal("newsequentialid()", property.Relational().DefaultExpression);
+            Assert.Equal("newsequentialid()", ((IProperty)property).Relational().DefaultExpression);
+            Assert.Equal("newsequentialid()", property.SqlServer().DefaultExpression);
+            Assert.Equal("newsequentialid()", ((IProperty)property).SqlServer().DefaultExpression);
+
+            property.SqlServer().DefaultExpression = "expressyourself()";
+
+            Assert.Equal("newsequentialid()", property.Relational().DefaultExpression);
+            Assert.Equal("newsequentialid()", ((IProperty)property).Relational().DefaultExpression);
+            Assert.Equal("expressyourself()", property.SqlServer().DefaultExpression);
+            Assert.Equal("expressyourself()", ((IProperty)property).SqlServer().DefaultExpression);
+
+            property.SqlServer().DefaultExpression = null;
+
+            Assert.Equal("newsequentialid()", property.Relational().DefaultExpression);
+            Assert.Equal("newsequentialid()", ((IProperty)property).Relational().DefaultExpression);
+            Assert.Equal("newsequentialid()", property.SqlServer().DefaultExpression);
+            Assert.Equal("newsequentialid()", ((IProperty)property).SqlServer().DefaultExpression);
+        }
+
+        [Fact]
+        public void Can_get_and_set_column_key_name()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            var key = modelBuilder
+                .Entity<Customer>()
+                .Key(e => e.Id)
+                .Metadata;
+
+            Assert.Null(key.Relational().Name);
+            Assert.Null(((IKey)key).Relational().Name);
+            Assert.Null(key.SqlServer().Name);
+            Assert.Null(((IKey)key).SqlServer().Name);
+
+            key.Relational().Name = "PrimaryKey";
+
+            Assert.Equal("PrimaryKey", key.Relational().Name);
+            Assert.Equal("PrimaryKey", ((IKey)key).Relational().Name);
+            Assert.Equal("PrimaryKey", key.SqlServer().Name);
+            Assert.Equal("PrimaryKey", ((IKey)key).SqlServer().Name);
+
+            key.SqlServer().Name = "PrimarySchool";
+
+            Assert.Equal("PrimaryKey", key.Relational().Name);
+            Assert.Equal("PrimaryKey", ((IKey)key).Relational().Name);
+            Assert.Equal("PrimarySchool", key.SqlServer().Name);
+            Assert.Equal("PrimarySchool", ((IKey)key).SqlServer().Name);
+
+            key.SqlServer().Name = null;
+
+            Assert.Equal("PrimaryKey", key.Relational().Name);
+            Assert.Equal("PrimaryKey", ((IKey)key).Relational().Name);
+            Assert.Equal("PrimaryKey", key.SqlServer().Name);
+            Assert.Equal("PrimaryKey", ((IKey)key).SqlServer().Name);
+        }
+
+        [Fact]
+        public void Can_get_and_set_column_foreign_key_name()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Key(e => e.Id);
+
+            var foreignKey = modelBuilder
+                .Entity<Order>()
+                .ForeignKey<Customer>(e => e.CustomerId)
+                .Metadata;
+
+            Assert.Null(foreignKey.Relational().Name);
+            Assert.Null(((IForeignKey)foreignKey).Relational().Name);
+            Assert.Null(foreignKey.SqlServer().Name);
+            Assert.Null(((IForeignKey)foreignKey).SqlServer().Name);
+
+            foreignKey.Relational().Name = "FK";
+
+            Assert.Equal("FK", foreignKey.Relational().Name);
+            Assert.Equal("FK", ((IForeignKey)foreignKey).Relational().Name);
+            Assert.Equal("FK", foreignKey.SqlServer().Name);
+            Assert.Equal("FK", ((IForeignKey)foreignKey).SqlServer().Name);
+
+            foreignKey.SqlServer().Name = "KFC";
+
+            Assert.Equal("FK", foreignKey.Relational().Name);
+            Assert.Equal("FK", ((IForeignKey)foreignKey).Relational().Name);
+            Assert.Equal("KFC", foreignKey.SqlServer().Name);
+            Assert.Equal("KFC", ((IForeignKey)foreignKey).SqlServer().Name);
+
+            foreignKey.SqlServer().Name = null;
+
+            Assert.Equal("FK", foreignKey.Relational().Name);
+            Assert.Equal("FK", ((IForeignKey)foreignKey).Relational().Name);
+            Assert.Equal("FK", foreignKey.SqlServer().Name);
+            Assert.Equal("FK", ((IForeignKey)foreignKey).SqlServer().Name);
+        }
+
+        [Fact]
+        public void Can_get_and_set_index_name()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            var index = modelBuilder
+                .Entity<Customer>()
+                .Index(e => e.Id)
+                .Metadata;
+
+            Assert.Null(index.Relational().Name);
+            Assert.Null(((IIndex)index).Relational().Name);
+            Assert.Null(index.SqlServer().Name);
+            Assert.Null(((IIndex)index).SqlServer().Name);
+
+            index.Relational().Name = "MyIndex";
+
+            Assert.Equal("MyIndex", index.Relational().Name);
+            Assert.Equal("MyIndex", ((IIndex)index).Relational().Name);
+            Assert.Equal("MyIndex", index.SqlServer().Name);
+            Assert.Equal("MyIndex", ((IIndex)index).SqlServer().Name);
+
+            index.SqlServer().Name = "DexKnows";
+
+            Assert.Equal("MyIndex", index.Relational().Name);
+            Assert.Equal("MyIndex", ((IIndex)index).Relational().Name);
+            Assert.Equal("DexKnows", index.SqlServer().Name);
+            Assert.Equal("DexKnows", ((IIndex)index).SqlServer().Name);
+
+            index.SqlServer().Name = null;
+
+            Assert.Equal("MyIndex", index.Relational().Name);
+            Assert.Equal("MyIndex", ((IIndex)index).Relational().Name);
+            Assert.Equal("MyIndex", index.SqlServer().Name);
+            Assert.Equal("MyIndex", ((IIndex)index).SqlServer().Name);
+        }
+
+        private class Customer
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class Order
+        {
+            public int OrderId { get; set; }
+            public int CustomerId { get; set; }
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.Tests/SqlServerMetadataExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerMetadataExtensionsTest.cs
@@ -479,23 +479,23 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
         private static void ValidateSequence(MetadataBase property)
         {
-            Assert.Equal(SqlServerMetadataExtensions.Annotations.Sequence, property[SqlServerMetadataExtensions.Annotations.ValueGeneration]);
-            Assert.Null(property[SqlServerMetadataExtensions.Annotations.SequenceBlockSize]);
-            Assert.Null(property[SqlServerMetadataExtensions.Annotations.SequenceName]);
+            Assert.Equal(Entity.Metadata.SqlServerMetadataExtensions.Annotations.Sequence, property[Entity.Metadata.SqlServerMetadataExtensions.Annotations.ValueGeneration]);
+            Assert.Null(property[Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceBlockSize]);
+            Assert.Null(property[Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceName]);
         }
 
         private static void ValidateSequenceWithOptions(MetadataBase property)
         {
-            Assert.Equal(SqlServerMetadataExtensions.Annotations.Sequence, property[SqlServerMetadataExtensions.Annotations.ValueGeneration]);
-            Assert.Equal("8", property[SqlServerMetadataExtensions.Annotations.SequenceBlockSize]);
-            Assert.Equal("SlimShady", property[SqlServerMetadataExtensions.Annotations.SequenceName]);
+            Assert.Equal(Entity.Metadata.SqlServerMetadataExtensions.Annotations.Sequence, property[Entity.Metadata.SqlServerMetadataExtensions.Annotations.ValueGeneration]);
+            Assert.Equal("8", property[Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceBlockSize]);
+            Assert.Equal("SlimShady", property[Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceName]);
         }
 
         private static void ValidateIdentity(MetadataBase property)
         {
-            Assert.Equal(SqlServerMetadataExtensions.Annotations.Identity, property[SqlServerMetadataExtensions.Annotations.ValueGeneration]);
-            Assert.Null(property[SqlServerMetadataExtensions.Annotations.SequenceBlockSize]);
-            Assert.Null(property[SqlServerMetadataExtensions.Annotations.SequenceName]);
+            Assert.Equal(Entity.Metadata.SqlServerMetadataExtensions.Annotations.Identity, property[Entity.Metadata.SqlServerMetadataExtensions.Annotations.ValueGeneration]);
+            Assert.Null(property[Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceBlockSize]);
+            Assert.Null(property[Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceName]);
         }
 
         private static Property GetProperty(Model model, string propertyName)

--- a/test/EntityFramework.SqlServer.Tests/SqlServerSequenceValueGeneratorFactoryTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerSequenceValueGeneratorFactoryTest.cs
@@ -18,9 +18,9 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Block_size_is_obtained_from_property_annotation()
         {
             var property = CreateProperty();
-            property[SqlServerMetadataExtensions.Annotations.SequenceBlockSize] = "11";
-            property.EntityType[SqlServerMetadataExtensions.Annotations.SequenceBlockSize] = "-1";
-            property.EntityType.Model[SqlServerMetadataExtensions.Annotations.SequenceBlockSize] = "-1";
+            property[Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceBlockSize] = "11";
+            property.EntityType[Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceBlockSize] = "-1";
+            property.EntityType.Model[Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceBlockSize] = "-1";
 
             var factory = new SqlServerSequenceValueGeneratorFactory(new SqlStatementExecutor(new NullLoggerFactory()));
 
@@ -31,8 +31,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Block_size_is_obtained_from_entity_type_annotation_if_not_set_on_property()
         {
             var property = CreateProperty();
-            property.EntityType[SqlServerMetadataExtensions.Annotations.SequenceBlockSize] = "11";
-            property.EntityType.Model[SqlServerMetadataExtensions.Annotations.SequenceBlockSize] = "-1";
+            property.EntityType[Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceBlockSize] = "11";
+            property.EntityType.Model[Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceBlockSize] = "-1";
 
             var factory = new SqlServerSequenceValueGeneratorFactory(new SqlStatementExecutor(new NullLoggerFactory()));
 
@@ -43,7 +43,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Block_size_is_obtained_from_model_annotation_if_not_set_on_property_or_type()
         {
             var property = CreateProperty();
-            property.EntityType.Model[SqlServerMetadataExtensions.Annotations.SequenceBlockSize] = "11";
+            property.EntityType.Model[Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceBlockSize] = "11";
 
             var factory = new SqlServerSequenceValueGeneratorFactory(new SqlStatementExecutor(new NullLoggerFactory()));
 
@@ -64,9 +64,9 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Sequence_name_is_obtained_from_property_annotation()
         {
             var property = CreateProperty();
-            property[SqlServerMetadataExtensions.Annotations.SequenceName] = "Robert";
-            property.EntityType[SqlServerMetadataExtensions.Annotations.SequenceName] = "Jimmy";
-            property.EntityType.Model[SqlServerMetadataExtensions.Annotations.SequenceName] = "Jimmy";
+            property[Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceName] = "Robert";
+            property.EntityType[Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceName] = "Jimmy";
+            property.EntityType.Model[Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceName] = "Jimmy";
 
             var factory = new SqlServerSequenceValueGeneratorFactory(new SqlStatementExecutor(new NullLoggerFactory()));
 
@@ -77,8 +77,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Sequence_name_is_obtained_from_entity_type_annotation_if_not_set_on_property()
         {
             var property = CreateProperty();
-            property.EntityType[SqlServerMetadataExtensions.Annotations.SequenceName] = "Robert";
-            property.EntityType.Model[SqlServerMetadataExtensions.Annotations.SequenceName] = "Jimmy";
+            property.EntityType[Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceName] = "Robert";
+            property.EntityType.Model[Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceName] = "Jimmy";
 
             var factory = new SqlServerSequenceValueGeneratorFactory(new SqlStatementExecutor(new NullLoggerFactory()));
 
@@ -89,7 +89,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Sequence_name_is_obtained_from_model_annotation_if_not_set_on_property_or_type()
         {
             var property = CreateProperty();
-            property.EntityType.Model[SqlServerMetadataExtensions.Annotations.SequenceName] = "Robert";
+            property.EntityType.Model[Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceName] = "Robert";
 
             var factory = new SqlServerSequenceValueGeneratorFactory(new SqlStatementExecutor(new NullLoggerFactory()));
 
@@ -110,8 +110,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Creates_CreateSequenceOperation()
         {
             var property = CreateProperty();
-            property[SqlServerMetadataExtensions.Annotations.SequenceBlockSize] = "11";
-            property[SqlServerMetadataExtensions.Annotations.SequenceName] = "Plant";
+            property[Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceBlockSize] = "11";
+            property[Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceName] = "Plant";
 
             var factory = new SqlServerSequenceValueGeneratorFactory(new SqlStatementExecutor(new NullLoggerFactory()));
 
@@ -127,7 +127,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Creates_DropSequenceOperation()
         {
             var property = CreateProperty();
-            property[SqlServerMetadataExtensions.Annotations.SequenceName] = "Page";
+            property[Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceName] = "Page";
 
             var factory = new SqlServerSequenceValueGeneratorFactory(new SqlStatementExecutor(new NullLoggerFactory()));
 
@@ -140,8 +140,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Creates_the_appropriate_value_generator()
         {
             var property = CreateProperty();
-            property[SqlServerMetadataExtensions.Annotations.SequenceBlockSize] = "11";
-            property[SqlServerMetadataExtensions.Annotations.SequenceName] = "Zeppelin";
+            property[Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceBlockSize] = "11";
+            property[Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceName] = "Zeppelin";
 
             var factory = new SqlServerSequenceValueGeneratorFactory(new SqlStatementExecutor(new NullLoggerFactory()));
 
@@ -165,7 +165,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Sequence_name_is_the_cache_key()
         {
             var property = CreateProperty();
-            property[SqlServerMetadataExtensions.Annotations.SequenceName] = "Led";
+            property[Entity.Metadata.SqlServerMetadataExtensions.Annotations.SequenceName] = "Led";
 
             var factory = new SqlServerSequenceValueGeneratorFactory(new SqlStatementExecutor(new NullLoggerFactory()));
 

--- a/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerValueGeneratorSelectorTest.cs
@@ -27,19 +27,19 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
             Assert.Same(
                 sequenceFactory, 
-                selector.Select(CreateProperty(typeof(long), ValueGeneration.OnAdd, SqlServerMetadataExtensions.Annotations.Sequence)));
+                selector.Select(CreateProperty(typeof(long), ValueGeneration.OnAdd, Entity.Metadata.SqlServerMetadataExtensions.Annotations.Sequence)));
 
             Assert.Same(
                 sequenceFactory,
-                selector.Select(CreateProperty(typeof(int), ValueGeneration.OnAdd, SqlServerMetadataExtensions.Annotations.Sequence)));
+                selector.Select(CreateProperty(typeof(int), ValueGeneration.OnAdd, Entity.Metadata.SqlServerMetadataExtensions.Annotations.Sequence)));
 
             Assert.Same(
                 sequenceFactory,
-                selector.Select(CreateProperty(typeof(short), ValueGeneration.OnAdd, SqlServerMetadataExtensions.Annotations.Sequence)));
+                selector.Select(CreateProperty(typeof(short), ValueGeneration.OnAdd, Entity.Metadata.SqlServerMetadataExtensions.Annotations.Sequence)));
 
             Assert.Same(
                 sequenceFactory,
-                selector.Select(CreateProperty(typeof(byte), ValueGeneration.OnAdd, SqlServerMetadataExtensions.Annotations.Sequence)));
+                selector.Select(CreateProperty(typeof(byte), ValueGeneration.OnAdd, Entity.Metadata.SqlServerMetadataExtensions.Annotations.Sequence)));
         }
 
         [Fact]
@@ -55,15 +55,15 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
             Assert.Same(
                 tempFactory,
-                selector.Select(CreateProperty(typeof(long), ValueGeneration.OnAdd, SqlServerMetadataExtensions.Annotations.Identity)));
+                selector.Select(CreateProperty(typeof(long), ValueGeneration.OnAdd, Entity.Metadata.SqlServerMetadataExtensions.Annotations.Identity)));
 
             Assert.Same(
                 tempFactory,
-                selector.Select(CreateProperty(typeof(int), ValueGeneration.OnAdd, SqlServerMetadataExtensions.Annotations.Identity)));
+                selector.Select(CreateProperty(typeof(int), ValueGeneration.OnAdd, Entity.Metadata.SqlServerMetadataExtensions.Annotations.Identity)));
 
             Assert.Same(
                 tempFactory,
-                selector.Select(CreateProperty(typeof(short), ValueGeneration.OnAdd, SqlServerMetadataExtensions.Annotations.Identity)));
+                selector.Select(CreateProperty(typeof(short), ValueGeneration.OnAdd, Entity.Metadata.SqlServerMetadataExtensions.Annotations.Identity)));
         }
 
         [Fact] // TODO: This will change when sequence becomes the default
@@ -139,7 +139,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
             if (annotation != null)
             {
-                property[SqlServerMetadataExtensions.Annotations.ValueGeneration] = annotation;
+                property[Entity.Metadata.SqlServerMetadataExtensions.Annotations.ValueGeneration] = annotation;
             }
 
             return property;


### PR DESCRIPTION
Initial work on provider-specific Code First and core metadata extensions.

This is the initial work for relational and SQL Server extensions. It doesn't yet replace what we currently have--that code still exists as well. Write-only extensions can be used for the fluent APIs together with read/write extensions for mutable metadata and read-only extensions for metadata interfaces.

The following things still need to be done:
- Extensions that are specific to SQL Server and not just overrides of the relational extensions  (Clustered, UseSequence, UseIdentity)
- Extensions for ATS
- The relational model builder
- DefaultValue is not implemented because it really needs non-string annotations.

There are a lot of files here but there is not much actual code and it is all simple stuff.
