### PR TITLE
fix to issue 788

### DIFF
--- a/src/EntityFramework/Query/EntityQueryModelVisitor.cs
+++ b/src/EntityFramework/Query/EntityQueryModelVisitor.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Data.Entity.Query
                 {
                     if (entity != null)
                     {
-                        queryContext.QueryBuffer.StartTracking(entity);
+                        entity = (T)queryContext.QueryBuffer.StartTracking(entity);
                     }
 
                     return entity;


### PR DESCRIPTION
Tracking entities has a discrepancy in behavior between sync and async. For sync, objects returned to the customer have the same reference as ones created and stored in state manager. For async, we do create and store objects in state manager, but return the original ones to the customer. This could cause errors for some scenarios (issue 788) - we would end up with same entity being tracked twice which then would lead to a validation error.
@anpete @ajcvickers 
