### PR TITLE
Stop using DbContextConfiguration to get ILoggerFactory

### DIFF
--- a/src/EntityFramework.AzureTableStorage/AtsConnection.cs
+++ b/src/EntityFramework.AzureTableStorage/AtsConnection.cs
@@ -28,8 +28,8 @@ namespace Microsoft.Data.Entity.AzureTableStorage
         {
         }
 
-        public AtsConnection([NotNull] DbContextConfiguration configuration)
-            : base(configuration.LoggerFactory)
+        public AtsConnection([NotNull] DbContextConfiguration configuration, [NotNull] ILoggerFactory loggerFactory)
+            : base(loggerFactory)
         {
             Check.NotNull(configuration, "configuration");
 

--- a/src/EntityFramework.AzureTableStorage/AtsDataStore.cs
+++ b/src/EntityFramework.AzureTableStorage/AtsDataStore.cs
@@ -16,6 +16,7 @@ using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Update;
+using Microsoft.Framework.Logging;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Table;
 using Remotion.Linq;
@@ -33,7 +34,11 @@ namespace Microsoft.Data.Entity.AzureTableStorage
         /// <summary>
         ///     Provided only for testing purposes. Do not use.
         /// </summary>
-        protected AtsDataStore(DbContextConfiguration configuration, AtsConnection connection, TableEntityAdapterFactory entityFactory)
+        protected AtsDataStore(
+            DbContextConfiguration configuration, 
+            AtsConnection connection, 
+            TableEntityAdapterFactory entityFactory)
+            : base(configuration, new LoggerFactory())
         {
             _configuration = configuration;
             Connection = connection;
@@ -43,8 +48,9 @@ namespace Microsoft.Data.Entity.AzureTableStorage
         public AtsDataStore([NotNull] DbContextConfiguration configuration,
             [NotNull] AtsConnection connection,
             [NotNull] AtsQueryFactory queryFactory,
-            [NotNull] TableEntityAdapterFactory tableEntityFactory)
-            : base(configuration)
+            [NotNull] TableEntityAdapterFactory tableEntityFactory, 
+            [NotNull] ILoggerFactory loggerFactory)
+            : base(configuration, loggerFactory)
         {
             Check.NotNull(connection, "connection");
             Check.NotNull(queryFactory, "queryFactory");

--- a/src/EntityFramework.AzureTableStorage/AtsDatabase.cs
+++ b/src/EntityFramework.AzureTableStorage/AtsDatabase.cs
@@ -3,13 +3,14 @@
 
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.AzureTableStorage
 {
     public class AtsDatabase : Database
     {
-        public AtsDatabase([NotNull] DbContextConfiguration configuration)
-            : base(configuration)
+        public AtsDatabase([NotNull] DbContextConfiguration configuration, [NotNull] ILoggerFactory loggerFactory)
+            : base(configuration, loggerFactory)
         {
         }
 

--- a/src/EntityFramework.Commands/MigrationTool.cs
+++ b/src/EntityFramework.Commands/MigrationTool.cs
@@ -175,7 +175,9 @@ namespace Microsoft.Data.Entity.Commands
         {
             var context = ContextTool.CreateContext(type);
 
-            context.Configuration.LoggerFactory.AddProvider(_loggerProvider);
+            // TODO: Decouple from DbContextConfiguration (Issue #641)
+            var loggerFactory = (ILoggerFactory)context.Configuration.Services.ServiceProvider.GetService(typeof(ILoggerFactory));
+            loggerFactory.AddProvider(_loggerProvider);
 
             var extension = RelationalOptionsExtension.Extract(context.Configuration);
             if (extension.MigrationAssembly == null)

--- a/src/EntityFramework.InMemory/InMemoryDataStore.cs
+++ b/src/EntityFramework.InMemory/InMemoryDataStore.cs
@@ -14,6 +14,7 @@ using Microsoft.Data.Entity.InMemory.Utilities;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
+using Microsoft.Framework.Logging;
 using Remotion.Linq;
 
 namespace Microsoft.Data.Entity.InMemory
@@ -34,8 +35,9 @@ namespace Microsoft.Data.Entity.InMemory
 
         public InMemoryDataStore(
             [NotNull] DbContextConfiguration configuration,
-            [NotNull] InMemoryDatabase persistentDatabase)
-            : base(configuration)
+            [NotNull] InMemoryDatabase persistentDatabase,
+            [NotNull] ILoggerFactory loggerFactory)
+            : base(configuration, loggerFactory)
         {
             Check.NotNull(configuration, "configuration");
             Check.NotNull(persistentDatabase, "persistentDatabase");
@@ -49,7 +51,7 @@ namespace Microsoft.Data.Entity.InMemory
             _database = new ThreadSafeLazyRef<InMemoryDatabase>(
                 () => _persist
                     ? persistentDatabase
-                    : new InMemoryDatabase(configuration.LoggerFactory));
+                    : new InMemoryDatabase(loggerFactory));
         }
 
         public virtual InMemoryDatabase Database

--- a/src/EntityFramework.Migrations/Infrastructure/Migrator.cs
+++ b/src/EntityFramework.Migrations/Infrastructure/Migrator.cs
@@ -44,7 +44,8 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
             [NotNull] ModelDiffer modelDiffer,
             [NotNull] IMigrationOperationSqlGeneratorFactory ddlSqlGeneratorFactory,
             [NotNull] SqlGenerator dmlSqlGenerator,
-            [NotNull] SqlStatementExecutor sqlExecutor)
+            [NotNull] SqlStatementExecutor sqlExecutor,
+            [NotNull] ILoggerFactory loggerFactory)
         {
             Check.NotNull(contextConfiguration, "contextConfiguration");
             Check.NotNull(historyRepository, "historyRepository");
@@ -53,6 +54,7 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
             Check.NotNull(ddlSqlGeneratorFactory, "ddlSqlGeneratorFactory");
             Check.NotNull(dmlSqlGenerator, "dmlSqlGenerator");
             Check.NotNull(sqlExecutor, "sqlExecutor");
+            Check.NotNull(loggerFactory, "loggerFactory");
 
             _contextConfiguration = contextConfiguration;
             _historyRepository = historyRepository;
@@ -61,7 +63,7 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
             _ddlSqlGeneratorFactory = ddlSqlGeneratorFactory;
             _dmlSqlGenerator = dmlSqlGenerator;
             _sqlExecutor = sqlExecutor;
-            _logger = new LazyRef<ILogger>(() => ContextConfiguration.LoggerFactory.Create<Migrator>());
+            _logger = new LazyRef<ILogger>(loggerFactory.Create<Migrator>);
         }
 
         protected virtual DbContextConfiguration ContextConfiguration

--- a/src/EntityFramework.Redis/RedisConnection.cs
+++ b/src/EntityFramework.Redis/RedisConnection.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Redis.Utilities;
 using Microsoft.Data.Entity.Storage;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.Redis
 {
@@ -20,10 +21,11 @@ namespace Microsoft.Data.Entity.Redis
         {
         }
 
-        public RedisConnection([NotNull] DbContextConfiguration configuration)
-            : base(configuration.LoggerFactory)
+        public RedisConnection([NotNull] DbContextConfiguration configuration, [NotNull] ILoggerFactory loggerFactory)
+            : base(loggerFactory)
         {
             Check.NotNull(configuration, "configuration");
+
             var optionsExtension = RedisOptionsExtension.Extract(configuration);
 
             _connectionString = optionsExtension.HostName + ":" + optionsExtension.Port;

--- a/src/EntityFramework.Redis/RedisDataStore.cs
+++ b/src/EntityFramework.Redis/RedisDataStore.cs
@@ -12,6 +12,7 @@ using Microsoft.Data.Entity.Redis.Query;
 using Microsoft.Data.Entity.Redis.Utilities;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
+using Microsoft.Framework.Logging;
 using Remotion.Linq;
 
 namespace Microsoft.Data.Entity.Redis
@@ -20,8 +21,10 @@ namespace Microsoft.Data.Entity.Redis
     {
         private readonly LazyRef<RedisDatabase> _database;
 
-        public RedisDataStore([NotNull] DbContextConfiguration configuration)
-            : base(configuration)
+        public RedisDataStore(
+            [NotNull] DbContextConfiguration configuration,
+            [NotNull] ILoggerFactory loggerFactory)
+            : base(configuration, loggerFactory)
         {
             _database = new LazyRef<RedisDatabase>(() => (RedisDatabase)configuration.Database);
         }

--- a/src/EntityFramework.Redis/RedisDatabase.cs
+++ b/src/EntityFramework.Redis/RedisDatabase.cs
@@ -15,6 +15,7 @@ using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Redis.Query;
 using Microsoft.Data.Entity.Redis.Utilities;
+using Microsoft.Framework.Logging;
 using StackExchange.Redis;
 
 namespace Microsoft.Data.Entity.Redis
@@ -51,8 +52,8 @@ namespace Microsoft.Data.Entity.Redis
         private static readonly ConcurrentDictionary<string, ConnectionMultiplexer> _connectionMultiplexers
             = new ConcurrentDictionary<string, ConnectionMultiplexer>(); // key = ConfigurationOptions.ToString()
 
-        public RedisDatabase([NotNull] DbContextConfiguration configuration)
-            : base(configuration)
+        public RedisDatabase([NotNull] DbContextConfiguration configuration, [NotNull] ILoggerFactory loggerFactory)
+            : base(configuration, loggerFactory)
         {
         }
 

--- a/src/EntityFramework.Relational/RelationalConnection.cs
+++ b/src/EntityFramework.Relational/RelationalConnection.cs
@@ -31,8 +31,8 @@ namespace Microsoft.Data.Entity.Relational
         {
         }
 
-        protected RelationalConnection([NotNull] DbContextConfiguration configuration)
-            : base(configuration.LoggerFactory)
+        protected RelationalConnection([NotNull] DbContextConfiguration configuration, [NotNull] ILoggerFactory loggerFactory)
+            : base(loggerFactory)
         {
             Check.NotNull(configuration, "configuration");
 

--- a/src/EntityFramework.Relational/RelationalDataStore.cs
+++ b/src/EntityFramework.Relational/RelationalDataStore.cs
@@ -14,6 +14,7 @@ using Microsoft.Data.Entity.Relational.Query.Methods;
 using Microsoft.Data.Entity.Relational.Update;
 using Microsoft.Data.Entity.Relational.Utilities;
 using Microsoft.Data.Entity.Storage;
+using Microsoft.Framework.Logging;
 using Remotion.Linq;
 
 namespace Microsoft.Data.Entity.Relational
@@ -37,8 +38,9 @@ namespace Microsoft.Data.Entity.Relational
             [NotNull] DbContextConfiguration configuration,
             [NotNull] RelationalConnection connection,
             [NotNull] CommandBatchPreparer batchPreparer,
-            [NotNull] BatchExecutor batchExecutor)
-            : base(configuration)
+            [NotNull] BatchExecutor batchExecutor,
+            [NotNull] ILoggerFactory loggerFactory)
+            : base(configuration, loggerFactory)
         {
             Check.NotNull(connection, "connection");
             Check.NotNull(batchPreparer, "batchPreparer");

--- a/src/EntityFramework.Relational/RelationalDatabase.cs
+++ b/src/EntityFramework.Relational/RelationalDatabase.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Data.Entity.Relational
 {
     public class RelationalDatabase : Database
     {
-        public RelationalDatabase([NotNull] DbContextConfiguration configuration)
-            : base(configuration)
+        public RelationalDatabase([NotNull] DbContextConfiguration configuration, [NotNull] ILoggerFactory loggerFactory)
+            : base(configuration, loggerFactory)
         {
         }
 

--- a/src/EntityFramework.Relational/Update/BatchExecutor.cs
+++ b/src/EntityFramework.Relational/Update/BatchExecutor.cs
@@ -31,14 +31,16 @@ namespace Microsoft.Data.Entity.Relational.Update
 
         public BatchExecutor(
             [NotNull] RelationalTypeMapper typeMapper,
-            [NotNull] DbContextConfiguration contextConfiguration)
+            [NotNull] DbContextConfiguration contextConfiguration,
+            [NotNull] ILoggerFactory loggerFactory)
         {
             Check.NotNull(typeMapper, "typeMapper");
             Check.NotNull(contextConfiguration, "contextConfiguration");
+            Check.NotNull(loggerFactory, "loggerFactory");
 
             _typeMapper = typeMapper;
             _context = contextConfiguration.Context;
-            _logger = new LazyRef<ILogger>(() => (_context.Configuration.LoggerFactory.Create<BatchExecutor>()));
+            _logger = new LazyRef<ILogger>(() => (loggerFactory.Create<BatchExecutor>()));
         }
 
         protected virtual ILogger Logger

--- a/src/EntityFramework.SQLite/SQLiteBatchExecutor.cs
+++ b/src/EntityFramework.SQLite/SQLiteBatchExecutor.cs
@@ -5,6 +5,7 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Relational.Update;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SQLite
 {
@@ -21,8 +22,9 @@ namespace Microsoft.Data.Entity.SQLite
 
         public SQLiteBatchExecutor(
             [NotNull] SQLiteTypeMapper typeMapper,
-            [NotNull] DbContextConfiguration contextConfiguration)
-            : base(typeMapper, contextConfiguration)
+            [NotNull] DbContextConfiguration contextConfiguration, 
+            [NotNull] ILoggerFactory loggerFactory)
+            : base(typeMapper, contextConfiguration, loggerFactory)
         {
         }
     }

--- a/src/EntityFramework.SQLite/SQLiteConnection.cs
+++ b/src/EntityFramework.SQLite/SQLiteConnection.cs
@@ -6,13 +6,14 @@ using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.SQLite;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SQLite
 {
     public class SQLiteConnection : RelationalConnection
     {
-        public SQLiteConnection([NotNull] DbContextConfiguration configuration)
-            : base(configuration)
+        public SQLiteConnection([NotNull] DbContextConfiguration configuration, [NotNull] ILoggerFactory loggerFactory)
+            : base(configuration, loggerFactory)
         {
         }
 

--- a/src/EntityFramework.SQLite/SQLiteDataStore.cs
+++ b/src/EntityFramework.SQLite/SQLiteDataStore.cs
@@ -9,6 +9,7 @@ using Microsoft.Data.Entity.Relational.Query;
 using Microsoft.Data.Entity.Relational.Query.Methods;
 using Microsoft.Data.Entity.SQLite.Query;
 using Microsoft.Data.Entity.SQLite.Utilities;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SQLite
 {
@@ -18,8 +19,9 @@ namespace Microsoft.Data.Entity.SQLite
             [NotNull] DbContextConfiguration configuration,
             [NotNull] SQLiteConnection connection,
             [NotNull] SQLiteCommandBatchPreparer batchPreparer,
-            [NotNull] SQLiteBatchExecutor batchExecutor)
-            : base(configuration, connection, batchPreparer, batchExecutor)
+            [NotNull] SQLiteBatchExecutor batchExecutor, 
+            [NotNull] ILoggerFactory loggerFactory)
+            : base(configuration, connection, batchPreparer, batchExecutor, loggerFactory)
         {
         }
 

--- a/src/EntityFramework.SQLite/SQLiteMigrator.cs
+++ b/src/EntityFramework.SQLite/SQLiteMigrator.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Migrations.Infrastructure;
 using Microsoft.Data.Entity.Relational;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SQLite
 {
@@ -17,7 +18,8 @@ namespace Microsoft.Data.Entity.SQLite
             [NotNull] SQLiteModelDiffer modelDiffer,
             [NotNull] SQLiteMigrationOperationSqlGeneratorFactory ddlSqlGeneratorFactory,
             [NotNull] SQLiteSqlGenerator dmlSqlGenerator,
-            [NotNull] SqlStatementExecutor sqlExecutor)
+            [NotNull] SqlStatementExecutor sqlExecutor,
+            [NotNull] ILoggerFactory loggerFactory)
             : base(
                 contextConfiguration,
                 historyRepository,
@@ -25,7 +27,8 @@ namespace Microsoft.Data.Entity.SQLite
                 modelDiffer,
                 ddlSqlGeneratorFactory,
                 dmlSqlGenerator,
-                sqlExecutor)
+                sqlExecutor,
+                loggerFactory)
         {
         }
     }

--- a/src/EntityFramework.SqlServer/SqlServerConnection.cs
+++ b/src/EntityFramework.SqlServer/SqlServerConnection.cs
@@ -6,13 +6,14 @@ using System.Data.SqlClient;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Relational;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SqlServer
 {
     public class SqlServerConnection : RelationalConnection
     {
-        public SqlServerConnection([NotNull] DbContextConfiguration configuration)
-            : base(configuration)
+        public SqlServerConnection([NotNull] DbContextConfiguration configuration, [NotNull] ILoggerFactory loggerFactory)
+            : base(configuration, loggerFactory)
         {
         }
 

--- a/src/EntityFramework.SqlServer/SqlServerDataStore.cs
+++ b/src/EntityFramework.SqlServer/SqlServerDataStore.cs
@@ -10,6 +10,7 @@ using Microsoft.Data.Entity.Relational.Query.Methods;
 using Microsoft.Data.Entity.SqlServer.Query;
 using Microsoft.Data.Entity.SqlServer.Update;
 using Microsoft.Data.Entity.SqlServer.Utilities;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SqlServer
 {
@@ -19,8 +20,9 @@ namespace Microsoft.Data.Entity.SqlServer
             [NotNull] DbContextConfiguration configuration,
             [NotNull] SqlServerConnection connection,
             [NotNull] SqlServerCommandBatchPreparer batchPreparer,
-            [NotNull] SqlServerBatchExecutor batchExecutor)
-            : base(configuration, connection, batchPreparer, batchExecutor)
+            [NotNull] SqlServerBatchExecutor batchExecutor, 
+            [NotNull] ILoggerFactory loggerFactory)
+            : base(configuration, connection, batchPreparer, batchExecutor, loggerFactory)
         {
         }
 

--- a/src/EntityFramework.SqlServer/SqlServerMigrator.cs
+++ b/src/EntityFramework.SqlServer/SqlServerMigrator.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Migrations.Infrastructure;
 using Microsoft.Data.Entity.Relational;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SqlServer
 {
@@ -20,7 +21,8 @@ namespace Microsoft.Data.Entity.SqlServer
             [NotNull] SqlServerModelDiffer modelDiffer,
             [NotNull] SqlServerMigrationOperationSqlGeneratorFactory sqlGeneratorFactory,
             [NotNull] SqlServerSqlGenerator sqlGenerator,
-            [NotNull] SqlStatementExecutor sqlStatementExecutor)
+            [NotNull] SqlStatementExecutor sqlStatementExecutor,
+            [NotNull] ILoggerFactory loggerFactory)
             : base(
                 contextConfiguration,
                 historyRepository,
@@ -28,7 +30,8 @@ namespace Microsoft.Data.Entity.SqlServer
                 modelDiffer,
                 sqlGeneratorFactory,
                 sqlGenerator,
-                sqlStatementExecutor)
+                sqlStatementExecutor,
+                loggerFactory)
         {
         }
     }

--- a/src/EntityFramework.SqlServer/Update/SqlServerBatchExecutor.cs
+++ b/src/EntityFramework.SqlServer/Update/SqlServerBatchExecutor.cs
@@ -5,6 +5,7 @@ using System;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Relational.Update;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SqlServer.Update
 {
@@ -21,8 +22,9 @@ namespace Microsoft.Data.Entity.SqlServer.Update
 
         public SqlServerBatchExecutor(
             [NotNull] SqlServerTypeMapper typeMapper,
-            [NotNull] DbContextConfiguration contextConfiguration)
-            : base(typeMapper, contextConfiguration)
+            [NotNull] DbContextConfiguration contextConfiguration,
+            [NotNull] ILoggerFactory loggerFactory)
+            : base(typeMapper, contextConfiguration, loggerFactory)
         {
         }
     }

--- a/src/EntityFramework/DbContext.cs
+++ b/src/EntityFramework/DbContext.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Data.Entity
 
             InitializeSets(serviceProvider, options);
             _configuration = new LazyRef<DbContextConfiguration>(() => Initialize(serviceProvider, options));
-            _logger = new LazyRef<ILogger>(() => _configuration.Value.LoggerFactory.Create<DbContext>());
+            _logger = new LazyRef<ILogger>(CreateLogger);
         }
 
         public DbContext([NotNull] IServiceProvider serviceProvider)
@@ -47,7 +47,7 @@ namespace Microsoft.Data.Entity
             _configuration = new LazyRef<DbContextConfiguration>(
                 () => Initialize(serviceProvider, options));
 
-            _logger = new LazyRef<ILogger>(() => _configuration.Value.LoggerFactory.Create<DbContext>());
+            _logger = new LazyRef<ILogger>(CreateLogger);
         }
 
         private DbContextOptions GetOptions(IServiceProvider serviceProvider)
@@ -95,7 +95,7 @@ namespace Microsoft.Data.Entity
 
             InitializeSets(serviceProvider, options);
             _configuration = new LazyRef<DbContextConfiguration>(() => Initialize(serviceProvider, options));
-            _logger = new LazyRef<ILogger>(() => _configuration.Value.LoggerFactory.Create<DbContext>());
+            _logger = new LazyRef<ILogger>(CreateLogger);
         }
 
         // TODO: Consider removing this constructor if DbContextOptions should be obtained from serviceProvider
@@ -107,7 +107,12 @@ namespace Microsoft.Data.Entity
 
             InitializeSets(serviceProvider, options);
             _configuration = new LazyRef<DbContextConfiguration>(() => Initialize(serviceProvider, options));
-            _logger = new LazyRef<ILogger>(() => _configuration.Value.LoggerFactory.Create<DbContext>());
+            _logger = new LazyRef<ILogger>(CreateLogger);
+        }
+
+        private ILogger CreateLogger()
+        {
+            return _configuration.Value.Services.ServiceProvider.GetRequiredServiceChecked<ILoggerFactory>().Create<DbContext>();
         }
 
         private DbContextConfiguration Initialize(IServiceProvider serviceProvider, DbContextOptions options)

--- a/src/EntityFramework/DbSet`.cs
+++ b/src/EntityFramework/DbSet`.cs
@@ -11,6 +11,8 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Utilities;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity
 {
@@ -31,8 +33,11 @@ namespace Microsoft.Data.Entity
         public DbSet([NotNull] DbContext context)
             : base(Check.NotNull(context, "context"))
         {
+            // TODO: Decouple from DbContextConfiguration (Issue #641)
             _entityQueryable
-                = new EntityQueryable<TEntity>(new EntityQueryExecutor(context));
+                = new EntityQueryable<TEntity>(new EntityQueryExecutor(
+                    context, 
+                    new LazyRef<ILoggerFactory>(() => context.Configuration.Services.ServiceProvider.GetRequiredServiceChecked<ILoggerFactory>())));
         }
 
         public virtual TEntity Add([NotNull] TEntity entity)

--- a/src/EntityFramework/Infrastructure/Database.cs
+++ b/src/EntityFramework/Infrastructure/Database.cs
@@ -15,12 +15,13 @@ namespace Microsoft.Data.Entity.Infrastructure
         private readonly DbContextConfiguration _configuration;
         private readonly LazyRef<ILogger> _logger;
 
-        public Database([NotNull] DbContextConfiguration configuration)
+        public Database([NotNull] DbContextConfiguration configuration, [NotNull] ILoggerFactory loggerFactory)
         {
             Check.NotNull(configuration, "configuration");
+            Check.NotNull(loggerFactory, "loggerFactory");
 
             _configuration = configuration;
-            _logger = new LazyRef<ILogger>(() => Configuration.LoggerFactory.Create<Database>());
+            _logger = new LazyRef<ILogger>(loggerFactory.Create<Database>);
         }
 
         protected virtual DbContextConfiguration Configuration

--- a/src/EntityFramework/Infrastructure/DbContextConfiguration.cs
+++ b/src/EntityFramework/Infrastructure/DbContextConfiguration.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Data.Entity.Infrastructure
         }
 
         private ContextServices _services;
-        private IServiceProvider _externalProvider;
         private DbContextOptions _contextOptions;
         private DbContext _context;
         private LazyRef<IModel> _modelFromSource;
@@ -31,7 +30,6 @@ namespace Microsoft.Data.Entity.Infrastructure
         private LazyRef<DataStoreConnection> _connection;
         private LazyRef<StateManager> _stateManager;
         private ServiceProviderSource _serviceProviderSource;
-        private LazyRef<ILoggerFactory> _loggerFactory;
         private LazyRef<Database> _database;
         private bool _inOnModelCreating;
 
@@ -48,7 +46,6 @@ namespace Microsoft.Data.Entity.Infrastructure
             Check.NotNull(context, "context");
             Check.IsDefined(serviceProviderSource, "serviceProviderSource");
 
-            _externalProvider = externalProvider;
             _services = new ContextServices(scopedProvider);
             _serviceProviderSource = serviceProviderSource;
             _contextOptions = contextOptions;
@@ -57,7 +54,6 @@ namespace Microsoft.Data.Entity.Infrastructure
             _modelFromSource = new LazyRef<IModel>(CreateModel);
             _dataStore = new LazyRef<DataStore>(() => _dataStoreServices.Value.Store);
             _connection = new LazyRef<DataStoreConnection>(() => _dataStoreServices.Value.Connection);
-            _loggerFactory = new LazyRef<ILoggerFactory>(() => _externalProvider.GetRequiredServiceChecked<ILoggerFactory>());
             _database = new LazyRef<Database>(() => _dataStoreServices.Value.Database);
             _stateManager = new LazyRef<StateManager>(() => _services.StateManager);
 
@@ -135,11 +131,6 @@ namespace Microsoft.Data.Entity.Infrastructure
         public virtual ServiceProviderSource ProviderSource
         {
             get { return _serviceProviderSource; }
-        }
-
-        public virtual ILoggerFactory LoggerFactory
-        {
-            get { return _loggerFactory.Value; }
         }
 
         public virtual StateManager StateManager

--- a/src/EntityFramework/Query/EntityQueryExecutor.cs
+++ b/src/EntityFramework/Query/EntityQueryExecutor.cs
@@ -21,12 +21,14 @@ namespace Microsoft.Data.Entity.Query
         private readonly DbContext _context;
         private readonly LazyRef<ILogger> _logger;
 
-        public EntityQueryExecutor([NotNull] DbContext context)
+        // TODO: Currently using a LazyRef here while other parts of the fix for Issue #641 are in progress.
+        public EntityQueryExecutor([NotNull] DbContext context, [NotNull] LazyRef<ILoggerFactory> loggerFactory)
         {
             Check.NotNull(context, "context");
+            Check.NotNull(loggerFactory, "loggerFactory");
 
             _context = context;
-            _logger = new LazyRef<ILogger>(() => (_context.Configuration.LoggerFactory.Create<EntityQueryExecutor>()));
+            _logger = new LazyRef<ILogger>(() => loggerFactory.Value.Create<EntityQueryExecutor>());
         }
 
         public virtual T ExecuteScalar<T>([NotNull] QueryModel queryModel)

--- a/src/EntityFramework/Storage/DataStore.cs
+++ b/src/EntityFramework/Storage/DataStore.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Data.Entity.Storage
     public abstract class DataStore
     {
         private readonly DbContextConfiguration _configuration;
-        private readonly ILogger _logger;
+        private readonly LazyRef<ILogger> _logger;
 
         /// <summary>
         ///     This constructor is intended only for use when creating test doubles that will override members
@@ -30,17 +30,18 @@ namespace Microsoft.Data.Entity.Storage
         {
         }
 
-        protected DataStore([NotNull] DbContextConfiguration configuration)
+        protected DataStore([NotNull] DbContextConfiguration configuration, [NotNull] ILoggerFactory loggerFactory)
         {
             Check.NotNull(configuration, "configuration");
+            Check.NotNull(loggerFactory, "loggerFactory");
 
             _configuration = configuration;
-            _logger = configuration.LoggerFactory.Create<DataStore>();
+            _logger = new LazyRef<ILogger>(loggerFactory.Create<DataStore>());
         }
 
         public virtual ILogger Logger
         {
-            get { return _logger; }
+            get { return _logger.Value; }
         }
 
         public virtual IModel Model

--- a/test/EntityFramework.AzureTableStorage.Tests/AtsDatabaseTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/AtsDatabaseTests.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
 
@@ -24,7 +25,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests
             configurationMock.Setup(m => m.Model).Returns(model);
             configurationMock.Setup(m => m.Connection).Returns(connection);
 
-            var database = new AtsDatabase(configurationMock.Object);
+            var database = new AtsDatabase(configurationMock.Object, new LoggerFactory());
 
             Assert.True(database.EnsureCreated());
             creatorMock.Verify(m => m.EnsureCreated(model), Times.Once);

--- a/test/EntityFramework.AzureTableStorage.Tests/Extensions/AtsDatabaseExtensionTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Extensions/AtsDatabaseExtensionTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
 
@@ -14,7 +15,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Extensions
         public void Returns_typed_database_object()
         {
             var configurationMock = new Mock<DbContextConfiguration>();
-            var database = new AtsDatabase(configurationMock.Object);
+            var database = new AtsDatabase(configurationMock.Object, new LoggerFactory());
 
             Assert.Same(database, database.AsAzureTableStorageDatabase());
         }
@@ -23,7 +24,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Extensions
         public void Throws_when_non_ats_provider_is_in_use()
         {
             var configurationMock = new Mock<DbContextConfiguration>();
-            var database = new Database(configurationMock.Object);
+            var database = new Database(configurationMock.Object, new LoggerFactory());
 
             Assert.Equal(
                 Strings.AtsDatabaseNotInUse,

--- a/test/EntityFramework.AzureTableStorage.Tests/Query/QueryGenerationTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Query/QueryGenerationTests.cs
@@ -10,6 +10,7 @@ using Microsoft.Data.Entity.AzureTableStorage.Query.Expressions;
 using Microsoft.Data.Entity.AzureTableStorage.Tests.Helpers;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Moq;
 using Remotion.Linq;
@@ -157,12 +158,12 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Query
         private static QueryModel Query<T>(Expression<Func<DbSet<T>, IQueryable>> expression) where T : class
         {
             var query = expression.Compile()(new DbSet<T>(Mock.Of<DbContext>()));
-            return new EntityQueryProvider(new EntityQueryExecutor(Mock.Of<DbContext>())).GenerateQueryModel(query.Expression);
+            return new EntityQueryProvider(new EntityQueryExecutor(Mock.Of<DbContext>(), new LazyRef<ILoggerFactory>(new LoggerFactory()))).GenerateQueryModel(query.Expression);
         }
 
         private MainFromClause CreateWithEntityQueryable<T>()
         {
-            var queryable = new EntityQueryable<T>(new EntityQueryExecutor(Mock.Of<DbContext>()));
+            var queryable = new EntityQueryable<T>(new EntityQueryExecutor(Mock.Of<DbContext>(), new LazyRef<ILoggerFactory>(new LoggerFactory())));
             return new MainFromClause("s", typeof(T), Expression.Constant(queryable));
         }
     }

--- a/test/EntityFramework.AzureTableStorage.Tests/Query/QueryModelVisitorTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Query/QueryModelVisitorTests.cs
@@ -8,6 +8,7 @@ using System.Linq.Expressions;
 using Microsoft.Data.Entity.AzureTableStorage.Query;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Moq;
 using Remotion.Linq;
@@ -83,7 +84,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Query
 
         private int CountQuery(IQueryable query)
         {
-            var queryModel = new EntityQueryProvider(new EntityQueryExecutor(Mock.Of<DbContext>())).GenerateQueryModel(query.Expression);
+            var queryModel = new EntityQueryProvider(new EntityQueryExecutor(Mock.Of<DbContext>(), new LazyRef<ILoggerFactory>(new LoggerFactory()))).GenerateQueryModel(query.Expression);
 
             return CountQueryModel(queryModel);
         }

--- a/test/EntityFramework.InMemory.Tests/InMemoryDataStoreCreatorTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryDataStoreCreatorTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             var entityType = model.GetEntityType(typeof(Test));
             var persistentDatabase = new InMemoryDatabase(new LoggerFactory());
 
-            var inMemoryDataStore = new InMemoryDataStore(configuration, persistentDatabase);
+            var inMemoryDataStore = new InMemoryDataStore(configuration, persistentDatabase, new LoggerFactory());
 
             var creator = new InMemoryDataStoreCreator(inMemoryDataStore);
 
@@ -36,7 +36,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             var configuration = CreateConfiguration(new DbContextOptions().UseInMemoryStore(persist: false));
             var entityType = model.GetEntityType(typeof(Test));
             var nonPersistentDatabase = new InMemoryDatabase(new LoggerFactory());
-            var inMemoryDataStore = new InMemoryDataStore(configuration, nonPersistentDatabase);
+            var inMemoryDataStore = new InMemoryDataStore(configuration, nonPersistentDatabase, new LoggerFactory());
 
             var creator = new InMemoryDataStoreCreator(inMemoryDataStore);
 
@@ -52,7 +52,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             var configuration = CreateConfiguration(new DbContextOptions().UseInMemoryStore(persist: true));
             var entityType = model.GetEntityType(typeof(Test));
             var persistentDatabase = new InMemoryDatabase(new LoggerFactory());
-            var inMemoryDataStore = new InMemoryDataStore(configuration, persistentDatabase);
+            var inMemoryDataStore = new InMemoryDataStore(configuration, persistentDatabase, new LoggerFactory());
 
             var creator = new InMemoryDataStoreCreator(inMemoryDataStore);
 
@@ -68,7 +68,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             var configuration = CreateConfiguration(new DbContextOptions().UseInMemoryStore(persist: false));
             var entityType = model.GetEntityType(typeof(Test));
             var nonPersistentDatabase = new InMemoryDatabase(new LoggerFactory());
-            var inMemoryDataStore = new InMemoryDataStore(configuration, nonPersistentDatabase);
+            var inMemoryDataStore = new InMemoryDataStore(configuration, nonPersistentDatabase, new LoggerFactory());
 
             var creator = new InMemoryDataStoreCreator(inMemoryDataStore);
 

--- a/test/EntityFramework.InMemory.Tests/InMemoryDataStoreTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryDataStoreTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             var configuration = CreateConfiguration();
             var persistentDatabase = new InMemoryDatabase(new LoggerFactory());
 
-            var inMemoryDataStore = new InMemoryDataStore(configuration, persistentDatabase);
+            var inMemoryDataStore = new InMemoryDataStore(configuration, persistentDatabase, new LoggerFactory());
 
             Assert.Same(persistentDatabase, inMemoryDataStore.Database);
         }
@@ -33,7 +33,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 
             var persistentDatabase = new InMemoryDatabase(new LoggerFactory());
 
-            var inMemoryDataStore = new InMemoryDataStore(configuration, persistentDatabase);
+            var inMemoryDataStore = new InMemoryDataStore(configuration, persistentDatabase, new LoggerFactory());
 
             Assert.Same(persistentDatabase, inMemoryDataStore.Database);
         }
@@ -45,7 +45,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 
             var persistentDatabase = new InMemoryDatabase(new LoggerFactory());
 
-            var inMemoryDataStore = new InMemoryDataStore(configuration, persistentDatabase);
+            var inMemoryDataStore = new InMemoryDataStore(configuration, persistentDatabase, new LoggerFactory());
 
             Assert.NotNull(inMemoryDataStore.Database);
             Assert.NotSame(persistentDatabase, inMemoryDataStore.Database);
@@ -60,7 +60,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 
             var persistentDatabase = new InMemoryDatabase(new LoggerFactory());
 
-            var inMemoryDataStore = new InMemoryDataStore(configuration, persistentDatabase);
+            var inMemoryDataStore = new InMemoryDataStore(configuration, persistentDatabase, new LoggerFactory());
 
             Assert.True(inMemoryDataStore.EnsureDatabaseCreated(model));
             Assert.False(inMemoryDataStore.EnsureDatabaseCreated(model));
@@ -75,7 +75,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 
             var nonPersistentDatabase = new InMemoryDatabase(new LoggerFactory());
 
-            var inMemoryDataStore = new InMemoryDataStore(configuration, nonPersistentDatabase);
+            var inMemoryDataStore = new InMemoryDataStore(configuration, nonPersistentDatabase, new LoggerFactory());
 
             Assert.True(inMemoryDataStore.EnsureDatabaseCreated(model));
             Assert.False(inMemoryDataStore.EnsureDatabaseCreated(model));
@@ -93,7 +93,8 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             var entityEntry = new ClrStateEntry(configuration, entityType, customer);
             await entityEntry.SetEntityStateAsync(EntityState.Added);
 
-            var inMemoryDataStore = new InMemoryDataStore(configuration, new InMemoryDatabase(new LoggerFactory()));
+            var loggerFactory = new LoggerFactory();
+            var inMemoryDataStore = new InMemoryDataStore(configuration, new InMemoryDatabase(loggerFactory), loggerFactory);
 
             await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry });
 
@@ -112,7 +113,8 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             var entityEntry = new ClrStateEntry(configuration, entityType, customer);
             await entityEntry.SetEntityStateAsync(EntityState.Added);
 
-            var inMemoryDataStore = new InMemoryDataStore(configuration, new InMemoryDatabase(new LoggerFactory()));
+            var loggerFactory = new LoggerFactory();
+            var inMemoryDataStore = new InMemoryDataStore(configuration, new InMemoryDatabase(loggerFactory), loggerFactory);
 
             await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry });
 
@@ -136,7 +138,8 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             var entityEntry = new ClrStateEntry(configuration, entityType, customer);
             await entityEntry.SetEntityStateAsync(EntityState.Added);
 
-            var inMemoryDataStore = new InMemoryDataStore(configuration, new InMemoryDatabase(new LoggerFactory()));
+            var loggerFactory = new LoggerFactory();
+            var inMemoryDataStore = new InMemoryDataStore(configuration, new InMemoryDatabase(loggerFactory), loggerFactory);
 
             await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry });
 
@@ -168,7 +171,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             var mockFactory = new Mock<ILoggerFactory>();
             mockFactory.Setup(m => m.Create(It.IsAny<string>())).Returns(mockLogger.Object);
 
-            var inMemoryDataStore = new InMemoryDataStore(configuration, new InMemoryDatabase(mockFactory.Object));
+            var inMemoryDataStore = new InMemoryDataStore(configuration, new InMemoryDatabase(mockFactory.Object), mockFactory.Object);
 
             await inMemoryDataStore.SaveChangesAsync(new[] { entityEntry });
 

--- a/test/EntityFramework.Migrations.Tests/Infrastructure/MigratorTest.cs
+++ b/test/EntityFramework.Migrations.Tests/Infrastructure/MigratorTest.cs
@@ -1244,7 +1244,8 @@ new StringBuilder()
                     new TestModelDiffer(),
                     MockMigrationOperationSqlGeneratorFactory().Object,
                     new Mock<SqlGenerator>().Object,
-                    sqlStatementExecutorMock.Object)
+                    sqlStatementExecutorMock.Object,
+                    loggerFactory)
                 {
                     CallBase = true
                 }
@@ -1408,8 +1409,8 @@ new StringBuilder()
 
         private class FakeRelationalConnection : RelationalConnection
         {
-            public FakeRelationalConnection(DbContextConfiguration configuration)
-                : base(configuration)
+            public FakeRelationalConnection(DbContextConfiguration configuration, ILoggerFactory loggerFactory)
+                : base(configuration, loggerFactory)
             {
             }
 

--- a/test/EntityFramework.Redis.Tests/RedisDataStoreCreatorTests.cs
+++ b/test/EntityFramework.Redis.Tests/RedisDataStoreCreatorTests.cs
@@ -4,6 +4,7 @@
 using System.Threading;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
 
@@ -36,7 +37,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
         {
             var model = Mock.Of<IModel>();
             var configurationMock = new Mock<DbContextConfiguration>();
-            var databaseMock = new Mock<RedisDatabase>(configurationMock.Object);
+            var databaseMock = new Mock<RedisDatabase>(configurationMock.Object, new LoggerFactory());
             configurationMock.SetupGet(m => m.Database).Returns(databaseMock.Object);
 
             var creator = new RedisDataStoreCreator(configurationMock.Object);
@@ -49,7 +50,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
         {
             var model = Mock.Of<IModel>();
             var configurationMock = new Mock<DbContextConfiguration>();
-            var databaseMock = new Mock<RedisDatabase>(configurationMock.Object);
+            var databaseMock = new Mock<RedisDatabase>(configurationMock.Object, new LoggerFactory());
             configurationMock.SetupGet(m => m.Database).Returns(databaseMock.Object);
 
             var creator = new RedisDataStoreCreator(configurationMock.Object);

--- a/test/EntityFramework.Redis.Tests/RedisDatabaseTests.cs
+++ b/test/EntityFramework.Redis.Tests/RedisDatabaseTests.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
 
@@ -24,7 +25,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
             creatorMock.Setup(m => m.EnsureDeleted(model)).Returns(true);
             configurationMock.Setup(m => m.DataStoreCreator).Returns(creatorMock.Object);
 
-            var database = new RedisDatabase(configurationMock.Object);
+            var database = new RedisDatabase(configurationMock.Object, new LoggerFactory());
 
             Assert.True(database.EnsureCreated());
             creatorMock.Verify(m => m.EnsureCreated(model), Times.Once);

--- a/test/EntityFramework.Redis.Tests/RedisSequenceValueGeneratorTest.cs
+++ b/test/EntityFramework.Redis.Tests/RedisSequenceValueGeneratorTest.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Tests;
+using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
 
@@ -27,7 +28,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
             var blockSize = 1;
             var incrementingValue = 0L;
             var dbConfigurationMock = new Mock<DbContextConfiguration>();
-            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object);
+            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object, new LoggerFactory());
             redisDatabaseMock
                 .Setup(db => db.GetNextGeneratedValue(It.IsAny<IProperty>(), It.IsAny<long>(), It.IsAny<string>()))
                 .Returns<IProperty, long, string>((p, l, s) =>
@@ -122,7 +123,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
             var blockSize = 1;
             var incrementingValue = 0L;
             var dbConfigurationMock = new Mock<DbContextConfiguration>();
-            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object);
+            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object, new LoggerFactory());
             redisDatabaseMock
                 .Setup(db => db.GetNextGeneratedValueAsync(
                     It.IsAny<IProperty>(), It.IsAny<long>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -214,7 +215,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
         {
             var incrementingValue = 0L;
             var dbConfigurationMock = new Mock<DbContextConfiguration>();
-            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object);
+            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object, new LoggerFactory());
             redisDatabaseMock
                 .Setup(db => db.GetNextGeneratedValue(It.IsAny<IProperty>(), It.IsAny<long>(), It.IsAny<string>()))
                 .Returns<IProperty, long, string>((p, l, s) =>
@@ -271,7 +272,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
         {
             var incrementingValue = 0L;
             var dbConfigurationMock = new Mock<DbContextConfiguration>();
-            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object);
+            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object, new LoggerFactory());
             redisDatabaseMock
                 .Setup(db => db.GetNextGeneratedValueAsync(
                     It.IsAny<IProperty>(), It.IsAny<long>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -335,7 +336,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
             var blockSize = 10;
             var incrementingValue = 0L;
             var dbConfigurationMock = new Mock<DbContextConfiguration>();
-            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object);
+            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object, new LoggerFactory());
             redisDatabaseMock
                 .Setup(db => db.GetNextGeneratedValue(It.IsAny<IProperty>(), It.IsAny<long>(), It.IsAny<string>()))
                 .Returns<IProperty, long, string>((p, l, s) =>
@@ -364,7 +365,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
         {
             var incrementingValue = 256L;
             var dbConfigurationMock = new Mock<DbContextConfiguration>();
-            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object);
+            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object, new LoggerFactory());
             redisDatabaseMock
                 .Setup(db => db.GetNextGeneratedValue(It.IsAny<IProperty>(), It.IsAny<long>(), It.IsAny<string>()))
                 .Returns<IProperty, long, string>((p, l, s) => incrementingValue);

--- a/test/EntityFramework.Redis.Tests/RedisValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework.Redis.Tests/RedisValueGeneratorSelectorTest.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using Microsoft.Data.Entity.Identity;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
 
@@ -18,7 +19,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
         public void Select_returns_RedisValueGeneratorFactory_for_all_integer_types_with_ValueGeneration_set_to_OnAdd()
         {
             var dbConfigurationMock = new Mock<DbContextConfiguration>();
-            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object);
+            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object, new LoggerFactory());
             var guidValueGenerator = new SimpleValueGeneratorFactory<GuidValueGenerator>();
             var redisValueGeneratorFactory = new RedisValueGeneratorFactory(redisDatabaseMock.Object);
 
@@ -38,7 +39,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
         public void Select_returns_GuidValueGenerator_for_Guid_type_with_ValueGeneration_set_to_OnAdd()
         {
             var dbConfigurationMock = new Mock<DbContextConfiguration>();
-            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object);
+            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object, new LoggerFactory());
             var guidValueGenerator = new SimpleValueGeneratorFactory<GuidValueGenerator>();
             var redisValueGeneratorFactory = new RedisValueGeneratorFactory(redisDatabaseMock.Object);
 
@@ -51,7 +52,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
         public void Select_returns_null_for_all_types_with_ValueGeneration_set_to_None()
         {
             var dbConfigurationMock = new Mock<DbContextConfiguration>();
-            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object);
+            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object, new LoggerFactory());
             var guidValueGenerator = new SimpleValueGeneratorFactory<GuidValueGenerator>();
             var redisValueGeneratorFactory = new RedisValueGeneratorFactory(redisDatabaseMock.Object);
 
@@ -77,7 +78,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
         public void Select_throws_for_unsupported_combinations()
         {
             var dbConfigurationMock = new Mock<DbContextConfiguration>();
-            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object);
+            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object, new LoggerFactory());
             var guidValueGenerator = new SimpleValueGeneratorFactory<GuidValueGenerator>();
             var redisValueGeneratorFactory = new RedisValueGeneratorFactory(redisDatabaseMock.Object);
 

--- a/test/EntityFramework.Relational.Tests/RelationalConnectionTest.cs
+++ b/test/EntityFramework.Relational.Tests/RelationalConnectionTest.cs
@@ -341,7 +341,6 @@ namespace Microsoft.Data.Entity.Relational.Tests
 
             var contextConfigurationMock = new Mock<DbContextConfiguration>();
             contextConfigurationMock.Setup(m => m.ContextOptions).Returns(contextOptions);
-            contextConfigurationMock.Setup(m => m.LoggerFactory).Returns(new LoggerFactory());
 
             return contextConfigurationMock.Object;
         }
@@ -349,7 +348,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
         private class FakeConnection : RelationalConnection
         {
             public FakeConnection(DbContextConfiguration configuration)
-                : base(configuration)
+                : base(configuration, new LoggerFactory())
             {
             }
 

--- a/test/EntityFramework.Relational.Tests/RelationalDataStoreTest.cs
+++ b/test/EntityFramework.Relational.Tests/RelationalDataStoreTest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,61 +16,6 @@ namespace Microsoft.Data.Entity.Relational.Tests
     public class RelationalDataStoreTest
     {
         [Fact]
-        public void Constructor_check_arguments()
-        {
-            Assert.Equal(
-                "configuration",
-                // ReSharper disable once AssignNullToNotNullAttribute
-                Assert.Throws<ArgumentNullException>(() =>
-                    (RelationalDataStore)new FakeRelationalDataStore(null,
-                        new Mock<RelationalConnection>().Object,
-                        new Mock<CommandBatchPreparer>().Object,
-                        new Mock<BatchExecutor>().Object)).ParamName);
-
-            Assert.Equal(
-                "connection",
-                // ReSharper disable once AssignNullToNotNullAttribute
-                Assert.Throws<ArgumentNullException>(() =>
-                    (RelationalDataStore)new FakeRelationalDataStore(CreateDbContextConfiguration(),
-                        null,
-                        new Mock<CommandBatchPreparer>().Object,
-                        new Mock<BatchExecutor>().Object)).ParamName);
-
-            Assert.Equal(
-                "batchPreparer",
-                // ReSharper disable once AssignNullToNotNullAttribute
-                Assert.Throws<ArgumentNullException>(() =>
-                    (RelationalDataStore)new FakeRelationalDataStore(CreateDbContextConfiguration(),
-                        new Mock<RelationalConnection>().Object,
-                        null,
-                        new Mock<BatchExecutor>().Object)).ParamName);
-
-            Assert.Equal(
-                "batchExecutor",
-                // ReSharper disable once AssignNullToNotNullAttribute
-                Assert.Throws<ArgumentNullException>(() =>
-                    (RelationalDataStore)new FakeRelationalDataStore(CreateDbContextConfiguration(),
-                        new Mock<RelationalConnection>().Object,
-                        new Mock<CommandBatchPreparer>().Object,
-                        null)).ParamName);
-        }
-
-        [Fact]
-        public void SaveChangesAsync_checks_arguments()
-        {
-            var relationalDataStore = (RelationalDataStore)new FakeRelationalDataStore(CreateDbContextConfiguration(),
-                new Mock<RelationalConnection>().Object,
-                new Mock<CommandBatchPreparer>().Object,
-                new Mock<BatchExecutor>().Object);
-
-            Assert.Equal(
-                "stateEntries",
-                // ReSharper disable once AssignNullToNotNullAttribute
-                Assert.Throws<ArgumentNullException>(() =>
-                    relationalDataStore.SaveChangesAsync(null).Wait()).ParamName);
-        }
-
-        [Fact]
         public async Task SaveChangesAsync_delegates()
         {
             var relationalConnectionMock = new Mock<RelationalConnection>();
@@ -80,7 +24,8 @@ namespace Microsoft.Data.Entity.Relational.Tests
             var relationalDataStore = (RelationalDataStore)new FakeRelationalDataStore(CreateDbContextConfiguration(),
                 relationalConnectionMock.Object,
                 commandBatchPreparerMock.Object,
-                batchExecutorMock.Object);
+                batchExecutorMock.Object,
+                new LoggerFactory());
 
             var stateEntries = new List<StateEntry>();
             var cancellationToken = new CancellationTokenSource().Token;
@@ -93,11 +38,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
 
         private DbContextConfiguration CreateDbContextConfiguration()
         {
-            var mockDbContextConfiguration = new Mock<DbContextConfiguration>();
-
-            mockDbContextConfiguration.Setup(m => m.LoggerFactory).Returns(new Mock<ILoggerFactory>().Object);
-
-            return mockDbContextConfiguration.Object;
+            return new Mock<DbContextConfiguration>().Object;
         }
 
         private class FakeRelationalDataStore : RelationalDataStore
@@ -106,8 +47,9 @@ namespace Microsoft.Data.Entity.Relational.Tests
                 DbContextConfiguration configuration,
                 RelationalConnection connection,
                 CommandBatchPreparer batchPreparer,
-                BatchExecutor batchExecutor)
-                : base(configuration, connection, batchPreparer, batchExecutor)
+                BatchExecutor batchExecutor,
+                ILoggerFactory loggerFactory)
+                : base(configuration, connection, batchPreparer, batchExecutor, loggerFactory)
             {
             }
         }

--- a/test/EntityFramework.Relational.Tests/RelationalDatabaseExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/RelationalDatabaseExtensionsTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
 
@@ -14,7 +15,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
         public void Returns_typed_database_object()
         {
             var configurationMock = new Mock<DbContextConfiguration>();
-            var database = new RelationalDatabase(configurationMock.Object);
+            var database = new RelationalDatabase(configurationMock.Object, new LoggerFactory());
 
             Assert.Same(database, database.AsRelational());
         }
@@ -23,7 +24,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
         public void Throws_when_non_relational_provider_is_in_use()
         {
             var configurationMock = new Mock<DbContextConfiguration>();
-            var database = new Database(configurationMock.Object);
+            var database = new Database(configurationMock.Object, new LoggerFactory());
 
             Assert.Equal(
                 Strings.RelationalNotInUse,

--- a/test/EntityFramework.Relational.Tests/RelationalDatabaseTest.cs
+++ b/test/EntityFramework.Relational.Tests/RelationalDatabaseTest.cs
@@ -30,11 +30,10 @@ namespace Microsoft.Data.Entity.Relational.Tests
             configurationMock.Setup(m => m.DataStoreCreator).Returns(creatorMock.Object);
             configurationMock.Setup(m => m.Model).Returns(model);
             configurationMock.Setup(m => m.Connection).Returns(connectionMock.Object);
-            configurationMock.Setup(m => m.LoggerFactory).Returns(new LoggerFactory());
             connectionMock.SetupGet(m => m.DbConnection).Returns(dbConnectionMock.Object);
             dbConnectionMock.SetupGet(m => m.Database).Returns("MyDb");
 
-            var database = new RelationalDatabase(configurationMock.Object);
+            var database = new RelationalDatabase(configurationMock.Object, new LoggerFactory());
 
             Assert.True(database.Exists());
             creatorMock.Verify(m => m.Exists(), Times.Once);
@@ -78,11 +77,10 @@ namespace Microsoft.Data.Entity.Relational.Tests
             configurationMock.Setup(m => m.DataStoreCreator).Returns(creatorMock.Object);
             configurationMock.Setup(m => m.Model).Returns(model);
             configurationMock.Setup(m => m.Connection).Returns(connectionMock.Object);
-            configurationMock.Setup(m => m.LoggerFactory).Returns(new LoggerFactory());
             connectionMock.SetupGet(m => m.DbConnection).Returns(dbConnectionMock.Object);
             dbConnectionMock.SetupGet(m => m.Database).Returns("MyDb");
 
-            var database = new RelationalDatabase(configurationMock.Object);
+            var database = new RelationalDatabase(configurationMock.Object, new LoggerFactory());
 
             Assert.True(await database.ExistsAsync(cancellationToken));
             creatorMock.Verify(m => m.ExistsAsync(cancellationToken), Times.Once);

--- a/test/EntityFramework.Relational.Tests/Update/BatchExecutorTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/BatchExecutorTest.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         private class BatchExecutorForTest : BatchExecutor
         {
             public BatchExecutorForTest(RelationalTypeMapper typeMapper, DbContextConfiguration context)
-                : base(typeMapper, context)
+                : base(typeMapper, context, new LoggerFactory())
             {
             }
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -18,6 +18,7 @@ using Microsoft.Data.Entity.SqlServer.Update;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Advanced;
 using Microsoft.Framework.DependencyInjection.Fallback;
+using Microsoft.Framework.Logging;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
@@ -92,8 +93,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 DbContextConfiguration configuration,
                 SqlServerConnection connection,
                 SqlServerCommandBatchPreparer batchPreparer,
-                SqlServerBatchExecutor batchExecutor)
-                : base(configuration, connection, batchPreparer, batchExecutor)
+                SqlServerBatchExecutor batchExecutor,
+                ILoggerFactory loggerFactory)
+                : base(configuration, connection, batchPreparer, batchExecutor, loggerFactory)
             {
             }
 

--- a/test/EntityFramework.SqlServer.Tests/SqlServerConnectionTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerConnectionTest.cs
@@ -5,6 +5,7 @@ using System.Data.SqlClient;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Fallback;
+using Microsoft.Framework.Logging;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.Tests
@@ -14,7 +15,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void Creates_SQL_Server_connection_string()
         {
-            using (var connection = new SqlServerConnection(CreateConfiguration()))
+            using (var connection = new SqlServerConnection(CreateConfiguration(), new LoggerFactory()))
             {
                 Assert.IsType<SqlConnection>(connection.DbConnection);
             }
@@ -23,7 +24,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void Can_create_master_connection_string()
         {
-            using (var connection = new SqlServerConnection(CreateConfiguration()))
+            using (var connection = new SqlServerConnection(CreateConfiguration(), new LoggerFactory()))
             {
                 using (var master = connection.CreateMasterConnection())
                 {

--- a/test/EntityFramework.Tests/DatabaseTest.cs
+++ b/test/EntityFramework.Tests/DatabaseTest.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
+using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
 
@@ -27,7 +28,7 @@ namespace Microsoft.Data.Entity.Tests
             configurationMock.Setup(m => m.Model).Returns(model);
             configurationMock.Setup(m => m.Connection).Returns(connection);
 
-            var database = new Database(configurationMock.Object);
+            var database = new Database(configurationMock.Object, new LoggerFactory());
 
             Assert.True(database.EnsureCreated());
             creatorMock.Verify(m => m.EnsureCreated(model), Times.Once);
@@ -52,7 +53,7 @@ namespace Microsoft.Data.Entity.Tests
             configurationMock.Setup(m => m.DataStoreCreator).Returns(creatorMock.Object);
             configurationMock.Setup(m => m.Model).Returns(model);
 
-            var database = new Database(configurationMock.Object);
+            var database = new Database(configurationMock.Object, new LoggerFactory());
 
             Assert.True(await database.EnsureCreatedAsync(cancellationToken));
             creatorMock.Verify(m => m.EnsureCreatedAsync(model, cancellationToken), Times.Once);


### PR DESCRIPTION
This is part of Issue #641 which is about cleaning up the use of DbContextConfiguration. DbContextConfiguration is intended to help resolve dynamic services--that is, services for which the actual type/instance of service to use depends on the current context configuration. However, it has gradually spread throughout the code as a general purpose service locator. This causes dependencies to be hidden and creates a lot of coupling to DbContextConfiguration throughout the code, so I am making a set of changes to help fix this.

This change makes things that need and ILoggerFactory depend on it in the normal way rather than getting one from DbContextConfiguration.
