### PR TITLE
Update AddEntityFramework to ensure low-level required services are available

### DIFF
--- a/src/EntityFramework.InMemory/InMemoryDataStore.cs
+++ b/src/EntityFramework.InMemory/InMemoryDataStore.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -48,7 +49,7 @@ namespace Microsoft.Data.Entity.InMemory
             _database = new ThreadSafeLazyRef<InMemoryDatabase>(
                 () => _persist
                     ? persistentDatabase
-                    : new InMemoryDatabase(new[] { configuration.LoggerFactory }));
+                    : new InMemoryDatabase(configuration.LoggerFactory));
         }
 
         public virtual InMemoryDatabase Database

--- a/src/EntityFramework.InMemory/InMemoryDatabase.cs
+++ b/src/EntityFramework.InMemory/InMemoryDatabase.cs
@@ -4,10 +4,10 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Globalization;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.InMemory.Utilities;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
@@ -22,11 +22,11 @@ namespace Microsoft.Data.Entity.InMemory
             = new ThreadSafeLazyRef<ImmutableDictionary<IEntityType, InMemoryTable>>(
                 () => ImmutableDictionary<IEntityType, InMemoryTable>.Empty);
 
-        public InMemoryDatabase([CanBeNull] IEnumerable<ILoggerFactory> loggerFactories)
+        public InMemoryDatabase([NotNull] ILoggerFactory loggerFactory)
         {
-            var factory = (loggerFactories == null ? null : loggerFactories.FirstOrDefault()) ?? new LoggerFactory();
+            Check.NotNull(loggerFactory, "loggerFactory");
 
-            _logger = factory.Create<InMemoryDatabase>();
+            _logger = loggerFactory.Create<InMemoryDatabase>();
         }
 
         /// <summary>

--- a/src/EntityFramework.Relational/SqlStatementExecutor.cs
+++ b/src/EntityFramework.Relational/SqlStatementExecutor.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Data.Entity.Relational
         {
             Check.NotNull(loggerFactory, "loggerFactory");
 
-            _logger = new LazyRef<ILogger>(() => loggerFactory.Create<SqlStatementExecutor>());
+            _logger = new LazyRef<ILogger>(loggerFactory.Create<SqlStatementExecutor>);
         }
 
         protected virtual ILogger Logger

--- a/src/EntityFramework/Infrastructure/DbContextConfiguration.cs
+++ b/src/EntityFramework/Infrastructure/DbContextConfiguration.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Data.Entity.Infrastructure
             _modelFromSource = new LazyRef<IModel>(() => _services.ModelSource.GetModel(_context, _dataStoreServices.Value.ModelBuilderFactory));
             _dataStore = new LazyRef<DataStore>(() => _dataStoreServices.Value.Store);
             _connection = new LazyRef<DataStoreConnection>(() => _dataStoreServices.Value.Connection);
-            _loggerFactory = new LazyRef<ILoggerFactory>(() => _externalProvider.TryGetService<ILoggerFactory>() ?? new LoggerFactory());
+            _loggerFactory = new LazyRef<ILoggerFactory>(() => _externalProvider.GetRequiredService<ILoggerFactory>());
             _database = new LazyRef<Database>(() => _dataStoreServices.Value.Database);
             _stateManager = new LazyRef<StateManager>(() => _services.StateManager);
 

--- a/src/EntityFramework/ServiceProviderCache.cs
+++ b/src/EntityFramework/ServiceProviderCache.cs
@@ -29,11 +29,6 @@ namespace Microsoft.Data.Entity
             var services = new ServiceCollection();
             var builder = services.AddEntityFramework();
 
-            if (services.All(s => s.ServiceType != typeof(ILoggerFactory)))
-            {
-                builder.UseLoggerFactory<LoggerFactory>();
-            }
-
             foreach (var extension in options.Extensions)
             {
                 extension.ApplyServices(builder);

--- a/test/EntityFramework.InMemory.FunctionalTests/CompositeKeyEndToEndTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/CompositeKeyEndToEndTest.cs
@@ -7,9 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 using Xunit;
 
 namespace Microsoft.Data.Entity.InMemory.FunctionalTests
@@ -22,7 +20,6 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             var serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddInMemoryStore()
-                .UseLoggerFactory<LoggerFactory>()
                 .ServiceCollection
                 .BuildServiceProvider();
 
@@ -66,7 +63,6 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             var serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddInMemoryStore()
-                .UseLoggerFactory<LoggerFactory>()
                 .ServiceCollection
                 .BuildServiceProvider();
 
@@ -124,7 +120,6 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             var serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddInMemoryStore()
-                .UseLoggerFactory<LoggerFactory>()
                 .ServiceCollection
                 .BuildServiceProvider();
 

--- a/test/EntityFramework.InMemory.FunctionalTests/GuidValueGeneratorEndToEndTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/GuidValueGeneratorEndToEndTest.cs
@@ -6,9 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 using Xunit;
 
 namespace Microsoft.Data.Entity.InMemory.FunctionalTests
@@ -21,7 +19,6 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             var serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddInMemoryStore()
-                .UseLoggerFactory<LoggerFactory>()
                 .ServiceCollection
                 .BuildServiceProvider();
 

--- a/test/EntityFramework.InMemory.FunctionalTests/InMemoryConfigPatternsTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/InMemoryConfigPatternsTest.cs
@@ -5,9 +5,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 using Xunit;
 
 namespace Microsoft.Data.Entity.InMemory.FunctionalTests
@@ -84,7 +82,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             public void Can_save_and_query_with_explicit_services_and_OnConfiguring()
             {
                 var services = new ServiceCollection();
-                services.AddEntityFramework().AddInMemoryStore().UseLoggerFactory<LoggerFactory>();
+                services.AddEntityFramework().AddInMemoryStore();
                 var serviceProvider = services.BuildServiceProvider();
 
                 using (var context = new BlogContext(serviceProvider))
@@ -124,7 +122,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             public void Can_save_and_query_with_explicit_services_and_explicit_config()
             {
                 var services = new ServiceCollection();
-                services.AddEntityFramework().AddInMemoryStore().UseLoggerFactory<LoggerFactory>();
+                services.AddEntityFramework().AddInMemoryStore();
                 var serviceProvider = services.BuildServiceProvider();
 
                 var options = new DbContextOptions().UseInMemoryStore();
@@ -161,7 +159,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             public void Can_save_and_query_with_explicit_services_and_no_config()
             {
                 var services = new ServiceCollection();
-                services.AddEntityFramework().AddInMemoryStore().UseLoggerFactory<LoggerFactory>();
+                services.AddEntityFramework().AddInMemoryStore();
                 var serviceProvider = services.BuildServiceProvider();
 
                 using (var context = new BlogContext(serviceProvider))
@@ -259,8 +257,8 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
                 services.AddTransient<BlogContext>()
                     .AddTransient<MyController>()
                     .AddEntityFramework()
-                    .AddInMemoryStore()
-                    .UseLoggerFactory<LoggerFactory>();
+                    .AddInMemoryStore();
+
                 var serviceProvider = services.BuildServiceProvider();
 
                 serviceProvider.GetService<MyController>().Test();
@@ -313,8 +311,8 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
                     .AddTransient<MyController>()
                     .AddInstance(options)
                     .AddEntityFramework()
-                    .AddInMemoryStore()
-                    .UseLoggerFactory<LoggerFactory>();
+                    .AddInMemoryStore();
+
                 var serviceProvider = services.BuildServiceProvider();
 
                 serviceProvider.GetService<MyController>().Test();
@@ -371,8 +369,8 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
                     .AddTransient<MyController>()
                     .AddInstance(options)
                     .AddEntityFramework()
-                    .AddInMemoryStore()
-                    .UseLoggerFactory<LoggerFactory>();
+                    .AddInMemoryStore();
+
                 var serviceProvider = services.BuildServiceProvider();
 
                 serviceProvider.GetService<MyController>().Test();
@@ -429,8 +427,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
                     .AddInstance(blogOptions)
                     .AddInstance(accountOptions)
                     .AddEntityFramework()
-                    .AddInMemoryStore()
-                    .UseLoggerFactory<LoggerFactory>();
+                    .AddInMemoryStore();
 
                 var serviceProvider = services.BuildServiceProvider();
 
@@ -535,8 +532,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
                     .AddInstance(blogOptions)
                     .AddInstance(accountOptions)
                     .AddEntityFramework()
-                    .AddInMemoryStore()
-                    .UseLoggerFactory<LoggerFactory>();
+                    .AddInMemoryStore();
 
                 var serviceProvider = services.BuildServiceProvider();
 

--- a/test/EntityFramework.InMemory.FunctionalTests/InMemoryIntegerGeneratorEndToEndTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/InMemoryIntegerGeneratorEndToEndTest.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             var serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddInMemoryStore()
-                .UseLoggerFactory<LoggerFactory>()
                 .ServiceCollection
                 .BuildServiceProvider();
 
@@ -60,7 +59,6 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             var serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddInMemoryStore()
-                .UseLoggerFactory<LoggerFactory>()
                 .ServiceCollection
                 .BuildServiceProvider();
 
@@ -100,7 +98,6 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             var serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddInMemoryStore()
-                .UseLoggerFactory<LoggerFactory>()
                 .ServiceCollection
                 .BuildServiceProvider();
 

--- a/test/EntityFramework.InMemory.FunctionalTests/MonsterFixupTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/MonsterFixupTest.cs
@@ -7,9 +7,7 @@ using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.FunctionalTests.TestModels;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 {
@@ -17,7 +15,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
     {
         protected override IServiceProvider CreateServiceProvider(bool throwingStateManager = false)
         {
-            var serviceCollection = new ServiceCollection().AddEntityFramework().AddInMemoryStore().UseLoggerFactory<LoggerFactory>().ServiceCollection;
+            var serviceCollection = new ServiceCollection().AddEntityFramework().AddInMemoryStore().ServiceCollection;
 
             if (throwingStateManager)
             {

--- a/test/EntityFramework.InMemory.FunctionalTests/MusicStoreQueryTests.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/MusicStoreQueryTests.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
                 = new ServiceCollection()
                     .AddEntityFramework()
                     .AddInMemoryStore()
-                    .UseLoggerFactory<LoggerFactory>()
                     .ServiceCollection
                     .BuildServiceProvider();
 

--- a/test/EntityFramework.InMemory.FunctionalTests/NorthwindQueryFixture.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/NorthwindQueryFixture.cs
@@ -5,9 +5,7 @@ using System;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 using Northwind;
 
 namespace Microsoft.Data.Entity.InMemory.FunctionalTests
@@ -24,7 +22,6 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
                 = new ServiceCollection()
                     .AddEntityFramework()
                     .AddInMemoryStore()
-                    .UseLoggerFactory<LoggerFactory>()
                     .ServiceCollection
                     .BuildServiceProvider();
 

--- a/test/EntityFramework.InMemory.FunctionalTests/OneToOneQueryFixture.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/OneToOneQueryFixture.cs
@@ -4,9 +4,7 @@
 using System;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 {
@@ -21,7 +19,6 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
                 = new ServiceCollection()
                     .AddEntityFramework()
                     .AddInMemoryStore()
-                    .UseLoggerFactory<LoggerFactory>()
                     .ServiceCollection
                     .BuildServiceProvider();
 

--- a/test/EntityFramework.InMemory.Tests/InMemoryDataStoreCreatorTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryDataStoreCreatorTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             var model = CreateModel();
             var configuration = CreateConfiguration(new DbContextOptions().UseInMemoryStore(persist: true));
             var entityType = model.GetEntityType(typeof(Test));
-            var persistentDatabase = new InMemoryDatabase(new[] { new LoggerFactory() });
+            var persistentDatabase = new InMemoryDatabase(new LoggerFactory());
 
             var inMemoryDataStore = new InMemoryDataStore(configuration, persistentDatabase);
 
@@ -35,7 +35,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             var model = CreateModel();
             var configuration = CreateConfiguration(new DbContextOptions().UseInMemoryStore(persist: false));
             var entityType = model.GetEntityType(typeof(Test));
-            var nonPersistentDatabase = new InMemoryDatabase(new[] { new LoggerFactory() });
+            var nonPersistentDatabase = new InMemoryDatabase(new LoggerFactory());
             var inMemoryDataStore = new InMemoryDataStore(configuration, nonPersistentDatabase);
 
             var creator = new InMemoryDataStoreCreator(inMemoryDataStore);
@@ -51,7 +51,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             var model = CreateModel();
             var configuration = CreateConfiguration(new DbContextOptions().UseInMemoryStore(persist: true));
             var entityType = model.GetEntityType(typeof(Test));
-            var persistentDatabase = new InMemoryDatabase(new[] { new LoggerFactory() });
+            var persistentDatabase = new InMemoryDatabase(new LoggerFactory());
             var inMemoryDataStore = new InMemoryDataStore(configuration, persistentDatabase);
 
             var creator = new InMemoryDataStoreCreator(inMemoryDataStore);
@@ -67,7 +67,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             var model = CreateModel();
             var configuration = CreateConfiguration(new DbContextOptions().UseInMemoryStore(persist: false));
             var entityType = model.GetEntityType(typeof(Test));
-            var nonPersistentDatabase = new InMemoryDatabase(new[] { new LoggerFactory() });
+            var nonPersistentDatabase = new InMemoryDatabase(new LoggerFactory());
             var inMemoryDataStore = new InMemoryDataStore(configuration, nonPersistentDatabase);
 
             var creator = new InMemoryDataStoreCreator(inMemoryDataStore);

--- a/test/EntityFramework.InMemory.Tests/InMemoryDataStoreTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryDataStoreTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         public void Uses_persistent_database_by_default()
         {
             var configuration = CreateConfiguration();
-            var persistentDatabase = new InMemoryDatabase(new[] { new LoggerFactory() });
+            var persistentDatabase = new InMemoryDatabase(new LoggerFactory());
 
             var inMemoryDataStore = new InMemoryDataStore(configuration, persistentDatabase);
 
@@ -31,7 +31,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         {
             var configuration = CreateConfiguration(new DbContextOptions().UseInMemoryStore(persist: true));
 
-            var persistentDatabase = new InMemoryDatabase(new[] { new LoggerFactory() });
+            var persistentDatabase = new InMemoryDatabase(new LoggerFactory());
 
             var inMemoryDataStore = new InMemoryDataStore(configuration, persistentDatabase);
 
@@ -43,7 +43,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         {
             var configuration = CreateConfiguration(new DbContextOptions().UseInMemoryStore(persist: false));
 
-            var persistentDatabase = new InMemoryDatabase(new[] { new LoggerFactory() });
+            var persistentDatabase = new InMemoryDatabase(new LoggerFactory());
 
             var inMemoryDataStore = new InMemoryDataStore(configuration, persistentDatabase);
 
@@ -59,7 +59,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             var configuration = CreateConfiguration(new DbContextOptions().UseInMemoryStore(persist: true));
             var entityType = model.GetEntityType(typeof(Customer));
 
-            var persistentDatabase = new InMemoryDatabase(new[] { new LoggerFactory() });
+            var persistentDatabase = new InMemoryDatabase(new LoggerFactory());
 
             var inMemoryDataStore = new InMemoryDataStore(configuration, persistentDatabase);
 
@@ -75,7 +75,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             var configuration = CreateConfiguration(new DbContextOptions().UseInMemoryStore(persist: false));
             var entityType = model.GetEntityType(typeof(Customer));
 
-            var nonPersistentDatabase = new InMemoryDatabase(new[] { new LoggerFactory() });
+            var nonPersistentDatabase = new InMemoryDatabase(new LoggerFactory());
 
             var inMemoryDataStore = new InMemoryDataStore(configuration, nonPersistentDatabase);
 
@@ -95,7 +95,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             var entityEntry = new ClrStateEntry(configuration, entityType, customer);
             await entityEntry.SetEntityStateAsync(EntityState.Added);
 
-            var inMemoryDataStore = new InMemoryDataStore(configuration, new InMemoryDatabase(new[] { new LoggerFactory() }));
+            var inMemoryDataStore = new InMemoryDataStore(configuration, new InMemoryDatabase(new LoggerFactory()));
 
             await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry });
 
@@ -114,7 +114,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             var entityEntry = new ClrStateEntry(configuration, entityType, customer);
             await entityEntry.SetEntityStateAsync(EntityState.Added);
 
-            var inMemoryDataStore = new InMemoryDataStore(configuration, new InMemoryDatabase(new[] { new LoggerFactory() }));
+            var inMemoryDataStore = new InMemoryDataStore(configuration, new InMemoryDatabase(new LoggerFactory()));
 
             await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry });
 
@@ -138,7 +138,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             var entityEntry = new ClrStateEntry(configuration, entityType, customer);
             await entityEntry.SetEntityStateAsync(EntityState.Added);
 
-            var inMemoryDataStore = new InMemoryDataStore(configuration, new InMemoryDatabase(new[] { new LoggerFactory() }));
+            var inMemoryDataStore = new InMemoryDataStore(configuration, new InMemoryDatabase(new LoggerFactory()));
 
             await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry });
 
@@ -170,7 +170,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             var mockFactory = new Mock<ILoggerFactory>();
             mockFactory.Setup(m => m.Create(It.IsAny<string>())).Returns(mockLogger.Object);
 
-            var inMemoryDataStore = new InMemoryDataStore(configuration, new InMemoryDatabase(new[] { mockFactory.Object }));
+            var inMemoryDataStore = new InMemoryDataStore(configuration, new InMemoryDatabase(mockFactory.Object));
 
             await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry });
 

--- a/test/EntityFramework.SQLite.FunctionalTests/BuiltInDataTypesFixture.cs
+++ b/test/EntityFramework.SQLite.FunctionalTests/BuiltInDataTypesFixture.cs
@@ -4,9 +4,7 @@
 using System;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SQLite.FunctionalTests
 {
@@ -20,7 +18,6 @@ namespace Microsoft.Data.Entity.SQLite.FunctionalTests
                 = new ServiceCollection()
                     .AddEntityFramework()
                     .AddSQLite()
-                    .UseLoggerFactory<LoggerFactory>()
                     .ServiceCollection
                     .BuildServiceProvider();
         }

--- a/test/EntityFramework.SQLite.FunctionalTests/MonsterFixupTest.cs
+++ b/test/EntityFramework.SQLite.FunctionalTests/MonsterFixupTest.cs
@@ -12,9 +12,7 @@ using Microsoft.Data.Entity.FunctionalTests.TestModels;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SQLite.FunctionalTests
 {
@@ -31,7 +29,6 @@ namespace Microsoft.Data.Entity.SQLite.FunctionalTests
             var serviceCollection = new ServiceCollection()
                 .AddEntityFramework()
                 .AddSQLite()
-                .UseLoggerFactory<LoggerFactory>()
                 .ServiceCollection;
 
             if (throwingStateManager)

--- a/test/EntityFramework.SQLite.FunctionalTests/SQLiteTransactionTest.cs
+++ b/test/EntityFramework.SQLite.FunctionalTests/SQLiteTransactionTest.cs
@@ -7,9 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.Data.Entity.Relational.FunctionalTests;
 using Microsoft.Data.SQLite;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SQLite.FunctionalTests
 {
@@ -23,7 +21,6 @@ namespace Microsoft.Data.Entity.SQLite.FunctionalTests
                 = new ServiceCollection()
                     .AddEntityFramework()
                     .AddSQLite()
-                    .UseLoggerFactory<LoggerFactory>()
                     .ServiceCollection
                     .BuildServiceProvider();
         }

--- a/test/EntityFramework.SqlServer.FunctionalTests/CompositeKeyEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/CompositeKeyEndToEndTest.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             var serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddSqlServer()
-                .UseLoggerFactory<LoggerFactory>()
                 .ServiceCollection
                 .BuildServiceProvider();
 
@@ -68,7 +67,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             var serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddSqlServer()
-                .UseLoggerFactory<LoggerFactory>()
                 .ServiceCollection
                 .BuildServiceProvider();
 
@@ -130,7 +128,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             var serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddSqlServer()
-                .UseLoggerFactory<LoggerFactory>()
                 .ServiceCollection
                 .BuildServiceProvider();
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/ConnectionSpecificationTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/ConnectionSpecificationTest.cs
@@ -23,9 +23,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             var serviceCollection = new ServiceCollection();
             serviceCollection
-                .AddSingleton<ITypeActivator, TypeActivator>()
-                .AddSingleton<ILoggerFactory, LoggerFactory>()
-                .Add(OptionsServices.GetDefaultServices())
                 .AddEntityFramework()
                 .AddSqlServer()
                 .AddDbContext<StringInOnConfiguringContext>();
@@ -66,9 +63,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             var serviceCollection = new ServiceCollection();
             serviceCollection
-                .AddSingleton<ITypeActivator, TypeActivator>()
-                .AddSingleton<ILoggerFactory, LoggerFactory>()
-                .Add(OptionsServices.GetDefaultServices())
                 .AddScoped<SqlConnection>(p => new SqlConnection(SqlServerTestDatabase.NorthwindConnectionString))
                 .AddEntityFramework()
                 .AddSqlServer()
@@ -136,9 +130,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             var serviceCollection = new ServiceCollection();
             serviceCollection
-                .AddSingleton<ITypeActivator, TypeActivator>()
-                .AddSingleton<ILoggerFactory, LoggerFactory>()
-                .Add(OptionsServices.GetDefaultServices())
                 .AddEntityFramework(configuration)
                 .AddSqlServer()
                 .AddDbContext<StringInConfigContext>();
@@ -169,9 +160,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             var serviceCollection = new ServiceCollection();
             serviceCollection
-                .AddSingleton<ITypeActivator, TypeActivator>()
-                .AddSingleton<ILoggerFactory, LoggerFactory>()
-                .Add(OptionsServices.GetDefaultServices())
                 .AddEntityFramework(configuration)
                 .AddSqlServer()
                 .AddDbContext<StringInConfigContext>();
@@ -197,9 +185,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             var serviceCollection = new ServiceCollection();
             serviceCollection
-                .AddSingleton<ITypeActivator, TypeActivator>()
-                .AddSingleton<ILoggerFactory, LoggerFactory>()
-                .Add(OptionsServices.GetDefaultServices())
                 .AddEntityFramework(configuration)
                 .AddSqlServer()
                 .AddDbContext<StringInConfigContext>();
@@ -219,9 +204,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             var serviceCollection = new ServiceCollection();
             serviceCollection
-                .AddSingleton<ITypeActivator, TypeActivator>()
-                .AddSingleton<ILoggerFactory, LoggerFactory>()
-                .Add(OptionsServices.GetDefaultServices())
                 .AddEntityFramework()
                 .AddSqlServer()
                 .AddDbContext<StringInConfigContext>();
@@ -273,9 +255,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             var serviceCollection = new ServiceCollection();
             serviceCollection
-                .AddSingleton<ITypeActivator, TypeActivator>()
-                .AddSingleton<ILoggerFactory, LoggerFactory>()
-                .Add(OptionsServices.GetDefaultServices())
                 .AddEntityFramework(configuration)
                 .AddSqlServer()
                 .AddDbContext<NoUseSqlServerContext>();
@@ -306,9 +285,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             var serviceCollection = new ServiceCollection();
             serviceCollection
-                .AddSingleton<ITypeActivator, TypeActivator>()
-                .AddSingleton<ILoggerFactory, LoggerFactory>()
-                .Add(OptionsServices.GetDefaultServices())
                 .AddEntityFramework(configuration)
                 .AddSqlServer()
                 .AddDbContext<NoUseSqlServerContext>();
@@ -334,9 +310,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             var serviceCollection = new ServiceCollection();
             serviceCollection
-                .AddSingleton<ITypeActivator, TypeActivator>()
-                .AddSingleton<ILoggerFactory, LoggerFactory>()
-                .Add(OptionsServices.GetDefaultServices())
                 .AddEntityFramework(configuration)
                 .AddSqlServer()
                 .AddDbContext<NoUseSqlServerContext>();
@@ -356,9 +329,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             var serviceCollection = new ServiceCollection();
             serviceCollection
-                .AddSingleton<ITypeActivator, TypeActivator>()
-                .AddSingleton<ILoggerFactory, LoggerFactory>()
-                .Add(OptionsServices.GetDefaultServices())
                 .AddEntityFramework()
                 .AddSqlServer()
                 .AddDbContext<NoUseSqlServerContext>();
@@ -382,9 +352,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             var serviceCollection = new ServiceCollection();
             serviceCollection
-                .AddSingleton<ITypeActivator, TypeActivator>()
-                .AddSingleton<ILoggerFactory, LoggerFactory>()
-                .Add(OptionsServices.GetDefaultServices())
                 .AddEntityFramework()
                 .AddSqlServer()
                 .AddInMemoryStore()
@@ -465,9 +432,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             var serviceCollection = new ServiceCollection();
             serviceCollection
-                .AddSingleton<ITypeActivator, TypeActivator>()
-                .AddSingleton<ILoggerFactory, LoggerFactory>()
-                .Add(OptionsServices.GetDefaultServices())
                 .AddScoped<SqlConnection>(p => new SqlConnection(SqlServerTestDatabase.NorthwindConnectionString))
                 .AddEntityFramework()
                 .AddSqlServer()
@@ -529,9 +493,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             var serviceCollection = new ServiceCollection();
             serviceCollection
-                .AddSingleton<ITypeActivator, TypeActivator>()
-                .AddSingleton<ILoggerFactory, LoggerFactory>()
-                .Add(OptionsServices.GetDefaultServices())
                 .AddEntityFramework()
                 .AddSqlServer()
                 .AddInMemoryStore()
@@ -612,9 +573,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             var serviceCollection = new ServiceCollection();
             serviceCollection
-                .AddSingleton<ITypeActivator, TypeActivator>()
-                .AddSingleton<ILoggerFactory, LoggerFactory>()
-                .Add(OptionsServices.GetDefaultServices())
                 .AddEntityFramework()
                 .AddSqlServer()
                 .AddInMemoryStore()

--- a/test/EntityFramework.SqlServer.FunctionalTests/ConnectionStringTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/ConnectionStringTest.cs
@@ -62,8 +62,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             serviceCollection
                 .AddInstance<IConfiguration>(configuration)
                 .AddEntityFramework()
-                .AddSqlServer()
-                .UseLoggerFactory<LoggerFactory>();
+                .AddSqlServer();
 
             var serviceProvider = serviceCollection.BuildServiceProvider();
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/DefaultValuesTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/DefaultValuesTest.cs
@@ -5,9 +5,7 @@ using System;
 using System.Linq;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
@@ -20,7 +18,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             var serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddSqlServer()
-                .UseLoggerFactory<LoggerFactory>()
                 .ServiceCollection
                 .BuildServiceProvider();
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/ExistingConnectionTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/ExistingConnectionTest.cs
@@ -8,9 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
@@ -37,8 +35,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             var serviceCollection = new ServiceCollection();
             serviceCollection
                 .AddEntityFramework()
-                .AddSqlServer()
-                .UseLoggerFactory<LoggerFactory>();
+                .AddSqlServer();
+
             var serviceProvider = serviceCollection.BuildServiceProvider();
 
             using (await SqlServerTestDatabase.Northwind())

--- a/test/EntityFramework.SqlServer.FunctionalTests/MonsterFixupTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/MonsterFixupTest.cs
@@ -11,9 +11,7 @@ using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.FunctionalTests.TestModels;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 {
@@ -29,7 +27,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             var serviceCollection = new ServiceCollection()
                 .AddEntityFramework()
                 .AddSqlServer()
-                .UseLoggerFactory<LoggerFactory>()
                 .ServiceCollection;
 
             if (throwingStateManager)

--- a/test/EntityFramework.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
@@ -6,9 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
@@ -21,7 +19,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             var serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddSqlServer()
-                .UseLoggerFactory<LoggerFactory>()
                 .ServiceCollection
                 .BuildServiceProvider();
 
@@ -39,7 +36,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddSqlServer()
-                .UseLoggerFactory<LoggerFactory>()
                 .ServiceCollection
                 .BuildServiceProvider();
 
@@ -77,7 +73,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             var serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddSqlServer()
-                .UseLoggerFactory<LoggerFactory>()
                 .ServiceCollection
                 .BuildServiceProvider();
 
@@ -95,7 +90,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddSqlServer()
-                .UseLoggerFactory<LoggerFactory>()
                 .ServiceCollection
                 .BuildServiceProvider();
 
@@ -133,7 +127,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             var serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddSqlServer()
-                .UseLoggerFactory<LoggerFactory>()
                 .ServiceCollection
                 .BuildServiceProvider();
 
@@ -177,7 +170,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             var serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddSqlServer()
-                .UseLoggerFactory<LoggerFactory>()
                 .ServiceCollection
                 .BuildServiceProvider();
 
@@ -195,7 +187,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddSqlServer()
-                .UseLoggerFactory<LoggerFactory>()
                 .ServiceCollection
                 .BuildServiceProvider();
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/SequentialGuidEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SequentialGuidEndToEndTest.cs
@@ -6,9 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
@@ -21,7 +19,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             var serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddSqlServer()
-                .UseLoggerFactory<LoggerFactory>()
                 .ServiceCollection
                 .BuildServiceProvider();
 
@@ -55,7 +52,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             var serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddSqlServer()
-                .UseLoggerFactory<LoggerFactory>()
                 .ServiceCollection
                 .BuildServiceProvider();
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerConfigPatternsTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerConfigPatternsTest.cs
@@ -8,9 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
@@ -89,8 +87,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     var serviceCollection = new ServiceCollection();
                     serviceCollection
                         .AddEntityFramework()
-                        .AddSqlServer()
-                        .UseLoggerFactory<LoggerFactory>();
+                        .AddSqlServer();
+
                     var serviceProvider = serviceCollection.BuildServiceProvider();
 
                     using (var context = new NorthwindContext(serviceProvider))
@@ -131,8 +129,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     var serviceCollection = new ServiceCollection();
                     serviceCollection
                         .AddEntityFramework()
-                        .AddSqlServer()
-                        .UseLoggerFactory<LoggerFactory>();
+                        .AddSqlServer();
+
                     var serviceProvider = serviceCollection.BuildServiceProvider();
 
                     var options = new DbContextOptions().UseSqlServer(SqlServerTestDatabase.NorthwindConnectionString);
@@ -170,8 +168,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     var serviceCollection = new ServiceCollection();
                     serviceCollection
                         .AddEntityFramework()
-                        .AddSqlServer()
-                        .UseLoggerFactory<LoggerFactory>();
+                        .AddSqlServer();
+
                     var serviceProvider = serviceCollection.BuildServiceProvider();
 
                     Assert.Equal(
@@ -241,8 +239,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 {
                     var serviceCollection = new ServiceCollection();
                     serviceCollection
-                        .AddEntityFramework()
-                        .UseLoggerFactory<LoggerFactory>();
+                        .AddEntityFramework();
+
                     var serviceProvider = serviceCollection.BuildServiceProvider();
 
                     Assert.Equal(
@@ -286,8 +284,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 var serviceCollection = new ServiceCollection();
                 serviceCollection
                     .AddEntityFramework()
-                    .AddSqlServer()
-                    .UseLoggerFactory<LoggerFactory>();
+                    .AddSqlServer();
+
                 var serviceProvider = serviceCollection
                     .AddTransient<NorthwindContext>()
                     .AddTransient<MyController>()
@@ -348,8 +346,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 var serviceCollection = new ServiceCollection();
                 serviceCollection
                     .AddEntityFramework()
-                    .AddSqlServer()
-                    .UseLoggerFactory<LoggerFactory>();
+                    .AddSqlServer();
+
                 serviceCollection
                     .AddTransient<MyController>()
                     .AddTransient<NorthwindContext>()
@@ -410,8 +408,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 var serviceCollection = new ServiceCollection();
                 serviceCollection
                     .AddEntityFramework()
-                    .AddSqlServer()
-                    .UseLoggerFactory<LoggerFactory>();
+                    .AddSqlServer();
+
                 serviceCollection
                     .AddTransient<NorthwindContext>()
                     .AddTransient<MyController>()
@@ -535,8 +533,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     var serviceCollection = new ServiceCollection();
                     serviceCollection
                         .AddEntityFramework()
-                        .AddSqlServer()
-                        .UseLoggerFactory<LoggerFactory>();
+                        .AddSqlServer();
+
                     var serviceProvider = serviceCollection.BuildServiceProvider();
 
                     using (var context1 = new NorthwindContext(serviceProvider))
@@ -592,8 +590,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     serviceCollection
                         .AddEntityFramework()
                         .AddSqlServer()
-                        .AddInMemoryStore()
-                        .UseLoggerFactory<LoggerFactory>();
+                        .AddInMemoryStore();
+
                     var serviceProvider = serviceCollection.BuildServiceProvider();
 
                     await NestedContextTest(() => new BlogContext(serviceProvider), () => new NorthwindContext(serviceProvider));

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerDataStoreCreatorTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerDataStoreCreatorTest.cs
@@ -11,9 +11,7 @@ using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
@@ -221,8 +219,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 var serviceCollection = new ServiceCollection();
                 serviceCollection
                     .AddEntityFramework()
-                    .AddSqlServer()
-                    .UseLoggerFactory<LoggerFactory>();
+                    .AddSqlServer();
+
                 var serviceProvider = serviceCollection.BuildServiceProvider();
 
                 var options = new DbContextOptions().UseSqlServer(testDatabase.Connection.ConnectionString);
@@ -367,8 +365,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             var serviceCollection = new ServiceCollection();
             serviceCollection
                 .AddEntityFramework()
-                .AddSqlServer()
-                .UseLoggerFactory<LoggerFactory>();
+                .AddSqlServer();
+
             return new DbContext(
                 serviceCollection.BuildServiceProvider(),
                 new DbContextOptions().UseSqlServer(testDatabase.Connection.ConnectionString))

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerDatabaseCreationTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerDatabaseCreationTest.cs
@@ -7,9 +7,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
@@ -280,8 +278,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             var serviceCollection = new ServiceCollection();
             serviceCollection
                 .AddEntityFramework()
-                .AddSqlServer()
-                .UseLoggerFactory<LoggerFactory>();
+                .AddSqlServer();
+
             return serviceCollection.BuildServiceProvider();
         }
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -16,7 +16,6 @@ using Microsoft.Data.Entity.SqlServer.Update;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
@@ -57,8 +56,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 var serviceCollection = new ServiceCollection();
                 serviceCollection
                     .AddEntityFramework()
-                    .AddSqlServer()
-                    .UseLoggerFactory<LoggerFactory>();
+                    .AddSqlServer();
+
                 serviceCollection.AddScoped<SqlServerDataStore, SqlStoreWithBufferReader>();
                 var serviceProvider = serviceCollection.BuildServiceProvider();
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerOptimisticConcurrencyTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerOptimisticConcurrencyTest.cs
@@ -2,16 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Data.SqlClient;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.ConcurrencyModel;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.FunctionalTests;
-using Microsoft.Data.Entity.Storage;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 {
@@ -24,7 +20,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             _serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddSqlServer()
-                .UseLoggerFactory<LoggerFactory>()
                 .ServiceCollection
                 .BuildServiceProvider();
         }

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerTransactionTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerTransactionTest.cs
@@ -6,9 +6,7 @@ using System.Data.Common;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.Relational.FunctionalTests;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 {
@@ -21,7 +19,6 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             _serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
                 .AddSqlServer()
-                .UseLoggerFactory<LoggerFactory>()
                 .ServiceCollection
                 .BuildServiceProvider();
         }

--- a/test/EntityFramework.SqlServer.Tests/SqlServerConnectionTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerConnectionTest.cs
@@ -5,9 +5,7 @@ using System.Data.SqlClient;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.Tests
@@ -40,8 +38,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             var serviceCollection = new ServiceCollection();
             serviceCollection
                 .AddEntityFramework()
-                .AddSqlServer()
-                .UseLoggerFactory<LoggerFactory>();
+                .AddSqlServer();
+
             return new DbContext(serviceCollection.BuildServiceProvider(),
                 new DbContextOptions()
                     .UseSqlServer(@"Server=(localdb)\v11.0;Database=SqlServerConnectionTest;Trusted_Connection=True;"))

--- a/test/EntityFramework.SqlServer.Tests/SqlServerEntityServicesBuilderExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerEntityServicesBuilderExtensionsTest.cs
@@ -9,9 +9,7 @@ using Microsoft.Data.Entity.SqlServer.Update;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.Tests
@@ -24,8 +22,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             var services = new ServiceCollection();
             services
                 .AddEntityFramework()
-                .AddSqlServer()
-                .UseLoggerFactory<LoggerFactory>();
+                .AddSqlServer();
 
             // Relational
             Assert.True(services.Any(sd => sd.ServiceType == typeof(SqlServerDatabaseBuilder)));
@@ -60,8 +57,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             var services = new ServiceCollection();
             services
                 .AddEntityFramework()
-                .AddSqlServer()
-                .UseLoggerFactory<LoggerFactory>();
+                .AddSqlServer();
+
             var serviceProvider = services.BuildServiceProvider();
 
             var context = new DbContext(

--- a/test/EntityFramework.Tests/ContextConfigurationTest.cs
+++ b/test/EntityFramework.Tests/ContextConfigurationTest.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Data.Entity.Tests
         public void Scoped_data_store_services_can_be_obtained_from_configuration()
         {
             var services = new ServiceCollection();
-            services.AddEntityFramework().AddInMemoryStore().UseLoggerFactory<LoggerFactory>();
+            services.AddEntityFramework().AddInMemoryStore();
             var serviceProvider = services.BuildServiceProvider();
 
             DataStore store;

--- a/test/Performance/EntityFramework.Performance.CUD.Tests/CudTests.cs
+++ b/test/Performance/EntityFramework.Performance.CUD.Tests/CudTests.cs
@@ -7,9 +7,7 @@ using Cud.Model;
 using Microsoft.Data.Entity;
 using Microsoft.Framework.ConfigurationModel;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 
 #if K10
 using Cud.Utilities;
@@ -26,7 +24,7 @@ namespace Cud
         public static IServiceProvider CreateServiceProvider(Configuration configuration)
         {
             var services = new ServiceCollection();
-            services.AddEntityFramework().AddSqlServer().UseLoggerFactory<LoggerFactory>();
+            services.AddEntityFramework().AddSqlServer();
             services.AddInstance<IConfiguration>(configuration);
             return services.BuildServiceProvider();
         }

--- a/test/Performance/EntityFramework.Performance.DbContext.Tests/DbContextPerfTestsBase.cs
+++ b/test/Performance/EntityFramework.Performance.DbContext.Tests/DbContextPerfTestsBase.cs
@@ -10,9 +10,7 @@ using DbContextPerfTests.Model;
 using Microsoft.Data.Entity;
 using Microsoft.Framework.ConfigurationModel;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 
 namespace DbContextPerfTests
 {
@@ -35,7 +33,7 @@ namespace DbContextPerfTests
         public static IServiceProvider CreateServiceProvider()
         {
             var services = new ServiceCollection();
-            services.AddEntityFramework().AddSqlServer().UseLoggerFactory<LoggerFactory>();
+            services.AddEntityFramework().AddSqlServer();
             return services.BuildServiceProvider();
         }
 

--- a/test/Performance/EntityFramework.Performance.QueryExecution.Tests/QueryExecution.Tests.TPT.cs
+++ b/test/Performance/EntityFramework.Performance.QueryExecution.Tests/QueryExecution.Tests.TPT.cs
@@ -5,9 +5,7 @@ using System;
 using Microsoft.Data.Entity;
 using Microsoft.Framework.ConfigurationModel;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 using QueryExecution.Model;
 
 namespace QueryExecution
@@ -19,7 +17,7 @@ namespace QueryExecution
         public static IServiceProvider CreateServiceProvider()
         {
             var services = new ServiceCollection();
-            services.AddEntityFramework().AddSqlServer().UseLoggerFactory<LoggerFactory>();
+            services.AddEntityFramework().AddSqlServer();
             return services.BuildServiceProvider();
         }
 

--- a/test/Performance/EntityFramework.Performance.StateManager.Tests/StateManagerTestBase.cs
+++ b/test/Performance/EntityFramework.Performance.StateManager.Tests/StateManagerTestBase.cs
@@ -7,9 +7,7 @@ using System.Linq;
 using Microsoft.Data.Entity;
 using Microsoft.Framework.ConfigurationModel;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 using StateManager.Model;
 
 namespace StateManager
@@ -26,7 +24,7 @@ namespace StateManager
         public static IServiceProvider CreateServiceProvider()
         {
             var services = new ServiceCollection();
-            services.AddEntityFramework().AddSqlServer().UseLoggerFactory<LoggerFactory>();
+            services.AddEntityFramework().AddSqlServer();
             return services.BuildServiceProvider();
         }
 

--- a/test/Shared/TestHelpers.cs
+++ b/test/Shared/TestHelpers.cs
@@ -8,9 +8,7 @@ using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
-using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.Tests
 {
@@ -31,7 +29,6 @@ namespace Microsoft.Data.Entity.Tests
             var services = new ServiceCollection();
             services
                 .AddEntityFramework()
-                .UseLoggerFactory<LoggerFactory>()
                 .AddProviderServices();
             return services.BuildServiceProvider();
         }


### PR DESCRIPTION
Or: It's our collection and we'll look if we want to...

Issue #890

These services are normally setup by the app environment in an ASP vNext app, but are not setup when we create the service provider or the service provider is being setup in some other app environment. This changes makes sure that however the service provider is used, then these required services are available just like all other services required by EF to run correctly.
