### PR TITLE
Escrow: Fix for #603 - SqlException: New transaction is not allowed because ther...

### DIFF
--- a/src/EntityFramework/Query/AsyncLinqOperatorProvider.cs
+++ b/src/EntityFramework/Query/AsyncLinqOperatorProvider.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 using Remotion.Linq.Clauses;
@@ -264,8 +265,10 @@ namespace Microsoft.Data.Entity.Query
         private static readonly MethodInfo _defaultIfEmpty = GetMethod("DefaultIfEmpty");
         private static readonly MethodInfo _defaultIfEmptyArg = GetMethod("DefaultIfEmpty", 1);
         private static readonly MethodInfo _distinct = GetMethod("Distinct");
-        private static readonly MethodInfo _first = GetMethod("First");
-        private static readonly MethodInfo _firstOrDefault = GetMethod("FirstOrDefault");
+        
+        // TODO: Workaround https://github.com/Reactive-Extensions/Rx.NET/issues/5
+        //private static readonly MethodInfo _first = GetMethod("First");
+        //private static readonly MethodInfo _firstOrDefault = GetMethod("FirstOrDefault");
 
         public virtual MethodInfo Any
         {
@@ -302,9 +305,55 @@ namespace Microsoft.Data.Entity.Query
             get { return _distinct; }
         }
 
+        private static readonly MethodInfo _first
+            = typeof(AsyncLinqOperatorProvider).GetTypeInfo().GetDeclaredMethod("_First");
+
+        [UsedImplicitly]
+        private static async Task<TSource> _First<TSource>(
+            IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
+        {
+            using (var asyncEnumerator = source.GetEnumerator())
+            {
+                if (!await asyncEnumerator.MoveNext(cancellationToken))
+                {
+                    throw new InvalidOperationException();
+                }
+
+                var result = asyncEnumerator.Current;
+
+                // TODO: Workaround https://github.com/Reactive-Extensions/Rx.NET/issues/5
+                await asyncEnumerator.MoveNext(cancellationToken);
+
+                return result;
+            }
+        }
+
         public virtual MethodInfo First
         {
             get { return _first; }
+        }
+
+        private static readonly MethodInfo _firstOrDefault
+            = typeof(AsyncLinqOperatorProvider).GetTypeInfo().GetDeclaredMethod("_FirstOrDefault");
+
+        [UsedImplicitly]
+        private static async Task<TSource> _FirstOrDefault<TSource>(
+            IAsyncEnumerable<TSource> source, CancellationToken cancellationToken)
+        {
+            using (var asyncEnumerator = source.GetEnumerator())
+            {
+                var result = default(TSource);
+
+                if (await asyncEnumerator.MoveNext(cancellationToken))
+                {
+                    result = asyncEnumerator.Current;
+                }
+
+                // TODO: Workaround https://github.com/Reactive-Extensions/Rx.NET/issues/5
+                await asyncEnumerator.MoveNext(cancellationToken);
+
+                return result;
+            }
         }
 
         public virtual MethodInfo FirstOrDefault

--- a/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="NorthwindAsyncQueryTest.cs" />
     <Compile Include="NorthwindQueryLoggingTest.cs" />
     <Compile Include="NorthwindQueryTest.cs" />
+    <Compile Include="QueryBugsTest.cs" />
     <Compile Include="SqlServerOptimisticConcurrencyTest.cs" />
     <Compile Include="SequenceEndToEndTest.cs" />
     <Compile Include="SequentialGuidEndToEndTest.cs" />

--- a/test/EntityFramework.SqlServer.FunctionalTests/QueryBugsTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/QueryBugsTest.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public class QueryBugsTest
+    {
+        [Fact]
+        public async Task First_ix_async_bug_603()
+        {
+            using (var context = new MyContext())
+            {
+                await context.Database.EnsureDeletedAsync();
+                await context.Database.EnsureCreatedAsync();
+
+                context.Products.Add(new Product { Name = "Product 1" });
+                context.SaveChanges();
+            }
+
+            using (var ctx = new MyContext())
+            {
+                var product = await ctx.Products.FirstAsync();
+
+                ctx.Products.Remove(product);
+
+                await ctx.SaveChangesAsync();
+            }
+        }
+
+        [Fact]
+        public async Task First_or_default_ix_async_bug_603()
+        {
+            using (var context = new MyContext())
+            {
+                await context.Database.EnsureDeletedAsync();
+                await context.Database.EnsureCreatedAsync();
+
+                context.Products.Add(new Product { Name = "Product 1" });
+                context.SaveChanges();
+            }
+
+            using (var ctx = new MyContext())
+            {
+                var product = await ctx.Products.FirstOrDefaultAsync();
+
+                ctx.Products.Remove(product);
+
+                await ctx.SaveChangesAsync();
+            }
+        }
+
+        private class Product
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class MyContext : DbContext
+        {
+            public DbSet<Product> Products { get; set; }
+
+            protected override void OnConfiguring(DbContextOptions options)
+            {
+                options.UseSqlServer(SqlServerTestDatabase.CreateConnectionString("Repro603"));
+            }
+        }
+    }
+}


### PR DESCRIPTION
...e are other threads running in the session.
- Applies workaround for Reactive-Extensions/Rx.NET#5 to First operators.
