### PR TITLE
Cool checks - performance fix for #848

### DIFF
--- a/src/EntityFramework.AzureTableStorage/Utilities/Check.cs
+++ b/src/EntityFramework.AzureTableStorage/Utilities/Check.cs
@@ -14,10 +14,9 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Utilities
         [ContractAnnotation("value:null => halt")]
         public static T NotNull<T>([NoEnumeration] T value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (ReferenceEquals(value, null))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentNullException(parameterName);
             }
 
@@ -27,11 +26,11 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Utilities
         [ContractAnnotation("value:null => halt")]
         public static IReadOnlyList<T> NotEmpty<T>(IReadOnlyList<T> value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
             NotNull(value, parameterName);
 
             if (value.Count == 0)
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatCollectionArgumentIsEmpty(parameterName));
             }
 
@@ -41,24 +40,21 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Utilities
         [ContractAnnotation("value:null => halt")]
         public static string NotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            if (ReferenceEquals(parameterName, null))
-            {
-                throw new ArgumentNullException("parameterName");
-            }
-
-            if (parameterName.Length == 0)
-            {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty("parameterName"));
-            }
-
+            Exception e = null;
             if (ReferenceEquals(value, null))
             {
-                throw new ArgumentNullException(parameterName);
+                e = new ArgumentNullException(parameterName);
             }
 
             if (value.Length == 0)
             {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+                e = new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+            }
+
+            if (e != null)
+            {
+                NotEmpty(parameterName, "parameterName");
+                throw e;
             }
 
             return value;
@@ -67,10 +63,9 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Utilities
         public static T IsDefined<T>(T value, [InvokerParameterName] [NotNull] string parameterName)
             where T : struct
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (!Enum.IsDefined(typeof(T), value))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatInvalidEnumValue(parameterName, typeof(T)));
             }
 

--- a/src/EntityFramework.Commands/Utilities/Check.cs
+++ b/src/EntityFramework.Commands/Utilities/Check.cs
@@ -14,10 +14,9 @@ namespace Microsoft.Data.Entity.Commands.Utilities
         [ContractAnnotation("value:null => halt")]
         public static T NotNull<T>([NoEnumeration] T value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (ReferenceEquals(value, null))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentNullException(parameterName);
             }
 
@@ -27,11 +26,11 @@ namespace Microsoft.Data.Entity.Commands.Utilities
         [ContractAnnotation("value:null => halt")]
         public static IReadOnlyList<T> NotEmpty<T>(IReadOnlyList<T> value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
             NotNull(value, parameterName);
 
             if (value.Count == 0)
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatCollectionArgumentIsEmpty(parameterName));
             }
 
@@ -41,24 +40,21 @@ namespace Microsoft.Data.Entity.Commands.Utilities
         [ContractAnnotation("value:null => halt")]
         public static string NotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            if (ReferenceEquals(parameterName, null))
-            {
-                throw new ArgumentNullException("parameterName");
-            }
-
-            if (parameterName.Length == 0)
-            {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty("parameterName"));
-            }
-
+            Exception e = null;
             if (ReferenceEquals(value, null))
             {
-                throw new ArgumentNullException(parameterName);
+                e = new ArgumentNullException(parameterName);
             }
 
             if (value.Length == 0)
             {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+                e = new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+            }
+
+            if (e != null)
+            {
+                NotEmpty(parameterName, "parameterName");
+                throw e;
             }
 
             return value;
@@ -67,10 +63,9 @@ namespace Microsoft.Data.Entity.Commands.Utilities
         public static T IsDefined<T>(T value, [InvokerParameterName] [NotNull] string parameterName)
             where T : struct
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (!Enum.IsDefined(typeof(T), value))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatInvalidEnumValue(parameterName, typeof(T)));
             }
 

--- a/src/EntityFramework.InMemory/Utilities/Check.cs
+++ b/src/EntityFramework.InMemory/Utilities/Check.cs
@@ -13,10 +13,9 @@ namespace Microsoft.Data.Entity.InMemory.Utilities
         [ContractAnnotation("value:null => halt")]
         public static T NotNull<T>([NoEnumeration] T value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (ReferenceEquals(value, null))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentNullException(parameterName);
             }
 
@@ -26,24 +25,21 @@ namespace Microsoft.Data.Entity.InMemory.Utilities
         [ContractAnnotation("value:null => halt")]
         public static string NotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            if (ReferenceEquals(parameterName, null))
-            {
-                throw new ArgumentNullException("parameterName");
-            }
-
-            if (parameterName.Length == 0)
-            {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty("parameterName"));
-            }
-
+            Exception e = null;
             if (ReferenceEquals(value, null))
             {
-                throw new ArgumentNullException(parameterName);
+                e = new ArgumentNullException(parameterName);
             }
 
             if (value.Length == 0)
             {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+                e = new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+            }
+
+            if (e != null)
+            {
+                NotEmpty(parameterName, "parameterName");
+                throw e;
             }
 
             return value;
@@ -52,10 +48,9 @@ namespace Microsoft.Data.Entity.InMemory.Utilities
         public static T IsDefined<T>(T value, [InvokerParameterName] [NotNull] string parameterName)
             where T : struct
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (!Enum.IsDefined(typeof(T), value))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatInvalidEnumValue(parameterName, typeof(T)));
             }
 

--- a/src/EntityFramework.Migrations/Utilities/Check.cs
+++ b/src/EntityFramework.Migrations/Utilities/Check.cs
@@ -13,10 +13,9 @@ namespace Microsoft.Data.Entity.Migrations.Utilities
         [ContractAnnotation("value:null => halt")]
         public static T NotNull<T>([NoEnumeration] T value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (ReferenceEquals(value, null))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentNullException(parameterName);
             }
 
@@ -26,24 +25,21 @@ namespace Microsoft.Data.Entity.Migrations.Utilities
         [ContractAnnotation("value:null => halt")]
         public static string NotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            if (ReferenceEquals(parameterName, null))
-            {
-                throw new ArgumentNullException("parameterName");
-            }
-
-            if (parameterName.Length == 0)
-            {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty("parameterName"));
-            }
-
+            Exception e = null;
             if (ReferenceEquals(value, null))
             {
-                throw new ArgumentNullException(parameterName);
+                e = new ArgumentNullException(parameterName);
             }
 
             if (value.Length == 0)
             {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+                e = new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+            }
+
+            if (e != null)
+            {
+                NotEmpty(parameterName, "parameterName");
+                throw e;
             }
 
             return value;
@@ -52,10 +48,9 @@ namespace Microsoft.Data.Entity.Migrations.Utilities
         public static T IsDefined<T>(T value, [InvokerParameterName] [NotNull] string parameterName)
             where T : struct
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (!Enum.IsDefined(typeof(T), value))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatInvalidEnumValue(parameterName, typeof(T)));
             }
 

--- a/src/EntityFramework.Redis/Utilities/Check.cs
+++ b/src/EntityFramework.Redis/Utilities/Check.cs
@@ -13,10 +13,9 @@ namespace Microsoft.Data.Entity.Redis.Utilities
         [ContractAnnotation("value:null => halt")]
         public static T NotNull<T>([NoEnumeration] T value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (ReferenceEquals(value, null))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentNullException(parameterName);
             }
 
@@ -26,24 +25,21 @@ namespace Microsoft.Data.Entity.Redis.Utilities
         [ContractAnnotation("value:null => halt")]
         public static string NotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            if (ReferenceEquals(parameterName, null))
-            {
-                throw new ArgumentNullException("parameterName");
-            }
-
-            if (parameterName.Length == 0)
-            {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty("parameterName"));
-            }
-
+            Exception e = null;
             if (ReferenceEquals(value, null))
             {
-                throw new ArgumentNullException(parameterName);
+                e = new ArgumentNullException(parameterName);
             }
 
             if (value.Length == 0)
             {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+                e = new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+            }
+
+            if (e != null)
+            {
+                NotEmpty(parameterName, "parameterName");
+                throw e;
             }
 
             return value;
@@ -52,10 +48,9 @@ namespace Microsoft.Data.Entity.Redis.Utilities
         public static T IsDefined<T>(T value, [InvokerParameterName] [NotNull] string parameterName)
             where T : struct
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (!Enum.IsDefined(typeof(T), value))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatInvalidEnumValue(parameterName, typeof(T)));
             }
 

--- a/src/EntityFramework.Relational/Utilities/Check.cs
+++ b/src/EntityFramework.Relational/Utilities/Check.cs
@@ -14,10 +14,9 @@ namespace Microsoft.Data.Entity.Relational.Utilities
         [ContractAnnotation("value:null => halt")]
         public static T NotNull<T>([NoEnumeration] T value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (ReferenceEquals(value, null))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentNullException(parameterName);
             }
 
@@ -30,11 +29,10 @@ namespace Microsoft.Data.Entity.Relational.Utilities
             [InvokerParameterName] [NotNull] string parameterName,
             [NotNull] string propertyName)
         {
-            NotEmpty(parameterName, "parameterName");
-            NotEmpty(propertyName, "propertyName");
-
             if (ReferenceEquals(value, null))
             {
+                NotEmpty(parameterName, "parameterName");
+                NotEmpty(propertyName, "propertyName");
                 throw new ArgumentException(Strings.FormatArgumentPropertyNull(propertyName, parameterName));
             }
 
@@ -44,11 +42,11 @@ namespace Microsoft.Data.Entity.Relational.Utilities
         [ContractAnnotation("value:null => halt")]
         public static IReadOnlyList<T> NotEmpty<T>(IReadOnlyList<T> value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
             NotNull(value, parameterName);
 
             if (value.Count == 0)
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatCollectionArgumentIsEmpty(parameterName));
             }
 
@@ -58,24 +56,21 @@ namespace Microsoft.Data.Entity.Relational.Utilities
         [ContractAnnotation("value:null => halt")]
         public static string NotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            if (ReferenceEquals(parameterName, null))
-            {
-                throw new ArgumentNullException("parameterName");
-            }
-
-            if (parameterName.Length == 0)
-            {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty("parameterName"));
-            }
-
+            Exception e = null;
             if (ReferenceEquals(value, null))
             {
-                throw new ArgumentNullException(parameterName);
+                e = new ArgumentNullException(parameterName);
             }
 
             if (value.Length == 0)
             {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+                e = new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+            }
+
+            if (e != null)
+            {
+                NotEmpty(parameterName, "parameterName");
+                throw e;
             }
 
             return value;
@@ -83,19 +78,10 @@ namespace Microsoft.Data.Entity.Relational.Utilities
 
         public static string NullButNotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            if (ReferenceEquals(parameterName, null))
-            {
-                throw new ArgumentNullException("parameterName");
-            }
-
-            if (parameterName.Length == 0)
-            {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty("parameterName"));
-            }
-
             if (!ReferenceEquals(value, null)
                 && value.Length == 0)
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
             }
 
@@ -105,10 +91,9 @@ namespace Microsoft.Data.Entity.Relational.Utilities
         public static T IsDefined<T>(T value, [InvokerParameterName] [NotNull] string parameterName)
             where T : struct
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (!Enum.IsDefined(typeof(T), value))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatInvalidEnumValue(parameterName, typeof(T)));
             }
 

--- a/src/EntityFramework.SQLite/Utilities/Check.cs
+++ b/src/EntityFramework.SQLite/Utilities/Check.cs
@@ -13,10 +13,9 @@ namespace Microsoft.Data.Entity.SQLite.Utilities
         [ContractAnnotation("value:null => halt")]
         public static T NotNull<T>([NoEnumeration] T value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (ReferenceEquals(value, null))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentNullException(parameterName);
             }
 
@@ -26,24 +25,21 @@ namespace Microsoft.Data.Entity.SQLite.Utilities
         [ContractAnnotation("value:null => halt")]
         public static string NotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            if (ReferenceEquals(parameterName, null))
-            {
-                throw new ArgumentNullException("parameterName");
-            }
-
-            if (parameterName.Length == 0)
-            {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty("parameterName"));
-            }
-
+            Exception e = null;
             if (ReferenceEquals(value, null))
             {
-                throw new ArgumentNullException(parameterName);
+                e = new ArgumentNullException(parameterName);
             }
 
             if (value.Length == 0)
             {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+                e = new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+            }
+
+            if (e != null)
+            {
+                NotEmpty(parameterName, "parameterName");
+                throw e;
             }
 
             return value;
@@ -52,10 +48,10 @@ namespace Microsoft.Data.Entity.SQLite.Utilities
         public static T IsDefined<T>(T value, [InvokerParameterName] [NotNull] string parameterName)
             where T : struct
         {
-            NotEmpty(parameterName, "parameterName");
 
             if (!Enum.IsDefined(typeof(T), value))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatInvalidEnumValue(parameterName, typeof(T)));
             }
 

--- a/src/EntityFramework.SqlServer/Utilities/Check.cs
+++ b/src/EntityFramework.SqlServer/Utilities/Check.cs
@@ -14,10 +14,9 @@ namespace Microsoft.Data.Entity.SqlServer.Utilities
         [ContractAnnotation("value:null => halt")]
         public static T NotNull<T>([NoEnumeration] T value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (ReferenceEquals(value, null))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentNullException(parameterName);
             }
 
@@ -27,11 +26,11 @@ namespace Microsoft.Data.Entity.SqlServer.Utilities
         [ContractAnnotation("value:null => halt")]
         public static IReadOnlyList<T> NotEmpty<T>(IReadOnlyList<T> value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
             NotNull(value, parameterName);
 
             if (value.Count == 0)
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatCollectionArgumentIsEmpty(parameterName));
             }
 
@@ -41,24 +40,22 @@ namespace Microsoft.Data.Entity.SqlServer.Utilities
         [ContractAnnotation("value:null => halt")]
         public static string NotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            if (ReferenceEquals(parameterName, null))
-            {
-                throw new ArgumentNullException("parameterName");
-            }
 
-            if (parameterName.Length == 0)
-            {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty("parameterName"));
-            }
-
+            Exception e = null;
             if (ReferenceEquals(value, null))
             {
-                throw new ArgumentNullException(parameterName);
+                e = new ArgumentNullException(parameterName);
             }
 
             if (value.Length == 0)
             {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+                e = new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+            }
+
+            if (e != null)
+            {
+                NotEmpty(parameterName, "parameterName");
+                throw e;
             }
 
             return value;
@@ -66,19 +63,10 @@ namespace Microsoft.Data.Entity.SqlServer.Utilities
 
         public static string NullButNotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            if (ReferenceEquals(parameterName, null))
-            {
-                throw new ArgumentNullException("parameterName");
-            }
-
-            if (parameterName.Length == 0)
-            {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty("parameterName"));
-            }
-
             if (!ReferenceEquals(value, null)
                 && value.Length == 0)
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
             }
 
@@ -88,10 +76,9 @@ namespace Microsoft.Data.Entity.SqlServer.Utilities
         public static T IsDefined<T>(T value, [InvokerParameterName] [NotNull] string parameterName)
             where T : struct
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (!Enum.IsDefined(typeof(T), value))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatInvalidEnumValue(parameterName, typeof(T)));
             }
 

--- a/src/EntityFramework/Utilities/Check.cs
+++ b/src/EntityFramework/Utilities/Check.cs
@@ -15,10 +15,9 @@ namespace Microsoft.Data.Entity.Utilities
         [ContractAnnotation("value:null => halt")]
         public static T NotNull<T>([NoEnumeration] T value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (ReferenceEquals(value, null))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentNullException(parameterName);
             }
 
@@ -28,11 +27,11 @@ namespace Microsoft.Data.Entity.Utilities
         [ContractAnnotation("value:null => halt")]
         public static IReadOnlyCollection<T> NotEmpty<T>(IReadOnlyCollection<T> value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
             NotNull(value, parameterName);
 
             if (value.Count == 0)
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatCollectionArgumentIsEmpty(parameterName));
             }
 
@@ -42,11 +41,11 @@ namespace Microsoft.Data.Entity.Utilities
         [ContractAnnotation("value:null => halt")]
         public static IList<T> NotEmpty<T>(IList<T> value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
             NotNull(value, parameterName);
 
             if (value.Count == 0)
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatCollectionArgumentIsEmpty(parameterName));
             }
 
@@ -62,24 +61,21 @@ namespace Microsoft.Data.Entity.Utilities
         [ContractAnnotation("value:null => halt")]
         public static string NotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            if (ReferenceEquals(parameterName, null))
-            {
-                throw new ArgumentNullException("parameterName");
-            }
-
-            if (parameterName.Length == 0)
-            {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty("parameterName"));
-            }
-
+            Exception e = null;
             if (ReferenceEquals(value, null))
             {
-                throw new ArgumentNullException(parameterName);
+                e = new ArgumentNullException(parameterName);
             }
 
             if (value.Length == 0)
             {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+                e = new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+            }
+
+            if (e != null)
+            {
+                NotEmpty(parameterName, "parameterName");
+                throw e;
             }
 
             return value;
@@ -88,11 +84,11 @@ namespace Microsoft.Data.Entity.Utilities
         public static IReadOnlyList<T> HasNoNulls<T>(IReadOnlyList<T> value, [InvokerParameterName] [NotNull] string parameterName)
             where T : class
         {
-            NotEmpty(parameterName, "parameterName");
             NotNull(value, parameterName);
 
             if (value.Any(e => e == null))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatCollectionArgumentContainsNulls(parameterName));
             }
 
@@ -102,10 +98,9 @@ namespace Microsoft.Data.Entity.Utilities
         public static T IsDefined<T>(T value, [InvokerParameterName] [NotNull] string parameterName)
             where T : struct
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (!Enum.IsDefined(typeof(T), value))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatInvalidEnumValue(parameterName, typeof(T)));
             }
 


### PR DESCRIPTION
Parameter names will only be checked for NotEmpty if the value is not compliant to the check at hand. This may not be the expected behavior when the code was first written but I think it's reasonable given that:
- It's perf-optimized for the positive case.
- The required checks can still be in place in the hot path without causing perf interference.
