### PR TITLE
Change implementation of TryGetService based on DI behavior change

### DIFF
--- a/src/EntityFramework/DbContext.cs
+++ b/src/EntityFramework/DbContext.cs
@@ -122,12 +122,12 @@ namespace Microsoft.Data.Entity
             serviceProvider = serviceProvider ?? ServiceProviderCache.Instance.GetOrAdd(options);
 
             _scopedServiceProvider = serviceProvider
-                .GetService<IServiceScopeFactory>()
+                .GetRequiredServiceChecked<IServiceScopeFactory>()
                 .CreateScope()
                 .ServiceProvider;
 
             return _scopedServiceProvider
-                .GetService<DbContextConfiguration>()
+                .GetRequiredServiceChecked<DbContextConfiguration>()
                 .Initialize(serviceProvider, _scopedServiceProvider, options, this, providerSource);
         }
 
@@ -135,7 +135,7 @@ namespace Microsoft.Data.Entity
         {
             serviceProvider = serviceProvider ?? ServiceProviderCache.Instance.GetOrAdd(options);
 
-            serviceProvider.GetService<DbSetInitializer>().InitializeSets(this);
+            serviceProvider.GetRequiredServiceChecked<DbSetInitializer>().InitializeSets(this);
         }
 
         public virtual DbContextConfiguration Configuration

--- a/src/EntityFramework/Extensions/EntityServiceCollectionExtensions.cs
+++ b/src/EntityFramework/Extensions/EntityServiceCollectionExtensions.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Framework.DependencyInjection
             Check.NotNull(builder, "builder");
 
             builder.ServiceCollection.AddSingleton<DbContextOptions<TContext>>(
-                sp => sp.GetService<IOptions<DbContextOptions<TContext>>>().Options);
+                sp => sp.GetRequiredServiceChecked<IOptions<DbContextOptions<TContext>>>().Options);
 
             if (builder.Configuration != null)
             {

--- a/src/EntityFramework/Infrastructure/ContextServices.cs
+++ b/src/EntityFramework/Infrastructure/ContextServices.cs
@@ -46,77 +46,77 @@ namespace Microsoft.Data.Entity.Infrastructure
 
         public virtual ClrPropertyGetterSource ClrPropertyGetterSource
         {
-            get { return _serviceProvider.GetService<ClrPropertyGetterSource>(); }
+            get { return _serviceProvider.GetRequiredServiceChecked<ClrPropertyGetterSource>(); }
         }
 
         public virtual ClrPropertySetterSource ClrPropertySetterSource
         {
-            get { return _serviceProvider.GetService<ClrPropertySetterSource>(); }
+            get { return _serviceProvider.GetRequiredServiceChecked<ClrPropertySetterSource>(); }
         }
 
         public virtual ClrCollectionAccessorSource ClrCollectionAccessorSource
         {
-            get { return _serviceProvider.GetService<ClrCollectionAccessorSource>(); }
+            get { return _serviceProvider.GetRequiredServiceChecked<ClrCollectionAccessorSource>(); }
         }
 
         public virtual ContextSets ContextSets
         {
-            get { return ServiceProvider.GetService<ContextSets>(); }
+            get { return ServiceProvider.GetRequiredServiceChecked<ContextSets>(); }
         }
 
         public virtual DataStoreSelector DataStoreSelector
         {
-            get { return _serviceProvider.GetService<DataStoreSelector>(); }
+            get { return _serviceProvider.GetRequiredServiceChecked<DataStoreSelector>(); }
         }
 
         public virtual EntityMaterializerSource EntityMaterializerSource
         {
-            get { return _serviceProvider.GetService<EntityMaterializerSource>(); }
+            get { return _serviceProvider.GetRequiredServiceChecked<EntityMaterializerSource>(); }
         }
 
         public virtual StateManager StateManager
         {
-            get { return ServiceProvider.GetService<StateManager>(); }
+            get { return ServiceProvider.GetRequiredServiceChecked<StateManager>(); }
         }
 
         public virtual EntityKeyFactorySource EntityKeyFactorySource
         {
-            get { return _serviceProvider.GetService<EntityKeyFactorySource>(); }
+            get { return _serviceProvider.GetRequiredServiceChecked<EntityKeyFactorySource>(); }
         }
 
         public virtual IModelSource ModelSource
         {
-            get { return _serviceProvider.GetService<IModelSource>(); }
+            get { return _serviceProvider.GetRequiredServiceChecked<IModelSource>(); }
         }
 
         public virtual OriginalValuesFactory OriginalValuesFactory
         {
-            get { return _serviceProvider.GetService<OriginalValuesFactory>(); }
+            get { return _serviceProvider.GetRequiredServiceChecked<OriginalValuesFactory>(); }
         }
 
         public virtual RelationshipsSnapshotFactory RelationshipsSnapshotFactory
         {
-            get { return _serviceProvider.GetService<RelationshipsSnapshotFactory>(); }
+            get { return _serviceProvider.GetRequiredServiceChecked<RelationshipsSnapshotFactory>(); }
         }
 
         public virtual StateEntryNotifier StateEntryNotifier
         {
-            get { return ServiceProvider.GetService<StateEntryNotifier>(); }
+            get { return ServiceProvider.GetRequiredServiceChecked<StateEntryNotifier>(); }
         }
 
         public virtual ChangeDetector ChangeDetector
         {
-            get { return ServiceProvider.GetService<ChangeDetector>(); }
+            get { return ServiceProvider.GetRequiredServiceChecked<ChangeDetector>(); }
         }
 
         public virtual StoreGeneratedValuesFactory StoreGeneratedValuesFactory
         {
-            get { return _serviceProvider.GetService<StoreGeneratedValuesFactory>(); }
+            get { return _serviceProvider.GetRequiredServiceChecked<StoreGeneratedValuesFactory>(); }
         }
 
         public virtual StateEntryFactory StateEntryFactory
         {
-            get { return ServiceProvider.GetService<StateEntryFactory>(); }
+            get { return ServiceProvider.GetRequiredServiceChecked<StateEntryFactory>(); }
         }
 
         public virtual IEnumerable<IEntityStateListener> EntityStateListeners

--- a/src/EntityFramework/Infrastructure/DbContextActivator.cs
+++ b/src/EntityFramework/Infrastructure/DbContextActivator.cs
@@ -24,8 +24,7 @@ namespace Microsoft.Data.Entity.Infrastructure
         {
             Check.NotNull(serviceProvider, "serviceProvider");
 
-            // TODO: Figure out what needs to be done if there is no ITypeActivator.
-            var typeActivator = serviceProvider.GetService<ITypeActivator>();
+            var typeActivator = serviceProvider.GetRequiredServiceChecked<ITypeActivator>();
 
             try
             {

--- a/src/EntityFramework/Infrastructure/DbContextConfiguration.cs
+++ b/src/EntityFramework/Infrastructure/DbContextConfiguration.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Data.Entity.Infrastructure
             _modelFromSource = new LazyRef<IModel>(() => _services.ModelSource.GetModel(_context, _dataStoreServices.Value.ModelBuilderFactory));
             _dataStore = new LazyRef<DataStore>(() => _dataStoreServices.Value.Store);
             _connection = new LazyRef<DataStoreConnection>(() => _dataStoreServices.Value.Connection);
-            _loggerFactory = new LazyRef<ILoggerFactory>(() => _externalProvider.GetRequiredService<ILoggerFactory>());
+            _loggerFactory = new LazyRef<ILoggerFactory>(() => _externalProvider.GetRequiredServiceChecked<ILoggerFactory>());
             _database = new LazyRef<Database>(() => _dataStoreServices.Value.Database);
             _stateManager = new LazyRef<StateManager>(() => _services.StateManager);
 

--- a/src/EntityFramework/Storage/DataStoreSource`.cs
+++ b/src/EntityFramework/Storage/DataStoreSource`.cs
@@ -26,19 +26,7 @@ namespace Microsoft.Data.Entity.Storage
 
         public override DataStoreServices StoreServices
         {
-            get
-            {
-                try
-                {
-                    return _configuration.Services.ServiceProvider.GetService<TStoreServices>();
-                }
-                catch (TargetInvocationException ex)
-                {
-                    // See DependencyInjection Issue #127
-                    ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
-                    return null;
-                }
-            }
+            get { return _configuration.Services.ServiceProvider.GetRequiredServiceChecked<TStoreServices>(); }
         }
 
         public override bool IsConfigured

--- a/src/EntityFramework/Utilities/ServiceProviderExtensions.cs
+++ b/src/EntityFramework/Utilities/ServiceProviderExtensions.cs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 
@@ -18,9 +18,16 @@ namespace Microsoft.Framework.DependencyInjection
         {
             Check.NotNull(serviceProvider, "serviceProvider");
 
-            var services = serviceProvider.GetService<IEnumerable<TService>>();
-
-            return services == null ? null : services.FirstOrDefault();
+            try
+            {
+                return serviceProvider.GetService<TService>();
+            }
+            catch (TargetInvocationException ex)
+            {
+                // TODO: See DependencyInjection Issue #127
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                throw;
+            }
         }
 
         public static object TryGetService([NotNull] this IServiceProvider serviceProvider, Type serviceType)
@@ -28,14 +35,49 @@ namespace Microsoft.Framework.DependencyInjection
             Check.NotNull(serviceProvider, "serviceProvider");
             Check.NotNull(serviceType, "serviceType");
 
-            // Use try-catch here to avoid use of MakeGenericType for IEnumerbale pattern
             try
             {
                 return serviceProvider.GetService(serviceType);
             }
-            catch
+            catch (TargetInvocationException ex)
             {
-                return null;
+                // TODO: See DependencyInjection Issue #127
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                throw;
+            }
+        }
+
+        public static TService GetRequiredServiceChecked<TService>([NotNull] this IServiceProvider serviceProvider)
+            where TService : class
+        {
+            Check.NotNull(serviceProvider, "serviceProvider");
+
+            try
+            {
+                return serviceProvider.GetRequiredService<TService>();
+            }
+            catch (TargetInvocationException ex)
+            {
+                // TODO: See DependencyInjection Issue #127
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                throw;
+            }
+        }
+
+        public static object GetRequiredServiceChecked([NotNull] this IServiceProvider serviceProvider, Type serviceType)
+        {
+            Check.NotNull(serviceProvider, "serviceProvider");
+            Check.NotNull(serviceType, "serviceType");
+
+            try
+            {
+                return serviceProvider.GetRequiredService(serviceType);
+            }
+            catch (TargetInvocationException ex)
+            {
+                // TODO: See DependencyInjection Issue #127
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+                throw;
             }
         }
     }

--- a/test/EntityFramework.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Tests/DbContextTest.cs
@@ -1087,6 +1087,7 @@ namespace Microsoft.Data.Entity.Tests
 
             services
                 .AddSingleton<FakeService>()
+                .Add(OptionsServices.GetDefaultServices())
                 .AddEntityFramework()
                 .AddDbContext<ContextWithDefaults>();
 

--- a/test/EntityFramework.Tests/EntityFramework.Tests.csproj
+++ b/test/EntityFramework.Tests/EntityFramework.Tests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="DefaultModelSourceTest.cs" />
     <Compile Include="DbContextOptionsTest.cs" />
     <Compile Include="EntitySetFinderTest.cs" />
+    <Compile Include="Extensions\ServiceProviderExtensionsTest.cs" />
     <Compile Include="Extensions\TaskExtensionsTest.cs" />
     <Compile Include="Identity\ForeignKeyValueGeneratorTest.cs" />
     <Compile Include="Identity\GuidValueGeneratorTest.cs" />

--- a/test/EntityFramework.Tests/Extensions/ServiceProviderExtensionsTest.cs
+++ b/test/EntityFramework.Tests/Extensions/ServiceProviderExtensionsTest.cs
@@ -1,0 +1,115 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests
+{
+    public class ServiceProviderExtensionsTest
+    {
+        [Fact]
+        public void GetRequiredService_throws_useful_exception_if_service_not_registered()
+        {
+            var serviceProvider = new ServiceCollection().BuildServiceProvider();
+
+            Assert.Throws<Exception>(
+                () => serviceProvider.GetRequiredServiceChecked<IPilkington>());
+        }
+
+        [Fact]
+        public void Non_generic_GetRequiredService_throws_useful_exception_if_service_not_registered()
+        {
+            var serviceProvider = new ServiceCollection().BuildServiceProvider();
+
+            Assert.Throws<Exception>(
+                () => serviceProvider.GetRequiredServiceChecked(typeof(IPilkington)));
+        }
+
+        [Fact]
+        public void GetRequiredService_throws_useful_exception_if_resolution_fails()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddScoped<IPilkington, Karl>();
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            Assert.Equal(
+                KarlQuote,
+                Assert.Throws<NotSupportedException>(
+                    () => serviceProvider.GetRequiredServiceChecked<IPilkington>()).Message);
+        }
+
+        [Fact]
+        public void Non_generic_GetRequiredService_throws_useful_exception_if_resolution_fails()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddScoped<IPilkington, Karl>();
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            Assert.Equal(
+                KarlQuote,
+                Assert.Throws<NotSupportedException>(
+                    () => serviceProvider.GetRequiredServiceChecked(typeof(IPilkington))).Message);
+        }
+
+        [Fact]
+        public void GetService_returns_null_if_service_not_registered()
+        {
+            var serviceProvider = new ServiceCollection().BuildServiceProvider();
+
+            Assert.Null(serviceProvider.TryGetService<IPilkington>());
+        }
+
+        [Fact]
+        public void Non_generic_GetService_returns_null_if_service_not_registered()
+        {
+            var serviceProvider = new ServiceCollection().BuildServiceProvider();
+
+            Assert.Null(serviceProvider.TryGetService(typeof(IPilkington)));
+        }
+
+        [Fact]
+        public void GetService_throws_useful_exception_if_resolution_fails()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddScoped<IPilkington, Karl>();
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            Assert.Equal(
+                KarlQuote,
+                Assert.Throws<NotSupportedException>(
+                    () => serviceProvider.TryGetService<IPilkington>()).Message);
+        }
+
+        [Fact]
+        public void Non_generic_GetService_throws_useful_exception_if_resolution_fails()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddScoped<IPilkington, Karl>();
+
+            var serviceProvider = serviceCollection.BuildServiceProvider();
+
+            Assert.Equal(
+                KarlQuote,
+                Assert.Throws<NotSupportedException>(
+                    () => serviceProvider.TryGetService(typeof(IPilkington))).Message);
+        }
+
+        private const string KarlQuote = "You can only talk rubbish if you're aware of knowledge.";
+
+        private interface IPilkington
+        {
+        }
+
+        private class Karl
+        {
+            public Karl()
+            {
+                throw new NotSupportedException(KarlQuote);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Or: Karl says, "You don't have to do it straight away, but just do it before it gets really bad."

Issue #900. Note that due to Dependency Injection Issue #127 the methods are still present in addition to new required service methods such that TargetInvocationException is unwrapped thereby removing this implementation detail from the call stack. This then simplifies the fix in #937.
