### PR TITLE
Adding null logger to Perf models 

### DIFF
--- a/test/Performance/EntityFramework.Performance.CUD.Tests/CudTests.cs
+++ b/test/Performance/EntityFramework.Performance.CUD.Tests/CudTests.cs
@@ -1,12 +1,17 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Linq;
 using Cud.Model;
 #if K10
 using Cud.Utilities;
 #endif
 using Microsoft.Data.Entity;
+using Microsoft.Data.Entity.Services;
 using Microsoft.Framework.ConfigurationModel;
 using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
 
 namespace Cud
@@ -20,7 +25,7 @@ namespace Cud
         public static IServiceProvider CreateServiceProvider(Configuration configuration)
         {
             var services = new ServiceCollection();
-            services.AddEntityFramework().AddSqlServer();
+            services.AddEntityFramework().AddSqlServer().UseLoggerFactory<NullLoggerFactory>();
             services.AddInstance<IConfiguration>(configuration);
             return services.BuildServiceProvider();
         }

--- a/test/Performance/EntityFramework.Performance.DbContext.Tests/DbContextPerfTestsBase.cs
+++ b/test/Performance/EntityFramework.Performance.DbContext.Tests/DbContextPerfTestsBase.cs
@@ -1,17 +1,21 @@
-﻿
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace DbContextPerfTests
 {
+    using Microsoft.Data.Entity;
+    using Microsoft.Data.Entity.Services;
+    using Microsoft.Framework.ConfigurationModel;
+    using Microsoft.Framework.DependencyInjection;
+    using Microsoft.Framework.DependencyInjection.Advanced;
+    using Microsoft.Framework.DependencyInjection.Fallback;
+    using Model;
     using System;
     using System.Collections.Generic;
     using System.Data.SqlClient;
     using System.Diagnostics;
     using System.Linq;
-    using Microsoft.Data.Entity;
-    using Microsoft.Framework.DependencyInjection;
-    using Microsoft.Framework.DependencyInjection.Fallback;
-    using Microsoft.Framework.ConfigurationModel;
-    using Model;
+
 
     public class DbContextPerfTestsBase
     {
@@ -32,7 +36,7 @@ namespace DbContextPerfTests
         public static IServiceProvider CreateServiceProvider()
         {
             var services = new ServiceCollection();
-            services.AddEntityFramework().AddSqlServer();
+            services.AddEntityFramework().AddSqlServer().UseLoggerFactory<NullLoggerFactory>();
             return services.BuildServiceProvider();
         }
 

--- a/test/Performance/EntityFramework.Performance.QueryExecution.Tests/QueryExecution.Tests.TPT.cs
+++ b/test/Performance/EntityFramework.Performance.QueryExecution.Tests/QueryExecution.Tests.TPT.cs
@@ -3,12 +3,15 @@
 
 namespace QueryExecution
 {
-    using System;
-    using QueryExecution.Model;
     using Microsoft.Data.Entity;
-    using Microsoft.Framework.DependencyInjection;
-    using Microsoft.Framework.DependencyInjection.Fallback;
+    using Microsoft.Data.Entity.Services;
     using Microsoft.Framework.ConfigurationModel;
+    using Microsoft.Framework.DependencyInjection;
+    using Microsoft.Framework.DependencyInjection.Advanced;
+    using Microsoft.Framework.DependencyInjection.Fallback;
+    using QueryExecution.Model;
+    using System;
+
 
     public class QueryExecutionTestsTPT : QueryExecutionBase
     {
@@ -17,7 +20,7 @@ namespace QueryExecution
         public static IServiceProvider CreateServiceProvider()
         {
             var services = new ServiceCollection();
-            services.AddEntityFramework().AddSqlServer();
+            services.AddEntityFramework().AddSqlServer().UseLoggerFactory<NullLoggerFactory>();
             return services.BuildServiceProvider();
         }
 

--- a/test/Performance/EntityFramework.Performance.StateManager.Tests/StateManagerTestBase.cs
+++ b/test/Performance/EntityFramework.Performance.StateManager.Tests/StateManagerTestBase.cs
@@ -3,14 +3,17 @@
 
 namespace StateManager
 {
+    using Microsoft.Data.Entity;
+    using Microsoft.Data.Entity.Services;
+    using Microsoft.Framework.ConfigurationModel;
+    using Microsoft.Framework.DependencyInjection;
+    using Microsoft.Framework.DependencyInjection.Advanced;
+    using Microsoft.Framework.DependencyInjection.Fallback;
+    using StateManager.Model;
     using System;
     using System.Globalization;
     using System.Linq;
-    using Microsoft.Data.Entity;
-    using Microsoft.Framework.ConfigurationModel;
-    using Microsoft.Framework.DependencyInjection;
-    using Microsoft.Framework.DependencyInjection.Fallback;
-    using StateManager.Model;
+
 
     public class StateManagerTestBase
     {
@@ -24,7 +27,7 @@ namespace StateManager
         public static IServiceProvider CreateServiceProvider()
         {
             var services = new ServiceCollection();
-            services.AddEntityFramework().AddSqlServer();
+            services.AddEntityFramework().AddSqlServer().UseLoggerFactory<NullLoggerFactory>();
             return services.BuildServiceProvider();
         }
 


### PR DESCRIPTION
The models have been failing to run, the solution is to add the NullLoggerFactory to extinguish a runtime error from DI. 

@emilcicos 
