### PR TITLE
Create abstraction for state entry metadata services

### DIFF
--- a/src/EntityFramework/ChangeTracking/ClrStateEntry.cs
+++ b/src/EntityFramework/ChangeTracking/ClrStateEntry.cs
@@ -25,8 +25,9 @@ namespace Microsoft.Data.Entity.ChangeTracking
         public ClrStateEntry(
             [NotNull] DbContextConfiguration configuration,
             [NotNull] IEntityType entityType,
+            [NotNull] StateEntryMetadataServices metadataServices,
             [NotNull] object entity)
-            : base(configuration, entityType)
+            : base(configuration, entityType, metadataServices)
         {
             Check.NotNull(entity, "entity");
 

--- a/src/EntityFramework/ChangeTracking/MixedStateEntry.cs
+++ b/src/EntityFramework/ChangeTracking/MixedStateEntry.cs
@@ -26,8 +26,9 @@ namespace Microsoft.Data.Entity.ChangeTracking
         public MixedStateEntry(
             [NotNull] DbContextConfiguration configuration,
             [NotNull] IEntityType entityType,
+            [NotNull] StateEntryMetadataServices metadataServices,
             [NotNull] object entity)
-            : base(configuration, entityType)
+            : base(configuration, entityType, metadataServices)
         {
             Check.NotNull(entity, "entity");
 
@@ -38,9 +39,10 @@ namespace Microsoft.Data.Entity.ChangeTracking
         public MixedStateEntry(
             [NotNull] DbContextConfiguration configuration,
             [NotNull] IEntityType entityType,
+            [NotNull] StateEntryMetadataServices metadataServices,
             [NotNull] object entity,
             [NotNull] IValueReader valueReader)
-            : base(configuration, entityType)
+            : base(configuration, entityType, metadataServices)
         {
             Check.NotNull(entity, "entity");
             Check.NotNull(valueReader, "valueReader");

--- a/src/EntityFramework/ChangeTracking/PropertyBagEntryExtensions.cs
+++ b/src/EntityFramework/ChangeTracking/PropertyBagEntryExtensions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.ChangeTracking
+{
+    public static class PropertyBagEntryExtensions
+    {
+        public static bool HasDefaultValue([NotNull] this IPropertyBagEntry entry, [NotNull] IProperty property)
+        {
+            Check.NotNull(entry, "entry");
+            Check.NotNull(property, "property");
+
+            var value = entry[property];
+            return value == null || value.Equals(property.PropertyType.GetDefaultValue());
+        }
+    }
+}

--- a/src/EntityFramework/ChangeTracking/ShadowStateEntry.cs
+++ b/src/EntityFramework/ChangeTracking/ShadowStateEntry.cs
@@ -30,8 +30,9 @@ namespace Microsoft.Data.Entity.ChangeTracking
 
         public ShadowStateEntry(
             [NotNull] DbContextConfiguration configuration,
-            [NotNull] IEntityType entityType)
-            : base(configuration, entityType)
+            [NotNull] IEntityType entityType,
+            [NotNull] StateEntryMetadataServices metadataServices)
+            : base(configuration, entityType, metadataServices)
         {
             _propertyValues = new object[entityType.ShadowPropertyCount];
         }
@@ -39,8 +40,9 @@ namespace Microsoft.Data.Entity.ChangeTracking
         public ShadowStateEntry(
             [NotNull] DbContextConfiguration configuration,
             [NotNull] IEntityType entityType,
+            [NotNull] StateEntryMetadataServices metadataServices,
             [NotNull] IValueReader valueReader)
-            : base(configuration, entityType)
+            : base(configuration, entityType, metadataServices)
         {
             Check.NotNull(valueReader, "valueReader");
 

--- a/src/EntityFramework/ChangeTracking/StateEntryMetadataServices.cs
+++ b/src/EntityFramework/ChangeTracking/StateEntryMetadataServices.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.ChangeTracking
+{
+    public class StateEntryMetadataServices
+    {
+        private readonly ClrPropertyGetterSource _getterSource;
+        private readonly ClrPropertySetterSource _setterSource;
+        private readonly OriginalValuesFactory _originalValuesFactory;
+        private readonly RelationshipsSnapshotFactory _relationshipsSnapshotFactory;
+        private readonly StoreGeneratedValuesFactory _storeGeneratedValuesFactory;
+        private readonly EntityKeyFactorySource _entityKeyFactorySource;
+
+        public StateEntryMetadataServices(
+            [NotNull] ClrPropertyGetterSource getterSource,
+            [NotNull] ClrPropertySetterSource setterSource,
+            [NotNull] OriginalValuesFactory originalValuesFactory,
+            [NotNull] RelationshipsSnapshotFactory relationshipsSnapshotFactory,
+            [NotNull] StoreGeneratedValuesFactory storeGeneratedValuesFactory,
+            [NotNull] EntityKeyFactorySource entityKeyFactorySource)
+        {
+            Check.NotNull(getterSource, "getterSource");
+            Check.NotNull(setterSource, "setterSource");
+            Check.NotNull(originalValuesFactory, "originalValuesFactory");
+            Check.NotNull(relationshipsSnapshotFactory, "relationshipsSnapshotFactory");
+            Check.NotNull(storeGeneratedValuesFactory, "storeGeneratedValuesFactory");
+            Check.NotNull(entityKeyFactorySource, "entityKeyFactorySource");
+
+            _getterSource = getterSource;
+            _setterSource = setterSource;
+            _originalValuesFactory = originalValuesFactory;
+            _relationshipsSnapshotFactory = relationshipsSnapshotFactory;
+            _storeGeneratedValuesFactory = storeGeneratedValuesFactory;
+            _entityKeyFactorySource = entityKeyFactorySource;
+        }
+
+        public virtual object ReadValue([NotNull] object entity, [NotNull] IPropertyBase propertyBase)
+        {
+            Check.NotNull(entity, "entity");
+            Check.NotNull(propertyBase, "propertyBase");
+
+            return _getterSource.GetAccessor(propertyBase).GetClrValue(entity);
+        }
+
+        public virtual void WriteValue([NotNull] object entity, [NotNull] IPropertyBase propertyBase, [CanBeNull] object value)
+        {
+            Check.NotNull(entity, "entity");
+            Check.NotNull(propertyBase, "propertyBase");
+
+            _setterSource.GetAccessor(propertyBase).SetClrValue(entity, value);
+        }
+
+        public virtual Sidecar CreateOriginalValues([NotNull] StateEntry stateEntry)
+        {
+            Check.NotNull(stateEntry, "stateEntry");
+
+            return _originalValuesFactory.Create(stateEntry);
+        }
+
+        public virtual Sidecar CreateRelationshipSnapshot([NotNull] StateEntry stateEntry)
+        {
+            Check.NotNull(stateEntry, "stateEntry");
+
+            return _relationshipsSnapshotFactory.Create(stateEntry);
+        }
+
+        public virtual Sidecar CreateStoreGeneratedValues([NotNull] StateEntry stateEntry)
+        {
+            Check.NotNull(stateEntry, "stateEntry");
+
+            return _storeGeneratedValuesFactory.Create(stateEntry);
+        }
+
+        public virtual EntityKey CreateKey(
+            [NotNull] IEntityType entityType,
+            [NotNull] IReadOnlyList<IProperty> properties,
+            [NotNull] IPropertyBagEntry propertyBagEntry)
+        {
+            Check.NotNull(entityType, "entityType");
+            Check.NotEmpty(properties, "properties");
+            Check.NotNull(propertyBagEntry, "propertyBagEntry");
+
+            return _entityKeyFactorySource
+                .GetKeyFactory(properties)
+                .Create(entityType, properties, propertyBagEntry);
+        }
+    }
+}

--- a/src/EntityFramework/EntityFramework.csproj
+++ b/src/EntityFramework/EntityFramework.csproj
@@ -64,10 +64,12 @@
       <Link>LoggingExtensions.cs</Link>
     </Compile>
     <Compile Include="ChangeTracking\ChangeDetector.cs" />
+    <Compile Include="ChangeTracking\PropertyBagEntryExtensions.cs" />
     <Compile Include="ChangeTracking\RelationshipsSnapshot.cs" />
     <Compile Include="ChangeTracking\RelationshipsSnapshotFactory.cs" />
     <Compile Include="ChangeTracking\IPropertyBagEntry.cs" />
     <Compile Include="ChangeTracking\SimpleNullableEntityKeyFactory.cs" />
+    <Compile Include="ChangeTracking\StateEntryMetadataServices.cs" />
     <Compile Include="DbContext.cs" />
     <Compile Include="Infrastructure\DbContextActivator.cs" />
     <Compile Include="DbContextOptions.cs" />

--- a/src/EntityFramework/Extensions/EntityServiceCollectionExtensions.cs
+++ b/src/EntityFramework/Extensions/EntityServiceCollectionExtensions.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddSingleton<RelationshipsSnapshotFactory>()
                 .AddSingleton<StoreGeneratedValuesFactory>()
                 .AddSingleton<ValueGeneratorSelector>()
+                .AddSingleton<StateEntryMetadataServices>()
                 .AddScoped<DataStoreSelector>()
                 .AddScoped<StateEntryFactory>()
                 .AddScoped<IEntityStateListener, NavigationFixer>()

--- a/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -10,6 +10,7 @@ using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.Metadata;
 using Microsoft.Data.Entity.Relational.Update;
 using Microsoft.Data.Entity.Utilities;
+using Microsoft.Framework.DependencyInjection;
 using Moq;
 using Xunit;
 
@@ -64,8 +65,9 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         [Fact]
         public async Task BatchCommands_creates_valid_batch_for_added_entities()
         {
-            var stateEntry = new MixedStateEntry(
-                CreateConfiguration(),
+            var factory = CreateConfiguration().ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
+
+            var stateEntry = factory.Create(
                 CreateSimpleFKModel().GetEntityType(typeof(FakeEntity)), new FakeEntity { Id = 42, Value = "Test" });
 
             await stateEntry.SetEntityStateAsync(EntityState.Added);
@@ -102,8 +104,9 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         [Fact]
         public async Task BatchCommands_creates_valid_batch_for_modified_entities()
         {
-            var stateEntry = new MixedStateEntry(
-                CreateConfiguration(),
+            var factory = CreateConfiguration().ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
+
+            var stateEntry = factory.Create(
                 CreateSimpleFKModel().GetEntityType(typeof(FakeEntity)), new FakeEntity { Id = 42, Value = "Test" });
 
             await stateEntry.SetEntityStateAsync(EntityState.Modified);
@@ -141,8 +144,9 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         [Fact]
         public async Task BatchCommands_creates_valid_batch_for_deleted_entities()
         {
-            var stateEntry = new MixedStateEntry(
-                CreateConfiguration(),
+            var factory = CreateConfiguration().ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
+
+            var stateEntry = factory.Create(
                 CreateSimpleFKModel().GetEntityType(typeof(FakeEntity)), new FakeEntity { Id = 42, Value = "Test" });
 
             await stateEntry.SetEntityStateAsync(EntityState.Deleted);
@@ -171,14 +175,13 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             var configuration = CreateConfiguration();
             var model = CreateSimpleFKModel();
+            var factory = configuration.ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
 
-            var stateEntry = new MixedStateEntry(
-                configuration,
+            var stateEntry = factory.Create(
                 model.GetEntityType(typeof(FakeEntity)), new FakeEntity { Id = 42, Value = "Test" });
             await stateEntry.SetEntityStateAsync(EntityState.Added);
 
-            var relatedStateEntry = new MixedStateEntry(
-                configuration,
+            var relatedStateEntry = factory.Create(
                 model.GetEntityType(typeof(RelatedFakeEntity)), new RelatedFakeEntity { Id = 42 });
             await relatedStateEntry.SetEntityStateAsync(EntityState.Added);
 
@@ -194,14 +197,13 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             var configuration = CreateConfiguration();
             var model = CreateSimpleFKModel();
+            var factory = configuration.ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
 
-            var stateEntry = new MixedStateEntry(
-                configuration,
+            var stateEntry = factory.Create(
                 model.GetEntityType(typeof(FakeEntity)), new FakeEntity { Id = 42, Value = "Test" });
             await stateEntry.SetEntityStateAsync(EntityState.Added);
 
-            var relatedStateEntry = new MixedStateEntry(
-                configuration,
+            var relatedStateEntry = factory.Create(
                 model.GetEntityType(typeof(RelatedFakeEntity)), new RelatedFakeEntity { Id = 42 });
             await relatedStateEntry.SetEntityStateAsync(EntityState.Modified);
 
@@ -217,14 +219,13 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             var configuration = CreateConfiguration();
             var model = CreateSimpleFKModel();
+            var factory = configuration.ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
 
-            var firstStateEntry = new MixedStateEntry(
-                configuration,
+            var firstStateEntry = factory.Create(
                 model.GetEntityType(typeof(FakeEntity)), new FakeEntity { Id = 42, Value = "Test" });
             await firstStateEntry.SetEntityStateAsync(EntityState.Added);
 
-            var secondStateEntry = new MixedStateEntry(
-                configuration,
+            var secondStateEntry = factory.Create(
                 model.GetEntityType(typeof(RelatedFakeEntity)), new RelatedFakeEntity { Id = 1 });
             await secondStateEntry.SetEntityStateAsync(EntityState.Added);
 
@@ -240,19 +241,17 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             var configuration = CreateConfiguration();
             var model = CreateCyclicFKModel();
+            var factory = configuration.ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
 
-            var previousParent = new MixedStateEntry(
-                configuration,
+            var previousParent = factory.Create(
                 model.GetEntityType(typeof(FakeEntity)), new FakeEntity { Id = 42, Value = "Test" });
             await previousParent.SetEntityStateAsync(EntityState.Deleted);
 
-            var newParent = new MixedStateEntry(
-                configuration,
+            var newParent = factory.Create(
                 model.GetEntityType(typeof(FakeEntity)), new FakeEntity { Id = 3, Value = "Test" });
             await newParent.SetEntityStateAsync(EntityState.Added);
 
-            var relatedStateEntry = new MixedStateEntry(
-                configuration,
+            var relatedStateEntry = factory.Create(
                 model.GetEntityType(typeof(RelatedFakeEntity)), new RelatedFakeEntity { Id = 1, RelatedId = 3 });
             await relatedStateEntry.SetEntityStateAsync(EntityState.Modified);
             relatedStateEntry.OriginalValues[relatedStateEntry.EntityType.GetProperty("RelatedId")] = 42;
@@ -270,15 +269,14 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             var configuration = CreateConfiguration();
             var model = CreateSimpleFKModel();
+            var factory = configuration.ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
 
             var fakeEntity = new FakeEntity { Id = 42, Value = "Test" };
-            var stateEntry = new MixedStateEntry(
-                configuration,
+            var stateEntry = factory.Create(
                 model.GetEntityType(typeof(FakeEntity)), fakeEntity);
             await stateEntry.SetEntityStateAsync(EntityState.Added);
 
-            var relatedStateEntry = new MixedStateEntry(
-                configuration,
+            var relatedStateEntry = factory.Create(
                 model.GetEntityType(typeof(RelatedFakeEntity)), new RelatedFakeEntity { Id = 42 });
             await relatedStateEntry.SetEntityStateAsync(EntityState.Added);
 

--- a/test/EntityFramework.Relational.Tests/Update/ModificationCommandComparerTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ModificationCommandComparerTest.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Relational.Update;
+using Microsoft.Framework.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Relational.Tests.Update
@@ -15,24 +16,25 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             var mCC = new ModificationCommandComparer();
 
             var configuration = new DbContext(new DbContextOptions().UseInMemoryStore(persist: false)).Configuration;
+            var factory = configuration.ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
 
             var entityType = new Entity.Metadata.Model().AddEntityType(typeof(object));
             var key = entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
             entityType.GetOrSetPrimaryKey(key);
 
-            var stateEntry1 = new MixedStateEntry(configuration, entityType, new object());
+            var stateEntry1 = factory.Create(entityType, new object());
             stateEntry1[key] = 0;
             stateEntry1.EntityState = EntityState.Added;
             var modificationCommandAdded = new ModificationCommand(new SchemaQualifiedName("A"), new ParameterNameGenerator(), p => p.Relational());
             modificationCommandAdded.AddStateEntry(stateEntry1);
 
-            var stateEntry2 = new MixedStateEntry(configuration, entityType, new object());
+            var stateEntry2 = factory.Create(entityType, new object());
             stateEntry2[key] = 1;
             stateEntry2.EntityState = EntityState.Modified;
             var modificationCommandModified = new ModificationCommand(new SchemaQualifiedName("A"), new ParameterNameGenerator(), p => p.Relational());
             modificationCommandModified.AddStateEntry(stateEntry2);
 
-            var stateEntry3 = new MixedStateEntry(configuration, entityType, new object());
+            var stateEntry3 = factory.Create(entityType, new object());
             stateEntry3[key] = 2;
             stateEntry3.EntityState = EntityState.Deleted;
             var modificationCommandDeleted = new ModificationCommand(new SchemaQualifiedName("A"), new ParameterNameGenerator(), p => p.Relational());

--- a/test/EntityFramework.Tests/ChangeTracking/CompositeEntityKeyFactoryTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/CompositeEntityKeyFactoryTest.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Framework.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.ChangeTracking
@@ -15,11 +16,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
+            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
 
             var random = new Random();
             var entity = new Banana { P1 = 7, P2 = "Ate", P3 = random };
 
-            var entry = new ClrStateEntry(TestHelpers.CreateContextConfiguration(model), type, entity);
+            var entry = factory.Create(type, entity);
 
             var key = (CompositeEntityKey)new CompositeEntityKeyFactory().Create(type, type.GetPrimaryKey().Properties, entry);
 
@@ -31,11 +33,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
+            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
 
             var random = new Random();
             var entity = new Banana { P5 = "Ate", P6 = random };
 
-            var entry = new ClrStateEntry(TestHelpers.CreateContextConfiguration(model), type, entity);
+            var entry = factory.Create(type, entity);
 
             var key = (CompositeEntityKey)new CompositeEntityKeyFactory().Create(
                 type, new[] { type.GetProperty("P6"), type.GetProperty("P5") }, entry);
@@ -48,11 +51,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
+            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
 
             var random = new Random();
             var entity = new Banana { P4 = 7, P5 = "Ate", P6 = random };
 
-            var entry = new ClrStateEntry(TestHelpers.CreateContextConfiguration(model), type, entity);
+            var entry = factory.Create(type, entity);
 
             var sidecar = new RelationshipsSnapshot(entry);
             sidecar[type.GetProperty("P4")] = 77;
@@ -68,11 +72,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
+            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
 
             var random = new Random();
             var entity = new Banana { P1 = 7, P2 = null, P3 = random };
 
-            var entry = new ClrStateEntry(TestHelpers.CreateContextConfiguration(model), type, entity);
+            var entry = factory.Create(type, entity);
 
             Assert.Equal(EntityKey.NullEntityKey, new CompositeEntityKeyFactory().Create(type, type.GetPrimaryKey().Properties, entry));
         }

--- a/test/EntityFramework.Tests/ChangeTracking/SimpleEntityKeyFactoryTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/SimpleEntityKeyFactoryTest.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Framework.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.ChangeTracking
@@ -14,9 +15,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
+            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
 
             var entity = new Banana { P1 = 7, P2 = 8 };
-            var entry = new ClrStateEntry(TestHelpers.CreateContextConfiguration(model), type, entity);
+            var entry = factory.Create(type, entity);
 
             var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>().Create(type, type.GetPrimaryKey().Properties, entry);
 
@@ -28,9 +30,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
+            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
 
             var entity = new Banana { P1 = 7, P2 = 8 };
-            var entry = new ClrStateEntry(TestHelpers.CreateContextConfiguration(model), type, entity);
+            var entry = factory.Create(type, entity);
 
             var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>().Create(
                 type, new[] { type.GetProperty("P2") }, entry);
@@ -43,9 +46,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
+            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
 
             var entity = new Banana { P1 = 7, P2 = null };
-            var entry = new ClrStateEntry(TestHelpers.CreateContextConfiguration(model), type, entity);
+            var entry = factory.Create(type, entity);
 
             Assert.Equal(EntityKey.NullEntityKey, new SimpleEntityKeyFactory<string>().Create(type, new[] { type.GetProperty("P2") }, entry));
         }
@@ -79,9 +83,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
+            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
 
             var entity = new Banana { P1 = 7, P2 = 8 };
-            var entry = new ClrStateEntry(TestHelpers.CreateContextConfiguration(model), type, entity);
+            var entry = factory.Create(type, entity);
 
             var sidecar = new RelationshipsSnapshot(entry);
             sidecar[type.GetProperty("P2")] = "Eaten";
@@ -97,9 +102,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
+            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
 
             var entity = new Banana { P1 = 7, P2 = 8 };
-            var entry = new ClrStateEntry(TestHelpers.CreateContextConfiguration(model), type, entity);
+            var entry = factory.Create(type, entity);
 
             var sidecar = new RelationshipsSnapshot(entry);
 

--- a/test/EntityFramework.Tests/ChangeTracking/SimpleNullableEntityKeyFactoryTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/SimpleNullableEntityKeyFactoryTest.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Framework.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.ChangeTracking
@@ -14,9 +15,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
+            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
 
             var entity = new Banana { P1 = 7 };
-            var entry = new ClrStateEntry(TestHelpers.CreateContextConfiguration(model), type, entity);
+            var entry = factory.Create(type, entity);
 
             var key = (SimpleEntityKey<int>)new SimpleNullableEntityKeyFactory<int, int?>().Create(type, type.GetPrimaryKey().Properties, entry);
 
@@ -28,9 +30,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
+            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
 
             var entity = new Banana { P1 = 7, P2 = null };
-            var entry = new ClrStateEntry(TestHelpers.CreateContextConfiguration(model), type, entity);
+            var entry = factory.Create(type, entity);
 
             Assert.Equal(EntityKey.NullEntityKey, new SimpleNullableEntityKeyFactory<int, int?>().Create(type, new[] { type.GetProperty("P2") }, entry));
         }
@@ -62,9 +65,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
+            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
 
             var entity = new Banana { P1 = 7, P2 = 77 };
-            var entry = new ClrStateEntry(TestHelpers.CreateContextConfiguration(model), type, entity);
+            var entry = factory.Create(type, entity);
 
             var sidecar = new RelationshipsSnapshot(entry);
             sidecar[type.GetProperty("P2")] = 78;
@@ -80,9 +84,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
+            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
 
             var entity = new Banana { P1 = 7, P2 = 77 };
-            var entry = new ClrStateEntry(TestHelpers.CreateContextConfiguration(model), type, entity);
+            var entry = factory.Create(type, entity);
 
             var sidecar = new RelationshipsSnapshot(entry);
 

--- a/test/EntityFramework.Tests/ChangeTracking/StateEntryTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/StateEntryTest.cs
@@ -1144,7 +1144,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             return configuration.Services.ServiceProvider.GetService<StateEntrySubscriber>().SnapshotAndSubscribe(
                 new StateEntryFactory(
                     configuration,
-                    configuration.Services.ServiceProvider.GetService<EntityMaterializerSource>())
+                    configuration.Services.ServiceProvider.GetService<EntityMaterializerSource>(),
+                    configuration.Services.ServiceProvider.GetService<StateEntryMetadataServices>())
                     .Create(entityType, entity));
         }
 
@@ -1153,7 +1154,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             return configuration.Services.ServiceProvider.GetService<StateEntrySubscriber>().SnapshotAndSubscribe(
                 new StateEntryFactory(
                     configuration,
-                    configuration.Services.ServiceProvider.GetService<EntityMaterializerSource>())
+                    configuration.Services.ServiceProvider.GetService<EntityMaterializerSource>(),
+                    configuration.Services.ServiceProvider.GetService<StateEntryMetadataServices>())
                     .Create(entityType, valueReader));
         }
 


### PR DESCRIPTION
This is part of Issue #641 which is about cleaning up the use of DbContextConfiguration. DbContextConfiguration is intended to help resolve dynamic services--that is, services for which the actual type/instance of service to use depends on the current context configuration. However, it has gradually spread throughout the code as a general purpose service locator. This causes dependencies to be hidden and creates a lot of coupling to DbContextConfiguration throughout the code, so I am making a set of changes to help fix this.

A lot of the services used by a StateEntry are about accessing and using metadata related to the entity type. These have been abstracted out so that the StateEntry does not need to use the DbContextConfiguration service locator for these things.
