### PR TITLE
Updated unit tests to get services/context in consistent way

### DIFF
--- a/src/EntityFramework.Migrations/Infrastructure/MigrationAssembly.cs
+++ b/src/EntityFramework.Migrations/Infrastructure/MigrationAssembly.cs
@@ -22,6 +22,15 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
         private IReadOnlyList<Migration> _migrations;
         private IModel _model;
 
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected MigrationAssembly()
+        {
+        }
+
         public MigrationAssembly([NotNull] LazyRef<DbContext> context, [NotNull] LazyRef<IDbContextOptions> options)
         {
             Check.NotNull(context, "context");

--- a/src/EntityFramework.Migrations/MigrationOperationSqlGenerator.cs
+++ b/src/EntityFramework.Migrations/MigrationOperationSqlGenerator.cs
@@ -29,6 +29,15 @@ namespace Microsoft.Data.Entity.Migrations
         private readonly RelationalTypeMapper _typeMapper;
         private DatabaseModel _database;
 
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected MigrationOperationSqlGenerator()
+        {
+        }
+
         protected MigrationOperationSqlGenerator([NotNull] RelationalTypeMapper typeMapper)
         {
             Check.NotNull(typeMapper, "typeMapper");

--- a/src/EntityFramework/DbContext.cs
+++ b/src/EntityFramework/DbContext.cs
@@ -182,7 +182,6 @@ namespace Microsoft.Data.Entity
             get { return _configuration.Value.ScopedServiceProvider; }
         }
 
-
         protected internal virtual void OnConfiguring(DbContextOptions options)
         {
         }

--- a/test/EntityFramework.AzureTableStorage.Tests/Adapters/StateEntryTableEntityAdapterTest.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Adapters/StateEntryTableEntityAdapterTest.cs
@@ -8,10 +8,9 @@ using Microsoft.Data.Entity.AzureTableStorage.Query;
 using Microsoft.Data.Entity.AzureTableStorage.Tests.Helpers;
 using Microsoft.Data.Entity.AzureTableStorage.Utilities;
 using Microsoft.Data.Entity.ChangeTracking;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Tests;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Fallback;
 using Microsoft.WindowsAzure.Storage.Table;
 using Xunit;
 
@@ -19,19 +18,6 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Adapters
 {
     public class StateEntryTableEntityAdapterTest
     {
-        private static IServiceProvider CreateContextServices(IModel model)
-        {
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFramework()
-                .AddAzureTableStorage()
-                .ServiceCollection
-                .BuildServiceProvider();
-
-            return ((IDbContextServices)new DbContext(serviceProvider, new DbContextOptions()
-                .UseModel(model)
-                .UseAzureTableStorage("Moria", "mellon"))).ScopedServiceProvider;
-        }
-
         private static IModel CreateModel()
         {
             var model = new Model();
@@ -73,7 +59,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Adapters
         public void It_wraps_poco_in_adapter()
         {
             var model = CreateModel();
-            var stateManager = CreateContextServices(model).GetRequiredService<StateManager>();
+            var stateManager = TestHelpers.CreateContextServices(model).GetRequiredService<StateManager>();
 
             var obj = new ClrPoco();
             var entry = stateManager.GetOrCreateEntry(obj);
@@ -85,7 +71,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Adapters
         public void It_writes_to_clr_properties()
         {
             var model = CreateModel();
-            var stateManager = CreateContextServices(model).GetRequiredService<StateManager>();
+            var stateManager = TestHelpers.CreateContextServices(model).GetRequiredService<StateManager>();
 
             var obj = new ClrPoco();
             var entry = stateManager.GetOrCreateEntry(obj);
@@ -105,7 +91,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Adapters
         public void It_writes_to_shadow_state_properties()
         {
             var model = CreateModel();
-            var stateManager = CreateContextServices(model).GetRequiredService<StateManager>();
+            var stateManager = TestHelpers.CreateContextServices(model).GetRequiredService<StateManager>();
 
             var entityType = model.GetEntityType("ShadowEntity");
             var entry = stateManager.GetOrMaterializeEntry(entityType, new AtsObjectArrayValueReader(new object[] { "PK", "RK", null, null }));
@@ -132,7 +118,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Adapters
         public void It_reads_from_shadow_state_properties()
         {
             var model = CreateModel();
-            var stateManager = CreateContextServices(model).GetRequiredService<StateManager>();
+            var stateManager = TestHelpers.CreateContextServices(model).GetRequiredService<StateManager>();
 
             var entityType = model.GetEntityType("ShadowEntity");
             var entry = stateManager.GetOrMaterializeEntry(entityType, new AtsObjectArrayValueReader(new object[] { "PK", "RK", null, null }));
@@ -156,7 +142,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Adapters
         public void It_casts_to_int_keys()
         {
             var model = CreateModel();
-            var stateManager = CreateContextServices(model).GetRequiredService<StateManager>();
+            var stateManager = TestHelpers.CreateContextServices(model).GetRequiredService<StateManager>();
 
             var data = new object[] { "42", "1980", "11/11/2011 11:11:11 PM" };
             var entityType = model.GetEntityType(typeof(IntKeysPoco));
@@ -172,7 +158,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Adapters
         public void It_casts_from_int_keys()
         {
             var model = CreateModel();
-            var stateManager = CreateContextServices(model).GetRequiredService<StateManager>();
+            var stateManager = TestHelpers.CreateContextServices(model).GetRequiredService<StateManager>();
 
             var obj = new IntKeysPoco { PartitionID = 42, RowID = 1980 };
             var entry = stateManager.GetOrCreateEntry(obj);
@@ -186,7 +172,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Adapters
         public void It_interprets_guid_keys()
         {
             var model = CreateModel();
-            var stateManager = CreateContextServices(model).GetRequiredService<StateManager>();
+            var stateManager = TestHelpers.CreateContextServices(model).GetRequiredService<StateManager>();
 
             var data = new object[] { "80d401da-ef77-4bc6-a2b0-300025098a0e", "4b240e4f-b886-4d23-a63c-017a3d79885a", "timestamp" };
             var entityType = model.GetEntityType(typeof(GuidKeysPoco));
@@ -201,7 +187,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Adapters
         public void It_reads_from_dictionary()
         {
             var model = CreateModel();
-            var stateManager = CreateContextServices(model).GetRequiredService<StateManager>();
+            var stateManager = TestHelpers.CreateContextServices(model).GetRequiredService<StateManager>();
 
             var data = new Dictionary<string, EntityProperty>
                 {
@@ -223,7 +209,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Adapters
         public void It_skips_mismatched_types()
         {
             var model = CreateModel();
-            var stateManager = CreateContextServices(model).GetRequiredService<StateManager>();
+            var stateManager = TestHelpers.CreateContextServices(model).GetRequiredService<StateManager>();
 
             var data = new Dictionary<string, EntityProperty>
                 {
@@ -245,7 +231,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Adapters
         public void It_writes_to_dictionary()
         {
             var model = CreateModel();
-            var stateManager = CreateContextServices(model).GetRequiredService<StateManager>();
+            var stateManager = TestHelpers.CreateContextServices(model).GetRequiredService<StateManager>();
 
             var instance = new ClrPocoWithProp
             {

--- a/test/EntityFramework.AzureTableStorage.Tests/EntityFramework.AzureTableStorage.Tests.csproj
+++ b/test/EntityFramework.AzureTableStorage.Tests/EntityFramework.AzureTableStorage.Tests.csproj
@@ -111,7 +111,9 @@
     <Compile Include="Query\QueryModelVisitorTests.cs" />
     <Compile Include="Query\TableQueryGeneratorTests.cs" />
     <Compile Include="Requests\TableOperationRequestTests.cs" />
+    <Compile Include="TestHelperExtensions.cs" />
     <Compile Include="Utilities\EntityTypeExtensionsTest.cs" />
+    <Compile Include="..\Shared\TestHelpers.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="project.json" />

--- a/test/EntityFramework.AzureTableStorage.Tests/Query/QueryGenerationTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Query/QueryGenerationTests.cs
@@ -12,9 +12,9 @@ using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Tests;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Fallback;
 using Microsoft.Framework.Logging;
 using Moq;
 using Remotion.Linq;
@@ -161,15 +161,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Query
 
         private static QueryModel Query<T>(Expression<Func<DbSet<T>, IQueryable>> expression) where T : class
         {
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFramework()
-                .AddAzureTableStorage()
-                .ServiceCollection
-                .BuildServiceProvider();
-
-            var options = new DbContextOptions().UseAzureTableStorage("X");
-
-            using (var context = new DbContext(serviceProvider, options))
+            using (var context = TestHelpers.CreateContext())
             {
                 var executor = ((IDbContextServices)context).ScopedServiceProvider.GetRequiredService<EntityQueryExecutor>();
                 var query = expression.Compile()(new DbSet<T>(context));

--- a/test/EntityFramework.AzureTableStorage.Tests/Query/QueryModelVisitorTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Query/QueryModelVisitorTests.cs
@@ -9,8 +9,8 @@ using Microsoft.Data.Entity.AzureTableStorage.Query;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query;
+using Microsoft.Data.Entity.Tests;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Fallback;
 using Microsoft.Framework.Logging;
 using Remotion.Linq;
 using Remotion.Linq.Clauses.Expressions;
@@ -73,17 +73,8 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Query
 
         private int CountScans<T>(Expression<Func<DbSet<T>, IQueryable>> expression) where T : class, new()
         {
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFramework()
-                .AddAzureTableStorage()
-                .ServiceCollection
-                .BuildServiceProvider();
-
-            var options = new DbContextOptions().UseAzureTableStorage("X");
-
-            using (var context = new DbContext(serviceProvider, options))
+            using (var context = TestHelpers.CreateContext())
             {
-                var executor = ((IDbContextServices)context).ScopedServiceProvider.GetRequiredService<EntityQueryExecutor>();
                 var query = expression.Compile()(new DbSet<T>(context));
                 return CountQuery(query);
             }
@@ -91,17 +82,8 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Query
 
         private int CountScans<T1, T2>(Expression<Func<DbSet<T1>, DbSet<T2>, IQueryable>> expression) where T1 : class, new() where T2 : class
         {
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFramework()
-                .AddAzureTableStorage()
-                .ServiceCollection
-                .BuildServiceProvider();
-
-            var options = new DbContextOptions().UseAzureTableStorage("X");
-
-            using (var context = new DbContext(serviceProvider, options))
+            using (var context = TestHelpers.CreateContext())
             {
-                var executor = ((IDbContextServices)context).ScopedServiceProvider.GetRequiredService<EntityQueryExecutor>();
                 var query = expression.Compile()(new DbSet<T1>(context), new DbSet<T2>(context));
                 return CountQuery(query);
             }
@@ -109,15 +91,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Query
 
         private int CountQuery(IQueryable query)
         {
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFramework()
-                .AddAzureTableStorage()
-                .ServiceCollection
-                .BuildServiceProvider();
-
-            var options = new DbContextOptions().UseAzureTableStorage("X");
-
-            using (var context = new DbContext(serviceProvider, options))
+            using (var context = TestHelpers.CreateContext())
             {
                 var executor = ((IDbContextServices)context).ScopedServiceProvider.GetRequiredService<EntityQueryExecutor>();
                 var queryModel = new EntityQueryProvider(executor).GenerateQueryModel(query.Expression);

--- a/test/EntityFramework.AzureTableStorage.Tests/TestHelperExtensions.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/TestHelperExtensions.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Framework.DependencyInjection;
+
+namespace Microsoft.Data.Entity.Tests
+{
+    public static class TestHelperExtensions
+    {
+        public static EntityServicesBuilder AddProviderServices(this EntityServicesBuilder entityServicesBuilder)
+        {
+            return entityServicesBuilder.AddAzureTableStorage();
+        }
+
+        public static DbContextOptions UseProviderOptions(this DbContextOptions options)
+        {
+            return options.UseAzureTableStorage("DummyConnection");
+        }
+    }
+}

--- a/test/EntityFramework.AzureTableStorage.Tests/project.json
+++ b/test/EntityFramework.AzureTableStorage.Tests/project.json
@@ -7,7 +7,7 @@
     "commands": {
         "test": "Xunit.KRunner"
     },
-    "code": [ "**\\*.cs", "..\\Shared\\ApiConsistencyTestBase.cs" ],
+    "code": [ "**\\*.cs", "..\\Shared\\ApiConsistencyTestBase.cs", "..\\Shared\\TestHelpers.cs" ],
     "frameworks": {
         "aspnet50": { }
     }

--- a/test/EntityFramework.InMemory.Tests/InMemoryDataStoreCreatorTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryDataStoreCreatorTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Tests;
 using Microsoft.Framework.DependencyInjection;
@@ -84,9 +83,9 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 
         private static InMemoryDataStore CreateStore(IServiceProvider serviceProvider, bool persist)
         {
-            var contextServices = ((IDbContextServices)new DbContext(serviceProvider, new DbContextOptions().UseInMemoryStore(persist: persist))).ScopedServiceProvider;
+            var options = new DbContextOptions().UseInMemoryStore(persist: persist);
 
-            return contextServices.GetRequiredService<InMemoryDataStore>();
+            return TestHelpers.CreateContextServices(serviceProvider, options).GetRequiredService<InMemoryDataStore>();
         }
 
         [Fact]

--- a/test/EntityFramework.InMemory.Tests/InMemoryEntityServicesBuilderExtensionsTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryEntityServicesBuilderExtensionsTest.cs
@@ -4,8 +4,8 @@
 using System.Linq;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Tests;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Fallback;
 using Xunit;
 
 namespace Microsoft.Data.Entity.InMemory.Tests
@@ -25,11 +25,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         [Fact]
         public void Services_wire_up_correctly()
         {
-            var services = new ServiceCollection();
-            services.AddEntityFramework().AddInMemoryStore();
-            var serviceProvider = services.BuildServiceProvider();
-
-            using (var context = new DbContext(serviceProvider, new DbContextOptions()))
+            using (var context = TestHelpers.CreateContext())
             {
                 var scopedProvider = ((IDbContextServices)context).ScopedServiceProvider;
 

--- a/test/EntityFramework.Migrations.Tests/EntityFramework.Migrations.Tests.csproj
+++ b/test/EntityFramework.Migrations.Tests/EntityFramework.Migrations.Tests.csproj
@@ -115,6 +115,8 @@
     <Compile Include="Model\RenameTableOperationTest.cs" />
     <Compile Include="..\Shared\ApiConsistencyTestBase.cs" />
     <Compile Include="Model\SqlOperationTest.cs" />
+    <Compile Include="..\Shared\TestHelpers.cs" />
+    <Compile Include="TestHelperExtensions.cs" />
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>

--- a/test/EntityFramework.Migrations.Tests/Infrastructure/HistoryRepositoryTest.cs
+++ b/test/EntityFramework.Migrations.Tests/Infrastructure/HistoryRepositoryTest.cs
@@ -9,9 +9,9 @@ using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Migrations.Infrastructure;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Relational.Update;
+using Microsoft.Data.Entity.Tests;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Fallback;
 using Moq;
 using Moq.Protected;
 using Xunit;
@@ -23,7 +23,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
         [Fact]
         public void Get_table_name()
         {
-            var serviceProvider = CreateServiceProvider();
+            var serviceProvider = TestHelpers.CreateServiceProvider();
 
             using (var context = new Context(serviceProvider))
             {
@@ -39,7 +39,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
         [Fact]
         public void Create_and_cache_history_model()
         {
-            var serviceProvider = CreateServiceProvider();
+            var serviceProvider = TestHelpers.CreateServiceProvider();
 
             using (var context = new Context(serviceProvider))
             {
@@ -68,7 +68,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
         [Fact]
         public void Create_history_context_from_user_context()
         {
-            var serviceProvider = CreateServiceProvider();
+            var serviceProvider = TestHelpers.CreateServiceProvider();
 
             using (var context = new Context(serviceProvider))
             {
@@ -100,7 +100,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
         [Fact]
         public void Get_migrations_query()
         {
-            var serviceProvider = CreateServiceProvider();
+            var serviceProvider = TestHelpers.CreateServiceProvider();
 
             using (var context = new Context(serviceProvider))
             {
@@ -138,7 +138,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
         [Fact]
         public void Get_migrations()
         {
-            var serviceProvider = CreateServiceProvider();
+            var serviceProvider = TestHelpers.CreateServiceProvider();
 
             using (var context = new Context(serviceProvider))
             {
@@ -159,16 +159,6 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
             }
         }
 
-        private static IServiceProvider CreateServiceProvider()
-        {
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFramework()
-                .AddMigrations()
-                .ServiceCollection
-                .BuildServiceProvider();
-            return serviceProvider;
-        }
-
         private static IQueryable<HistoryRow> MigrationQueryableCallback()
         {
             return new[]
@@ -182,7 +172,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
         [Fact]
         public void Generate_insert_migration_sql()
         {
-            var serviceProvider = CreateServiceProvider();
+            var serviceProvider = TestHelpers.CreateServiceProvider();
 
             using (var context = new Context(serviceProvider))
             {
@@ -204,7 +194,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
         [Fact]
         public void Generate_insert_migration_sql_with_custom_context_key()
         {
-            var serviceProvider = CreateServiceProvider();
+            var serviceProvider = TestHelpers.CreateServiceProvider();
 
             using (var context = new Context(serviceProvider))
             {
@@ -229,7 +219,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
         [Fact]
         public void Generate_delete_migration_sql()
         {
-            var serviceProvider = CreateServiceProvider();
+            var serviceProvider = TestHelpers.CreateServiceProvider();
 
             using (var context = new Context(serviceProvider))
             {

--- a/test/EntityFramework.Migrations.Tests/Infrastructure/MigratorTest.cs
+++ b/test/EntityFramework.Migrations.Tests/Infrastructure/MigratorTest.cs
@@ -3,12 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data;
-using System.Data.Common;
 using System.Linq;
 using System.Text;
-using Microsoft.Data.Entity.Identity;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Builders;
 using Microsoft.Data.Entity.Migrations.Infrastructure;
@@ -17,12 +13,9 @@ using Microsoft.Data.Entity.Migrations.Utilities;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
+using Microsoft.Data.Entity.Tests;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Fallback;
 using Microsoft.Framework.Logging;
-using Moq;
-using Moq.Protected;
 using Xunit;
 using RelationalStrings = Microsoft.Data.Entity.Relational.Strings;
 
@@ -41,7 +34,8 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                     };
             var databaseMigrations = localMigrations;
 
-            var migrator = MockMigrator(databaseMigrations, localMigrations);
+            var migrator = CreateMigrator(databaseMigrations, localMigrations);
+
             var migrations = migrator.GetDatabaseMigrations();
 
             Assert.Equal(databaseMigrations.Length, migrations.Count);
@@ -62,7 +56,8 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                         new MigrationInfo("000000000000002_Migration2")
                     };
 
-            var migrator = MockMigrator(new MigrationInfo[0], localMigrations);
+            var migrator = CreateMigrator(new MigrationInfo[0], localMigrations);
+
             var migrations = migrator.GetLocalMigrations();
 
             Assert.Equal(localMigrations.Length, migrations.Count);
@@ -92,7 +87,8 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                         new MigrationInfo("000000000000004_M4")
                     };
 
-            var migrator = MockMigrator(databaseMigrations, localMigrations);
+            var migrator = CreateMigrator(databaseMigrations, localMigrations);
+
             var migrations = migrator.GetPendingMigrations();
 
             Assert.Equal(2, migrations.Count);
@@ -104,7 +100,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
         [Fact]
         public void ScriptMigrations_with_single_initial_migration()
         {
-            var migrator = MockMigrator(
+            var migrator = CreateMigrator(
                 new MigrationInfo[0],
                 new[]
                     {
@@ -130,7 +126,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
         [Fact]
         public void ScriptMigrations_with_multiple_initial_migrations()
         {
-            var migrator = MockMigrator(
+            var migrator = CreateMigrator(
                 new MigrationInfo[0],
                 new[]
                     {
@@ -169,7 +165,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
         [Fact]
         public void ScriptMigrations_with_single_migration()
         {
-            var migrator = MockMigrator(
+            var migrator = CreateMigrator(
                 new[]
                     {
                         new MigrationInfo("000000000000001_Migration1")
@@ -204,7 +200,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
         [Fact]
         public void ScriptMigrations_with_multiple_migrations()
         {
-            var migrator = MockMigrator(
+            var migrator = CreateMigrator(
                 new[]
                     {
                         new MigrationInfo("000000000000001_Migration1"),
@@ -255,7 +251,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
         [Fact]
         public void ScriptMigrations_with_target_last_local_migration()
         {
-            var migrator = MockMigrator(
+            var migrator = CreateMigrator(
                 new[]
                     {
                         new MigrationInfo("000000000000001_Migration1"),
@@ -306,7 +302,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
         [Fact]
         public void ScriptMigrations_with_target_local_migration()
         {
-            var migrator = MockMigrator(
+            var migrator = CreateMigrator(
                 new[]
                     {
                         new MigrationInfo("000000000000001_Migration1"),
@@ -355,7 +351,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
         [Fact]
         public void ScriptMigrations_with_target_last_database_migration()
         {
-            var migrator = MockMigrator(
+            var migrator = CreateMigrator(
                 new[]
                     {
                         new MigrationInfo("000000000000001_Migration1"),
@@ -379,7 +375,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
         [Fact]
         public void ScriptMigrations_with_target_database_migration()
         {
-            var migrator = MockMigrator(
+            var migrator = CreateMigrator(
                 new[]
                     {
                         new MigrationInfo("000000000000001_Migration1"),
@@ -433,7 +429,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
         [Fact]
         public void ScriptMigrations_with_local_migration_before_last_database_migration()
         {
-            var migrator = MockMigrator(
+            var migrator = CreateMigrator(
                 new[]
                     {
                         new MigrationInfo("000000000000001_Migration1"),
@@ -475,7 +471,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
         [Fact]
         public void ScriptMigrations_with_target_local_migration_before_last_database_migration()
         {
-            var migrator = MockMigrator(
+            var migrator = CreateMigrator(
                 new[]
                     {
                         new MigrationInfo("000000000000001_Migration1"),
@@ -557,7 +553,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                             }
                     };
 
-            var migrator = MockMigrator(databaseMigrations, localMigrations);
+            var migrator = CreateMigrator(databaseMigrations, localMigrations);
 
             var sqlStatements = migrator.ScriptMigrations(Migrator.InitialDatabase);
 
@@ -588,7 +584,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                             }
                     };
 
-            var migrator = MockMigrator(databaseMigrations, localMigrations, databaseExists: true, historyRepositoryExists: false);
+            var migrator = CreateMigrator(databaseMigrations, localMigrations, historyRepositoryExists: false);
 
             var sqlStatements = migrator.ScriptMigrations();
 
@@ -601,7 +597,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
         [Fact]
         public void ScriptMigrations_throws_if_local_migrations_do_not_include_all_database_migrations()
         {
-            var migrator = MockMigrator(
+            var migrator = CreateMigrator(
                 new[]
                     {
                         new MigrationInfo("000000000000001_Migration1"),
@@ -620,7 +616,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                 Strings.LocalMigrationNotFound("000000000000002_Migration2"),
                 Assert.Throws<InvalidOperationException>(() => migrator.ScriptMigrations("Migration1")).Message);
 
-            migrator = MockMigrator(
+            migrator = CreateMigrator(
                 new[]
                     {
                         new MigrationInfo("000000000000001_Migration1"),
@@ -645,7 +641,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
         [Fact]
         public void ScriptMigrations_throws_if_target_migration_not_found()
         {
-            var migrator = MockMigrator(
+            var migrator = CreateMigrator(
                 new[]
                     {
                         new MigrationInfo("000000000000001_Migration1")
@@ -668,57 +664,42 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
             var databaseMigrations = new MigrationInfo[0];
             var localMigrations
                 = new[]
-                      {
-                          new MigrationInfo("000000000000001_Migration1")
-                              {
-                                  UpgradeOperations = new[] { new SqlOperation("SomeSql") },
-                                  TargetModel = new Metadata.Model()
-                              }
-                      };
-
-            Mock<RelationalDataStoreCreator> dbCreatorMock;
-            Mock<DbConnection> dbConnectionMock;
-            Mock<DbTransaction> dbTransactionMock;
-            Mock<SqlStatementExecutor> sqlStatementExecutorMock;
-
-            var migrator
-                = MockMigrator(
-                    databaseMigrations,
-                    localMigrations,
-                    /*databaseExists*/ false,
-                    /*historyTableExists*/ false,
-                    out dbCreatorMock,
-                    out dbConnectionMock,
-                    out dbTransactionMock,
-                    out sqlStatementExecutorMock);
-
-            var callCount = 0;
-
-            sqlStatementExecutorMock.Setup(m => m.ExecuteNonQuery(It.IsAny<DbConnection>(), It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<SqlStatement>>()))
-                .Callback<DbConnection, DbTransaction, IEnumerable<SqlStatement>>(
-                    (_, __, statements) =>
-                        {
-                            switch (++callCount)
+                    {
+                        new MigrationInfo("000000000000001_Migration1")
                             {
-                                case 1:
-                                    Assert.Equal(new[] { "Create__MigrationHistorySql" }, statements.Select(s => s.Sql));
-                                    break;
-                                case 2:
-                                    Assert.Equal(new[] { "SomeSql", "Migration1InsertSql" }, statements.Select(s => s.Sql));
-                                    break;
-                                default:
-                                    Assert.False(true, "Unexpected call count.");
-                                    break;
+                                UpgradeOperations = new[] { new SqlOperation("SomeSql") },
+                                TargetModel = new Metadata.Model()
                             }
-                        });
+                    };
+
+            var contextServices = CreateContextServices(databaseMigrations, localMigrations, historyRepositoryExists: false);
+            var migrator = contextServices.GetRequiredService<TestMigrator>();
+            var creator = contextServices.GetRequiredService<RecordingDataStoreCreator>();
+            var executor = (RecordingSqlStatementExecutor)contextServices.GetRequiredService<SqlStatementExecutor>();
+
+            creator.ExistsState = false;
 
             migrator.ApplyMigrations();
 
-            dbCreatorMock.Verify(m => m.Exists(), Times.Once);
-            dbCreatorMock.Verify(m => m.Create(), Times.Once);
-            dbConnectionMock.Protected().Verify("BeginDbTransaction", Times.Exactly(2), IsolationLevel.Serializable);
-            dbTransactionMock.Verify(m => m.Commit(), Times.Exactly(2));
-            sqlStatementExecutorMock.Verify(m => m.ExecuteNonQuery(It.IsAny<DbConnection>(), It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<SqlStatement>>()), Times.Exactly(2));
+            Assert.Equal(
+                new[]
+                    {
+                        "Create__MigrationHistorySql",
+                        "SomeSql",
+                        "Migration1InsertSql",
+                    },
+                executor.NonQueries.SelectMany(t => t.Item3));
+
+            Assert.Equal(
+                new[]
+                    {
+                        true,
+                        true
+                    },
+                executor.NonQueries.Select(t => ((FakeDbTransaction)t.Item2).Committed));
+
+            Assert.True(creator.Created);
+            Assert.True(creator.ExistsState);
         }
 
         [Fact]
@@ -735,49 +716,32 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                               }
                       };
 
-            Mock<RelationalDataStoreCreator> dbCreatorMock;
-            Mock<DbConnection> dbConnectionMock;
-            Mock<DbTransaction> dbTransactionMock;
-            Mock<SqlStatementExecutor> sqlStatementExecutorMock;
-
-            var migrator
-                = MockMigrator(
-                    databaseMigrations,
-                    localMigrations,
-                    /*databaseExists*/ true,
-                    /*historyTableExists*/ false,
-                    out dbCreatorMock,
-                    out dbConnectionMock,
-                    out dbTransactionMock,
-                    out sqlStatementExecutorMock);
-
-            var callCount = 0;
-
-            sqlStatementExecutorMock.Setup(m => m.ExecuteNonQuery(It.IsAny<DbConnection>(), It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<SqlStatement>>()))
-                .Callback<DbConnection, DbTransaction, IEnumerable<SqlStatement>>(
-                    (_, __, statements) =>
-                        {
-                            switch (++callCount)
-                            {
-                                case 1:
-                                    Assert.Equal(new[] { "Create__MigrationHistorySql" }, statements.Select(s => s.Sql));
-                                    break;
-                                case 2:
-                                    Assert.Equal(new[] { "SomeSql", "Migration1InsertSql" }, statements.Select(s => s.Sql));
-                                    break;
-                                default:
-                                    Assert.False(true, "Unexpected call count.");
-                                    break;
-                            }
-                        });
+            var contextServices = CreateContextServices(databaseMigrations, localMigrations, historyRepositoryExists: false);
+            var migrator = contextServices.GetRequiredService<TestMigrator>();
+            var creator = contextServices.GetRequiredService<RecordingDataStoreCreator>();
+            var executor = (RecordingSqlStatementExecutor)contextServices.GetRequiredService<SqlStatementExecutor>();
 
             migrator.ApplyMigrations();
 
-            dbCreatorMock.Verify(m => m.Exists(), Times.Once);
-            dbCreatorMock.Verify(m => m.Create(), Times.Never);
-            dbConnectionMock.Protected().Verify("BeginDbTransaction", Times.Exactly(2), IsolationLevel.Serializable);
-            dbTransactionMock.Verify(m => m.Commit(), Times.Exactly(2));
-            sqlStatementExecutorMock.Verify(m => m.ExecuteNonQuery(It.IsAny<DbConnection>(), It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<SqlStatement>>()), Times.Exactly(2));
+            Assert.Equal(
+                new[]
+                    {
+                        "Create__MigrationHistorySql",
+                        "SomeSql",
+                        "Migration1InsertSql",
+                    },
+                executor.NonQueries.SelectMany(t => t.Item3));
+
+            Assert.Equal(
+                new[]
+                    {
+                        true,
+                        true
+                    },
+                executor.NonQueries.Select(t => ((FakeDbTransaction)t.Item2).Committed));
+
+            Assert.False(creator.Created);
+            Assert.True(creator.ExistsState);
         }
 
         [Fact]
@@ -794,35 +758,30 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                               }
                       };
 
-            Mock<RelationalDataStoreCreator> dbCreatorMock;
-            Mock<DbConnection> dbConnectionMock;
-            Mock<DbTransaction> dbTransactionMock;
-            Mock<SqlStatementExecutor> sqlStatementExecutorMock;
-
-            var migrator
-                = MockMigrator(
-                    databaseMigrations,
-                    localMigrations,
-                    /*databaseExists*/ true,
-                    /*historyTableExists*/ true,
-                    out dbCreatorMock,
-                    out dbConnectionMock,
-                    out dbTransactionMock,
-                    out sqlStatementExecutorMock);
-
-            var expectedSql = new[] { "SomeSql", "Migration1InsertSql" };
-
-            sqlStatementExecutorMock.Setup(m => m.ExecuteNonQuery(It.IsAny<DbConnection>(), It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<SqlStatement>>()))
-                .Callback<DbConnection, DbTransaction, IEnumerable<SqlStatement>>(
-                    (_, __, statements) => Assert.Equal(expectedSql, statements.Select(s => s.Sql)));
+            var contextServices = CreateContextServices(databaseMigrations, localMigrations);
+            var migrator = contextServices.GetRequiredService<TestMigrator>();
+            var creator = contextServices.GetRequiredService<RecordingDataStoreCreator>();
+            var executor = (RecordingSqlStatementExecutor)contextServices.GetRequiredService<SqlStatementExecutor>();
 
             migrator.ApplyMigrations();
 
-            dbCreatorMock.Verify(m => m.Exists(), Times.Once);
-            dbCreatorMock.Verify(m => m.Create(), Times.Never);
-            dbConnectionMock.Protected().Verify("BeginDbTransaction", Times.Once(), IsolationLevel.Serializable);
-            dbTransactionMock.Verify(m => m.Commit(), Times.Once);
-            sqlStatementExecutorMock.Verify(m => m.ExecuteNonQuery(It.IsAny<DbConnection>(), It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<SqlStatement>>()), Times.Once);
+            Assert.Equal(
+                new[]
+                    {
+                        "SomeSql",
+                        "Migration1InsertSql",
+                    },
+                executor.NonQueries.SelectMany(t => t.Item3));
+
+            Assert.Equal(
+                new[]
+                    {
+                        true
+                    },
+                executor.NonQueries.Select(t => ((FakeDbTransaction)t.Item2).Committed));
+
+            Assert.False(creator.Created);
+            Assert.True(creator.ExistsState);
         }
 
         [Fact]
@@ -847,35 +806,30 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                               }
                       };
 
-            Mock<RelationalDataStoreCreator> dbCreatorMock;
-            Mock<DbConnection> dbConnectionMock;
-            Mock<DbTransaction> dbTransactionMock;
-            Mock<SqlStatementExecutor> sqlStatementExecutorMock;
-
-            var migrator
-                = MockMigrator(
-                    databaseMigrations,
-                    localMigrations,
-                    /*databaseExists*/ true,
-                    /*historyTableExists*/ true,
-                    out dbCreatorMock,
-                    out dbConnectionMock,
-                    out dbTransactionMock,
-                    out sqlStatementExecutorMock);
-
-            var expectedSql = new[] { "SomeSql", "Migration2DeleteSql" };
-
-            sqlStatementExecutorMock.Setup(m => m.ExecuteNonQuery(It.IsAny<DbConnection>(), It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<SqlStatement>>()))
-                .Callback<DbConnection, DbTransaction, IEnumerable<SqlStatement>>(
-                    (_, __, statements) => Assert.Equal(expectedSql, statements.Select(s => s.Sql)));
+            var contextServices = CreateContextServices(databaseMigrations, localMigrations);
+            var migrator = contextServices.GetRequiredService<TestMigrator>();
+            var creator = contextServices.GetRequiredService<RecordingDataStoreCreator>();
+            var executor = (RecordingSqlStatementExecutor)contextServices.GetRequiredService<SqlStatementExecutor>();
 
             migrator.ApplyMigrations("Migration1");
 
-            dbCreatorMock.Verify(m => m.Exists(), Times.Once);
-            dbCreatorMock.Verify(m => m.Create(), Times.Never);
-            dbConnectionMock.Protected().Verify("BeginDbTransaction", Times.Once(), IsolationLevel.Serializable);
-            dbTransactionMock.Verify(m => m.Commit(), Times.Once);
-            sqlStatementExecutorMock.Verify(m => m.ExecuteNonQuery(It.IsAny<DbConnection>(), It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<SqlStatement>>()), Times.Once);
+            Assert.Equal(
+                new[]
+                    {
+                        "SomeSql",
+                        "Migration2DeleteSql",
+                    },
+                executor.NonQueries.SelectMany(t => t.Item3));
+
+            Assert.Equal(
+                new[]
+                    {
+                        true
+                    },
+                executor.NonQueries.Select(t => ((FakeDbTransaction)t.Item2).Committed));
+
+            Assert.False(creator.Created);
+            Assert.True(creator.ExistsState);
         }
 
         [Fact]
@@ -888,88 +842,65 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                     };
             var localMigrations
                 = new[]
-                      {
-                          new MigrationInfo("000000000000001_Migration1")
-                              {
-                                  DowngradeOperations = new[] { new SqlOperation("SomeSql") },
-                              }
-                      };
-
-            Mock<RelationalDataStoreCreator> dbCreatorMock;
-            Mock<DbConnection> dbConnectionMock;
-            Mock<DbTransaction> dbTransactionMock;
-            Mock<SqlStatementExecutor> sqlStatementExecutorMock;
-
-            var migrator
-                = MockMigrator(
-                    databaseMigrations,
-                    localMigrations,
-                    /*databaseExists*/ true,
-                    /*historyTableExists*/ true,
-                    out dbCreatorMock,
-                    out dbConnectionMock,
-                    out dbTransactionMock,
-                    out sqlStatementExecutorMock);
-
-            var callCount = 0;
-
-            sqlStatementExecutorMock.Setup(m => m.ExecuteNonQuery(It.IsAny<DbConnection>(), It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<SqlStatement>>()))
-                .Callback<DbConnection, DbTransaction, IEnumerable<SqlStatement>>(
-                    (_, __, statements) =>
-                        {
-                            switch (++callCount)
+                    {
+                        new MigrationInfo("000000000000001_Migration1")
                             {
-                                case 1:
-                                    Assert.Equal(new[] { "SomeSql", "Migration1DeleteSql" }, statements.Select(s => s.Sql));
-                                    break;
-                                case 2:
-                                    Assert.Equal(new[] { "Drop__MigrationHistorySql" }, statements.Select(s => s.Sql));
-                                    break;
-                                default:
-                                    Assert.False(true, "Unexpected call count.");
-                                    break;
+                                DowngradeOperations = new[] { new SqlOperation("SomeSql") },
                             }
-                        });
+                    };
+
+            var contextServices = CreateContextServices(databaseMigrations, localMigrations);
+            var migrator = contextServices.GetRequiredService<TestMigrator>();
+            var creator = contextServices.GetRequiredService<RecordingDataStoreCreator>();
+            var executor = (RecordingSqlStatementExecutor)contextServices.GetRequiredService<SqlStatementExecutor>();
 
             migrator.ApplyMigrations(Migrator.InitialDatabase);
 
-            dbCreatorMock.Verify(m => m.Exists(), Times.Once);
-            dbCreatorMock.Verify(m => m.Create(), Times.Never);
-            dbConnectionMock.Protected().Verify("BeginDbTransaction", Times.Exactly(2), IsolationLevel.Serializable);
-            dbTransactionMock.Verify(m => m.Commit(), Times.Exactly(2));
-            sqlStatementExecutorMock.Verify(m => m.ExecuteNonQuery(It.IsAny<DbConnection>(), It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<SqlStatement>>()), Times.Exactly(2));
+            Assert.Equal(
+                new[]
+                    {
+                        "SomeSql",
+                        "Migration1DeleteSql",
+                        "Drop__MigrationHistorySql"
+                    },
+                executor.NonQueries.SelectMany(t => t.Item3));
+
+            Assert.Equal(
+                new[]
+                    {
+                        true,
+                        true
+                    },
+                executor.NonQueries.Select(t => ((FakeDbTransaction)t.Item2).Committed));
+
+            Assert.False(creator.Created);
+            Assert.True(creator.ExistsState);
         }
 
         [Fact]
         public void ApplyMigrations_creates_database_if_no_migrations()
         {
-            Mock<RelationalDataStoreCreator> dbCreatorMock;
-            Mock<DbConnection> dbConnectionMock;
-            Mock<DbTransaction> dbTransactionMock;
-            Mock<SqlStatementExecutor> sqlStatementExecutorMock;
+            var contextServices = CreateContextServices(new MigrationInfo[0], new MigrationInfo[0], historyRepositoryExists: false);
+            var migrator = contextServices.GetRequiredService<TestMigrator>();
+            var creator = contextServices.GetRequiredService<RecordingDataStoreCreator>();
+            var executor = (RecordingSqlStatementExecutor)contextServices.GetRequiredService<SqlStatementExecutor>();
 
-            var migrator
-                = MockMigrator(
-                    new MigrationInfo[0],
-                    new MigrationInfo[0],
-                    /*databaseExists*/ false,
-                    /*historyTableExists*/ false,
-                    out dbCreatorMock,
-                    out dbConnectionMock,
-                    out dbTransactionMock,
-                    out sqlStatementExecutorMock);
+            creator.ExistsState = false;
 
             migrator.ApplyMigrations();
 
-            dbCreatorMock.Verify(m => m.Exists(), Times.Once);
-            dbCreatorMock.Verify(m => m.Create(), Times.Once);
+            Assert.Empty(executor.NonQueries);
+            Assert.True(creator.Created);
+            Assert.True(creator.ExistsState);
+
+            creator.ExistsState = false;
+            creator.Created = false;
 
             migrator.ApplyMigrations(Migrator.InitialDatabase);
 
-            dbCreatorMock.Verify(m => m.Exists(), Times.Exactly(2));
-            dbCreatorMock.Verify(m => m.Create(), Times.Exactly(2));
-
-            sqlStatementExecutorMock.Verify(m => m.ExecuteNonQuery(It.IsAny<DbConnection>(), It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<SqlStatement>>()), Times.Never);
+            Assert.Empty(executor.NonQueries);
+            Assert.True(creator.Created);
+            Assert.True(creator.ExistsState);
         }
 
         [Fact]
@@ -996,66 +927,36 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                               }
                       };
 
-            Mock<RelationalDataStoreCreator> dbCreatorMock;
-            Mock<DbConnection> dbConnectionMock;
-            Mock<DbTransaction> dbTransactionMock;
-            Mock<SqlStatementExecutor> sqlStatementExecutorMock;
-
-            var migrator
-                = MockMigrator(
-                    databaseMigrations,
-                    localMigrations,
-                    /*databaseExists*/ true,
-                    /*historyTableExists*/ true,
-                    out dbCreatorMock,
-                    out dbConnectionMock,
-                    out dbTransactionMock,
-                    out sqlStatementExecutorMock);
-
-            var callCount = 0;
-
-            sqlStatementExecutorMock.Setup(m => m.ExecuteNonQuery(It.IsAny<DbConnection>(), It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<SqlStatement>>()))
-                .Callback<DbConnection, DbTransaction, IEnumerable<SqlStatement>>(
-                    (connection, transaction, statements) =>
-                        {
-                            switch (++callCount)
-                            {
-                                case 1:
-                                    Assert.Null(transaction);
-                                    Assert.Equal(new[] { "1" }, statements.Select(s => s.Sql));
-                                    break;
-                                case 2:
-                                    Assert.Equal(new[] { "2", "3" }, statements.Select(s => s.Sql));
-                                    break;
-                                case 3:
-                                    Assert.Null(transaction);
-                                    Assert.Equal(new[] { "4" }, statements.Select(s => s.Sql));
-                                    break;
-                                case 4:
-                                    Assert.NotNull(transaction);
-                                    Assert.Equal(new[] { "5", "6" }, statements.Select(s => s.Sql));
-                                    break;
-                                case 5:
-                                    Assert.Null(transaction);
-                                    Assert.Equal(new[] { "7" }, statements.Select(s => s.Sql));
-                                    break;
-                                case 6:
-                                    Assert.NotNull(transaction);
-                                    Assert.Equal(new[] { "Migration1InsertSql" }, statements.Select(s => s.Sql));
-                                    break;
-                                default:
-                                    Assert.False(true, "Unexpected call count.");
-                                    break;
-                            }
-                        });
+            var contextServices = CreateContextServices(databaseMigrations, localMigrations);
+            var migrator = contextServices.GetRequiredService<TestMigrator>();
+            var creator = contextServices.GetRequiredService<RecordingDataStoreCreator>();
+            var executor = (RecordingSqlStatementExecutor)contextServices.GetRequiredService<SqlStatementExecutor>();
 
             migrator.ApplyMigrations();
 
-            dbCreatorMock.Verify(m => m.Exists(), Times.Once);
-            dbCreatorMock.Verify(m => m.Create(), Times.Never);
-            dbConnectionMock.Protected().Verify("BeginDbTransaction", Times.Exactly(3), IsolationLevel.Serializable);
-            dbTransactionMock.Verify(m => m.Commit(), Times.Exactly(3));
-            sqlStatementExecutorMock.Verify(m => m.ExecuteNonQuery(It.IsAny<DbConnection>(), It.IsAny<DbTransaction>(), It.IsAny<IEnumerable<SqlStatement>>()), Times.Exactly(6));
+            Assert.Equal(
+                new[]
+                    {
+                        new [] {  "1" },
+                        new [] {  "2", "3" },
+                        new [] {  "4" },
+                        new [] {  "5", "6" },
+                        new [] {  "7" },
+                        new [] {  "Migration1InsertSql" }
+                    },
+                executor.NonQueries.Select(t => t.Item3).ToArray());
+
+            var transactions = executor.NonQueries.Select(t => ((FakeDbTransaction)t.Item2)).ToList();
+
+            Assert.Null(transactions[0]);
+            Assert.True(transactions[1].Committed);
+            Assert.Null(transactions[2]);
+            Assert.True(transactions[3].Committed);
+            Assert.Null(transactions[4]);
+            Assert.True(transactions[5].Committed);
+
+            Assert.False(creator.Created);
+            Assert.True(creator.ExistsState);
         }
 
         [Fact]
@@ -1072,14 +973,12 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                               }
                       };
 
-            var loggerFactory = new TestLoggerFactory();
-            var migrator
-                = MockMigrator(
-                    databaseMigrations,
-                    localMigrations,
-                    /*databaseExists*/ false,
-                    /*historyTableExists*/ false,
-                    loggerFactory);
+            var contextServices = CreateContextServices(databaseMigrations, localMigrations, historyRepositoryExists: false);
+            var migrator = contextServices.GetRequiredService<TestMigrator>();
+            var creator = contextServices.GetRequiredService<RecordingDataStoreCreator>();
+            var loggerFactory = (RecordingLoggerFactory)contextServices.GetRequiredService<ILoggerFactory>();
+
+            creator.ExistsState = false;
 
             migrator.ApplyMigrations();
 
@@ -1129,14 +1028,9 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                               }
                       };
 
-            var loggerFactory = new TestLoggerFactory();
-            var migrator
-                = MockMigrator(
-                    databaseMigrations,
-                    localMigrations,
-                    /*databaseExists*/ true,
-                    /*historyTableExists*/ true,
-                    loggerFactory);
+            var contextServices = CreateContextServices(databaseMigrations, localMigrations);
+            var migrator = contextServices.GetRequiredService<TestMigrator>();
+            var loggerFactory = (RecordingLoggerFactory)contextServices.GetRequiredService<ILoggerFactory>();
 
             migrator.ApplyMigrations(Migrator.InitialDatabase);
 
@@ -1169,312 +1063,70 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                 loggerFactory.LogContent);
         }
 
-        #region Fixture
-
-        private static Migrator MockMigrator(
+        private static TestMigrator CreateMigrator(
             IReadOnlyList<MigrationInfo> databaseMigrations,
             IReadOnlyList<MigrationInfo> localMigrations,
-            bool databaseExists = true,
-            bool historyRepositoryExists = true,
-            ILoggerFactory loggerFactory = null)
-        {
-            Mock<RelationalDataStoreCreator> dbCreatorMock;
-            Mock<DbConnection> dbConnectionMock;
-            Mock<DbTransaction> dbTransactionMock;
-            Mock<SqlStatementExecutor> sqlStatementExecutorMock;
-
-            return MockMigrator(
-                databaseMigrations,
-                localMigrations,
-                databaseExists,
-                historyRepositoryExists,
-                out dbCreatorMock,
-                out dbConnectionMock,
-                out dbTransactionMock,
-                out sqlStatementExecutorMock,
-                loggerFactory);
-        }
-
-        private static Migrator MockMigrator(
-            IReadOnlyList<MigrationInfo> databaseMigrations,
-            IReadOnlyList<MigrationInfo> localMigrations,
-            bool databaseExists,
-            bool historyRepositoryExists,
-            out Mock<RelationalDataStoreCreator> dbCreatorMock,
-            out Mock<DbConnection> dbConnectionMock,
-            out Mock<DbTransaction> dbTransactionMock,
-            out Mock<SqlStatementExecutor> sqlStatementExecutorMock,
-            ILoggerFactory loggerFactory = null)
-        {
-            if (loggerFactory == null)
-            {
-                loggerFactory = new LoggerFactory();
-            }
-
-            dbCreatorMock = new Mock<RelationalDataStoreCreator>();
-            dbConnectionMock = new Mock<DbConnection>();
-            dbTransactionMock = new Mock<DbTransaction>();
-            sqlStatementExecutorMock = new Mock<SqlStatementExecutor>(loggerFactory) { CallBase = true };
-
-            dbCreatorMock.Setup(m => m.Exists()).Returns(databaseExists);
-            dbConnectionMock.SetupGet(m => m.Database).Returns("MyDatabase");
-            dbConnectionMock.SetupGet(m => m.ConnectionString).Returns("MyConnectionString");
-            dbConnectionMock.Protected().Setup<DbTransaction>("BeginDbTransaction", ItExpr.IsAny<IsolationLevel>()).Returns(dbTransactionMock.Object);
-            dbTransactionMock.Protected().SetupGet<DbConnection>("DbConnection").Returns(dbConnectionMock.Object);
-            sqlStatementExecutorMock.Protected()
-                .Setup<DbCommand>("CreateCommand", ItExpr.IsAny<DbConnection>(), ItExpr.IsAny<DbTransaction>(), ItExpr.IsAny<SqlStatement>())
-                .Returns(new Mock<DbCommand>().Object);
-
-            var contextServices = CreateContextServices(dbCreatorMock.Object, dbConnectionMock.Object, loggerFactory);
-
-            return
-                new Mock<Migrator>(
-                    MockHistoryRepository(contextServices, databaseMigrations, historyRepositoryExists).Object,
-                    MockMigrationAssembly(contextServices.GetRequiredService<LazyRef<DbContext>>(), contextServices.GetRequiredService<LazyRef<IDbContextOptions>>(), localMigrations).Object,
-                    new TestModelDiffer(),
-                    MockMigrationOperationSqlGeneratorFactory().Object,
-                    new Mock<SqlGenerator>().Object,
-                    sqlStatementExecutorMock.Object,
-                    dbCreatorMock.Object,
-                    contextServices.GetRequiredService<FakeRelationalConnection>(),
-                    loggerFactory)
-                {
-                    CallBase = true
-                }
-                    .Object;
-        }
-
-        private static IServiceProvider CreateContextServices(RelationalDataStoreCreator dbCreator,
-            DbConnection dbConnection, ILoggerFactory loggerFactory)
-        {
-            var services = new ServiceCollection()
-                .AddEntityFramework()
-                .AddMigrations()
-                .ServiceCollection
-                .AddScoped<DataStoreSource, FakeDataStoreSource>()
-                .AddScoped<DataStoreSelector>()
-                .AddScoped<FakeRelationalDataStoreServices>()
-                .AddScoped<FakeDatabase>()
-                .AddScoped<FakeRelationalOptionsExtension>()
-                .AddScoped<FakeRelationalConnection>()
-                .AddScoped<FakeMigrator>()
-                .AddInstance(dbCreator)
-                .AddInstance(loggerFactory);
-
-            var serviceProvider = services.BuildServiceProvider();
-
-            var contextOptions = new DbContextOptions();
-
-            ((IDbContextOptions)contextOptions)
-                .AddOrUpdateExtension<FakeRelationalOptionsExtension>(
-                    x => { x.Connection = dbConnection; });
-
-            var context = new DbContext(serviceProvider, contextOptions);
-
-            return ((IDbContextServices)context).ScopedServiceProvider;
-        }
-
-        private static Mock<HistoryRepository> MockHistoryRepository(
-            IServiceProvider contextServices, IReadOnlyList<MigrationInfo> migrations,
             bool historyRepositoryExists = true)
         {
-            var mock = new Mock<HistoryRepository>(
-                        contextServices,
-                        new LazyRef<IDbContextOptions>(new DbContextOptions()),
-                        new LazyRef<DbContext>(() => null))
-            { CallBase = true };
+            return CreateContextServices(databaseMigrations, localMigrations, historyRepositoryExists).GetRequiredService<TestMigrator>();
+        }
 
-            if (historyRepositoryExists)
+        private static IServiceProvider CreateContextServices(IReadOnlyList<MigrationInfo> databaseMigrations, IReadOnlyList<MigrationInfo> localMigrations, bool historyRepositoryExists = true)
+        {
+            var customServices = new ServiceCollection()
+                .AddInstance<HistoryRepository>(new FakeHistoryRepository(databaseMigrations, historyRepositoryExists))
+                .AddInstance<MigrationAssembly>(new FakeMigrationAssembly(localMigrations));
+
+            var contextServices = TestHelpers.CreateContextServices(customServices);
+            return contextServices;
+        }
+
+        private class FakeHistoryRepository : HistoryRepository
+        {
+            private readonly IReadOnlyList<MigrationInfo> _migrations;
+            private readonly bool _historyRepositoryExists;
+
+            public FakeHistoryRepository(IReadOnlyList<MigrationInfo> migrations, bool historyRepositoryExists = true)
             {
-                mock.Protected().Setup<IReadOnlyList<HistoryRow>>("GetRows")
-                    .Returns(migrations.Select(m => new HistoryRow { MigrationId = m.MigrationId }).ToArray());
-            }
-            else
-            {
-                var dbException = new Mock<DbException>();
-
-                mock.Protected().Setup<IReadOnlyList<HistoryRow>>("GetRows").Throws(dbException.Object);
-            }
-
-            mock.Setup(hr => hr.GenerateInsertMigrationSql(It.IsAny<IMigrationMetadata>(), It.IsAny<SqlGenerator>()))
-                .Returns<IMigrationMetadata, SqlGenerator>((m, sg) => new[] { new SqlStatement(m.GetMigrationName() + "InsertSql") });
-
-            mock.Setup(hr => hr.GenerateDeleteMigrationSql(It.IsAny<IMigrationMetadata>(), It.IsAny<SqlGenerator>()))
-                .Returns<IMigrationMetadata, SqlGenerator>((m, sg) => new[] { new SqlStatement(m.GetMigrationName() + "DeleteSql") });
-
-            return mock;
-        }
-
-        private static Mock<MigrationAssembly> MockMigrationAssembly(
-            LazyRef<DbContext> context, LazyRef<IDbContextOptions> options, IReadOnlyList<MigrationInfo> migrations)
-        {
-            var mock = new Mock<MigrationAssembly>(context, options);
-
-            mock.SetupGet(ma => ma.Migrations).Returns(migrations.Select(m => new FakeMigration(m)).ToArray());
-
-            return mock;
-        }
-
-        private static Mock<IMigrationOperationSqlGeneratorFactory> MockMigrationOperationSqlGeneratorFactory()
-        {
-            var mock = new Mock<IMigrationOperationSqlGeneratorFactory>();
-
-            mock.Setup(mosgf => mosgf.Create())
-                .Returns(MockMigrationOperationSqlGenerator().Object);
-
-            mock.Setup(mosgf => mosgf.Create(It.IsAny<DatabaseModel>()))
-                .Returns(MockMigrationOperationSqlGenerator().Object);
-
-            return mock;
-        }
-
-        private static Mock<MigrationOperationSqlGenerator> MockMigrationOperationSqlGenerator()
-        {
-            var mock = new Mock<MigrationOperationSqlGenerator>(new RelationalTypeMapper());
-
-            mock.Setup(mosg => mosg.Generate(It.IsAny<IReadOnlyList<MigrationOperation>>()))
-                .Returns<IReadOnlyList<MigrationOperation>>(
-                    operations => FakeSqlGenerator.Instance.Generate(operations));
-
-            return mock;
-        }
-
-        private class FakeDataStoreSource : DataStoreSource<FakeRelationalDataStoreServices, FakeRelationalOptionsExtension>
-        {
-            public FakeDataStoreSource(DbContextConfiguration configuration, LazyRef<IDbContextOptions> options)
-                : base(configuration, options)
-            {
+                _migrations = migrations;
+                _historyRepositoryExists = historyRepositoryExists;
             }
 
-            public override string Name
+            protected override IReadOnlyList<HistoryRow> GetRows()
             {
-                get { return GetType().Name; }
+                if (_historyRepositoryExists)
+                {
+                    return _migrations.Select(m => new HistoryRow { MigrationId = m.MigrationId }).ToArray();
+                }
+                throw new FakeDbException();
+            }
+
+            public override IReadOnlyList<SqlStatement> GenerateInsertMigrationSql(IMigrationMetadata migration, SqlGenerator sqlGenerator)
+            {
+                return new[] { new SqlStatement(migration.GetMigrationName() + "InsertSql") };
+            }
+
+            public override IReadOnlyList<SqlStatement> GenerateDeleteMigrationSql(IMigrationMetadata migration, SqlGenerator sqlGenerator)
+            {
+                return new[] { new SqlStatement(migration.GetMigrationName() + "DeleteSql") };
             }
         }
 
-        private class FakeRelationalDataStoreServices : DataStoreServices
+        private class FakeMigrationAssembly : MigrationAssembly
         {
-            private readonly RelationalDataStoreCreator _creator;
-            private readonly FakeRelationalConnection _connection;
-            private readonly FakeDatabase _database;
+            private readonly IReadOnlyList<MigrationInfo> _migrations;
 
-            public FakeRelationalDataStoreServices(RelationalDataStoreCreator creator,
-                FakeRelationalConnection connection, FakeDatabase database)
+            public FakeMigrationAssembly(IReadOnlyList<MigrationInfo> migrations)
             {
-                _creator = creator;
-                _connection = connection;
-                _database = database;
+                _migrations = migrations;
             }
 
-            public override DataStore Store
+            public override IReadOnlyList<Migration> Migrations
             {
-                get { throw new NotImplementedException(); }
-            }
-
-            public override DataStoreCreator Creator
-            {
-                get { return _creator; }
-            }
-
-            public override DataStoreConnection Connection
-            {
-                get { return _connection; }
-            }
-
-            public override ValueGeneratorCache ValueGeneratorCache
-            {
-                get { throw new NotImplementedException(); }
-            }
-
-            public override Database Database
-            {
-                get { return _database; }
-            }
-
-            public override IModelBuilderFactory ModelBuilderFactory
-            {
-                get { throw new NotImplementedException(); }
-            }
-        }
-
-        private class FakeDatabase : MigrationsEnabledDatabase
-        {
-            public FakeDatabase(
-                LazyRef<IModel> model,
-                RelationalDataStoreCreator dataStoreCreator,
-                FakeRelationalConnection connection,
-                FakeMigrator migrator,
-                ILoggerFactory loggerFactory)
-                : base(model, dataStoreCreator, connection, migrator, loggerFactory)
-            {
-            }
-        }
-
-        private class FakeRelationalOptionsExtension : RelationalOptionsExtension
-        {
-            protected override void ApplyServices(EntityServicesBuilder builder)
-            {
-                throw new NotImplementedException();
-            }
-        }
-
-        private class FakeRelationalConnection : RelationalConnection
-        {
-            public FakeRelationalConnection(LazyRef<IDbContextOptions> options, ILoggerFactory loggerFactory)
-                : base(options, loggerFactory)
-            {
-            }
-
-            protected override DbConnection CreateDbConnection()
-            {
-                throw new NotImplementedException();
-            }
-        }
-
-        private class FakeMigrator : Migrator
-        {
-        }
-
-        private class FakeSqlGenerator : MigrationOperationVisitor<IndentedStringBuilder>
-        {
-            public static readonly FakeSqlGenerator Instance = new FakeSqlGenerator();
-
-            public virtual IEnumerable<SqlStatement> Generate(IEnumerable<MigrationOperation> operations)
-            {
-                return operations.Select(
-                    o =>
-                        {
-                            var sqlOperation = o as SqlOperation;
-                            var builder = new IndentedStringBuilder();
-
-                            o.Accept(this, builder);
-
-                            return
-                                new SqlStatement(builder.ToString())
-                                {
-                                    SuppressTransaction = sqlOperation != null && sqlOperation.SuppressTransaction
-                                };
-                        });
-            }
-
-            public override void Visit(CreateTableOperation operation, IndentedStringBuilder builder)
-            {
-                builder.Append("Create").Append(operation.TableName).Append("Sql");
-            }
-
-            public override void Visit(DropTableOperation operation, IndentedStringBuilder builder)
-            {
-                builder.Append("Drop").Append(operation.TableName).Append("Sql");
-            }
-
-            public override void Visit(SqlOperation operation, IndentedStringBuilder builder)
-            {
-                builder.Append(operation.Sql);
-            }
-
-            protected override void VisitDefault(MigrationOperation operation, IndentedStringBuilder builder)
-            {
-                builder.Append(operation.GetType().Name).Append("Sql");
+                get
+                {
+                    return _migrations.Select(m => new FakeMigration(m)).ToArray();
+                }
             }
         }
 
@@ -1518,85 +1170,5 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
                 get { return _migration.TargetModel; }
             }
         }
-
-        private class TestLoggerFactory : ILoggerFactory
-        {
-            private readonly StringBuilder _builder = new StringBuilder();
-
-            public string LogContent
-            {
-                get { return _builder.ToString(); }
-            }
-
-            public ILogger Create(string name)
-            {
-                return new TestLogger(name, _builder);
-            }
-
-            public void AddProvider(ILoggerProvider provider)
-            {
-                throw new NotImplementedException();
-            }
-        }
-
-        private class TestLogger : ILogger
-        {
-            private readonly string _name;
-            private readonly StringBuilder _builder;
-
-            public TestLogger(string name, StringBuilder builder)
-            {
-                _name = name;
-                _builder = builder;
-            }
-
-            public void Write(LogLevel logLevel, int eventId, object state, Exception exception, Func<object, Exception, string> formatter)
-            {
-                _builder
-                    .Append(_name)
-                    .Append(" ")
-                    .Append(logLevel.ToString("G"))
-                    .Append(" ")
-                    .AppendLine(formatter(state, exception));
-            }
-
-            public bool IsEnabled(LogLevel logLevel)
-            {
-                return true;
-            }
-
-            public IDisposable BeginScope(object state)
-            {
-                throw new NotImplementedException();
-            }
-        }
-
-        private class TestDatabaseBuilder : DatabaseBuilder
-        {
-            public TestDatabaseBuilder()
-                : base(new RelationalTypeMapper())
-            {
-            }
-
-            protected override Sequence BuildSequence(IProperty property)
-            {
-                return null;
-            }
-        }
-
-        private class TestModelDiffer : ModelDiffer
-        {
-            public TestModelDiffer()
-                : base(new TestDatabaseBuilder())
-            {
-            }
-
-            protected override string GetSequenceName(Column column)
-            {
-                return null;
-            }
-        }
-
-        #endregion
     }
 }

--- a/test/EntityFramework.Migrations.Tests/TestHelperExtensions.cs
+++ b/test/EntityFramework.Migrations.Tests/TestHelperExtensions.cs
@@ -1,0 +1,666 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Identity;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Metadata;
+using Microsoft.Data.Entity.Migrations;
+using Microsoft.Data.Entity.Migrations.Infrastructure;
+using Microsoft.Data.Entity.Migrations.Model;
+using Microsoft.Data.Entity.Migrations.Utilities;
+using Microsoft.Data.Entity.Relational;
+using Microsoft.Data.Entity.Relational.Metadata;
+using Microsoft.Data.Entity.Relational.Model;
+using Microsoft.Data.Entity.Relational.Update;
+using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Utilities;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.Logging;
+using Sequence = Microsoft.Data.Entity.Relational.Model.Sequence;
+
+// ReSharper disable once CheckNamespace
+
+namespace Microsoft.Data.Entity.Tests
+{
+    public static class TestHelperExtensions
+    {
+        public static EntityServicesBuilder AddProviderServices(this EntityServicesBuilder entityServicesBuilder)
+        {
+            entityServicesBuilder
+                .AddRelational().ServiceCollection
+                .AddSingleton<ILoggerFactory, RecordingLoggerFactory>()
+                .AddSingleton<FakeDatabaseBuilder>()
+                .AddSingleton<FakeValueGeneratorCache>()
+                .AddSingleton<FakeSqlGenerator>()
+                .AddSingleton<SqlStatementExecutor, RecordingSqlStatementExecutor>()
+                .AddSingleton<FakeTypeMapper>()
+                .AddSingleton<ModificationCommandBatchFactory>()
+                .AddSingleton<FakeCommandBatchPreparer>()
+                .AddScoped<BatchExecutor>()
+                .AddScoped<DataStoreSource, FakeDataStoreSource>()
+                .AddScoped<FakeDataStoreServices>()
+                .AddScoped<FakeDataStore>()
+                .AddScoped<FakeRelationalConnection>()
+                .AddScoped<FakeModelDiffer>()
+                .AddScoped<FakeDatabase>()
+                .AddScoped<FakeMigrationOperationSqlGeneratorFactory>()
+                .AddScoped<RecordingDataStoreCreator>()
+                .AddScoped<MigrationAssembly>()
+                .AddScoped<HistoryRepository>()
+                .AddScoped<TestMigrator>();
+
+            return entityServicesBuilder;
+        }
+
+        public static DbContextOptions UseProviderOptions(this DbContextOptions options)
+        {
+            ((IDbContextOptions)options).AddOrUpdateExtension<FakeRelationalOptionsExtension>(e => e.Connection = new FakeDbConnection());
+
+            return options;
+        }
+    }
+
+    public class TestMigrator : Migrator
+    {
+        public TestMigrator(
+            HistoryRepository historyRepository,
+            MigrationAssembly migrationAssembly,
+            FakeModelDiffer modelDiffer,
+            FakeMigrationOperationSqlGeneratorFactory ddlSqlGeneratorFactory,
+            FakeSqlGenerator dmlSqlGenerator,
+            SqlStatementExecutor sqlExecutor,
+            RecordingDataStoreCreator storeCreator,
+            FakeRelationalConnection connection,
+            ILoggerFactory loggerFactory)
+            : base(
+                historyRepository,
+                migrationAssembly,
+                modelDiffer,
+                ddlSqlGeneratorFactory,
+                dmlSqlGenerator,
+                sqlExecutor,
+                storeCreator,
+                connection,
+                loggerFactory)
+        {
+        }
+    }
+
+    public class FakeDatabaseBuilder : DatabaseBuilder
+    {
+        public FakeDatabaseBuilder([NotNull] FakeTypeMapper typeMapper)
+            : base(typeMapper)
+        {
+        }
+
+        protected override Sequence BuildSequence(IProperty property)
+        {
+            return null;
+        }
+    }
+
+    public class FakeModelDiffer : ModelDiffer
+    {
+        public FakeModelDiffer(FakeDatabaseBuilder databaseBuilder)
+            : base(databaseBuilder)
+        {
+        }
+
+        protected override string GetSequenceName(Column column)
+        {
+            Check.NotNull(column, "column");
+
+            return null;
+        }
+    }
+
+    public class FakeTypeMapper : RelationalTypeMapper
+    {
+    }
+
+    public class FakeSqlGenerator : SqlGenerator
+    {
+        public override void AppendSelectAffectedCountCommand(StringBuilder commandStringBuilder, SchemaQualifiedName schemaQualifiedName)
+        {
+        }
+
+        protected override void AppendRowsAffectedWhereCondition(StringBuilder commandStringBuilder, int expectedRowsAffected)
+        {
+        }
+
+        protected override void AppendIdentityWhereCondition(StringBuilder commandStringBuilder, ColumnModification columnModification)
+        {
+        }
+    }
+
+    public class FakeMigrationOperationSqlGeneratorFactory : IMigrationOperationSqlGeneratorFactory
+    {
+        public virtual MigrationOperationSqlGenerator Create()
+        {
+            return new FakeMigrationOperationSqlGenerator();
+        }
+
+        public virtual MigrationOperationSqlGenerator Create(DatabaseModel database)
+        {
+            return new FakeMigrationOperationSqlGenerator();
+        }
+    }
+
+    public class FakeMigrationOperationSqlGenerator : MigrationOperationSqlGenerator
+    {
+        public override IEnumerable<SqlStatement> Generate(IEnumerable<MigrationOperation> migrationOperations)
+        {
+            return new FakeMigrationsSqlGenerator().Generate(migrationOperations);
+        }
+
+        public override void Generate(RenameSequenceOperation renameSequenceOperation, IndentedStringBuilder stringBuilder)
+        {
+        }
+
+        public override void Generate(MoveSequenceOperation moveSequenceOperation, IndentedStringBuilder stringBuilder)
+        {
+        }
+
+        public override void Generate(RenameTableOperation renameTableOperation, IndentedStringBuilder stringBuilder)
+        {
+        }
+
+        public override void Generate(MoveTableOperation moveTableOperation, IndentedStringBuilder stringBuilder)
+        {
+        }
+
+        public override void Generate(RenameColumnOperation renameColumnOperation, IndentedStringBuilder stringBuilder)
+        {
+        }
+
+        public override void Generate(RenameIndexOperation renameIndexOperation, IndentedStringBuilder stringBuilder)
+        {
+        }
+    }
+
+    public class FakeMigrationsSqlGenerator : MigrationOperationVisitor<IndentedStringBuilder>
+    {
+        public virtual IEnumerable<SqlStatement> Generate(IEnumerable<MigrationOperation> operations)
+        {
+            return operations.Select(
+                o =>
+                {
+                    var sqlOperation = o as SqlOperation;
+                    var builder = new IndentedStringBuilder();
+
+                    o.Accept(this, builder);
+
+                    return
+                            new SqlStatement(builder.ToString())
+                            {
+                                SuppressTransaction = sqlOperation != null && sqlOperation.SuppressTransaction
+                            };
+                });
+        }
+
+        public override void Visit(CreateTableOperation operation, IndentedStringBuilder builder)
+        {
+            builder.Append("Create").Append(operation.TableName).Append("Sql");
+        }
+
+        public override void Visit(DropTableOperation operation, IndentedStringBuilder builder)
+        {
+            builder.Append("Drop").Append(operation.TableName).Append("Sql");
+        }
+
+        public override void Visit(SqlOperation operation, IndentedStringBuilder builder)
+        {
+            builder.Append(operation.Sql);
+        }
+
+        protected override void VisitDefault(MigrationOperation operation, IndentedStringBuilder builder)
+        {
+            builder.Append(operation.GetType().Name).Append("Sql");
+        }
+    }
+
+    public class RecordingSqlStatementExecutor : SqlStatementExecutor
+    {
+        private List<Tuple<DbConnection, DbTransaction, string[]>> _nonQueries
+            = new List<Tuple<DbConnection, DbTransaction, string[]>>();
+
+        public RecordingSqlStatementExecutor(ILoggerFactory loggerFactory)
+            : base(loggerFactory)
+        {
+        }
+
+        public List<Tuple<DbConnection, DbTransaction, string[]>> NonQueries
+        {
+            get { return _nonQueries; }
+        }
+
+        public override void ExecuteNonQuery(DbConnection connection, DbTransaction transaction, IEnumerable<SqlStatement> statements)
+        {
+            _nonQueries.Add(Tuple.Create(connection, transaction, statements.Select(s => s.Sql).ToArray()));
+
+            base.ExecuteNonQuery(connection, transaction, statements);
+        }
+    }
+
+    public class RecordingLoggerFactory : ILoggerFactory
+    {
+        private readonly StringBuilder _builder = new StringBuilder();
+
+        public string LogContent
+        {
+            get { return _builder.ToString(); }
+        }
+
+        public ILogger Create(string name)
+        {
+            return new RecordingLogger(name, _builder);
+        }
+
+        public void AddProvider(ILoggerProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class RecordingLogger : ILogger
+    {
+        private readonly string _name;
+        private readonly StringBuilder _builder;
+
+        public RecordingLogger(string name, StringBuilder builder)
+        {
+            _name = name;
+            _builder = builder;
+        }
+
+        public void Write(LogLevel logLevel, int eventId, object state, Exception exception, Func<object, Exception, string> formatter)
+        {
+            _builder
+                .Append(_name)
+                .Append(" ")
+                .Append(logLevel.ToString("G"))
+                .Append(" ")
+                .AppendLine(formatter(state, exception));
+        }
+
+        public bool IsEnabled(LogLevel logLevel)
+        {
+            return true;
+        }
+
+        public IDisposable BeginScope(object state)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class RecordingDataStoreCreator : RelationalDataStoreCreator
+    {
+        private bool _existsState = true;
+
+        public bool ExistsState
+        {
+            get { return _existsState; }
+            set { _existsState = value; }
+        }
+
+        public bool Created { get; set; }
+
+        public override bool Exists()
+        {
+            return ExistsState;
+        }
+
+        public override Task<bool> ExistsAsync(CancellationToken cancellationToken = new CancellationToken())
+        {
+            return Task.FromResult(false);
+        }
+
+        public override void Create()
+        {
+            ExistsState = true;
+            Created = true;
+        }
+
+        public override Task CreateAsync(CancellationToken cancellationToken = new CancellationToken())
+        {
+            ExistsState = true;
+            Created = true;
+            return Task.FromResult(0);
+        }
+
+        public override void Delete()
+        {
+            ExistsState = false;
+        }
+
+        public override Task DeleteAsync(CancellationToken cancellationToken = new CancellationToken())
+        {
+            ExistsState = false;
+            return Task.FromResult(0);
+        }
+
+        public override void CreateTables(IModel model)
+        {
+        }
+
+        public override Task CreateTablesAsync(IModel model, CancellationToken cancellationToken = new CancellationToken())
+        {
+            return Task.FromResult(0);
+        }
+
+        public override bool HasTables()
+        {
+            return false;
+        }
+
+        public override Task<bool> HasTablesAsync(CancellationToken cancellationToken = new CancellationToken())
+        {
+            return Task.FromResult(false);
+        }
+    }
+
+    public class FakeRelationalConnection : RelationalConnection
+    {
+        public FakeRelationalConnection(LazyRef<IDbContextOptions> options, ILoggerFactory loggerFactory)
+            : base(options, loggerFactory)
+        {
+        }
+
+        protected override DbConnection CreateDbConnection()
+        {
+            return new FakeDbConnection();
+        }
+    }
+
+    public class FakeDataStoreSource : DataStoreSource<FakeDataStoreServices, FakeRelationalOptionsExtension>
+    {
+        public FakeDataStoreSource(DbContextConfiguration configuration, LazyRef<IDbContextOptions> options)
+            : base(configuration, options)
+        {
+        }
+
+        public override string Name
+        {
+            get { return GetType().Name; }
+        }
+
+        public override bool IsAvailable
+        {
+            get { return true; }
+        }
+
+        public override bool IsConfigured
+        {
+            get { return true; }
+        }
+    }
+
+    public class FakeDataStoreServices : MigrationsDataStoreServices
+    {
+        private readonly FakeDataStore _store;
+        private readonly RecordingDataStoreCreator _creator;
+        private readonly FakeRelationalConnection _connection;
+        private readonly FakeValueGeneratorCache _valueGeneratorCache;
+        private readonly FakeDatabase _database;
+        private readonly ModelBuilderFactory _modelBuilderFactory;
+        private readonly TestMigrator _migrator;
+
+        public FakeDataStoreServices(
+            FakeDataStore store,
+            RecordingDataStoreCreator creator,
+            FakeRelationalConnection connection,
+            FakeValueGeneratorCache valueGeneratorCache,
+            FakeDatabase database,
+            ModelBuilderFactory modelBuilderFactory,
+            TestMigrator migrator)
+        {
+            _store = store;
+            _creator = creator;
+            _connection = connection;
+            _valueGeneratorCache = valueGeneratorCache;
+            _database = database;
+            _modelBuilderFactory = modelBuilderFactory;
+            _migrator = migrator;
+        }
+
+        public override DataStore Store
+        {
+            get { return _store; }
+        }
+
+        public override DataStoreCreator Creator
+        {
+            get { return _creator; }
+        }
+
+        public override DataStoreConnection Connection
+        {
+            get { return _connection; }
+        }
+
+        public override ValueGeneratorCache ValueGeneratorCache
+        {
+            get { return _valueGeneratorCache; }
+        }
+
+        public override Database Database
+        {
+            get { return _database; }
+        }
+
+        public override IModelBuilderFactory ModelBuilderFactory
+        {
+            get { return _modelBuilderFactory; }
+        }
+
+        public override Migrator Migrator
+        {
+            get { return _migrator; }
+        }
+    }
+
+    public class FakeDatabase : MigrationsEnabledDatabase
+    {
+        public FakeDatabase(
+            LazyRef<IModel> model,
+            RecordingDataStoreCreator dataStoreCreator,
+            FakeRelationalConnection connection,
+            TestMigrator migrator,
+            ILoggerFactory loggerFactory)
+            : base(model, dataStoreCreator, connection, migrator, loggerFactory)
+        {
+        }
+    }
+
+    public class FakeRelationalOptionsExtension : RelationalOptionsExtension
+    {
+        protected override void ApplyServices(EntityServicesBuilder builder)
+        {
+        }
+    }
+
+    public class FakeDataStore : RelationalDataStore
+    {
+        public FakeDataStore(
+            StateManager stateManager,
+            LazyRef<IModel> model,
+            EntityKeyFactorySource entityKeyFactorySource,
+            EntityMaterializerSource entityMaterializerSource,
+            ClrCollectionAccessorSource collectionAccessorSource,
+            ClrPropertySetterSource propertySetterSource,
+            FakeRelationalConnection connection,
+            FakeCommandBatchPreparer batchPreparer,
+            BatchExecutor batchExecutor,
+            ILoggerFactory loggerFactory)
+            : base(stateManager, model, entityKeyFactorySource, entityMaterializerSource,
+                collectionAccessorSource, propertySetterSource, connection, batchPreparer, batchExecutor, loggerFactory)
+        {
+        }
+    }
+
+    public class FakeValueGeneratorCache : ValueGeneratorCache
+    {
+    }
+
+    public class FakeCommandBatchPreparer : CommandBatchPreparer
+    {
+        public override IRelationalPropertyExtensions GetPropertyExtensions(IProperty property)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IRelationalEntityTypeExtensions GetEntityTypeExtensions(IEntityType entityType)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class FakeDbTransaction : DbTransaction
+    {
+        private readonly DbConnection _connection;
+
+        public FakeDbTransaction(DbConnection connection)
+        {
+            _connection = connection;
+        }
+
+        public bool Committed { get; set; }
+
+        public override void Commit()
+        {
+            Committed = true;
+        }
+
+        public override void Rollback()
+        {
+        }
+
+        protected override DbConnection DbConnection
+        {
+            get { return _connection; }
+        }
+
+        public override IsolationLevel IsolationLevel
+        {
+            get { return IsolationLevel.Chaos; }
+        }
+    }
+
+
+    public class FakeDbException : DbException
+    {
+    }
+
+    public class FakeDbConnection : DbConnection
+    {
+        protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)
+        {
+            return new FakeDbTransaction(this);
+        }
+
+        public override void Close()
+        {
+        }
+
+        public override void ChangeDatabase(string databaseName)
+        {
+        }
+
+        public override void Open()
+        {
+        }
+
+        public override string ConnectionString
+        {
+            get { return "MyConnectionString"; }
+            set { }
+        }
+
+        public override string Database
+        {
+            get { return ""; }
+        }
+
+        public override ConnectionState State
+        {
+            get { return ConnectionState.Closed; }
+        }
+
+        public override string DataSource
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public override string ServerVersion
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        protected override DbCommand CreateDbCommand()
+        {
+            return new FakeDbCommand();
+        }
+    }
+
+    public class FakeDbCommand : DbCommand
+    {
+        public override void Prepare()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override string CommandText { get; set; }
+
+        public override int CommandTimeout { get; set; }
+
+        public override CommandType CommandType { get; set; }
+
+        public override UpdateRowSource UpdatedRowSource { get; set; }
+
+        protected override DbConnection DbConnection { get; set; }
+
+        protected override DbParameterCollection DbParameterCollection
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        protected override DbTransaction DbTransaction { get; set; }
+
+        public override bool DesignTimeVisible { get; set; }
+
+        public override void Cancel()
+        {
+        }
+
+        protected override DbParameter CreateDbParameter()
+        {
+            throw new NotImplementedException();
+        }
+
+        protected override DbDataReader ExecuteDbDataReader(CommandBehavior behavior)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int ExecuteNonQuery()
+        {
+            return 1;
+        }
+
+        public override object ExecuteScalar()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/EntityFramework.Migrations.Tests/project.json
+++ b/test/EntityFramework.Migrations.Tests/project.json
@@ -4,7 +4,7 @@
         "Moq": "4.2.1312.1622",
         "Xunit.KRunner": "1.0.0-*"
     },
-    "code": [ "**\\*.cs", "..\\Shared\\ApiConsistencyTestBase.cs" ],
+    "code": [ "**\\*.cs", "..\\Shared\\ApiConsistencyTestBase.cs", "..\\Shared\\TestHelpers.cs" ],
     "commands": {
         "test": "Xunit.KRunner"
     },

--- a/test/EntityFramework.Relational.Tests/EntityFramework.Relational.Tests.csproj
+++ b/test/EntityFramework.Relational.Tests/EntityFramework.Relational.Tests.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Model\RelationalTypeMapperTest.cs" />
     <Compile Include="Model\SequenceTest.cs" />
     <Compile Include="Model\TableTest.cs" />
+    <Compile Include="TestHelperExtensions.cs" />
     <Compile Include="Update\BatchExecutorTest.cs" />
     <Compile Include="Update\ColumnModificationTest.cs" />
     <Compile Include="Update\CommandBatchPreparerTest.cs" />
@@ -108,6 +109,7 @@
     <Compile Include="Update\ModificationCommandTest.cs" />
     <Compile Include="Utilities\StringBuilderExtensionsTest.cs" />
     <Compile Include="..\Shared\ApiConsistencyTestBase.cs" />
+    <Compile Include="..\Shared\TestHelpers.cs" />
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>

--- a/test/EntityFramework.Relational.Tests/RelationalDataStoreTest.cs
+++ b/test/EntityFramework.Relational.Tests/RelationalDataStoreTest.cs
@@ -7,9 +7,9 @@ using System.Threading.Tasks;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.Update;
+using Microsoft.Data.Entity.Tests;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Fallback;
 using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
@@ -25,17 +25,15 @@ namespace Microsoft.Data.Entity.Relational.Tests
             var commandBatchPreparerMock = new Mock<CommandBatchPreparer>();
             var batchExecutorMock = new Mock<BatchExecutor>();
 
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFramework()
-                .AddInMemoryStore()
-                .ServiceCollection
+            var customServices = new ServiceCollection()
                 .AddInstance(relationalConnectionMock.Object)
                 .AddInstance(commandBatchPreparerMock.Object)
                 .AddInstance(batchExecutorMock.Object)
-                .AddSingleton<FakeRelationalDataStore>()
-                .BuildServiceProvider();
+                .AddSingleton<FakeRelationalDataStore>();
 
-            var relationalDataStore = serviceProvider.GetRequiredService<FakeRelationalDataStore>();
+            var contextServices = TestHelpers.CreateContextServices(customServices);
+
+            var relationalDataStore = contextServices.GetRequiredService<FakeRelationalDataStore>();
 
             var stateEntries = new List<StateEntry>();
             var cancellationToken = new CancellationTokenSource().Token;
@@ -53,17 +51,15 @@ namespace Microsoft.Data.Entity.Relational.Tests
             var commandBatchPreparerMock = new Mock<CommandBatchPreparer>();
             var batchExecutorMock = new Mock<BatchExecutor>();
 
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFramework()
-                .AddInMemoryStore()
-                .ServiceCollection
+            var customServices = new ServiceCollection()
                 .AddInstance(relationalConnectionMock.Object)
                 .AddInstance(commandBatchPreparerMock.Object)
                 .AddInstance(batchExecutorMock.Object)
-                .AddSingleton<FakeRelationalDataStore>()
-                .BuildServiceProvider();
+                .AddSingleton<FakeRelationalDataStore>();
 
-            var relationalDataStore = serviceProvider.GetRequiredService<FakeRelationalDataStore>();
+            var contextServices = TestHelpers.CreateContextServices(customServices);
+
+            var relationalDataStore = contextServices.GetRequiredService<FakeRelationalDataStore>();
 
             var stateEntries = new List<StateEntry>();
 

--- a/test/EntityFramework.Relational.Tests/TestHelperExtensions.cs
+++ b/test/EntityFramework.Relational.Tests/TestHelperExtensions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational;
+
+// ReSharper disable once CheckNamespace
+
+namespace Microsoft.Data.Entity.Tests
+{
+    public static class TestHelperExtensions
+    {
+        public static EntityServicesBuilder AddProviderServices(this EntityServicesBuilder entityServicesBuilder)
+        {
+            return entityServicesBuilder.AddRelational();
+        }
+
+        public static DbContextOptions UseProviderOptions(this DbContextOptions options)
+        {
+            return options;
+        }
+    }
+}

--- a/test/EntityFramework.Relational.Tests/Update/ModificationCommandTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ModificationCommandTest.cs
@@ -3,11 +3,9 @@
 
 using System;
 using Microsoft.Data.Entity.ChangeTracking;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.Update;
-using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Fallback;
+using Microsoft.Data.Entity.Tests;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Relational.Tests.Update
@@ -377,26 +375,14 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             return model;
         }
 
-        private static IServiceProvider CreateContextServices(IModel model)
-        {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddEntityFramework().AddInMemoryStore();
-            return ((IDbContextServices)new DbContext(serviceCollection.BuildServiceProvider(),
-                new DbContextOptions()
-                    .UseModel(model)))
-                .ScopedServiceProvider;
-        }
-
         private static StateEntry CreateStateEntry(
             EntityState entityState,
             bool generateKeyValues = false,
             bool computeNonKeyValue = false)
         {
             var model = BuildModel(generateKeyValues, computeNonKeyValue);
-            var stateEntry = CreateContextServices(model).GetRequiredService<StateManager>().GetOrCreateEntry(
-                new T1 { Id = 1, Name = "Test" });
-            stateEntry.EntityState = entityState;
-            return stateEntry;
+
+            return TestHelpers.CreateStateEntry(model, entityState, new T1 { Id = 1, Name = "Test" });
         }
     }
 }

--- a/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -9,14 +9,12 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.ChangeTracking;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.Metadata;
 using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Relational.Update;
+using Microsoft.Data.Entity.Tests;
 using Microsoft.Data.Entity.Update;
-using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Fallback;
 using Microsoft.Framework.Logging;
 using Moq;
 using Moq.Protected;
@@ -579,27 +577,14 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             return model;
         }
 
-        private static IServiceProvider CreateContextServices(IModel model)
-        {
-            var serviceCollection = new ServiceCollection();
-            serviceCollection.AddEntityFramework().AddInMemoryStore();
-            return ((IDbContextServices)new DbContext(serviceCollection.BuildServiceProvider(),
-                new DbContextOptions()
-                    .UseInMemoryStore(false)
-                    .UseModel(model)))
-                .ScopedServiceProvider;
-        }
-
         private static StateEntry CreateStateEntry(
             EntityState entityState,
             bool generateKeyValues = false,
             bool computeNonKeyValue = false)
         {
             var model = BuildModel(generateKeyValues, computeNonKeyValue);
-            var stateEntry = CreateContextServices(model).GetRequiredService<StateManager>().GetOrCreateEntry(
-                new T1 { Id = 1, Name = "Test" });
-            stateEntry.EntityState = entityState;
-            return stateEntry;
+
+            return TestHelpers.CreateStateEntry(model, entityState, new T1 { Id = 1, Name = "Test" });
         }
 
         private class ModificationCommandBatchFake : ReaderModificationCommandBatch

--- a/test/EntityFramework.Relational.Tests/project.json
+++ b/test/EntityFramework.Relational.Tests/project.json
@@ -5,7 +5,7 @@
         "Moq": "4.2.1312.1622",
         "Xunit.KRunner": "1.0.0-*"
     },
-    "code": [ "**\\*.cs", "..\\Shared\\ApiConsistencyTestBase.cs" ],
+    "code": [ "**\\*.cs", "..\\Shared\\ApiConsistencyTestBase.cs", "..\\Shared\\TestHelpers.cs" ],
     "commands": {
         "test": "Xunit.KRunner"
     },

--- a/test/EntityFramework.SQLite.Tests/EntityFramework.SQLite.Tests.csproj
+++ b/test/EntityFramework.SQLite.Tests/EntityFramework.SQLite.Tests.csproj
@@ -82,6 +82,8 @@
     <Compile Include="SQLiteMigrationOperationSqlGeneratorTest.cs" />
     <Compile Include="SQLiteSqlGeneratorTest.cs" />
     <Compile Include="SQLiteValueGeneratorSelectorTest.cs" />
+    <Compile Include="..\Shared\TestHelpers.cs" />
+    <Compile Include="TestHelperExtensions.cs" />
     <None Include="project.json" />
   </ItemGroup>
   <ItemGroup>

--- a/test/EntityFramework.SQLite.Tests/TestHelperExtensions.cs
+++ b/test/EntityFramework.SQLite.Tests/TestHelperExtensions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Framework.DependencyInjection;
+
+// ReSharper disable once CheckNamespace
+
+namespace Microsoft.Data.Entity.Tests
+{
+    public static class TestHelperExtensions
+    {
+        public static EntityServicesBuilder AddProviderServices(this EntityServicesBuilder entityServicesBuilder)
+        {
+            return entityServicesBuilder.AddSQLite();
+        }
+
+        public static DbContextOptions UseProviderOptions(this DbContextOptions options)
+        {
+            return options.UseSQLite("DummyConnection");
+        }
+    }
+}

--- a/test/EntityFramework.SQLite.Tests/project.json
+++ b/test/EntityFramework.SQLite.Tests/project.json
@@ -7,7 +7,8 @@
     "code": [
         "**\\*.cs",
         "..\\Shared\\ApiConsistencyTestBase.cs",
-        "..\\EntityFramework.Relational.Tests\\SqlGeneratorTestBase.cs"
+        "..\\EntityFramework.Relational.Tests\\SqlGeneratorTestBase.cs",
+        "..\\Shared\\TestHelpers.cs"
     ],
     "commands": {
         "test": "Xunit.KRunner"

--- a/test/EntityFramework.SqlServer.Tests/SqlServerEntityServicesBuilderExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerEntityServicesBuilderExtensionsTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Data.SqlClient;
 using System.Linq;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Migrations.Infrastructure;
@@ -9,9 +8,9 @@ using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Relational.Update;
 using Microsoft.Data.Entity.SqlServer.Update;
 using Microsoft.Data.Entity.Storage;
+using Microsoft.Data.Entity.Tests;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Fallback;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.Tests
@@ -56,17 +55,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void Services_wire_up_correctly()
         {
-            var services = new ServiceCollection();
-            services
-                .AddEntityFramework()
-                .AddSqlServer();
-
-            var serviceProvider = services.BuildServiceProvider();
-
-            var context = new DbContext(
-                serviceProvider,
-                new DbContextOptions().UseSqlServer("goo=boo"));
-
+            var serviceProvider = TestHelpers.CreateServiceProvider();
+            var context = TestHelpers.CreateContext(serviceProvider);
             var scopedProvider = ((IDbContextServices)context).ScopedServiceProvider;
 
             var databaseBuilder = scopedProvider.GetRequiredService<SqlServerDatabaseBuilder>();
@@ -117,10 +107,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
             context.Dispose();
 
-            context = new DbContext(
-                serviceProvider,
-                new DbContextOptions().UseSqlServer("goo=boo"));
-
+            context = TestHelpers.CreateContext(serviceProvider);
             scopedProvider = ((IDbContextServices)context).ScopedServiceProvider;
 
             // Dingletons

--- a/test/EntityFramework.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
@@ -4,18 +4,15 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Tests;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Fallback;
 using Microsoft.Framework.Logging;
 using Xunit;
 
@@ -194,10 +191,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public void Multiple_threads_can_use_the_same_generator()
         {
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFramework()
-                .AddSqlServer().ServiceCollection
-                .BuildServiceProvider();
+            var serviceProvider = TestHelpers.CreateServiceProvider();
 
             var property = _model.GetEntityType(typeof(AnEntity)).GetProperty("Long");
 
@@ -245,10 +239,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         [Fact]
         public async Task Multiple_threads_can_use_the_same_generator_async()
         {
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFramework()
-                .AddSqlServer().ServiceCollection
-                .BuildServiceProvider();
+            var serviceProvider = TestHelpers.CreateServiceProvider();
 
             var property = _model.GetEntityType(typeof(AnEntity)).GetProperty("Long");
 
@@ -300,18 +291,9 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
         private LazyRef<DataStoreServices> CreateStoreServices(IServiceProvider serviceProvider = null)
         {
-            serviceProvider = serviceProvider ?? new ServiceCollection()
-                .AddEntityFramework()
-                .AddSqlServer().ServiceCollection
-                .BuildServiceProvider();
+            serviceProvider = serviceProvider ?? TestHelpers.CreateServiceProvider();
 
-            var contextServices = ((IDbContextServices)new DbContext(
-                serviceProvider,
-                new DbContextOptions()
-                    .UseModel(_model)
-                    .UseSqlServer(new SqlConnection()))).ScopedServiceProvider;
-
-            return contextServices.GetRequiredService<LazyRef<DataStoreServices>>();
+            return TestHelpers.CreateContextServices(serviceProvider, _model).GetRequiredService<LazyRef<DataStoreServices>>();
         }
 
         private class FakeSqlStatementExecutor : SqlStatementExecutor

--- a/test/EntityFramework.Tests/ChangeTracking/ChangeDetectorTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/ChangeDetectorTest.cs
@@ -6,7 +6,6 @@ using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Fallback;
 using Moq;
 using Xunit;
 
@@ -19,7 +18,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var notifierMock = new Mock<StateEntryNotifier>();
             var model = BuildModel();
-            var contextServices = TestHelpers.CreateContextServices(CreateServiceProvider(notifierMock.Object), model);
+            var contextServices = CreateContextServices(notifierMock.Object, model);
             var stateManager = contextServices.GetRequiredService<StateManager>();
 
             var entityType = model.GetEntityType(typeof(Category));
@@ -48,7 +47,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var notifierMock = new Mock<StateEntryNotifier>();
             var model = BuildModel();
-            var contextServices = TestHelpers.CreateContextServices(CreateServiceProvider(notifierMock.Object), model);
+            var contextServices = CreateContextServices(notifierMock.Object, model);
             var stateManager = contextServices.GetRequiredService<StateManager>();
 
             var entityType = model.GetEntityType(typeof(Category));
@@ -77,7 +76,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var notifierMock = new Mock<StateEntryNotifier>();
             var model = BuildModel();
-            var contextServices = TestHelpers.CreateContextServices(CreateServiceProvider(notifierMock.Object), model);
+            var contextServices = CreateContextServices(notifierMock.Object, model);
             var stateManager = contextServices.GetRequiredService<StateManager>();
 
             var entityType = model.GetEntityType(typeof(Category));
@@ -106,7 +105,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var notifierMock = new Mock<StateEntryNotifier>();
             var model = BuildModel();
-            var contextServices = TestHelpers.CreateContextServices(CreateServiceProvider(notifierMock.Object), model);
+            var contextServices = CreateContextServices(notifierMock.Object, model);
             var stateManager = contextServices.GetRequiredService<StateManager>();
 
             var entityType = model.GetEntityType(typeof(Category));
@@ -135,7 +134,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var notifierMock = new Mock<StateEntryNotifier>();
             var model = BuildModel();
-            var contextServices = TestHelpers.CreateContextServices(CreateServiceProvider(notifierMock.Object), model);
+            var contextServices = CreateContextServices(notifierMock.Object, model);
             var stateManager = contextServices.GetRequiredService<StateManager>();
 
             var entityType = model.GetEntityType(typeof(Category));
@@ -165,7 +164,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var notifierMock = new Mock<StateEntryNotifier>();
             var model = BuildModel();
-            var contextServices = TestHelpers.CreateContextServices(CreateServiceProvider(notifierMock.Object), model);
+            var contextServices = CreateContextServices(notifierMock.Object, model);
             var stateManager = contextServices.GetRequiredService<StateManager>();
 
             var entityType = model.GetEntityType(typeof(Category));
@@ -195,7 +194,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var notifierMock = new Mock<StateEntryNotifier>();
             var model = BuildModel();
-            var contextServices = TestHelpers.CreateContextServices(CreateServiceProvider(notifierMock.Object), model);
+            var contextServices = CreateContextServices(notifierMock.Object, model);
             var stateManager = contextServices.GetRequiredService<StateManager>();
 
             var entityType = model.GetEntityType(typeof(Category));
@@ -224,7 +223,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         {
             var notifierMock = new Mock<StateEntryNotifier>();
             var model = BuildModel();
-            var contextServices = TestHelpers.CreateContextServices(CreateServiceProvider(notifierMock.Object), model);
+            var contextServices = CreateContextServices(notifierMock.Object, model);
             var stateManager = contextServices.GetRequiredService<StateManager>();
 
             var entityType = model.GetEntityType(typeof(Category));
@@ -279,14 +278,9 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             return model;
         }
 
-        public static IServiceProvider CreateServiceProvider(StateEntryNotifier notifier)
+        private static IServiceProvider CreateContextServices(StateEntryNotifier notifier, IModel model)
         {
-            return new ServiceCollection()
-                .AddEntityFramework()
-                .AddInMemoryStore()
-                .ServiceCollection
-                .AddInstance(notifier)
-                .BuildServiceProvider();
+            return TestHelpers.CreateContextServices(new ServiceCollection().AddInstance(notifier), model);
         }
     }
 }

--- a/test/EntityFramework.Tests/ContextConfigurationTest.cs
+++ b/test/EntityFramework.Tests/ContextConfigurationTest.cs
@@ -1,14 +1,11 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Fallback;
-using Moq;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests
@@ -18,7 +15,7 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Requesting_a_singleton_always_returns_same_instance()
         {
-            var provider = CreateDefaultProvider();
+            var provider = TestHelpers.CreateServiceProvider();
             var contextServices1 = TestHelpers.CreateContextServices(provider);
             var contextServices2 = TestHelpers.CreateContextServices(provider);
 
@@ -28,7 +25,7 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Requesting_a_scoped_service_always_returns_same_instance_in_scope()
         {
-            var provider = CreateDefaultProvider();
+            var provider = TestHelpers.CreateServiceProvider();
             var contextServices = TestHelpers.CreateContextServices(provider);
 
             Assert.Same(contextServices.GetRequiredService<StateManager>(), contextServices.GetRequiredService<StateManager>());
@@ -37,7 +34,7 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Requesting_a_scoped_service_always_returns_a_different_instance_in_a_different_scope()
         {
-            var provider = CreateDefaultProvider();
+            var provider = TestHelpers.CreateServiceProvider();
             var contextServices1 = TestHelpers.CreateContextServices(provider);
             var contextServices2 = TestHelpers.CreateContextServices(provider);
 
@@ -47,9 +44,7 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Scoped_data_store_services_can_be_obtained_from_configuration()
         {
-            var services = new ServiceCollection();
-            services.AddEntityFramework().AddInMemoryStore();
-            var serviceProvider = services.BuildServiceProvider();
+            var serviceProvider = TestHelpers.CreateServiceProvider();
 
             DataStore store;
             DataStoreCreator creator;
@@ -114,20 +109,6 @@ namespace Microsoft.Data.Entity.Tests
             {
                 options.UseInMemoryStore();
             }
-        }
-
-        private static IServiceProvider CreateDefaultProvider()
-        {
-            var services = new ServiceCollection();
-            services.AddEntityFramework().AddInMemoryStore();
-            return services.BuildServiceProvider();
-        }
-
-        private static DbContextConfiguration CreateEmptyConfiguration()
-        {
-            var provider = new ServiceCollection().BuildServiceProvider();
-            return new DbContextConfiguration()
-                .Initialize(provider, new DbContextOptions(), Mock.Of<DbContext>(), DbContextConfiguration.ServiceProviderSource.Explicit);
         }
     }
 }

--- a/test/EntityFramework.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Tests/DbContextTest.cs
@@ -61,9 +61,7 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Each_context_gets_new_scoped_services()
         {
-            var services = new ServiceCollection();
-            services.AddEntityFramework();
-            var serviceProvider = services.BuildServiceProvider();
+            var serviceProvider = TestHelpers.CreateServiceProvider();
 
             IServiceProvider contextServices;
             using (var context = new DbContext(serviceProvider))
@@ -97,9 +95,7 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Each_context_gets_new_scoped_services_with_explicit_config()
         {
-            var services = new ServiceCollection();
-            services.AddEntityFramework();
-            var serviceProvider = services.BuildServiceProvider();
+            var serviceProvider = TestHelpers.CreateServiceProvider();
 
             var options = new DbContextOptions();
 
@@ -137,13 +133,11 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void SaveChanges_calls_DetectChanges()
         {
-            var services = new ServiceCollection();
-            services.AddEntityFramework()
-                .ServiceCollection
+            var services = new ServiceCollection()
                 .AddScoped<StateManager, FakeStateManager>()
                 .AddScoped<ChangeDetector, FakeChangeDetector>();
 
-            var serviceProvider = services.BuildServiceProvider();
+            var serviceProvider = TestHelpers.CreateServiceProvider(services);
 
             var options = new DbContextOptions();
 
@@ -162,13 +156,11 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void SaveChanges_calls_state_manager_SaveChanges()
         {
-            var services = new ServiceCollection();
-            services.AddEntityFramework()
-                .ServiceCollection
+            var services = new ServiceCollection()
                 .AddScoped<StateManager, FakeStateManager>()
                 .AddScoped<ChangeDetector, FakeChangeDetector>();
 
-            var serviceProvider = services.BuildServiceProvider();
+            var serviceProvider = TestHelpers.CreateServiceProvider(services);
 
             var options = new DbContextOptions();
 
@@ -191,13 +183,11 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public async Task SaveChangesAsync_calls_state_manager_SaveChangesAsync()
         {
-            var services = new ServiceCollection();
-            services.AddEntityFramework()
-                .ServiceCollection
+            var services = new ServiceCollection()
                 .AddScoped<StateManager, FakeStateManager>()
                 .AddScoped<ChangeDetector, FakeChangeDetector>();
 
-            var serviceProvider = services.BuildServiceProvider();
+            var serviceProvider = TestHelpers.CreateServiceProvider(services);
 
             var options = new DbContextOptions();
 
@@ -705,12 +695,10 @@ namespace Microsoft.Data.Entity.Tests
         {
             var modelSource = Mock.Of<IModelSource>();
 
-            var services = new ServiceCollection();
-            services
-                .AddEntityFramework().ServiceCollection
+            var services = new ServiceCollection()
                 .AddInstance(modelSource);
 
-            var provider = services.BuildServiceProvider();
+            var provider = TestHelpers.CreateServiceProvider(services);
 
             using (var context = new EarlyLearningCenter(provider))
             {
@@ -723,12 +711,10 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Can_set_known_singleton_services_using_type_activation()
         {
-            var services = new ServiceCollection();
-            services
-                .AddEntityFramework().ServiceCollection
+            var services = new ServiceCollection()
                 .AddSingleton<IModelSource, FakeModelSource>();
 
-            var provider = services.BuildServiceProvider();
+            var provider = TestHelpers.CreateServiceProvider(services);
 
             using (var context = new EarlyLearningCenter(provider))
             {
@@ -741,12 +727,10 @@ namespace Microsoft.Data.Entity.Tests
         [Fact]
         public void Can_set_known_context_scoped_services_using_type_activation()
         {
-            var services = new ServiceCollection();
-            services
-                .AddEntityFramework().ServiceCollection
+            var services = new ServiceCollection()
                 .AddScoped<StateManager, FakeStateManager>();
 
-            var provider = services.BuildServiceProvider();
+            var provider = TestHelpers.CreateServiceProvider(services);
 
             using (var context = new EarlyLearningCenter(provider))
             {

--- a/test/EntityFramework.Tests/DbSetInitializerTest.cs
+++ b/test/EntityFramework.Tests/DbSetInitializerTest.cs
@@ -5,7 +5,6 @@ using System;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Framework.DependencyInjection;
-using Microsoft.Framework.DependencyInjection.Fallback;
 using Moq;
 using Xunit;
 
@@ -26,10 +25,10 @@ namespace Microsoft.Data.Entity.Tests
                         new DbSetFinder.DbSetProperty(typeof(JustAContext), "Four", typeof(string), hasSetter: false)
                     });
 
-            var serviceProvider = new ServiceCollection()
-                .AddEntityFramework().ServiceCollection
-                .AddInstance(new DbSetInitializer(setFinderMock.Object, new ClrPropertySetterSource(), new DbSetSource()))
-                .BuildServiceProvider();
+            var customServices = new ServiceCollection()
+                .AddInstance(new DbSetInitializer(setFinderMock.Object, new ClrPropertySetterSource(), new DbSetSource()));
+
+            var serviceProvider = TestHelpers.CreateServiceProvider(customServices);
 
             var options = new DbContextOptions();
 

--- a/test/Shared/TestHelpers.cs
+++ b/test/Shared/TestHelpers.cs
@@ -19,36 +19,115 @@ namespace Microsoft.Data.Entity.Tests
 
         public static DbContextOptions CreateOptions()
         {
-            return new DbContextOptions();
+            return new DbContextOptions().UseProviderOptions();
         }
 
-        public static IServiceProvider CreateServiceProvider()
+        public static IServiceProvider CreateServiceProvider(IServiceCollection customServices = null)
         {
             var services = new ServiceCollection();
             services
                 .AddEntityFramework()
                 .AddProviderServices();
+
+            if (customServices != null)
+            {
+                foreach (var service in customServices)
+                {
+                    services.Add(service);
+                }
+            }
+
             return services.BuildServiceProvider();
+        }
+
+        public static DbContext CreateContext(IServiceProvider serviceProvider, IModel model)
+        {
+            return new DbContext(serviceProvider, CreateOptions(model));
+        }
+
+        public static DbContext CreateContext(IServiceProvider serviceProvider, DbContextOptions options)
+        {
+            return new DbContext(serviceProvider, options);
+        }
+
+        public static DbContext CreateContext(IServiceProvider serviceProvider)
+        {
+            return new DbContext(serviceProvider, CreateOptions());
+        }
+
+        public static DbContext CreateContext(IModel model)
+        {
+            return new DbContext(CreateServiceProvider(), CreateOptions(model));
+        }
+
+        public static DbContext CreateContext(DbContextOptions options)
+        {
+            return new DbContext(CreateServiceProvider(), options);
+        }
+
+        public static DbContext CreateContext()
+        {
+            return new DbContext(CreateServiceProvider(), CreateOptions());
+        }
+
+        public static DbContext CreateContext(IServiceCollection customServices, IModel model)
+        {
+            return new DbContext(CreateServiceProvider(customServices), CreateOptions(model));
+        }
+
+        public static DbContext CreateContext(IServiceCollection customServices, DbContextOptions options)
+        {
+            return new DbContext(CreateServiceProvider(customServices), options);
+        }
+
+        public static DbContext CreateContext(IServiceCollection customServices)
+        {
+            return new DbContext(CreateServiceProvider(customServices), CreateOptions());
         }
 
         public static IServiceProvider CreateContextServices(IServiceProvider serviceProvider, IModel model)
         {
-            return ((IDbContextServices)new DbContext(serviceProvider, CreateOptions(model))).ScopedServiceProvider;
+            return ((IDbContextServices)CreateContext(serviceProvider, model)).ScopedServiceProvider;
+        }
+
+        public static IServiceProvider CreateContextServices(IServiceProvider serviceProvider, DbContextOptions options)
+        {
+            return ((IDbContextServices)CreateContext(serviceProvider, options)).ScopedServiceProvider;
         }
 
         public static IServiceProvider CreateContextServices(IServiceProvider serviceProvider)
         {
-            return ((IDbContextServices)new DbContext(serviceProvider, CreateOptions())).ScopedServiceProvider;
+            return ((IDbContextServices)CreateContext(serviceProvider)).ScopedServiceProvider;
         }
 
         public static IServiceProvider CreateContextServices(IModel model)
         {
-            return ((IDbContextServices)new DbContext(CreateServiceProvider(), CreateOptions(model))).ScopedServiceProvider;
+            return ((IDbContextServices)CreateContext(model)).ScopedServiceProvider;
+        }
+
+        public static IServiceProvider CreateContextServices(DbContextOptions options)
+        {
+            return ((IDbContextServices)CreateContext(options)).ScopedServiceProvider;
         }
 
         public static IServiceProvider CreateContextServices()
         {
-            return ((IDbContextServices)new DbContext(CreateServiceProvider(), CreateOptions())).ScopedServiceProvider;
+            return ((IDbContextServices)CreateContext()).ScopedServiceProvider;
+        }
+
+        public static IServiceProvider CreateContextServices(IServiceCollection customServices, IModel model)
+        {
+            return ((IDbContextServices)CreateContext(customServices, model)).ScopedServiceProvider;
+        }
+
+        public static IServiceProvider CreateContextServices(IServiceCollection customServices, DbContextOptions options)
+        {
+            return ((IDbContextServices)CreateContext(customServices, options)).ScopedServiceProvider;
+        }
+
+        public static IServiceProvider CreateContextServices(IServiceCollection customServices)
+        {
+            return ((IDbContextServices)CreateContext(customServices)).ScopedServiceProvider;
         }
 
         public static Model BuildModelFor<TEntity>()


### PR DESCRIPTION
All tests now using TestHelpers to create service provider and/or context and/or scoped context services, unless there is a specific reason for the test not to do so. Tests that use this mechanism run isolated from each other and are quite resilient to internal refactoring. Also updated MigratorTest per issue #1050
