### PR TITLE
Testing around and some tweaks to EF DI/options infrastructure

### DIFF
--- a/src/EntityFramework.SQLite/Extensions/SQLiteDbContextOptionsExtensions.cs
+++ b/src/EntityFramework.SQLite/Extensions/SQLiteDbContextOptionsExtensions.cs
@@ -29,8 +29,7 @@ namespace Microsoft.Data.Entity
             return (DbContextOptions<T>)UseSQLite((DbContextOptions)options, connectionString);
         }
 
-        // TODO: Use SQLiteConnection instead of DbConnection?
-        // Issue #772
+        // Note: Decision made to use DbConnection not SQLiteConnection: Issue #772
         public static DbContextOptions UseSQLite([NotNull] this DbContextOptions options, [NotNull] DbConnection connection)
         {
             Check.NotNull(options, "options");
@@ -42,8 +41,7 @@ namespace Microsoft.Data.Entity
             return options;
         }
 
-        // TODO: Use SQLiteConnection instead of DbConnection?
-        // Issue #772
+        // Note: Decision made to use DbConnection not SQLiteConnection: Issue #772
         public static DbContextOptions<T> UseSQLite<T>([NotNull] this DbContextOptions<T> options, [NotNull] DbConnection connection)
         {
             return (DbContextOptions<T>)UseSQLite((DbContextOptions)options, connection);

--- a/src/EntityFramework.SqlServer/Extensions/SqlServerDbContextOptionsExtensions.cs
+++ b/src/EntityFramework.SqlServer/Extensions/SqlServerDbContextOptionsExtensions.cs
@@ -39,8 +39,7 @@ namespace Microsoft.Data.Entity
             return (DbContextOptions<T>)UseSqlServer((DbContextOptions)options, connectionString);
         }
 
-        // TODO: Use SqlConnection instead of DbConnection?
-        // Issue #772
+        // Note: Decision made to use DbConnection not SqlConnection: Issue #772
         public static DbContextOptions UseSqlServer([NotNull] this DbContextOptions options, [NotNull] DbConnection connection)
         {
             Check.NotNull(options, "options");
@@ -52,8 +51,7 @@ namespace Microsoft.Data.Entity
             return options;
         }
 
-        // TODO: Use SqlConnection instead of DbConnection?
-        // Issue #772
+        // Note: Decision made to use DbConnection not SqlConnection: Issue #772
         public static DbContextOptions<T> UseSqlServer<T>([NotNull] this DbContextOptions<T> options, [NotNull] DbConnection connection)
         {
             return (DbContextOptions<T>)UseSqlServer((DbContextOptions)options, connection);

--- a/src/EntityFramework.SqlServer/SqlServerDataStoreSource.cs
+++ b/src/EntityFramework.SqlServer/SqlServerDataStoreSource.cs
@@ -18,5 +18,10 @@ namespace Microsoft.Data.Entity.SqlServer
         {
             get { return typeof(SqlServerDataStore).Name; }
         }
+
+        public override void AutoConfigure()
+        {
+            ContextOptions.UseSqlServer();
+        }
     }
 }

--- a/src/EntityFramework/DbContext.cs
+++ b/src/EntityFramework/DbContext.cs
@@ -115,7 +115,6 @@ namespace Microsoft.Data.Entity
             {
                 OnConfiguring(options);
             }
-            options.Lock();
 
             var providerSource = serviceProvider != null
                 ? DbContextConfiguration.ServiceProviderSource.Explicit

--- a/src/EntityFramework/Properties/Strings.Designer.cs
+++ b/src/EntityFramework/Properties/Strings.Designer.cs
@@ -491,7 +491,7 @@ namespace Microsoft.Data.Entity
         }
 
         /// <summary>
-        /// No data stores are configured. Configure a data store using OnConfiguring or by creating an ImmutableDbContextOptions with a data store configured and passing it to the context.
+        /// No data stores are configured. Configure a data store by overriding OnConfiguring in your DbContext class or in the AddDbContext method when setting up services.
         /// </summary>
         internal static string NoDataStoreConfigured
         {
@@ -499,7 +499,7 @@ namespace Microsoft.Data.Entity
         }
 
         /// <summary>
-        /// No data stores are configured. Configure a data store using OnConfiguring or by creating an ImmutableDbContextOptions with a data store configured and passing it to the context.
+        /// No data stores are configured. Configure a data store by overriding OnConfiguring in your DbContext class or in the AddDbContext method when setting up services.
         /// </summary>
         internal static string FormatNoDataStoreConfigured()
         {
@@ -523,7 +523,7 @@ namespace Microsoft.Data.Entity
         }
 
         /// <summary>
-        /// The data stores {storeNames}are available. A context can only be configured to use a single data store. Configure a data store using OnConfiguring or by creating an ImmutableDbContextOptions with a data store configured and passing it to the context.
+        /// The data stores {storeNames}are available. A context can only be configured to use a single data store. Configure a data store by overriding OnConfiguring in your DbContext class or in the AddDbContext method when setting up services.
         /// </summary>
         internal static string MultipleDataStoresAvailable
         {
@@ -531,7 +531,7 @@ namespace Microsoft.Data.Entity
         }
 
         /// <summary>
-        /// The data stores {storeNames}are available. A context can only be configured to use a single data store. Configure a data store using OnConfiguring or by creating an ImmutableDbContextOptions with a data store configured and passing it to the context.
+        /// The data stores {storeNames}are available. A context can only be configured to use a single data store. Configure a data store by overriding OnConfiguring in your DbContext class or in the AddDbContext method when setting up services.
         /// </summary>
         internal static string FormatMultipleDataStoresAvailable(object storeNames)
         {
@@ -539,7 +539,7 @@ namespace Microsoft.Data.Entity
         }
 
         /// <summary>
-        /// Cannot change the ImmutableDbContextOptions by calling '{memberName}' because it is locked. Use ImmutableDbContextOptionsBuilder to create ImmutableDbContextOptionss.
+        /// Attempt to modify DbContextOptions by calling '{memberName}' failed because it is locked.
         /// </summary>
         internal static string EntityConfigurationLocked
         {
@@ -547,7 +547,7 @@ namespace Microsoft.Data.Entity
         }
 
         /// <summary>
-        /// Cannot change the ImmutableDbContextOptions by calling '{memberName}' because it is locked. Use ImmutableDbContextOptionsBuilder to create ImmutableDbContextOptionss.
+        /// Attempt to modify DbContextOptions by calling '{memberName}' failed because it is locked.
         /// </summary>
         internal static string FormatEntityConfigurationLocked(object memberName)
         {

--- a/src/EntityFramework/Properties/Strings.resx
+++ b/src/EntityFramework/Properties/Strings.resx
@@ -208,16 +208,16 @@
     <value>The data stores {storeNames}are configured. A context can only be configured to use a single data store.</value>
   </data>
   <data name="NoDataStoreConfigured" xml:space="preserve">
-    <value>No data stores are configured. Configure a data store using OnConfiguring or by creating an ImmutableDbContextOptions with a data store configured and passing it to the context.</value>
+    <value>No data stores are configured. Configure a data store by overriding OnConfiguring in your DbContext class or in the AddDbContext method when setting up services.</value>
   </data>
   <data name="NoDataStoreService" xml:space="preserve">
     <value>No data stores are available. Ensure that data store services are added inside the call to AddEntityFramework on your ServiceCollection.</value>
   </data>
   <data name="MultipleDataStoresAvailable" xml:space="preserve">
-    <value>The data stores {storeNames}are available. A context can only be configured to use a single data store. Configure a data store using OnConfiguring or by creating an ImmutableDbContextOptions with a data store configured and passing it to the context.</value>
+    <value>The data stores {storeNames}are available. A context can only be configured to use a single data store. Configure a data store by overriding OnConfiguring in your DbContext class or in the AddDbContext method when setting up services.</value>
   </data>
   <data name="EntityConfigurationLocked" xml:space="preserve">
-    <value>Cannot change the ImmutableDbContextOptions by calling '{memberName}' because it is locked. Use ImmutableDbContextOptionsBuilder to create ImmutableDbContextOptionss.</value>
+    <value>Attempt to modify DbContextOptions by calling '{memberName}' failed because it is locked.</value>
   </data>
   <data name="MultiplePropertiesMatchedAsKeys" xml:space="preserve">
     <value>Multiple potential primary key properties named '{property}' but differing only by case were found on entity type '{entityType}'. Configure the primary key explicitly using the SetKey fluent API.</value>

--- a/src/EntityFramework/Storage/DataStoreSelector.cs
+++ b/src/EntityFramework/Storage/DataStoreSelector.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Data.Entity.Storage
 
             if (configured.Length == 1)
             {
+                configured[0].ContextOptions.Lock();
+
                 return configured[0].StoreServices;
             }
 
@@ -55,11 +57,14 @@ namespace Microsoft.Data.Entity.Storage
                 throw new InvalidOperationException(Strings.FormatMultipleDataStoresAvailable(BuildStoreNamesString(_sources)));
             }
 
+            _sources[0].AutoConfigure();
+
             if (!_sources[0].IsAvailable)
             {
                 throw new InvalidOperationException(Strings.NoDataStoreConfigured);
             }
 
+            _sources[0].ContextOptions.Lock();
             return _sources[0].StoreServices;
         }
 

--- a/src/EntityFramework/Storage/DataStoreSource.cs
+++ b/src/EntityFramework/Storage/DataStoreSource.cs
@@ -9,5 +9,10 @@ namespace Microsoft.Data.Entity.Storage
         public abstract bool IsAvailable { get; }
         public abstract bool IsConfigured { get; }
         public abstract string Name { get; }
+        public abstract DbContextOptions ContextOptions { get; }
+
+        public virtual void AutoConfigure()
+        {
+        }
     }
 }

--- a/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
@@ -49,6 +49,9 @@
     <PackageReference Include="Microsoft.Framework.Logging">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>
+    <PackageReference Include="Microsoft.Framework.OptionsModel">
+      <TargetFramework>net45</TargetFramework>
+    </PackageReference>
     <PackageReference Include="Microsoft.Framework.Logging.Interfaces">
       <TargetFramework>net45</TargetFramework>
     </PackageReference>
@@ -73,6 +76,7 @@
     <Compile Include="AsNoTrackingTest.cs" />
     <Compile Include="BuiltInDataTypesFixture.cs" />
     <Compile Include="BuiltInDataTypesTest.cs" />
+    <Compile Include="ConnectionSpecificationTest.cs" />
     <Compile Include="ConnectionStringTest.cs" />
     <Compile Include="CompositeKeyEndToEndTest.cs" />
     <Compile Include="DeadlockTest.cs" />

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerConfigPatternsTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerConfigPatternsTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Relational;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
@@ -174,7 +175,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     var serviceProvider = serviceCollection.BuildServiceProvider();
 
                     Assert.Equal(
-                        GetString("FormatNoDataStoreConfigured"),
+                        GetRelationalString("FormatNoConnectionOrConnectionString"),
                         Assert.Throws<InvalidOperationException>(() =>
                             {
                                 using (var context = new NorthwindContext(serviceProvider))
@@ -711,6 +712,12 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         private static string GetString(string stringName)
         {
             var strings = typeof(DbContext).GetTypeInfo().Assembly.GetType(typeof(DbContext).Namespace + ".Strings");
+            return (string)strings.GetTypeInfo().GetDeclaredMethods(stringName).Single().Invoke(null, null);
+        }
+
+        private static string GetRelationalString(string stringName)
+        {
+            var strings = typeof(RelationalConnection).GetTypeInfo().Assembly.GetType(typeof(RelationalConnection).Namespace + ".Strings");
             return (string)strings.GetTypeInfo().GetDeclaredMethods(stringName).Single().Invoke(null, null);
         }
     }

--- a/test/EntityFramework.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Tests/DbContextTest.cs
@@ -463,6 +463,7 @@ namespace Microsoft.Data.Entity.Tests
             sourceMock.Setup(m => m.IsAvailable).Returns(true);
             sourceMock.Setup(m => m.IsConfigured).Returns(true);
             sourceMock.Setup(m => m.StoreServices).Returns(servicesMock.Object);
+            sourceMock.Setup(m => m.ContextOptions).Returns(new DbContextOptions());
 
             var services = new ServiceCollection();
             services.AddEntityFramework();
@@ -503,6 +504,7 @@ namespace Microsoft.Data.Entity.Tests
             sourceMock.Setup(m => m.IsAvailable).Returns(true);
             sourceMock.Setup(m => m.IsConfigured).Returns(true);
             sourceMock.Setup(m => m.StoreServices).Returns(servicesMock.Object);
+            sourceMock.Setup(m => m.ContextOptions).Returns(new DbContextOptions());
 
             var services = new ServiceCollection();
             services.AddEntityFramework();
@@ -547,6 +549,7 @@ namespace Microsoft.Data.Entity.Tests
             sourceMock.Setup(m => m.IsAvailable).Returns(true);
             sourceMock.Setup(m => m.IsConfigured).Returns(true);
             sourceMock.Setup(m => m.StoreServices).Returns(servicesMock.Object);
+            sourceMock.Setup(m => m.ContextOptions).Returns(new DbContextOptions());
 
             var services = new ServiceCollection();
             services.AddEntityFramework();

--- a/test/EntityFramework.Tests/Storage/DataStoreSelectorTest.cs
+++ b/test/EntityFramework.Tests/Storage/DataStoreSelectorTest.cs
@@ -102,6 +102,7 @@ namespace Microsoft.Data.Entity.Tests.Storage
             sourceMock.Setup(m => m.IsAvailable).Returns(available);
             sourceMock.Setup(m => m.StoreServices).Returns(services);
             sourceMock.Setup(m => m.Name).Returns(name);
+            sourceMock.Setup(m => m.ContextOptions).Returns(new DbContextOptions());
 
             return sourceMock.Object;
         }


### PR DESCRIPTION
Or: What's on the end of the stick ,Vic?

This is mostly testing making use of the new patterns for service provider and options injection, including:
- Multiple context types
- Multiple providers
- Constructor injection of OptionsContext
- Readining config (indrectly) from IConfiguration or inline

Also, added the ability to auto-configure a provider if it is the only provider regsitered, which also paves the way for auto-configuring from file-based configuration only.
