### PR TITLE
Unladen swallow...

### DIFF
--- a/src/EntityFramework.Relational/Metadata/IRelationalPropertyExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/IRelationalPropertyExtensions.cs
@@ -14,5 +14,8 @@ namespace Microsoft.Data.Entity.Relational.Metadata
 
         [CanBeNull]
         string DefaultExpression { get; }
+
+        [CanBeNull]
+        object DefaultValue { get; }
     }
 }

--- a/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalPropertyExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/ReadOnlyRelationalPropertyExtensions.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Data.Entity.Relational.Metadata
         protected const string NameAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.ColumnName;
         protected const string ColumnTypeAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.ColumnType;
         protected const string DefaultExpressionAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.ColumnDefaultExpression;
+        protected const string DefaultValueAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.ColumnDefaultValue;
+        protected const string DefaultValueTypeAnnotation = RelationalAnnotationNames.Prefix + RelationalAnnotationNames.ColumnDefaultValueType;
 
         private readonly IProperty _property;
 
@@ -35,6 +37,11 @@ namespace Microsoft.Data.Entity.Relational.Metadata
         public virtual string DefaultExpression
         {
             get { return _property[DefaultExpressionAnnotation]; }
+        }
+
+        public virtual object DefaultValue
+        {
+            get { return new TypedAnnotation(_property[DefaultValueTypeAnnotation], _property[DefaultValueAnnotation]).Value; }
         }
 
         protected virtual IProperty Property

--- a/src/EntityFramework.Relational/Metadata/RelationalAnnotationNames.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalAnnotationNames.cs
@@ -7,8 +7,10 @@ namespace Microsoft.Data.Entity.Relational.Metadata
     {
         public const string Prefix = "Relational:";
         public const string ColumnName = "ColumnName";
-        public const string ColumnType = "ColumnName";
-        public const string ColumnDefaultExpression = "ColumnName";
+        public const string ColumnType = "ColumnType";
+        public const string ColumnDefaultExpression = "ColumnDefaultExpression";
+        public const string ColumnDefaultValue = "ColumnDefaultValue";
+        public const string ColumnDefaultValueType = "ColumnDefaultValueType";
         public const string TableName = "TableName";
         public const string Schema = "Schema";
         public const string Name = "Name";

--- a/src/EntityFramework.Relational/Metadata/RelationalPropertyBuilder.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalPropertyBuilder.cs
@@ -44,5 +44,12 @@ namespace Microsoft.Data.Entity.Relational.Metadata
 
             return this;
         }
+
+        public virtual RelationalPropertyBuilder DefaultValue([CanBeNull] object value)
+        {
+            _property.Relational().DefaultValue = value;
+
+            return this;
+        }
     }
 }

--- a/src/EntityFramework.Relational/Metadata/RelationalPropertyExtensions.cs
+++ b/src/EntityFramework.Relational/Metadata/RelationalPropertyExtensions.cs
@@ -49,5 +49,18 @@ namespace Microsoft.Data.Entity.Relational.Metadata
                 ((Property)Property)[DefaultExpressionAnnotation] = value;
             }
         }
+
+        public new virtual object DefaultValue
+        {
+            get { return base.DefaultValue; }
+            [param: CanBeNull]
+            set
+            {
+                var typedAnnotation = new TypedAnnotation(value);
+
+                ((Property)Property)[DefaultValueTypeAnnotation] = typedAnnotation.TypeString;
+                ((Property)Property)[DefaultValueAnnotation] = typedAnnotation.ValueString;
+            }
+        }
     }
 }

--- a/src/EntityFramework.SqlServer/Metadata/ReadOnlySqlServerPropertyExtensions.cs
+++ b/src/EntityFramework.SqlServer/Metadata/ReadOnlySqlServerPropertyExtensions.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata
         protected const string SqlServerValueGenerationAnnotation = SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.ValueGeneration;
         protected const string SqlServerSequenceNameAnnotation = SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.SequenceName;
         protected const string SqlServerSequenceSchemaAnnotation = SqlServerAnnotationNames.Prefix + SqlServerAnnotationNames.SequenceSchema;
+        protected const string SqlServerDefaultValueAnnotation = SqlServerAnnotationNames.Prefix + RelationalAnnotationNames.ColumnDefaultValue;
+        protected const string SqlServerDefaultValueTypeAnnotation = SqlServerAnnotationNames.Prefix + RelationalAnnotationNames.ColumnDefaultValueType;
 
         public ReadOnlySqlServerPropertyExtensions([NotNull] IProperty property)
             : base(property)
@@ -29,12 +31,21 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata
 
         public override string ColumnType
         {
-            get { return Property[SqlServerNameAnnotation] ?? base.ColumnType; }
+            get { return Property[SqlServerColumnTypeAnnotation] ?? base.ColumnType; }
         }
 
         public override string DefaultExpression
         {
             get { return Property[SqlServerDefaultExpressionAnnotation] ?? base.DefaultExpression; }
+        }
+
+        public override object DefaultValue
+        {
+            get
+            {
+                return new TypedAnnotation(Property[SqlServerDefaultValueTypeAnnotation], Property[SqlServerDefaultValueAnnotation]).Value 
+                    ?? base.DefaultValue;
+            }
         }
 
         public virtual SqlServerValueGenerationStrategy? ValueGenerationStrategy

--- a/src/EntityFramework.SqlServer/Metadata/SqlServerPropertyBuilder.cs
+++ b/src/EntityFramework.SqlServer/Metadata/SqlServerPropertyBuilder.cs
@@ -45,6 +45,13 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata
             return this;
         }
 
+        public virtual SqlServerPropertyBuilder DefaultValue([CanBeNull] object value)
+        {
+            _property.SqlServer().DefaultValue = value;
+
+            return this;
+        }
+
         public virtual SqlServerPropertyBuilder UseSequence()
         {
             _property.SqlServer().ValueGenerationStrategy = SqlServerValueGenerationStrategy.Sequence;

--- a/src/EntityFramework.SqlServer/Metadata/SqlServerPropertyExtensions.cs
+++ b/src/EntityFramework.SqlServer/Metadata/SqlServerPropertyExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational.Metadata;
 using Microsoft.Data.Entity.SqlServer.Utilities;
 
 namespace Microsoft.Data.Entity.SqlServer.Metadata
@@ -50,6 +51,19 @@ namespace Microsoft.Data.Entity.SqlServer.Metadata
                 Check.NullButNotEmpty(value, "value");
 
                 ((Property)Property)[SqlServerDefaultExpressionAnnotation] = value;
+            }
+        }
+
+        public new virtual object DefaultValue
+        {
+            get { return base.DefaultValue; }
+            [param: CanBeNull]
+            set
+            {
+                var typedAnnotation = new TypedAnnotation(value);
+
+                ((Property)Property)[SqlServerDefaultValueTypeAnnotation] = typedAnnotation.TypeString;
+                ((Property)Property)[SqlServerDefaultValueAnnotation] = typedAnnotation.ValueString;
             }
         }
 

--- a/src/EntityFramework/EntityFramework.csproj
+++ b/src/EntityFramework/EntityFramework.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Metadata\IOneToOneBuilder.cs" />
     <Compile Include="Metadata\IPropertyBuilder.cs" />
     <Compile Include="Metadata\ModelBuilder.cs" />
+    <Compile Include="Metadata\TypedAnnotation.cs" />
     <Compile Include="QueryExtensions.cs" />
     <Compile Include="Query\IAsyncEnumerableAccessor.cs" />
     <Compile Include="Query\ResultOperators\IncludeExpressionNode.cs" />

--- a/src/EntityFramework/Metadata/TypedAnnotation.cs
+++ b/src/EntityFramework/Metadata/TypedAnnotation.cs
@@ -1,0 +1,146 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+
+namespace Microsoft.Data.Entity.Metadata
+{
+    public class TypedAnnotation
+    {
+        private static readonly HashSet<Type> _supportedTypes = new HashSet<Type>
+            {
+                typeof(string),
+                typeof(int),
+                typeof(long),
+                typeof(short),
+                typeof(byte),
+                typeof(decimal),
+                typeof(float),
+                typeof(double),
+                typeof(bool),
+                typeof(DateTime),
+                typeof(char),
+                typeof(sbyte),
+                typeof(ulong),
+                typeof(uint),
+                typeof(ushort),
+                typeof(Guid),
+                typeof(DateTimeOffset),
+                typeof(TimeSpan),
+                typeof(byte[])
+            };
+
+        private readonly object _value;
+
+        public TypedAnnotation([CanBeNull] object value)
+        {
+            _value = value;
+
+            if (value != null)
+            {
+                CheckType(value.GetType());
+            }
+        }
+
+        public TypedAnnotation([CanBeNull] string typeString, [CanBeNull] string valueString)
+        {
+            _value = typeString == null || valueString == null
+                ? null
+                : Deserialize(CheckType(Type.GetType(typeString)), valueString);
+        }
+
+        private static Type CheckType(Type type)
+        {
+            if (!_supportedTypes.Contains(type))
+            {
+                throw new NotSupportedException(Strings.FormatUnsupportedAnnotationType(type.Name));
+            }
+
+            return type;
+        }
+
+        public virtual object Value
+        {
+            get { return _value; }
+        }
+
+        public virtual string ValueString
+        {
+            get { return _value == null ? null : Serialize(); }
+        }
+
+        public virtual string TypeString
+        {
+            get { return _value == null ? null : _value.GetType().FullName; }
+        }
+
+        private string Serialize()
+        {
+            var type = _value.GetType();
+
+            if (type == typeof(DateTimeOffset))
+            {
+                var dto = (DateTimeOffset)_value;
+
+                return dto.Ticks + ", " + dto.Offset.Ticks;
+            }
+
+            if (type == typeof(DateTime))
+            {
+                return ((DateTime)_value).Ticks.ToString();
+            }
+
+            if (type == typeof(TimeSpan))
+            {
+                return ((TimeSpan)_value).Ticks.ToString();
+            }
+
+            if (type == typeof(byte[]))
+            {
+                return Convert.ToBase64String((byte[])_value);
+            }
+
+            return _value.ToString();
+        }
+
+        private static object Deserialize(Type type, string value)
+        {
+            if (type == typeof(string))
+            {
+                return value;
+            }
+
+            if (type == typeof(Guid))
+            {
+                return new Guid(value);
+            }
+
+            if (type == typeof(DateTimeOffset))
+            {
+                var commaIndex = value.IndexOf(",");
+                return new DateTimeOffset(
+                    (long)Deserialize(typeof(long), value.Substring(0, commaIndex)),
+                    (TimeSpan)Deserialize(typeof(TimeSpan), value.Substring(commaIndex + 1)));
+            }
+
+            if (type == typeof(DateTime))
+            {
+                return new DateTime((long)Deserialize(typeof(long), value));
+            }
+
+            if (type == typeof(TimeSpan))
+            {
+                return new TimeSpan((long)Deserialize(typeof(long), value));
+            }
+
+            if (type == typeof(byte[]))
+            {
+                return Convert.FromBase64String(value);
+            }
+
+            return Convert.ChangeType(value, type);
+        }
+    }
+}

--- a/src/EntityFramework/Properties/Strings.Designer.cs
+++ b/src/EntityFramework/Properties/Strings.Designer.cs
@@ -1226,6 +1226,22 @@ namespace Microsoft.Data.Entity
             return string.Format(CultureInfo.CurrentCulture, GetString("DuplicateEntityType", "entityType"), entityType);
         }
 
+        /// <summary>
+        /// Annotations of type '{type}' are not supported. Only common simple .NET types are currently supported.
+        /// </summary>
+        internal static string UnsupportedAnnotationType
+        {
+            get { return GetString("UnsupportedAnnotationType"); }
+        }
+
+        /// <summary>
+        /// Annotations of type '{type}' are not supported. Only common simple .NET types are currently supported.
+        /// </summary>
+        internal static string FormatUnsupportedAnnotationType(object type)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("UnsupportedAnnotationType", "type"), type);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EntityFramework/Properties/Strings.resx
+++ b/src/EntityFramework/Properties/Strings.resx
@@ -345,4 +345,7 @@
   <data name="DuplicateEntityType" xml:space="preserve">
     <value>The entity type '{entityType}' cannot be added to the model because an entity with the same name already exists.</value>
   </data>
+  <data name="UnsupportedAnnotationType" xml:space="preserve">
+    <value>Annotations of type '{type}' are not supported. Only common simple .NET types are currently supported.</value>
+  </data>
 </root>

--- a/test/EntityFramework.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Data.Entity.Metadata;
@@ -222,6 +223,80 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
             var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
 
             Assert.Equal("CherryCoke", property.Relational().DefaultExpression);
+        }
+
+        [Fact]
+        public void Can_set_column_default_value_with_basic_builder()
+        {
+            var modelBuilder = new BasicModelBuilder();
+            var guid = new Guid("{3FDFC4F5-AEAB-4D72-9C96-201E004349FA}");
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational()
+                .DefaultValue(guid);
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal(guid, property.Relational().DefaultValue);
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational()
+                .DefaultValue(null);
+
+            Assert.Null(property.Relational().DefaultValue);
+        }
+
+        [Fact]
+        public void Can_set_column_default_value_with_basic_builder_using_nested_closure()
+        {
+            var modelBuilder = new BasicModelBuilder();
+            var guid = new Guid("{3FDFC4F5-AEAB-4D72-9C96-201E004349FA}");
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational(b => { b.DefaultValue(guid); });
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal(guid, property.Relational().DefaultValue);
+        }
+
+        [Fact]
+        public void Can_set_column_default_value_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+            var guid = new Guid("{3FDFC4F5-AEAB-4D72-9C96-201E004349FA}");
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational()
+                .DefaultValue(guid);
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal(guid, property.Relational().DefaultValue);
+        }
+
+        [Fact]
+        public void Can_set_column_default_value_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+            var guid = new Guid("{3FDFC4F5-AEAB-4D72-9C96-201E004349FA}");
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational(b => { b.DefaultValue(guid); });
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal(guid, property.Relational().DefaultValue);
         }
 
         [Fact]

--- a/test/EntityFramework.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Data.Entity.Metadata;
 using Xunit;
 
@@ -128,6 +129,32 @@ namespace Microsoft.Data.Entity.Relational.Metadata.Tests
 
             Assert.Null(property.Relational().DefaultExpression);
             Assert.Null(((IProperty)property).Relational().DefaultExpression);
+        }
+
+        [Fact]
+        public void Can_get_and_set_column_default_value()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            var property = modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .Metadata;
+
+            Assert.Null(property.Relational().DefaultValue);
+            Assert.Null(((IProperty)property).Relational().DefaultValue);
+
+            var guid = new Guid("{3FDFC4F5-AEAB-4D72-9C96-201E004349FA}");
+
+            property.Relational().DefaultValue = guid;
+
+            Assert.Equal(guid, property.Relational().DefaultValue);
+            Assert.Equal(guid, ((IProperty)property).Relational().DefaultValue);
+
+            property.Relational().DefaultValue = null;
+
+            Assert.Null(property.Relational().DefaultValue);
+            Assert.Null(((IProperty)property).Relational().DefaultValue);
         }
 
         [Fact]

--- a/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Data.Entity.Metadata;
@@ -282,6 +283,95 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
 
             Assert.Equal("CherryCoke", property.Relational().DefaultExpression);
             Assert.Equal("VanillaCoke", property.SqlServer().DefaultExpression);
+        }
+
+        [Fact]
+        public void Can_set_column_default_value_with_basic_builder()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational()
+                .DefaultValue(new DateTimeOffset(1973, 9, 3, 0, 10, 0, new TimeSpan(1, 0, 0)));
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForSqlServer()
+                .DefaultValue(new DateTimeOffset(2006, 9, 19, 19, 0, 0, new TimeSpan(-8, 0, 0)));
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal(new DateTimeOffset(1973, 9, 3, 0, 10, 0, new TimeSpan(1, 0, 0)), property.Relational().DefaultValue);
+            Assert.Equal(new DateTimeOffset(2006, 9, 19, 19, 0, 0, new TimeSpan(-8, 0, 0)), property.SqlServer().DefaultValue);
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForSqlServer()
+                .DefaultValue(null);
+
+            Assert.Equal(new DateTimeOffset(1973, 9, 3, 0, 10, 0, new TimeSpan(1, 0, 0)), property.Relational().DefaultValue);
+            Assert.Equal(new DateTimeOffset(1973, 9, 3, 0, 10, 0, new TimeSpan(1, 0, 0)), property.SqlServer().DefaultValue);
+        }
+
+        [Fact]
+        public void Can_set_column_default_value_with_basic_builder_using_nested_closure()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational(b => { b.DefaultValue(new DateTimeOffset(1973, 9, 3, 0, 10, 0, new TimeSpan(1, 0, 0))); })
+                .ForSqlServer(b => { b.DefaultValue(new DateTimeOffset(2006, 9, 19, 19, 0, 0, new TimeSpan(-8, 0, 0))); });
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal(new DateTimeOffset(1973, 9, 3, 0, 10, 0, new TimeSpan(1, 0, 0)), property.Relational().DefaultValue);
+            Assert.Equal(new DateTimeOffset(2006, 9, 19, 19, 0, 0, new TimeSpan(-8, 0, 0)), property.SqlServer().DefaultValue);
+        }
+
+        [Fact]
+        public void Can_set_column_default_value_with_convention_builder()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational()
+                .DefaultValue(new DateTimeOffset(1973, 9, 3, 0, 10, 0, new TimeSpan(1, 0, 0)));
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForSqlServer()
+                .DefaultValue(new DateTimeOffset(2006, 9, 19, 19, 0, 0, new TimeSpan(-8, 0, 0)));
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal(new DateTimeOffset(1973, 9, 3, 0, 10, 0, new TimeSpan(1, 0, 0)), property.Relational().DefaultValue);
+            Assert.Equal(new DateTimeOffset(2006, 9, 19, 19, 0, 0, new TimeSpan(-8, 0, 0)), property.SqlServer().DefaultValue);
+        }
+
+        [Fact]
+        public void Can_set_column_default_value_with_convention_builder_using_nested_closure()
+        {
+            var modelBuilder = new ModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .ForRelational(b => { b.DefaultValue(new DateTimeOffset(1973, 9, 3, 0, 10, 0, new TimeSpan(1, 0, 0))); })
+                .ForSqlServer(b => { b.DefaultValue(new DateTimeOffset(2006, 9, 19, 19, 0, 0, new TimeSpan(-8, 0, 0))); });
+
+            var property = modelBuilder.Model.GetEntityType(typeof(Customer)).GetProperty("Name");
+
+            Assert.Equal(new DateTimeOffset(1973, 9, 3, 0, 10, 0, new TimeSpan(1, 0, 0)), property.Relational().DefaultValue);
+            Assert.Equal(new DateTimeOffset(2006, 9, 19, 19, 0, 0, new TimeSpan(-8, 0, 0)), property.SqlServer().DefaultValue);
         }
 
         [Fact]

--- a/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/Metadata/SqlServerMetadataExtensionsTest.cs
@@ -203,6 +203,43 @@ namespace Microsoft.Data.Entity.SqlServer.Tests.Metadata
         }
 
         [Fact]
+        public void Can_get_and_set_column_default_value()
+        {
+            var modelBuilder = new BasicModelBuilder();
+
+            var property = modelBuilder
+                .Entity<Customer>()
+                .Property(e => e.Name)
+                .Metadata;
+
+            Assert.Null(property.Relational().DefaultValue);
+            Assert.Null(((IProperty)property).Relational().DefaultValue);
+            Assert.Null(property.SqlServer().DefaultValue);
+            Assert.Null(((IProperty)property).SqlServer().DefaultValue);
+
+            property.Relational().DefaultValue = new Byte[] { 69, 70, 32, 82, 79, 67, 75, 83 };
+
+            Assert.Equal(new Byte[] { 69, 70, 32, 82, 79, 67, 75, 83 }, property.Relational().DefaultValue);
+            Assert.Equal(new Byte[] { 69, 70, 32, 82, 79, 67, 75, 83 }, ((IProperty)property).Relational().DefaultValue);
+            Assert.Equal(new Byte[] { 69, 70, 32, 82, 79, 67, 75, 83 }, property.SqlServer().DefaultValue);
+            Assert.Equal(new Byte[] { 69, 70, 32, 82, 79, 67, 75, 83 }, ((IProperty)property).SqlServer().DefaultValue);
+
+            property.SqlServer().DefaultValue = new Byte[] { 69, 70, 32, 83, 79, 67, 75, 83 };
+
+            Assert.Equal(new Byte[] { 69, 70, 32, 82, 79, 67, 75, 83 }, property.Relational().DefaultValue);
+            Assert.Equal(new Byte[] { 69, 70, 32, 82, 79, 67, 75, 83 }, ((IProperty)property).Relational().DefaultValue);
+            Assert.Equal(new Byte[] { 69, 70, 32, 83, 79, 67, 75, 83 }, property.SqlServer().DefaultValue);
+            Assert.Equal(new Byte[] { 69, 70, 32, 83, 79, 67, 75, 83 }, ((IProperty)property).SqlServer().DefaultValue);
+
+            property.SqlServer().DefaultValue = null;
+
+            Assert.Equal(new Byte[] { 69, 70, 32, 82, 79, 67, 75, 83 }, property.Relational().DefaultValue);
+            Assert.Equal(new Byte[] { 69, 70, 32, 82, 79, 67, 75, 83 }, ((IProperty)property).Relational().DefaultValue);
+            Assert.Equal(new Byte[] { 69, 70, 32, 82, 79, 67, 75, 83 }, property.SqlServer().DefaultValue);
+            Assert.Equal(new Byte[] { 69, 70, 32, 82, 79, 67, 75, 83 }, ((IProperty)property).SqlServer().DefaultValue);
+        }
+
+        [Fact]
         public void Can_get_and_set_column_key_name()
         {
             var modelBuilder = new BasicModelBuilder();

--- a/test/EntityFramework.Tests/EntityFramework.Tests.csproj
+++ b/test/EntityFramework.Tests/EntityFramework.Tests.csproj
@@ -108,6 +108,7 @@
     <Compile Include="Metadata\NonGenericRelationshipBuilderTest.cs" />
     <Compile Include="Metadata\PropertyExtensionsTest.cs" />
     <Compile Include="Metadata\StringRelationshipBuilderTest.cs" />
+    <Compile Include="Metadata\TypedAnnotationTest.cs" />
     <Compile Include="TestHelperExtensions.cs" />
     <Compile Include="ServiceProviderCacheTest.cs" />
     <Compile Include="ChangeTracking\ChangeTrackerTest.cs" />

--- a/test/EntityFramework.Tests/Metadata/TypedAnnotationTest.cs
+++ b/test/EntityFramework.Tests/Metadata/TypedAnnotationTest.cs
@@ -1,0 +1,199 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.Metadata;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests.Metadata
+{
+    public class TypedAnnotationTest
+    {
+        [Fact]
+        public void Can_covert_to_and_from_string()
+        {
+            var annotation = new TypedAnnotation("Forty Two");
+
+            Assert.Equal("Forty Two", annotation.Value);
+            Assert.Equal("Forty Two", new TypedAnnotation(annotation.TypeString, annotation.ValueString).Value);
+        }
+
+        [Fact]
+        public void Can_covert_to_and_from_int()
+        {
+            var annotation = new TypedAnnotation(42);
+
+            Assert.Equal(42, annotation.Value);
+            Assert.Equal(42, new TypedAnnotation(annotation.TypeString, annotation.ValueString).Value);
+        }
+
+        [Fact]
+        public void Can_covert_to_and_from_long()
+        {
+            var annotation = new TypedAnnotation(42L);
+
+            Assert.Equal(42L, annotation.Value);
+            Assert.Equal(42L, new TypedAnnotation(annotation.TypeString, annotation.ValueString).Value);
+        }
+
+        [Fact]
+        public void Can_covert_to_and_from_short()
+        {
+            var annotation = new TypedAnnotation((short)42);
+
+            Assert.Equal((short)42, annotation.Value);
+            Assert.Equal((short)42, new TypedAnnotation(annotation.TypeString, annotation.ValueString).Value);
+        }
+
+        [Fact]
+        public void Can_covert_to_and_from_byte()
+        {
+            var annotation = new TypedAnnotation((byte)42);
+
+            Assert.Equal((byte)42, annotation.Value);
+            Assert.Equal((byte)42, new TypedAnnotation(annotation.TypeString, annotation.ValueString).Value);
+        }
+
+        [Fact]
+        public void Can_covert_to_and_from_decimal()
+        {
+            var annotation = new TypedAnnotation((decimal)42);
+
+            Assert.Equal((decimal)42, annotation.Value);
+            Assert.Equal((decimal)42, new TypedAnnotation(annotation.TypeString, annotation.ValueString).Value);
+        }
+
+        [Fact]
+        public void Can_covert_to_and_from_float()
+        {
+            var annotation = new TypedAnnotation((float)42);
+
+            Assert.Equal((float)42, annotation.Value);
+            Assert.Equal((float)42, new TypedAnnotation(annotation.TypeString, annotation.ValueString).Value);
+        }
+
+        [Fact]
+        public void Can_covert_to_and_from_double()
+        {
+            var annotation = new TypedAnnotation((double)42);
+
+            Assert.Equal((double)42, annotation.Value);
+            Assert.Equal((double)42, new TypedAnnotation(annotation.TypeString, annotation.ValueString).Value);
+        }
+
+        [Fact]
+        public void Can_covert_to_and_from_bool()
+        {
+            var annotation = new TypedAnnotation(true);
+
+            Assert.Equal(true, annotation.Value);
+            Assert.Equal(true, new TypedAnnotation(annotation.TypeString, annotation.ValueString).Value);
+        }
+
+        [Fact]
+        public void Can_covert_to_and_from_DateTime()
+        {
+            var annotation = new TypedAnnotation(new DateTime(1973, 9, 3, 0, 10, 1, 333));
+
+            Assert.Equal(new DateTime(1973, 9, 3, 0, 10, 1, 333), annotation.Value);
+            Assert.Equal(new DateTime(1973, 9, 3, 0, 10, 1, 333), new TypedAnnotation(annotation.TypeString, annotation.ValueString).Value);
+        }
+
+        [Fact]
+        public void Can_covert_to_and_from_char()
+        {
+            var annotation = new TypedAnnotation(' ');
+
+            Assert.Equal(' ', annotation.Value);
+            Assert.Equal(' ', new TypedAnnotation(annotation.TypeString, annotation.ValueString).Value);
+        }
+
+        [Fact]
+        public void Can_covert_to_and_from_uint()
+        {
+            var annotation = new TypedAnnotation((uint)42);
+
+            Assert.Equal((uint)42, annotation.Value);
+            Assert.Equal((uint)42, new TypedAnnotation(annotation.TypeString, annotation.ValueString).Value);
+        }
+
+        [Fact]
+        public void Can_covert_to_and_from_ulong()
+        {
+            var annotation = new TypedAnnotation((ulong)42);
+
+            Assert.Equal((ulong)42, annotation.Value);
+            Assert.Equal((ulong)42, new TypedAnnotation(annotation.TypeString, annotation.ValueString).Value);
+        }
+
+        [Fact]
+        public void Can_covert_to_and_from_ushort()
+        {
+            var annotation = new TypedAnnotation((ushort)42);
+
+            Assert.Equal((ushort)42, annotation.Value);
+            Assert.Equal((ushort)42, new TypedAnnotation(annotation.TypeString, annotation.ValueString).Value);
+        }
+
+        [Fact]
+        public void Can_covert_to_and_from_sbyte()
+        {
+            var annotation = new TypedAnnotation((sbyte)42);
+
+            Assert.Equal((sbyte)42, annotation.Value);
+            Assert.Equal((sbyte)42, new TypedAnnotation(annotation.TypeString, annotation.ValueString).Value);
+        }
+
+        [Fact]
+        public void Can_covert_to_and_from_Guid()
+        {
+            var guid = new Guid("{6569CBEA-1E24-4D3E-A60E-6B663B4831F8}");
+            var annotation = new TypedAnnotation(guid);
+
+            Assert.Equal(guid, annotation.Value);
+            Assert.Equal(guid, new TypedAnnotation(annotation.TypeString, annotation.ValueString).Value);
+        }
+
+        [Fact]
+        public void Can_covert_to_and_from_DateTimeOffset()
+        {
+            var dateTimeOffset = new DateTimeOffset(new DateTime(1973, 9, 3, 0, 10, 1, 333), new TimeSpan(-8, 0, 0));
+            var annotation = new TypedAnnotation(dateTimeOffset);
+
+            Assert.Equal(dateTimeOffset, annotation.Value);
+            Assert.Equal(dateTimeOffset, new TypedAnnotation(annotation.TypeString, annotation.ValueString).Value);
+        }
+
+        [Fact]
+        public void Can_covert_to_and_from_TimeSpan()
+        {
+            var annotation = new TypedAnnotation(new TimeSpan(-8, 1, 3));
+
+            Assert.Equal(new TimeSpan(-8, 1, 3), annotation.Value);
+            Assert.Equal(new TimeSpan(-8, 1, 3), new TypedAnnotation(annotation.TypeString, annotation.ValueString).Value);
+        }
+
+        [Fact]
+        public void Can_covert_to_and_from_byte_array()
+        {
+            var annotation = new TypedAnnotation(new Byte[] { 69, 70, 32, 82, 79, 67, 75, 83 });
+
+            Assert.Equal(new Byte[] { 69, 70, 32, 82, 79, 67, 75, 83 }, annotation.Value);
+            Assert.Equal(
+                new Byte[] { 69, 70, 32, 82, 79, 67, 75, 83 },
+                new TypedAnnotation(annotation.TypeString, annotation.ValueString).Value);
+        }
+
+        [Fact]
+        public void Throws_for_unsupported_types()
+        {
+            Assert.Equal(
+                Strings.FormatUnsupportedAnnotationType("Random"),
+                Assert.Throws<NotSupportedException>(() => new TypedAnnotation(new Random())).Message);
+
+            Assert.Equal(
+                Strings.FormatUnsupportedAnnotationType("Random"),
+                Assert.Throws<NotSupportedException>(() => new TypedAnnotation(typeof(Random).FullName, "Rand!")).Message);
+        }
+    }
+}


### PR DESCRIPTION
Add support for DefaultValue relational API

This one required a little more work than the others to allow a variety of different objects to be used. This is the last provider-specific relational API in the current batch so I can now work on removing the old code.
