### PR TITLE
Consistentizing logging usage.

### DIFF
--- a/src/EntityFramework.AzureTableStorage/EntityFramework.AzureTableStorage.csproj
+++ b/src/EntityFramework.AzureTableStorage/EntityFramework.AzureTableStorage.csproj
@@ -70,6 +70,9 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.tt</DependentUpon>
     </Compile>
+    <Compile Include="..\Shared\LoggingExtensions.cs">
+      <Link>LoggingExtensions.cs</Link>
+    </Compile>
     <Compile Include="AtsBuilderExtensions.cs" />
     <Compile Include="AtsDatabase.cs" />
     <Compile Include="AtsConnection.cs" />

--- a/src/EntityFramework.AzureTableStorage/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.AzureTableStorage/Properties/Strings.Designer.cs
@@ -266,6 +266,70 @@ namespace Microsoft.Data.Entity.AzureTableStorage
             return string.Format(CultureInfo.CurrentCulture, GetString("BadTimestampType", "property", "entityType", "propertyType"), property, entityType, propertyType);
         }
 
+        /// <summary>
+        /// Executing request '{name}'
+        /// </summary>
+        internal static string LogExecutingRequest
+        {
+            get { return GetString("LogExecutingRequest"); }
+        }
+
+        /// <summary>
+        /// Executing request '{name}'
+        /// </summary>
+        internal static string FormatLogExecutingRequest(object name)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("LogExecutingRequest", "name"), name);
+        }
+
+        /// <summary>
+        /// Retrying request to '{uri}'
+        /// </summary>
+        internal static string LogRequestRetry
+        {
+            get { return GetString("LogRequestRetry"); }
+        }
+
+        /// <summary>
+        /// Retrying request to '{uri}'
+        /// </summary>
+        internal static string FormatLogRequestRetry(object uri)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("LogRequestRetry", "uri"), uri);
+        }
+
+        /// <summary>
+        /// Response from '{uri}' = {statusCode} {description}
+        /// </summary>
+        internal static string LogResponseReceived
+        {
+            get { return GetString("LogResponseReceived"); }
+        }
+
+        /// <summary>
+        /// Response from '{uri}' = {statusCode} {description}
+        /// </summary>
+        internal static string FormatLogResponseReceived(object uri, object statusCode, object description)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("LogResponseReceived", "uri", "statusCode", "description"), uri, statusCode, description);
+        }
+
+        /// <summary>
+        /// Sending request to '{uri}'
+        /// </summary>
+        internal static string LogSendingRequest
+        {
+            get { return GetString("LogSendingRequest"); }
+        }
+
+        /// <summary>
+        /// Sending request to '{uri}'
+        /// </summary>
+        internal static string FormatLogSendingRequest(object uri)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("LogSendingRequest", "uri"), uri);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EntityFramework.AzureTableStorage/Properties/Strings.resx
+++ b/src/EntityFramework.AzureTableStorage/Properties/Strings.resx
@@ -165,4 +165,16 @@
   <data name="BadTimestampType" xml:space="preserve">
     <value>The property '{property}' on entity type '{entityType}' cannot be used as an Azure Table Storage timestamp because its type is '{propertyType}'. Only 'DateTimeOffset' properties can be used as timestamps.</value>
   </data>
+  <data name="LogExecutingRequest" xml:space="preserve">
+    <value>Executing request '{name}'</value>
+  </data>
+  <data name="LogRequestRetry" xml:space="preserve">
+    <value>Retrying request to '{uri}'</value>
+  </data>
+  <data name="LogResponseReceived" xml:space="preserve">
+    <value>Response from '{uri}' = {statusCode} {description}</value>
+  </data>
+  <data name="LogSendingRequest" xml:space="preserve">
+    <value>Sending request to '{uri}'</value>
+  </data>
 </root>

--- a/src/EntityFramework.InMemory/EntityFramework.InMemory.csproj
+++ b/src/EntityFramework.InMemory/EntityFramework.InMemory.csproj
@@ -59,6 +59,9 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.tt</DependentUpon>
     </Compile>
+    <Compile Include="..\Shared\LoggingExtensions.cs">
+      <Link>LoggingExtensions.cs</Link>
+    </Compile>
     <Compile Include="InMemoryDataStoreServices.cs" />
     <Compile Include="InMemoryOptionsExtension.cs" />
     <Compile Include="InMemoryConnection.cs" />

--- a/src/EntityFramework.InMemory/InMemoryDatabase.cs
+++ b/src/EntityFramework.InMemory/InMemoryDatabase.cs
@@ -92,11 +92,7 @@ namespace Microsoft.Data.Entity.InMemory
                     return ts;
                 });
 
-            _logger.WriteInformation(
-                string.Format(
-                    CultureInfo.InvariantCulture,
-                    "Saved {0} entities to in-memory database.",
-                    rowsAffected));
+            _logger.WriteInformation(() => Strings.FormatLogSavedChanges(rowsAffected));
 
             return rowsAffected;
         }

--- a/src/EntityFramework.InMemory/Properties/Strings.Designer.cs
+++ b/src/EntityFramework.InMemory/Properties/Strings.Designer.cs
@@ -42,6 +42,22 @@ namespace Microsoft.Data.Entity.InMemory
             return string.Format(CultureInfo.CurrentCulture, GetString("InvalidEnumValue", "argumentName", "enumType"), argumentName, enumType);
         }
 
+        /// <summary>
+        /// Saved {count} entities to in-memory store.
+        /// </summary>
+        internal static string LogSavedChanges
+        {
+            get { return GetString("LogSavedChanges"); }
+        }
+
+        /// <summary>
+        /// Saved {count} entities to in-memory store.
+        /// </summary>
+        internal static string FormatLogSavedChanges(object count)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("LogSavedChanges", "count"), count);
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EntityFramework.InMemory/Properties/Strings.resx
+++ b/src/EntityFramework.InMemory/Properties/Strings.resx
@@ -123,4 +123,7 @@
   <data name="InvalidEnumValue" xml:space="preserve">
     <value>The value provided for argument '{argumentName}' must be a valid value of enum type '{enumType}'.</value>
   </data>
+  <data name="LogSavedChanges" xml:space="preserve">
+    <value>Saved {count} entities to in-memory store.</value>
+  </data>
 </root>

--- a/src/EntityFramework.Migrations/EntityFramework.Migrations.csproj
+++ b/src/EntityFramework.Migrations/EntityFramework.Migrations.csproj
@@ -49,6 +49,9 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.tt</DependentUpon>
     </Compile>
+    <Compile Include="..\Shared\LoggingExtensions.cs">
+      <Link>LoggingExtensions.cs</Link>
+    </Compile>
     <Compile Include="IMigrationOperationSqlGeneratorFactory.cs" />
     <Compile Include="Infrastructure\ContextTypeAttribute.cs" />
     <Compile Include="Infrastructure\HistoryRepository.cs" />

--- a/src/EntityFramework.Migrations/Infrastructure/MigratorLoggerExtensions.cs
+++ b/src/EntityFramework.Migrations/Infrastructure/MigratorLoggerExtensions.cs
@@ -13,16 +13,18 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
         {
             Check.NotNull(logger, "logger");
 
-            logger.Write(TraceType.Information, MigratorLoggerEventIds.CreatingHistoryTable, null, null,
-                (_, __) => Strings.MigratorLoggerCreatingHistoryTable);
+            logger.WriteInformation(
+                MigratorLoggerEventIds.CreatingHistoryTable,
+                Strings.FormatMigratorLoggerCreatingHistoryTable);
         }
 
         public static void DroppingHistoryTable([NotNull] this ILogger logger)
         {
             Check.NotNull(logger, "logger");
 
-            logger.Write(TraceType.Information, MigratorLoggerEventIds.DroppingHistoryTable, null, null,
-                (_, __) => Strings.MigratorLoggerDroppingHistoryTable);
+            logger.WriteInformation(
+                MigratorLoggerEventIds.DroppingHistoryTable,
+                Strings.FormatMigratorLoggerDroppingHistoryTable);
         }
 
         public static void ApplyingMigration([NotNull] this ILogger logger, [NotNull] string migrationId)
@@ -30,8 +32,9 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
             Check.NotNull(logger, "logger");
             Check.NotEmpty(migrationId, "migrationId");
 
-            logger.Write(TraceType.Information, MigratorLoggerEventIds.ApplyingMigration, migrationId, null,
-                (o, _) => Strings.FormatMigratorLoggerApplyingMigration(o));
+            logger.WriteInformation(
+                MigratorLoggerEventIds.ApplyingMigration, migrationId,
+                Strings.FormatMigratorLoggerApplyingMigration);
         }
 
         public static void RevertingMigration([NotNull] this ILogger logger, [NotNull] string migrationId)
@@ -39,16 +42,18 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
             Check.NotNull(logger, "logger");
             Check.NotEmpty(migrationId, "migrationId");
 
-            logger.Write(TraceType.Information, MigratorLoggerEventIds.RevertingMigration, migrationId, null,
-                (o, _) => Strings.FormatMigratorLoggerRevertingMigration(o));
+            logger.WriteInformation(
+                MigratorLoggerEventIds.RevertingMigration, migrationId,
+                Strings.FormatMigratorLoggerRevertingMigration);
         }
 
         public static void UpToDate([NotNull] this ILogger logger)
         {
             Check.NotNull(logger, "logger");
 
-            logger.Write(TraceType.Information, MigratorLoggerEventIds.UpToDate, null, null,
-                (_, __) => Strings.MigratorLoggerUpToDate);
+            logger.WriteInformation(
+                MigratorLoggerEventIds.UpToDate,
+                Strings.FormatMigratorLoggerUpToDate);
         }
     }
 }

--- a/src/EntityFramework.Relational/EntityFramework.Relational.csproj
+++ b/src/EntityFramework.Relational/EntityFramework.Relational.csproj
@@ -61,6 +61,9 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.tt</DependentUpon>
     </Compile>
+    <Compile Include="..\Shared\LoggingExtensions.cs">
+      <Link>LoggingExtensions.cs</Link>
+    </Compile>
     <Compile Include="ConnectionStringResolver.cs" />
     <Compile Include="DatabaseBuilder.cs" />
     <Compile Include="IDbCommandExecutor.cs" />

--- a/src/EntityFramework.Relational/RelationalLoggerExtensions.cs
+++ b/src/EntityFramework.Relational/RelationalLoggerExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Framework.Logging
             Check.NotNull(logger, "logger");
             Check.NotEmpty(sql, "sql");
 
-            logger.Write(TraceType.Verbose, RelationalLoggingEventIds.Sql, sql, null, (o, _) => (string)o);
+            logger.WriteVerbose(RelationalLoggingEventIds.Sql, sql);
         }
 
         public static void CreatingDatabase([NotNull] this ILogger logger, [NotNull] string databaseName)
@@ -25,8 +25,10 @@ namespace Microsoft.Framework.Logging
             Check.NotNull(logger, "logger");
             Check.NotEmpty(databaseName, "databaseName");
 
-            logger.Write(TraceType.Information, RelationalLoggingEventIds.CreatingDatabase, databaseName, null,
-                (o, _) => Strings.FormatRelationalLoggerCreatingDatabase(databaseName));
+            logger.WriteInformation(
+                RelationalLoggingEventIds.CreatingDatabase,
+                databaseName,
+                Strings.FormatRelationalLoggerCreatingDatabase);
         }
 
         public static void OpeningConnection([NotNull] this ILogger logger, [NotNull] string connectionString)
@@ -34,8 +36,10 @@ namespace Microsoft.Framework.Logging
             Check.NotNull(logger, "logger");
             Check.NotEmpty(connectionString, "connectionString");
 
-            logger.Write(TraceType.Verbose, RelationalLoggingEventIds.OpeningConnection, connectionString, null,
-                (o, _) => Strings.FormatRelationalLoggerOpeningConnection(o));
+            logger.WriteVerbose(
+                RelationalLoggingEventIds.OpeningConnection,
+                connectionString,
+                Strings.FormatRelationalLoggerOpeningConnection);
         }
 
         public static void ClosingConnection([NotNull] this ILogger logger, [NotNull] string connectionString)
@@ -43,32 +47,38 @@ namespace Microsoft.Framework.Logging
             Check.NotNull(logger, "logger");
             Check.NotEmpty(connectionString, "connectionString");
 
-            logger.Write(TraceType.Verbose, RelationalLoggingEventIds.ClosingConnection, connectionString, null,
-                (o, _) => Strings.FormatRelationalLoggerClosingConnection(o));
+            logger.WriteVerbose(
+                RelationalLoggingEventIds.ClosingConnection,
+                connectionString,
+                Strings.FormatRelationalLoggerClosingConnection);
         }
 
         public static void BeginningTransaction([NotNull] this ILogger logger, IsolationLevel isolationLevel)
         {
             Check.NotNull(logger, "logger");
 
-            logger.Write(TraceType.Verbose, RelationalLoggingEventIds.BeginningTransaction, isolationLevel.ToString("G"), null,
-                (o, _) => Strings.FormatRelationalLoggerBeginningTransaction(o));
+            logger.WriteVerbose(
+                RelationalLoggingEventIds.BeginningTransaction,
+                isolationLevel,
+                il => Strings.FormatRelationalLoggerBeginningTransaction(il.ToString("G")));
         }
 
         public static void CommittingTransaction([NotNull] this ILogger logger)
         {
             Check.NotNull(logger, "logger");
 
-            logger.Write(TraceType.Verbose, RelationalLoggingEventIds.CommittingTransaction, null, null,
-                (_, __) => Strings.RelationalLoggerCommittingTransaction);
+            logger.WriteVerbose(
+                RelationalLoggingEventIds.CommittingTransaction,
+                Strings.RelationalLoggerCommittingTransaction);
         }
 
         public static void RollingbackTransaction([NotNull] this ILogger logger)
         {
             Check.NotNull(logger, "logger");
 
-            logger.Write(TraceType.Verbose, RelationalLoggingEventIds.RollingbackTransaction, null, null,
-                (_, __) => Strings.RelationalLoggerRollingbackTransaction);
+            logger.WriteVerbose(
+                RelationalLoggingEventIds.RollingbackTransaction,
+                Strings.RelationalLoggerRollingbackTransaction);
         }
     }
 }

--- a/src/EntityFramework/DbContext.cs
+++ b/src/EntityFramework/DbContext.cs
@@ -167,12 +167,11 @@ namespace Microsoft.Data.Entity
             }
             catch (Exception ex)
             {
-                _logger.Value.Write(
-                    TraceType.Error,
-                    0,
+                _logger.Value.WriteError(
                     new DataStoreErrorLogState(GetType()),
                     ex,
-                    (state, exception) => string.Format("{0}" + Environment.NewLine + "{1}", Strings.LogExceptionDuringSaveChanges, exception.ToString()));
+                    (state, exception) =>
+                        Strings.FormatLogExceptionDuringSaveChanges(Environment.NewLine, exception));
 
                 throw;
             }
@@ -192,12 +191,11 @@ namespace Microsoft.Data.Entity
             }
             catch (Exception ex)
             {
-                _logger.Value.Write(
-                    TraceType.Error,
-                    0,
+                _logger.Value.WriteError(
                     new DataStoreErrorLogState(GetType()),
                     ex,
-                    (state, exception) => string.Format("{0}" + Environment.NewLine + "{1}", Strings.LogExceptionDuringSaveChanges, exception.ToString()));
+                    (state, exception) =>
+                        Strings.FormatLogExceptionDuringSaveChanges(Environment.NewLine, exception));
 
                 throw;
             }

--- a/src/EntityFramework/EntityFramework.csproj
+++ b/src/EntityFramework/EntityFramework.csproj
@@ -61,6 +61,9 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>Resources.tt</DependentUpon>
     </Compile>
+    <Compile Include="..\Shared\LoggingExtensions.cs">
+      <Link>LoggingExtensions.cs</Link>
+    </Compile>
     <Compile Include="ChangeTracking\ChangeDetector.cs" />
     <Compile Include="ChangeTracking\RelationshipsSnapshot.cs" />
     <Compile Include="ChangeTracking\RelationshipsSnapshotFactory.cs" />

--- a/src/EntityFramework/Properties/Strings.Designer.cs
+++ b/src/EntityFramework/Properties/Strings.Designer.cs
@@ -635,7 +635,7 @@ namespace Microsoft.Data.Entity
         }
 
         /// <summary>
-        /// An exception occurred in the data store while iterating the results of a query.
+        /// An exception occurred in the data store while iterating the results of a query.{newline}{error}
         /// </summary>
         internal static string LogExceptionDuringQueryIteration
         {
@@ -643,15 +643,15 @@ namespace Microsoft.Data.Entity
         }
 
         /// <summary>
-        /// An exception occurred in the data store while iterating the results of a query.
+        /// An exception occurred in the data store while iterating the results of a query.{newline}{error}
         /// </summary>
-        internal static string FormatLogExceptionDuringQueryIteration()
+        internal static string FormatLogExceptionDuringQueryIteration(object newline, object error)
         {
-            return GetString("LogExceptionDuringQueryIteration");
+            return string.Format(CultureInfo.CurrentCulture, GetString("LogExceptionDuringQueryIteration", "newline", "error"), newline, error);
         }
 
         /// <summary>
-        /// An exception occurred in the data store while saving changes.
+        /// An exception occurred in the data store while saving changes.{newline}{error}
         /// </summary>
         internal static string LogExceptionDuringSaveChanges
         {
@@ -659,11 +659,11 @@ namespace Microsoft.Data.Entity
         }
 
         /// <summary>
-        /// An exception occurred in the data store while saving changes.
+        /// An exception occurred in the data store while saving changes.{newline}{error}
         /// </summary>
-        internal static string FormatLogExceptionDuringSaveChanges()
+        internal static string FormatLogExceptionDuringSaveChanges(object newline, object error)
         {
-            return GetString("LogExceptionDuringSaveChanges");
+            return string.Format(CultureInfo.CurrentCulture, GetString("LogExceptionDuringSaveChanges", "newline", "error"), newline, error);
         }
 
         /// <summary>
@@ -1304,6 +1304,22 @@ namespace Microsoft.Data.Entity
         internal static string FormatIncludeNonBindableExpression(object expression)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("IncludeNonBindableExpression", "expression"), expression);
+        }
+
+        /// <summary>
+        /// Compiling query model{newline}{newline}{queryModel}
+        /// </summary>
+        internal static string LogCompilingQueryModel
+        {
+            get { return GetString("LogCompilingQueryModel"); }
+        }
+
+        /// <summary>
+        /// Compiling query model{newline}{newline}{queryModel}
+        /// </summary>
+        internal static string FormatLogCompilingQueryModel(object newline, object queryModel)
+        {
+            return string.Format(CultureInfo.CurrentCulture, GetString("LogCompilingQueryModel", "newline", "queryModel"), newline, queryModel);
         }
 
         private static string GetString(string name, params string[] formatterNames)

--- a/src/EntityFramework/Properties/Strings.resx
+++ b/src/EntityFramework/Properties/Strings.resx
@@ -235,10 +235,10 @@
     <value>An error occured while running a data store operation. See InnerException for details.</value>
   </data>
   <data name="LogExceptionDuringQueryIteration" xml:space="preserve">
-    <value>An exception occurred in the data store while iterating the results of a query.</value>
+    <value>An exception occurred in the data store while iterating the results of a query.{newline}{error}</value>
   </data>
   <data name="LogExceptionDuringSaveChanges" xml:space="preserve">
-    <value>An exception occurred in the data store while saving changes.</value>
+    <value>An exception occurred in the data store while saving changes.{newline}{error}</value>
   </data>
   <data name="PropertyExtensionInvoked" xml:space="preserve">
     <value>The Property&amp;lt;T&amp;gt; extension method may only be used within LINQ queries.</value>
@@ -359,5 +359,8 @@
   </data>
   <data name="IncludeNonBindableExpression" xml:space="preserve">
     <value>The expression '{expression}' passed to the Include operator could not be bound. Only single-level navigation expressions are supported. </value>
+  </data>
+  <data name="LogCompilingQueryModel" xml:space="preserve">
+    <value>Compiling query model{newline}{newline}{queryModel}</value>
   </data>
 </root>

--- a/src/EntityFramework/Query/EntityQueryExecutor.cs
+++ b/src/EntityFramework/Query/EntityQueryExecutor.cs
@@ -73,12 +73,11 @@ namespace Microsoft.Data.Entity.Query
             }
             catch (Exception ex)
             {
-                _logger.Value.Write(
-                    TraceType.Error,
-                    0,
+                _logger.Value.WriteError(
                     new DataStoreErrorLogState(_context.GetType()),
                     ex,
-                    (state, exception) => string.Format("{0}" + Environment.NewLine + "{1}", Strings.LogExceptionDuringQueryIteration, exception.ToString()));
+                    (state, exception) =>
+                        Strings.FormatLogExceptionDuringQueryIteration(Environment.NewLine, exception));
 
                 throw;
             }
@@ -101,12 +100,11 @@ namespace Microsoft.Data.Entity.Query
             }
             catch (Exception ex)
             {
-                _logger.Value.Write(
-                    TraceType.Error,
-                    0,
+                _logger.Value.WriteError(
                     new DataStoreErrorLogState(_context.GetType()),
                     ex,
-                    (state, exception) => string.Format("{0}" + Environment.NewLine + "{1}", Strings.LogExceptionDuringQueryIteration, exception.ToString()));
+                    (state, exception) =>
+                        Strings.FormatLogExceptionDuringQueryIteration(Environment.NewLine, exception));
 
                 throw;
             }
@@ -114,10 +112,9 @@ namespace Microsoft.Data.Entity.Query
 
         private void LogQueryModel(QueryModel queryModel)
         {
-            if (_logger.Value.IsEnabled(TraceType.Information))
-            {
-                _logger.Value.WriteInformation(queryModel + Environment.NewLine);
-            }
+            _logger.Value.WriteInformation(
+                queryModel,
+                qm => Strings.FormatLogCompilingQueryModel(Environment.NewLine, qm));
         }
 
         private sealed class EnumerableExceptionInterceptor<T> : IEnumerable<T>
@@ -175,13 +172,11 @@ namespace Microsoft.Data.Entity.Query
                     }
                     catch (Exception ex)
                     {
-                        _logger.Value.Write(
-                            TraceType.Error,
-                            0,
+                        _logger.Value.WriteError(
                             new DataStoreErrorLogState(_context.GetType()),
                             ex,
-                            (state, exception) => string.Format("{0}" + Environment.NewLine
-                                                                + "{1}", Strings.LogExceptionDuringQueryIteration, exception.ToString()));
+                            (state, exception) =>
+                                Strings.FormatLogExceptionDuringQueryIteration(Environment.NewLine, exception));
 
                         throw;
                     }
@@ -245,12 +240,11 @@ namespace Microsoft.Data.Entity.Query
                     }
                     catch (Exception ex)
                     {
-                        _logger.Value.Write(
-                            TraceType.Error,
-                            0,
+                        _logger.Value.WriteError(
                             new DataStoreErrorLogState(_context.GetType()),
                             ex,
-                            (state, exception) => string.Format("{0}" + Environment.NewLine + "{1}", Strings.LogExceptionDuringQueryIteration, exception.ToString()));
+                            (state, exception) =>
+                                Strings.FormatLogExceptionDuringQueryIteration(Environment.NewLine, exception));
 
                         throw;
                     }

--- a/src/Shared/LoggingExtensions.cs
+++ b/src/Shared/LoggingExtensions.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+// ReSharper disable once CheckNamespace
+
+namespace Microsoft.Framework.Logging
+{
+    internal static class LoggingExtensions
+    {
+        public static void WriteInformation(this ILogger logger, Func<string> formatter)
+        {
+            logger.WriteInformation(0, default(object), _ => formatter());
+        }
+
+        public static void WriteInformation<TState>(this ILogger logger, TState state, Func<TState, string> formatter)
+        {
+            logger.WriteInformation(0, state, formatter);
+        }
+
+        public static void WriteInformation(this ILogger logger, int eventId, Func<string> formatter)
+        {
+            logger.WriteInformation(eventId, default(object), _ => formatter());
+        }
+
+        public static void WriteInformation<TState>(
+            this ILogger logger, int eventId, TState state, Func<TState, string> formatter)
+        {
+            if (logger.IsEnabled(TraceType.Information))
+            {
+                logger.Write(TraceType.Information, eventId, state, null, (s, _) => formatter((TState)s));
+            }
+        }
+
+        public static void WriteError<TState>(
+            this ILogger logger, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            if (logger.IsEnabled(TraceType.Error))
+            {
+                logger.Write(TraceType.Error, 0, null, exception, (s, e) => formatter((TState)s, e));
+            }
+        }
+
+        public static void WriteError<TState>(
+            this ILogger logger, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            if (logger.IsEnabled(TraceType.Error))
+            {
+                logger.Write(TraceType.Error, 0, state, exception, (s, e) => formatter((TState)s, e));
+            }
+        }
+
+        public static void WriteVerbose<TState>(this ILogger logger, int eventId, TState state)
+        {
+            logger.WriteVerbose(eventId, state, s => s != null ? s.ToString() : null);
+        }
+
+        public static void WriteVerbose<TState>(
+            this ILogger logger, TState state, Func<TState, string> formatter)
+        {
+            if (logger.IsEnabled(TraceType.Verbose))
+            {
+                logger.Write(TraceType.Verbose, 0, state, null, (s, _) => formatter((TState)s));
+            }
+        }
+
+        public static void WriteVerbose<TState>(
+            this ILogger logger, int eventId, TState state, Func<TState, string> formatter)
+        {
+            if (logger.IsEnabled(TraceType.Verbose))
+            {
+                logger.Write(TraceType.Verbose, eventId, state, null, (s, _) => formatter((TState)s));
+            }
+        }
+    }
+}

--- a/test/EntityFramework.InMemory.Tests/InMemoryDataStoreTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryDataStoreTest.cs
@@ -165,6 +165,8 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             await entityEntry.SetEntityStateAsync(EntityState.Added);
 
             var mockLogger = new Mock<ILogger>();
+            mockLogger.Setup(l => l.IsEnabled(TraceType.Information)).Returns(true);
+
             var mockFactory = new Mock<ILoggerFactory>();
             mockFactory.Setup(m => m.Create(It.IsAny<string>())).Returns(mockLogger.Object);
 


### PR DESCRIPTION
- Introduce EF LoggingExtensions (internal, shared) in order to provide consistent, easier logger usage.
