### PR TITLE
Remove DbContextConfiguration dependency from StateEntry and related classes

### DIFF
--- a/src/EntityFramework/ChangeTracking/ClrStateEntry.cs
+++ b/src/EntityFramework/ChangeTracking/ClrStateEntry.cs
@@ -3,7 +3,6 @@
 
 using System;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 
@@ -23,11 +22,11 @@ namespace Microsoft.Data.Entity.ChangeTracking
         }
 
         public ClrStateEntry(
-            [NotNull] DbContextConfiguration configuration,
+            [NotNull] StateManager stateManager,
             [NotNull] IEntityType entityType,
             [NotNull] StateEntryMetadataServices metadataServices,
             [NotNull] object entity)
-            : base(configuration, entityType, metadataServices)
+            : base(stateManager, entityType, metadataServices)
         {
             Check.NotNull(entity, "entity");
 

--- a/src/EntityFramework/ChangeTracking/IEntityStateListener.cs
+++ b/src/EntityFramework/ChangeTracking/IEntityStateListener.cs
@@ -1,9 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Metadata;
 
 namespace Microsoft.Data.Entity.ChangeTracking
 {
@@ -13,9 +11,5 @@ namespace Microsoft.Data.Entity.ChangeTracking
     {
         void StateChanging([NotNull] StateEntry entry, EntityState newState);
         void StateChanged([NotNull] StateEntry entry, EntityState oldState);
-        void ForeignKeyPropertyChanged([NotNull] StateEntry entry, [NotNull] IProperty property, [CanBeNull] object oldValue, [CanBeNull] object newValue);
-        void NavigationReferenceChanged([NotNull] StateEntry entry, [NotNull] INavigation property, [CanBeNull] object oldValue, [CanBeNull] object newValue);
-        void NavigationCollectionChanged([NotNull] StateEntry entry, [NotNull] INavigation navigation, [NotNull] ISet<object> added, [NotNull] ISet<object> removed);
-        void PrincipalKeyPropertyChanged([NotNull] StateEntry entry, [NotNull] IProperty property, [CanBeNull] object oldValue, [CanBeNull] object newValue);
     }
 }

--- a/src/EntityFramework/ChangeTracking/IPropertyListener.cs
+++ b/src/EntityFramework/ChangeTracking/IPropertyListener.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.ChangeTracking
+{
+    public interface IPropertyListener
+    {
+        void SidecarPropertyChanged([NotNull] StateEntry entry, [NotNull] IPropertyBase property);
+        void SidecarPropertyChanging([NotNull] StateEntry entry, [NotNull] IPropertyBase property);
+        void PropertyChanged([NotNull] StateEntry entry, [NotNull] IPropertyBase property);
+        void PropertyChanging([NotNull] StateEntry entry, [NotNull] IPropertyBase property);
+    }
+}

--- a/src/EntityFramework/ChangeTracking/IRelationshipListener.cs
+++ b/src/EntityFramework/ChangeTracking/IRelationshipListener.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Metadata;
+
+namespace Microsoft.Data.Entity.ChangeTracking
+{
+    public interface IRelationshipListener
+    {
+        void ForeignKeyPropertyChanged([NotNull] StateEntry entry, [NotNull] IProperty property, [CanBeNull] object oldValue, [CanBeNull] object newValue);
+        void NavigationReferenceChanged([NotNull] StateEntry entry, [NotNull] INavigation property, [CanBeNull] object oldValue, [CanBeNull] object newValue);
+        void NavigationCollectionChanged([NotNull] StateEntry entry, [NotNull] INavigation navigation, [NotNull] ISet<object> added, [NotNull] ISet<object> removed);
+        void PrincipalKeyPropertyChanged([NotNull] StateEntry entry, [NotNull] IProperty property, [CanBeNull] object oldValue, [CanBeNull] object newValue);
+    }
+}

--- a/src/EntityFramework/ChangeTracking/MixedStateEntry.cs
+++ b/src/EntityFramework/ChangeTracking/MixedStateEntry.cs
@@ -3,7 +3,6 @@
 
 using System;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 
@@ -24,11 +23,11 @@ namespace Microsoft.Data.Entity.ChangeTracking
         }
 
         public MixedStateEntry(
-            [NotNull] DbContextConfiguration configuration,
+            [NotNull] StateManager stateManager,
             [NotNull] IEntityType entityType,
             [NotNull] StateEntryMetadataServices metadataServices,
             [NotNull] object entity)
-            : base(configuration, entityType, metadataServices)
+            : base(stateManager, entityType, metadataServices)
         {
             Check.NotNull(entity, "entity");
 
@@ -37,12 +36,12 @@ namespace Microsoft.Data.Entity.ChangeTracking
         }
 
         public MixedStateEntry(
-            [NotNull] DbContextConfiguration configuration,
+            [NotNull] StateManager stateManager,
             [NotNull] IEntityType entityType,
             [NotNull] StateEntryMetadataServices metadataServices,
             [NotNull] object entity,
             [NotNull] IValueReader valueReader)
-            : base(configuration, entityType, metadataServices)
+            : base(stateManager, entityType, metadataServices)
         {
             Check.NotNull(entity, "entity");
             Check.NotNull(valueReader, "valueReader");

--- a/src/EntityFramework/ChangeTracking/ShadowStateEntry.cs
+++ b/src/EntityFramework/ChangeTracking/ShadowStateEntry.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics.Contracts;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 
@@ -29,20 +28,20 @@ namespace Microsoft.Data.Entity.ChangeTracking
         }
 
         public ShadowStateEntry(
-            [NotNull] DbContextConfiguration configuration,
+            [NotNull] StateManager stateManager,
             [NotNull] IEntityType entityType,
             [NotNull] StateEntryMetadataServices metadataServices)
-            : base(configuration, entityType, metadataServices)
+            : base(stateManager, entityType, metadataServices)
         {
             _propertyValues = new object[entityType.ShadowPropertyCount];
         }
 
         public ShadowStateEntry(
-            [NotNull] DbContextConfiguration configuration,
+            [NotNull] StateManager stateManager,
             [NotNull] IEntityType entityType,
             [NotNull] StateEntryMetadataServices metadataServices,
             [NotNull] IValueReader valueReader)
-            : base(configuration, entityType, metadataServices)
+            : base(stateManager, entityType, metadataServices)
         {
             Check.NotNull(valueReader, "valueReader");
 

--- a/src/EntityFramework/ChangeTracking/StateEntryFactory.cs
+++ b/src/EntityFramework/ChangeTracking/StateEntryFactory.cs
@@ -3,7 +3,6 @@
 
 using System;
 using JetBrains.Annotations;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 
@@ -11,10 +10,8 @@ namespace Microsoft.Data.Entity.ChangeTracking
 {
     public class StateEntryFactory
     {
-        private readonly DbContextConfiguration _configuration;
         private readonly EntityMaterializerSource _materializerSource;
         private readonly StateEntryMetadataServices _metadataServices;
-
 
         /// <summary>
         ///     This constructor is intended only for use when creating test doubles that will override members
@@ -26,82 +23,91 @@ namespace Microsoft.Data.Entity.ChangeTracking
         }
 
         public StateEntryFactory(
-            [NotNull] DbContextConfiguration configuration,
             [NotNull] EntityMaterializerSource materializerSource,
             [NotNull] StateEntryMetadataServices metadataServices)
         {
-            Check.NotNull(configuration, "configuration");
             Check.NotNull(materializerSource, "materializerSource");
             Check.NotNull(metadataServices, "metadataServices");
 
-            _configuration = configuration;
             _materializerSource = materializerSource;
             _metadataServices = metadataServices;
         }
 
-        public virtual StateEntry Create([NotNull] IEntityType entityType, [CanBeNull] object entity)
+        public virtual StateEntry Create(
+            [NotNull] StateManager stateManager,
+            [NotNull] IEntityType entityType,
+            [CanBeNull] object entity)
         {
+            Check.NotNull(stateManager, "stateManager");
             Check.NotNull(entityType, "entityType");
 
-            return NewStateEntry(entityType, entity);
-        }
-
-        public virtual StateEntry Create([NotNull] IEntityType entityType, [NotNull] IValueReader valueReader)
-        {
-            Check.NotNull(entityType, "entityType");
-            Check.NotNull(valueReader, "valueReader");
-
-            return NewStateEntry(entityType, valueReader);
+            return NewStateEntry(stateManager, entityType, entity);
         }
 
         public virtual StateEntry Create(
-            [NotNull] IEntityType entityType, [NotNull] object entity, [NotNull] IValueReader valueReader)
+            [NotNull] StateManager stateManager,
+            [NotNull] IEntityType entityType,
+            [NotNull] IValueReader valueReader)
         {
+            Check.NotNull(stateManager, "stateManager");
+            Check.NotNull(entityType, "entityType");
+            Check.NotNull(valueReader, "valueReader");
+
+            return NewStateEntry(stateManager, entityType, valueReader);
+        }
+
+        public virtual StateEntry Create(
+            [NotNull] StateManager stateManager,
+            [NotNull] IEntityType entityType,
+            [NotNull] object entity,
+            [NotNull] IValueReader valueReader)
+        {
+            Check.NotNull(stateManager, "stateManager");
             Check.NotNull(entityType, "entityType");
             Check.NotNull(entity, "entity");
             Check.NotNull(valueReader, "valueReader");
 
-            return NewStateEntry(entityType, entity, valueReader);
+            return NewStateEntry(stateManager, entityType, entity, valueReader);
         }
 
-        private StateEntry NewStateEntry(IEntityType entityType, object entity)
+        private StateEntry NewStateEntry(StateManager stateManager, IEntityType entityType, object entity)
         {
             if (!entityType.HasClrType)
             {
-                return new ShadowStateEntry(_configuration, entityType, _metadataServices);
+                return new ShadowStateEntry(stateManager, entityType, _metadataServices);
             }
 
             Check.NotNull(entity, "entity");
 
             return entityType.ShadowPropertyCount > 0
-                ? (StateEntry)new MixedStateEntry(_configuration, entityType, _metadataServices, entity)
-                : new ClrStateEntry(_configuration, entityType, _metadataServices, entity);
+                ? (StateEntry)new MixedStateEntry(stateManager, entityType, _metadataServices, entity)
+                : new ClrStateEntry(stateManager, entityType, _metadataServices, entity);
         }
 
-        private StateEntry NewStateEntry(IEntityType entityType, IValueReader valueReader)
+        private StateEntry NewStateEntry(StateManager stateManager, IEntityType entityType, IValueReader valueReader)
         {
             if (!entityType.HasClrType)
             {
-                return new ShadowStateEntry(_configuration, entityType, _metadataServices, valueReader);
+                return new ShadowStateEntry(stateManager, entityType, _metadataServices, valueReader);
             }
 
             var entity = _materializerSource.GetMaterializer(entityType)(valueReader);
 
             return entityType.ShadowPropertyCount > 0
-                ? (StateEntry)new MixedStateEntry(_configuration, entityType, _metadataServices, entity, valueReader)
-                : new ClrStateEntry(_configuration, entityType, _metadataServices, entity);
+                ? (StateEntry)new MixedStateEntry(stateManager, entityType, _metadataServices, entity, valueReader)
+                : new ClrStateEntry(stateManager, entityType, _metadataServices, entity);
         }
 
-        private StateEntry NewStateEntry(IEntityType entityType, object entity, IValueReader valueReader)
+        private StateEntry NewStateEntry(StateManager stateManager, IEntityType entityType, object entity, IValueReader valueReader)
         {
             if (!entityType.HasClrType)
             {
-                return new ShadowStateEntry(_configuration, entityType, _metadataServices, valueReader);
+                return new ShadowStateEntry(stateManager, entityType, _metadataServices, valueReader);
             }
 
             return entityType.ShadowPropertyCount > 0
-                ? (StateEntry)new MixedStateEntry(_configuration, entityType, _metadataServices, entity, valueReader)
-                : new ClrStateEntry(_configuration, entityType, _metadataServices, entity);
+                ? (StateEntry)new MixedStateEntry(stateManager, entityType, _metadataServices, entity, valueReader)
+                : new ClrStateEntry(stateManager, entityType, _metadataServices, entity);
         }
     }
 }

--- a/src/EntityFramework/ChangeTracking/StateEntrySubscriber.cs
+++ b/src/EntityFramework/ChangeTracking/StateEntrySubscriber.cs
@@ -11,13 +11,13 @@ namespace Microsoft.Data.Entity.ChangeTracking
 {
     public class StateEntrySubscriber
     {
-        private readonly ChangeDetector _changeDetector;
+        private readonly StateEntryNotifier _notifier;
 
-        public StateEntrySubscriber([NotNull] ChangeDetector changeDetector)
+        public StateEntrySubscriber([NotNull] StateEntryNotifier notifier)
         {
-            Check.NotNull(changeDetector, "changeDetector");
+            Check.NotNull(notifier, "notifier");
 
-            _changeDetector = changeDetector;
+            _notifier = notifier;
         }
 
         public virtual StateEntry SnapshotAndSubscribe([NotNull] StateEntry entry)
@@ -34,26 +34,26 @@ namespace Microsoft.Data.Entity.ChangeTracking
             if (changing != null)
             {
                 changing.PropertyChanging += (s, e) =>
+                {
+                    var property = TryGetPropertyBase(entityType, e.PropertyName);
+                    if (property != null)
                     {
-                        var property = TryGetPropertyBase(entityType, e.PropertyName);
-                        if (property != null)
-                        {
-                            _changeDetector.PropertyChanging(entry, property);
-                        }
-                    };
+                        _notifier.PropertyChanging(entry, property);
+                    }
+                };
             }
 
             var changed = entry.Entity as INotifyPropertyChanged;
             if (changed != null)
             {
                 changed.PropertyChanged += (s, e) =>
+                {
+                    var property = TryGetPropertyBase(entityType, e.PropertyName);
+                    if (property != null)
                     {
-                        var property = TryGetPropertyBase(entityType, e.PropertyName);
-                        if (property != null)
-                        {
-                            _changeDetector.PropertyChanged(entry, property);
-                        }
-                    };
+                        _notifier.PropertyChanged(entry, property);
+                    }
+                };
             }
 
             return entry;

--- a/src/EntityFramework/EntityFramework.csproj
+++ b/src/EntityFramework/EntityFramework.csproj
@@ -64,6 +64,8 @@
       <Link>LoggingExtensions.cs</Link>
     </Compile>
     <Compile Include="ChangeTracking\ChangeDetector.cs" />
+    <Compile Include="ChangeTracking\IPropertyListener.cs" />
+    <Compile Include="ChangeTracking\IRelationshipListener.cs" />
     <Compile Include="ChangeTracking\PropertyBagEntryExtensions.cs" />
     <Compile Include="ChangeTracking\RelationshipsSnapshot.cs" />
     <Compile Include="ChangeTracking\RelationshipsSnapshotFactory.cs" />

--- a/src/EntityFramework/Extensions/EntityServiceCollectionExtensions.cs
+++ b/src/EntityFramework/Extensions/EntityServiceCollectionExtensions.cs
@@ -54,9 +54,13 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddSingleton<StateEntryMetadataServices>()
                 .AddScoped<DataStoreSelector>()
                 .AddScoped<StateEntryFactory>()
-                .AddScoped<IEntityStateListener, NavigationFixer>()
-                .AddScoped<StateEntryNotifier>()
+                .AddScoped<NavigationFixer>()
                 .AddScoped<ChangeDetector>()
+                // TODO: Is this the appropriate way to register listeners?
+                .AddScoped<IEntityStateListener>(p => p.GetService<NavigationFixer>())
+                .AddScoped<IRelationshipListener>(p => p.GetService<NavigationFixer>())
+                .AddScoped<IPropertyListener>(p => p.GetService<ChangeDetector>())
+                .AddScoped<StateEntryNotifier>()
                 .AddScoped<StateEntrySubscriber>()
                 .AddScoped<DbContextConfiguration>()
                 .AddScoped<ContextSets>()
@@ -124,9 +128,9 @@ namespace Microsoft.Framework.DependencyInjection
                 // TODO: Allows parser to be obtained from service provider. Issue #947
                 builder.ServiceCollection.ConfigureOptions(
                     new DbContextConfigureOptions<TContext>(builder.Configuration, new DbContextOptionsParser())
-                        {
-                            Order = ConfigurationOrder
-                        });
+                    {
+                        Order = ConfigurationOrder
+                    });
             }
 
             if (optionsAction != null)

--- a/src/EntityFramework/Identity/ForeignKeyValuePropagator.cs
+++ b/src/EntityFramework/Identity/ForeignKeyValuePropagator.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Data.Entity.Identity
             Contract.Assert(property.IsForeignKey());
 
             var entityType = property.EntityType;
-            var stateManager = stateEntry.Configuration.StateManager;
+            var stateManager = stateEntry.StateManager;
 
             foreach (var foreignKey in entityType.ForeignKeys)
             {

--- a/test/EntityFramework.FunctionalTests/ThrowingMonsterStateManager.cs
+++ b/test/EntityFramework.FunctionalTests/ThrowingMonsterStateManager.cs
@@ -6,19 +6,23 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.ChangeTracking;
-using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.FunctionalTests
 {
     public class ThrowingMonsterStateManager : StateManager
     {
         public ThrowingMonsterStateManager(
-            DbContextConfiguration configuration,
             StateEntryFactory factory,
             EntityKeyFactorySource entityKeyFactorySource,
             StateEntrySubscriber subscriber,
-            ValueGenerationManager valueGeneration)
-            : base(configuration, factory, entityKeyFactorySource, subscriber, valueGeneration)
+            StateEntryNotifier notifier,
+            ValueGenerationManager valueGeneration,
+            LazyRef<IModel> model,
+            LazyRef<DataStore> dataStore)
+            : base(factory, entityKeyFactorySource, subscriber, notifier, valueGeneration, model, dataStore)
         {
         }
 

--- a/test/EntityFramework.Relational.Tests/Update/ModificationCommandComparerTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ModificationCommandComparerTest.cs
@@ -13,32 +13,34 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         [Fact]
         public void Compare_returns_0_only_for_commands_that_are_equal()
         {
-            var mCC = new ModificationCommandComparer();
+            var model = new Entity.Metadata.Model();
+            var entityType = model.AddEntityType(typeof(object));
 
-            var configuration = new DbContext(new DbContextOptions().UseInMemoryStore(persist: false)).Configuration;
-            var factory = configuration.ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
+            var configuration = new DbContext(new DbContextOptions().UseModel(model).UseInMemoryStore(persist: false)).Configuration;
+            var stateManager = configuration.ScopedServiceProvider.GetRequiredService<StateManager>();
 
-            var entityType = new Entity.Metadata.Model().AddEntityType(typeof(object));
             var key = entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true);
             entityType.GetOrSetPrimaryKey(key);
 
-            var stateEntry1 = factory.Create(entityType, new object());
+            var stateEntry1 = stateManager.GetOrCreateEntry(new object());
             stateEntry1[key] = 0;
             stateEntry1.EntityState = EntityState.Added;
             var modificationCommandAdded = new ModificationCommand(new SchemaQualifiedName("A"), new ParameterNameGenerator(), p => p.Relational());
             modificationCommandAdded.AddStateEntry(stateEntry1);
 
-            var stateEntry2 = factory.Create(entityType, new object());
+            var stateEntry2 = stateManager.GetOrCreateEntry(new object());
             stateEntry2[key] = 1;
             stateEntry2.EntityState = EntityState.Modified;
             var modificationCommandModified = new ModificationCommand(new SchemaQualifiedName("A"), new ParameterNameGenerator(), p => p.Relational());
             modificationCommandModified.AddStateEntry(stateEntry2);
 
-            var stateEntry3 = factory.Create(entityType, new object());
+            var stateEntry3 = stateManager.GetOrCreateEntry(new object());
             stateEntry3[key] = 2;
             stateEntry3.EntityState = EntityState.Deleted;
             var modificationCommandDeleted = new ModificationCommand(new SchemaQualifiedName("A"), new ParameterNameGenerator(), p => p.Relational());
             modificationCommandDeleted.AddStateEntry(stateEntry3);
+
+            var mCC = new ModificationCommandComparer();
 
             Assert.True(0 == mCC.Compare(modificationCommandAdded, modificationCommandAdded));
             Assert.True(0 == mCC.Compare(null, null));

--- a/test/EntityFramework.Relational.Tests/Update/ModificationCommandTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ModificationCommandTest.cs
@@ -393,8 +393,8 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             bool computeNonKeyValue = false)
         {
             var model = BuildModel(generateKeyValues, computeNonKeyValue);
-            var stateEntry = CreateConfiguration(model).Services.StateEntryFactory.Create(
-                model.GetEntityType(typeof(T1).FullName), new T1 { Id = 1, Name = "Test" });
+            var stateEntry = CreateConfiguration(model).ScopedServiceProvider.GetService<StateManager>().GetOrCreateEntry(
+                new T1 { Id = 1, Name = "Test" });
             stateEntry.EntityState = entityState;
             return stateEntry;
         }

--- a/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -596,8 +596,8 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             bool computeNonKeyValue = false)
         {
             var model = BuildModel(generateKeyValues, computeNonKeyValue);
-            var stateEntry = CreateConfiguration(model).Services.StateEntryFactory.Create(
-                model.GetEntityType(typeof(T1).FullName), new T1 { Id = 1, Name = "Test" });
+            var stateEntry = CreateConfiguration(model).ScopedServiceProvider.GetService<StateManager>().GetOrCreateEntry(
+                new T1 { Id = 1, Name = "Test" });
             stateEntry.EntityState = entityState;
             return stateEntry;
         }

--- a/test/EntityFramework.Tests/ChangeTracking/ChangeDetectorTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/ChangeDetectorTest.cs
@@ -4,6 +4,9 @@
 using System;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Utilities;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
 using Moq;
 using Xunit;
 
@@ -14,8 +17,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         [Fact]
         public void Detects_principal_key_change()
         {
+            var notifierMock = new Mock<StateEntryNotifier>();
             var model = BuildModel();
-            var configuration = TestHelpers.CreateContextConfiguration(model);
+            var configuration = TestHelpers.CreateContextConfiguration(CreateServiceProvider(notifierMock.Object), model);
             var stateManager = configuration.Services.StateManager;
 
             var entityType = model.GetEntityType(typeof(Category));
@@ -26,8 +30,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             principalEntry.RelationshipsSnapshot[keyProperty] = 77;
             principalEntry.EntityState = EntityState.Added;
 
-            var notifierMock = new Mock<StateEntryNotifier>();
-            var changeDetector = new ChangeDetector(configuration, notifierMock.Object);
+            var changeDetector = new ChangeDetector(new LazyRef<IModel>(model));
 
             Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
 
@@ -43,8 +46,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         [Fact]
         public void Reacts_to_principal_key_change_in_sidecar()
         {
+            var notifierMock = new Mock<StateEntryNotifier>();
             var model = BuildModel();
-            var configuration = TestHelpers.CreateContextConfiguration(model);
+            var configuration = TestHelpers.CreateContextConfiguration(CreateServiceProvider(notifierMock.Object), model);
             var stateManager = configuration.Services.StateManager;
 
             var entityType = model.GetEntityType(typeof(Category));
@@ -55,8 +59,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             principalEntry.RelationshipsSnapshot[keyProperty] = 77;
             principalEntry.EntityState = EntityState.Added;
 
-            var notifierMock = new Mock<StateEntryNotifier>();
-            var changeDetector = new ChangeDetector(configuration, notifierMock.Object);
+            var changeDetector = new ChangeDetector(new LazyRef<IModel>(model));
 
             Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
 
@@ -72,8 +75,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         [Fact]
         public void Detects_primary_key_change()
         {
+            var notifierMock = new Mock<StateEntryNotifier>();
             var model = BuildModel();
-            var configuration = TestHelpers.CreateContextConfiguration(model);
+            var configuration = TestHelpers.CreateContextConfiguration(CreateServiceProvider(notifierMock.Object), model);
             var stateManager = configuration.Services.StateManager;
 
             var entityType = model.GetEntityType(typeof(Category));
@@ -84,8 +88,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             principalEntry.RelationshipsSnapshot[keyProperty] = -1;
             principalEntry.EntityState = EntityState.Added;
 
-            var notifierMock = new Mock<StateEntryNotifier>();
-            var changeDetector = new ChangeDetector(configuration, notifierMock.Object);
+            var changeDetector = new ChangeDetector(new LazyRef<IModel>(model));
 
             Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
 
@@ -101,8 +104,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         [Fact]
         public void Reacts_to_primary_key_change_in_sidecar()
         {
+            var notifierMock = new Mock<StateEntryNotifier>();
             var model = BuildModel();
-            var configuration = TestHelpers.CreateContextConfiguration(model);
+            var configuration = TestHelpers.CreateContextConfiguration(CreateServiceProvider(notifierMock.Object), model);
             var stateManager = configuration.Services.StateManager;
 
             var entityType = model.GetEntityType(typeof(Category));
@@ -113,8 +117,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             principalEntry.RelationshipsSnapshot[keyProperty] = -1;
             principalEntry.EntityState = EntityState.Added;
 
-            var notifierMock = new Mock<StateEntryNotifier>();
-            var changeDetector = new ChangeDetector(configuration, notifierMock.Object);
+            var changeDetector = new ChangeDetector(new LazyRef<IModel>(model));
 
             Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
 
@@ -130,8 +133,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         [Fact]
         public void Ignores_non_principal_key_change()
         {
+            var notifierMock = new Mock<StateEntryNotifier>();
             var model = BuildModel();
-            var configuration = TestHelpers.CreateContextConfiguration(model);
+            var configuration = TestHelpers.CreateContextConfiguration(CreateServiceProvider(notifierMock.Object), model);
             var stateManager = configuration.Services.StateManager;
 
             var entityType = model.GetEntityType(typeof(Category));
@@ -142,8 +146,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             principalEntry.RelationshipsSnapshot[property] = "Blue";
             principalEntry.EntityState = EntityState.Added;
 
-            var notifierMock = new Mock<StateEntryNotifier>();
-            var changeDetector = new ChangeDetector(configuration, notifierMock.Object);
+            var changeDetector = new ChangeDetector(new LazyRef<IModel>(model));
 
             Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
 
@@ -160,8 +163,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         [Fact]
         public void Ignores_non_principal_key_change_in_sidecar()
         {
+            var notifierMock = new Mock<StateEntryNotifier>();
             var model = BuildModel();
-            var configuration = TestHelpers.CreateContextConfiguration(model);
+            var configuration = TestHelpers.CreateContextConfiguration(CreateServiceProvider(notifierMock.Object), model);
             var stateManager = configuration.Services.StateManager;
 
             var entityType = model.GetEntityType(typeof(Category));
@@ -172,8 +176,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             principalEntry.RelationshipsSnapshot[property] = "Blue";
             principalEntry.EntityState = EntityState.Added;
 
-            var notifierMock = new Mock<StateEntryNotifier>();
-            var changeDetector = new ChangeDetector(configuration, notifierMock.Object);
+            var changeDetector = new ChangeDetector(new LazyRef<IModel>(model));
 
             Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
 
@@ -190,8 +193,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         [Fact]
         public void Ignores_no_change_to_principal_key()
         {
+            var notifierMock = new Mock<StateEntryNotifier>();
             var model = BuildModel();
-            var configuration = TestHelpers.CreateContextConfiguration(model);
+            var configuration = TestHelpers.CreateContextConfiguration(CreateServiceProvider(notifierMock.Object), model);
             var stateManager = configuration.Services.StateManager;
 
             var entityType = model.GetEntityType(typeof(Category));
@@ -202,8 +206,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             principalEntry.RelationshipsSnapshot[keyProperty] = 77;
             principalEntry.EntityState = EntityState.Added;
 
-            var notifierMock = new Mock<StateEntryNotifier>();
-            var changeDetector = new ChangeDetector(configuration, notifierMock.Object);
+            var changeDetector = new ChangeDetector(new LazyRef<IModel>(model));
 
             Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
 
@@ -219,8 +222,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         [Fact]
         public void Ignores_no_change_to_principal_key_in_sidecar()
         {
+            var notifierMock = new Mock<StateEntryNotifier>();
             var model = BuildModel();
-            var configuration = TestHelpers.CreateContextConfiguration(model);
+            var configuration = TestHelpers.CreateContextConfiguration(CreateServiceProvider(notifierMock.Object), model);
             var stateManager = configuration.Services.StateManager;
 
             var entityType = model.GetEntityType(typeof(Category));
@@ -231,8 +235,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             principalEntry.RelationshipsSnapshot[keyProperty] = 77;
             principalEntry.EntityState = EntityState.Added;
 
-            var notifierMock = new Mock<StateEntryNotifier>();
-            var changeDetector = new ChangeDetector(configuration, notifierMock.Object);
+            var changeDetector = new ChangeDetector(new LazyRef<IModel>(model));
 
             Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
 
@@ -274,6 +277,16 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             productType.GetOrAddForeignKey(productType.GetProperty("DependentId"), new Key(new[] { categoryType.GetProperty("PrincipalId") }));
 
             return model;
+        }
+
+        public static IServiceProvider CreateServiceProvider(StateEntryNotifier notifier)
+        {
+            return new ServiceCollection()
+                .AddEntityFramework()
+                .AddInMemoryStore()
+                .ServiceCollection
+                .AddInstance(notifier)
+                .BuildServiceProvider();
         }
     }
 }

--- a/test/EntityFramework.Tests/ChangeTracking/CompositeEntityKeyFactoryTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/CompositeEntityKeyFactoryTest.cs
@@ -16,12 +16,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
-            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
+            var stateManager = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateManager>();
 
             var random = new Random();
             var entity = new Banana { P1 = 7, P2 = "Ate", P3 = random };
 
-            var entry = factory.Create(type, entity);
+            var entry = stateManager.GetOrCreateEntry(entity);
 
             var key = (CompositeEntityKey)new CompositeEntityKeyFactory().Create(type, type.GetPrimaryKey().Properties, entry);
 
@@ -33,12 +33,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
-            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
+            var stateManager = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateManager>();
 
             var random = new Random();
             var entity = new Banana { P5 = "Ate", P6 = random };
 
-            var entry = factory.Create(type, entity);
+            var entry = stateManager.GetOrCreateEntry(entity);
 
             var key = (CompositeEntityKey)new CompositeEntityKeyFactory().Create(
                 type, new[] { type.GetProperty("P6"), type.GetProperty("P5") }, entry);
@@ -51,12 +51,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
-            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
+            var stateManager = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateManager>();
 
             var random = new Random();
             var entity = new Banana { P4 = 7, P5 = "Ate", P6 = random };
 
-            var entry = factory.Create(type, entity);
+            var entry = stateManager.GetOrCreateEntry(entity);
 
             var sidecar = new RelationshipsSnapshot(entry);
             sidecar[type.GetProperty("P4")] = 77;
@@ -72,12 +72,12 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
-            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
+            var stateManager = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateManager>();
 
             var random = new Random();
             var entity = new Banana { P1 = 7, P2 = null, P3 = random };
 
-            var entry = factory.Create(type, entity);
+            var entry = stateManager.GetOrCreateEntry(entity);
 
             Assert.Equal(EntityKey.NullEntityKey, new CompositeEntityKeyFactory().Create(type, type.GetPrimaryKey().Properties, entry));
         }

--- a/test/EntityFramework.Tests/ChangeTracking/NavigationFixerTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/NavigationFixerTest.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Framework.DependencyInjection;
 using Moq;
 using Xunit;
 
@@ -988,7 +989,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
 
         private static NavigationFixer CreateNavigationFixer(DbContextConfiguration contextConfiguration)
         {
-            return new NavigationFixer(contextConfiguration, new ClrPropertyGetterSource(), new ClrPropertySetterSource(), new ClrCollectionAccessorSource(new CollectionTypeFactory()));
+            return (NavigationFixer)contextConfiguration.ScopedServiceProvider.GetService<IEntityStateListener>();
         }
     }
 }

--- a/test/EntityFramework.Tests/ChangeTracking/RelationshipsSnapshotTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/RelationshipsSnapshotTest.cs
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using System.Linq;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Framework.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.ChangeTracking
@@ -285,9 +286,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             entity = entity ?? new Banana { Id = 77 };
 
-            var configuration = TestHelpers.CreateContextConfiguration(BuildModel());
+            var configuration = TestHelpers.CreateContextConfiguration(_model);
 
-            return configuration.Services.StateEntryFactory.Create(_model.GetEntityType(typeof(Banana)), entity);
+            return configuration.ScopedServiceProvider.GetService<StateManager>().GetOrCreateEntry(entity);
         }
 
         private static Model BuildModel()

--- a/test/EntityFramework.Tests/ChangeTracking/SimpleEntityKeyFactoryTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/SimpleEntityKeyFactoryTest.cs
@@ -15,10 +15,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
-            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
+            var stateManager = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateManager>();
 
             var entity = new Banana { P1 = 7, P2 = 8 };
-            var entry = factory.Create(type, entity);
+            var entry = stateManager.GetOrCreateEntry(entity);
 
             var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>().Create(type, type.GetPrimaryKey().Properties, entry);
 
@@ -30,10 +30,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
-            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
+            var stateManager = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateManager>();
 
             var entity = new Banana { P1 = 7, P2 = 8 };
-            var entry = factory.Create(type, entity);
+            var entry = stateManager.GetOrCreateEntry(entity);
 
             var key = (SimpleEntityKey<int>)new SimpleEntityKeyFactory<int>().Create(
                 type, new[] { type.GetProperty("P2") }, entry);
@@ -46,10 +46,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
-            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
+            var stateManager = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateManager>();
 
             var entity = new Banana { P1 = 7, P2 = null };
-            var entry = factory.Create(type, entity);
+            var entry = stateManager.GetOrCreateEntry(entity);
 
             Assert.Equal(EntityKey.NullEntityKey, new SimpleEntityKeyFactory<string>().Create(type, new[] { type.GetProperty("P2") }, entry));
         }
@@ -83,10 +83,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
-            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
+            var stateManager = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateManager>();
 
             var entity = new Banana { P1 = 7, P2 = 8 };
-            var entry = factory.Create(type, entity);
+            var entry = stateManager.GetOrCreateEntry(entity);
 
             var sidecar = new RelationshipsSnapshot(entry);
             sidecar[type.GetProperty("P2")] = "Eaten";
@@ -102,10 +102,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
-            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
+            var stateManager = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateManager>();
 
             var entity = new Banana { P1 = 7, P2 = 8 };
-            var entry = factory.Create(type, entity);
+            var entry = stateManager.GetOrCreateEntry(entity);
 
             var sidecar = new RelationshipsSnapshot(entry);
 

--- a/test/EntityFramework.Tests/ChangeTracking/SimpleNullableEntityKeyFactoryTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/SimpleNullableEntityKeyFactoryTest.cs
@@ -15,10 +15,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
-            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
+            var stateManager = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateManager>();
 
             var entity = new Banana { P1 = 7 };
-            var entry = factory.Create(type, entity);
+            var entry = stateManager.GetOrCreateEntry(entity);
 
             var key = (SimpleEntityKey<int>)new SimpleNullableEntityKeyFactory<int, int?>().Create(type, type.GetPrimaryKey().Properties, entry);
 
@@ -30,10 +30,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
-            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
+            var stateManager = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateManager>();
 
             var entity = new Banana { P1 = 7, P2 = null };
-            var entry = factory.Create(type, entity);
+            var entry = stateManager.GetOrCreateEntry(entity);
 
             Assert.Equal(EntityKey.NullEntityKey, new SimpleNullableEntityKeyFactory<int, int?>().Create(type, new[] { type.GetProperty("P2") }, entry));
         }
@@ -65,10 +65,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
-            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
+            var stateManager = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateManager>();
 
             var entity = new Banana { P1 = 7, P2 = 77 };
-            var entry = factory.Create(type, entity);
+            var entry = stateManager.GetOrCreateEntry(entity);
 
             var sidecar = new RelationshipsSnapshot(entry);
             sidecar[type.GetProperty("P2")] = 78;
@@ -84,10 +84,10 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var model = BuildModel();
             var type = model.GetEntityType(typeof(Banana));
-            var factory = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
+            var stateManager = TestHelpers.CreateContextConfiguration(model).ScopedServiceProvider.GetRequiredService<StateManager>();
 
             var entity = new Banana { P1 = 7, P2 = 77 };
-            var entry = factory.Create(type, entity);
+            var entry = stateManager.GetOrCreateEntry(entity);
 
             var sidecar = new RelationshipsSnapshot(entry);
 

--- a/test/EntityFramework.Tests/ChangeTracking/StateEntryFactoryTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/StateEntryFactoryTest.cs
@@ -20,14 +20,14 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entityType.GetOrAddProperty("Hammer", typeof(string), shadowProperty: true);
 
             var configuration = TestHelpers.CreateContextConfiguration(model);
-
+            var stateManager = configuration.ScopedServiceProvider.GetRequiredService<StateManager>();
             var factory = configuration.ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
 
-            var entry = factory.Create(entityType, new Random());
+            var entry = factory.Create(stateManager, entityType, new Random());
 
             Assert.IsType<ShadowStateEntry>(entry);
 
-            Assert.Same(configuration, entry.Configuration);
+            Assert.Same(stateManager, entry.StateManager);
             Assert.Same(entityType, entry.EntityType);
             Assert.Null(entry.Entity);
         }
@@ -41,15 +41,15 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entityType.GetOrAddProperty("Hammer", typeof(string));
 
             var configuration = TestHelpers.CreateContextConfiguration(model);
-
+            var stateManager = configuration.ScopedServiceProvider.GetRequiredService<StateManager>();
             var factory = configuration.ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
 
             var entity = new RedHook();
-            var entry = factory.Create(entityType, entity);
+            var entry = factory.Create(stateManager, entityType, entity);
 
             Assert.IsType<ClrStateEntry>(entry);
 
-            Assert.Same(configuration, entry.Configuration);
+            Assert.Same(stateManager, entry.StateManager);
             Assert.Same(entityType, entry.EntityType);
             Assert.Same(entity, entry.Entity);
         }
@@ -63,15 +63,15 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entityType.GetOrAddProperty("Hammer", typeof(string), shadowProperty: true);
 
             var configuration = TestHelpers.CreateContextConfiguration(model);
-
+            var stateManager = configuration.ScopedServiceProvider.GetRequiredService<StateManager>();
             var factory = configuration.ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
 
             var entity = new RedHook();
-            var entry = factory.Create(entityType, entity);
+            var entry = factory.Create(stateManager, entityType, entity);
 
             Assert.IsType<MixedStateEntry>(entry);
 
-            Assert.Same(configuration, entry.Configuration);
+            Assert.Same(stateManager, entry.StateManager);
             Assert.Same(entityType, entry.EntityType);
             Assert.Same(entity, entry.Entity);
         }
@@ -85,13 +85,13 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var property2 = entityType.GetOrAddProperty("Hammer", typeof(string), shadowProperty: true);
 
             var configuration = TestHelpers.CreateContextConfiguration(model);
-
+            var stateManager = configuration.ScopedServiceProvider.GetRequiredService<StateManager>();
             var factory = configuration.ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
-            var entry = factory.Create(entityType, new ObjectArrayValueReader(new object[] { "Green", 77 }));
+            var entry = factory.Create(stateManager, entityType, new ObjectArrayValueReader(new object[] { "Green", 77 }));
 
             Assert.IsType<ShadowStateEntry>(entry);
 
-            Assert.Same(configuration, entry.Configuration);
+            Assert.Same(stateManager, entry.StateManager);
             Assert.Same(entityType, entry.EntityType);
             Assert.Equal(77, entry[property1]);
             Assert.Equal("Green", entry[property2]);
@@ -107,14 +107,14 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var property2 = entityType.GetOrAddProperty("Hammer", typeof(string));
 
             var configuration = TestHelpers.CreateContextConfiguration(model);
-
+            var stateManager = configuration.ScopedServiceProvider.GetRequiredService<StateManager>();
             var factory = configuration.ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
 
-            var entry = factory.Create(entityType, new ObjectArrayValueReader(new object[] { "Green", 77 }));
+            var entry = factory.Create(stateManager, entityType, new ObjectArrayValueReader(new object[] { "Green", 77 }));
 
             Assert.IsType<ClrStateEntry>(entry);
 
-            Assert.Same(configuration, entry.Configuration);
+            Assert.Same(stateManager, entry.StateManager);
             Assert.Same(entityType, entry.EntityType);
             Assert.Equal(77, entry[property1]);
             Assert.Equal("Green", entry[property2]);
@@ -133,14 +133,14 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             var property2 = entityType.GetOrAddProperty("Hammer", typeof(string), shadowProperty: true);
 
             var configuration = TestHelpers.CreateContextConfiguration(model);
-
+            var stateManager = configuration.ScopedServiceProvider.GetRequiredService<StateManager>();
             var factory = configuration.ScopedServiceProvider.GetRequiredService<StateEntryFactory>();
 
-            var entry = factory.Create(entityType, new ObjectArrayValueReader(new object[] { "Green", 77 }));
+            var entry = factory.Create(stateManager, entityType, new ObjectArrayValueReader(new object[] { "Green", 77 }));
 
             Assert.IsType<MixedStateEntry>(entry);
 
-            Assert.Same(configuration, entry.Configuration);
+            Assert.Same(stateManager, entry.StateManager);
             Assert.Same(entityType, entry.EntityType);
             Assert.Equal(77, entry[property1]);
             Assert.Equal("Green", entry[property2]);

--- a/test/EntityFramework.Tests/ChangeTracking/StateEntrySubscriberTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/StateEntrySubscriberTest.cs
@@ -5,7 +5,6 @@ using System;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Microsoft.Data.Entity.ChangeTracking;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Moq;
 using Xunit;
@@ -61,13 +60,13 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entryMock.Setup(m => m.EntityType).Returns(entityType);
             entryMock.Setup(m => m.Entity).Returns(entity);
 
-            var detectorMock = new Mock<ChangeDetector>();
-            new StateEntrySubscriber(detectorMock.Object).SnapshotAndSubscribe(entryMock.Object);
+            var notifierMock = new Mock<StateEntryNotifier>();
+            new StateEntrySubscriber(notifierMock.Object).SnapshotAndSubscribe(entryMock.Object);
 
             entity.Name = "George";
 
-            detectorMock.Verify(m => m.PropertyChanging(entryMock.Object, property));
-            detectorMock.Verify(m => m.PropertyChanged(entryMock.Object, property));
+            notifierMock.Verify(m => m.PropertyChanging(entryMock.Object, property));
+            notifierMock.Verify(m => m.PropertyChanged(entryMock.Object, property));
         }
 
         [Fact]
@@ -82,18 +81,18 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entryMock.Setup(m => m.EntityType).Returns(entityType);
             entryMock.Setup(m => m.Entity).Returns(entity);
 
-            var detectorMock = new Mock<ChangeDetector>();
-            new StateEntrySubscriber(detectorMock.Object).SnapshotAndSubscribe(entryMock.Object);
+            var notifierMock = new Mock<StateEntryNotifier>();
+            new StateEntrySubscriber(notifierMock.Object).SnapshotAndSubscribe(entryMock.Object);
 
             entity.NotMapped = "Formby";
 
-            detectorMock.Verify(m => m.PropertyChanging(It.IsAny<StateEntry>(), It.IsAny<IProperty>()), Times.Never);
-            detectorMock.Verify(m => m.PropertyChanged(It.IsAny<StateEntry>(), It.IsAny<IProperty>()), Times.Never);
+            notifierMock.Verify(m => m.PropertyChanging(It.IsAny<StateEntry>(), It.IsAny<IProperty>()), Times.Never);
+            notifierMock.Verify(m => m.PropertyChanged(It.IsAny<StateEntry>(), It.IsAny<IProperty>()), Times.Never);
         }
 
         private static StateEntrySubscriber CreateSubscriber()
         {
-            return new StateEntrySubscriber(new ChangeDetector(Mock.Of<DbContextConfiguration>(), Mock.Of<StateEntryNotifier>()));
+            return new StateEntrySubscriber(Mock.Of<StateEntryNotifier>());
         }
 
         private class FullNotificationEntity : INotifyPropertyChanging, INotifyPropertyChanged

--- a/test/EntityFramework.Tests/ChangeTracking/StateEntryTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/StateEntryTest.cs
@@ -756,7 +756,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
                 Assert.False(entry.IsPropertyModified(nameProperty));
                 Assert.Equal(EntityState.Unchanged, entry.EntityState);
 
-                entry.DetectChanges();
+                configuration.ScopedServiceProvider.GetRequiredService<ChangeDetector>().DetectChanges(entry);
             }
 
             Assert.True(entry.IsPropertyModified(nameProperty));
@@ -1143,20 +1143,18 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             return configuration.Services.ServiceProvider.GetService<StateEntrySubscriber>().SnapshotAndSubscribe(
                 new StateEntryFactory(
-                    configuration,
                     configuration.Services.ServiceProvider.GetService<EntityMaterializerSource>(),
                     configuration.Services.ServiceProvider.GetService<StateEntryMetadataServices>())
-                    .Create(entityType, entity));
+                    .Create(configuration.ScopedServiceProvider.GetService<StateManager>(), entityType, entity));
         }
 
         protected virtual StateEntry CreateStateEntry(DbContextConfiguration configuration, IEntityType entityType, IValueReader valueReader)
         {
             return configuration.Services.ServiceProvider.GetService<StateEntrySubscriber>().SnapshotAndSubscribe(
                 new StateEntryFactory(
-                    configuration,
                     configuration.Services.ServiceProvider.GetService<EntityMaterializerSource>(),
                     configuration.Services.ServiceProvider.GetService<StateEntryMetadataServices>())
-                    .Create(entityType, valueReader));
+                    .Create(configuration.ScopedServiceProvider.GetService<StateManager>(), entityType, valueReader));
         }
 
         protected virtual Model BuildModel()

--- a/test/EntityFramework.Tests/ChangeTracking/StateManagerTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/StateManagerTest.cs
@@ -237,15 +237,6 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
-        public void Can_get_model()
-        {
-            var model = BuildModel();
-            var stateManager = CreateStateManager(model);
-
-            Assert.Same(model, stateManager.Model);
-        }
-
-        [Fact]
         public void Listeners_are_notified_when_entity_states_change()
         {
             var listeners = new[]

--- a/test/Shared/TestHelpers.cs
+++ b/test/Shared/TestHelpers.cs
@@ -66,8 +66,8 @@ namespace Microsoft.Data.Entity.Tests
         {
             var entry = CreateContextConfiguration(model)
                 .Services
-                .StateEntryFactory
-                .Create(model.GetEntityType(typeof(TEntity)), entity ?? new TEntity());
+                .StateManager
+                .GetOrCreateEntry(entity ?? new TEntity());
 
             entry.EntityState = entityState;
 


### PR DESCRIPTION
This is part of Issue #641 which is about cleaning up the use of DbContextConfiguration. DbContextConfiguration is intended to help resolve dynamic services--that is, services for which the actual type/instance of service to use depends on the current context configuration. However, it has gradually spread throughout the code as a general purpose service locator. This causes dependencies to be hidden and creates a lot of coupling to DbContextConfiguration throughout the code, so I am making a set of changes to help fix this.

StateEntry now depends on the state manager and its metadata services. StateManager uses data store services through the mechanism introduced in previous commits. The ChangeDetection reactions to property changes through notifications removing a coupling and a potential circular dependency.
