### PR TITLE
Make DataStoreConnection not depend on DbContextConfiguration

### DIFF
--- a/src/EntityFramework.AzureTableStorage/AtsConnection.cs
+++ b/src/EntityFramework.AzureTableStorage/AtsConnection.cs
@@ -31,13 +31,12 @@ namespace Microsoft.Data.Entity.AzureTableStorage
         {
         }
 
-        public AtsConnection([NotNull] DbContextConfiguration configuration, [NotNull] ILoggerFactory loggerFactory)
+        public AtsConnection([NotNull] LazyRef<IDbContextOptions> options, [NotNull] ILoggerFactory loggerFactory)
             : base(loggerFactory)
         {
-            Check.NotNull(configuration, "configuration");
+            Check.NotNull(options, "options");
 
-            var storeConfig = configuration
-                .ContextOptions
+            var storeConfig = options.Value
                 .Extensions
                 .OfType<AtsOptionsExtension>()
                 .Single();

--- a/src/EntityFramework.AzureTableStorage/Extensions/AtsDbContextExtensions.cs
+++ b/src/EntityFramework.AzureTableStorage/Extensions/AtsDbContextExtensions.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Data.Entity
             Check.NotNull(options, "options");
             Check.NotEmpty(connectionString, "connectionString");
 
-            ((IDbContextOptionsExtensions)options).AddOrUpdateExtension<AtsOptionsExtension>(
+            ((IDbContextOptions)options).AddOrUpdateExtension<AtsOptionsExtension>(
                 e =>
                     {
                         e.ConnectionString = connectionString;

--- a/src/EntityFramework.Commands/MigrationTool.cs
+++ b/src/EntityFramework.Commands/MigrationTool.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Data.Entity.Commands
             {
                 var configuration = context.Configuration;
 
-                var extension = RelationalOptionsExtension.Extract(configuration);
+                var extension = RelationalOptionsExtension.Extract(configuration.ContextOptions);
                 if (extension.MigrationNamespace == null)
                 {
                     extension.MigrationNamespace = rootNamespace + ".Migrations";
@@ -179,7 +179,7 @@ namespace Microsoft.Data.Entity.Commands
             var loggerFactory = (ILoggerFactory)context.Configuration.Services.ServiceProvider.GetService(typeof(ILoggerFactory));
             loggerFactory.AddProvider(_loggerProvider);
 
-            var extension = RelationalOptionsExtension.Extract(context.Configuration);
+            var extension = RelationalOptionsExtension.Extract(context.Configuration.ContextOptions);
             if (extension.MigrationAssembly == null)
             {
                 extension.MigrationAssembly = _assembly;

--- a/src/EntityFramework.InMemory/Extensions/InMemoryDbContextOptionsExtensions.cs
+++ b/src/EntityFramework.InMemory/Extensions/InMemoryDbContextOptionsExtensions.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.Entity
         {
             Check.NotNull(options, "options");
 
-            ((IDbContextOptionsExtensions)options)
+            ((IDbContextOptions)options)
                 .AddOrUpdateExtension<InMemoryOptionsExtension>(x => x.Persist = persist);
 
             return options;

--- a/src/EntityFramework.Migrations/Infrastructure/HistoryRepository.cs
+++ b/src/EntityFramework.Migrations/Infrastructure/HistoryRepository.cs
@@ -170,18 +170,17 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
 
         protected virtual DbContextOptions CreateHistoryContextOptions()
         {
-            var contextOptions = new DbContextOptions().UseModel(HistoryModel);
-            var contextOptionsExtensions = (IDbContextOptionsExtensions)contextOptions;
+            IDbContextOptions contextOptions = new DbContextOptions().UseModel(HistoryModel);
 
             // TODO: Figure out whether it is ok to reuse all the extensions
             // from the user context configuration for the history context.
             foreach (var item in ContextConfiguration.ContextOptions.Extensions)
             {
                 var extension = item;
-                contextOptionsExtensions.AddExtension(extension);
+                contextOptions.AddExtension(extension);
             }
 
-            return contextOptions;
+            return (DbContextOptions)contextOptions;
         }
 
         protected virtual string GetContextKey()

--- a/src/EntityFramework.Migrations/Utilities/DbContextConfigurationExtensions.cs
+++ b/src/EntityFramework.Migrations/Utilities/DbContextConfigurationExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Data.Entity.Migrations.Utilities
         {
             Check.NotNull(configuration, "configuration");
 
-            return RelationalOptionsExtension.Extract(configuration).MigrationAssembly
+            return RelationalOptionsExtension.Extract(configuration.ContextOptions).MigrationAssembly
                    ?? configuration.Context.GetType().GetTypeInfo().Assembly;
         }
 
@@ -22,7 +22,7 @@ namespace Microsoft.Data.Entity.Migrations.Utilities
         {
             Check.NotNull(configuration, "configuration");
 
-            return RelationalOptionsExtension.Extract(configuration).MigrationNamespace;
+            return RelationalOptionsExtension.Extract(configuration.ContextOptions).MigrationNamespace;
         }
     }
 }

--- a/src/EntityFramework.Redis/Extensions/RedisDbContextOptionsExtensions.cs
+++ b/src/EntityFramework.Redis/Extensions/RedisDbContextOptionsExtensions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Data.Entity.Redis.Extensions
         {
             Check.NotNull(options, "options");
 
-            ((IDbContextOptionsExtensions)options).AddOrUpdateExtension<RedisOptionsExtension>(
+            ((IDbContextOptions)options).AddOrUpdateExtension<RedisOptionsExtension>(
                 optionsExtension =>
                     {
                         optionsExtension.HostName = hostName;

--- a/src/EntityFramework.Redis/RedisConnection.cs
+++ b/src/EntityFramework.Redis/RedisConnection.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Redis.Utilities;
@@ -12,36 +13,36 @@ namespace Microsoft.Data.Entity.Redis
 {
     public class RedisConnection : DataStoreConnection
     {
-        private readonly LazyRef<string> _connectionString;
-        private readonly LazyRef<int> _database;
-        private readonly LazyRef<RedisOptionsExtension> _options;
+        private readonly string _connectionString;
+        private readonly int _database;
 
         /// <summary>
-        ///     For testing. Improper usage may lead to NullReference exceptions
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
         /// </summary>
         protected RedisConnection()
         {
         }
 
-        public RedisConnection([NotNull] DbContextConfiguration configuration, [NotNull] ILoggerFactory loggerFactory)
+        public RedisConnection([NotNull] LazyRef<IDbContextOptions> options, [NotNull] ILoggerFactory loggerFactory)
             : base(loggerFactory)
         {
-            Check.NotNull(configuration, "configuration");
+            Check.NotNull(options, "options");
 
-            // TODO: Decouple from DbContextConfiguration (Issue #641)
-            _options = new LazyRef<RedisOptionsExtension>(() => RedisOptionsExtension.Extract(configuration));
-            _connectionString = new LazyRef<string>(() => _options.Value.HostName + ":" + _options.Value.Port);
-            _database = new LazyRef<int>(() => _options.Value.Database);
+            var extracted = RedisOptionsExtension.Extract(options.Value);
+            _connectionString = extracted.HostName + ":" + extracted.Port;
+            _database = extracted.Database;
         }
 
         public virtual string ConnectionString
         {
-            get { return _connectionString.Value; }
+            get { return _connectionString; }
         }
 
         public virtual int Database
         {
-            get { return _database.Value; }
+            get { return _database; }
         }
     }
 }

--- a/src/EntityFramework.Redis/RedisOptionsExtension.cs
+++ b/src/EntityFramework.Redis/RedisOptionsExtension.cs
@@ -18,11 +18,11 @@ namespace Microsoft.Data.Entity.Redis
 
         public virtual int Database { get; internal set; }
 
-        public static RedisOptionsExtension Extract([NotNull] DbContextConfiguration configuration)
+        public static RedisOptionsExtension Extract([NotNull] IDbContextOptions options)
         {
-            Check.NotNull(configuration, "configuration");
+            Check.NotNull(options, "options");
 
-            var redisOptionsExtensions = configuration.ContextOptions.Extensions
+            var redisOptionsExtensions = options.Extensions
                 .OfType<RedisOptionsExtension>()
                 .ToArray();
 

--- a/src/EntityFramework.Redis/RedisValueGeneratorFactory.cs
+++ b/src/EntityFramework.Redis/RedisValueGeneratorFactory.cs
@@ -12,18 +12,9 @@ namespace Microsoft.Data.Entity.Redis
     {
         public const int DefaultBlockSize = 10;
 
-        private readonly RedisDatabase _redisDatabase;
-
-        public RedisValueGeneratorFactory([NotNull] RedisDatabase redisDatabase)
-        {
-            Check.NotNull(redisDatabase, "redisDatabase");
-
-            _redisDatabase = redisDatabase;
-        }
-
         IValueGenerator IValueGeneratorFactory.Create(IProperty property)
         {
-            return new RedisSequenceValueGenerator(_redisDatabase, GetSequenceName(property), GetBlockSize(property));
+            return new RedisSequenceValueGenerator(GetSequenceName(property), GetBlockSize(property));
         }
 
         // TODO: investigate how to make pool size configurable

--- a/src/EntityFramework.Relational/RelationalConnection.cs
+++ b/src/EntityFramework.Relational/RelationalConnection.cs
@@ -31,12 +31,12 @@ namespace Microsoft.Data.Entity.Relational
         {
         }
 
-        protected RelationalConnection([NotNull] DbContextConfiguration configuration, [NotNull] ILoggerFactory loggerFactory)
+        protected RelationalConnection([NotNull] LazyRef<IDbContextOptions> options, [NotNull] ILoggerFactory loggerFactory)
             : base(loggerFactory)
         {
-            Check.NotNull(configuration, "configuration");
+            Check.NotNull(options, "options");
 
-            var storeConfig = RelationalOptionsExtension.Extract(configuration);
+            var storeConfig = RelationalOptionsExtension.Extract(options.Value);
 
             if (storeConfig.Connection != null)
             {

--- a/src/EntityFramework.Relational/RelationalOptionsExtension.cs
+++ b/src/EntityFramework.Relational/RelationalOptionsExtension.cs
@@ -72,11 +72,11 @@ namespace Microsoft.Data.Entity.Relational
             // TODO: Read other options.
         }
 
-        public static RelationalOptionsExtension Extract([NotNull] DbContextConfiguration configuration)
+        public static RelationalOptionsExtension Extract([NotNull] IDbContextOptions options)
         {
-            Check.NotNull(configuration, "configuration");
+            Check.NotNull(options, "options");
 
-            var storeConfigs = configuration.ContextOptions.Extensions
+            var storeConfigs = options.Extensions
                 .OfType<RelationalOptionsExtension>()
                 .ToArray();
 

--- a/src/EntityFramework.SQLite/Extensions/SQLiteDbContextOptionsExtensions.cs
+++ b/src/EntityFramework.SQLite/Extensions/SQLiteDbContextOptionsExtensions.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Data.Entity
             Check.NotNull(options, "options");
             Check.NotEmpty(connectionString, "connectionString");
 
-            ((IDbContextOptionsExtensions)options)
+            ((IDbContextOptions)options)
                 .AddOrUpdateExtension<SQLiteOptionsExtension>(x => x.ConnectionString = connectionString);
 
             return options;
@@ -35,7 +35,7 @@ namespace Microsoft.Data.Entity
             Check.NotNull(options, "options");
             Check.NotNull(connection, "connection");
 
-            ((IDbContextOptionsExtensions)options)
+            ((IDbContextOptions)options)
                 .AddOrUpdateExtension<SQLiteOptionsExtension>(x => x.Connection = connection);
 
             return options;

--- a/src/EntityFramework.SQLite/SQLiteConnection.cs
+++ b/src/EntityFramework.SQLite/SQLiteConnection.cs
@@ -6,6 +6,7 @@ using System.Data.Common;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Relational;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Data.SQLite;
 using Microsoft.Framework.Logging;
 
@@ -22,8 +23,8 @@ namespace Microsoft.Data.Entity.SQLite
         {
         }
 
-        public SQLiteConnection([NotNull] DbContextConfiguration configuration, [NotNull] ILoggerFactory loggerFactory)
-            : base(configuration, loggerFactory)
+        public SQLiteConnection([NotNull] LazyRef<IDbContextOptions> options, [NotNull] ILoggerFactory loggerFactory)
+            : base(options, loggerFactory)
         {
         }
 

--- a/src/EntityFramework.SqlServer/Extensions/SqlServerDbContextOptionsExtensions.cs
+++ b/src/EntityFramework.SqlServer/Extensions/SqlServerDbContextOptionsExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Data.Entity
         {
             Check.NotNull(options, "options");
 
-            ((IDbContextOptionsExtensions)options)
+            ((IDbContextOptions)options)
                 .AddOrUpdateExtension<SqlServerOptionsExtension>(x => { });
 
             return options;
@@ -28,7 +28,7 @@ namespace Microsoft.Data.Entity
             Check.NotNull(options, "options");
             Check.NotEmpty(connectionString, "connectionString");
 
-            ((IDbContextOptionsExtensions)options)
+            ((IDbContextOptions)options)
                 .AddOrUpdateExtension<SqlServerOptionsExtension>(x => x.ConnectionString = connectionString);
 
             return options;
@@ -45,7 +45,7 @@ namespace Microsoft.Data.Entity
             Check.NotNull(options, "options");
             Check.NotNull(connection, "connection");
 
-            ((IDbContextOptionsExtensions)options)
+            ((IDbContextOptions)options)
                 .AddOrUpdateExtension<SqlServerOptionsExtension>(x => x.Connection = connection);
 
             return options;

--- a/src/EntityFramework.SqlServer/SqlServerConnection.cs
+++ b/src/EntityFramework.SqlServer/SqlServerConnection.cs
@@ -7,6 +7,7 @@ using System.Data.SqlClient;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Relational;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SqlServer
@@ -22,8 +23,8 @@ namespace Microsoft.Data.Entity.SqlServer
         {
         }
 
-        public SqlServerConnection([NotNull] DbContextConfiguration configuration, [NotNull] ILoggerFactory loggerFactory)
-            : base(configuration, loggerFactory)
+        public SqlServerConnection([NotNull] LazyRef<IDbContextOptions> options, [NotNull] ILoggerFactory loggerFactory)
+            : base(options, loggerFactory)
         {
         }
 

--- a/src/EntityFramework/DbContextOptions.cs
+++ b/src/EntityFramework/DbContextOptions.cs
@@ -13,7 +13,7 @@ using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity
 {
-    public class DbContextOptions : IDbContextOptionsExtensions
+    public class DbContextOptions : IDbContextOptions
     {
         private IModel _model;
         private readonly List<DbContextOptionsExtension> _extensions;
@@ -39,7 +39,7 @@ namespace Microsoft.Data.Entity
             return new DbContextOptions(this);
         }
 
-        public virtual DbContextOptions UseModel([NotNull] IModel model)
+        public virtual DbContextOptions UseModel(IModel model)
         {
             Check.NotNull(model, "model");
 
@@ -48,13 +48,12 @@ namespace Microsoft.Data.Entity
             return this;
         }
 
-        [CanBeNull]
         public virtual IModel Model
         {
             get { return _model; }
         }
 
-        void IDbContextOptionsExtensions.AddOrUpdateExtension<TExtension>(Action<TExtension> updater)
+        void IDbContextOptions.AddOrUpdateExtension<TExtension>(Action<TExtension> updater)
         {
             Check.NotNull(updater, "updater");
 
@@ -70,7 +69,7 @@ namespace Microsoft.Data.Entity
             updater(extension);
         }
 
-        void IDbContextOptionsExtensions.AddExtension(DbContextOptionsExtension extension)
+        void IDbContextOptions.AddExtension(DbContextOptionsExtension extension)
         {
             Check.NotNull(extension, "extension");
 
@@ -80,12 +79,12 @@ namespace Microsoft.Data.Entity
             _extensions.Add(extension);
         }
 
-        IReadOnlyList<DbContextOptionsExtension> IDbContextOptionsExtensions.Extensions
+        IReadOnlyList<DbContextOptionsExtension> IDbContextOptions.Extensions
         {
             get { return _extensions; }
         }
 
-        IReadOnlyDictionary<string, string> IDbContextOptionsExtensions.RawOptions
+        IReadOnlyDictionary<string, string> IDbContextOptions.RawOptions
         {
             get { return _rawOptions; }
             set

--- a/src/EntityFramework/EntityFramework.csproj
+++ b/src/EntityFramework/EntityFramework.csproj
@@ -145,7 +145,7 @@
     <Compile Include="Query\ExpressionTreeVisitors\TaskBlockingExpressionTreeVisitor.cs" />
     <Compile Include="Storage\DataStoreErrorLogState.cs" />
     <Compile Include="Storage\DataStoreException.cs" />
-    <Compile Include="Infrastructure\IDbContextOptionsExtensions.cs" />
+    <Compile Include="Infrastructure\IDbContextOptions.cs" />
     <Compile Include="INotifyPropertyChanging.cs" />
     <Compile Include="Metadata\EntityTypeExtensions.cs" />
     <Compile Include="Metadata\IIndex.cs" />

--- a/src/EntityFramework/Extensions/EntityServiceCollectionExtensions.cs
+++ b/src/EntityFramework/Extensions/EntityServiceCollectionExtensions.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddScoped<StateManager>()
                 .AddScoped<LazyRef<IModel>>(DbContextConfiguration.ModelFactory)
                 .AddScoped<LazyRef<DbContext>>(DbContextConfiguration.ContextFactory)
-                .AddScoped<LazyRef<DbContextOptions>>(DbContextConfiguration.ContextOptionsFactory)
+                .AddScoped<LazyRef<IDbContextOptions>>(DbContextConfiguration.ContextOptionsFactory)
                 .AddScoped<LazyRef<DataStore>>(DataStoreServices.DataStoreFactory)
                 .AddScoped<LazyRef<DataStoreConnection>>(DataStoreServices.ConnectionFactory)
                 .AddScoped<LazyRef<Database>>(DataStoreServices.DatabaseFactory)

--- a/src/EntityFramework/Infrastructure/DbContextConfiguration.cs
+++ b/src/EntityFramework/Infrastructure/DbContextConfiguration.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Data.Entity.Infrastructure
             get { return _contextOptions.Model ?? _modelFromSource.Value; }
         }
 
-        public virtual IDbContextOptionsExtensions ContextOptions
+        public virtual IDbContextOptions ContextOptions
         {
             get { return _contextOptions; }
         }
@@ -109,9 +109,9 @@ namespace Microsoft.Data.Entity.Infrastructure
             get { return p => new LazyRef<IModel>(() => p.GetRequiredServiceChecked<DbContextConfiguration>().Model); }
         }
 
-        public static Func<IServiceProvider, LazyRef<DbContextOptions>> ContextOptionsFactory
+        public static Func<IServiceProvider, LazyRef<IDbContextOptions>> ContextOptionsFactory
         {
-            get { return p => new LazyRef<DbContextOptions>(() => (DbContextOptions)p.GetRequiredServiceChecked<DbContextConfiguration>().ContextOptions); }
+            get { return p => new LazyRef<IDbContextOptions>(() => p.GetRequiredServiceChecked<DbContextConfiguration>().ContextOptions); }
         }
 
         public virtual ServiceProviderSource ProviderSource

--- a/src/EntityFramework/Infrastructure/DbContextConfigureOptions.cs
+++ b/src/EntityFramework/Infrastructure/DbContextConfigureOptions.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Data.Entity.Infrastructure
         public DbContextConfigureOptions([NotNull] IConfiguration configuration, [NotNull] DbContextOptionsParser parser)
             : base(o =>
                 {
-                    var extensions = ((IDbContextOptionsExtensions)o);
+                    var extensions = ((IDbContextOptions)o);
                     extensions.RawOptions = parser.ReadRawOptions<TContext>(configuration, extensions.RawOptions);
                 })
         {

--- a/src/EntityFramework/Infrastructure/IDbContextOptions.cs
+++ b/src/EntityFramework/Infrastructure/IDbContextOptions.cs
@@ -4,11 +4,19 @@
 using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.Infrastructure
 {
-    public interface IDbContextOptionsExtensions
+    public interface IDbContextOptions
     {
+        DbContextOptions Clone();
+
+        DbContextOptions UseModel([NotNull] IModel model);
+
+        [CanBeNull]
+        IModel Model { get; }
+
         void AddOrUpdateExtension<TExtension>([NotNull] Action<TExtension> updater)
             where TExtension : DbContextOptionsExtension, new();
 

--- a/src/EntityFramework/ServiceProviderCache.cs
+++ b/src/EntityFramework/ServiceProviderCache.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Data.Entity
             get { return _instance; }
         }
 
-        public virtual IServiceProvider GetOrAdd(IDbContextOptionsExtensions options)
+        public virtual IServiceProvider GetOrAdd(IDbContextOptions options)
         {
             var services = new ServiceCollection();
             var builder = services.AddEntityFramework();

--- a/src/EntityFramework/Storage/DataStoreConnection.cs
+++ b/src/EntityFramework/Storage/DataStoreConnection.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
@@ -25,7 +26,7 @@ namespace Microsoft.Data.Entity.Storage
         {
             Check.NotNull(loggerFactory, "loggerFactory");
 
-            _logger = new LazyRef<ILogger>(() => loggerFactory.Create<DataStoreConnection>());
+            _logger = new LazyRef<ILogger>(loggerFactory.Create<DataStoreConnection>);
         }
 
         protected virtual ILogger Logger

--- a/test/EntityFramework.AzureTableStorage.Tests/Extensions/AtsDbContextExtensionsTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Extensions/AtsDbContextExtensionsTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Extensions
 
         private static AtsOptionsExtension GetAtsExtension(DbContextOptions options)
         {
-            var result = ((IDbContextOptionsExtensions)options).Extensions
+            var result = ((IDbContextOptions)options).Extensions
                 .First(s => s.GetType() == typeof(AtsOptionsExtension)) as AtsOptionsExtension;
             return result;
         }

--- a/test/EntityFramework.Commands.Tests/Migrations/MigrationScaffolderTest.cs
+++ b/test/EntityFramework.Commands.Tests/Migrations/MigrationScaffolderTest.cs
@@ -858,7 +858,7 @@ namespace MyNamespace
 
             protected override void OnConfiguring(DbContextOptions builder)
             {
-                var contextOptionsExtensions = (IDbContextOptionsExtensions)builder;
+                var contextOptionsExtensions = (IDbContextOptions)builder;
 
                 builder.UseModel(_model);
                 contextOptionsExtensions.AddOrUpdateExtension<MyRelationalOptionsExtension>(x => x.ConnectionString = "ConnectionString");

--- a/test/EntityFramework.InMemory.Tests/InMemoryDataStoreSourceTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryDataStoreSourceTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         [Fact]
         public void Is_configured_when_configuration_contains_associated_extension()
         {
-            IDbContextOptionsExtensions options = new DbContextOptions();
+            IDbContextOptions options = new DbContextOptions();
             options.AddOrUpdateExtension<InMemoryOptionsExtension>(e => { });
 
             var configurationMock = new Mock<DbContextConfiguration>();
@@ -30,7 +30,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         [Fact]
         public void Is_not_configured_when_configuration_does_not_contain_associated_extension()
         {
-            IDbContextOptionsExtensions options = new DbContextOptions();
+            IDbContextOptions options = new DbContextOptions();
 
             var configurationMock = new Mock<DbContextConfiguration>();
             configurationMock.Setup(m => m.ContextOptions).Returns(options);

--- a/test/EntityFramework.InMemory.Tests/InMemoryDbContextOptionsExtensionsTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryDbContextOptionsExtensionsTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 
             options = options.UseInMemoryStore(persist: false);
 
-            var extension = ((IDbContextOptionsExtensions)options).Extensions.OfType<InMemoryOptionsExtension>().Single();
+            var extension = ((IDbContextOptions)options).Extensions.OfType<InMemoryOptionsExtension>().Single();
 
             Assert.False(extension.Persist);
         }
@@ -28,7 +28,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 
             options = options.UseInMemoryStore(persist: false);
 
-            var extension = ((IDbContextOptionsExtensions)options).Extensions.OfType<InMemoryOptionsExtension>().Single();
+            var extension = ((IDbContextOptions)options).Extensions.OfType<InMemoryOptionsExtension>().Single();
 
             Assert.False(extension.Persist);
         }
@@ -40,7 +40,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 
             options = options.UseInMemoryStore(persist: true);
 
-            var extension = ((IDbContextOptionsExtensions)options).Extensions.OfType<InMemoryOptionsExtension>().Single();
+            var extension = ((IDbContextOptions)options).Extensions.OfType<InMemoryOptionsExtension>().Single();
 
             Assert.True(extension.Persist);
         }

--- a/test/EntityFramework.Migrations.Tests/Infrastructure/MigrationAssemblyTest.cs
+++ b/test/EntityFramework.Migrations.Tests/Infrastructure/MigrationAssemblyTest.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
 
             protected override void OnConfiguring(DbContextOptions builder)
             {
-                var contextOptionsExtensions = (IDbContextOptionsExtensions)builder;
+                var contextOptionsExtensions = (IDbContextOptions)builder;
 
                 contextOptionsExtensions.AddOrUpdateExtension<MyRelationalOptionsExtension>(x => x.ConnectionString = "ConnectionString");
 

--- a/test/EntityFramework.Migrations.Tests/Infrastructure/MigratorTest.cs
+++ b/test/EntityFramework.Migrations.Tests/Infrastructure/MigratorTest.cs
@@ -1273,7 +1273,7 @@ new StringBuilder()
 
             var contextOptions = new DbContextOptions();
 
-            ((IDbContextOptionsExtensions)contextOptions)
+            ((IDbContextOptions)contextOptions)
                 .AddOrUpdateExtension<FakeRelationalOptionsExtension>(
                     x => { x.Connection = dbConnection; });
 
@@ -1424,8 +1424,8 @@ new StringBuilder()
 
         private class FakeRelationalConnection : RelationalConnection
         {
-            public FakeRelationalConnection(DbContextConfiguration configuration, ILoggerFactory loggerFactory)
-                : base(configuration, loggerFactory)
+            public FakeRelationalConnection(LazyRef<IDbContextOptions> options, ILoggerFactory loggerFactory)
+                : base(options, loggerFactory)
             {
             }
 

--- a/test/EntityFramework.Redis.Tests/RedisValueGeneratorSelectorTest.cs
+++ b/test/EntityFramework.Redis.Tests/RedisValueGeneratorSelectorTest.cs
@@ -5,9 +5,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using Microsoft.Data.Entity.Identity;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
-using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
 
@@ -19,7 +17,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
         public void Select_returns_RedisValueGeneratorFactory_for_all_integer_types_with_ValueGeneration_set_to_OnAdd()
         {
             var guidValueGenerator = new SimpleValueGeneratorFactory<GuidValueGenerator>();
-            var redisValueGeneratorFactory = new RedisValueGeneratorFactory(Mock.Of<RedisDatabase>());
+            var redisValueGeneratorFactory = new RedisValueGeneratorFactory();
 
             var selector = new RedisValueGeneratorSelector(guidValueGenerator, redisValueGeneratorFactory);
 
@@ -37,7 +35,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
         public void Select_returns_GuidValueGenerator_for_Guid_type_with_ValueGeneration_set_to_OnAdd()
         {
             var guidValueGenerator = new SimpleValueGeneratorFactory<GuidValueGenerator>();
-            var redisValueGeneratorFactory = new RedisValueGeneratorFactory(Mock.Of<RedisDatabase>());
+            var redisValueGeneratorFactory = new RedisValueGeneratorFactory();
 
             var selector = new RedisValueGeneratorSelector(guidValueGenerator, redisValueGeneratorFactory);
 
@@ -48,7 +46,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
         public void Select_returns_null_for_all_types_with_ValueGeneration_set_to_None()
         {
             var guidValueGenerator = new SimpleValueGeneratorFactory<GuidValueGenerator>();
-            var redisValueGeneratorFactory = new RedisValueGeneratorFactory(Mock.Of<RedisDatabase>());
+            var redisValueGeneratorFactory = new RedisValueGeneratorFactory();
 
             var selector = new RedisValueGeneratorSelector(guidValueGenerator, redisValueGeneratorFactory);
 
@@ -72,7 +70,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
         public void Select_throws_for_unsupported_combinations()
         {
             var guidValueGenerator = new SimpleValueGeneratorFactory<GuidValueGenerator>();
-            var redisValueGeneratorFactory = new RedisValueGeneratorFactory(Mock.Of<RedisDatabase>());
+            var redisValueGeneratorFactory = new RedisValueGeneratorFactory();
 
             var selector = new RedisValueGeneratorSelector(guidValueGenerator, redisValueGeneratorFactory);
 

--- a/test/EntityFramework.SQLite.Tests/SQLiteDbContextOptionsExtensionsTest.cs
+++ b/test/EntityFramework.SQLite.Tests/SQLiteDbContextOptionsExtensionsTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Data.Entity.SQLite.Tests
 
             options = options.UseSQLite("Database=Crunchie");
 
-            var extension = ((IDbContextOptionsExtensions)options).Extensions.OfType<SQLiteOptionsExtension>().Single();
+            var extension = ((IDbContextOptions)options).Extensions.OfType<SQLiteOptionsExtension>().Single();
 
             Assert.Equal("Database=Crunchie", extension.ConnectionString);
         }
@@ -28,7 +28,7 @@ namespace Microsoft.Data.Entity.SQLite.Tests
 
             options = options.UseSQLite("Database=Whisper");
 
-            var extension = ((IDbContextOptionsExtensions)options).Extensions.OfType<SQLiteOptionsExtension>().Single();
+            var extension = ((IDbContextOptions)options).Extensions.OfType<SQLiteOptionsExtension>().Single();
 
             Assert.Equal("Database=Whisper", extension.ConnectionString);
         }

--- a/test/EntityFramework.SqlServer.FunctionalTests/ConnectionSpecificationTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/ConnectionSpecificationTest.cs
@@ -498,7 +498,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 _options = options;
                 _connection = connection;
 
-                ((IDbContextOptionsExtensions)_options).AddExtension(new FakeDbContextOptionsExtension());
+                ((IDbContextOptions)_options).AddExtension(new FakeDbContextOptionsExtension());
             }
 
             protected override void OnConfiguring(DbContextOptions options)
@@ -508,7 +508,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 // Options was cloned
                 Assert.NotSame(options, _options);
 
-                Assert.Equal(1, ((IDbContextOptionsExtensions)options).Extensions.OfType<FakeDbContextOptionsExtension>().Count());
+                Assert.Equal(1, ((IDbContextOptions)options).Extensions.OfType<FakeDbContextOptionsExtension>().Count());
             }
 
             public override void Dispose()
@@ -648,7 +648,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             {
                 _options = options;
 
-                ((IDbContextOptionsExtensions)_options).AddExtension(new FakeDbContextOptionsExtension());
+                ((IDbContextOptions)_options).AddExtension(new FakeDbContextOptionsExtension());
             }
 
             protected override void OnConfiguring(DbContextOptions options)
@@ -658,7 +658,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 // Options was cloned
                 Assert.NotSame(options, _options);
 
-                Assert.Equal(1, ((IDbContextOptionsExtensions)options).Extensions.OfType<FakeDbContextOptionsExtension>().Count());
+                Assert.Equal(1, ((IDbContextOptions)options).Extensions.OfType<FakeDbContextOptionsExtension>().Count());
             }
         }
 

--- a/test/EntityFramework.SqlServer.Tests/SqlServerConnectionTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerConnectionTest.cs
@@ -3,8 +3,7 @@
 
 using System.Data.SqlClient;
 using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Fallback;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Xunit;
 
@@ -15,7 +14,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void Creates_SQL_Server_connection_string()
         {
-            using (var connection = new SqlServerConnection(CreateConfiguration(), new LoggerFactory()))
+            using (var connection = new SqlServerConnection(CreateOptions(), new LoggerFactory()))
             {
                 Assert.IsType<SqlConnection>(connection.DbConnection);
             }
@@ -24,7 +23,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void Can_create_master_connection_string()
         {
-            using (var connection = new SqlServerConnection(CreateConfiguration(), new LoggerFactory()))
+            using (var connection = new SqlServerConnection(CreateOptions(), new LoggerFactory()))
             {
                 using (var master = connection.CreateMasterConnection())
                 {
@@ -33,17 +32,10 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             }
         }
 
-        public static DbContextConfiguration CreateConfiguration()
+        public static LazyRef<IDbContextOptions> CreateOptions()
         {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection
-                .AddEntityFramework()
-                .AddSqlServer();
-
-            return new DbContext(serviceCollection.BuildServiceProvider(),
-                new DbContextOptions()
-                    .UseSqlServer(@"Server=(localdb)\v11.0;Database=SqlServerConnectionTest;Trusted_Connection=True;"))
-                .Configuration;
+            return new LazyRef<IDbContextOptions>(() => new DbContextOptions()
+                .UseSqlServer(@"Server=(localdb)\v11.0;Database=SqlServerConnectionTest;Trusted_Connection=True;"));
         }
     }
 }

--- a/test/EntityFramework.SqlServer.Tests/SqlServerDataStoreSourceTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerDataStoreSourceTest.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void Is_configured_when_configuration_contains_associated_extension()
         {
-            var options = new DbContextOptions();
-            ((IDbContextOptionsExtensions)options).AddOrUpdateExtension<SqlServerOptionsExtension>(e => { });
+            IDbContextOptions options = new DbContextOptions();
+            options.AddOrUpdateExtension<SqlServerOptionsExtension>(e => { });
 
             var configurationMock = new Mock<DbContextConfiguration>();
             configurationMock.Setup(m => m.ContextOptions).Returns(options);
@@ -41,8 +41,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void Is_available_when_configured()
         {
-            var options = new DbContextOptions();
-            ((IDbContextOptionsExtensions)options).AddOrUpdateExtension<SqlServerOptionsExtension>(e => { });
+            IDbContextOptions options = new DbContextOptions();
+            options.AddOrUpdateExtension<SqlServerOptionsExtension>(e => { });
 
             var configurationMock = new Mock<DbContextConfiguration>();
             configurationMock.Setup(m => m.ContextOptions).Returns(options);

--- a/test/EntityFramework.SqlServer.Tests/SqlServerDbContextOptionsExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerDbContextOptionsExtensionsTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
             options = options.UseSqlServer("Database=Crunchie");
 
-            var extension = ((IDbContextOptionsExtensions)options).Extensions.OfType<SqlServerOptionsExtension>().Single();
+            var extension = ((IDbContextOptions)options).Extensions.OfType<SqlServerOptionsExtension>().Single();
 
             Assert.Equal("Database=Crunchie", extension.ConnectionString);
             Assert.Null(extension.Connection);
@@ -31,7 +31,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
             options = options.UseSqlServer("Database=Whisper");
 
-            var extension = ((IDbContextOptionsExtensions)options).Extensions.OfType<SqlServerOptionsExtension>().Single();
+            var extension = ((IDbContextOptions)options).Extensions.OfType<SqlServerOptionsExtension>().Single();
 
             Assert.Equal("Database=Whisper", extension.ConnectionString);
             Assert.Null(extension.Connection);
@@ -45,7 +45,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
             options = options.UseSqlServer(connection);
 
-            var extension = ((IDbContextOptionsExtensions)options).Extensions.OfType<SqlServerOptionsExtension>().Single();
+            var extension = ((IDbContextOptions)options).Extensions.OfType<SqlServerOptionsExtension>().Single();
 
             Assert.Same(connection, extension.Connection);
             Assert.Null(extension.ConnectionString);
@@ -59,7 +59,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
             options = options.UseSqlServer(connection);
 
-            var extension = ((IDbContextOptionsExtensions)options).Extensions.OfType<SqlServerOptionsExtension>().Single();
+            var extension = ((IDbContextOptions)options).Extensions.OfType<SqlServerOptionsExtension>().Single();
 
             Assert.Same(connection, extension.Connection);
             Assert.Null(extension.ConnectionString);
@@ -69,11 +69,11 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void UseSqlServer_uses_connection_string_from_raw_options()
         {
             var options = new DbContextOptions();
-            ((IDbContextOptionsExtensions)options).RawOptions = new Dictionary<string, string> { { "ConnectionString", "Database=Crunchie" } };
+            ((IDbContextOptions)options).RawOptions = new Dictionary<string, string> { { "ConnectionString", "Database=Crunchie" } };
 
             options = options.UseSqlServer();
 
-            var extension = ((IDbContextOptionsExtensions)options).Extensions.OfType<SqlServerOptionsExtension>().Single();
+            var extension = ((IDbContextOptions)options).Extensions.OfType<SqlServerOptionsExtension>().Single();
 
             Assert.Equal("Database=Crunchie", extension.ConnectionString);
             Assert.Null(extension.Connection);

--- a/test/EntityFramework.Tests/DbContextOptionsTest.cs
+++ b/test/EntityFramework.Tests/DbContextOptionsTest.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Extensions_can_be_added_to_options()
         {
-            IDbContextOptionsExtensions options = new DbContextOptions();
+            IDbContextOptions options = new DbContextOptions();
 
             options.AddOrUpdateExtension<FakeDbContextOptionsExtension1>(e => { });
             options.AddOrUpdateExtension<FakeDbContextOptionsExtension2>(e => { });
@@ -44,7 +44,7 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Can_update_an_existing_extension()
         {
-            IDbContextOptionsExtensions options = new DbContextOptions();
+            IDbContextOptions options = new DbContextOptions();
 
             options.AddOrUpdateExtension<FakeDbContextOptionsExtension1>(e => e.Something += "One");
             options.AddOrUpdateExtension<FakeDbContextOptionsExtension1>(e => e.Something += "Two");
@@ -92,19 +92,18 @@ namespace Microsoft.Data.Entity.Tests
         {
             var model = Mock.Of<IModel>();
 
-            var options = new DbContextOptions<UnkoolContext>().UseModel(model);
+            IDbContextOptions options = new DbContextOptions<UnkoolContext>().UseModel(model);
 
-            var optionsAsExtensions = ((IDbContextOptionsExtensions)options);
-            optionsAsExtensions.AddOrUpdateExtension<FakeDbContextOptionsExtension1>(e => { });
+            options.AddOrUpdateExtension<FakeDbContextOptionsExtension1>(e => { });
 
-            optionsAsExtensions.RawOptions = new Dictionary<string, string> { { "ConnectionString", "Database=Crunchie" } };
+            options.RawOptions = new Dictionary<string, string> { { "ConnectionString", "Database=Crunchie" } };
 
             var clone = options.Clone();
 
             Assert.IsType<DbContextOptions<UnkoolContext>>(clone);
             Assert.Same(model, clone.Model);
 
-            var cloneAsExtensions = ((IDbContextOptionsExtensions)clone);
+            var cloneAsExtensions = ((IDbContextOptions)clone);
 
             Assert.Equal(1, cloneAsExtensions.Extensions.Count);
             Assert.IsType<FakeDbContextOptionsExtension1>(cloneAsExtensions.Extensions[0]);
@@ -124,8 +123,8 @@ namespace Microsoft.Data.Entity.Tests
 
             Assert.Same(model, options.Model);
 
-            Assert.Equal(1, optionsAsExtensions.Extensions.Count);
-            Assert.IsType<FakeDbContextOptionsExtension1>(optionsAsExtensions.Extensions[0]);
+            Assert.Equal(1, options.Extensions.Count);
+            Assert.IsType<FakeDbContextOptionsExtension1>(options.Extensions[0]);
         }
     }
 }

--- a/test/EntityFramework.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Tests/DbContextTest.cs
@@ -919,7 +919,7 @@ namespace Microsoft.Data.Entity.Tests
             {
                 Assert.NotNull(serviceProvider.GetService<FakeService>());
                 Assert.NotSame(serviceProvider, context.Configuration.Services.ServiceProvider);
-                Assert.Equal(0, context.Configuration.ContextOptions.Extensions.Count);
+                Assert.Equal(0, ((IDbContextOptions)context.Configuration.ContextOptions).Extensions.Count);
             }
         }
 
@@ -932,7 +932,7 @@ namespace Microsoft.Data.Entity.Tests
             services
                 .AddSingleton<FakeService>()
                 .AddEntityFramework()
-                .AddDbContext<ContextWithDefaults>(options => ((IDbContextOptionsExtensions)options).AddExtension(contextOptionsExtension));
+                .AddDbContext<ContextWithDefaults>(options => ((IDbContextOptions)options).AddExtension(contextOptionsExtension));
 
             var serviceProvider = services.BuildServiceProvider();
 
@@ -953,7 +953,7 @@ namespace Microsoft.Data.Entity.Tests
             services
                 .AddSingleton<FakeService>()
                 .AddEntityFramework()
-                .AddDbContext<ContextWithServiceProvider>(options => ((IDbContextOptionsExtensions)options).AddExtension(contextOptionsExtension));
+                .AddDbContext<ContextWithServiceProvider>(options => ((IDbContextOptions)options).AddExtension(contextOptionsExtension));
 
             var serviceProvider = services.BuildServiceProvider();
 
@@ -974,7 +974,7 @@ namespace Microsoft.Data.Entity.Tests
             services
                 .AddSingleton<FakeService>()
                 .AddEntityFramework()
-                .AddDbContext<ContextWithOptions>(options => ((IDbContextOptionsExtensions)options).AddExtension(contextOptionsExtension));
+                .AddDbContext<ContextWithOptions>(options => ((IDbContextOptions)options).AddExtension(contextOptionsExtension));
 
             var serviceProvider = services.BuildServiceProvider();
 
@@ -1016,7 +1016,7 @@ namespace Microsoft.Data.Entity.Tests
 
             services
                 .AddEntityFramework(config)
-                .AddDbContext<ContextT>(options => ((IDbContextOptionsExtensions)options).AddExtension(contextOptionsExtension));
+                .AddDbContext<ContextT>(options => ((IDbContextOptions)options).AddExtension(contextOptionsExtension));
 
             var serviceProvider = services.BuildServiceProvider();
 
@@ -1025,7 +1025,7 @@ namespace Microsoft.Data.Entity.Tests
                 var contextOptions = context.Configuration.ContextOptions as DbContextOptions<ContextT>;
 
                 Assert.NotNull(contextOptions);
-                var rawOptions = ((IDbContextOptionsExtensions)contextOptions).RawOptions;
+                var rawOptions = ((IDbContextOptions)contextOptions).RawOptions;
                 Assert.Equal(1, rawOptions.Count);
                 Assert.Equal("MyConnectionString", rawOptions["ConnectionString"]);
                 Assert.Equal(1, context.Configuration.ContextOptions.Extensions.Count);
@@ -1056,7 +1056,7 @@ namespace Microsoft.Data.Entity.Tests
                 var contextOptions = context.Configuration.ContextOptions as DbContextOptions<ContextWithDefaults>;
 
                 Assert.NotNull(contextOptions);
-                var rawOptions = ((IDbContextOptionsExtensions)contextOptions).RawOptions;
+                var rawOptions = ((IDbContextOptions)contextOptions).RawOptions;
                 Assert.Equal(1, rawOptions.Count);
                 Assert.Equal("MyConnectionString", rawOptions["ConnectionString"]);
             }

--- a/test/EntityFramework.Tests/ServiceProviderCacheTest.cs
+++ b/test/EntityFramework.Tests/ServiceProviderCacheTest.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Data.Entity.Tests
 
         private static DbContextOptions CreateOptions(Action<EntityServicesBuilder> builderAction)
         {
-            IDbContextOptionsExtensions options = new DbContextOptions();
+            IDbContextOptions options = new DbContextOptions();
             options.AddOrUpdateExtension<FakeDbContextOptionsExtension>(e => e.BuilderActions.Add(builderAction));
             return (DbContextOptions)options;
         }


### PR DESCRIPTION
This is part of Issue #641 which is about cleaning up the use of DbContextConfiguration. DbContextConfiguration is intended to help resolve dynamic services--that is, services for which the actual type/instance of service to use depends on the current context configuration. However, it has gradually spread throughout the code as a general purpose service locator. This causes dependencies to be hidden and creates a lot of coupling to DbContextConfiguration throughout the code, so I am making a set of changes to help fix this.

The main change here is to get the current options by depending on LazyRef<DbContextOptions>. I also needed to update the Redis provider to not depend on scoped services in singleton services.
