### PR TITLE
Colder code - performance improvement of parameter checking helpers

### DIFF
--- a/src/EntityFramework.AzureTableStorage/Utilities/Check.cs
+++ b/src/EntityFramework.AzureTableStorage/Utilities/Check.cs
@@ -14,10 +14,9 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Utilities
         [ContractAnnotation("value:null => halt")]
         public static T NotNull<T>([NoEnumeration] T value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (ReferenceEquals(value, null))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentNullException(parameterName);
             }
 
@@ -27,11 +26,11 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Utilities
         [ContractAnnotation("value:null => halt")]
         public static IReadOnlyList<T> NotEmpty<T>(IReadOnlyList<T> value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
             NotNull(value, parameterName);
 
             if (value.Count == 0)
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatCollectionArgumentIsEmpty(parameterName));
             }
 
@@ -41,24 +40,20 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Utilities
         [ContractAnnotation("value:null => halt")]
         public static string NotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            if (ReferenceEquals(parameterName, null))
-            {
-                throw new ArgumentNullException("parameterName");
-            }
-
-            if (parameterName.Length == 0)
-            {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty("parameterName"));
-            }
-
+            Exception e = null;
             if (ReferenceEquals(value, null))
             {
-                throw new ArgumentNullException(parameterName);
+                e = new ArgumentNullException(parameterName);
+            }
+            else if (value.Trim().Length == 0)
+            {
+                e = new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
             }
 
-            if (value.Length == 0)
+            if (e != null)
             {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+                NotEmpty(parameterName, "parameterName");
+                throw e;
             }
 
             return value;
@@ -88,10 +83,9 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Utilities
         public static T IsDefined<T>(T value, [InvokerParameterName] [NotNull] string parameterName)
             where T : struct
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (!Enum.IsDefined(typeof(T), value))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatInvalidEnumValue(parameterName, typeof(T)));
             }
 

--- a/src/EntityFramework.Commands/Utilities/Check.cs
+++ b/src/EntityFramework.Commands/Utilities/Check.cs
@@ -14,10 +14,9 @@ namespace Microsoft.Data.Entity.Commands.Utilities
         [ContractAnnotation("value:null => halt")]
         public static T NotNull<T>([NoEnumeration] T value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (ReferenceEquals(value, null))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentNullException(parameterName);
             }
 
@@ -27,11 +26,11 @@ namespace Microsoft.Data.Entity.Commands.Utilities
         [ContractAnnotation("value:null => halt")]
         public static IReadOnlyList<T> NotEmpty<T>(IReadOnlyList<T> value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
             NotNull(value, parameterName);
 
             if (value.Count == 0)
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatCollectionArgumentIsEmpty(parameterName));
             }
 
@@ -41,24 +40,20 @@ namespace Microsoft.Data.Entity.Commands.Utilities
         [ContractAnnotation("value:null => halt")]
         public static string NotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            if (ReferenceEquals(parameterName, null))
-            {
-                throw new ArgumentNullException("parameterName");
-            }
-
-            if (parameterName.Length == 0)
-            {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty("parameterName"));
-            }
-
+            Exception e = null;
             if (ReferenceEquals(value, null))
             {
-                throw new ArgumentNullException(parameterName);
+                e = new ArgumentNullException(parameterName);
+            }
+            else if (value.Trim().Length == 0)
+            {
+                e = new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
             }
 
-            if (value.Length == 0)
+            if (e != null)
             {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+                NotEmpty(parameterName, "parameterName");
+                throw e;
             }
 
             return value;
@@ -67,10 +62,9 @@ namespace Microsoft.Data.Entity.Commands.Utilities
         public static T IsDefined<T>(T value, [InvokerParameterName] [NotNull] string parameterName)
             where T : struct
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (!Enum.IsDefined(typeof(T), value))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatInvalidEnumValue(parameterName, typeof(T)));
             }
 

--- a/src/EntityFramework.InMemory/Utilities/Check.cs
+++ b/src/EntityFramework.InMemory/Utilities/Check.cs
@@ -13,10 +13,9 @@ namespace Microsoft.Data.Entity.InMemory.Utilities
         [ContractAnnotation("value:null => halt")]
         public static T NotNull<T>([NoEnumeration] T value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (ReferenceEquals(value, null))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentNullException(parameterName);
             }
 
@@ -26,24 +25,20 @@ namespace Microsoft.Data.Entity.InMemory.Utilities
         [ContractAnnotation("value:null => halt")]
         public static string NotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            if (ReferenceEquals(parameterName, null))
-            {
-                throw new ArgumentNullException("parameterName");
-            }
-
-            if (parameterName.Length == 0)
-            {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty("parameterName"));
-            }
-
+            Exception e = null;
             if (ReferenceEquals(value, null))
             {
-                throw new ArgumentNullException(parameterName);
+                e = new ArgumentNullException(parameterName);
+            }
+            else if (value.Trim().Length == 0)
+            {
+                e = new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
             }
 
-            if (value.Length == 0)
+            if (e != null)
             {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+                NotEmpty(parameterName, "parameterName");
+                throw e;
             }
 
             return value;
@@ -52,10 +47,9 @@ namespace Microsoft.Data.Entity.InMemory.Utilities
         public static T IsDefined<T>(T value, [InvokerParameterName] [NotNull] string parameterName)
             where T : struct
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (!Enum.IsDefined(typeof(T), value))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatInvalidEnumValue(parameterName, typeof(T)));
             }
 

--- a/src/EntityFramework.Migrations/Utilities/Check.cs
+++ b/src/EntityFramework.Migrations/Utilities/Check.cs
@@ -13,10 +13,9 @@ namespace Microsoft.Data.Entity.Migrations.Utilities
         [ContractAnnotation("value:null => halt")]
         public static T NotNull<T>([NoEnumeration] T value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (ReferenceEquals(value, null))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentNullException(parameterName);
             }
 
@@ -26,24 +25,20 @@ namespace Microsoft.Data.Entity.Migrations.Utilities
         [ContractAnnotation("value:null => halt")]
         public static string NotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            if (ReferenceEquals(parameterName, null))
-            {
-                throw new ArgumentNullException("parameterName");
-            }
-
-            if (parameterName.Length == 0)
-            {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty("parameterName"));
-            }
-
+            Exception e = null;
             if (ReferenceEquals(value, null))
             {
-                throw new ArgumentNullException(parameterName);
+                e = new ArgumentNullException(parameterName);
+            }
+            else if (value.Trim().Length == 0)
+            {
+                e = new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
             }
 
-            if (value.Length == 0)
+            if (e != null)
             {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+                NotEmpty(parameterName, "parameterName");
+                throw e;
             }
 
             return value;
@@ -52,10 +47,9 @@ namespace Microsoft.Data.Entity.Migrations.Utilities
         public static T IsDefined<T>(T value, [InvokerParameterName] [NotNull] string parameterName)
             where T : struct
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (!Enum.IsDefined(typeof(T), value))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatInvalidEnumValue(parameterName, typeof(T)));
             }
 

--- a/src/EntityFramework.Redis/Utilities/Check.cs
+++ b/src/EntityFramework.Redis/Utilities/Check.cs
@@ -13,10 +13,9 @@ namespace Microsoft.Data.Entity.Redis.Utilities
         [ContractAnnotation("value:null => halt")]
         public static T NotNull<T>([NoEnumeration] T value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (ReferenceEquals(value, null))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentNullException(parameterName);
             }
 
@@ -26,24 +25,20 @@ namespace Microsoft.Data.Entity.Redis.Utilities
         [ContractAnnotation("value:null => halt")]
         public static string NotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            if (ReferenceEquals(parameterName, null))
-            {
-                throw new ArgumentNullException("parameterName");
-            }
-
-            if (parameterName.Length == 0)
-            {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty("parameterName"));
-            }
-
+            Exception e = null;
             if (ReferenceEquals(value, null))
             {
-                throw new ArgumentNullException(parameterName);
+                e = new ArgumentNullException(parameterName);
+            }
+            else if (value.Trim().Length == 0)
+            {
+                e = new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
             }
 
-            if (value.Length == 0)
+            if (e != null)
             {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+                NotEmpty(parameterName, "parameterName");
+                throw e;
             }
 
             return value;
@@ -52,10 +47,9 @@ namespace Microsoft.Data.Entity.Redis.Utilities
         public static T IsDefined<T>(T value, [InvokerParameterName] [NotNull] string parameterName)
             where T : struct
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (!Enum.IsDefined(typeof(T), value))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatInvalidEnumValue(parameterName, typeof(T)));
             }
 

--- a/src/EntityFramework.Relational/Utilities/Check.cs
+++ b/src/EntityFramework.Relational/Utilities/Check.cs
@@ -14,10 +14,9 @@ namespace Microsoft.Data.Entity.Relational.Utilities
         [ContractAnnotation("value:null => halt")]
         public static T NotNull<T>([NoEnumeration] T value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (ReferenceEquals(value, null))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentNullException(parameterName);
             }
 
@@ -30,11 +29,10 @@ namespace Microsoft.Data.Entity.Relational.Utilities
             [InvokerParameterName] [NotNull] string parameterName,
             [NotNull] string propertyName)
         {
-            NotEmpty(parameterName, "parameterName");
-            NotEmpty(propertyName, "propertyName");
-
             if (ReferenceEquals(value, null))
             {
+                NotEmpty(parameterName, "parameterName");
+                NotEmpty(propertyName, "propertyName");
                 throw new ArgumentException(Strings.FormatArgumentPropertyNull(propertyName, parameterName));
             }
 
@@ -44,11 +42,11 @@ namespace Microsoft.Data.Entity.Relational.Utilities
         [ContractAnnotation("value:null => halt")]
         public static IReadOnlyList<T> NotEmpty<T>(IReadOnlyList<T> value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
             NotNull(value, parameterName);
 
             if (value.Count == 0)
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatCollectionArgumentIsEmpty(parameterName));
             }
 
@@ -58,24 +56,20 @@ namespace Microsoft.Data.Entity.Relational.Utilities
         [ContractAnnotation("value:null => halt")]
         public static string NotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            if (ReferenceEquals(parameterName, null))
-            {
-                throw new ArgumentNullException("parameterName");
-            }
-
-            if (parameterName.Length == 0)
-            {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty("parameterName"));
-            }
-
+            Exception e = null;
             if (ReferenceEquals(value, null))
             {
-                throw new ArgumentNullException(parameterName);
+                e = new ArgumentNullException(parameterName);
+            }
+            else if (value.Trim().Length == 0)
+            {
+                e = new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
             }
 
-            if (value.Length == 0)
+            if (e != null)
             {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+                NotEmpty(parameterName, "parameterName");
+                throw e;
             }
 
             return value;
@@ -83,19 +77,10 @@ namespace Microsoft.Data.Entity.Relational.Utilities
 
         public static string NullButNotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            if (ReferenceEquals(parameterName, null))
-            {
-                throw new ArgumentNullException("parameterName");
-            }
-
-            if (parameterName.Length == 0)
-            {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty("parameterName"));
-            }
-
             if (!ReferenceEquals(value, null)
                 && value.Length == 0)
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
             }
 
@@ -105,10 +90,9 @@ namespace Microsoft.Data.Entity.Relational.Utilities
         public static T IsDefined<T>(T value, [InvokerParameterName] [NotNull] string parameterName)
             where T : struct
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (!Enum.IsDefined(typeof(T), value))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatInvalidEnumValue(parameterName, typeof(T)));
             }
 

--- a/src/EntityFramework.SQLite/Utilities/Check.cs
+++ b/src/EntityFramework.SQLite/Utilities/Check.cs
@@ -13,10 +13,9 @@ namespace Microsoft.Data.Entity.SQLite.Utilities
         [ContractAnnotation("value:null => halt")]
         public static T NotNull<T>([NoEnumeration] T value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (ReferenceEquals(value, null))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentNullException(parameterName);
             }
 
@@ -26,24 +25,20 @@ namespace Microsoft.Data.Entity.SQLite.Utilities
         [ContractAnnotation("value:null => halt")]
         public static string NotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            if (ReferenceEquals(parameterName, null))
-            {
-                throw new ArgumentNullException("parameterName");
-            }
-
-            if (parameterName.Length == 0)
-            {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty("parameterName"));
-            }
-
+            Exception e = null;
             if (ReferenceEquals(value, null))
             {
-                throw new ArgumentNullException(parameterName);
+                e = new ArgumentNullException(parameterName);
+            }
+            else if (value.Trim().Length == 0)
+            {
+                e = new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
             }
 
-            if (value.Length == 0)
+            if (e != null)
             {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+                NotEmpty(parameterName, "parameterName");
+                throw e;
             }
 
             return value;
@@ -52,10 +47,10 @@ namespace Microsoft.Data.Entity.SQLite.Utilities
         public static T IsDefined<T>(T value, [InvokerParameterName] [NotNull] string parameterName)
             where T : struct
         {
-            NotEmpty(parameterName, "parameterName");
 
             if (!Enum.IsDefined(typeof(T), value))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatInvalidEnumValue(parameterName, typeof(T)));
             }
 

--- a/src/EntityFramework.SqlServer/Utilities/Check.cs
+++ b/src/EntityFramework.SqlServer/Utilities/Check.cs
@@ -14,10 +14,9 @@ namespace Microsoft.Data.Entity.SqlServer.Utilities
         [ContractAnnotation("value:null => halt")]
         public static T NotNull<T>([NoEnumeration] T value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (ReferenceEquals(value, null))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentNullException(parameterName);
             }
 
@@ -27,11 +26,11 @@ namespace Microsoft.Data.Entity.SqlServer.Utilities
         [ContractAnnotation("value:null => halt")]
         public static IReadOnlyList<T> NotEmpty<T>(IReadOnlyList<T> value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
             NotNull(value, parameterName);
 
             if (value.Count == 0)
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatCollectionArgumentIsEmpty(parameterName));
             }
 
@@ -41,24 +40,21 @@ namespace Microsoft.Data.Entity.SqlServer.Utilities
         [ContractAnnotation("value:null => halt")]
         public static string NotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            if (ReferenceEquals(parameterName, null))
-            {
-                throw new ArgumentNullException("parameterName");
-            }
 
-            if (parameterName.Length == 0)
-            {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty("parameterName"));
-            }
-
+            Exception e = null;
             if (ReferenceEquals(value, null))
             {
-                throw new ArgumentNullException(parameterName);
+                e = new ArgumentNullException(parameterName);
+            }
+            else if (value.Trim().Length == 0)
+            {
+                e = new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
             }
 
-            if (value.Length == 0)
+            if (e != null)
             {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+                NotEmpty(parameterName, "parameterName");
+                throw e;
             }
 
             return value;
@@ -66,19 +62,10 @@ namespace Microsoft.Data.Entity.SqlServer.Utilities
 
         public static string NullButNotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            if (ReferenceEquals(parameterName, null))
-            {
-                throw new ArgumentNullException("parameterName");
-            }
-
-            if (parameterName.Length == 0)
-            {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty("parameterName"));
-            }
-
             if (!ReferenceEquals(value, null)
                 && value.Length == 0)
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
             }
 
@@ -88,10 +75,9 @@ namespace Microsoft.Data.Entity.SqlServer.Utilities
         public static T IsDefined<T>(T value, [InvokerParameterName] [NotNull] string parameterName)
             where T : struct
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (!Enum.IsDefined(typeof(T), value))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatInvalidEnumValue(parameterName, typeof(T)));
             }
 

--- a/src/EntityFramework/Utilities/Check.cs
+++ b/src/EntityFramework/Utilities/Check.cs
@@ -15,10 +15,9 @@ namespace Microsoft.Data.Entity.Utilities
         [ContractAnnotation("value:null => halt")]
         public static T NotNull<T>([NoEnumeration] T value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (ReferenceEquals(value, null))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentNullException(parameterName);
             }
 
@@ -28,11 +27,11 @@ namespace Microsoft.Data.Entity.Utilities
         [ContractAnnotation("value:null => halt")]
         public static IReadOnlyCollection<T> NotEmpty<T>(IReadOnlyCollection<T> value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
             NotNull(value, parameterName);
 
             if (value.Count == 0)
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatCollectionArgumentIsEmpty(parameterName));
             }
 
@@ -42,11 +41,11 @@ namespace Microsoft.Data.Entity.Utilities
         [ContractAnnotation("value:null => halt")]
         public static IList<T> NotEmpty<T>(IList<T> value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            NotEmpty(parameterName, "parameterName");
             NotNull(value, parameterName);
 
             if (value.Count == 0)
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatCollectionArgumentIsEmpty(parameterName));
             }
 
@@ -62,24 +61,20 @@ namespace Microsoft.Data.Entity.Utilities
         [ContractAnnotation("value:null => halt")]
         public static string NotEmpty(string value, [InvokerParameterName] [NotNull] string parameterName)
         {
-            if (ReferenceEquals(parameterName, null))
-            {
-                throw new ArgumentNullException("parameterName");
-            }
-
-            if (parameterName.Length == 0)
-            {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty("parameterName"));
-            }
-
+            Exception e = null;
             if (ReferenceEquals(value, null))
             {
-                throw new ArgumentNullException(parameterName);
+                e = new ArgumentNullException(parameterName);
+            }
+            else if (value.Trim().Length == 0)
+            {
+                e = new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
             }
 
-            if (value.Length == 0)
+            if (e != null)
             {
-                throw new ArgumentException(Strings.FormatArgumentIsEmpty(parameterName));
+                NotEmpty(parameterName, "parameterName");
+                throw e;
             }
 
             return value;
@@ -88,11 +83,11 @@ namespace Microsoft.Data.Entity.Utilities
         public static IReadOnlyList<T> HasNoNulls<T>(IReadOnlyList<T> value, [InvokerParameterName] [NotNull] string parameterName)
             where T : class
         {
-            NotEmpty(parameterName, "parameterName");
             NotNull(value, parameterName);
 
             if (value.Any(e => e == null))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatCollectionArgumentContainsNulls(parameterName));
             }
 
@@ -102,10 +97,9 @@ namespace Microsoft.Data.Entity.Utilities
         public static T IsDefined<T>(T value, [InvokerParameterName] [NotNull] string parameterName)
             where T : struct
         {
-            NotEmpty(parameterName, "parameterName");
-
             if (!Enum.IsDefined(typeof(T), value))
             {
+                NotEmpty(parameterName, "parameterName");
                 throw new ArgumentException(Strings.FormatInvalidEnumValue(parameterName, typeof(T)));
             }
 

--- a/test/EntityFramework.Tests/Utilities/CheckTest.cs
+++ b/test/EntityFramework.Tests/Utilities/CheckTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.Entity.Tests.Utilities
         [Fact]
         public void Not_null_throws_when_arg_name_empty()
         {
-            Assert.Throws<ArgumentException>(() => Check.NotNull(new object(), string.Empty));
+            Assert.Throws<ArgumentException>(() => Check.NotNull(null as object, string.Empty));
         }
 
         [Fact]
@@ -38,7 +38,7 @@ namespace Microsoft.Data.Entity.Tests.Utilities
         public void Not_empty_throws_when_parameter_name_null()
         {
             // ReSharper disable once AssignNullToNotNullAttribute
-            Assert.Throws<ArgumentNullException>(() => Check.NotEmpty("42", null));
+            Assert.Throws<ArgumentNullException>(() => Check.NotEmpty(null, null));
         }
 
         [Fact]
@@ -58,7 +58,7 @@ namespace Microsoft.Data.Entity.Tests.Utilities
         [Fact]
         public void Generic_Not_empty_throws_when_arg_name_empty()
         {
-            Assert.Throws<ArgumentException>(() => Check.NotEmpty(new[] { string.Empty }, string.Empty));
+            Assert.Throws<ArgumentException>(() => Check.NotEmpty(null, string.Empty));
         }
 
         [Fact]


### PR DESCRIPTION
This is a fix for bug #848. Parameter names will only be checked for NotEmpty if the value is not compliant to the check at hand. This may not be the expected behavior when the code was first written but I think it's reasonable given that:
- It's perf-optimized for the positive case.
- The required checks can still be in place in the hot path without causing perf interference.

All tests passing.
