### PR TITLE
String resource tidy up

### DIFF
--- a/src/EntityFramework.SqlServer/project.json
+++ b/src/EntityFramework.SqlServer/project.json
@@ -1,6 +1,6 @@
 {
     "version": "7.0.0-*",
-    "description":  "SQLite data store for Entity Framework.",
+    "description":  "Microsoft SQL Server data store for Entity Framework.",
     "compilationOptions": {
         "warningsAsErrors": true
     },

--- a/src/Microsoft.AspNet.Diagnostics.Entity/Properties/Strings.Designer.cs
+++ b/src/Microsoft.AspNet.Diagnostics.Entity/Properties/Strings.Designer.cs
@@ -155,6 +155,22 @@ namespace Microsoft.AspNet.Diagnostics.Entity
         }
 
         /// <summary>
+        /// To use migrations from a command prompt you will need to <a href='http://go.microsoft.com/fwlink/?LinkId=518242'>install K Version Manager (KVM)</a>. Once installed, you can run migration commands from a standard command prompt in the project directory.
+        /// </summary>
+        internal static string DatabaseErrorPage_EnableMigrationsCommandsInfo
+        {
+            get { return GetString("DatabaseErrorPage_EnableMigrationsCommandsInfo"); }
+        }
+
+        /// <summary>
+        /// To use migrations from a command prompt you will need to <a href='http://go.microsoft.com/fwlink/?LinkId=518242'>install K Version Manager (KVM)</a>. Once installed, you can run migration commands from a standard command prompt in the project directory.
+        /// </summary>
+        internal static string FormatDatabaseErrorPage_EnableMigrationsCommandsInfo()
+        {
+            return GetString("DatabaseErrorPage_EnableMigrationsCommandsInfo");
+        }
+
+        /// <summary>
         /// You can also apply migrations from the command line
         /// </summary>
         internal static string DatabaseErrorPage_HowToApplyFromCmd
@@ -280,6 +296,22 @@ namespace Microsoft.AspNet.Diagnostics.Entity
         internal static string FormatDatabaseErrorPage_PendingMigrationsTitle(object p0)
         {
             return string.Format(CultureInfo.CurrentCulture, GetString("DatabaseErrorPage_PendingMigrationsTitle"), p0);
+        }
+
+        /// <summary>
+        /// A database operartion failed while processing the request.
+        /// </summary>
+        internal static string DatabaseErrorPage_Title
+        {
+            get { return GetString("DatabaseErrorPage_Title"); }
+        }
+
+        /// <summary>
+        /// A database operartion failed while processing the request.
+        /// </summary>
+        internal static string FormatDatabaseErrorPage_Title()
+        {
+            return GetString("DatabaseErrorPage_Title");
         }
 
         /// <summary>

--- a/src/Microsoft.AspNet.Diagnostics.Entity/Properties/Strings.resx
+++ b/src/Microsoft.AspNet.Diagnostics.Entity/Properties/Strings.resx
@@ -127,7 +127,7 @@
     <value>The context type '{0}' was not found in services. This usually means the context was not registered in services during startup. You probably want to call AddScoped&lt;{0}&gt;() inside the UseServices(...) call in your application startup code. Skipping display of the database error page.</value>
   </data>
   <data name="DatabaseErrorPageMiddleware_Exception" xml:space="preserve">
-    <value>An exception occured while calculating the database error page content. Skipping display of the database error page.</value>
+    <value>An exception occurred while calculating the database error page content. Skipping display of the database error page.</value>
   </data>
   <data name="DatabaseErrorPage_AddMigrationCommand" xml:space="preserve">
     <value>&gt; k ef migration add [migration name]</value>
@@ -142,22 +142,22 @@
     <value>Applying Migrations...</value>
   </data>
   <data name="DatabaseErrorPage_ApplyMigrationsFailed" xml:space="preserve">
-    <value>An error occured applying migrations, try applying them from the command line</value>
+    <value>An error occurred applying migrations, try applying them from the command line</value>
   </data>
   <data name="DatabaseErrorPage_HowToApplyFromCmd" xml:space="preserve">
-    <value>You can also apply migrations from the command line</value>
+    <value>You can also apply migrations from the command line:</value>
   </data>
   <data name="DatabaseErrorPage_MigrationsAppliedRefresh" xml:space="preserve">
     <value>Try refreshing the page</value>
   </data>
   <data name="DatabaseErrorPage_NoDbOrMigrationsInfo" xml:space="preserve">
-    <value>From the command line, scaffold a new migration and apply it to the database</value>
+    <value>From the command line, scaffold a new migration and apply it to the database:</value>
   </data>
   <data name="DatabaseErrorPage_NoDbOrMigrationsTitle" xml:space="preserve">
     <value>Use migrations to create the database for {0}</value>
   </data>
   <data name="DatabaseErrorPage_PendingChangesInfo" xml:space="preserve">
-    <value>Scaffold a new migration for these changes and apply them to the database from the command line</value>
+    <value>Scaffold a new migration for these changes and apply them to the database from the command line:</value>
   </data>
   <data name="DatabaseErrorPage_PendingChangesTitle" xml:space="preserve">
     <value>There are pending model changes for {0}</value>
@@ -184,7 +184,7 @@
     <value>The context type '{0}' was not found in services. This usually means the context was not registered in services during startup. You probably want to call AddScoped&lt;{0}&gt;() inside the UseServices(...) call in your application startup code.</value>
   </data>
   <data name="MigrationsEndPointMiddleware_Exception" xml:space="preserve">
-    <value>An error occured while applying the migrations for '{0}'. See InnerException for details.</value>
+    <value>An error occurred while applying the migrations for '{0}'. See InnerException for details.</value>
   </data>
   <data name="MigrationsEndPointMiddleware_InvalidContextType" xml:space="preserve">
     <value>The context type '{0}' could not be loaded. Ensure this is the correct type name for the context you are trying to apply migrations for.</value>
@@ -194,5 +194,11 @@
   </data>
   <data name="MigrationsEndPointMiddleware_RequestPathMatched" xml:space="preserve">
     <value>Request path matched the path configured for this migrations endpoint ({0}). Attempting to process the migrations request.</value>
+  </data>
+  <data name="DatabaseErrorPage_Title" xml:space="preserve">
+    <value>A database operation failed while processing the request.</value>
+  </data>
+  <data name="DatabaseErrorPage_EnableMigrationsCommandsInfo" xml:space="preserve">
+    <value>To use migrations from a command prompt you will need to &lt;a href='http://go.microsoft.com/fwlink/?LinkId=518242'&gt;install K Version Manager (KVM)&lt;/a&gt;. Once installed, you can run migration commands from a standard command prompt in the project directory.</value>
   </data>
 </root>

--- a/src/Microsoft.AspNet.Diagnostics.Entity/Views/DatabaseErrorPage.cs
+++ b/src/Microsoft.AspNet.Diagnostics.Entity/Views/DatabaseErrorPage.cs
@@ -83,8 +83,13 @@ using Microsoft.AspNet.Diagnostics.Entity.Views
 
 #line default
 #line hidden
-            WriteLiteral("\r\n    </style>\r\n</head>\r\n<body>\r\n    <h1>A database operartion failed while proce" +
-"ssing the request.</h1>\r\n");
+            WriteLiteral("\r\n    </style>\r\n</head>\r\n<body>\r\n    <h1>");
+#line 41 "DatabaseErrorPage.cshtml"
+   Write(Strings.DatabaseErrorPage_Title);
+
+#line default
+#line hidden
+            WriteLiteral("</h1>\r\n");
 #line 42 "DatabaseErrorPage.cshtml"
     
 
@@ -176,8 +181,14 @@ using Microsoft.AspNet.Diagnostics.Entity.Views
 
 #line default
 #line hidden
-            WriteLiteral(" </code>\r\n        <hr />\r\n");
-#line 62 "DatabaseErrorPage.cshtml"
+            WriteLiteral(" </code>\r\n        <p><strong>");
+#line 61 "DatabaseErrorPage.cshtml"
+              WriteLiteral(Strings.DatabaseErrorPage_EnableMigrationsCommandsInfo);
+
+#line default
+#line hidden
+            WriteLiteral("</strong></p>\r\n        <hr />\r\n");
+#line 63 "DatabaseErrorPage.cshtml"
     }
     else if (Model.PendingMigrations.Any())
     {
@@ -186,25 +197,25 @@ using Microsoft.AspNet.Diagnostics.Entity.Views
 #line hidden
 
             WriteLiteral("        <div>\r\n            <h2>");
-#line 66 "DatabaseErrorPage.cshtml"
+#line 67 "DatabaseErrorPage.cshtml"
            Write(Strings.FormatDatabaseErrorPage_PendingMigrationsTitle(Model.ContextType.Name));
 
 #line default
 #line hidden
             WriteLiteral("</h2>\r\n            <p>");
-#line 67 "DatabaseErrorPage.cshtml"
+#line 68 "DatabaseErrorPage.cshtml"
           Write(Strings.FormatDatabaseErrorPage_PendingMigrationsInfo(Model.ContextType.Name));
 
 #line default
 #line hidden
             WriteLiteral("</p>\r\n\r\n");
-#line 69 "DatabaseErrorPage.cshtml"
+#line 70 "DatabaseErrorPage.cshtml"
             
 
 #line default
 #line hidden
 
-#line 69 "DatabaseErrorPage.cshtml"
+#line 70 "DatabaseErrorPage.cshtml"
              if (Model.Options.ListMigrations)
             {
 
@@ -212,13 +223,13 @@ using Microsoft.AspNet.Diagnostics.Entity.Views
 #line hidden
 
             WriteLiteral("                <ul>\r\n");
-#line 72 "DatabaseErrorPage.cshtml"
+#line 73 "DatabaseErrorPage.cshtml"
                     
 
 #line default
 #line hidden
 
-#line 72 "DatabaseErrorPage.cshtml"
+#line 73 "DatabaseErrorPage.cshtml"
                      foreach (var migration in Model.PendingMigrations)
                     {
 
@@ -226,33 +237,33 @@ using Microsoft.AspNet.Diagnostics.Entity.Views
 #line hidden
 
             WriteLiteral("                        <li>");
-#line 74 "DatabaseErrorPage.cshtml"
+#line 75 "DatabaseErrorPage.cshtml"
                        Write(migration);
 
 #line default
 #line hidden
             WriteLiteral("</li>\r\n");
-#line 75 "DatabaseErrorPage.cshtml"
+#line 76 "DatabaseErrorPage.cshtml"
                     }
 
 #line default
 #line hidden
 
             WriteLiteral("                </ul>\r\n");
-#line 77 "DatabaseErrorPage.cshtml"
+#line 78 "DatabaseErrorPage.cshtml"
             }
 
 #line default
 #line hidden
 
             WriteLiteral("\r\n");
-#line 79 "DatabaseErrorPage.cshtml"
+#line 80 "DatabaseErrorPage.cshtml"
             
 
 #line default
 #line hidden
 
-#line 79 "DatabaseErrorPage.cshtml"
+#line 80 "DatabaseErrorPage.cshtml"
              if (Model.Options.EnableMigrationCommands)
             {
 
@@ -261,7 +272,7 @@ using Microsoft.AspNet.Diagnostics.Entity.Views
 
             WriteLiteral("                <p>\r\n                    <button id=\"applyMigrations\" onclick=\" A" +
 "pplyMigrations() \">");
-#line 82 "DatabaseErrorPage.cshtml"
+#line 83 "DatabaseErrorPage.cshtml"
                                                                           Write(Strings.DatabaseErrorPage_ApplyMigrationsButton);
 
 #line default
@@ -275,21 +286,21 @@ using Microsoft.AspNet.Diagnostics.Entity.Views
                         applyMigrations.disabled = true;
                         applyMigrationsError.innerHTML = """";
                         applyMigrations.innerHTML = """);
-#line 90 "DatabaseErrorPage.cshtml"
+#line 91 "DatabaseErrorPage.cshtml"
                                                 Write(Strings.DatabaseErrorPage_ApplyMigrationsButtonRunning);
 
 #line default
 #line hidden
             WriteLiteral("\";\r\n\r\n                        var req = new XMLHttpRequest();\r\n                  " +
 "      req.open(\"POST\", \"");
-#line 93 "DatabaseErrorPage.cshtml"
+#line 94 "DatabaseErrorPage.cshtml"
                                      Write(Model.Options.MigrationsEndPointPath.Value);
 
 #line default
 #line hidden
             WriteLiteral("\", true);\r\n                        var params = \"context=\" + encodeURIComponent(\"" +
 "");
-#line 94 "DatabaseErrorPage.cshtml"
+#line 95 "DatabaseErrorPage.cshtml"
                                                                  Write(Model.ContextType.AssemblyQualifiedName);
 
 #line default
@@ -302,19 +313,18 @@ using Microsoft.AspNet.Diagnostics.Entity.Views
                         req.onload = function (e) {
                             if (req.status == 204) {
                                 applyMigrations.innerHTML = """);
-#line 101 "DatabaseErrorPage.cshtml"
+#line 102 "DatabaseErrorPage.cshtml"
                                                         Write(Strings.DatabaseErrorPage_ApplyMigrationsButtonDone);
 
 #line default
 #line hidden
-            WriteLiteral("\";\r\n                                applyMigrationsSuccess.innerHTML = \"<a href=\'" +
-".\'>");
-#line 102 "DatabaseErrorPage.cshtml"
-                                                                           Write(Strings.DatabaseErrorPage_MigrationsAppliedRefresh);
+            WriteLiteral("\";\r\n                                applyMigrationsSuccess.innerHTML = \"");
+#line 103 "DatabaseErrorPage.cshtml"
+                                                               Write(Strings.DatabaseErrorPage_MigrationsAppliedRefresh);
 
 #line default
 #line hidden
-            WriteLiteral(@"</a>"";
+            WriteLiteral(@""";
                             } else {
                                 ErrorApplyingMigrations();
                             }
@@ -329,39 +339,45 @@ using Microsoft.AspNet.Diagnostics.Entity.Views
 
                     function ErrorApplyingMigrations() {
                         applyMigrations.innerHTML = """);
-#line 116 "DatabaseErrorPage.cshtml"
+#line 117 "DatabaseErrorPage.cshtml"
                                                 Write(Strings.DatabaseErrorPage_ApplyMigrationsButton);
 
 #line default
 #line hidden
             WriteLiteral("\";\r\n                        applyMigrationsError.innerHTML = \"");
-#line 117 "DatabaseErrorPage.cshtml"
+#line 118 "DatabaseErrorPage.cshtml"
                                                      Write(Strings.DatabaseErrorPage_ApplyMigrationsFailed);
 
 #line default
 #line hidden
             WriteLiteral("\";\r\n                        applyMigrations.disabled = false;\r\n                  " +
 "  }\r\n                </script>\r\n");
-#line 121 "DatabaseErrorPage.cshtml"
+#line 122 "DatabaseErrorPage.cshtml"
             }
 
 #line default
 #line hidden
 
             WriteLiteral("\r\n            <p>");
-#line 123 "DatabaseErrorPage.cshtml"
+#line 124 "DatabaseErrorPage.cshtml"
           Write(Strings.DatabaseErrorPage_HowToApplyFromCmd);
 
 #line default
 #line hidden
             WriteLiteral("</p>\r\n            <code>");
-#line 124 "DatabaseErrorPage.cshtml"
+#line 125 "DatabaseErrorPage.cshtml"
              Write(Strings.DatabaseErrorPage_ApplyMigrationsCommand);
 
 #line default
 #line hidden
-            WriteLiteral("</code>\r\n            <hr />\r\n        </div>\r\n");
-#line 127 "DatabaseErrorPage.cshtml"
+            WriteLiteral("</code>\r\n            <p><strong>");
+#line 126 "DatabaseErrorPage.cshtml"
+                  WriteLiteral(Strings.DatabaseErrorPage_EnableMigrationsCommandsInfo);
+
+#line default
+#line hidden
+            WriteLiteral("</strong></p>\r\n            <hr />\r\n        </div>\r\n");
+#line 129 "DatabaseErrorPage.cshtml"
     }
     else if (Model.PendingModelChanges)
     {
@@ -370,31 +386,37 @@ using Microsoft.AspNet.Diagnostics.Entity.Views
 #line hidden
 
             WriteLiteral("        <div>\r\n            <h2>");
-#line 131 "DatabaseErrorPage.cshtml"
+#line 133 "DatabaseErrorPage.cshtml"
            Write(Strings.FormatDatabaseErrorPage_PendingChangesTitle(Model.ContextType.Name));
 
 #line default
 #line hidden
             WriteLiteral("</h2>\r\n            <p>");
-#line 132 "DatabaseErrorPage.cshtml"
+#line 134 "DatabaseErrorPage.cshtml"
           Write(Strings.DatabaseErrorPage_PendingChangesInfo);
 
 #line default
 #line hidden
             WriteLiteral("</p>\r\n            <code>");
-#line 133 "DatabaseErrorPage.cshtml"
+#line 135 "DatabaseErrorPage.cshtml"
              Write(Strings.DatabaseErrorPage_AddMigrationCommand);
 
 #line default
 #line hidden
             WriteLiteral("</code>\r\n            <br />\r\n            <code>");
-#line 135 "DatabaseErrorPage.cshtml"
+#line 137 "DatabaseErrorPage.cshtml"
              Write(Strings.DatabaseErrorPage_ApplyMigrationsCommand);
 
 #line default
 #line hidden
-            WriteLiteral("</code>\r\n            <hr />\r\n        </div>\r\n");
+            WriteLiteral("</code>\r\n            <p><strong>");
 #line 138 "DatabaseErrorPage.cshtml"
+                  WriteLiteral(Strings.DatabaseErrorPage_EnableMigrationsCommandsInfo);
+
+#line default
+#line hidden
+            WriteLiteral("</strong></p>\r\n            <hr />\r\n        </div>\r\n");
+#line 141 "DatabaseErrorPage.cshtml"
     }
 
 #line default

--- a/src/Microsoft.AspNet.Diagnostics.Entity/Views/DatabaseErrorPage.cshtml
+++ b/src/Microsoft.AspNet.Diagnostics.Entity/Views/DatabaseErrorPage.cshtml
@@ -38,7 +38,7 @@
     </style>
 </head>
 <body>
-    <h1>A database operartion failed while processing the request.</h1>
+    <h1>@Strings.DatabaseErrorPage_Title</h1>
     @if (Model.Options.ShowExceptionDetails)
     {
         <p>
@@ -57,7 +57,8 @@
         <p>@Strings.DatabaseErrorPage_NoDbOrMigrationsInfo</p>
         <code> @Strings.DatabaseErrorPage_AddMigrationCommand </code>
         <br />
-        <code> @Strings.DatabaseErrorPage_UpdateDatabaseCommand </code>
+        <code> @Strings.DatabaseErrorPage_ApplyMigrationsCommand </code>
+        <p><strong>@Strings.DatabaseErrorPage_EnableMigrationsCommandsInfo</strong></p>
         <hr />
     }
     else if (Model.PendingMigrations.Any())
@@ -99,7 +100,7 @@
                         req.onload = function (e) {
                             if (req.status == 204) {
                                 applyMigrations.innerHTML = "@Strings.DatabaseErrorPage_ApplyMigrationsButtonDone";
-                                applyMigrationsSuccess.innerHTML = "<a href='.'>@Strings.DatabaseErrorPage_MigrationsAppliedRefresh</a>";
+                                applyMigrationsSuccess.innerHTML = "@Strings.DatabaseErrorPage_MigrationsAppliedRefresh";
                             } else {
                                 ErrorApplyingMigrations();
                             }
@@ -121,7 +122,8 @@
             }
 
             <p>@Strings.DatabaseErrorPage_HowToApplyFromCmd</p>
-            <code>@Strings.DatabaseErrorPage_UpdateDatabaseCommand</code>
+            <code>@Strings.DatabaseErrorPage_ApplyMigrationsCommand</code>
+            <p><strong>@Strings.DatabaseErrorPage_EnableMigrationsCommandsInfo</strong></p>
             <hr />
         </div>
     }
@@ -132,7 +134,8 @@
             <p>@Strings.DatabaseErrorPage_PendingChangesInfo</p>
             <code>@Strings.DatabaseErrorPage_AddMigrationCommand</code>
             <br />
-            <code>@Strings.DatabaseErrorPage_UpdateDatabaseCommand</code>
+            <code>@Strings.DatabaseErrorPage_ApplyMigrationsCommand</code>
+            <p><strong>@Strings.DatabaseErrorPage_EnableMigrationsCommandsInfo</strong></p>
             <hr />
         </div>
     }


### PR DESCRIPTION
- Add info about installing KVM to use migrations commands to Database Error Page
- Removing 'refresh the page' <a> which was broken as it doesn't work with post requests
- Fixing typos (all strings run thru spell check - thought I had done this but evidently not)
- Fixing package description for SQL Server package
