### PR TITLE
Autumn Cleaning - Cleanup in Database Error Page

### DIFF
--- a/src/Microsoft.AspNet.Diagnostics.Entity/DatabaseErrorPageExtensions.cs
+++ b/src/Microsoft.AspNet.Diagnostics.Entity/DatabaseErrorPageExtensions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.AspNet.Builder
         {
             Check.NotNull(builder, "builder");
 
-            return builder.UseDatabaseErrorPage(new DatabaseErrorPageOptions());
+            return builder.UseDatabaseErrorPage(DatabaseErrorPageOptions.ShowAll);
         }
 
         public static IApplicationBuilder UseDatabaseErrorPage([NotNull] this IApplicationBuilder builder, [NotNull] DatabaseErrorPageOptions options)
@@ -21,11 +21,14 @@ namespace Microsoft.AspNet.Builder
             Check.NotNull(builder, "builder");
             Check.NotNull(options, "options");
 
-            /* TODO: Development, Staging, or Production
-            string appMode = new AppProperties(builder.Properties).Get<string>(Constants.HostAppMode);
-            bool isDevMode = string.Equals(Constants.DevMode, appMode, StringComparison.Ordinal);*/
-            var isDevMode = true;
-            return builder.UseMiddleware<DatabaseErrorPageMiddleware>(options, isDevMode);
+            builder = builder.UseMiddleware<DatabaseErrorPageMiddleware>(options);
+
+            if(options.EnableMigrationCommands)
+            {
+                builder.UseMigrationsEndPoint(new MigrationsEndPointOptions { Path = options.MigrationsEndPointPath });
+            }
+
+            return builder;
         }
     }
 }

--- a/src/Microsoft.AspNet.Diagnostics.Entity/DatabaseErrorPageMiddleware.cs
+++ b/src/Microsoft.AspNet.Diagnostics.Entity/DatabaseErrorPageMiddleware.cs
@@ -26,15 +26,10 @@ namespace Microsoft.AspNet.Diagnostics.Entity
         private readonly ILogger _logger;
         private readonly DataStoreErrorLoggerProvider _loggerProvider;
 
-        public DatabaseErrorPageMiddleware([NotNull] RequestDelegate next, [NotNull] ILoggerFactory loggerFactory, [NotNull] DatabaseErrorPageOptions options, bool isDevMode)
+        public DatabaseErrorPageMiddleware([NotNull] RequestDelegate next, [NotNull] ILoggerFactory loggerFactory, [NotNull] DatabaseErrorPageOptions options)
         {
             Check.NotNull(next, "next");
             Check.NotNull(options, "options");
-
-            if (isDevMode)
-            {
-                options.SetDefaultVisibility(isVisible: true);
-            }
 
             _next = next;
             _options = options;

--- a/src/Microsoft.AspNet.Diagnostics.Entity/DatabaseErrorPageOptions.cs
+++ b/src/Microsoft.AspNet.Diagnostics.Entity/DatabaseErrorPageOptions.cs
@@ -14,6 +14,20 @@ namespace Microsoft.AspNet.Diagnostics.Entity
         private bool? _listMigrations;
         private bool? _enableMigrationCommands;
 
+        public static DatabaseErrorPageOptions ShowAll
+        {
+            get
+            {
+                // We don't use a static instance because it's mutable.
+                return new DatabaseErrorPageOptions()
+                {
+                    ShowExceptionDetails = true,
+                    ListMigrations = true,
+                    EnableMigrationCommands = true
+                };
+            }
+        }
+
         public virtual PathString MigrationsEndPointPath
         {
             get { return _migrationsEndPointPath; }

--- a/test/Microsoft.AspNet.Diagnostics.Entity.FunctionalTests/DatabaseErrorPageMiddlewareTest.cs
+++ b/test/Microsoft.AspNet.Diagnostics.Entity.FunctionalTests/DatabaseErrorPageMiddlewareTest.cs
@@ -235,7 +235,9 @@ namespace Microsoft.AspNet.Diagnostics.Entity.Tests
                     services.AddInstance<DbContextOptions>(new DbContextOptions().UseSqlServer(database.Connection.ConnectionString));
                 });
 
-                app.UseDatabaseErrorPage(new DatabaseErrorPageOptions { MigrationsEndPointPath = new PathString(migrationsEndpoint) });
+                var options = DatabaseErrorPageOptions.ShowAll;
+                options.MigrationsEndPointPath = new PathString(migrationsEndpoint);
+                app.UseDatabaseErrorPage(options);
 
                 app.UseMiddleware<PendingMigrationsMiddleware>();
             });
@@ -381,8 +383,6 @@ namespace Microsoft.AspNet.Diagnostics.Entity.Tests
                         new DbContextOptions()
                             .UseSqlServer(database.Connection.ConnectionString));
                 });
-
-                app.UseMigrationsEndPoint();
 
                 app.UseDatabaseErrorPage();
 


### PR DESCRIPTION
Removing isDevMode since this concept is handled in Startup.cs.
Keeping UseDatabaseErrorPage behavior consistent with general ASP.NET UseErrorPage:
- Parameterless overload results in everything being shown.
- Adding DatabaseErrorPageOptions.ShowAll pattern to allow UseDatabaseErrorPage(DatabaseErrorPageOptions.ShowAll)

Updating UseDatabaseErrorPage to also register the Migrations Endpoint when it's going to be needed
