### PR TITLE
Make DataStore not depend on DbContextConfiguration

### DIFF
--- a/src/EntityFramework.InMemory/InMemoryDataStore.cs
+++ b/src/EntityFramework.InMemory/InMemoryDataStore.cs
@@ -34,15 +34,21 @@ namespace Microsoft.Data.Entity.InMemory
         }
 
         public InMemoryDataStore(
-            [NotNull] DbContextConfiguration configuration,
-            [NotNull] InMemoryDatabase persistentDatabase,
-            [NotNull] ILoggerFactory loggerFactory)
-            : base(configuration, loggerFactory)
+             [NotNull] StateManager stateManager,
+             [NotNull] LazyRef<IModel> model,
+             [NotNull] EntityKeyFactorySource entityKeyFactorySource,
+             [NotNull] EntityMaterializerSource entityMaterializerSource,
+             [NotNull] ClrCollectionAccessorSource collectionAccessorSource,
+             [NotNull] ClrPropertySetterSource propertySetterSource,
+             [NotNull] InMemoryDatabase persistentDatabase,
+             [NotNull] LazyRef<IDbContextOptions> options,
+             [NotNull] ILoggerFactory loggerFactory)
+            : base(stateManager, model, entityKeyFactorySource, entityMaterializerSource,
+                collectionAccessorSource, propertySetterSource, loggerFactory)
         {
-            Check.NotNull(configuration, "configuration");
             Check.NotNull(persistentDatabase, "persistentDatabase");
 
-            var storeConfig = configuration.ContextOptions.Extensions
+            var storeConfig = options.Value.Extensions
                 .OfType<InMemoryOptionsExtension>()
                 .FirstOrDefault();
 

--- a/src/EntityFramework.Redis/RedisDataStore.cs
+++ b/src/EntityFramework.Redis/RedisDataStore.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Redis.Query;
 using Microsoft.Data.Entity.Redis.Utilities;
@@ -22,11 +23,18 @@ namespace Microsoft.Data.Entity.Redis
         private readonly LazyRef<RedisDatabase> _database;
 
         public RedisDataStore(
-            [NotNull] DbContextConfiguration configuration,
-            [NotNull] ILoggerFactory loggerFactory)
-            : base(configuration, loggerFactory)
+             [NotNull] StateManager stateManager,
+             [NotNull] LazyRef<IModel> model,
+             [NotNull] EntityKeyFactorySource entityKeyFactorySource,
+             [NotNull] EntityMaterializerSource entityMaterializerSource,
+             [NotNull] ClrCollectionAccessorSource collectionAccessorSource,
+             [NotNull] ClrPropertySetterSource propertySetterSource,
+             [NotNull] LazyRef<Database> database,
+             [NotNull] ILoggerFactory loggerFactory)
+            : base(stateManager, model, entityKeyFactorySource, entityMaterializerSource,
+                collectionAccessorSource, propertySetterSource, loggerFactory)
         {
-            _database = new LazyRef<RedisDatabase>(() => (RedisDatabase)configuration.Database);
+            _database = new LazyRef<RedisDatabase>(() => (RedisDatabase)database.Value);
         }
 
         public override int SaveChanges(

--- a/src/EntityFramework.Relational/RelationalDataStore.cs
+++ b/src/EntityFramework.Relational/RelationalDataStore.cs
@@ -7,13 +7,14 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking;
-using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Relational.Query;
 using Microsoft.Data.Entity.Relational.Query.Methods;
 using Microsoft.Data.Entity.Relational.Update;
 using Microsoft.Data.Entity.Relational.Utilities;
 using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Remotion.Linq;
 
@@ -35,12 +36,18 @@ namespace Microsoft.Data.Entity.Relational
         }
 
         protected RelationalDataStore(
-            [NotNull] DbContextConfiguration configuration,
+            [NotNull] StateManager stateManager,
+            [NotNull] LazyRef<IModel> model,
+            [NotNull] EntityKeyFactorySource entityKeyFactorySource,
+            [NotNull] EntityMaterializerSource entityMaterializerSource,
+            [NotNull] ClrCollectionAccessorSource collectionAccessorSource,
+            [NotNull] ClrPropertySetterSource propertySetterSource,
             [NotNull] RelationalConnection connection,
             [NotNull] CommandBatchPreparer batchPreparer,
             [NotNull] BatchExecutor batchExecutor,
             [NotNull] ILoggerFactory loggerFactory)
-            : base(configuration, loggerFactory)
+            : base(stateManager, model, entityKeyFactorySource, entityMaterializerSource,
+                collectionAccessorSource, propertySetterSource, loggerFactory)
         {
             Check.NotNull(connection, "connection");
             Check.NotNull(batchPreparer, "batchPreparer");
@@ -145,11 +152,11 @@ namespace Microsoft.Data.Entity.Relational
 
             return new RelationalQueryCompilationContext(
                 Model,
-                Logger, 
-                linqOperatorProvider, 
-                resultOperatorHandler, 
-                EntityMaterializerSource, 
-                queryMethodProvider, 
+                Logger,
+                linqOperatorProvider,
+                resultOperatorHandler,
+                EntityMaterializerSource,
+                queryMethodProvider,
                 methodCallTranslator);
         }
     }

--- a/src/EntityFramework.SQLite/SQLiteDataStore.cs
+++ b/src/EntityFramework.SQLite/SQLiteDataStore.cs
@@ -2,13 +2,15 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Relational.Query;
 using Microsoft.Data.Entity.Relational.Query.Methods;
 using Microsoft.Data.Entity.SQLite.Query;
 using Microsoft.Data.Entity.SQLite.Utilities;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SQLite
@@ -16,12 +18,18 @@ namespace Microsoft.Data.Entity.SQLite
     public class SQLiteDataStore : RelationalDataStore
     {
         public SQLiteDataStore(
-            [NotNull] DbContextConfiguration configuration,
+            [NotNull] StateManager stateManager,
+            [NotNull] LazyRef<IModel> model,
+            [NotNull] EntityKeyFactorySource entityKeyFactorySource,
+            [NotNull] EntityMaterializerSource entityMaterializerSource,
+            [NotNull] ClrCollectionAccessorSource collectionAccessorSource,
+            [NotNull] ClrPropertySetterSource propertySetterSource,
             [NotNull] SQLiteConnection connection,
             [NotNull] SQLiteCommandBatchPreparer batchPreparer,
-            [NotNull] SQLiteBatchExecutor batchExecutor, 
+            [NotNull] SQLiteBatchExecutor batchExecutor,
             [NotNull] ILoggerFactory loggerFactory)
-            : base(configuration, connection, batchPreparer, batchExecutor, loggerFactory)
+            : base(stateManager, model, entityKeyFactorySource, entityMaterializerSource,
+                collectionAccessorSource, propertySetterSource, connection, batchPreparer, batchExecutor, loggerFactory)
         {
         }
 
@@ -41,12 +49,12 @@ namespace Microsoft.Data.Entity.SQLite
             Check.NotNull(queryMethodProvider, "queryMethodProvider");
 
             return new SQLiteQueryCompilationContext(
-                Model, 
-                Logger, 
-                linqOperatorProvider, 
-                resultOperatorHandler, 
+                Model,
+                Logger,
+                linqOperatorProvider,
+                resultOperatorHandler,
                 EntityMaterializerSource,
-                queryMethodProvider, 
+                queryMethodProvider,
                 methodCallTranslator);
         }
     }

--- a/src/EntityFramework.SqlServer/SqlServerDataStore.cs
+++ b/src/EntityFramework.SqlServer/SqlServerDataStore.cs
@@ -2,7 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Relational.Query;
@@ -10,6 +11,7 @@ using Microsoft.Data.Entity.Relational.Query.Methods;
 using Microsoft.Data.Entity.SqlServer.Query;
 using Microsoft.Data.Entity.SqlServer.Update;
 using Microsoft.Data.Entity.SqlServer.Utilities;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SqlServer
@@ -17,12 +19,18 @@ namespace Microsoft.Data.Entity.SqlServer
     public class SqlServerDataStore : RelationalDataStore
     {
         public SqlServerDataStore(
-            [NotNull] DbContextConfiguration configuration,
+            [NotNull] StateManager stateManager,
+            [NotNull] LazyRef<IModel> model,
+            [NotNull] EntityKeyFactorySource entityKeyFactorySource,
+            [NotNull] EntityMaterializerSource entityMaterializerSource,
+            [NotNull] ClrCollectionAccessorSource collectionAccessorSource,
+            [NotNull] ClrPropertySetterSource propertySetterSource,
             [NotNull] SqlServerConnection connection,
             [NotNull] SqlServerCommandBatchPreparer batchPreparer,
             [NotNull] SqlServerBatchExecutor batchExecutor,
             [NotNull] ILoggerFactory loggerFactory)
-            : base(configuration, connection, batchPreparer, batchExecutor, loggerFactory)
+            : base(stateManager, model, entityKeyFactorySource, entityMaterializerSource,
+                collectionAccessorSource, propertySetterSource, connection, batchPreparer, batchExecutor, loggerFactory)
         {
         }
 

--- a/test/EntityFramework.AzureTableStorage.Tests/Query/QueryCachingTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Query/QueryCachingTests.cs
@@ -41,10 +41,16 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Query
             configuration.SetupGet(s => s.Services.ClrPropertySetterSource).Returns(new Mock<ClrPropertySetterSource>().Object);
 
             _dataStore = new AtsDataStore(
-                configuration.Object,
+                Mock.Of<StateManager>(),
+                new LazyRef<IModel>(CreateModel),
+                Mock.Of<EntityKeyFactorySource>(),
+                Mock.Of<EntityMaterializerSource>(),
+                Mock.Of<ClrCollectionAccessorSource>(),
+                Mock.Of<ClrPropertySetterSource>(),
                 _connection.Object,
                 new AtsQueryFactory(new AtsValueReaderFactory()),
                 new TableEntityAdapterFactory(),
+                new LazyRef<DbContext>(() => null),
                 new LoggerFactory());
         }
 

--- a/test/EntityFramework.Relational.Tests/RelationalDataStoreTest.cs
+++ b/test/EntityFramework.Relational.Tests/RelationalDataStoreTest.cs
@@ -5,8 +5,11 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.ChangeTracking;
-using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.Update;
+using Microsoft.Data.Entity.Utilities;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
 using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
@@ -21,11 +24,18 @@ namespace Microsoft.Data.Entity.Relational.Tests
             var relationalConnectionMock = new Mock<RelationalConnection>();
             var commandBatchPreparerMock = new Mock<CommandBatchPreparer>();
             var batchExecutorMock = new Mock<BatchExecutor>();
-            var relationalDataStore = (RelationalDataStore)new FakeRelationalDataStore(CreateDbContextConfiguration(),
-                relationalConnectionMock.Object,
-                commandBatchPreparerMock.Object,
-                batchExecutorMock.Object,
-                new LoggerFactory());
+
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFramework()
+                .AddInMemoryStore()
+                .ServiceCollection
+                .AddInstance(relationalConnectionMock.Object)
+                .AddInstance(commandBatchPreparerMock.Object)
+                .AddInstance(batchExecutorMock.Object)
+                .AddSingleton<FakeRelationalDataStore>()
+                .BuildServiceProvider();
+
+            var relationalDataStore = serviceProvider.GetRequiredService<FakeRelationalDataStore>();
 
             var stateEntries = new List<StateEntry>();
             var cancellationToken = new CancellationTokenSource().Token;
@@ -36,20 +46,48 @@ namespace Microsoft.Data.Entity.Relational.Tests
             batchExecutorMock.Verify(be => be.ExecuteAsync(It.IsAny<IEnumerable<ModificationCommandBatch>>(), relationalConnectionMock.Object, cancellationToken));
         }
 
-        private DbContextConfiguration CreateDbContextConfiguration()
+        [Fact]
+        public void SaveChanges_delegates()
         {
-            return new Mock<DbContextConfiguration>().Object;
+            var relationalConnectionMock = new Mock<RelationalConnection>();
+            var commandBatchPreparerMock = new Mock<CommandBatchPreparer>();
+            var batchExecutorMock = new Mock<BatchExecutor>();
+
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFramework()
+                .AddInMemoryStore()
+                .ServiceCollection
+                .AddInstance(relationalConnectionMock.Object)
+                .AddInstance(commandBatchPreparerMock.Object)
+                .AddInstance(batchExecutorMock.Object)
+                .AddSingleton<FakeRelationalDataStore>()
+                .BuildServiceProvider();
+
+            var relationalDataStore = serviceProvider.GetRequiredService<FakeRelationalDataStore>();
+
+            var stateEntries = new List<StateEntry>();
+
+            relationalDataStore.SaveChanges(stateEntries);
+
+            commandBatchPreparerMock.Verify(c => c.BatchCommands(stateEntries));
+            batchExecutorMock.Verify(be => be.Execute(It.IsAny<IEnumerable<ModificationCommandBatch>>(), relationalConnectionMock.Object));
         }
 
         private class FakeRelationalDataStore : RelationalDataStore
         {
             public FakeRelationalDataStore(
-                DbContextConfiguration configuration,
+                StateManager stateManager,
+                LazyRef<IModel> model,
+                EntityKeyFactorySource entityKeyFactorySource,
+                EntityMaterializerSource entityMaterializerSource,
+                ClrCollectionAccessorSource collectionAccessorSource,
+                ClrPropertySetterSource propertySetterSource,
                 RelationalConnection connection,
                 CommandBatchPreparer batchPreparer,
                 BatchExecutor batchExecutor,
                 ILoggerFactory loggerFactory)
-                : base(configuration, connection, batchPreparer, batchExecutor, loggerFactory)
+                : base(stateManager, model, entityKeyFactorySource, entityMaterializerSource,
+                    collectionAccessorSource, propertySetterSource, connection, batchPreparer, batchExecutor, loggerFactory)
             {
             }
         }

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -9,12 +9,13 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Relational.FunctionalTests;
 using Microsoft.Data.Entity.SqlServer.FunctionalTests.TestModels;
 using Microsoft.Data.Entity.SqlServer.Update;
+using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Fallback;
 using Microsoft.Framework.Logging;
@@ -89,12 +90,18 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         private class SqlStoreWithBufferReader : SqlServerDataStore
         {
             public SqlStoreWithBufferReader(
-                DbContextConfiguration configuration,
+                StateManager stateManager,
+                LazyRef<IModel> model,
+                EntityKeyFactorySource entityKeyFactorySource,
+                EntityMaterializerSource entityMaterializerSource,
+                ClrCollectionAccessorSource collectionAccessorSource,
+                ClrPropertySetterSource propertySetterSource,
                 SqlServerConnection connection,
                 SqlServerCommandBatchPreparer batchPreparer,
                 SqlServerBatchExecutor batchExecutor,
                 ILoggerFactory loggerFactory)
-                : base(configuration, connection, batchPreparer, batchExecutor, loggerFactory)
+                : base(stateManager, model, entityKeyFactorySource, entityMaterializerSource,
+                    collectionAccessorSource, propertySetterSource, connection, batchPreparer, batchExecutor, loggerFactory)
             {
             }
 
@@ -499,6 +506,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         }
 
         private readonly SqlServerFixture _fixture;
+
         public SqlServerEndToEndTest(SqlServerFixture fixture)
         {
             _fixture = fixture;


### PR DESCRIPTION
This is part of Issue #641 which is about cleaning up the use of DbContextConfiguration. DbContextConfiguration is intended to help resolve dynamic services--that is, services for which the actual type/instance of service to use depends on the current context configuration. However, it has gradually spread throughout the code as a general purpose service locator. This causes dependencies to be hidden and creates a lot of coupling to DbContextConfiguration throughout the code, so I am making a set of changes to help fix this.
