### PR TITLE
Fix break that made SQL Server keys non-clustered by default

### DIFF
--- a/src/EntityFramework.SqlServer/SqlServerDatabaseBuilder.cs
+++ b/src/EntityFramework.SqlServer/SqlServerDatabaseBuilder.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Data.Entity.SqlServer
 
         protected override bool IsKeyClustered(IKey key)
         {
-            return key.SqlServer().IsClustered == true;
+            return key.SqlServer().IsClustered != false;
         }
 
         protected override bool IsIndexClustered(IIndex index)


### PR DESCRIPTION
Or: Nuclear collapse of the tri-valued cluster bomb

Issue #911
The clustered annotation is now SQL Server specific and default to null, meaning not specified. The Migrations database builder does not have the concept of not specified and was interpreting null as false. This resulted in keys being created explicitly as non-clustered. This change makes null be treated as clustered by default to revert the break, but note that the core/Migrations difference in how clustering is supported still needs to be addressed--see issue #879
