### PR TITLE
add gears of war model to tests - needs to be refactored

### DIFF
--- a/test/EntityFramework.FunctionalTests/EntityFramework.FunctionalTests.csproj
+++ b/test/EntityFramework.FunctionalTests/EntityFramework.FunctionalTests.csproj
@@ -104,6 +104,14 @@
     <Compile Include="OptimisticConcurrencyTestBase.cs" />
     <Compile Include="SupplementalBuiltInDataTypesFixtureBase.cs" />
     <Compile Include="SupplementalBuiltInDataTypesTestBase.cs" />
+    <Compile Include="TestModels\GearsOfWarModel\City.cs" />
+    <Compile Include="TestModels\GearsOfWarModel\CogTag.cs" />
+    <Compile Include="TestModels\GearsOfWarModel\Gear.cs" />
+    <Compile Include="TestModels\GearsOfWarModel\GearsOfWarContext.cs" />
+    <Compile Include="TestModels\GearsOfWarModel\GearsOfWarModelInitializer.cs" />
+    <Compile Include="TestModels\GearsOfWarModel\MilitaryRank.cs" />
+    <Compile Include="TestModels\GearsOfWarModel\Squad.cs" />
+    <Compile Include="TestModels\GearsOfWarModel\Weapon.cs" />
     <Compile Include="TestStore.cs" />
     <Compile Include="TestFileLogger.cs" />
     <Compile Include="TestModels\ChangedChangingMonsterContext.cs" />

--- a/test/EntityFramework.FunctionalTests/TestModels/GearsOfWarModel/City.cs
+++ b/test/EntityFramework.FunctionalTests/TestModels/GearsOfWarModel/City.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
+{
+    public class City
+    {
+        // non-integer key with not conventional name
+        public string Name { get; set; }
+        public string Location { get; set; }
+    }
+}

--- a/test/EntityFramework.FunctionalTests/TestModels/GearsOfWarModel/CogTag.cs
+++ b/test/EntityFramework.FunctionalTests/TestModels/GearsOfWarModel/CogTag.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
+{
+    public class CogTag
+    {
+        // auto generated key (identity for now)
+        public Guid Id { get; set; }
+        public string Note { get; set; }
+
+        public string GearNickName { get; set; }
+        public int? GearSquadId { get; set; }
+        public virtual Gear Gear { get; set; }
+    }
+}

--- a/test/EntityFramework.FunctionalTests/TestModels/GearsOfWarModel/Gear.cs
+++ b/test/EntityFramework.FunctionalTests/TestModels/GearsOfWarModel/Gear.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
+{
+    public class Gear
+    {
+        public Gear()
+        {
+            Weapons = new List<Weapon>();
+            Reports = new List<Gear>();
+        }
+
+        // composite key
+        public string Nickname { get; set; }
+        public int SquadId { get; set; }
+
+        public string FullName { get; set; }
+
+        public string CityOrBirthName { get; set; }
+        public virtual City CityOfBirth { get; set; }
+
+        public MilitaryRank Rank { get; set; }
+
+        public virtual CogTag Tag { get; set; }
+        public virtual Squad Squad { get; set; }
+
+        // TODO: make this many to many - not supported at the moment
+        public virtual ICollection<Weapon> Weapons { get; set; }
+
+        public string LeaderNickname { get; set; }
+        public int LeaderSquadId { get; set; }
+
+        // 1 - many self reference
+        public virtual ICollection<Gear> Reports { get; set; }
+    }
+}

--- a/test/EntityFramework.FunctionalTests/TestModels/GearsOfWarModel/GearsOfWarContext.cs
+++ b/test/EntityFramework.FunctionalTests/TestModels/GearsOfWarModel/GearsOfWarContext.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
+{
+    public class GearsOfWarContext : DbContext
+    {
+        public GearsOfWarContext(IServiceProvider serviceProvider, DbContextOptions options)
+            : base(serviceProvider, options)
+        {
+        }
+
+        public DbSet<Gear> Gears { get; set; }
+        public DbSet<Squad> Squads { get; set; }
+        public DbSet<CogTag> Tags { get; set; }
+        public DbSet<Weapon> Weapons { get; set; }
+        public DbSet<City> Cities { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder builder)
+        {
+            builder.Entity<City>().Key(c => c.Name);
+
+            builder.Entity<Gear>().Key(g => new { g.Nickname, g.SquadId });
+            builder.Entity<Gear>().ManyToOne(g => g.CityOfBirth).ForeignKey(g => g.CityOrBirthName);
+            builder.Entity<Gear>().OneToMany(g => g.Reports).ForeignKey(g => new { g.LeaderNickname, g.LeaderSquadId });
+            builder.Entity<Gear>().OneToOne(g => g.Tag, t => t.Gear).ForeignKey<CogTag>(t => new { t.GearNickName, t.GearSquadId });
+
+            builder.Entity<CogTag>().Key(t => t.Id);
+            builder.Model.GetEntityType(typeof(CogTag)).GetProperty("Id").ValueGeneration = ValueGeneration.OnAdd;
+
+            builder.Entity<Squad>().Key(s => s.Id);
+            builder.Entity<Squad>().OneToMany(s => s.Members, g => g.Squad).ForeignKey(g => g.SquadId);
+            builder.Model.GetEntityType(typeof(Squad)).GetProperty("Id").ValueGeneration = ValueGeneration.OnAdd;
+
+            builder.Entity<Weapon>().OneToOne(w => w.SynergyWith).ForeignKey<Weapon>(w => w.SynergyWithId);
+            builder.Entity<Weapon>().ManyToOne(w => w.Owner, g => g.Weapons).ForeignKey(w => new { w.OwnerNickname, w.OwnerSquadId });
+        }
+    }
+}

--- a/test/EntityFramework.FunctionalTests/TestModels/GearsOfWarModel/GearsOfWarModelInitializer.cs
+++ b/test/EntityFramework.FunctionalTests/TestModels/GearsOfWarModel/GearsOfWarModelInitializer.cs
@@ -1,0 +1,231 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
+{
+    public class GearsOfWarModelInitializer
+    {
+        public static async Task SeedAsync(GearsOfWarContext context)
+        {
+            // TODO: only delete if model has changed
+            await context.Database.EnsureDeletedAsync();
+            if (await context.Database.EnsureCreatedAsync())
+            {
+                var deltaSquad = new Squad
+                {
+                    Name = "Delta",
+                    Members = new List<Gear>(),
+                };
+
+                await context.Squads.AddAsync(deltaSquad);
+                await context.SaveChangesAsync();
+
+                var kiloSquad = new Squad
+                {
+                    Name = "Kilo",
+                    Members = new List<Gear>(),
+                };
+
+                await context.Squads.AddAsync(kiloSquad);
+                await context.SaveChangesAsync();
+
+                var jacinto = new City
+                {
+                    Location = "Jacinto's location",
+                    Name = "Jacinto",
+                };
+
+                var ephyra = new City
+                {
+                    Location = "Ephyra's location",
+                    Name = "Ephyra",
+                };
+
+                var hanover = new City
+                {
+                    Location = "Hanover's location",
+                    Name = "Hanover",
+                };
+
+                await context.Cities.AddAsync(jacinto);
+                await context.Cities.AddAsync(ephyra);
+                await context.Cities.AddAsync(hanover);
+
+                await context.SaveChangesAsync();
+
+                var marcusLancer = new Weapon
+                {
+                    Name = "Marcus' Lancer",
+                };
+
+                var marcusGnasher = new Weapon
+                {
+                    Name = "Marcus' Gnasher",
+                    SynergyWith = marcusLancer,
+                };
+
+                var domsHammerburst = new Weapon
+                {
+                    Name = "Dom's Hammerburst",
+                };
+
+                var domsGnasher = new Weapon
+                {
+                    Name = "Dom's Gnasher",
+                };
+
+                var colesGnasher = new Weapon
+                {
+                    Name = "Cole's Gnasher",
+                };
+
+                var colesMulcher = new Weapon
+                {
+                    Name = "Cole's Mulcher",
+                };
+
+                var bairdsLancer = new Weapon
+                {
+                    Name = "Baird's Lancer",
+                };
+
+                var bairdsGnasher = new Weapon
+                {
+                    Name = "Baird's Gnasher",
+                };
+
+                var paduksMarkza = new Weapon
+                {
+                    Name = "Paduk's Markza",
+                };
+
+                await context.Weapons.AddAsync(marcusLancer);
+                await context.Weapons.AddAsync(marcusGnasher);
+                await context.Weapons.AddAsync(domsHammerburst);
+                await context.Weapons.AddAsync(domsGnasher);
+                await context.Weapons.AddAsync(colesGnasher);
+                await context.Weapons.AddAsync(colesMulcher);
+                await context.Weapons.AddAsync(bairdsLancer);
+                await context.Weapons.AddAsync(bairdsGnasher);
+                await context.Weapons.AddAsync(paduksMarkza);
+                await context.SaveChangesAsync();
+
+                var marcusTag = new CogTag
+                {
+                    Id = Guid.NewGuid(),
+                    Note = "Marcus's Tag",
+                };
+
+                var domsTag = new CogTag
+                {
+                    Id = Guid.NewGuid(),
+                    Note = "Dom's Tag",
+                };
+
+                var colesTag = new CogTag
+                {
+                    Id = Guid.NewGuid(),
+                    Note = "Cole's Tag",
+                };
+
+                var bairdsTag = new CogTag
+                {
+                    Id = Guid.NewGuid(),
+                    Note = "Bairds's Tag",
+                };
+
+                var paduksTag = new CogTag
+                {
+                    Id = Guid.NewGuid(),
+                    Note = "Paduk's Tag",
+                };
+
+                var kiaTag = new CogTag
+                {
+                    Id = Guid.NewGuid(),
+                    Note = "K.I.A.",
+                };
+
+                await context.Tags.AddAsync(marcusTag);
+                await context.Tags.AddAsync(domsTag);
+                await context.Tags.AddAsync(colesTag);
+                await context.Tags.AddAsync(bairdsTag);
+                await context.Tags.AddAsync(paduksTag);
+                await context.Tags.AddAsync(kiaTag);
+                await context.SaveChangesAsync();
+
+                var dom = new Gear
+                {
+                    Nickname = "Dom",
+                    FullName = "Dominic Santiago",
+                    SquadId = deltaSquad.Id,
+                    Rank = MilitaryRank.Corporal,
+                    CityOrBirthName = ephyra.Name,
+                    Tag = domsTag,
+                    Reports = new List<Gear>(),
+                    Weapons = new List<Weapon> { domsHammerburst, domsGnasher }
+                };
+
+                var cole = new Gear
+                {
+                    Nickname = "Cole Train",
+                    FullName = "Augustus Cole",
+                    SquadId = deltaSquad.Id,
+                    Rank = MilitaryRank.Private,
+                    CityOrBirthName = hanover.Name,
+                    Tag = colesTag,
+                    Reports = new List<Gear>(),
+                    Weapons = new List<Weapon> { colesGnasher, colesMulcher }
+                };
+
+                var paduk = new Gear
+                {
+                    Nickname = "Paduk",
+                    FullName = "Garron Paduk",
+                    SquadId = kiloSquad.Id,
+                    Rank = MilitaryRank.Private,
+                    Tag = paduksTag,
+                    Reports = new List<Gear>(),
+                    Weapons = new List<Weapon> { paduksMarkza },
+                };
+
+                var baird = new Gear
+                {
+                    Nickname = "Baird",
+                    FullName = "Damon Baird",
+                    SquadId = deltaSquad.Id,
+                    Rank = MilitaryRank.Corporal,
+                    Tag = bairdsTag,
+                    Reports = new List<Gear>() { paduk },
+                    Weapons = new List<Weapon> { bairdsLancer, bairdsGnasher }
+                };
+
+                var marcus = new Gear
+                {
+                    Nickname = "Marcus",
+                    FullName = "Marcus Fenix",
+                    SquadId = deltaSquad.Id,
+                    Rank = MilitaryRank.Sergeant,
+                    CityOrBirthName = jacinto.Name,
+                    Tag = marcusTag,
+                    Reports = new List<Gear>() { dom, cole, baird },
+                    Weapons = new List<Weapon> { marcusLancer, marcusGnasher },
+                };
+
+                await context.Gears.AddAsync(marcus);
+                await context.Gears.AddAsync(dom);
+                await context.Gears.AddAsync(cole);
+                await context.Gears.AddAsync(baird);
+                await context.Gears.AddAsync(paduk);
+
+                await context.SaveChangesAsync();
+            }
+        }
+    }
+}

--- a/test/EntityFramework.FunctionalTests/TestModels/GearsOfWarModel/MilitaryRank.cs
+++ b/test/EntityFramework.FunctionalTests/TestModels/GearsOfWarModel/MilitaryRank.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
+{
+    public enum MilitaryRank
+    {
+        Private,
+        Corporal,
+        Sergeant,
+        Lieutenant,
+        Captain,
+        Major,
+        Colonel,
+        General,
+    }
+}

--- a/test/EntityFramework.FunctionalTests/TestModels/GearsOfWarModel/Squad.cs
+++ b/test/EntityFramework.FunctionalTests/TestModels/GearsOfWarModel/Squad.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
+{
+    public class Squad
+    {
+        public Squad()
+        {
+            Members = new List<Gear>();
+        }
+
+        // non-auto generated key
+        public int Id { get; set; }
+        public string Name { get; set; }
+
+        // auto-generated non-key (sequence)
+        public int InternalNumber { get; set; }
+
+        public virtual ICollection<Gear> Members { get; set; }
+    }
+}

--- a/test/EntityFramework.FunctionalTests/TestModels/GearsOfWarModel/Weapon.cs
+++ b/test/EntityFramework.FunctionalTests/TestModels/GearsOfWarModel/Weapon.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.Data.Entity.FunctionalTests.TestModels.GearsOfWarModel
+{
+    public class Weapon
+    {
+        // auto generated key (sequence) TODO: make nullable when issue #478 is fixed
+        public int Id { get; set; }
+        public string Name { get; set; }
+
+        // 1 - 1 self reference
+        public int? SynergyWithId { get; set; }
+        public virtual Weapon SynergyWith { get; set; }
+
+        public string OwnerNickname { get; set; }
+        public int OwnerSquadId { get; set; }
+        public Gear Owner { get; set; }
+    }
+}


### PR DESCRIPTION
Adding model for some query tests in the future - only entity classes, context and data initializer - fixtures etc need to be added in order to use it in the tests effectively.

@AndriySvyryd 
