### PR TITLE
Fix #906: Some queries in MonsterFixupTest throw InvalidCastException

### DIFF
--- a/src/EntityFramework.AzureTableStorage/AtsDataStore.cs
+++ b/src/EntityFramework.AzureTableStorage/AtsDataStore.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage
         {
             Check.NotNull(queryModel, "queryModel");
 
-            var compilationContext = _queryFactory.MakeCompilationContext(Model, Logger);
+            var compilationContext = _queryFactory.MakeCompilationContext(Model, Logger, EntityMaterializerSource);
             var queryExecutor = compilationContext.CreateQueryModelVisitor().CreateQueryExecutor<TResult>(queryModel);
 
             var queryContext

--- a/src/EntityFramework.AzureTableStorage/Query/AtsQueryCompilationContext.cs
+++ b/src/EntityFramework.AzureTableStorage/Query/AtsQueryCompilationContext.cs
@@ -11,12 +11,16 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Query
 {
     public class AtsQueryCompilationContext : QueryCompilationContext
     {
-        public AtsQueryCompilationContext([NotNull] IModel model, [NotNull] ILogger logger)
+        public AtsQueryCompilationContext(
+            [NotNull] IModel model,
+            [NotNull] ILogger logger,
+            [NotNull] EntityMaterializerSource entityMaterializerSource)
             : base(
                 Check.NotNull(model, "model"),
                 Check.NotNull(logger, "logger"),
                 new LinqOperatorProvider(),
-                new ResultOperatorHandler())
+                new ResultOperatorHandler(),
+                Check.NotNull(entityMaterializerSource, "entityMaterializerSource"))
         {
         }
 

--- a/src/EntityFramework.AzureTableStorage/Query/AtsQueryFactory.cs
+++ b/src/EntityFramework.AzureTableStorage/Query/AtsQueryFactory.cs
@@ -21,12 +21,15 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Query
         }
 
         public virtual AtsQueryCompilationContext MakeCompilationContext(
-            [NotNull] IModel model, [NotNull] ILogger logger)
+            [NotNull] IModel model, 
+            [NotNull] ILogger logger,
+            [NotNull] EntityMaterializerSource entityMaterializerSource)
         {
             Check.NotNull(model, "model");
             Check.NotNull(logger, "logger");
+            Check.NotNull(entityMaterializerSource, "entityMaterializerSource");
 
-            return new AtsQueryCompilationContext(model, logger);
+            return new AtsQueryCompilationContext(model, logger, entityMaterializerSource);
         }
 
         public virtual AtsQueryContext MakeQueryContext(

--- a/src/EntityFramework.InMemory/InMemoryDataStore.cs
+++ b/src/EntityFramework.InMemory/InMemoryDataStore.cs
@@ -82,6 +82,7 @@ namespace Microsoft.Data.Entity.InMemory
                 = new InMemoryQueryCompilationContext(
                     Model,
                     Logger,
+                    EntityMaterializerSource,
                     EntityKeyFactorySource,
                     _database.Value);
 

--- a/src/EntityFramework.InMemory/Query/InMemoryQueryCompilationContext.cs
+++ b/src/EntityFramework.InMemory/Query/InMemoryQueryCompilationContext.cs
@@ -18,13 +18,15 @@ namespace Microsoft.Data.Entity.InMemory.Query
         public InMemoryQueryCompilationContext(
             [NotNull] IModel model,
             [NotNull] ILogger logger,
+            [NotNull] EntityMaterializerSource entityMaterializerSource,
             [NotNull] EntityKeyFactorySource entityKeyFactorySource,
             [NotNull] InMemoryDatabase database)
             : base(
                 Check.NotNull(model, "model"),
                 Check.NotNull(logger, "logger"),
                 new LinqOperatorProvider(),
-                new ResultOperatorHandler())
+                new ResultOperatorHandler(),
+                Check.NotNull(entityMaterializerSource, "entityMaterializerSource"))
         {
             Check.NotNull(entityKeyFactorySource, "entityKeyFactorySource");
             Check.NotNull(database, "database");

--- a/src/EntityFramework.Redis/Query/RedisQueryCompilationContext.cs
+++ b/src/EntityFramework.Redis/Query/RedisQueryCompilationContext.cs
@@ -18,12 +18,14 @@ namespace Microsoft.Data.Entity.Redis.Query
             [NotNull] ILogger logger,
             [NotNull] ILinqOperatorProvider linqOperatorProvider,
             [NotNull] IResultOperatorHandler resultOperatorHandler,
+            [NotNull] EntityMaterializerSource entityMaterializerSource,
             [NotNull] IQueryMethodProvider queryMethodProvider)
             : base(
                 Check.NotNull(model, "model"),
                 Check.NotNull(logger, "logger"),
                 Check.NotNull(linqOperatorProvider, "linqOperatorProvider"),
-                Check.NotNull(resultOperatorHandler, "resultOperatorHandler"))
+                Check.NotNull(resultOperatorHandler, "resultOperatorHandler"),
+                Check.NotNull(entityMaterializerSource, "entityMaterializerSource"))
         {
             Check.NotNull(queryMethodProvider, "queryMethodProvider");
 

--- a/src/EntityFramework.Redis/RedisDataStore.cs
+++ b/src/EntityFramework.Redis/RedisDataStore.cs
@@ -107,7 +107,12 @@ namespace Microsoft.Data.Entity.Redis
             Check.NotNull(queryMethodProvider, "queryMethodProvider");
 
             return new RedisQueryCompilationContext(
-                Model, Logger, linqOperatorProvider, resultOperatorHandler, queryMethodProvider);
+                Model,
+                Logger,
+                linqOperatorProvider,
+                resultOperatorHandler,
+                EntityMaterializerSource,
+                queryMethodProvider);
         }
     }
 }

--- a/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/ResultTransformingExpressionTreeVisitor.cs
+++ b/src/EntityFramework.Relational/Query/ExpressionTreeVisitors/ResultTransformingExpressionTreeVisitor.cs
@@ -48,17 +48,6 @@ namespace Microsoft.Data.Entity.Relational.Query.ExpressionTreeVisitors
                 return methodCallExpression.Arguments[3];
             }
 
-            if (methodCallExpression.Method.MethodIsClosedFormOf(
-                QuerySourceScope.GetResultMethodInfo)
-                && ((ConstantExpression)methodCallExpression.Arguments[0]).Value == _outerQuerySource)
-            {
-                return
-                    QuerySourceScope.GetResult(
-                        methodCallExpression.Object,
-                        _outerQuerySource,
-                        typeof(TResult));
-            }
-
             if (newArguments != methodCallExpression.Arguments)
             {
                 if (methodCallExpression.Method.MethodIsClosedFormOf(

--- a/src/EntityFramework.Relational/Query/RelationalQueryCompilationContext.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryCompilationContext.cs
@@ -28,13 +28,15 @@ namespace Microsoft.Data.Entity.Relational.Query
             [NotNull] ILogger logger,
             [NotNull] ILinqOperatorProvider linqOperatorProvider, 
             [NotNull] IResultOperatorHandler resultOperatorHandler,
+            [NotNull] EntityMaterializerSource entityMaterializerSource,
             [NotNull] IQueryMethodProvider queryMethodProvider,
             [NotNull] IMethodCallTranslator methodCallTranslator)
             : base(
                 Check.NotNull(model, "model"),
                 Check.NotNull(logger, "logger"),
                 Check.NotNull(linqOperatorProvider, "linqOperatorProvider"),
-                Check.NotNull(resultOperatorHandler, "resultOperatorHandler"))
+                Check.NotNull(resultOperatorHandler, "resultOperatorHandler"),
+                Check.NotNull(entityMaterializerSource, "entityMaterializerSource"))
         {
             Check.NotNull(queryMethodProvider, "queryMethodProvider");
             Check.NotNull(methodCallTranslator, "methodCallTranslator");

--- a/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EntityFramework.Relational/Query/RelationalQueryModelVisitor.cs
@@ -69,6 +69,8 @@ namespace Microsoft.Data.Entity.Relational.Query
 
         protected override ExpressionTreeVisitor CreateQueryingExpressionTreeVisitor(IQuerySource querySource)
         {
+            Check.NotNull(querySource, "querySource");
+            
             return new RelationalEntityQueryableExpressionTreeVisitor(this, querySource);
         }
 
@@ -79,6 +81,8 @@ namespace Microsoft.Data.Entity.Relational.Query
 
         protected override ExpressionTreeVisitor CreateOrderingExpressionTreeVisitor(Ordering ordering)
         {
+            Check.NotNull(ordering, "ordering");
+
             return new RelationalOrderingExpressionTreeVisitor(this, ordering);
         }
 

--- a/src/EntityFramework.Relational/RelationalDataStore.cs
+++ b/src/EntityFramework.Relational/RelationalDataStore.cs
@@ -142,7 +142,13 @@ namespace Microsoft.Data.Entity.Relational
             Check.NotNull(methodCallTranslator, "methodCallTranslator");
 
             return new RelationalQueryCompilationContext(
-                Model, Logger, linqOperatorProvider, resultOperatorHandler, queryMethodProvider, methodCallTranslator);
+                Model,
+                Logger, 
+                linqOperatorProvider, 
+                resultOperatorHandler, 
+                EntityMaterializerSource, 
+                queryMethodProvider, 
+                methodCallTranslator);
         }
     }
 }

--- a/src/EntityFramework.SQLite/Query/SQLiteQueryCompilationContext.cs
+++ b/src/EntityFramework.SQLite/Query/SQLiteQueryCompilationContext.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Data.Entity.SQLite.Query
             [NotNull] ILogger logger,
             [NotNull] ILinqOperatorProvider linqOperatorProvider,
             [NotNull] IResultOperatorHandler resultOperatorHandler,
+            [NotNull] EntityMaterializerSource entityMaterializerSource,
             [NotNull] IQueryMethodProvider queryMethodProvider,
             [NotNull] IMethodCallTranslator methodCallTranslator)
             : base(
@@ -26,6 +27,7 @@ namespace Microsoft.Data.Entity.SQLite.Query
                 Check.NotNull(logger, "logger"),
                 Check.NotNull(linqOperatorProvider, "linqOperatorProvider"),
                 Check.NotNull(resultOperatorHandler, "resultOperatorHandler"),
+                Check.NotNull(entityMaterializerSource, "entityMaterializerSource"),
                 Check.NotNull(queryMethodProvider, "queryMethodProvider"),
                 Check.NotNull(methodCallTranslator, "methodCallTranslator"))
         {

--- a/src/EntityFramework.SQLite/SQLiteDataStore.cs
+++ b/src/EntityFramework.SQLite/SQLiteDataStore.cs
@@ -39,7 +39,13 @@ namespace Microsoft.Data.Entity.SQLite
             Check.NotNull(queryMethodProvider, "queryMethodProvider");
 
             return new SQLiteQueryCompilationContext(
-                Model, Logger, linqOperatorProvider, resultOperatorHandler, queryMethodProvider, methodCallTranslator);
+                Model, 
+                Logger, 
+                linqOperatorProvider, 
+                resultOperatorHandler, 
+                EntityMaterializerSource,
+                queryMethodProvider, 
+                methodCallTranslator);
         }
     }
 }

--- a/src/EntityFramework.SqlServer/Query/SqlServerQueryCompilationContext.cs
+++ b/src/EntityFramework.SqlServer/Query/SqlServerQueryCompilationContext.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Data.Entity.SqlServer.Query
             [NotNull] ILogger logger,
             [NotNull] ILinqOperatorProvider linqOperatorProvider,
             [NotNull] IResultOperatorHandler resultOperatorHandler,
+            [NotNull] EntityMaterializerSource entityMaterializerSource,
             [NotNull] IQueryMethodProvider queryMethodProvider,
             [NotNull] IMethodCallTranslator methodCallTranslator)
             : base(
@@ -26,6 +27,7 @@ namespace Microsoft.Data.Entity.SqlServer.Query
                 Check.NotNull(logger, "logger"),
                 Check.NotNull(linqOperatorProvider, "linqOperatorProvider"),
                 Check.NotNull(resultOperatorHandler, "resultOperatorHandler"),
+                Check.NotNull(entityMaterializerSource, "entityMaterializerSource"),
                 Check.NotNull(queryMethodProvider, "queryMethodProvider"),
                 Check.NotNull(methodCallTranslator, "methodCallTranslator"))
         {

--- a/src/EntityFramework.SqlServer/SqlServerDataStore.cs
+++ b/src/EntityFramework.SqlServer/SqlServerDataStore.cs
@@ -41,7 +41,13 @@ namespace Microsoft.Data.Entity.SqlServer
             Check.NotNull(methodCallTranslator, "methodCallTranslator");
 
             return new SqlServerQueryCompilationContext(
-                Model, Logger, linqOperatorProvider, resultOperatorHandler, enumerableMethodProvider, methodCallTranslator);
+                Model, 
+                Logger, 
+                linqOperatorProvider, 
+                resultOperatorHandler, 
+                EntityMaterializerSource,
+                enumerableMethodProvider,
+                methodCallTranslator);
         }
     }
 }

--- a/src/EntityFramework/Metadata/Property.cs
+++ b/src/EntityFramework/Metadata/Property.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Data.Entity.Metadata
 
         public virtual Type UnderlyingType
         {
-            get { return Nullable.GetUnderlyingType(_propertyType) ?? _propertyType; }
+            get { return _propertyType.UnwrapNullableType(); }
         }
 
         // TODO: Remove this once the model is readonly

--- a/src/EntityFramework/Query/EntityQueryExecutor.cs
+++ b/src/EntityFramework/Query/EntityQueryExecutor.cs
@@ -59,6 +59,7 @@ namespace Microsoft.Data.Entity.Query
             return AsyncExecuteCollection<T>(queryModel, cancellationToken).First(cancellationToken);
         }
 
+        [DebuggerStepThrough]
         public virtual IEnumerable<T> ExecuteCollection<T>([NotNull] QueryModel queryModel)
         {
             Check.NotNull(queryModel, "queryModel");
@@ -83,6 +84,7 @@ namespace Microsoft.Data.Entity.Query
             }
         }
 
+        [DebuggerStepThrough]
         public virtual IAsyncEnumerable<T> AsyncExecuteCollection<T>(
             [NotNull] QueryModel queryModel, CancellationToken cancellationToken)
         {

--- a/src/EntityFramework/Query/EntityQueryModelVisitor.cs
+++ b/src/EntityFramework/Query/EntityQueryModelVisitor.cs
@@ -76,14 +76,14 @@ namespace Microsoft.Data.Entity.Query
             get { return _streamedSequenceInfo; }
         }
 
-        protected abstract ExpressionTreeVisitor CreateQueryingExpressionTreeVisitor([CanBeNull] IQuerySource querySource);
+        protected abstract ExpressionTreeVisitor CreateQueryingExpressionTreeVisitor([NotNull] IQuerySource querySource);
 
         protected virtual ExpressionTreeVisitor CreateProjectionExpressionTreeVisitor()
         {
             return new ProjectionExpressionTreeVisitor(this);
         }
 
-        protected virtual ExpressionTreeVisitor CreateOrderingExpressionTreeVisitor(Ordering ordering)
+        protected virtual ExpressionTreeVisitor CreateOrderingExpressionTreeVisitor([NotNull] Ordering ordering)
         {
             return new DefaultQueryExpressionTreeVisitor(this);
         }
@@ -823,15 +823,10 @@ namespace Microsoft.Data.Entity.Query
                     => BindReadValueMethod(memberExpression.Type, expression, property.Index));
         }
 
-        private static readonly MethodInfo _readValueMethodInfo
-            = typeof(IValueReader).GetTypeInfo().GetDeclaredMethod("ReadValue");
-
-        protected static MethodCallExpression BindReadValueMethod(Type memberType, Expression expression, int index)
+        protected Expression BindReadValueMethod(Type memberType, Expression expression, int index)
         {
-            return Expression.Call(
-                expression,
-                _readValueMethodInfo.MakeGenericMethod(memberType),
-                Expression.Constant(index));
+            return QueryCompilationContext.EntityMaterializerSource
+                .CreateReadValueExpression(expression, memberType, index);
         }
 
         public virtual TResult BindNavigationMemberExpression<TResult>(

--- a/src/EntityFramework/Query/QueryCompilationContext.cs
+++ b/src/EntityFramework/Query/QueryCompilationContext.cs
@@ -14,22 +14,26 @@ namespace Microsoft.Data.Entity.Query
         private readonly ILogger _logger;
         private readonly ILinqOperatorProvider _linqOperatorProvider;
         private readonly IResultOperatorHandler _resultOperatorHandler;
+        private readonly EntityMaterializerSource _entityMaterializerSource;
 
         protected QueryCompilationContext(
             [NotNull] IModel model,
             [NotNull] ILogger logger,
             [NotNull] ILinqOperatorProvider linqOperatorProvider,
-            [NotNull] IResultOperatorHandler resultOperatorHandler)
+            [NotNull] IResultOperatorHandler resultOperatorHandler,
+            [NotNull] EntityMaterializerSource entityMaterializerSource)
         {
             Check.NotNull(model, "model");
             Check.NotNull(logger, "logger");
             Check.NotNull(linqOperatorProvider, "linqOperatorProvider");
             Check.NotNull(resultOperatorHandler, "resultOperatorHandler");
+            Check.NotNull(entityMaterializerSource, "entityMaterializerSource");
 
             _model = model;
             _logger = logger;
             _linqOperatorProvider = linqOperatorProvider;
             _resultOperatorHandler = resultOperatorHandler;
+            _entityMaterializerSource = entityMaterializerSource;
         }
 
         public virtual IModel Model
@@ -50,6 +54,11 @@ namespace Microsoft.Data.Entity.Query
         public virtual IResultOperatorHandler ResultOperatorHandler
         {
             get { return _resultOperatorHandler; }
+        }
+
+        public virtual EntityMaterializerSource EntityMaterializerSource
+        {
+            get { return _entityMaterializerSource; }
         }
 
         public virtual EntityQueryModelVisitor CreateQueryModelVisitor()

--- a/src/EntityFramework/Storage/DataStore.cs
+++ b/src/EntityFramework/Storage/DataStore.cs
@@ -53,12 +53,17 @@ namespace Microsoft.Data.Entity.Storage
             get { return _configuration.Services.EntityKeyFactorySource; }
         }
 
+        public virtual EntityMaterializerSource EntityMaterializerSource
+        {
+            get { return _configuration.Services.EntityMaterializerSource; }
+        }
+
         protected virtual IQueryBuffer CreateQueryBuffer()
         {
             return new QueryBuffer(
                 _configuration.StateManager,
-                _configuration.Services.EntityKeyFactorySource,
-                _configuration.Services.EntityMaterializerSource,
+                EntityKeyFactorySource,
+                EntityMaterializerSource,
                 _configuration.Services.ClrCollectionAccessorSource,
                 _configuration.Services.ClrPropertySetterSource);
         }

--- a/test/EntityFramework.AzureTableStorage.Tests/Query/QueryGenerationTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Query/QueryGenerationTests.cs
@@ -23,7 +23,10 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Query
         private readonly TableQueryGenerator _generator = new TableQueryGenerator();
 
         public QueryGenerationTests()
-            : base(new AtsQueryCompilationContext(SetupModel(), new LoggerFactory().Create("Fake")))
+            : base(
+                new AtsQueryCompilationContext(SetupModel(),
+                    new LoggerFactory().Create("Fake"),
+                    new EntityMaterializerSource(new MemberMapper(new FieldMatcher()))))
         {
         }
 

--- a/test/EntityFramework.AzureTableStorage.Tests/Query/QueryModelVisitorTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Query/QueryModelVisitorTests.cs
@@ -90,7 +90,10 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Query
 
         public int CountQueryModel(QueryModel queryModel)
         {
-            var context = new AtsQueryCompilationContext(CreateModel(), new LoggerFactory().Create("Fake"));
+            var context = new AtsQueryCompilationContext(
+                CreateModel(), 
+                new LoggerFactory().Create("Fake"),
+                new EntityMaterializerSource(new MemberMapper(new FieldMatcher())));
             var visitor = context.CreateQueryModelVisitor();
             visitor.VisitQueryModel(queryModel);
 

--- a/test/EntityFramework.FunctionalTests/MonsterFixupTestBase.cs
+++ b/test/EntityFramework.FunctionalTests/MonsterFixupTestBase.cs
@@ -1387,7 +1387,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 var driver1 = context.Drivers.Single(e => e.Name == "Eeky Bear");
                 var driver2 = context.Drivers.Single(e => e.Name == "Splash Bear");
 
-                // TODO: Quering for actual entity currently throws, so projecting to just FK instead
+                // TODO: Querying for actual entity currently throws, so projecting to just FK instead
                 // Issue #906 
                 var licenseName1 = context.Licenses.Where(e => e.LicenseNumber == "10").Select(e => e.Name).Single();
                 var licenseName2 = context.Licenses.Where(e => e.LicenseNumber == "11").Select(e => e.Name).Single();
@@ -1670,14 +1670,14 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                 // TODO: Currently these LINQ queries throw InvalidCastException
                 // Issue #906 
-                //var license1 = context.Licenses.Single(e => e.LicenseNumber == "10");
-                //var license2 = context.Licenses.Single(e => e.LicenseNumber == "11");
+                var license1 = context.Licenses.Single(e => e.LicenseNumber == "10");
+                var license2 = context.Licenses.Single(e => e.LicenseNumber == "11");
 
-                //Assert.Same(driver1, license1.Driver);
-                //Assert.Same(license1, driver1.License);
+                Assert.Same(driver1, license1.Driver);
+                Assert.Same(license1, driver1.License);
 
-                //Assert.Same(driver2, license2.Driver);
-                //Assert.Same(license2, driver2.License);
+                Assert.Same(driver2, license2.Driver);
+                Assert.Same(license2, driver2.License);
             }
         }
 

--- a/test/EntityFramework.Redis.Tests/Query/RedisQueryCompilationContextTests.cs
+++ b/test/EntityFramework.Redis.Tests/Query/RedisQueryCompilationContextTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Redis.Query;
 using Microsoft.Framework.Logging;
@@ -22,6 +23,7 @@ namespace Microsoft.Data.Entity.Redis.Tests.Query
                     loggerFactory.Create("Fake"),
                     new LinqOperatorProvider(),
                     new ResultOperatorHandler(),
+                    new EntityMaterializerSource(new MemberMapper(new FieldMatcher())), 
                     new QueryMethodProvider());
 
             var parentVisitor = new RedisQueryModelVisitor(redisQueryCompilationContext);

--- a/test/EntityFramework.Redis.Tests/Query/RedisQueryModelVisitorTests.cs
+++ b/test/EntityFramework.Redis.Tests/Query/RedisQueryModelVisitorTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Redis.Query;
 using Microsoft.Framework.Logging;
@@ -18,14 +19,9 @@ namespace Microsoft.Data.Entity.Redis.Tests.Query
                 new LoggerFactory().Create("Fake"),
                 new LinqOperatorProvider(),
                 new ResultOperatorHandler(),
+                new EntityMaterializerSource(new MemberMapper(new FieldMatcher())), 
                 new QueryMethodProvider()))
         {
-        }
-
-        [Fact]
-        public void Can_construct_RedisQueryModelVisitor()
-        {
-            // the fact that this class can be instantiated means that the base constructor works
         }
 
         [Fact]

--- a/test/EntityFramework.Relational.FunctionalTests/MappingQueryFixtureBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/MappingQueryFixtureBase.cs
@@ -26,6 +26,13 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
                     e.ForRelational(t => t.Table("Employees", "dbo"));
                 });
 
+            modelBuilder.Entity<MappingQueryTestBase.MappedOrder>(e =>
+                {
+                    e.Key(o => o.OrderID);
+                    e.Property(em => em.ShipVia2).ForRelational(c => c.Column("ShipVia"));
+                    e.ForRelational(t => t.Table("Orders", "dbo"));
+                });
+
             OnModelCreating(modelBuilder);
 
             return model;

--- a/test/EntityFramework.Relational.FunctionalTests/MappingQueryTestBase.cs
+++ b/test/EntityFramework.Relational.FunctionalTests/MappingQueryTestBase.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using Northwind;
 using Xunit;
@@ -35,16 +36,56 @@ namespace Microsoft.Data.Entity.Relational.FunctionalTests
             }
         }
 
+        [Fact]
+        public virtual void All_orders()
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = context.Set<MappedOrder>()
+                        .ToList();
+
+                Assert.Equal(830, orders.Count);
+            }
+        }
+        
+        [Fact]
+        public virtual void Project_nullable_enum()
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = context.Set<MappedOrder>()
+                        .Select(o => o.ShipVia2)
+                        .ToList();
+
+                Assert.Equal(830, orders.Count);
+            }
+        }
+
         protected abstract DbContext CreateContext();
 
         public class MappedCustomer : Customer
         {
             public string CompanyName2 { get; set; }
+
         }
 
         public class MappedEmployee : Employee
         {
             public string City2 { get; set; }
+        }
+
+        public class MappedOrder : Order
+        {
+            public ShipVia? ShipVia2 { get; set; }
+        }
+
+        public enum ShipVia
+        {
+            One = 1,
+            Two,
+            Three
         }
     }
 }

--- a/test/EntityFramework.SqlServer.FunctionalTests/MappingQueryTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/MappingQueryTest.cs
@@ -28,6 +28,26 @@ FROM [dbo].[Employees] AS [e]",
                 _fixture.Sql);
         }
 
+        public override void All_orders()
+        {
+            base.All_orders();
+
+            Assert.Equal(
+                @"SELECT [o].[OrderID], [o].[ShipVia]
+FROM [dbo].[Orders] AS [o]",
+                _fixture.Sql);
+        }
+
+        public override void Project_nullable_enum()
+        {
+            base.Project_nullable_enum();
+
+            Assert.Equal(
+                @"SELECT [o].[ShipVia]
+FROM [dbo].[Orders] AS [o]",
+                _fixture.Sql);
+        }
+
         private readonly MappingQueryFixture _fixture;
 
         public MappingQueryTest(MappingQueryFixture fixture)

--- a/test/EntityFramework.SqlServer.FunctionalTests/MonsterFixupTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/MonsterFixupTest.cs
@@ -22,6 +22,11 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         private static readonly ConcurrentDictionary<string, AsyncLock> _creationLocks
             = new ConcurrentDictionary<string, AsyncLock>();
 
+        public override Task Can_build_monster_model_with_changed_only_notification_entities_and_seed_data_using_FKs()
+        {
+            return base.Can_build_monster_model_with_changed_only_notification_entities_and_seed_data_using_FKs();
+        }
+
         protected override IServiceProvider CreateServiceProvider(bool throwingStateManager = false)
         {
             var serviceCollection = new ServiceCollection()

--- a/test/EntityFramework.Tests/EntityFramework.Tests.csproj
+++ b/test/EntityFramework.Tests/EntityFramework.Tests.csproj
@@ -8,7 +8,7 @@
     <ProjectGuid>{EF361118-7D0D-453E-ADA4-2F24FBEE196C}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Microsoft.Data.Entity</RootNamespace>
+    <RootNamespace>Microsoft.Data.Entity.Tests</RootNamespace>
     <AssemblyName>EntityFramework.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>

--- a/test/EntityFramework.Tests/Metadata/EntityMaterializerSourceTest.cs
+++ b/test/EntityFramework.Tests/Metadata/EntityMaterializerSourceTest.cs
@@ -37,36 +37,44 @@ namespace Microsoft.Data.Entity.Tests.Metadata
         public void Can_create_materializer_for_entity_with_auto_properties()
         {
             var entityType = new Model().AddEntityType(typeof(SomeEntity));
-            entityType.GetOrAddProperty("Id", typeof(int));
+            entityType.GetOrAddProperty("Enum", typeof(SomeEnum));
             entityType.GetOrAddProperty("Foo", typeof(string));
             entityType.GetOrAddProperty("Goo", typeof(Guid?));
+            entityType.GetOrAddProperty("Id", typeof(int));
+            entityType.GetOrAddProperty("MaybeEnum", typeof(SomeEnum?));
 
             var factory = new EntityMaterializerSource(new MemberMapper(new FieldMatcher())).GetMaterializer(entityType);
 
             var gu = Guid.NewGuid();
-            var entity = (SomeEntity)factory(new ObjectArrayValueReader(new object[] { "Fu", gu, 77 }));
+            var entity = (SomeEntity)factory(new ObjectArrayValueReader(new object[] { 0, "Fu", gu, 77, 0 }));
 
             Assert.Equal(77, entity.Id);
             Assert.Equal("Fu", entity.Foo);
             Assert.Equal(gu, entity.Goo);
+            Assert.Equal(SomeEnum.EnumValue, entity.Enum);
+            Assert.Equal(SomeEnum.EnumValue, entity.MaybeEnum);
         }
 
         [Fact]
         public void Can_create_materializer_for_entity_with_fields()
         {
             var entityType = new Model().AddEntityType(typeof(SomeEntityWithFields));
-            entityType.GetOrAddProperty("Id", typeof(int));
+            entityType.GetOrAddProperty("Enum", typeof(SomeEnum));
             entityType.GetOrAddProperty("Foo", typeof(string));
             entityType.GetOrAddProperty("Goo", typeof(Guid?));
+            entityType.GetOrAddProperty("Id", typeof(int));
+            entityType.GetOrAddProperty("MaybeEnum", typeof(SomeEnum?));
 
             var factory = new EntityMaterializerSource(new MemberMapper(new FieldMatcher())).GetMaterializer(entityType);
 
             var gu = Guid.NewGuid();
-            var entity = (SomeEntityWithFields)factory(new ObjectArrayValueReader(new object[] { "Fu", gu, 77 }));
+            var entity = (SomeEntityWithFields)factory(new ObjectArrayValueReader(new object[] { 0, "Fu", gu, 77, null }));
 
             Assert.Equal(77, entity.Id);
             Assert.Equal("Fu", entity.Foo);
             Assert.Equal(gu, entity.Goo);
+            Assert.Equal(SomeEnum.EnumValue, entity.Enum);
+            Assert.Null(entity.MaybeEnum);
         }
 
         [Fact]
@@ -117,9 +125,13 @@ namespace Microsoft.Data.Entity.Tests.Metadata
 
         private class SomeEntity
         {
+            // ReSharper disable UnusedAutoPropertyAccessor.Local
             public int Id { get; set; }
             public string Foo { get; set; }
             public Guid? Goo { get; set; }
+            public SomeEnum Enum { get; set; }
+            public SomeEnum? MaybeEnum { get; set; }
+            // ReSharper restore UnusedAutoPropertyAccessor.Local
         }
 
         private class SomeEntityWithFields
@@ -128,6 +140,8 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             private int _id;
             private string _foo;
             private Guid? _goo;
+            private SomeEnum _enum;
+            private SomeEnum? _maybeEnum;
 #pragma warning restore 649
 
             public int Id
@@ -144,6 +158,21 @@ namespace Microsoft.Data.Entity.Tests.Metadata
             {
                 get { return _goo; }
             }
+
+            public SomeEnum Enum
+            {
+                get { return _enum; }
+            }
+
+            public SomeEnum? MaybeEnum
+            {
+                get { return _maybeEnum; }
+            }
+        }
+
+        private enum SomeEnum
+        {
+            EnumValue
         }
     }
 }


### PR DESCRIPTION
Problem: Nullable enums were not being handled correctly in EntityMaterializerSource and EntityQueryModelVisitor.
Solution: Centralize logic for ReadValue expression creation. Add support for enums.
