### PR TITLE
Migration Fixes - Getting a ModelDiffer and usings in generated code

### DIFF
--- a/src/EntityFramework.Commands/MigrationTool.cs
+++ b/src/EntityFramework.Commands/MigrationTool.cs
@@ -47,11 +47,11 @@ namespace Microsoft.Data.Entity.Commands
                     extension.MigrationNamespace = rootNamespace + ".Migrations";
                 }
 
-                var serviceProvider = configuration.Services.ServiceProvider;
+                var migrator = CreateMigrator(context);
                 var scaffolder = new MigrationScaffolder(
                     configuration,
-                    serviceProvider.GetService<MigrationAssembly>(),
-                    serviceProvider.GetService<ModelDiffer>(),
+                    migrator.MigrationAssembly,
+                    migrator.ModelDiffer,
                     new CSharpMigrationCodeGenerator(new CSharpModelCodeGenerator()));
 
                 var migration = scaffolder.ScaffoldMigration(migrationName);
@@ -174,7 +174,8 @@ namespace Microsoft.Data.Entity.Commands
 
         private Migrator CreateMigrator(DbContext context)
         {
-            return context.Configuration.Services.ServiceProvider.GetService<Migrator>();
+            var services = (MigrationsDataStoreServices)context.Configuration.DataStoreServices;
+            return services.Migrator;
         }
 
         private IEnumerable<Type> GetMigrationTypes()

--- a/src/EntityFramework.Migrations/EntityFramework.Migrations.csproj
+++ b/src/EntityFramework.Migrations/EntityFramework.Migrations.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Infrastructure\MigrationAssembly.cs" />
     <Compile Include="Infrastructure\MigrationMetadataExtensions.cs" />
     <Compile Include="Infrastructure\MigrationInfo.cs" />
+    <Compile Include="Infrastructure\MigrationsDataStoreServices.cs" />
     <Compile Include="Infrastructure\Migrator.cs" />
     <Compile Include="Infrastructure\MigratorLoggerEventIds.cs" />
     <Compile Include="Infrastructure\MigratorLoggerExtensions.cs" />
@@ -104,6 +105,7 @@
       <DependentUpon>Strings.resx</DependentUpon>
     </Compile>
     <Compile Include="DatabaseModelModifier.cs" />
+    <Compile Include="RelationalDatabaseMigrationsExtensions.cs" />
     <Compile Include="Utilities\AssemblyExtensions.cs" />
     <Compile Include="Utilities\Check.cs" />
     <Compile Include="Utilities\DbContextConfigurationExtensions.cs" />

--- a/src/EntityFramework.Migrations/Infrastructure/MigrationsDataStoreServices.cs
+++ b/src/EntityFramework.Migrations/Infrastructure/MigrationsDataStoreServices.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Storage;
+
+namespace Microsoft.Data.Entity.Migrations.Infrastructure
+{
+    public abstract class MigrationsDataStoreServices : DataStoreServices
+    {
+        public abstract Migrator Migrator { get; }
+    }
+}

--- a/src/EntityFramework.Migrations/ModelCodeGenerator.cs
+++ b/src/EntityFramework.Migrations/ModelCodeGenerator.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Data.Entity.Migrations
         {
             return new[]
                 {
+                    "Microsoft.Data.Entity",
                     "Microsoft.Data.Entity.Metadata",
                     "Microsoft.Data.Entity.Migrations.Infrastructure",
                     "System"

--- a/src/EntityFramework.Migrations/RelationalDatabaseMigrationsExtensions.cs
+++ b/src/EntityFramework.Migrations/RelationalDatabaseMigrationsExtensions.cs
@@ -17,8 +17,8 @@ namespace Microsoft.Data.Entity
             Check.NotNull(database, "database");
 
             var config = ((IDbContextConfigurationAdapter)database).Configuration;
-            var migrator = config.Services.ServiceProvider.GetService<Migrator>();
-            migrator.ApplyMigrations();
+            var services = (MigrationsDataStoreServices)config.DataStoreServices;
+            services.Migrator.ApplyMigrations();
         }
     }
 }

--- a/src/EntityFramework.SQLite/Extensions/SQLiteEntityServicesBuilderExtensions.cs
+++ b/src/EntityFramework.SQLite/Extensions/SQLiteEntityServicesBuilderExtensions.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddScoped<SQLiteConnection>()
                 .AddScoped<SQLiteMigrationOperationSqlGeneratorFactory>()
                 .AddScoped<SQLiteDataStoreCreator>()
-                .AddScoped<Migrator, SQLiteMigrator>()
+                .AddScoped<SQLiteMigrator>()
                 // TODO: Move to an AddMigrations extension method?
                 // Issue #556
                 .AddScoped<ModelDiffer>()

--- a/src/EntityFramework.SQLite/SQLiteDataStoreServices.cs
+++ b/src/EntityFramework.SQLite/SQLiteDataStoreServices.cs
@@ -5,13 +5,14 @@ using JetBrains.Annotations;
 using Microsoft.Data.Entity.Identity;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Migrations.Infrastructure;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.SQLite.Utilities;
 using Microsoft.Data.Entity.Storage;
 
 namespace Microsoft.Data.Entity.SQLite
 {
-    public class SQLiteDataStoreServices : DataStoreServices
+    public class SQLiteDataStoreServices : MigrationsDataStoreServices
     {
         private readonly SQLiteDataStore _store;
         private readonly SQLiteDataStoreCreator _creator;
@@ -19,6 +20,7 @@ namespace Microsoft.Data.Entity.SQLite
         private readonly SQLiteValueGeneratorCache _valueGeneratorCache;
         private readonly RelationalDatabase _database;
         private readonly ModelBuilderFactory _modelBuilderFactory;
+        private readonly SQLiteMigrator _migrator;
 
         public SQLiteDataStoreServices(
             [NotNull] SQLiteDataStore store,
@@ -26,7 +28,8 @@ namespace Microsoft.Data.Entity.SQLite
             [NotNull] SQLiteConnection connection,
             [NotNull] SQLiteValueGeneratorCache valueGeneratorCache,
             [NotNull] RelationalDatabase database,
-            [NotNull] ModelBuilderFactory modelBuilderFactory)
+            [NotNull] ModelBuilderFactory modelBuilderFactory,
+            [NotNull] SQLiteMigrator migrator)
         {
             Check.NotNull(store, "store");
             Check.NotNull(creator, "creator");
@@ -34,6 +37,7 @@ namespace Microsoft.Data.Entity.SQLite
             Check.NotNull(valueGeneratorCache, "valueGeneratorCache");
             Check.NotNull(database, "database");
             Check.NotNull(modelBuilderFactory, "modelBuilderFactory");
+            Check.NotNull(migrator, "migrator");
 
             _store = store;
             _creator = creator;
@@ -41,6 +45,7 @@ namespace Microsoft.Data.Entity.SQLite
             _valueGeneratorCache = valueGeneratorCache;
             _database = database;
             _modelBuilderFactory = modelBuilderFactory;
+            _migrator = migrator;
         }
 
         public override DataStore Store
@@ -71,6 +76,11 @@ namespace Microsoft.Data.Entity.SQLite
         public override IModelBuilderFactory ModelBuilderFactory
         {
             get { return _modelBuilderFactory; }
+        }
+
+        public override Migrator Migrator
+        {
+            get { return _migrator; }
         }
     }
 }

--- a/src/EntityFramework.SqlServer/Extensions/SqlServerEntityServicesBuilderExtensions.cs
+++ b/src/EntityFramework.SqlServer/Extensions/SqlServerEntityServicesBuilderExtensions.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddScoped<SqlServerDataStoreCreator>()
                 .AddScoped<MigrationAssembly>()
                 .AddScoped<HistoryRepository>()
-                .AddScoped<Migrator, SqlServerMigrator>();
+                .AddScoped<SqlServerMigrator>();
 
             return builder;
         }

--- a/src/EntityFramework.SqlServer/SqlServerDataStoreServices.cs
+++ b/src/EntityFramework.SqlServer/SqlServerDataStoreServices.cs
@@ -5,13 +5,14 @@ using JetBrains.Annotations;
 using Microsoft.Data.Entity.Identity;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Migrations.Infrastructure;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.SqlServer.Utilities;
 using Microsoft.Data.Entity.Storage;
 
 namespace Microsoft.Data.Entity.SqlServer
 {
-    public class SqlServerDataStoreServices : DataStoreServices
+    public class SqlServerDataStoreServices : MigrationsDataStoreServices
     {
         private readonly SqlServerDataStore _store;
         private readonly SqlServerDataStoreCreator _creator;
@@ -19,6 +20,7 @@ namespace Microsoft.Data.Entity.SqlServer
         private readonly SqlServerValueGeneratorCache _valueGeneratorCache;
         private readonly RelationalDatabase _database;
         private readonly ModelBuilderFactory _modelBuilderFactory;
+        private readonly SqlServerMigrator _migrator;
 
         public SqlServerDataStoreServices(
             [NotNull] SqlServerDataStore store,
@@ -26,7 +28,8 @@ namespace Microsoft.Data.Entity.SqlServer
             [NotNull] SqlServerConnection connection,
             [NotNull] SqlServerValueGeneratorCache valueGeneratorCache,
             [NotNull] RelationalDatabase database,
-            [NotNull] ModelBuilderFactory modelBuilderFactory)
+            [NotNull] ModelBuilderFactory modelBuilderFactory,
+            [NotNull] SqlServerMigrator migrator)
         {
             Check.NotNull(store, "store");
             Check.NotNull(creator, "creator");
@@ -34,6 +37,7 @@ namespace Microsoft.Data.Entity.SqlServer
             Check.NotNull(valueGeneratorCache, "valueGeneratorCache");
             Check.NotNull(database, "database");
             Check.NotNull(modelBuilderFactory, "modelBuilderFactory");
+            Check.NotNull(migrator, "migrator");
 
             _store = store;
             _creator = creator;
@@ -41,6 +45,7 @@ namespace Microsoft.Data.Entity.SqlServer
             _valueGeneratorCache = valueGeneratorCache;
             _database = database;
             _modelBuilderFactory = modelBuilderFactory;
+            _migrator = migrator;
         }
 
         public override DataStore Store
@@ -71,6 +76,11 @@ namespace Microsoft.Data.Entity.SqlServer
         public override IModelBuilderFactory ModelBuilderFactory
         {
             get { return _modelBuilderFactory; }
+        }
+
+        public override Migrator Migrator
+        {
+            get { return _migrator; }
         }
     }
 }

--- a/src/EntityFramework/Infrastructure/DbContextConfiguration.cs
+++ b/src/EntityFramework/Infrastructure/DbContextConfiguration.cs
@@ -84,6 +84,11 @@ namespace Microsoft.Data.Entity.Infrastructure
             get { return _database.Value; }
         }
 
+        public virtual DataStoreServices DataStoreServices
+        {
+            get { return _dataStoreServices.Value; }
+        }
+
         public virtual DataStoreCreator DataStoreCreator
         {
             get { return _dataStoreServices.Value.Creator; }

--- a/src/Microsoft.AspNet.Diagnostics.Entity/DatabaseErrorPageMiddleware.cs
+++ b/src/Microsoft.AspNet.Diagnostics.Entity/DatabaseErrorPageMiddleware.cs
@@ -80,17 +80,15 @@ namespace Microsoft.AspNet.Diagnostics.Entity
                                 {
                                     var databaseExists = dbContext.Database.AsRelational().Exists();
 
-                                    var serviceProvider = dbContext.Configuration.Services.ServiceProvider;
+                                    var services = (MigrationsDataStoreServices)dbContext.Configuration.DataStoreServices;
 
-                                    var migrator = serviceProvider.GetService<Migrator>();
-
-                                    var pendingMigrations = migrator.GetPendingMigrations().Select(m => m.GetMigrationId());
+                                    var pendingMigrations = services.Migrator.GetPendingMigrations().Select(m => m.GetMigrationId());
 
                                     var pendingModelChanges = true;
-                                    var snapshot = migrator.MigrationAssembly.Model;
+                                    var snapshot = services.Migrator.MigrationAssembly.Model;
                                     if (snapshot != null)
                                     {
-                                        pendingModelChanges = migrator.ModelDiffer.Diff(snapshot, dbContext.Model).Any();
+                                        pendingModelChanges = services.Migrator.ModelDiffer.Diff(snapshot, dbContext.Model).Any();
                                     }
 
                                     if ((!databaseExists && pendingMigrations.Any()) || pendingMigrations.Any() || pendingModelChanges)

--- a/test/EntityFramework.Commands.Tests/Migrations/CSharpMigrationCodeGeneratorTest.cs
+++ b/test/EntityFramework.Commands.Tests/Migrations/CSharpMigrationCodeGeneratorTest.cs
@@ -630,7 +630,8 @@ namespace MyNamespace
             codeGenerator.GenerateMigrationMetadataClass("MyNamespace", "MyClass", migration, typeof(MyContext), stringBuilder);
 
             Assert.Equal(
-@"using Microsoft.Data.Entity.Commands.Tests.Migrations;
+@"using Microsoft.Data.Entity;
+using Microsoft.Data.Entity.Commands.Tests.Migrations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Infrastructure;
 using System;

--- a/test/EntityFramework.Commands.Tests/Migrations/CSharpModelCodeGeneratorTest.cs
+++ b/test/EntityFramework.Commands.Tests/Migrations/CSharpModelCodeGeneratorTest.cs
@@ -654,7 +654,8 @@ return builder.Model;",
                 .GenerateModelSnapshotClass("MyNamespace", "MyClass", model, typeof(MyContext), stringBuilder);
 
             Assert.Equal(
-                @"using Microsoft.Data.Entity.Commands.Tests.Migrations;
+                @"using Microsoft.Data.Entity;
+using Microsoft.Data.Entity.Commands.Tests.Migrations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Infrastructure;
 using System;

--- a/test/EntityFramework.Commands.Tests/Migrations/MigrationScaffolderTest.cs
+++ b/test/EntityFramework.Commands.Tests/Migrations/MigrationScaffolderTest.cs
@@ -117,7 +117,8 @@ namespace MyNamespace
                 migrationClass);
 
             Assert.Equal(
-@"using Microsoft.Data.Entity.Commands.Tests.Migrations;
+@"using Microsoft.Data.Entity;
+using Microsoft.Data.Entity.Commands.Tests.Migrations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Infrastructure;
 using System;
@@ -162,7 +163,8 @@ namespace MyNamespace
             Assert.Equal("ContextModelSnapshot", className);
 
             Assert.Equal(
-                @"using Microsoft.Data.Entity.Commands.Tests.Migrations;
+                @"using Microsoft.Data.Entity;
+using Microsoft.Data.Entity.Commands.Tests.Migrations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Infrastructure;
 using System;
@@ -218,7 +220,8 @@ namespace MyNamespace
                 migrationClass);
 
             Assert.Equal(
-@"using Microsoft.Data.Entity.Commands.Tests.Migrations;
+@"using Microsoft.Data.Entity;
+using Microsoft.Data.Entity.Commands.Tests.Migrations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Infrastructure;
 using System;
@@ -271,7 +274,8 @@ namespace MyNamespace
             Assert.Equal("ContextModelSnapshot", className);
 
             Assert.Equal(
-                @"using Microsoft.Data.Entity.Commands.Tests.Migrations;
+                @"using Microsoft.Data.Entity;
+using Microsoft.Data.Entity.Commands.Tests.Migrations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Infrastructure;
 using System;
@@ -364,7 +368,8 @@ namespace MyNamespace
                 migrationClass);
 
             Assert.Equal(
-@"using Microsoft.Data.Entity.Commands.Tests.Migrations;
+@"using Microsoft.Data.Entity;
+using Microsoft.Data.Entity.Commands.Tests.Migrations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Infrastructure;
 using System;
@@ -447,7 +452,8 @@ namespace MyNamespace
             Assert.Equal("ContextModelSnapshot", className);
 
             Assert.Equal(
-                @"using Microsoft.Data.Entity.Commands.Tests.Migrations;
+                @"using Microsoft.Data.Entity;
+using Microsoft.Data.Entity.Commands.Tests.Migrations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Infrastructure;
 using System;
@@ -573,7 +579,8 @@ namespace MyNamespace
                 migrationClass);
 
             Assert.Equal(
-@"using Microsoft.Data.Entity.Commands.Tests.Migrations;
+@"using Microsoft.Data.Entity;
+using Microsoft.Data.Entity.Commands.Tests.Migrations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Infrastructure;
 using System;
@@ -658,7 +665,8 @@ namespace MyNamespace
             Assert.Equal("ContextModelSnapshot", className);
 
             Assert.Equal(
-                @"using Microsoft.Data.Entity.Commands.Tests.Migrations;
+                @"using Microsoft.Data.Entity;
+using Microsoft.Data.Entity.Commands.Tests.Migrations;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Infrastructure;
 using System;

--- a/test/EntityFramework.SqlServer.Tests/SqlServerEntityServicesBuilderExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerEntityServicesBuilderExtensionsTest.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             Assert.True(services.Any(sd => sd.ServiceType == typeof(SqlServerDataStoreCreator)));
             Assert.True(services.Any(sd => sd.ServiceType == typeof(MigrationAssembly)));
             Assert.True(services.Any(sd => sd.ServiceType == typeof(HistoryRepository)));
-            Assert.True(services.Any(sd => sd.ServiceType == typeof(Migrator)));
+            Assert.True(services.Any(sd => sd.ServiceType == typeof(SqlServerMigrator)));
         }
 
         [Fact]
@@ -92,7 +92,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             var sqlServerDataStoreCreator = scopedProvider.GetService<SqlServerDataStoreCreator>();
             var migrationAssembly = scopedProvider.GetService<MigrationAssembly>();
             var historyRepository = scopedProvider.GetService<HistoryRepository>();
-            var sqlServerMigrator = scopedProvider.GetService<Migrator>() as SqlServerMigrator;
+            var sqlServerMigrator = scopedProvider.GetService<SqlServerMigrator>() as SqlServerMigrator;
 
             Assert.NotNull(databaseBuilder);
             Assert.NotNull(arrayReaderFactory);
@@ -148,7 +148,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             Assert.NotSame(sqlServerDataStoreCreator, scopedProvider.GetService<SqlServerDataStoreCreator>());
             Assert.NotSame(migrationAssembly, scopedProvider.GetService<MigrationAssembly>());
             Assert.NotSame(historyRepository, scopedProvider.GetService<HistoryRepository>());
-            Assert.NotSame(sqlServerMigrator, scopedProvider.GetService<Migrator>());
+            Assert.NotSame(sqlServerMigrator, scopedProvider.GetService<SqlServerMigrator>());
 
             context.Dispose();
         }

--- a/test/Microsoft.AspNet.Diagnostics.Entity.FunctionalTests/DatabaseErrorPageMiddlewareTest.cs
+++ b/test/Microsoft.AspNet.Diagnostics.Entity.FunctionalTests/DatabaseErrorPageMiddlewareTest.cs
@@ -158,8 +158,8 @@ namespace Microsoft.AspNet.Diagnostics.Entity.Tests
             {
                 using (var db = context.ApplicationServices.GetService<BloggingContextWithPendingModelChanges>())
                 {
-                    var migrator = db.Configuration.Services.ServiceProvider.GetService<Migrator>();
-                    migrator.ApplyMigrations();
+                    var services = (MigrationsDataStoreServices)db.Configuration.DataStoreServices;
+                    services.Migrator.ApplyMigrations();
 
                     db.Blogs.Add(new Blog());
                     db.SaveChanges();

--- a/test/Microsoft.AspNet.Diagnostics.Entity.FunctionalTests/MigrationsEndPointMiddlewareTest.cs
+++ b/test/Microsoft.AspNet.Diagnostics.Entity.FunctionalTests/MigrationsEndPointMiddlewareTest.cs
@@ -99,7 +99,8 @@ namespace Microsoft.AspNet.Diagnostics.Entity.Tests
                 Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
 
                 Assert.True(db.Database.AsRelational().Exists());
-                var appliedMigrations = db.Configuration.Services.ServiceProvider.GetService<Migrator>().GetDatabaseMigrations();
+                var services = (MigrationsDataStoreServices)db.Configuration.DataStoreServices;
+                var appliedMigrations = services.Migrator.GetDatabaseMigrations();
                 Assert.Equal(2, appliedMigrations.Count);
                 Assert.Equal("111111111111111_MigrationOne", appliedMigrations.ElementAt(0).GetMigrationId());
                 Assert.Equal("222222222222222_MigrationTwo", appliedMigrations.ElementAt(1).GetMigrationId());


### PR DESCRIPTION
Tooling was using GetService<ModelDiffer> but that was broken now we have specialized ModelDiffers. We were also registering specialized Migrators but they were registered as Migrator in DI so you would get multiples if you registered two providers (and random behavior ensued). Swapping to have Migrator resolved thru DataStoreServices.

Also adding a missing using from generated model code.

Tested with automated tests and manually testing k ef migration commands
