### PR TITLE
[SMALL] RelationalDatabase.ApplyMigrations

### DIFF
--- a/src/EntityFramework.Migrations/RelationalDatabaseMigrationsExtensions.cs
+++ b/src/EntityFramework.Migrations/RelationalDatabaseMigrationsExtensions.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Migrations.Infrastructure;
+using Microsoft.Data.Entity.Migrations.Utilities;
+using Microsoft.Data.Entity.Relational;
+using Microsoft.Framework.DependencyInjection;
+
+namespace Microsoft.Data.Entity
+{
+    public static class RelationalDatabaseMigrationsExtensions
+    {
+        public static void ApplyMigrations([NotNull] this RelationalDatabase database)
+        {
+            Check.NotNull(database, "database");
+
+            var config = ((IDbContextConfigurationAdapter)database).Configuration;
+            var migrator = config.Services.ServiceProvider.GetService<Migrator>();
+            migrator.UpdateDatabase();
+        }
+    }
+}

--- a/src/EntityFramework/EntityFramework.csproj
+++ b/src/EntityFramework/EntityFramework.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Identity\ValueGeneratorCache.cs" />
     <Compile Include="Identity\ValueGeneratorPool.cs" />
     <Compile Include="Identity\ValueGeneratorSelector.cs" />
+    <Compile Include="Infrastructure\IDbContextConfigurationAdapter.cs" />
     <Compile Include="Metadata\BasicModelBuilder.cs" />
     <Compile Include="Metadata\CollectionTypeFactory.cs" />
     <Compile Include="Metadata\IEntityBuilder.cs" />

--- a/src/EntityFramework/Infrastructure/Database.cs
+++ b/src/EntityFramework/Infrastructure/Database.cs
@@ -10,7 +10,7 @@ using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.Infrastructure
 {
-    public class Database
+    public class Database : IDbContextConfigurationAdapter
     {
         private readonly DbContextConfiguration _configuration;
         private readonly LazyRef<ILogger> _logger;
@@ -26,6 +26,14 @@ namespace Microsoft.Data.Entity.Infrastructure
         protected virtual DbContextConfiguration Configuration
         {
             get { return _configuration; }
+        }
+
+        DbContextConfiguration IDbContextConfigurationAdapter.Configuration
+        {
+            get
+            {
+                return Configuration;
+            }
         }
 
         protected virtual ILogger Logger

--- a/src/EntityFramework/Infrastructure/IDbContextConfigurationAdapter.cs
+++ b/src/EntityFramework/Infrastructure/IDbContextConfigurationAdapter.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.Infrastructure
+{
+    public interface IDbContextConfigurationAdapter
+    {
+        DbContextConfiguration Configuration { get; }
+    }
+}

--- a/src/Microsoft.AspNet.Diagnostics.Entity/MigrationsEndPointMiddleware.cs
+++ b/src/Microsoft.AspNet.Diagnostics.Entity/MigrationsEndPointMiddleware.cs
@@ -47,8 +47,7 @@ namespace Microsoft.AspNet.Diagnostics.Entity
                     {
                         _logger.WriteVerbose(Strings.FormatMigrationsEndPointMiddleware_ApplyingMigrations(db.GetType().FullName));
 
-                        var migrator = db.Configuration.Services.ServiceProvider.GetService<Migrator>();
-                        migrator.UpdateDatabase();
+                        db.Database.AsRelational().ApplyMigrations();
 
                         context.Response.StatusCode = (int)HttpStatusCode.NoContent;
                         context.Response.Headers.Add("Pragma", new[] { "no-cache" });


### PR DESCRIPTION
Adding an ApplyMigrations extension method to RelationalDatabase
Adding an interface that can be used to expose ContextConfiguration as an explicit implementation (useful for other components we want to hand extension methods off)
There is some level of testing as I swapped the MigrationsEndPointMiddleware over to use this API (and it has functional tests). Would be good to have at least one end-to-end test once we have migrations functional tests.
