### PR TITLE
[SMALL] Error with the Error Page, "How Meta" - Enable error page for non-collection queries

### DIFF
--- a/src/EntityFramework/Query/EntityQueryExecutor.cs
+++ b/src/EntityFramework/Query/EntityQueryExecutor.cs
@@ -71,9 +71,23 @@ namespace Microsoft.Data.Entity.Query
 
             LogQueryModel(queryModel);
 
-            var enumerable = _context.Configuration.DataStore.Query<T>(queryModel);
+            try
+            { 
+                var enumerable = _context.Configuration.DataStore.Query<T>(queryModel);
 
-            return new EnumerableExceptionInterceptor<T>(enumerable, _context, _logger);
+                return new EnumerableExceptionInterceptor<T>(enumerable, _context, _logger);
+            }
+            catch (Exception ex)
+            {
+                _logger.Value.Write(
+                    TraceType.Error,
+                    0,
+                    new DataStoreErrorLogState(_context.GetType()),
+                    ex,
+                    (state, exception) => string.Format("{0}" + Environment.NewLine + "{1}", Strings.LogExceptionDuringQueryIteration, exception.ToString()));
+
+                throw;
+            }
         }
 
         public virtual IAsyncEnumerable<T> AsyncExecuteCollection<T>(
@@ -85,11 +99,25 @@ namespace Microsoft.Data.Entity.Query
 
             LogQueryModel(queryModel);
 
-            var asyncEnumerable
-                = _context.Configuration.DataStore
-                    .AsyncQuery<T>(queryModel, cancellationToken);
+            try
+            {
+                var asyncEnumerable
+                    = _context.Configuration.DataStore
+                        .AsyncQuery<T>(queryModel, cancellationToken);
 
-            return new AsyncEnumerableExceptionInterceptor<T>(asyncEnumerable, _context, _logger);
+                return new AsyncEnumerableExceptionInterceptor<T>(asyncEnumerable, _context, _logger);
+            }
+            catch (Exception ex)
+            {
+                _logger.Value.Write(
+                    TraceType.Error,
+                    0,
+                    new DataStoreErrorLogState(_context.GetType()),
+                    ex,
+                    (state, exception) => string.Format("{0}" + Environment.NewLine + "{1}", Strings.LogExceptionDuringQueryIteration, exception.ToString()));
+
+                throw;
+            }
         }
 
         private void LogQueryModel(QueryModel queryModel)

--- a/test/EntityFramework.FunctionalTests/DataStoreErrorLogStateTest.cs
+++ b/test/EntityFramework.FunctionalTests/DataStoreErrorLogStateTest.cs
@@ -90,6 +90,30 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     .Wait());
         }
 
+        [Fact]
+        public void Query_logs_DataStoreErrorLogState_during_single()
+        {
+            Query_logs_DataStoreErrorLogState(c => c.Blogs.FirstOrDefault());
+        }
+
+        [Fact]
+        public void Query_logs_DataStoreErrorLogState_during_single_async()
+        {
+            Query_logs_DataStoreErrorLogState(c => c.Blogs.FirstOrDefaultAsync().Wait());
+        }
+
+        [Fact]
+        public void Query_logs_DataStoreErrorLogState_during_scalar()
+        {
+            Query_logs_DataStoreErrorLogState(c => c.Blogs.Count());
+        }
+
+        [Fact]
+        public void Query_logs_DataStoreErrorLogState_during_scalar_async()
+        {
+            Query_logs_DataStoreErrorLogState(c => c.Blogs.CountAsync().Wait());
+        }
+
         public void Query_logs_DataStoreErrorLogState(Action<BloggingContext> test)
         {
             var loggerFactory = new TestLoggerFactory();


### PR DESCRIPTION
Exceptions from queries that return a single entity or a scalar value were not triggering the error page as they do not go through MoveNext in our wrapping Enumerable. Adding logging to handle these cases (and applicable unit tests).
