### PR TITLE
Honor schema in SQL query (Issue #931)

### DIFF
--- a/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
+++ b/src/EntityFramework.Relational/Query/Sql/DefaultSqlQueryGenerator.cs
@@ -149,6 +149,12 @@ namespace Microsoft.Data.Entity.Relational.Query.Sql
         {
             Check.NotNull(tableExpression, "tableExpression");
 
+            if (tableExpression.Schema != null)
+            {
+                _sql.Append(DelimitIdentifier(tableExpression.Schema))
+                    .Append(".");
+            }
+
             _sql.Append(DelimitIdentifier(tableExpression.Table))
                 .Append(" AS ")
                 .Append(DelimitIdentifier(tableExpression.Alias));

--- a/test/EntityFramework.SqlServer.FunctionalTests/MappingQueryTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/MappingQueryTest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             
             Assert.Equal(
                 @"SELECT [c].[CompanyName], [c].[CustomerID]
-FROM [Customers] AS [c]",
+FROM [dbo].[Customers] AS [c]",
                 _fixture.Sql);
         }
         
@@ -24,7 +24,7 @@ FROM [Customers] AS [c]",
             
             Assert.Equal(
                 @"SELECT [e].[City], [e].[EmployeeID]
-FROM [Employees] AS [e]",
+FROM [dbo].[Employees] AS [e]",
                 _fixture.Sql);
         }
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Data.Common;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -280,6 +281,78 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     db.Customers.Remove(customer);
                 }
             }
+        }
+
+        [Fact] // Issue #931
+        public async Task Can_save_and_query_with_schema()
+        {
+            var serviceProvider
+                = new ServiceCollection()
+                    .AddEntityFramework()
+                    .AddSqlServer()
+                    .AddDbContext<SchemaContext>()
+                    .ServiceCollection
+                    .BuildServiceProvider();
+
+            using (var testDatabase = await SqlServerTestDatabase.Scratch())
+            {
+                await testDatabase.ExecuteNonQueryAsync("CREATE SCHEMA Apple");
+                await testDatabase.ExecuteNonQueryAsync("CREATE TABLE Apple.Jack (MyKey int)");
+                await testDatabase.ExecuteNonQueryAsync("CREATE TABLE Apple.Black (MyKey int)");
+
+                using (var context = serviceProvider.GetService<SchemaContext>())
+                {
+                    context.Connection = testDatabase.Connection;
+
+                    context.Add(new Jack());
+                    context.Add(new Black());
+                    context.SaveChanges();
+                }
+
+                using (var context = serviceProvider.GetService<SchemaContext>())
+                {
+                    context.Connection = testDatabase.Connection;
+
+                    Assert.Equal(1, context.Jacks.Count());
+                    Assert.Equal(1, context.Blacks.Count());
+                }
+            }
+        }
+
+        private class SchemaContext : DbContext
+        {
+            public DbConnection Connection { get; set; }
+
+            public DbSet<Jack> Jacks { get; set; }
+            public DbSet<Black> Blacks { get; set; }
+
+            protected override void OnConfiguring(DbContextOptions options)
+            {
+                options.UseSqlServer(Connection);
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder
+                    .Entity<Jack>()
+                    .ForRelational(b => b.Table("Jack", "Apple"))
+                    .Key(e => e.MyKey);
+
+                modelBuilder
+                    .Entity<Black>()
+                    .ForSqlServer(b => b.Table("Black", "Apple"))
+                    .Key(e => e.MyKey);
+            }
+        }
+
+        private class Jack
+        {
+            public int MyKey { get; set; }
+        }
+
+        private class Black
+        {
+            public int MyKey { get; set; }
         }
 
         [Fact]


### PR DESCRIPTION
Or: Eating the same half of the pie twice

The issue was that even though the table expression has the correct schema the SQL generation was not using it.
