### PR TITLE
fix to issue 1029 - we were unable to drop database if it was already in use

### DIFF
--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerDataStoreCreatorTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerDataStoreCreatorTest.cs
@@ -192,11 +192,14 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             {
                 var creator = GetDataStoreCreator(testDatabase);
 
-                Assert.Equal(
-                    3701, // Database does not exist
-                    async
-                        ? (await Assert.ThrowsAsync<SqlException>(() => creator.DeleteAsync())).Number
-                        : Assert.Throws<SqlException>(() => creator.Delete()).Number);
+                if (async)
+                {
+                    await Assert.ThrowsAsync<SqlException>(() => creator.DeleteAsync());
+                }
+                else
+                {
+                    Assert.Throws<SqlException>(() => creator.Delete());
+                }
             }
         }
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerDatabaseCreationTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerDatabaseCreationTest.cs
@@ -67,20 +67,35 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         [Fact]
         public async Task EnsureDeleted_will_delete_database()
         {
-            await EnsureDeleted_will_delete_database_test(async: false);
+            await EnsureDeleted_will_delete_database_test(async: false, openConnection: false);
         }
 
         [Fact]
         public async Task EnsureDeletedAsync_will_delete_database()
         {
-            await EnsureDeleted_will_delete_database_test(async: true);
+            await EnsureDeleted_will_delete_database_test(async: true, openConnection: false);
         }
 
-        private static async Task EnsureDeleted_will_delete_database_test(bool async)
+        [Fact]
+        public async Task EnsureDeleted_will_delete_database_with_opened_connections()
+        {
+            await EnsureDeleted_will_delete_database_test(async: false, openConnection: true);
+        }
+
+        [Fact]
+        public async Task EnsureDeletedAsync_will_delete_database_with_opened_connections()
+        {
+            await EnsureDeleted_will_delete_database_test(async: true, openConnection: true);
+        }
+
+        private static async Task EnsureDeleted_will_delete_database_test(bool async, bool openConnection)
         {
             using (var testDatabase = await SqlServerTestStore.CreateScratchAsync(createDatabase: true))
             {
-                testDatabase.Connection.Close();
+                if (!openConnection)
+                {
+                    testDatabase.Connection.Close();
+                }
 
                 using (var context = new BloggingContext(testDatabase))
                 {


### PR DESCRIPTION
Fix is to apply "ALTER DATABASE ... SET SINGLE_USER WITH ROLLBACK IMMEDIATE" before trying to drop the database. This only applies to (non-Azure) SqlServer.

Sql Azure will drop the database even if it's in use, and I verified that the command is supported on SqlServer 2008 and above.
