### PR TITLE
Make Database not depend on DbContextConfiguration

### DIFF
--- a/src/EntityFramework.AzureTableStorage/AtsConnection.cs
+++ b/src/EntityFramework.AzureTableStorage/AtsConnection.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -22,7 +23,9 @@ namespace Microsoft.Data.Entity.AzureTableStorage
         private readonly ThreadSafeLazyRef<CloudTableClient> _tableClient;
 
         /// <summary>
-        ///     For testing. Improper usage may lead to NullReference exceptions
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
         /// </summary>
         protected AtsConnection()
         {

--- a/src/EntityFramework.AzureTableStorage/AtsDataStoreCreator.cs
+++ b/src/EntityFramework.AzureTableStorage/AtsDataStoreCreator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,6 +16,15 @@ namespace Microsoft.Data.Entity.AzureTableStorage
     public class AtsDataStoreCreator : DataStoreCreator
     {
         private readonly AtsConnection _connection;
+
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected AtsDataStoreCreator()
+        {
+        }
 
         public AtsDataStoreCreator([NotNull] AtsConnection connection)
         {

--- a/src/EntityFramework.AzureTableStorage/AtsDatabase.cs
+++ b/src/EntityFramework.AzureTableStorage/AtsDatabase.cs
@@ -3,25 +3,21 @@
 
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.AzureTableStorage
 {
     public class AtsDatabase : Database
     {
-        public AtsDatabase([NotNull] DbContextConfiguration configuration, [NotNull] ILoggerFactory loggerFactory)
-            : base(configuration, loggerFactory)
+        public AtsDatabase(
+            [NotNull] LazyRef<IModel> model,
+            [NotNull] AtsDataStoreCreator dataStoreCreator,
+            [NotNull] AtsConnection connection,
+            [NotNull] ILoggerFactory loggerFactory)
+            : base(model, dataStoreCreator, connection, loggerFactory)
         {
-        }
-
-        public virtual bool CreateTables()
-        {
-            return EnsureCreated();
-        }
-
-        public virtual bool DeleteTables()
-        {
-            return EnsureDeleted();
         }
     }
 }

--- a/src/EntityFramework.InMemory/InMemoryConnection.cs
+++ b/src/EntityFramework.InMemory/InMemoryConnection.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Framework.Logging;

--- a/src/EntityFramework.InMemory/InMemoryDataStoreCreator.cs
+++ b/src/EntityFramework.InMemory/InMemoryDataStoreCreator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,6 +15,15 @@ namespace Microsoft.Data.Entity.InMemory
     public class InMemoryDataStoreCreator : DataStoreCreator
     {
         private readonly InMemoryDataStore _dataStore;
+
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected InMemoryDataStoreCreator()
+        {
+        }
 
         public InMemoryDataStoreCreator([NotNull] InMemoryDataStore dataStore)
         {

--- a/src/EntityFramework.InMemory/InMemoryDatabaseFacade.cs
+++ b/src/EntityFramework.InMemory/InMemoryDatabaseFacade.cs
@@ -3,14 +3,20 @@
 
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.InMemory
 {
     public class InMemoryDatabaseFacade : Database
     {
-        public InMemoryDatabaseFacade([NotNull] DbContextConfiguration configuration, [NotNull] ILoggerFactory loggerFactory)
-            : base(configuration, loggerFactory)
+        public InMemoryDatabaseFacade(
+            [NotNull] LazyRef<IModel> model,
+            [NotNull] InMemoryDataStoreCreator dataStoreCreator,
+            [NotNull] InMemoryConnection connection,
+            [NotNull] ILoggerFactory loggerFactory)
+            : base(model, dataStoreCreator, connection, loggerFactory)
         {
         }
     }

--- a/src/EntityFramework.Migrations/Infrastructure/MigrationsDataStoreServices.cs
+++ b/src/EntityFramework.Migrations/Infrastructure/MigrationsDataStoreServices.cs
@@ -1,12 +1,19 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Migrations.Infrastructure
 {
     public abstract class MigrationsDataStoreServices : DataStoreServices
     {
         public abstract Migrator Migrator { get; }
+
+        public static Func<IServiceProvider, LazyRef<Migrator>> MigratorFactory
+        {
+            get { return p => new LazyRef<Migrator>(() => ((MigrationsDataStoreServices)GetStoreServices(p)).Migrator); }
+        }
     }
 }

--- a/src/EntityFramework.Migrations/MigrationsEnabledDatabase.cs
+++ b/src/EntityFramework.Migrations/MigrationsEnabledDatabase.cs
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Infrastructure;
+using Microsoft.Data.Entity.Migrations.Utilities;
 using Microsoft.Data.Entity.Relational;
+using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
@@ -12,15 +14,19 @@ namespace Microsoft.Data.Entity.Migrations
 {
     public abstract class MigrationsEnabledDatabase : RelationalDatabase, IMigrationsEnabledDatabaseInternals
     {
-        private readonly LazyRef<Migrator> _migrator;
+        private readonly Migrator _migrator;
 
         protected MigrationsEnabledDatabase(
-            [NotNull] DbContextConfiguration configuration,
+            [NotNull] LazyRef<IModel> model,
+            [NotNull] DataStoreCreator dataStoreCreator,
+            [NotNull] DataStoreConnection connection,
+            [NotNull] Migrator migrator,
             [NotNull] ILoggerFactory loggerFactory)
-            : base(configuration, loggerFactory)
+            : base(model, dataStoreCreator, connection, loggerFactory)
         {
-            // TODO: Decouple from DbContextConfiguration (Issue #641)
-            _migrator = new LazyRef<Migrator>(() => ((MigrationsDataStoreServices)configuration.DataStoreServices).Migrator);
+            Check.NotNull(migrator, "migrator");
+
+            _migrator = migrator;
         }
 
         public virtual void ApplyMigrations()
@@ -30,7 +36,7 @@ namespace Microsoft.Data.Entity.Migrations
 
         protected virtual Migrator Migrator
         {
-            get { return _migrator.Value; }
+            get { return _migrator; }
         }
 
         Migrator IMigrationsEnabledDatabaseInternals.Migrator

--- a/src/EntityFramework.Migrations/MigrationsEntityServicesBuilderExtensions.cs
+++ b/src/EntityFramework.Migrations/MigrationsEntityServicesBuilderExtensions.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 using Microsoft.Data.Entity.Migrations.Infrastructure;
 using Microsoft.Data.Entity.Migrations.Utilities;
 using Microsoft.Data.Entity.Relational;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
 
 namespace Microsoft.Data.Entity.Migrations
@@ -18,7 +19,8 @@ namespace Microsoft.Data.Entity.Migrations
             builder
                 .AddRelational().ServiceCollection
                 .AddScoped<MigrationAssembly>()
-                .AddScoped<HistoryRepository>();
+                .AddScoped<HistoryRepository>()
+                .AddScoped<LazyRef<Migrator>>(MigrationsDataStoreServices.MigratorFactory);
 
             return builder;
         }

--- a/src/EntityFramework.Redis/RedisDataStore.cs
+++ b/src/EntityFramework.Redis/RedisDataStore.cs
@@ -93,9 +93,9 @@ namespace Microsoft.Data.Entity.Redis
                     Logger,
                     CreateQueryBuffer(),
                     _database.Value)
-                    {
-                        CancellationToken = cancellationToken
-                    };
+                {
+                    CancellationToken = cancellationToken
+                };
 
             return queryExecutor(queryContext);
         }

--- a/src/EntityFramework.Redis/RedisDataStoreCreator.cs
+++ b/src/EntityFramework.Redis/RedisDataStoreCreator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -15,6 +16,15 @@ namespace Microsoft.Data.Entity.Redis
     public class RedisDataStoreCreator : DataStoreCreator
     {
         private readonly LazyRef<RedisDatabase> _database;
+
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected RedisDataStoreCreator()
+        {
+        }
 
         public RedisDataStoreCreator([NotNull] DbContextConfiguration configuration)
         {

--- a/src/EntityFramework.Redis/RedisDatabase.cs
+++ b/src/EntityFramework.Redis/RedisDatabase.cs
@@ -15,6 +15,7 @@ using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Redis.Query;
 using Microsoft.Data.Entity.Redis.Utilities;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using StackExchange.Redis;
 
@@ -52,8 +53,21 @@ namespace Microsoft.Data.Entity.Redis
         private static readonly ConcurrentDictionary<string, ConnectionMultiplexer> _connectionMultiplexers
             = new ConcurrentDictionary<string, ConnectionMultiplexer>(); // key = ConfigurationOptions.ToString()
 
-        public RedisDatabase([NotNull] DbContextConfiguration configuration, [NotNull] ILoggerFactory loggerFactory)
-            : base(configuration, loggerFactory)
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected RedisDatabase()
+        {
+        }
+
+        public RedisDatabase(
+            [NotNull] LazyRef<IModel> model,
+            [NotNull] RedisDataStoreCreator dataStoreCreator,
+            [NotNull] RedisConnection connection,
+            [NotNull] ILoggerFactory loggerFactory)
+            : base(model, dataStoreCreator, connection, loggerFactory)
         {
         }
 
@@ -87,7 +101,7 @@ namespace Microsoft.Data.Entity.Redis
         {
             get { return (RedisConnection)base.Connection; }
         }
-        
+
         public virtual IDatabase GetUnderlyingDatabase()
         {
             return ConnectionMultiplexer

--- a/src/EntityFramework.Relational/RelationalDatabase.cs
+++ b/src/EntityFramework.Relational/RelationalDatabase.cs
@@ -5,17 +5,23 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.Relational
 {
     public abstract class RelationalDatabase : Database
     {
-        protected RelationalDatabase([NotNull] DbContextConfiguration configuration, [NotNull] ILoggerFactory loggerFactory)
-            : base(configuration, loggerFactory)
+        protected RelationalDatabase(
+                   [NotNull] LazyRef<IModel> model,
+                   [NotNull] DataStoreCreator dataStoreCreator,
+                   [NotNull] DataStoreConnection connection,
+                   [NotNull] ILoggerFactory loggerFactory)
+            : base(model, dataStoreCreator, connection, loggerFactory)
         {
         }
-
         public new virtual RelationalConnection Connection
         {
             get { return (RelationalConnection)base.Connection; }

--- a/src/EntityFramework.SQLite/SQLiteConnection.cs
+++ b/src/EntityFramework.SQLite/SQLiteConnection.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Data.Common;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
@@ -12,6 +13,15 @@ namespace Microsoft.Data.Entity.SQLite
 {
     public class SQLiteConnection : RelationalConnection
     {
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected SQLiteConnection()
+        {
+        }
+
         public SQLiteConnection([NotNull] DbContextConfiguration configuration, [NotNull] ILoggerFactory loggerFactory)
             : base(configuration, loggerFactory)
         {

--- a/src/EntityFramework.SQLite/SQLiteDataStoreCreator.cs
+++ b/src/EntityFramework.SQLite/SQLiteDataStoreCreator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -19,6 +20,15 @@ namespace Microsoft.Data.Entity.SQLite
         private readonly SqlStatementExecutor _executor;
         private readonly SQLiteMigrationOperationSqlGeneratorFactory _generatorFactory;
         private readonly SQLiteModelDiffer _modelDiffer;
+
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected SQLiteDataStoreCreator()
+        {
+        }
 
         public SQLiteDataStoreCreator(
             [NotNull] SQLiteConnection connection,

--- a/src/EntityFramework.SQLite/SQLiteDatabase.cs
+++ b/src/EntityFramework.SQLite/SQLiteDatabase.cs
@@ -2,8 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SQLite
@@ -11,9 +12,12 @@ namespace Microsoft.Data.Entity.SQLite
     public class SQLiteDatabase : MigrationsEnabledDatabase
     {
         public SQLiteDatabase(
-            [NotNull] DbContextConfiguration configuration,
+            [NotNull] LazyRef<IModel> model,
+            [NotNull] SQLiteDataStoreCreator dataStoreCreator,
+            [NotNull] SQLiteConnection connection,
+            [NotNull] SQLiteMigrator migrator,
             [NotNull] ILoggerFactory loggerFactory)
-            : base(configuration, loggerFactory)
+            : base(model, dataStoreCreator, connection, migrator, loggerFactory)
         {
         }
     }

--- a/src/EntityFramework.SQLite/SQLiteMigrator.cs
+++ b/src/EntityFramework.SQLite/SQLiteMigrator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Migrations.Infrastructure;
@@ -11,6 +12,15 @@ namespace Microsoft.Data.Entity.SQLite
 {
     public class SQLiteMigrator : Migrator
     {
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected SQLiteMigrator()
+        {
+        }
+
         public SQLiteMigrator(
             [NotNull] DbContextConfiguration contextConfiguration,
             [NotNull] HistoryRepository historyRepository,

--- a/src/EntityFramework.SqlServer/SqlServerConnection.cs
+++ b/src/EntityFramework.SqlServer/SqlServerConnection.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Data.Common;
 using System.Data.SqlClient;
 using JetBrains.Annotations;
@@ -12,6 +13,15 @@ namespace Microsoft.Data.Entity.SqlServer
 {
     public class SqlServerConnection : RelationalConnection
     {
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected SqlServerConnection()
+        {
+        }
+
         public SqlServerConnection([NotNull] DbContextConfiguration configuration, [NotNull] ILoggerFactory loggerFactory)
             : base(configuration, loggerFactory)
         {

--- a/src/EntityFramework.SqlServer/SqlServerDataStoreCreator.cs
+++ b/src/EntityFramework.SqlServer/SqlServerDataStoreCreator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Threading;
@@ -19,6 +20,15 @@ namespace Microsoft.Data.Entity.SqlServer
         private readonly SqlServerModelDiffer _modelDiffer;
         private readonly SqlServerMigrationOperationSqlGeneratorFactory _sqlGeneratorFactory;
         private readonly SqlStatementExecutor _statementExecutor;
+
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected SqlServerDataStoreCreator()
+        {
+        }
 
         public SqlServerDataStoreCreator(
             [NotNull] SqlServerConnection connection,

--- a/src/EntityFramework.SqlServer/SqlServerDatabase.cs
+++ b/src/EntityFramework.SqlServer/SqlServerDatabase.cs
@@ -2,8 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SqlServer
@@ -11,9 +12,12 @@ namespace Microsoft.Data.Entity.SqlServer
     public class SqlServerDatabase : MigrationsEnabledDatabase
     {
         public SqlServerDatabase(
-            [NotNull] DbContextConfiguration configuration,
+            [NotNull] LazyRef<IModel> model,
+            [NotNull] SqlServerDataStoreCreator dataStoreCreator,
+            [NotNull] SqlServerConnection connection,
+            [NotNull] SqlServerMigrator migrator,
             [NotNull] ILoggerFactory loggerFactory)
-            : base(configuration, loggerFactory)
+            : base(model, dataStoreCreator, connection, migrator, loggerFactory)
         {
         }
     }

--- a/src/EntityFramework.SqlServer/SqlServerMigrator.cs
+++ b/src/EntityFramework.SqlServer/SqlServerMigrator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Migrations.Infrastructure;
@@ -14,6 +15,15 @@ namespace Microsoft.Data.Entity.SqlServer
     // and then uses the DataStoreSource/DataStoreSelector to get provider-specific Migrations services.
     public class SqlServerMigrator : Migrator
     {
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected SqlServerMigrator()
+        {
+        }
+
         public SqlServerMigrator(
             [NotNull] DbContextConfiguration contextConfiguration,
             [NotNull] HistoryRepository historyRepository,

--- a/src/EntityFramework/Extensions/EntityServiceCollectionExtensions.cs
+++ b/src/EntityFramework/Extensions/EntityServiceCollectionExtensions.cs
@@ -59,7 +59,15 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddScoped<StateEntrySubscriber>()
                 .AddScoped<DbContextConfiguration>()
                 .AddScoped<ContextSets>()
-                .AddScoped<StateManager>();
+                .AddScoped<StateManager>()
+                .AddScoped<LazyRef<IModel>>(DbContextConfiguration.ModelFactory)
+                .AddScoped<LazyRef<DbContext>>(DbContextConfiguration.ContextFactory)
+                .AddScoped<LazyRef<DbContextOptions>>(DbContextConfiguration.ContextOptionsFactory)
+                .AddScoped<LazyRef<DataStore>>(DataStoreServices.DataStoreFactory)
+                .AddScoped<LazyRef<DataStoreConnection>>(DataStoreServices.ConnectionFactory)
+                .AddScoped<LazyRef<Database>>(DataStoreServices.DatabaseFactory)
+                .AddScoped<LazyRef<ValueGeneratorCache>>(DataStoreServices.ValueGeneratorCacheFactory)
+                .AddScoped<LazyRef<DataStoreCreator>>(DataStoreServices.DataStoreCreatorFactory);
 
             EnsureLowLevelServices(serviceCollection);
 

--- a/src/EntityFramework/Infrastructure/Database.cs
+++ b/src/EntityFramework/Infrastructure/Database.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
@@ -13,50 +14,69 @@ namespace Microsoft.Data.Entity.Infrastructure
 {
     public abstract class Database : IDatabaseInternals
     {
-        private readonly DbContextConfiguration _configuration;
+        private readonly LazyRef<IModel> _model;
+        private readonly DataStoreCreator _dataStoreCreator;
+        private readonly DataStoreConnection _connection;
         private readonly LazyRef<ILogger> _logger;
 
-        protected Database([NotNull] DbContextConfiguration configuration, [NotNull] ILoggerFactory loggerFactory)
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected Database()
         {
-            Check.NotNull(configuration, "configuration");
+        }
+
+        protected Database(
+            [NotNull] LazyRef<IModel> model,
+            [NotNull] DataStoreCreator dataStoreCreator,
+            [NotNull] DataStoreConnection connection,
+            [NotNull] ILoggerFactory loggerFactory)
+        {
+            Check.NotNull(model, "model");
+            Check.NotNull(dataStoreCreator, "dataStoreCreator");
+            Check.NotNull(connection, "connection");
             Check.NotNull(loggerFactory, "loggerFactory");
 
-            _configuration = configuration;
+            _model = model;
+            _dataStoreCreator = dataStoreCreator;
+            _connection = connection;
             _logger = new LazyRef<ILogger>(loggerFactory.Create<Database>);
         }
 
         public virtual DataStoreConnection Connection
         {
-            get { return _configuration.Connection; }
+            get { return _connection; }
         }
 
         // TODO: Make sure API docs say that return value indicates whether or not the database or tables were created
         public virtual bool EnsureCreated()
         {
-            return _configuration.DataStoreCreator.EnsureCreated(_configuration.Model);
+            return DataStoreCreator.EnsureCreated(Model);
         }
 
         // TODO: Make sure API docs say that return value indicates whether or not the database or tables were created
         public virtual Task<bool> EnsureCreatedAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            return _configuration.DataStoreCreator.EnsureCreatedAsync(_configuration.Model, cancellationToken);
+            return DataStoreCreator.EnsureCreatedAsync(Model, cancellationToken);
         }
 
         // TODO: Make sure API docs say that return value indicates whether or not the database was deleted
         public virtual bool EnsureDeleted()
         {
-            return _configuration.DataStoreCreator.EnsureDeleted(_configuration.Model);
+            return DataStoreCreator.EnsureDeleted(Model);
         }
 
         // TODO: Make sure API docs say that return value indicates whether or not the database was deleted
         public virtual Task<bool> EnsureDeletedAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
-            return _configuration.DataStoreCreator.EnsureDeletedAsync(_configuration.Model, cancellationToken);
+            return DataStoreCreator.EnsureDeletedAsync(Model, cancellationToken);
         }
 
         protected virtual DataStoreCreator DataStoreCreator
         {
-            get { return _configuration.DataStoreCreator; }
+            get { return _dataStoreCreator; }
         }
 
         protected virtual ILogger Logger
@@ -66,9 +86,9 @@ namespace Microsoft.Data.Entity.Infrastructure
 
         protected virtual IModel Model
         {
-            get { return _configuration.Model; }
+            get { return _model.Value; }
         }
-        
+
         DataStoreCreator IDatabaseInternals.DataStoreCreator
         {
             get { return DataStoreCreator; }

--- a/src/EntityFramework/ServiceProviderCache.cs
+++ b/src/EntityFramework/ServiceProviderCache.cs
@@ -47,7 +47,9 @@ namespace Microsoft.Data.Entity
         {
             return ((((long)descriptor.Lifecycle * 397)
                      ^ descriptor.ServiceType.GetHashCode()) * 397)
-                   ^ (descriptor.ImplementationInstance ?? descriptor.ImplementationType).GetHashCode();
+                   ^ (descriptor.ImplementationInstance
+                      ?? descriptor.ImplementationType
+                      ?? (object)descriptor.ImplementationFactory).GetHashCode();
         }
     }
 }

--- a/src/EntityFramework/Storage/DataStoreServices.cs
+++ b/src/EntityFramework/Storage/DataStoreServices.cs
@@ -1,9 +1,13 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using JetBrains.Annotations;
 using Microsoft.Data.Entity.Identity;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+using Microsoft.Framework.DependencyInjection;
 
 namespace Microsoft.Data.Entity.Storage
 {
@@ -15,5 +19,37 @@ namespace Microsoft.Data.Entity.Storage
         public abstract ValueGeneratorCache ValueGeneratorCache { get; }
         public abstract Database Database { get; }
         public abstract IModelBuilderFactory ModelBuilderFactory { get; }
+
+        public static Func<IServiceProvider, LazyRef<DataStore>> DataStoreFactory
+        {
+            get { return p => new LazyRef<DataStore>(() => GetStoreServices(p).Store); }
+        }
+
+        public static Func<IServiceProvider, LazyRef<Database>> DatabaseFactory
+        {
+            get { return p => new LazyRef<Database>(() => GetStoreServices(p).Database); }
+        }
+
+        public static Func<IServiceProvider, LazyRef<DataStoreCreator>> DataStoreCreatorFactory
+        {
+            get { return p => new LazyRef<DataStoreCreator>(() => GetStoreServices(p).Creator); }
+        }
+
+        public static Func<IServiceProvider, LazyRef<ValueGeneratorCache>> ValueGeneratorCacheFactory
+        {
+            get { return p => new LazyRef<ValueGeneratorCache>(() => GetStoreServices(p).ValueGeneratorCache); }
+        }
+
+        public static Func<IServiceProvider, LazyRef<DataStoreConnection>> ConnectionFactory
+        {
+            get { return p => new LazyRef<DataStoreConnection>(() => GetStoreServices(p).Connection); }
+        }
+
+        protected static DataStoreServices GetStoreServices([NotNull] IServiceProvider serviceProvider)
+        {
+            Check.NotNull(serviceProvider, "serviceProvider");
+
+            return serviceProvider.GetRequiredServiceChecked<DbContextConfiguration>().DataStoreServices;
+        }
     }
 }

--- a/test/EntityFramework.AzureTableStorage.Tests/AtsDatabaseTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/AtsDatabaseTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
@@ -20,12 +20,11 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests
             creatorMock.Setup(m => m.EnsureCreated(model)).Returns(true);
             creatorMock.Setup(m => m.EnsureDeleted(model)).Returns(true);
 
-            var configurationMock = new Mock<DbContextConfiguration>();
-            configurationMock.Setup(m => m.DataStoreCreator).Returns(creatorMock.Object);
-            configurationMock.Setup(m => m.Model).Returns(model);
-            configurationMock.Setup(m => m.Connection).Returns(connection);
-
-            var database = new AtsDatabase(configurationMock.Object, new LoggerFactory());
+            var database = new AtsDatabase(
+                new LazyRef<IModel>(() => model),
+                creatorMock.Object,
+                connection,
+                new LoggerFactory());
 
             Assert.True(database.EnsureCreated());
             creatorMock.Verify(m => m.EnsureCreated(model), Times.Once);

--- a/test/EntityFramework.InMemory.Tests/InMemoryDatabaseExtensionsTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryDatabaseExtensionsTest.cs
@@ -3,6 +3,9 @@
 
 using System;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
@@ -14,8 +17,11 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         [Fact]
         public void Returns_typed_database_object()
         {
-            var configurationMock = new Mock<DbContextConfiguration>();
-            var database = new InMemoryDatabaseFacade(configurationMock.Object, new LoggerFactory());
+            var database = new InMemoryDatabaseFacade(
+                new LazyRef<IModel>(() => null), 
+                Mock.Of<InMemoryDataStoreCreator>(), 
+                Mock.Of<InMemoryConnection>(), 
+                new LoggerFactory());
 
             Assert.Same(database, database.AsInMemory());
         }
@@ -23,8 +29,11 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         [Fact]
         public void Throws_when_non_relational_provider_is_in_use()
         {
-            var configurationMock = new Mock<DbContextConfiguration>();
-            var database = new ConcreteDatabase(configurationMock.Object, new LoggerFactory());
+            var database = new ConcreteDatabase(
+                new LazyRef<IModel>(() => null),
+                Mock.Of<DataStoreCreator>(),
+                Mock.Of<DataStoreConnection>(),
+                new LoggerFactory());
 
             Assert.Equal(
                 Strings.InMemoryNotInUse,
@@ -33,8 +42,12 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 
         private class ConcreteDatabase : Database
         {
-            public ConcreteDatabase(DbContextConfiguration configuration, ILoggerFactory loggerFactory)
-                : base(configuration, loggerFactory)
+            public ConcreteDatabase(
+                LazyRef<IModel> model,
+                DataStoreCreator dataStoreCreator,
+                DataStoreConnection connection,
+                ILoggerFactory loggerFactory)
+                : base(model, dataStoreCreator, connection, loggerFactory)
             {
             }
         }

--- a/test/EntityFramework.Migrations.Tests/Infrastructure/MigratorTest.cs
+++ b/test/EntityFramework.Migrations.Tests/Infrastructure/MigratorTest.cs
@@ -1265,6 +1265,7 @@ new StringBuilder()
                 .AddScoped<FakeDatabase>()
                 .AddScoped<FakeRelationalOptionsExtension>()
                 .AddScoped<FakeRelationalConnection>()
+                .AddScoped<FakeMigrator>()
                 .AddInstance(dbCreator)
                 .AddInstance(loggerFactory);
 
@@ -1402,8 +1403,13 @@ new StringBuilder()
 
         private class FakeDatabase : MigrationsEnabledDatabase
         {
-            public FakeDatabase(DbContextConfiguration configuration, ILoggerFactory loggerFactory)
-                : base(configuration, loggerFactory)
+            public FakeDatabase(
+                LazyRef<IModel> model,
+                RelationalDataStoreCreator dataStoreCreator,
+                FakeRelationalConnection connection,
+                FakeMigrator migrator,
+                ILoggerFactory loggerFactory)
+                : base(model, dataStoreCreator, connection, migrator, loggerFactory)
             {
             }
         }
@@ -1427,6 +1433,10 @@ new StringBuilder()
             {
                 throw new NotImplementedException();
             }
+        }
+
+        private class FakeMigrator : Migrator
+        {
         }
 
         private class FakeSqlGenerator : MigrationOperationVisitor<IndentedStringBuilder>

--- a/test/EntityFramework.Redis.Tests/RedisDataStoreCreatorTests.cs
+++ b/test/EntityFramework.Redis.Tests/RedisDataStoreCreatorTests.cs
@@ -4,7 +4,6 @@
 using System.Threading;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
-using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
 
@@ -37,7 +36,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
         {
             var model = Mock.Of<IModel>();
             var configurationMock = new Mock<DbContextConfiguration>();
-            var databaseMock = new Mock<RedisDatabase>(configurationMock.Object, new LoggerFactory());
+            var databaseMock = new Mock<RedisDatabase>();
             configurationMock.SetupGet(m => m.Database).Returns(databaseMock.Object);
 
             var creator = new RedisDataStoreCreator(configurationMock.Object);
@@ -50,7 +49,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
         {
             var model = Mock.Of<IModel>();
             var configurationMock = new Mock<DbContextConfiguration>();
-            var databaseMock = new Mock<RedisDatabase>(configurationMock.Object, new LoggerFactory());
+            var databaseMock = new Mock<RedisDatabase>();
             configurationMock.SetupGet(m => m.Database).Returns(databaseMock.Object);
 
             var creator = new RedisDataStoreCreator(configurationMock.Object);

--- a/test/EntityFramework.Redis.Tests/RedisDatabaseExtensionsTest.cs
+++ b/test/EntityFramework.Redis.Tests/RedisDatabaseExtensionsTest.cs
@@ -3,6 +3,9 @@
 
 using System;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
@@ -14,8 +17,11 @@ namespace Microsoft.Data.Entity.Redis.Tests
         [Fact]
         public void Returns_typed_database_object()
         {
-            var configurationMock = new Mock<DbContextConfiguration>();
-            var database = new RedisDatabase(configurationMock.Object, new LoggerFactory());
+            var database = new RedisDatabase(
+                new LazyRef<IModel>(() => null),
+                Mock.Of<RedisDataStoreCreator>(),
+                Mock.Of<RedisConnection>(),
+                new LoggerFactory());
 
             Assert.Same(database, database.AsRedis());
         }
@@ -23,8 +29,11 @@ namespace Microsoft.Data.Entity.Redis.Tests
         [Fact]
         public void Throws_when_non_relational_provider_is_in_use()
         {
-            var configurationMock = new Mock<DbContextConfiguration>();
-            var database = new ConcreteDatabase(configurationMock.Object, new LoggerFactory());
+            var database = new ConcreteDatabase(
+                new LazyRef<IModel>(() => null),
+                Mock.Of<DataStoreCreator>(),
+                Mock.Of<DataStoreConnection>(),
+                new LoggerFactory());
 
             Assert.Equal(
                 Strings.RedisNotInUse,
@@ -33,8 +42,12 @@ namespace Microsoft.Data.Entity.Redis.Tests
 
         private class ConcreteDatabase : Database
         {
-            public ConcreteDatabase(DbContextConfiguration configuration, ILoggerFactory loggerFactory)
-                : base(configuration, loggerFactory)
+            public ConcreteDatabase(
+                LazyRef<IModel> model,
+                DataStoreCreator dataStoreCreator,
+                DataStoreConnection connection,
+                ILoggerFactory loggerFactory)
+                : base(model, dataStoreCreator, connection, loggerFactory)
             {
             }
         }

--- a/test/EntityFramework.Redis.Tests/RedisDatabaseTests.cs
+++ b/test/EntityFramework.Redis.Tests/RedisDatabaseTests.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
@@ -25,7 +26,11 @@ namespace Microsoft.Data.Entity.Redis.Tests
             creatorMock.Setup(m => m.EnsureDeleted(model)).Returns(true);
             configurationMock.Setup(m => m.DataStoreCreator).Returns(creatorMock.Object);
 
-            var database = new RedisDatabase(configurationMock.Object, new LoggerFactory());
+            var database = new RedisDatabase(
+                new LazyRef<IModel>(() => model),
+                creatorMock.Object,
+                connection,
+                new LoggerFactory());
 
             Assert.True(database.EnsureCreated());
             creatorMock.Verify(m => m.EnsureCreated(model), Times.Once);

--- a/test/EntityFramework.Redis.Tests/RedisSequenceValueGeneratorTest.cs
+++ b/test/EntityFramework.Redis.Tests/RedisSequenceValueGeneratorTest.cs
@@ -25,10 +25,9 @@ namespace Microsoft.Data.Entity.Redis.Tests
             var stateEntry = TestHelpers.CreateStateEntry<AnEntity>(_model);
             var property = stateEntry.EntityType.GetProperty("Id");
             var sequenceName = RedisDatabase.ConstructRedisValueGeneratorKeyName(property);
-            var blockSize = 1;
+            const int blockSize = 1;
             var incrementingValue = 0L;
-            var dbConfigurationMock = new Mock<DbContextConfiguration>();
-            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object, new LoggerFactory());
+            var redisDatabaseMock = new Mock<RedisDatabase>();
             redisDatabaseMock
                 .Setup(db => db.GetNextGeneratedValue(It.IsAny<IProperty>(), It.IsAny<long>(), It.IsAny<string>()))
                 .Returns<IProperty, long, string>((p, l, s) =>
@@ -120,10 +119,9 @@ namespace Microsoft.Data.Entity.Redis.Tests
             var stateEntry = TestHelpers.CreateStateEntry<AnEntity>(_model);
             var property = stateEntry.EntityType.GetProperty("Id");
             var sequenceName = RedisDatabase.ConstructRedisValueGeneratorKeyName(property);
-            var blockSize = 1;
+            const int blockSize = 1;
             var incrementingValue = 0L;
-            var dbConfigurationMock = new Mock<DbContextConfiguration>();
-            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object, new LoggerFactory());
+            var redisDatabaseMock = new Mock<RedisDatabase>();
             redisDatabaseMock
                 .Setup(db => db.GetNextGeneratedValueAsync(
                     It.IsAny<IProperty>(), It.IsAny<long>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -214,8 +212,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
         public void Multiple_threads_can_use_the_same_generator()
         {
             var incrementingValue = 0L;
-            var dbConfigurationMock = new Mock<DbContextConfiguration>();
-            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object, new LoggerFactory());
+            var redisDatabaseMock = new Mock<RedisDatabase>();
             redisDatabaseMock
                 .Setup(db => db.GetNextGeneratedValue(It.IsAny<IProperty>(), It.IsAny<long>(), It.IsAny<string>()))
                 .Returns<IProperty, long, string>((p, l, s) =>
@@ -271,8 +268,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
         public async Task Multiple_threads_can_use_the_same_generator_async()
         {
             var incrementingValue = 0L;
-            var dbConfigurationMock = new Mock<DbContextConfiguration>();
-            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object, new LoggerFactory());
+            var redisDatabaseMock = new Mock<RedisDatabase>();
             redisDatabaseMock
                 .Setup(db => db.GetNextGeneratedValueAsync(
                     It.IsAny<IProperty>(), It.IsAny<long>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
@@ -333,10 +329,9 @@ namespace Microsoft.Data.Entity.Redis.Tests
         [Fact]
         public void Generates_sequential_values_with_larger_block_size()
         {
-            var blockSize = 10;
+            const int blockSize = 10;
             var incrementingValue = 0L;
-            var dbConfigurationMock = new Mock<DbContextConfiguration>();
-            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object, new LoggerFactory());
+            var redisDatabaseMock = new Mock<RedisDatabase>();
             redisDatabaseMock
                 .Setup(db => db.GetNextGeneratedValue(It.IsAny<IProperty>(), It.IsAny<long>(), It.IsAny<string>()))
                 .Returns<IProperty, long, string>((p, l, s) =>
@@ -363,9 +358,8 @@ namespace Microsoft.Data.Entity.Redis.Tests
         [Fact]
         public void Throws_when_type_conversion_would_overflow()
         {
-            var incrementingValue = 256L;
-            var dbConfigurationMock = new Mock<DbContextConfiguration>();
-            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object, new LoggerFactory());
+            const long incrementingValue = 256L;
+            var redisDatabaseMock = new Mock<RedisDatabase>();
             redisDatabaseMock
                 .Setup(db => db.GetNextGeneratedValue(It.IsAny<IProperty>(), It.IsAny<long>(), It.IsAny<string>()))
                 .Returns<IProperty, long, string>((p, l, s) => incrementingValue);

--- a/test/EntityFramework.Redis.Tests/RedisValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework.Redis.Tests/RedisValueGeneratorSelectorTest.cs
@@ -18,10 +18,8 @@ namespace Microsoft.Data.Entity.Redis.Tests
         [Fact]
         public void Select_returns_RedisValueGeneratorFactory_for_all_integer_types_with_ValueGeneration_set_to_OnAdd()
         {
-            var dbConfigurationMock = new Mock<DbContextConfiguration>();
-            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object, new LoggerFactory());
             var guidValueGenerator = new SimpleValueGeneratorFactory<GuidValueGenerator>();
-            var redisValueGeneratorFactory = new RedisValueGeneratorFactory(redisDatabaseMock.Object);
+            var redisValueGeneratorFactory = new RedisValueGeneratorFactory(Mock.Of<RedisDatabase>());
 
             var selector = new RedisValueGeneratorSelector(guidValueGenerator, redisValueGeneratorFactory);
 
@@ -38,10 +36,8 @@ namespace Microsoft.Data.Entity.Redis.Tests
         [Fact]
         public void Select_returns_GuidValueGenerator_for_Guid_type_with_ValueGeneration_set_to_OnAdd()
         {
-            var dbConfigurationMock = new Mock<DbContextConfiguration>();
-            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object, new LoggerFactory());
             var guidValueGenerator = new SimpleValueGeneratorFactory<GuidValueGenerator>();
-            var redisValueGeneratorFactory = new RedisValueGeneratorFactory(redisDatabaseMock.Object);
+            var redisValueGeneratorFactory = new RedisValueGeneratorFactory(Mock.Of<RedisDatabase>());
 
             var selector = new RedisValueGeneratorSelector(guidValueGenerator, redisValueGeneratorFactory);
 
@@ -51,10 +47,8 @@ namespace Microsoft.Data.Entity.Redis.Tests
         [Fact]
         public void Select_returns_null_for_all_types_with_ValueGeneration_set_to_None()
         {
-            var dbConfigurationMock = new Mock<DbContextConfiguration>();
-            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object, new LoggerFactory());
             var guidValueGenerator = new SimpleValueGeneratorFactory<GuidValueGenerator>();
-            var redisValueGeneratorFactory = new RedisValueGeneratorFactory(redisDatabaseMock.Object);
+            var redisValueGeneratorFactory = new RedisValueGeneratorFactory(Mock.Of<RedisDatabase>());
 
             var selector = new RedisValueGeneratorSelector(guidValueGenerator, redisValueGeneratorFactory);
 
@@ -77,10 +71,8 @@ namespace Microsoft.Data.Entity.Redis.Tests
         [Fact]
         public void Select_throws_for_unsupported_combinations()
         {
-            var dbConfigurationMock = new Mock<DbContextConfiguration>();
-            var redisDatabaseMock = new Mock<RedisDatabase>(dbConfigurationMock.Object, new LoggerFactory());
             var guidValueGenerator = new SimpleValueGeneratorFactory<GuidValueGenerator>();
-            var redisValueGeneratorFactory = new RedisValueGeneratorFactory(redisDatabaseMock.Object);
+            var redisValueGeneratorFactory = new RedisValueGeneratorFactory(Mock.Of<RedisDatabase>());
 
             var selector = new RedisValueGeneratorSelector(guidValueGenerator, redisValueGeneratorFactory);
 

--- a/test/EntityFramework.Relational.Tests/RelationalDatabaseExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/RelationalDatabaseExtensionsTest.cs
@@ -3,6 +3,9 @@
 
 using System;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
@@ -14,8 +17,11 @@ namespace Microsoft.Data.Entity.Relational.Tests
         [Fact]
         public void Returns_typed_database_object()
         {
-            var configurationMock = new Mock<DbContextConfiguration>();
-            var database = new ConcreteRelationalDatabase(configurationMock.Object, new LoggerFactory());
+            var database = new ConcreteRelationalDatabase(
+                new LazyRef<IModel>(() => null),
+                Mock.Of<DataStoreCreator>(),
+                Mock.Of<DataStoreConnection>(),
+                new LoggerFactory());
 
             Assert.Same(database, database.AsRelational());
         }
@@ -23,8 +29,11 @@ namespace Microsoft.Data.Entity.Relational.Tests
         [Fact]
         public void Throws_when_non_relational_provider_is_in_use()
         {
-            var configurationMock = new Mock<DbContextConfiguration>();
-            var database = new ConcreteDatabase(configurationMock.Object, new LoggerFactory());
+            var database = new ConcreteDatabase(
+                new LazyRef<IModel>(() => null),
+                Mock.Of<DataStoreCreator>(),
+                Mock.Of<DataStoreConnection>(),
+                new LoggerFactory());
 
             Assert.Equal(
                 Strings.RelationalNotInUse,
@@ -33,16 +42,24 @@ namespace Microsoft.Data.Entity.Relational.Tests
 
         private class ConcreteDatabase : Database
         {
-            public ConcreteDatabase(DbContextConfiguration configuration, ILoggerFactory loggerFactory)
-                : base(configuration, loggerFactory)
+            public ConcreteDatabase(
+                LazyRef<IModel> model,
+                DataStoreCreator dataStoreCreator,
+                DataStoreConnection connection,
+                ILoggerFactory loggerFactory)
+                : base(model, dataStoreCreator, connection, loggerFactory)
             {
             }
         }
 
         private class ConcreteRelationalDatabase : RelationalDatabase
         {
-            public ConcreteRelationalDatabase(DbContextConfiguration configuration, ILoggerFactory loggerFactory)
-                : base(configuration, loggerFactory)
+            public ConcreteRelationalDatabase(
+                LazyRef<IModel> model,
+                DataStoreCreator dataStoreCreator,
+                DataStoreConnection connection,
+                ILoggerFactory loggerFactory)
+                : base(model, dataStoreCreator, connection, loggerFactory)
             {
             }
         }

--- a/test/EntityFramework.SQLite.Tests/SQLiteDatabaseExtensionsTest.cs
+++ b/test/EntityFramework.SQLite.Tests/SQLiteDatabaseExtensionsTest.cs
@@ -3,6 +3,9 @@
 
 using System;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
@@ -14,8 +17,12 @@ namespace Microsoft.Data.Entity.SQLite.Tests
         [Fact]
         public void Returns_typed_database_object()
         {
-            var configurationMock = new Mock<DbContextConfiguration>();
-            var database = new SQLiteDatabase(configurationMock.Object, new LoggerFactory());
+            var database = new SQLiteDatabase(
+                new LazyRef<IModel>(() => null),
+                Mock.Of<SQLiteDataStoreCreator>(),
+                Mock.Of<SQLiteConnection>(),
+                Mock.Of<SQLiteMigrator>(),
+                new LoggerFactory());
 
             Assert.Same(database, database.AsSQLite());
         }
@@ -23,8 +30,11 @@ namespace Microsoft.Data.Entity.SQLite.Tests
         [Fact]
         public void Throws_when_non_relational_provider_is_in_use()
         {
-            var configurationMock = new Mock<DbContextConfiguration>();
-            var database = new ConcreteDatabase(configurationMock.Object, new LoggerFactory());
+            var database = new ConcreteDatabase(
+                new LazyRef<IModel>(() => null),
+                Mock.Of<DataStoreCreator>(),
+                Mock.Of<DataStoreConnection>(),
+                new LoggerFactory());
 
             Assert.Equal(
                 Strings.SQLiteNotInUse,
@@ -33,8 +43,12 @@ namespace Microsoft.Data.Entity.SQLite.Tests
 
         private class ConcreteDatabase : Database
         {
-            public ConcreteDatabase(DbContextConfiguration configuration, ILoggerFactory loggerFactory)
-                : base(configuration, loggerFactory)
+            public ConcreteDatabase(
+                LazyRef<IModel> model,
+                DataStoreCreator dataStoreCreator,
+                DataStoreConnection connection,
+                ILoggerFactory loggerFactory)
+                : base(model, dataStoreCreator, connection, loggerFactory)
             {
             }
         }

--- a/test/EntityFramework.SqlServer.Tests/SqlServerDatabaseExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerDatabaseExtensionsTest.cs
@@ -1,5 +1,8 @@
 using System;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
@@ -11,8 +14,12 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void Returns_typed_database_object()
         {
-            var configurationMock = new Mock<DbContextConfiguration>();
-            var database = new SqlServerDatabase(configurationMock.Object, new LoggerFactory());
+            var database = new SqlServerDatabase(
+                new LazyRef<IModel>(() => null),
+                Mock.Of<SqlServerDataStoreCreator>(),
+                Mock.Of<SqlServerConnection>(),
+                Mock.Of<SqlServerMigrator>(),
+                new LoggerFactory());
 
             Assert.Same(database, database.AsSqlServer());
         }
@@ -20,8 +27,11 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void Throws_when_non_relational_provider_is_in_use()
         {
-            var configurationMock = new Mock<DbContextConfiguration>();
-            var database = new ConcreteDatabase(configurationMock.Object, new LoggerFactory());
+            var database = new ConcreteDatabase(
+                new LazyRef<IModel>(() => null),
+                Mock.Of<DataStoreCreator>(),
+                Mock.Of<DataStoreConnection>(),
+                new LoggerFactory());
 
             Assert.Equal(
                 Strings.SqlServerNotInUse,
@@ -30,8 +40,12 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
         private class ConcreteDatabase : Database
         {
-            public ConcreteDatabase(DbContextConfiguration configuration, ILoggerFactory loggerFactory)
-                : base(configuration, loggerFactory)
+            public ConcreteDatabase(
+                LazyRef<IModel> model,
+                DataStoreCreator dataStoreCreator,
+                DataStoreConnection connection,
+                ILoggerFactory loggerFactory)
+                : base(model, dataStoreCreator, connection, loggerFactory)
             {
             }
         }

--- a/test/EntityFramework.Tests/DatabaseTest.cs
+++ b/test/EntityFramework.Tests/DatabaseTest.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
@@ -23,12 +24,12 @@ namespace Microsoft.Data.Entity.Tests
             creatorMock.Setup(m => m.EnsureDeleted(model)).Returns(true);
 
             var connection = Mock.Of<DataStoreConnection>();
-            var configurationMock = new Mock<DbContextConfiguration>();
-            configurationMock.Setup(m => m.DataStoreCreator).Returns(creatorMock.Object);
-            configurationMock.Setup(m => m.Model).Returns(model);
-            configurationMock.Setup(m => m.Connection).Returns(connection);
 
-            var database = new ConcreteDatabase(configurationMock.Object, new LoggerFactory());
+            var database = new ConcreteDatabase(
+                    new LazyRef<IModel>(() => model),
+                    creatorMock.Object,
+                    connection,
+                    new LoggerFactory());
 
             Assert.True(database.EnsureCreated());
             creatorMock.Verify(m => m.EnsureCreated(model), Times.Once);
@@ -49,11 +50,11 @@ namespace Microsoft.Data.Entity.Tests
             creatorMock.Setup(m => m.EnsureCreatedAsync(model, cancellationToken)).Returns(Task.FromResult(true));
             creatorMock.Setup(m => m.EnsureDeletedAsync(model, cancellationToken)).Returns(Task.FromResult(true));
 
-            var configurationMock = new Mock<DbContextConfiguration>();
-            configurationMock.Setup(m => m.DataStoreCreator).Returns(creatorMock.Object);
-            configurationMock.Setup(m => m.Model).Returns(model);
-
-            var database = new ConcreteDatabase(configurationMock.Object, new LoggerFactory());
+            var database = new ConcreteDatabase(
+                    new LazyRef<IModel>(() => model),
+                    creatorMock.Object,
+                    Mock.Of<DataStoreConnection>(),
+                    new LoggerFactory());
 
             Assert.True(await database.EnsureCreatedAsync(cancellationToken));
             creatorMock.Verify(m => m.EnsureCreatedAsync(model, cancellationToken), Times.Once);
@@ -64,8 +65,12 @@ namespace Microsoft.Data.Entity.Tests
 
         private class ConcreteDatabase : Database
         {
-            public ConcreteDatabase(DbContextConfiguration configuration, ILoggerFactory loggerFactory)
-                : base(configuration, loggerFactory)
+            public ConcreteDatabase(
+                LazyRef<IModel> model,
+                DataStoreCreator dataStoreCreator,
+                DataStoreConnection connection,
+                ILoggerFactory loggerFactory)
+                : base(model, dataStoreCreator, connection, loggerFactory)
             {
             }
         }


### PR DESCRIPTION
This is part of Issue #641 which is about cleaning up the use of DbContextConfiguration. DbContextConfiguration is intended to help resolve dynamic services--that is, services for which the actual type/instance of service to use depends on the current context configuration. However, it has gradually spread throughout the code as a general purpose service locator. This causes dependencies to be hidden and creates a lot of coupling to DbContextConfiguration throughout the code, so I am making a set of changes to help fix this.

This change introduces the idea of registering delegates for dynamic services using the mechanism added recently to the DI abstraction. This allows dynamic services to be depended on in constructors in the normal way. However, since these dynamic services can result in work being done to initialize and build the service the delegates are generally registered to create LazyRef<TService> and so this should be depended on. This allows, for example Database to depend on the current model by depending on LazyRef<IModel> but the model will only be built if the database actually makes use of it.
