### PR TITLE
Tiny: Rename IsDatabaseCreated on in-memory database to EnsureDatabaseCreated

### DIFF
--- a/src/EntityFramework.InMemory/InMemoryDataStore.cs
+++ b/src/EntityFramework.InMemory/InMemoryDataStore.cs
@@ -98,9 +98,9 @@ namespace Microsoft.Data.Entity.InMemory
             return Query<TResult>(queryModel).ToAsyncEnumerable();
         }
 
-        public virtual bool IsDatabaseCreated([NotNull] IModel model)
+        public virtual bool EnsureDatabaseCreated([NotNull] IModel model)
         {
-            return _database.Value.IsCreated(model);
+            return _database.Value.EnsureCreated(model);
         }
     }
 }

--- a/src/EntityFramework.InMemory/InMemoryDataStoreCreator.cs
+++ b/src/EntityFramework.InMemory/InMemoryDataStoreCreator.cs
@@ -39,12 +39,12 @@ namespace Microsoft.Data.Entity.InMemory
 
         public override bool EnsureCreated(IModel model)
         {
-            return _dataStore.IsDatabaseCreated(model);
+            return _dataStore.EnsureDatabaseCreated(model);
         }
 
         public override Task<bool> EnsureCreatedAsync(IModel model, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return Task.FromResult(_dataStore.IsDatabaseCreated(model));
+            return Task.FromResult(_dataStore.EnsureDatabaseCreated(model));
         }
     }
 }

--- a/src/EntityFramework.InMemory/InMemoryDatabase.cs
+++ b/src/EntityFramework.InMemory/InMemoryDatabase.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Data.Entity.InMemory
         /// <returns>
         ///     true if the database has just been created, false otherwise
         /// </returns>
-        public virtual bool IsCreated([NotNull] IModel model)
+        public virtual bool EnsureCreated([NotNull] IModel model)
         {
             var returnValue = !_tables.HasValue;
             var _ = _tables.Value;

--- a/test/EntityFramework.InMemory.Tests/InMemoryDataStoreTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryDataStoreTest.cs
@@ -53,35 +53,33 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         }
 
         [Fact]
-        public void IsDatabaseCreated_returns_true_for_first_use_of_persistent_database_and_false_thereafter()
+        public void EnsureDatabaseCreated_returns_true_for_first_use_of_persistent_database_and_false_thereafter()
         {
             var model = CreateModel();
             var configuration = CreateConfiguration(new DbContextOptions().UseInMemoryStore(persist: true));
-            var entityType = model.GetEntityType(typeof(Customer));
 
             var persistentDatabase = new InMemoryDatabase(new LoggerFactory());
 
             var inMemoryDataStore = new InMemoryDataStore(configuration, persistentDatabase);
 
-            Assert.True(inMemoryDataStore.IsDatabaseCreated(model));
-            Assert.False(inMemoryDataStore.IsDatabaseCreated(model));
-            Assert.False(inMemoryDataStore.IsDatabaseCreated(model));
+            Assert.True(inMemoryDataStore.EnsureDatabaseCreated(model));
+            Assert.False(inMemoryDataStore.EnsureDatabaseCreated(model));
+            Assert.False(inMemoryDataStore.EnsureDatabaseCreated(model));
         }
 
         [Fact]
-        public void IsDatabaseCreated_returns_true_for_first_use_of_non_persistent_database_and_false_thereafter()
+        public void EnsureDatabaseCreated_returns_true_for_first_use_of_non_persistent_database_and_false_thereafter()
         {
             var model = CreateModel();
             var configuration = CreateConfiguration(new DbContextOptions().UseInMemoryStore(persist: false));
-            var entityType = model.GetEntityType(typeof(Customer));
 
             var nonPersistentDatabase = new InMemoryDatabase(new LoggerFactory());
 
             var inMemoryDataStore = new InMemoryDataStore(configuration, nonPersistentDatabase);
 
-            Assert.True(inMemoryDataStore.IsDatabaseCreated(model));
-            Assert.False(inMemoryDataStore.IsDatabaseCreated(model));
-            Assert.False(inMemoryDataStore.IsDatabaseCreated(model));
+            Assert.True(inMemoryDataStore.EnsureDatabaseCreated(model));
+            Assert.False(inMemoryDataStore.EnsureDatabaseCreated(model));
+            Assert.False(inMemoryDataStore.EnsureDatabaseCreated(model));
         }
 
         [Fact]


### PR DESCRIPTION
Because it doesn't return whether or not it is "created", but rather whether or not it was "created" by this call.
