### PR TITLE
Nullable bool metadata properties

### DIFF
--- a/src/EntityFramework/Metadata/EntityType.cs
+++ b/src/EntityFramework/Metadata/EntityType.cs
@@ -779,7 +779,7 @@ namespace Microsoft.Data.Entity.Metadata
         private bool RequiresOriginalValue(Property addedOrRemovedProperty)
         {
             return !_useLazyOriginalValues
-                   || addedOrRemovedProperty.IsConcurrencyToken
+                   || ((IProperty)addedOrRemovedProperty).IsConcurrencyToken
                    || ForeignKeys.SelectMany(k => k.Properties).Contains(addedOrRemovedProperty);
         }
 

--- a/src/EntityFramework/Metadata/ForeignKey.cs
+++ b/src/EntityFramework/Metadata/ForeignKey.cs
@@ -67,11 +67,21 @@ namespace Microsoft.Data.Entity.Metadata
             get { return _referencedKey.EntityType; }
         }
 
-        public virtual bool IsUnique { get; set; }
+        public virtual bool? IsUnique { get; set; }
 
-        public virtual bool IsRequired
+        protected virtual bool DefaultIsUnique
         {
-            get { return !Properties.Any(p => p.IsNullable); }
+            get { return false; }
+        }
+
+        public virtual bool? IsRequired
+        {
+            get
+            {
+                return Properties.All(p => p.IsNullable.HasValue)
+                    ? (bool?)!Properties.Any(p => p.IsNullable.Value)
+                    : null;
+            }
             set
             {
                 foreach (var property in Properties)
@@ -80,6 +90,11 @@ namespace Microsoft.Data.Entity.Metadata
                     property.IsNullable = !value;
                 }
             }
+        }
+
+        protected virtual bool DefaultIsRequired
+        {
+            get { return !((IForeignKey)this).Properties.Any(p => p.IsNullable); }
         }
 
         IReadOnlyList<IProperty> IForeignKey.ReferencedProperties
@@ -95,6 +110,16 @@ namespace Microsoft.Data.Entity.Metadata
         IKey IForeignKey.ReferencedKey
         {
             get { return ReferencedKey; }
+        }
+
+        bool IForeignKey.IsUnique
+        {
+            get { return IsUnique ?? DefaultIsUnique; }
+        }
+
+        bool IForeignKey.IsRequired
+        {
+            get { return IsRequired ?? DefaultIsRequired; }
         }
     }
 }

--- a/src/EntityFramework/Metadata/Index.cs
+++ b/src/EntityFramework/Metadata/Index.cs
@@ -30,7 +30,12 @@ namespace Microsoft.Data.Entity.Metadata
             _properties = properties;
         }
 
-        public virtual bool IsUnique { get; set; }
+        public virtual bool? IsUnique { get; set; }
+
+        protected virtual bool DefaultIsUnique
+        {
+            get { return false; }
+        }
 
         public virtual IReadOnlyList<Property> Properties
         {
@@ -50,6 +55,11 @@ namespace Microsoft.Data.Entity.Metadata
         IEntityType IIndex.EntityType
         {
             get { return EntityType; }
+        }
+
+        bool IIndex.IsUnique
+        {
+            get { return IsUnique ?? DefaultIsUnique; }
         }
     }
 }

--- a/src/EntityFramework/Metadata/Internal/InternalEntityBuilder.cs
+++ b/src/EntityFramework/Metadata/Internal/InternalEntityBuilder.cs
@@ -269,7 +269,7 @@ namespace Microsoft.Data.Entity.Metadata.Internal
                 relationshipBuilder.NavigationToDependent != null ? relationshipBuilder.NavigationToDependent.Name : null,
                 dependentProperties,
                 principalProperties,
-                relationshipBuilder.Metadata.IsUnique);
+                ((IForeignKey)relationshipBuilder.Metadata).IsUnique);
 
             // TODO: Remove principal key only if it was added by convention
             // Issue #213

--- a/src/EntityFramework/Metadata/ModelConventions/ForeignKeyConvention.cs
+++ b/src/EntityFramework/Metadata/ModelConventions/ForeignKeyConvention.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Data.Entity.Metadata.ModelConventions
             foreach (var properties in foreignKeyCandidates)
             {
                 var foreignKey = dependentType.ForeignKeys
-                    .FirstOrDefault(fk => fk.IsUnique == isUnique
+                    .FirstOrDefault(fk => ((IForeignKey)fk).IsUnique == isUnique
                                           && fk.ReferencedEntityType == principalType
                                           && fk.Properties.SequenceEqual(properties)
                                           && !fk.EntityType.Navigations.Any(n => n.ForeignKey == fk && n.Name != navigationToPrincipal)

--- a/test/EntityFramework.AzureTableStorage.Tests/Metadata/ETagConventionTest.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Metadata/ETagConventionTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Metadata
         {
             var entityType = new Model().AddEntityType("TestType");
             _convention.Apply(entityType);
-            var etagProp = entityType.GetProperty("ETag");
+            var etagProp = (IProperty)entityType.GetProperty("ETag");
             Assert.NotNull(etagProp);
             Assert.True(etagProp.IsShadowProperty);
             Assert.True(etagProp.IsConcurrencyToken);
@@ -29,7 +29,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Metadata
             entityType.GetOrAddProperty("ETag", typeof(int), shadowProperty: true);
 
             _convention.Apply(entityType);
-            var etagProp = entityType.GetProperty("ETag");
+            var etagProp = (IProperty)entityType.GetProperty("ETag");
             Assert.NotNull(etagProp);
             Assert.True(etagProp.IsShadowProperty);
             Assert.True(etagProp.IsConcurrencyToken);

--- a/test/EntityFramework.Tests/Metadata/BasicModelBuilderTest.cs
+++ b/test/EntityFramework.Tests/Metadata/BasicModelBuilderTest.cs
@@ -380,7 +380,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                     b.Property(typeof(string), "Bottom");
                 });
 
-            var entityType = model.GetEntityType(typeof(Quarks));
+            var entityType = (IEntityType)model.GetEntityType(typeof(Quarks));
 
             Assert.False(entityType.GetProperty("Up").IsNullable);
             Assert.True(entityType.GetProperty("Down").IsNullable);
@@ -406,7 +406,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                     b.Property(typeof(string), "Bottom").Required();
                 });
 
-            var entityType = model.GetEntityType(typeof(Quarks));
+            var entityType = (IEntityType)model.GetEntityType(typeof(Quarks));
 
             Assert.False(entityType.GetProperty("Up").IsNullable);
             Assert.False(entityType.GetProperty("Down").IsNullable);
@@ -432,7 +432,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                     b.Property(typeof(string), "Bottom").Required(false);
                 });
 
-            var entityType = model.GetEntityType(typeof(Quarks));
+            var entityType = (IEntityType)model.GetEntityType(typeof(Quarks));
 
             Assert.True(entityType.GetProperty("Up").IsNullable);
             Assert.True(entityType.GetProperty("Down").IsNullable);
@@ -520,7 +520,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                     b.Property(typeof(string), "Bottom").ConcurrencyToken(false);
                 });
 
-            var entityType = model.GetEntityType(typeof(Quarks));
+            var entityType = (IEntityType)model.GetEntityType(typeof(Quarks));
 
             Assert.False(entityType.GetProperty("Id").IsConcurrencyToken);
             Assert.True(entityType.GetProperty("Up").IsConcurrencyToken);
@@ -612,7 +612,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 b.Property(typeof(string), "Bottom").UseStoreDefault(false);
             });
 
-            var entityType = model.GetEntityType(typeof(Quarks));
+            var entityType = (IEntityType)model.GetEntityType(typeof(Quarks));
 
             Assert.False(entityType.GetProperty("Id").UseStoreDefault);
             Assert.True(entityType.GetProperty("Up").UseStoreDefault);
@@ -762,7 +762,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                     b.ForeignKey<Customer>(c => c.AnotherCustomerId).IsUnique();
                 });
 
-            var entityType = model.GetEntityType(typeof(Order));
+            var entityType = (IEntityType)model.GetEntityType(typeof(Order));
 
             Assert.Equal(2, entityType.ForeignKeys.Count());
             Assert.True(entityType.ForeignKeys.Last().IsUnique);
@@ -784,7 +784,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                     b.ForeignKey(typeof(Customer).FullName, "AnotherCustomerId").IsUnique();
                 });
 
-            var entityType = model.GetEntityType(typeof(Order));
+            var entityType = (IEntityType)model.GetEntityType(typeof(Order));
 
             Assert.Equal(2, entityType.ForeignKeys.Count());
             Assert.True(entityType.ForeignKeys.Last().IsUnique);
@@ -807,7 +807,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                         b.ForeignKey(typeof(Customer).FullName, "AnotherCustomerId").IsUnique();
                     });
 
-            var entityType = model.GetEntityType(typeof(Order));
+            var entityType = (IEntityType)model.GetEntityType(typeof(Order));
 
             Assert.Equal(2, entityType.ForeignKeys.Count());
             Assert.True(entityType.ForeignKeys.Last().IsUnique);
@@ -833,7 +833,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                     b.ForeignKey(typeof(Customer).FullName, "AnotherCustomerId").IsUnique();
                 });
 
-            var entityType = model.GetEntityType(typeof(Order));
+            var entityType = (IEntityType)model.GetEntityType(typeof(Order));
 
             Assert.Equal(2, entityType.ForeignKeys.Count());
             Assert.True(entityType.ForeignKeys.Last().IsUnique);
@@ -883,7 +883,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                     b.Index(ix => ix.Name).Annotation("A1", "V1");
                 });
 
-            var entityType = model.GetEntityType(typeof(Customer));
+            var entityType = (IEntityType)model.GetEntityType(typeof(Customer));
 
             Assert.Equal(2, entityType.Indexes.Count());
             Assert.True(entityType.Indexes.First().IsUnique);
@@ -905,7 +905,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                     b.Index("Name").Annotation("A1", "V1");
                 });
 
-            var entityType = model.GetEntityType(typeof(Customer));
+            var entityType = (IEntityType)model.GetEntityType(typeof(Customer));
 
             Assert.Equal(2, entityType.Indexes.Count());
             Assert.True(entityType.Indexes.First().IsUnique);

--- a/test/EntityFramework.Tests/Metadata/EntityTypeTest.cs
+++ b/test/EntityFramework.Tests/Metadata/EntityTypeTest.cs
@@ -274,13 +274,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var idProperty = entityType.GetOrAddProperty(Customer.IdProperty);
             var nameProperty = entityType.GetOrAddProperty(Customer.NameProperty);
 
-            Assert.False(idProperty.IsReadOnly);
-            Assert.False(nameProperty.IsReadOnly);
+            Assert.False(((IProperty)idProperty).IsReadOnly);
+            Assert.False(((IProperty)nameProperty).IsReadOnly);
 
             entityType.GetOrAddKey(new[] { idProperty, nameProperty });
 
-            Assert.True(idProperty.IsReadOnly);
-            Assert.True(nameProperty.IsReadOnly);
+            Assert.True(((IProperty)idProperty).IsReadOnly);
+            Assert.True(((IProperty)nameProperty).IsReadOnly);
 
             nameProperty.IsReadOnly = true;
 
@@ -288,8 +288,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 Strings.FormatKeyPropertyMustBeReadOnly(Customer.NameProperty.Name, typeof(Customer).FullName),
                 Assert.Throws<NotSupportedException>(() => nameProperty.IsReadOnly = false).Message);
 
-            Assert.True(idProperty.IsReadOnly);
-            Assert.True(nameProperty.IsReadOnly);
+            Assert.True(((IProperty)idProperty).IsReadOnly);
+            Assert.True(((IProperty)nameProperty).IsReadOnly);
         }
 
         [Fact]
@@ -743,7 +743,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.False(property1.IsShadowProperty);
             Assert.Equal("Id", property1.Name);
             Assert.Same(typeof(int), property1.PropertyType);
-            Assert.False(property1.IsConcurrencyToken);
+            Assert.False(((IProperty)property1).IsConcurrencyToken);
             Assert.Same(entityType, property1.EntityType);
 
             var property2 = entityType.AddProperty("Name", typeof(string));
@@ -765,7 +765,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         {
             var entityType = new EntityType(typeof(Customer), new Model());
 
-            var idProperty = entityType.GetOrAddProperty("Id", typeof(int));
+            var idProperty = (IProperty)entityType.GetOrAddProperty("Id", typeof(int));
 
             Assert.False(idProperty.IsShadowProperty);
             Assert.Equal("Id", idProperty.Name);
@@ -777,7 +777,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             Assert.Same(idProperty, entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true));
             Assert.False(idProperty.IsShadowProperty);
 
-            var nameProperty = entityType.GetOrAddProperty("Name", typeof(string), shadowProperty: true);
+            var nameProperty = (IProperty)entityType.GetOrAddProperty("Name", typeof(string), shadowProperty: true);
 
             Assert.True(nameProperty.IsShadowProperty);
             Assert.Equal("Name", nameProperty.Name);

--- a/test/EntityFramework.Tests/Metadata/IndexTest.cs
+++ b/test/EntityFramework.Tests/Metadata/IndexTest.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var index = new Index(new[] { property1, property2 });
 
             Assert.True(new[] { property1, property2 }.SequenceEqual(index.Properties));
-            Assert.False(index.IsUnique);
+            Assert.Null(index.IsUnique);
+            Assert.False(((IIndex)index).IsUnique);
         }
 
         [Fact]
@@ -34,7 +35,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             var index = new Index(new[] { property1, property2 }) { IsUnique = true, };
 
             Assert.True(new[] { property1, property2 }.SequenceEqual(index.Properties));
-            Assert.True(index.IsUnique);
+            Assert.True(index.IsUnique.Value);
         }
 
         [Fact]

--- a/test/EntityFramework.Tests/Metadata/ModelBuilderTest.cs
+++ b/test/EntityFramework.Tests/Metadata/ModelBuilderTest.cs
@@ -371,7 +371,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                     b.Property(typeof(string), "Bottom");
                 });
 
-            var entityType = model.GetEntityType(typeof(Quarks));
+            var entityType = (IEntityType)model.GetEntityType(typeof(Quarks));
 
             Assert.False(entityType.GetProperty("Up").IsNullable);
             Assert.True(entityType.GetProperty("Down").IsNullable);
@@ -397,7 +397,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                     b.Property(typeof(string), "Bottom").Required();
                 });
 
-            var entityType = model.GetEntityType(typeof(Quarks));
+            var entityType = (IEntityType)model.GetEntityType(typeof(Quarks));
 
             Assert.False(entityType.GetProperty("Up").IsNullable);
             Assert.False(entityType.GetProperty("Down").IsNullable);
@@ -423,7 +423,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                     b.Property(typeof(string), "Bottom").Required(false);
                 });
 
-            var entityType = model.GetEntityType(typeof(Quarks));
+            var entityType = (IEntityType)model.GetEntityType(typeof(Quarks));
 
             Assert.True(entityType.GetProperty("Up").IsNullable);
             Assert.True(entityType.GetProperty("Down").IsNullable);
@@ -509,7 +509,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                     b.Property(typeof(string), "Bottom").ConcurrencyToken(false);
                 });
 
-            var entityType = model.GetEntityType(typeof(Quarks));
+            var entityType = (IEntityType)model.GetEntityType(typeof(Quarks));
 
             Assert.False(entityType.GetProperty("Id").IsConcurrencyToken);
             Assert.True(entityType.GetProperty("Up").IsConcurrencyToken);
@@ -601,7 +601,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 b.Property(typeof(string), "Bottom").UseStoreDefault(false);
             });
 
-            var entityType = model.GetEntityType(typeof(Quarks));
+            var entityType = (IEntityType)model.GetEntityType(typeof(Quarks));
 
             Assert.False(entityType.GetProperty("Id").UseStoreDefault);
             Assert.True(entityType.GetProperty("Up").UseStoreDefault);
@@ -751,7 +751,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                     b.ForeignKey<Customer>(c => c.AnotherCustomerId).IsUnique();
                 });
 
-            var entityType = model.GetEntityType(typeof(Order));
+            var entityType = (IEntityType)model.GetEntityType(typeof(Order));
 
             Assert.Equal(2, entityType.ForeignKeys.Count());
             Assert.True(entityType.ForeignKeys.Last().IsUnique);
@@ -773,7 +773,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                     b.ForeignKey(typeof(Customer).FullName, "AnotherCustomerId").IsUnique();
                 });
 
-            var entityType = model.GetEntityType(typeof(Order));
+            var entityType = (IEntityType)model.GetEntityType(typeof(Order));
 
             Assert.Equal(2, entityType.ForeignKeys.Count());
             Assert.True(entityType.ForeignKeys.Last().IsUnique);
@@ -796,7 +796,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                         b.ForeignKey(typeof(Customer).FullName, "AnotherCustomerId").IsUnique();
                     });
 
-            var entityType = model.GetEntityType(typeof(Order).FullName);
+            var entityType = (IEntityType)model.GetEntityType(typeof(Order).FullName);
 
             Assert.Equal(2, entityType.ForeignKeys.Count());
             Assert.True(entityType.ForeignKeys.Last().IsUnique);
@@ -822,7 +822,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                     b.ForeignKey(typeof(Customer).FullName, "AnotherCustomerId").IsUnique();
                 });
 
-            var entityType = model.GetEntityType(typeof(Order));
+            var entityType = (IEntityType)model.GetEntityType(typeof(Order));
 
             Assert.Equal(2, entityType.ForeignKeys.Count());
             Assert.True(entityType.ForeignKeys.Last().IsUnique);
@@ -872,7 +872,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                     b.Index(ix => ix.Name).Annotation("A1", "V1");
                 });
 
-            var entityType = model.GetEntityType(typeof(Customer));
+            var entityType = (IEntityType)model.GetEntityType(typeof(Customer));
 
             Assert.Equal(2, entityType.Indexes.Count());
             Assert.True(entityType.Indexes.First().IsUnique);
@@ -894,7 +894,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                     b.Index("Name").Annotation("A1", "V1");
                 });
 
-            var entityType = model.GetEntityType(typeof(Customer));
+            var entityType = (IEntityType)model.GetEntityType(typeof(Customer));
 
             Assert.Equal(2, entityType.Indexes.Count());
             Assert.True(entityType.Indexes.First().IsUnique);
@@ -1618,7 +1618,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey<BigMak>(c => c.BurgerId)
                 .IsUnique();
 
-            var dependentType = model.GetEntityType(typeof(Pickle));
+            var dependentType = (IEntityType)model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
             var fk = dependentType.ForeignKeys.Single();
 
@@ -2754,7 +2754,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey<BigMak>(c => c.BurgerId)
                 .IsUnique();
 
-            var dependentType = model.GetEntityType(typeof(Pickle));
+            var dependentType = (IEntityType)model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
             var fk = dependentType.ForeignKeys.Single();
 
@@ -3827,7 +3827,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<Bun>()
                 .ForeignKey<BigMak>(c => c.BurgerId);
 
-            var dependentType = model.GetEntityType(typeof(Bun));
+            var dependentType = (IEntityType)model.GetEntityType(typeof(Bun));
             var principalType = model.GetEntityType(typeof(BigMak));
             var fk = dependentType.ForeignKeys.Single();
 
@@ -5929,7 +5929,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .OneToMany(e => e.Nobs, e => e.Hob)
                 .ForeignKey(e => new { e.HobId1, e.HobId2 });
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Nob));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
 
             Assert.True(entityType.GetProperty("HobId1").IsNullable);
             Assert.True(entityType.GetProperty("HobId1").IsNullable);
@@ -5946,7 +5946,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .OneToMany(e => e.Hobs, e => e.Nob)
                 .ForeignKey(e => new { e.NobId1, e.NobId2 });
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Hob));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
 
             Assert.False(entityType.GetProperty("NobId1").IsNullable);
             Assert.False(entityType.GetProperty("NobId1").IsNullable);
@@ -5963,7 +5963,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ManyToOne(e => e.Hob, e => e.Nobs)
                 .ForeignKey(e => new { e.HobId1, e.HobId2 });
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Nob));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
 
             Assert.True(entityType.GetProperty("HobId1").IsNullable);
             Assert.True(entityType.GetProperty("HobId1").IsNullable);
@@ -5980,7 +5980,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ManyToOne(e => e.Nob, e => e.Hobs)
                 .ForeignKey(e => new { e.NobId1, e.NobId2 });
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Hob));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
 
             Assert.False(entityType.GetProperty("NobId1").IsNullable);
             Assert.False(entityType.GetProperty("NobId1").IsNullable);
@@ -5997,7 +5997,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .OneToOne(e => e.Nob, e => e.Hob)
                 .ForeignKey<Nob>(e => new { e.HobId1, e.HobId2 });
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Nob));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
 
             Assert.True(entityType.GetProperty("HobId1").IsNullable);
             Assert.True(entityType.GetProperty("HobId1").IsNullable);
@@ -6014,7 +6014,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .OneToOne(e => e.Hob, e => e.Nob)
                 .ForeignKey<Hob>(e => new { e.NobId1, e.NobId2 });
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Hob));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
 
             Assert.False(entityType.GetProperty("NobId1").IsNullable);
             Assert.False(entityType.GetProperty("NobId1").IsNullable);
@@ -6032,7 +6032,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey(e => new { e.HobId1, e.HobId2 })
                 .Required();
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Nob));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
 
             Assert.False(entityType.GetProperty("HobId1").IsNullable);
             Assert.False(entityType.GetProperty("HobId1").IsNullable);
@@ -6050,7 +6050,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey(e => new { e.NobId1, e.NobId2 })
                 .Required(false);
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Hob));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
 
             Assert.True(entityType.GetProperty("NobId1").IsNullable);
             Assert.True(entityType.GetProperty("NobId1").IsNullable);
@@ -6068,7 +6068,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey(e => new { e.HobId1, e.HobId2 })
                 .Required();
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Nob));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
 
             Assert.False(entityType.GetProperty("HobId1").IsNullable);
             Assert.False(entityType.GetProperty("HobId1").IsNullable);
@@ -6086,7 +6086,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey(e => new { e.NobId1, e.NobId2 })
                 .Required(false);
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Hob));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
 
             Assert.True(entityType.GetProperty("NobId1").IsNullable);
             Assert.True(entityType.GetProperty("NobId1").IsNullable);
@@ -6104,7 +6104,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey<Nob>(e => new { e.HobId1, e.HobId2 })
                 .Required();
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Nob));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
 
             Assert.False(entityType.GetProperty("HobId1").IsNullable);
             Assert.False(entityType.GetProperty("HobId1").IsNullable);
@@ -6122,7 +6122,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey<Hob>(e => new { e.NobId1, e.NobId2 })
                 .Required(false);
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Hob));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
 
             Assert.True(entityType.GetProperty("NobId1").IsNullable);
             Assert.True(entityType.GetProperty("NobId1").IsNullable);
@@ -6215,7 +6215,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .OneToMany(e => e.Orders, e => e.Customer)
                 .Required(false));
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Order));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Order));
             Assert.False(entityType.ForeignKeys.Single().IsRequired);
         }
 
@@ -6275,7 +6275,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ManyToOne(e => e.Customer, e => e.Orders)
                 .Required(false));
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Order));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Order));
             Assert.False(entityType.ForeignKeys.Single().IsRequired);
         }
 

--- a/test/EntityFramework.Tests/Metadata/ModelConventions/ForeignKeyConventionTest.cs
+++ b/test/EntityFramework.Tests/Metadata/ModelConventions/ForeignKeyConventionTest.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
             var fkProperty = DependentType.GetOrAddProperty("No!No!", typeof(int), shadowProperty: true);
 
-            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(
+            var fk = (IForeignKey)new ForeignKeyConvention().FindOrCreateForeignKey(
                 PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { fkProperty }, new Property[0], isUnique: false);
 
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -126,7 +126,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
             var principalKeyProperty = PrincipalType.GetOrAddProperty("No!No!", typeof(int), shadowProperty: true);
 
-            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(
+            var fk = (IForeignKey)new ForeignKeyConvention().FindOrCreateForeignKey(
                 PrincipalType, DependentType, "SomeNav", "SomeInverse", new Property[0], new[] { principalKeyProperty }, isUnique: false);
 
             Assert.Same(fkProperty, fk.Properties.Single());
@@ -145,7 +145,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             var fkProperty = DependentType.GetOrAddProperty("No!", typeof(int), shadowProperty: true);
             var principalKeyProperty = PrincipalType.GetOrAddProperty("No!No!", typeof(int), shadowProperty: true);
 
-            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(
+            var fk = (IForeignKey)new ForeignKeyConvention().FindOrCreateForeignKey(
                 PrincipalType,
                 DependentType,
                 "SomeNav",
@@ -170,7 +170,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             var fkProperty1 = DependentType.GetOrAddProperty("ThatsNotTrue!", typeof(int), shadowProperty: true);
             var fkProperty2 = DependentType.GetOrAddProperty("ThatsImpossible!", typeof(int?), shadowProperty: true);
 
-            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(
+            var fk = (IForeignKey)new ForeignKeyConvention().FindOrCreateForeignKey(
                 PrincipalType,
                 DependentType,
                 "SomeNav",
@@ -204,7 +204,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             var principalKeyProperty1 = PrincipalType.GetOrAddProperty("SearchYourFeelings", typeof(int), shadowProperty: true);
             var principalKeyProperty2 = PrincipalType.GetOrAddProperty("YouKnowItToBeTrue!", typeof(int), shadowProperty: true);
 
-            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(
+            var fk = (IForeignKey)new ForeignKeyConvention().FindOrCreateForeignKey(
                 PrincipalType,
                 DependentType,
                 "SomeNav",
@@ -229,7 +229,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             DependentType.GetOrAddProperty("PrincipalEntityID", typeof(int), shadowProperty: true);
             DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
 
-            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: true);
+            var fk = (IForeignKey)new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: true);
 
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.ReferencedProperties.Single());
@@ -244,7 +244,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             DependentType.GetOrAddProperty("PrincipalEntityID", typeof(int), shadowProperty: true);
             DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
 
-            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: false);
+            var fk = (IForeignKey)new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: false);
 
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.ReferencedProperties.Single());
@@ -258,7 +258,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             var fkProperty = DependentType.GetOrAddProperty("PrincipalEntityID", typeof(int), shadowProperty: true);
             DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
 
-            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: true);
+            var fk = (IForeignKey)new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: true);
 
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.ReferencedProperties.Single());
@@ -271,7 +271,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         {
             var fkProperty = DependentType.GetOrAddProperty("PrincipalEntityPeEKaY", typeof(int), shadowProperty: true);
 
-            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: false);
+            var fk = (IForeignKey)new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: false);
 
             Assert.Same(fkProperty, fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.ReferencedProperties.Single());
@@ -282,7 +282,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         [Fact]
         public void Creates_foreign_key_based_on_nav_name_if_no_appropriate_property_is_found()
         {
-            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: false);
+            var fk = (IForeignKey)new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: false);
 
             Assert.Equal("SomeNavId", fk.Properties.Single().Name);
             Assert.Equal(typeof(int), fk.Properties.Single().PropertyType);
@@ -296,7 +296,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         [Fact]
         public void Creates_foreign_key_based_on_type_name_if_no_appropriate_property_is_found()
         {
-            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, null, null, isUnqiue: false);
+            var fk = (IForeignKey)new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, null, null, isUnqiue: false);
 
             Assert.Equal("PrincipalEntityId", fk.Properties.Single().Name);
             Assert.Equal(typeof(int), fk.Properties.Single().PropertyType);
@@ -314,7 +314,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             var fk = DependentType.GetOrAddForeignKey(fkProperty, PrincipalType.GetPrimaryKey());
             DependentType.AddNavigation("AnotherNav", fk, pointsToPrincipal: true);
 
-            var newFk = new ForeignKeyConvention().FindOrCreateForeignKey(
+            var newFk = (IForeignKey)new ForeignKeyConvention().FindOrCreateForeignKey(
                 PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { fkProperty }, new Property[0], isUnique: false);
 
             Assert.NotSame(fk, newFk);
@@ -331,7 +331,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             var fk = DependentType.GetOrAddForeignKey(fkProperty, PrincipalType.GetPrimaryKey());
             PrincipalType.AddNavigation("AnotherNav", fk, pointsToPrincipal: false);
 
-            var newFk = new ForeignKeyConvention().FindOrCreateForeignKey(
+            var newFk = (IForeignKey)new ForeignKeyConvention().FindOrCreateForeignKey(
                 PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { fkProperty }, new Property[0], isUnique: false);
 
             Assert.NotSame(fk, newFk);
@@ -348,7 +348,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
             var fk = DependentType.GetOrAddForeignKey(fkProperty, PrincipalType.GetPrimaryKey());
             fk.IsUnique = true;
 
-            var newFk = new ForeignKeyConvention().FindOrCreateForeignKey(
+            var newFk = (IForeignKey)new ForeignKeyConvention().FindOrCreateForeignKey(
                 PrincipalType, DependentType, "SomeNav", "SomeInverse", new[] { fkProperty }, new Property[0], isUnique: false);
 
             Assert.NotSame(fk, newFk);
@@ -361,7 +361,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata.ModelConventions
         [Fact]
         public void Creates_unique_foreign_key_using_dependent_PK_if_no_matching_FK_property_found()
         {
-            var fk = new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: true);
+            var fk = (IForeignKey)new ForeignKeyConvention().FindOrCreateForeignKey(PrincipalType, DependentType, "SomeNav", "SomeInverse", isUnqiue: true);
 
             Assert.Same(DependentType.GetPrimaryKey().Properties.Single(), fk.Properties.Single());
             Assert.Same(PrimaryKey, fk.ReferencedProperties.Single());

--- a/test/EntityFramework.Tests/Metadata/NonGenericRelationshipBuilderTest.cs
+++ b/test/EntityFramework.Tests/Metadata/NonGenericRelationshipBuilderTest.cs
@@ -727,7 +727,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey<BigMak>(c => c.BurgerId)
                 .IsUnique();
 
-            var dependentType = model.GetEntityType(typeof(Pickle));
+            var dependentType = (IEntityType)model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
             var fk = dependentType.ForeignKeys.Single();
 
@@ -1863,7 +1863,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey<BigMak>(c => c.BurgerId)
                 .IsUnique();
 
-            var dependentType = model.GetEntityType(typeof(Pickle));
+            var dependentType = (IEntityType)model.GetEntityType(typeof(Pickle));
             var principalType = model.GetEntityType(typeof(BigMak));
             var fk = dependentType.ForeignKeys.Single();
 
@@ -2936,7 +2936,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<Bun>()
                 .ForeignKey<BigMak>(c => c.BurgerId);
 
-            var dependentType = model.GetEntityType(typeof(Bun));
+            var dependentType = (IEntityType)model.GetEntityType(typeof(Bun));
             var principalType = model.GetEntityType(typeof(BigMak));
             var fk = dependentType.ForeignKeys.Single();
 
@@ -5038,7 +5038,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .OneToMany(typeof(Nob), "Nobs", "Hob")
                 .ForeignKey("HobId1", "HobId2");
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Nob));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
 
             Assert.True(entityType.GetProperty("HobId1").IsNullable);
             Assert.True(entityType.GetProperty("HobId1").IsNullable);
@@ -5055,7 +5055,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .OneToMany(typeof(Hob), "Hobs", "Nob")
                 .ForeignKey("NobId1", "NobId2");
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Hob));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
 
             Assert.False(entityType.GetProperty("NobId1").IsNullable);
             Assert.False(entityType.GetProperty("NobId1").IsNullable);
@@ -5072,7 +5072,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ManyToOne(typeof(Hob), "Hob", "Nobs")
                 .ForeignKey("HobId1", "HobId2");
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Nob));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
 
             Assert.True(entityType.GetProperty("HobId1").IsNullable);
             Assert.True(entityType.GetProperty("HobId1").IsNullable);
@@ -5089,7 +5089,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ManyToOne(typeof(Nob), "Nob", "Hobs")
                 .ForeignKey("NobId1", "NobId2");
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Hob));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
 
             Assert.False(entityType.GetProperty("NobId1").IsNullable);
             Assert.False(entityType.GetProperty("NobId1").IsNullable);
@@ -5106,7 +5106,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .OneToOne(typeof(Nob), "Nob", "Hob")
                 .ForeignKey(typeof(Nob), "HobId1", "HobId2");
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Nob));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
 
             Assert.True(entityType.GetProperty("HobId1").IsNullable);
             Assert.True(entityType.GetProperty("HobId1").IsNullable);
@@ -5123,7 +5123,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .OneToOne(typeof(Hob), "Hob", "Nob")
                 .ForeignKey(typeof(Hob), "NobId1", "NobId2");
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Hob));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
 
             Assert.False(entityType.GetProperty("NobId1").IsNullable);
             Assert.False(entityType.GetProperty("NobId1").IsNullable);
@@ -5141,7 +5141,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey("HobId1", "HobId2")
                 .Required();
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Nob));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
 
             Assert.False(entityType.GetProperty("HobId1").IsNullable);
             Assert.False(entityType.GetProperty("HobId1").IsNullable);
@@ -5159,7 +5159,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey("NobId1", "NobId2")
                 .Required(false);
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Hob));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
 
             Assert.True(entityType.GetProperty("NobId1").IsNullable);
             Assert.True(entityType.GetProperty("NobId1").IsNullable);
@@ -5177,7 +5177,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey("HobId1", "HobId2")
                 .Required();
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Nob));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
 
             Assert.False(entityType.GetProperty("HobId1").IsNullable);
             Assert.False(entityType.GetProperty("HobId1").IsNullable);
@@ -5195,7 +5195,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey("NobId1", "NobId2")
                 .Required(false);
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Hob));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
 
             Assert.True(entityType.GetProperty("NobId1").IsNullable);
             Assert.True(entityType.GetProperty("NobId1").IsNullable);
@@ -5213,7 +5213,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey(typeof(Nob), "HobId1", "HobId2")
                 .Required();
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Nob));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob));
 
             Assert.False(entityType.GetProperty("HobId1").IsNullable);
             Assert.False(entityType.GetProperty("HobId1").IsNullable);
@@ -5231,7 +5231,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey(typeof(Hob), "NobId1", "NobId2")
                 .Required(false);
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Hob));
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob));
 
             Assert.True(entityType.GetProperty("NobId1").IsNullable);
             Assert.True(entityType.GetProperty("NobId1").IsNullable);

--- a/test/EntityFramework.Tests/Metadata/PropertyTest.cs
+++ b/test/EntityFramework.Tests/Metadata/PropertyTest.cs
@@ -21,16 +21,38 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         [Fact]
         public void Default_nullability_of_property_is_based_on_nullability_of_CLR_type()
         {
-            Assert.True(new Property("Name", typeof(string), new Model().AddEntityType(typeof(object))).IsNullable);
-            Assert.True(new Property("Name", typeof(int?), new Model().AddEntityType(typeof(object))).IsNullable);
-            Assert.False(new Property("Name", typeof(int), new Model().AddEntityType(typeof(object))).IsNullable);
+            var stringProperty = new Property("Name", typeof(string), new Model().AddEntityType(typeof(object)));
+            var nullableIntProperty = new Property("Name", typeof(int?), new Model().AddEntityType(typeof(object)));
+            var intProperty = new Property("Name", typeof(int), new Model().AddEntityType(typeof(object)));
+
+            Assert.Null(stringProperty.IsNullable);
+            Assert.True(((IProperty)stringProperty).IsNullable);
+            Assert.Null(stringProperty.IsNullable);
+            Assert.True(((IProperty)nullableIntProperty).IsNullable);
+            Assert.Null(intProperty.IsNullable);
+            Assert.False(((IProperty)intProperty).IsNullable);
         }
 
         [Fact]
         public void Property_nullability_can_be_mutated()
         {
-            Assert.False(new Property("Name", typeof(string), new Model().AddEntityType(typeof(object))) { IsNullable = false }.IsNullable);
-            Assert.True(new Property("Name", typeof(int), new Model().AddEntityType(typeof(object))) { IsNullable = true }.IsNullable);
+            var stringProperty = new Property("Name", typeof(string), new Model().AddEntityType(typeof(object)));
+            var intProperty = new Property("Name", typeof(int), new Model().AddEntityType(typeof(object)));
+
+            stringProperty.IsNullable = false;
+            intProperty.IsNullable = true;
+            Assert.False(stringProperty.IsNullable.Value);
+            Assert.True(intProperty.IsNullable.Value);
+
+            stringProperty.IsNullable = true;
+            intProperty.IsNullable = false;
+            Assert.True(stringProperty.IsNullable.Value);
+            Assert.False(intProperty.IsNullable.Value);
+
+            stringProperty.IsNullable = null;
+            intProperty.IsNullable = null;
+            Assert.Null(stringProperty.IsNullable);
+            Assert.Null(intProperty.IsNullable);
         }
 
         [Fact]
@@ -49,38 +71,75 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         }
 
         [Fact]
+        public void Property_does_not_use_store_default_by_default()
+        {
+            var property = new Property("Name", typeof(string), new Model().AddEntityType(typeof(object)));
+
+            Assert.Null(property.UseStoreDefault);
+            Assert.False(((IProperty)property).UseStoreDefault);
+        }
+
+        [Fact]
+        public void Can_mark_property_as_using_store_default()
+        {
+            var property = new Property("Name", typeof(string), new Model().AddEntityType(typeof(Entity)));
+
+            property.UseStoreDefault = true;
+            Assert.True(property.UseStoreDefault.Value);
+
+            property.UseStoreDefault = false;
+            Assert.False(property.UseStoreDefault.Value);
+
+            property.UseStoreDefault = null;
+            Assert.Null(property.UseStoreDefault);
+        }
+
+        [Fact]
         public void Property_is_not_concurrency_token_by_default()
         {
-            Assert.False(new Property("Name", typeof(string), new Model().AddEntityType(typeof(object))).IsConcurrencyToken);
+            var property = new Property("Name", typeof(string), new Model().AddEntityType(typeof(object)));
+
+            Assert.Null(property.IsConcurrencyToken);
+            Assert.False(((IProperty)property).IsConcurrencyToken);
         }
 
         [Fact]
         public void Can_mark_property_as_concurrency_token()
         {
             var property = new Property("Name", typeof(string), new Model().AddEntityType(typeof(Entity)));
-            Assert.False(property.IsConcurrencyToken);
 
             property.IsConcurrencyToken = true;
-            Assert.True(property.IsConcurrencyToken);
+            Assert.True(property.IsConcurrencyToken.Value);
+
+            property.IsConcurrencyToken = false;
+            Assert.False(property.IsConcurrencyToken.Value);
+
+            property.IsConcurrencyToken = null;
+            Assert.Null(property.IsConcurrencyToken);
         }
 
         [Fact]
         public void Property_is_read_write_by_default()
         {
-            Assert.False(new Property("Name", typeof(string), new Model().AddEntityType(typeof(object))).IsReadOnly);
+            var property = new Property("Name", typeof(string), new Model().AddEntityType(typeof(object)));
+
+            Assert.Null(property.IsReadOnly);
+            Assert.False(((IProperty)property).IsReadOnly);
         }
 
         [Fact]
         public void Property_can_be_marked_as_read_only()
         {
             var property = new Property("Name", typeof(string), new Model().AddEntityType(typeof(object)));
-            Assert.False(property.IsReadOnly);
 
             property.IsReadOnly = true;
-            Assert.True(property.IsReadOnly);
+            Assert.True(property.IsReadOnly.Value);
 
             property.IsReadOnly = false;
-            Assert.False(property.IsReadOnly);
+            Assert.False(property.IsReadOnly.Value);
+
+            property.IsReadOnly = null;
+            Assert.Null(property.IsReadOnly);
         }
 
         [Fact]

--- a/test/EntityFramework.Tests/Metadata/StringRelationshipBuilderTest.cs
+++ b/test/EntityFramework.Tests/Metadata/StringRelationshipBuilderTest.cs
@@ -727,7 +727,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey<BigMak>(c => c.BurgerId)
                 .IsUnique();
 
-            var dependentType = model.GetEntityType(typeof(Pickle).FullName);
+            var dependentType = (IEntityType)model.GetEntityType(typeof(Pickle).FullName);
             var principalType = model.GetEntityType(typeof(BigMak).FullName);
             var fk = dependentType.ForeignKeys.Single();
 
@@ -1863,7 +1863,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey<BigMak>(c => c.BurgerId)
                 .IsUnique();
 
-            var dependentType = model.GetEntityType(typeof(Pickle).FullName);
+            var dependentType = (IEntityType)model.GetEntityType(typeof(Pickle).FullName);
             var principalType = model.GetEntityType(typeof(BigMak).FullName);
             var fk = dependentType.ForeignKeys.Single();
 
@@ -2936,7 +2936,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .Entity<Bun>()
                 .ForeignKey<BigMak>(c => c.BurgerId);
 
-            var dependentType = model.GetEntityType(typeof(Bun).FullName);
+            var dependentType = (IEntityType)model.GetEntityType(typeof(Bun).FullName);
             var principalType = model.GetEntityType(typeof(BigMak).FullName);
             var fk = dependentType.ForeignKeys.Single();
 
@@ -5038,7 +5038,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .OneToMany(typeof(Nob).FullName, "Nobs", "Hob")
                 .ForeignKey("HobId1", "HobId2");
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Nob).FullName);
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob).FullName);
 
             Assert.True(entityType.GetProperty("HobId1").IsNullable);
             Assert.True(entityType.GetProperty("HobId1").IsNullable);
@@ -5055,7 +5055,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .OneToMany(typeof(Hob).FullName, "Hobs", "Nob")
                 .ForeignKey("NobId1", "NobId2");
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Hob).FullName);
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob).FullName);
 
             Assert.False(entityType.GetProperty("NobId1").IsNullable);
             Assert.False(entityType.GetProperty("NobId1").IsNullable);
@@ -5072,7 +5072,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ManyToOne(typeof(Hob).FullName, "Hob", "Nobs")
                 .ForeignKey("HobId1", "HobId2");
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Nob).FullName);
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob).FullName);
 
             Assert.True(entityType.GetProperty("HobId1").IsNullable);
             Assert.True(entityType.GetProperty("HobId1").IsNullable);
@@ -5089,7 +5089,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ManyToOne(typeof(Nob).FullName, "Nob", "Hobs")
                 .ForeignKey("NobId1", "NobId2");
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Hob).FullName);
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob).FullName);
 
             Assert.False(entityType.GetProperty("NobId1").IsNullable);
             Assert.False(entityType.GetProperty("NobId1").IsNullable);
@@ -5106,7 +5106,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .OneToOne(typeof(Nob).FullName, "Nob", "Hob")
                 .ForeignKey(typeof(Nob).FullName, "HobId1", "HobId2");
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Nob).FullName);
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob).FullName);
 
             Assert.True(entityType.GetProperty("HobId1").IsNullable);
             Assert.True(entityType.GetProperty("HobId1").IsNullable);
@@ -5123,7 +5123,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .OneToOne(typeof(Hob).FullName, "Hob", "Nob")
                 .ForeignKey(typeof(Hob).FullName, "NobId1", "NobId2");
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Hob).FullName);
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob).FullName);
 
             Assert.False(entityType.GetProperty("NobId1").IsNullable);
             Assert.False(entityType.GetProperty("NobId1").IsNullable);
@@ -5141,7 +5141,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey("HobId1", "HobId2")
                 .Required();
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Nob).FullName);
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob).FullName);
 
             Assert.False(entityType.GetProperty("HobId1").IsNullable);
             Assert.False(entityType.GetProperty("HobId1").IsNullable);
@@ -5159,7 +5159,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey("NobId1", "NobId2")
                 .Required(false);
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Hob).FullName);
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob).FullName);
 
             Assert.True(entityType.GetProperty("NobId1").IsNullable);
             Assert.True(entityType.GetProperty("NobId1").IsNullable);
@@ -5177,7 +5177,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey("HobId1", "HobId2")
                 .Required();
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Nob).FullName);
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob).FullName);
 
             Assert.False(entityType.GetProperty("HobId1").IsNullable);
             Assert.False(entityType.GetProperty("HobId1").IsNullable);
@@ -5195,7 +5195,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey("NobId1", "NobId2")
                 .Required(false);
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Hob).FullName);
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob).FullName);
 
             Assert.True(entityType.GetProperty("NobId1").IsNullable);
             Assert.True(entityType.GetProperty("NobId1").IsNullable);
@@ -5213,7 +5213,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey(typeof(Nob).FullName, "HobId1", "HobId2")
                 .Required();
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Nob).FullName);
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Nob).FullName);
 
             Assert.False(entityType.GetProperty("HobId1").IsNullable);
             Assert.False(entityType.GetProperty("HobId1").IsNullable);
@@ -5231,7 +5231,7 @@ namespace Microsoft.Data.Entity.Tests.Metadata
                 .ForeignKey(typeof(Hob).FullName, "NobId1", "NobId2")
                 .Required(false);
 
-            var entityType = modelBuilder.Model.GetEntityType(typeof(Hob).FullName);
+            var entityType = (IEntityType)modelBuilder.Model.GetEntityType(typeof(Hob).FullName);
 
             Assert.True(entityType.GetProperty("NobId1").IsNullable);
             Assert.True(entityType.GetProperty("NobId1").IsNullable);


### PR DESCRIPTION
Adding information to the model about whether the bool metadata properties have been set to default values explicitly.
