### PR TITLE
Prevent context from being used in OnModelCreating and OnConfiguring (Issue #565)

### DIFF
--- a/src/EntityFramework/EntityFramework.csproj
+++ b/src/EntityFramework/EntityFramework.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Infrastructure\DbContextConfigureOptions.cs" />
     <Compile Include="Infrastructure\DbContextOptionsParser.cs" />
     <Compile Include="Infrastructure\IDbContextConfigurationAdapter.cs" />
+    <Compile Include="Infrastructure\ModelSourceHelpers.cs" />
     <Compile Include="Metadata\BasicModelBuilder.cs" />
     <Compile Include="Metadata\CollectionTypeFactory.cs" />
     <Compile Include="Metadata\IEntityBuilder.cs" />

--- a/src/EntityFramework/Infrastructure/DefaultModelSource.cs
+++ b/src/EntityFramework/Infrastructure/DefaultModelSource.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Data.Entity.Infrastructure
                 modelBuilder.Entity(setInfo.EntityType);
             }
 
-            context.OnModelCreating(modelBuilder);
+            ModelSourceHelpers.OnModelCreating(context, modelBuilder);
 
             return model;
         }

--- a/src/EntityFramework/Infrastructure/ModelSourceHelpers.cs
+++ b/src/EntityFramework/Infrastructure/ModelSourceHelpers.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Infrastructure
+{
+    public static class ModelSourceHelpers
+    {
+        public static void OnModelCreating([NotNull] DbContext context, [NotNull] ModelBuilder modelBuilder)
+        {
+            Check.NotNull(context, "context");
+            Check.NotNull(modelBuilder, "modelBuilder");
+
+            context.OnModelCreating(modelBuilder);
+        }
+    }
+}

--- a/src/EntityFramework/Properties/Strings.Designer.cs
+++ b/src/EntityFramework/Properties/Strings.Designer.cs
@@ -1386,6 +1386,38 @@ namespace Microsoft.Data.Entity
             return string.Format(CultureInfo.CurrentCulture, GetString("CannotBeNullable", "property", "entity", "propertyType"), property, entity, propertyType);
         }
 
+        /// <summary>
+        /// An attempt was made to use the model while it was being created. A DbContext instance cannot be used inside OnModelCreating in any way that makes use of the model that is being created.
+        /// </summary>
+        internal static string RecursiveOnModelCreating
+        {
+            get { return GetString("RecursiveOnModelCreating"); }
+        }
+
+        /// <summary>
+        /// An attempt was made to use the model while it was being created. A DbContext instance cannot be used inside OnModelCreating in any way that makes use of the model that is being created.
+        /// </summary>
+        internal static string FormatRecursiveOnModelCreating()
+        {
+            return GetString("RecursiveOnModelCreating");
+        }
+
+        /// <summary>
+        /// An attempt was made to use the context while it is being configured. A DbContext instance cannot be used inside OnConfiguring since it is still being configured at this point.
+        /// </summary>
+        internal static string RecursiveOnConfiguring
+        {
+            get { return GetString("RecursiveOnConfiguring"); }
+        }
+
+        /// <summary>
+        /// An attempt was made to use the context while it is being configured. A DbContext instance cannot be used inside OnConfiguring since it is still being configured at this point.
+        /// </summary>
+        internal static string FormatRecursiveOnConfiguring()
+        {
+            return GetString("RecursiveOnConfiguring");
+        }
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EntityFramework/Properties/Strings.resx
+++ b/src/EntityFramework/Properties/Strings.resx
@@ -375,4 +375,10 @@
   <data name="CannotBeNullable" xml:space="preserve">
     <value>The property '{property}' on entity type '{entity}' cannot be marked as nullable/optional because the type of the property is '{propertyType}' which is not a nullable type. Any property can be marked as non-nullable/required, but only properties of nullable types can be marked as nullable/optional.</value>
   </data>
+  <data name="RecursiveOnModelCreating" xml:space="preserve">
+    <value>An attempt was made to use the model while it was being created. A DbContext instance cannot be used inside OnModelCreating in any way that makes use of the model that is being created.</value>
+  </data>
+  <data name="RecursiveOnConfiguring" xml:space="preserve">
+    <value>An attempt was made to use the context while it is being configured. A DbContext instance cannot be used inside OnConfiguring since it is still being configured at this point.</value>
+  </data>
 </root>

--- a/test/EntityFramework.FunctionalTests/EntityFramework.FunctionalTests.csproj
+++ b/test/EntityFramework.FunctionalTests/EntityFramework.FunctionalTests.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Metadata\Compiled\Empty.cs" />
     <Compile Include="Metadata\Compiled\NoAnnotations.cs" />
     <Compile Include="Metadata\KoolModel.cs" />
+    <Compile Include="ModelSourceTest.cs" />
     <Compile Include="MonsterFixupTestBase.cs" />
     <Compile Include="OneToOneQueryFixtureBase.cs" />
     <Compile Include="NorthwindQueryFixtureBase.cs" />

--- a/test/EntityFramework.FunctionalTests/ModelSourceTest.cs
+++ b/test/EntityFramework.FunctionalTests/ModelSourceTest.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
+using Xunit;
+
+namespace Microsoft.Data.Entity.FunctionalTests
+{
+    public class ModelSourceTest
+    {
+        [Fact] // Issue #943
+        public void Can_replace_ModelSource_without_access_to_internals()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFramework()
+                .AddInMemoryStore()
+                .AddDbContext<JustSomeContext>()
+                .ServiceCollection
+                .AddSingleton<IModelSource, MyModelSource>()
+                .BuildServiceProvider();
+
+            using (var context = serviceProvider.GetService<JustSomeContext>())
+            {
+                var model = context.Model;
+
+                Assert.Equal("Us!", model["AllYourModelAreBelongTo"]);
+                Assert.Equal("Us!", model.EntityTypes.Single(e => e.SimpleName == "Base")["AllYourBaseAreBelongTo"]);
+                Assert.Contains("Peak", model.EntityTypes.Select(e => e.SimpleName));
+            }
+        }
+
+        private class MyModelSource : IModelSource
+        {
+            private readonly ThreadSafeDictionaryCache<Type, IModel> _models = new ThreadSafeDictionaryCache<Type, IModel>();
+
+            private readonly DbSetFinder _setFinder;
+
+            public MyModelSource(DbSetFinder setFinder)
+            {
+                _setFinder = setFinder;
+            }
+
+            public virtual IModel GetModel(DbContext context, IModelBuilderFactory modelBuilderFactory)
+            {
+                return _models.GetOrAdd(context.GetType(), k => CreateModel(context, modelBuilderFactory));
+            }
+
+            private IModel CreateModel(DbContext context, IModelBuilderFactory modelBuilderFactory)
+            {
+                var model = new Model();
+                var modelBuilder = modelBuilderFactory.CreateConventionBuilder(model);
+
+                foreach (var setInfo in _setFinder.FindSets(context))
+                {
+                    modelBuilder.Entity(setInfo.EntityType);
+                }
+
+                ModelSourceHelpers.OnModelCreating(context, modelBuilder);
+
+                model["AllYourModelAreBelongTo"] = "Us!";
+
+                return model;
+            }
+        }
+
+        private class JustSomeContext : DbContext
+        {
+            public JustSomeContext(IServiceProvider serviceProvider)
+                : base(serviceProvider)
+            {
+            }
+
+            public DbSet<Peak> Peaks { get; set; }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<Base>().Annotation("AllYourBaseAreBelongTo", "Us!");
+            }
+        }
+
+        private class Base
+        {
+            public int Id { get; set; }
+        }
+
+        private class Peak
+        {
+            public int Id { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Also Issue #943: Make DbContext.OnModelCreating publicly accessible

Just added a public static method for calling it. This is not easily discoverable and so should not cause much confusion but allows ModelSource to be implemented without access to internals.
