### PR TITLE
Use explicit class for dynamically resolved context services (Issue #1079)

### DIFF
--- a/src/EntityFramework.AzureTableStorage/AtsConnection.cs
+++ b/src/EntityFramework.AzureTableStorage/AtsConnection.cs
@@ -31,12 +31,12 @@ namespace Microsoft.Data.Entity.AzureTableStorage
         {
         }
 
-        public AtsConnection([NotNull] LazyRef<IDbContextOptions> options, [NotNull] ILoggerFactory loggerFactory)
+        public AtsConnection([NotNull] ContextService<IDbContextOptions> options, [NotNull] ILoggerFactory loggerFactory)
             : base(loggerFactory)
         {
             Check.NotNull(options, "options");
 
-            var storeConfig = options.Value
+            var storeConfig = options.Service
                 .Extensions
                 .OfType<AtsOptionsExtension>()
                 .Single();

--- a/src/EntityFramework.AzureTableStorage/AtsDataStoreSource.cs
+++ b/src/EntityFramework.AzureTableStorage/AtsDataStoreSource.cs
@@ -4,13 +4,12 @@
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.AzureTableStorage
 {
     public class AtsDataStoreSource : DataStoreSource<AtsDataStoreServices, AtsOptionsExtension>
     {
-        public AtsDataStoreSource([NotNull] DbContextConfiguration configuration, [NotNull] LazyRef<IDbContextOptions> options)
+        public AtsDataStoreSource([NotNull] DbContextConfiguration configuration, [NotNull] ContextService<IDbContextOptions> options)
             : base(configuration, options)
         {
         }

--- a/src/EntityFramework.AzureTableStorage/AtsDatabase.cs
+++ b/src/EntityFramework.AzureTableStorage/AtsDatabase.cs
@@ -4,7 +4,6 @@
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.AzureTableStorage
@@ -12,7 +11,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage
     public class AtsDatabase : Database
     {
         public AtsDatabase(
-            [NotNull] LazyRef<IModel> model,
+            [NotNull] ContextService<IModel> model,
             [NotNull] AtsDataStoreCreator dataStoreCreator,
             [NotNull] AtsConnection connection,
             [NotNull] ILoggerFactory loggerFactory)

--- a/src/EntityFramework.Commands/MigrationTool.cs
+++ b/src/EntityFramework.Commands/MigrationTool.cs
@@ -51,10 +51,10 @@ namespace Microsoft.Data.Entity.Commands
             using (var context = CreateContext(contextType))
             {
                 var scopedServiceProvider = ((IDbContextServices)context).ScopedServiceProvider;
-                var options = scopedServiceProvider.GetRequiredService<LazyRef<IDbContextOptions>>();
-                var model = scopedServiceProvider.GetRequiredService<LazyRef<IModel>>();
+                var options = scopedServiceProvider.GetRequiredService<ContextService<IDbContextOptions>>();
+                var model = scopedServiceProvider.GetRequiredService<ContextService<IModel>>();
 
-                var extension = RelationalOptionsExtension.Extract(options.Value);
+                var extension = RelationalOptionsExtension.Extract(options.Service);
                 if (extension.MigrationNamespace == null)
                 {
                     extension.MigrationNamespace = rootNamespace + ".Migrations";
@@ -63,8 +63,8 @@ namespace Microsoft.Data.Entity.Commands
                 var migrator = CreateMigrator(context);
                 var scaffolder = new MigrationScaffolder(
                     context,
-                    options.Value,
-                    model.Value,
+                    options.Service,
+                    model.Service,
                     migrator.MigrationAssembly,
                     migrator.ModelDiffer,
                     new CSharpMigrationCodeGenerator(new CSharpModelCodeGenerator()));
@@ -183,12 +183,12 @@ namespace Microsoft.Data.Entity.Commands
             var context = ContextTool.CreateContext(type);
 
             var scopedServiceProvider = ((IDbContextServices)context).ScopedServiceProvider;
-            var options = scopedServiceProvider.GetRequiredService<LazyRef<IDbContextOptions>>();
+            var options = scopedServiceProvider.GetRequiredService<ContextService<IDbContextOptions>>();
 
             var loggerFactory = scopedServiceProvider.GetRequiredService<ILoggerFactory>();
             loggerFactory.AddProvider(_loggerProvider);
 
-            var extension = RelationalOptionsExtension.Extract(options.Value);
+            var extension = RelationalOptionsExtension.Extract(options.Service);
             if (extension.MigrationAssembly == null)
             {
                 extension.MigrationAssembly = _assembly;
@@ -199,7 +199,7 @@ namespace Microsoft.Data.Entity.Commands
 
         private Migrator CreateMigrator(DbContext context)
         {
-            return ((IDbContextServices)context).ScopedServiceProvider.GetRequiredService<LazyRef<Migrator>>().Value;
+            return ((IDbContextServices)context).ScopedServiceProvider.GetRequiredService<ContextService<Migrator>>().Service;
         }
 
         private IEnumerable<Type> GetMigrationTypes()

--- a/src/EntityFramework.InMemory/InMemoryDataStore.cs
+++ b/src/EntityFramework.InMemory/InMemoryDataStore.cs
@@ -35,20 +35,20 @@ namespace Microsoft.Data.Entity.InMemory
 
         public InMemoryDataStore(
              [NotNull] StateManager stateManager,
-             [NotNull] LazyRef<IModel> model,
+             [NotNull] ContextService<IModel> model,
              [NotNull] EntityKeyFactorySource entityKeyFactorySource,
              [NotNull] EntityMaterializerSource entityMaterializerSource,
              [NotNull] ClrCollectionAccessorSource collectionAccessorSource,
              [NotNull] ClrPropertySetterSource propertySetterSource,
              [NotNull] InMemoryDatabase persistentDatabase,
-             [NotNull] LazyRef<IDbContextOptions> options,
+             [NotNull] ContextService<IDbContextOptions> options,
              [NotNull] ILoggerFactory loggerFactory)
             : base(stateManager, model, entityKeyFactorySource, entityMaterializerSource,
                 collectionAccessorSource, propertySetterSource, loggerFactory)
         {
             Check.NotNull(persistentDatabase, "persistentDatabase");
 
-            var storeConfig = options.Value.Extensions
+            var storeConfig = options.Service.Extensions
                 .OfType<InMemoryOptionsExtension>()
                 .FirstOrDefault();
 

--- a/src/EntityFramework.InMemory/InMemoryDataStoreSource.cs
+++ b/src/EntityFramework.InMemory/InMemoryDataStoreSource.cs
@@ -4,13 +4,12 @@
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.InMemory
 {
     public class InMemoryDataStoreSource : DataStoreSource<InMemoryDataStoreServices, InMemoryOptionsExtension>
     {
-        public InMemoryDataStoreSource([NotNull] DbContextConfiguration configuration, [NotNull] LazyRef<IDbContextOptions> options)
+        public InMemoryDataStoreSource([NotNull] DbContextConfiguration configuration, [NotNull] ContextService<IDbContextOptions> options)
             : base(configuration, options)
         {
         }

--- a/src/EntityFramework.InMemory/InMemoryDatabaseFacade.cs
+++ b/src/EntityFramework.InMemory/InMemoryDatabaseFacade.cs
@@ -4,7 +4,6 @@
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.InMemory
@@ -12,7 +11,7 @@ namespace Microsoft.Data.Entity.InMemory
     public class InMemoryDatabaseFacade : Database
     {
         public InMemoryDatabaseFacade(
-            [NotNull] LazyRef<IModel> model,
+            [NotNull] ContextService<IModel> model,
             [NotNull] InMemoryDataStoreCreator dataStoreCreator,
             [NotNull] InMemoryConnection connection,
             [NotNull] ILoggerFactory loggerFactory)

--- a/src/EntityFramework.Migrations/Infrastructure/HistoryRepository.cs
+++ b/src/EntityFramework.Migrations/Infrastructure/HistoryRepository.cs
@@ -11,15 +11,14 @@ using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Utilities;
 using Microsoft.Data.Entity.Relational;
-using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Migrations.Infrastructure
 {
     public class HistoryRepository
     {
         private readonly IServiceProvider _serviceProvider;
-        private readonly LazyRef<IDbContextOptions> _options;
-        private readonly LazyRef<DbContext> _context;
+        private readonly ContextService<IDbContextOptions> _options;
+        private readonly ContextService<DbContext> _context;
         private IModel _historyModel;
         private DbContextOptions _contextOptions;
 
@@ -34,8 +33,8 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
 
         public HistoryRepository(
             [NotNull] IServiceProvider serviceProvider,
-            [NotNull] LazyRef<IDbContextOptions> options,
-            [NotNull] LazyRef<DbContext> context)
+            [NotNull] ContextService<IDbContextOptions> options,
+            [NotNull] ContextService<DbContext> context)
         {
             Check.NotNull(serviceProvider, "serviceProvider");
 
@@ -187,7 +186,7 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
 
             // TODO: Figure out whether it is ok to reuse all the extensions
             // from the user context configuration for the history context.
-            foreach (var item in _options.Value.Extensions)
+            foreach (var item in _options.Service.Extensions)
             {
                 var extension = item;
                 contextOptions.AddExtension(extension);
@@ -198,7 +197,7 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
 
         protected virtual string GetContextKey()
         {
-            return _context.Value.GetType().FullName;
+            return _context.Service.GetType().FullName;
         }
     }
 }

--- a/src/EntityFramework.Migrations/Infrastructure/MigrationAssembly.cs
+++ b/src/EntityFramework.Migrations/Infrastructure/MigrationAssembly.cs
@@ -10,14 +10,13 @@ using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Utilities;
 using Microsoft.Data.Entity.Relational;
-using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Migrations.Infrastructure
 {
     public class MigrationAssembly
     {
-        private readonly LazyRef<DbContext> _context;
-        private readonly LazyRef<IDbContextOptions> _options;
+        private readonly ContextService<DbContext> _context;
+        private readonly ContextService<IDbContextOptions> _options;
 
         private IReadOnlyList<Migration> _migrations;
         private IModel _model;
@@ -31,7 +30,7 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
         {
         }
 
-        public MigrationAssembly([NotNull] LazyRef<DbContext> context, [NotNull] LazyRef<IDbContextOptions> options)
+        public MigrationAssembly([NotNull] ContextService<DbContext> context, [NotNull] ContextService<IDbContextOptions> options)
         {
             Check.NotNull(context, "context");
             Check.NotNull(options, "options");
@@ -44,8 +43,8 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
         {
             get
             {
-                return RelationalOptionsExtension.Extract(_options.Value).MigrationAssembly
-                       ?? _context.Value.GetType().GetTypeInfo().Assembly;
+                return RelationalOptionsExtension.Extract(_options.Service).MigrationAssembly
+                       ?? _context.Service.GetType().GetTypeInfo().Assembly;
             }
         }
 
@@ -84,14 +83,14 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
 
         protected virtual IReadOnlyList<Migration> LoadMigrations()
         {
-            var contextType = _context.Value.GetType();
+            var contextType = _context.Service.GetType();
             return LoadMigrations(GetMigrationTypes(Assembly), contextType)
                 .ToArray();
         }
 
         protected virtual IModel LoadModel()
         {
-            var contextType = _context.Value.GetType();
+            var contextType = _context.Service.GetType();
             var modelSnapshotType = Assembly.GetAccessibleTypes().SingleOrDefault(
                 t => t.GetTypeInfo().IsSubclassOf(typeof(ModelSnapshot))
                      && t.GetPublicConstructor() != null

--- a/src/EntityFramework.Migrations/Infrastructure/MigrationsDataStoreServices.cs
+++ b/src/EntityFramework.Migrations/Infrastructure/MigrationsDataStoreServices.cs
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Migrations.Infrastructure
 {
@@ -11,9 +11,9 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
     {
         public abstract Migrator Migrator { get; }
 
-        public static Func<IServiceProvider, LazyRef<Migrator>> MigratorFactory
+        public static Func<IServiceProvider, ContextService<Migrator>> MigratorFactory
         {
-            get { return p => new LazyRef<Migrator>(() => ((MigrationsDataStoreServices)GetStoreServices(p)).Migrator); }
+            get { return p => new ContextService<Migrator>(() => ((MigrationsDataStoreServices)GetStoreServices(p)).Migrator); }
         }
     }
 }

--- a/src/EntityFramework.Migrations/Infrastructure/Migrator.cs
+++ b/src/EntityFramework.Migrations/Infrastructure/Migrator.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Utilities;
 using Microsoft.Data.Entity.Relational;
@@ -26,7 +27,7 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
         private readonly SqlStatementExecutor _sqlExecutor;
         private readonly RelationalDataStoreCreator _storeCreator;
         private readonly RelationalConnection _connection;
-        private readonly LazyRef<ILogger> _logger;
+        private readonly ContextService<ILogger> _logger;
 
         /// <summary>
         ///     This constructor is intended only for use when creating test doubles that will override members
@@ -66,7 +67,7 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
             _sqlExecutor = sqlExecutor;
             _storeCreator = storeCreator;
             _connection = connection;
-            _logger = new LazyRef<ILogger>(loggerFactory.Create<Migrator>);
+            _logger = new ContextService<ILogger>(loggerFactory.Create<Migrator>);
         }
 
         public virtual HistoryRepository HistoryRepository
@@ -101,7 +102,7 @@ namespace Microsoft.Data.Entity.Migrations.Infrastructure
 
         protected virtual ILogger Logger
         {
-            get { return _logger.Value; }
+            get { return _logger.Service; }
         }
 
         public virtual IReadOnlyList<Migration> GetLocalMigrations()

--- a/src/EntityFramework.Migrations/MigrationsEnabledDatabase.cs
+++ b/src/EntityFramework.Migrations/MigrationsEnabledDatabase.cs
@@ -2,12 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Infrastructure;
 using Microsoft.Data.Entity.Migrations.Utilities;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.Migrations
@@ -17,7 +17,7 @@ namespace Microsoft.Data.Entity.Migrations
         private readonly Migrator _migrator;
 
         protected MigrationsEnabledDatabase(
-            [NotNull] LazyRef<IModel> model,
+            [NotNull] ContextService<IModel> model,
             [NotNull] DataStoreCreator dataStoreCreator,
             [NotNull] DataStoreConnection connection,
             [NotNull] Migrator migrator,

--- a/src/EntityFramework.Migrations/MigrationsEntityServicesBuilderExtensions.cs
+++ b/src/EntityFramework.Migrations/MigrationsEntityServicesBuilderExtensions.cs
@@ -5,7 +5,6 @@ using JetBrains.Annotations;
 using Microsoft.Data.Entity.Migrations.Infrastructure;
 using Microsoft.Data.Entity.Migrations.Utilities;
 using Microsoft.Data.Entity.Relational;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
 
 namespace Microsoft.Data.Entity.Migrations
@@ -20,7 +19,7 @@ namespace Microsoft.Data.Entity.Migrations
                 .AddRelational().ServiceCollection
                 .AddScoped<MigrationAssembly>()
                 .AddScoped<HistoryRepository>()
-                .AddScoped<LazyRef<Migrator>>(MigrationsDataStoreServices.MigratorFactory);
+                .AddScoped(MigrationsDataStoreServices.MigratorFactory);
 
             return builder;
         }

--- a/src/EntityFramework.Redis/RedisConnection.cs
+++ b/src/EntityFramework.Redis/RedisConnection.cs
@@ -6,7 +6,6 @@ using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Redis.Utilities;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.Redis
@@ -25,12 +24,12 @@ namespace Microsoft.Data.Entity.Redis
         {
         }
 
-        public RedisConnection([NotNull] LazyRef<IDbContextOptions> options, [NotNull] ILoggerFactory loggerFactory)
+        public RedisConnection([NotNull] ContextService<IDbContextOptions> options, [NotNull] ILoggerFactory loggerFactory)
             : base(loggerFactory)
         {
             Check.NotNull(options, "options");
 
-            var extracted = RedisOptionsExtension.Extract(options.Value);
+            var extracted = RedisOptionsExtension.Extract(options.Service);
             _connectionString = extracted.HostName + ":" + extracted.Port;
             _database = extracted.Database;
         }

--- a/src/EntityFramework.Redis/RedisDataStore.cs
+++ b/src/EntityFramework.Redis/RedisDataStore.cs
@@ -12,7 +12,6 @@ using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Redis.Query;
 using Microsoft.Data.Entity.Redis.Utilities;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Remotion.Linq;
 
@@ -20,21 +19,21 @@ namespace Microsoft.Data.Entity.Redis
 {
     public class RedisDataStore : DataStore
     {
-        private readonly LazyRef<RedisDatabase> _database;
+        private readonly ContextService<RedisDatabase> _database;
 
         public RedisDataStore(
              [NotNull] StateManager stateManager,
-             [NotNull] LazyRef<IModel> model,
+             [NotNull] ContextService<IModel> model,
              [NotNull] EntityKeyFactorySource entityKeyFactorySource,
              [NotNull] EntityMaterializerSource entityMaterializerSource,
              [NotNull] ClrCollectionAccessorSource collectionAccessorSource,
              [NotNull] ClrPropertySetterSource propertySetterSource,
-             [NotNull] LazyRef<Database> database,
+             [NotNull] ContextService<Database> database,
              [NotNull] ILoggerFactory loggerFactory)
             : base(stateManager, model, entityKeyFactorySource, entityMaterializerSource,
                 collectionAccessorSource, propertySetterSource, loggerFactory)
         {
-            _database = new LazyRef<RedisDatabase>(() => (RedisDatabase)database.Value);
+            _database = new ContextService<RedisDatabase>(() => (RedisDatabase)database.Service);
         }
 
         public override int SaveChanges(
@@ -42,7 +41,7 @@ namespace Microsoft.Data.Entity.Redis
         {
             Check.NotNull(stateEntries, "stateEntries");
 
-            return _database.Value.SaveChanges(stateEntries);
+            return _database.Service.SaveChanges(stateEntries);
         }
 
         public override Task<int> SaveChangesAsync(
@@ -51,7 +50,7 @@ namespace Microsoft.Data.Entity.Redis
         {
             Check.NotNull(stateEntries, "stateEntries");
 
-            return _database.Value.SaveChangesAsync(stateEntries, cancellationToken);
+            return _database.Service.SaveChangesAsync(stateEntries, cancellationToken);
         }
 
         public override IEnumerable<TResult> Query<TResult>(QueryModel queryModel)
@@ -73,7 +72,7 @@ namespace Microsoft.Data.Entity.Redis
                 = new RedisQueryContext(
                     Logger,
                     CreateQueryBuffer(),
-                    _database.Value);
+                    _database.Service);
 
             return queryExecutor(queryContext);
         }
@@ -100,7 +99,7 @@ namespace Microsoft.Data.Entity.Redis
                 = new RedisQueryContext(
                     Logger,
                     CreateQueryBuffer(),
-                    _database.Value)
+                    _database.Service)
                 {
                     CancellationToken = cancellationToken
                 };

--- a/src/EntityFramework.Redis/RedisDataStoreSource.cs
+++ b/src/EntityFramework.Redis/RedisDataStoreSource.cs
@@ -4,13 +4,12 @@
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Redis
 {
     public class RedisDataStoreSource : DataStoreSource<RedisDataStoreServices, RedisOptionsExtension>
     {
-        public RedisDataStoreSource([NotNull] DbContextConfiguration configuration, [NotNull] LazyRef<IDbContextOptions> options)
+        public RedisDataStoreSource([NotNull] DbContextConfiguration configuration, [NotNull] ContextService<IDbContextOptions> options)
             : base(configuration, options)
         {
         }

--- a/src/EntityFramework.Redis/RedisDatabase.cs
+++ b/src/EntityFramework.Redis/RedisDatabase.cs
@@ -15,7 +15,6 @@ using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Redis.Query;
 using Microsoft.Data.Entity.Redis.Utilities;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using StackExchange.Redis;
 
@@ -63,7 +62,7 @@ namespace Microsoft.Data.Entity.Redis
         }
 
         public RedisDatabase(
-            [NotNull] LazyRef<IModel> model,
+            [NotNull] ContextService<IModel> model,
             [NotNull] RedisDataStoreCreator dataStoreCreator,
             [NotNull] RedisConnection connection,
             [NotNull] ILoggerFactory loggerFactory)

--- a/src/EntityFramework.Redis/RedisSequenceValueGenerator.cs
+++ b/src/EntityFramework.Redis/RedisSequenceValueGenerator.cs
@@ -5,10 +5,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Identity;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Redis.Utilities;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Redis
 {
@@ -19,24 +19,24 @@ namespace Microsoft.Data.Entity.Redis
         {
         }
 
-        protected override long GetNewCurrentValue(IProperty property, LazyRef<DataStoreServices> dataStoreServices)
+        protected override long GetNewCurrentValue(IProperty property, ContextService<DataStoreServices> dataStoreServices)
         {
             Check.NotNull(property, "property");
             Check.NotNull(dataStoreServices, "dataStoreServices");
 
-            var database = (RedisDatabase)dataStoreServices.Value.Database;
+            var database = (RedisDatabase)dataStoreServices.Service.Database;
             return database.GetNextGeneratedValue(property, BlockSize, SequenceName);
         }
 
         protected override async Task<long> GetNewCurrentValueAsync(
-            IProperty property, LazyRef<DataStoreServices> dataStoreServices, CancellationToken cancellationToken)
+            IProperty property, ContextService<DataStoreServices> dataStoreServices, CancellationToken cancellationToken)
         {
             Check.NotNull(property, "property");
             Check.NotNull(dataStoreServices, "dataStoreServices");
 
             cancellationToken.ThrowIfCancellationRequested();
 
-            var database = (RedisDatabase)dataStoreServices.Value.Database;
+            var database = (RedisDatabase)dataStoreServices.Service.Database;
 
             return
                 await database.GetNextGeneratedValueAsync(

--- a/src/EntityFramework.Relational/RelationalConnection.cs
+++ b/src/EntityFramework.Relational/RelationalConnection.cs
@@ -31,12 +31,12 @@ namespace Microsoft.Data.Entity.Relational
         {
         }
 
-        protected RelationalConnection([NotNull] LazyRef<IDbContextOptions> options, [NotNull] ILoggerFactory loggerFactory)
+        protected RelationalConnection([NotNull] ContextService<IDbContextOptions> options, [NotNull] ILoggerFactory loggerFactory)
             : base(loggerFactory)
         {
             Check.NotNull(options, "options");
 
-            var storeConfig = RelationalOptionsExtension.Extract(options.Value);
+            var storeConfig = RelationalOptionsExtension.Extract(options.Service);
 
             if (storeConfig.Connection != null)
             {

--- a/src/EntityFramework.Relational/RelationalDataStore.cs
+++ b/src/EntityFramework.Relational/RelationalDataStore.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Relational.Query;
@@ -14,7 +15,6 @@ using Microsoft.Data.Entity.Relational.Query.Methods;
 using Microsoft.Data.Entity.Relational.Update;
 using Microsoft.Data.Entity.Relational.Utilities;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Remotion.Linq;
 
@@ -37,7 +37,7 @@ namespace Microsoft.Data.Entity.Relational
 
         protected RelationalDataStore(
             [NotNull] StateManager stateManager,
-            [NotNull] LazyRef<IModel> model,
+            [NotNull] ContextService<IModel> model,
             [NotNull] EntityKeyFactorySource entityKeyFactorySource,
             [NotNull] EntityMaterializerSource entityMaterializerSource,
             [NotNull] ClrCollectionAccessorSource collectionAccessorSource,

--- a/src/EntityFramework.Relational/RelationalDatabase.cs
+++ b/src/EntityFramework.Relational/RelationalDatabase.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Data.Entity.Relational
     public abstract class RelationalDatabase : Database
     {
         protected RelationalDatabase(
-                   [NotNull] LazyRef<IModel> model,
+                   [NotNull] ContextService<IModel> model,
                    [NotNull] DataStoreCreator dataStoreCreator,
                    [NotNull] DataStoreConnection connection,
                    [NotNull] ILoggerFactory loggerFactory)

--- a/src/EntityFramework.Relational/Update/BatchExecutor.cs
+++ b/src/EntityFramework.Relational/Update/BatchExecutor.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Relational.Utilities;
 using Microsoft.Data.Entity.Utilities;
@@ -16,7 +17,7 @@ namespace Microsoft.Data.Entity.Relational.Update
     public class BatchExecutor
     {
         private readonly RelationalTypeMapper _typeMapper;
-        private readonly LazyRef<DbContext> _context;
+        private readonly ContextService<DbContext> _context;
         private readonly LazyRef<ILogger> _logger;
 
         /// <summary>
@@ -30,7 +31,7 @@ namespace Microsoft.Data.Entity.Relational.Update
 
         public BatchExecutor(
             [NotNull] RelationalTypeMapper typeMapper,
-            [NotNull] LazyRef<DbContext> context,
+            [NotNull] ContextService<DbContext> context,
             [NotNull] ILoggerFactory loggerFactory)
         {
             Check.NotNull(typeMapper, "typeMapper");
@@ -69,7 +70,7 @@ namespace Microsoft.Data.Entity.Relational.Update
                     rowsAffected += commandbatch.Execute(
                         connection.Transaction,
                         _typeMapper,
-                        _context.Value,
+                        _context.Service,
                         Logger);
                 }
 
@@ -113,7 +114,7 @@ namespace Microsoft.Data.Entity.Relational.Update
                     rowsAffected += await commandbatch.ExecuteAsync(
                         connection.Transaction,
                         _typeMapper,
-                        _context.Value,
+                        _context.Service,
                         Logger, cancellationToken)
                         .WithCurrentCulture();
                 }

--- a/src/EntityFramework.SQLite/SQLiteBatchExecutor.cs
+++ b/src/EntityFramework.SQLite/SQLiteBatchExecutor.cs
@@ -3,8 +3,8 @@
 
 using System;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Relational.Update;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SQLite
@@ -22,7 +22,7 @@ namespace Microsoft.Data.Entity.SQLite
 
         public SQLiteBatchExecutor(
             [NotNull] SQLiteTypeMapper typeMapper,
-            [NotNull] LazyRef<DbContext> context,
+            [NotNull] ContextService<DbContext> context,
             [NotNull] ILoggerFactory loggerFactory)
             : base(typeMapper, context, loggerFactory)
         {

--- a/src/EntityFramework.SQLite/SQLiteConnection.cs
+++ b/src/EntityFramework.SQLite/SQLiteConnection.cs
@@ -6,7 +6,6 @@ using System.Data.Common;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Relational;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Data.SQLite;
 using Microsoft.Framework.Logging;
 
@@ -23,7 +22,7 @@ namespace Microsoft.Data.Entity.SQLite
         {
         }
 
-        public SQLiteConnection([NotNull] LazyRef<IDbContextOptions> options, [NotNull] ILoggerFactory loggerFactory)
+        public SQLiteConnection([NotNull] ContextService<IDbContextOptions> options, [NotNull] ILoggerFactory loggerFactory)
             : base(options, loggerFactory)
         {
         }

--- a/src/EntityFramework.SQLite/SQLiteDataStore.cs
+++ b/src/EntityFramework.SQLite/SQLiteDataStore.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Relational;
@@ -10,7 +11,6 @@ using Microsoft.Data.Entity.Relational.Query;
 using Microsoft.Data.Entity.Relational.Query.Methods;
 using Microsoft.Data.Entity.SQLite.Query;
 using Microsoft.Data.Entity.SQLite.Utilities;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SQLite
@@ -19,7 +19,7 @@ namespace Microsoft.Data.Entity.SQLite
     {
         public SQLiteDataStore(
             [NotNull] StateManager stateManager,
-            [NotNull] LazyRef<IModel> model,
+            [NotNull] ContextService<IModel> model,
             [NotNull] EntityKeyFactorySource entityKeyFactorySource,
             [NotNull] EntityMaterializerSource entityMaterializerSource,
             [NotNull] ClrCollectionAccessorSource collectionAccessorSource,

--- a/src/EntityFramework.SQLite/SQLiteDataStoreSource.cs
+++ b/src/EntityFramework.SQLite/SQLiteDataStoreSource.cs
@@ -4,13 +4,12 @@
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.SQLite
 {
     public class SQLiteDataStoreSource : DataStoreSource<SQLiteDataStoreServices, SQLiteOptionsExtension>
     {
-        public SQLiteDataStoreSource([NotNull] DbContextConfiguration configuration, [NotNull] LazyRef<IDbContextOptions> options)
+        public SQLiteDataStoreSource([NotNull] DbContextConfiguration configuration, [NotNull] ContextService<IDbContextOptions> options)
             : base(configuration, options)
         {
         }

--- a/src/EntityFramework.SQLite/SQLiteDatabase.cs
+++ b/src/EntityFramework.SQLite/SQLiteDatabase.cs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SQLite
@@ -12,7 +12,7 @@ namespace Microsoft.Data.Entity.SQLite
     public class SQLiteDatabase : MigrationsEnabledDatabase
     {
         public SQLiteDatabase(
-            [NotNull] LazyRef<IModel> model,
+            [NotNull] ContextService<IModel> model,
             [NotNull] SQLiteDataStoreCreator dataStoreCreator,
             [NotNull] SQLiteConnection connection,
             [NotNull] SQLiteMigrator migrator,

--- a/src/EntityFramework.SqlServer/SqlServerConnection.cs
+++ b/src/EntityFramework.SqlServer/SqlServerConnection.cs
@@ -7,7 +7,6 @@ using System.Data.SqlClient;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Relational;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SqlServer
@@ -23,7 +22,7 @@ namespace Microsoft.Data.Entity.SqlServer
         {
         }
 
-        public SqlServerConnection([NotNull] LazyRef<IDbContextOptions> options, [NotNull] ILoggerFactory loggerFactory)
+        public SqlServerConnection([NotNull] ContextService<IDbContextOptions> options, [NotNull] ILoggerFactory loggerFactory)
             : base(options, loggerFactory)
         {
         }

--- a/src/EntityFramework.SqlServer/SqlServerDataStore.cs
+++ b/src/EntityFramework.SqlServer/SqlServerDataStore.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Relational;
@@ -11,7 +12,6 @@ using Microsoft.Data.Entity.Relational.Query.Methods;
 using Microsoft.Data.Entity.SqlServer.Query;
 using Microsoft.Data.Entity.SqlServer.Update;
 using Microsoft.Data.Entity.SqlServer.Utilities;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SqlServer
@@ -20,7 +20,7 @@ namespace Microsoft.Data.Entity.SqlServer
     {
         public SqlServerDataStore(
             [NotNull] StateManager stateManager,
-            [NotNull] LazyRef<IModel> model,
+            [NotNull] ContextService<IModel> model,
             [NotNull] EntityKeyFactorySource entityKeyFactorySource,
             [NotNull] EntityMaterializerSource entityMaterializerSource,
             [NotNull] ClrCollectionAccessorSource collectionAccessorSource,

--- a/src/EntityFramework.SqlServer/SqlServerDataStoreSource.cs
+++ b/src/EntityFramework.SqlServer/SqlServerDataStoreSource.cs
@@ -4,13 +4,12 @@
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.SqlServer
 {
     public class SqlServerDataStoreSource : DataStoreSource<SqlServerDataStoreServices, SqlServerOptionsExtension>
     {
-        public SqlServerDataStoreSource([NotNull] DbContextConfiguration configuration, [NotNull] LazyRef<IDbContextOptions> options)
+        public SqlServerDataStoreSource([NotNull] DbContextConfiguration configuration, [NotNull] ContextService<IDbContextOptions> options)
             : base(configuration, options)
         {
         }

--- a/src/EntityFramework.SqlServer/SqlServerDatabase.cs
+++ b/src/EntityFramework.SqlServer/SqlServerDatabase.cs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SqlServer
@@ -12,7 +12,7 @@ namespace Microsoft.Data.Entity.SqlServer
     public class SqlServerDatabase : MigrationsEnabledDatabase
     {
         public SqlServerDatabase(
-            [NotNull] LazyRef<IModel> model,
+            [NotNull] ContextService<IModel> model,
             [NotNull] SqlServerDataStoreCreator dataStoreCreator,
             [NotNull] SqlServerConnection connection,
             [NotNull] SqlServerMigrator migrator,

--- a/src/EntityFramework.SqlServer/SqlServerSequenceValueGenerator.cs
+++ b/src/EntityFramework.SqlServer/SqlServerSequenceValueGenerator.cs
@@ -7,11 +7,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Identity;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.SqlServer.Utilities;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.SqlServer
 {
@@ -30,24 +30,24 @@ namespace Microsoft.Data.Entity.SqlServer
             _executor = executor;
         }
 
-        protected override long GetNewCurrentValue(IProperty property, LazyRef<DataStoreServices> dataStoreServices)
+        protected override long GetNewCurrentValue(IProperty property, ContextService<DataStoreServices> dataStoreServices)
         {
             Check.NotNull(property, "property");
             Check.NotNull(dataStoreServices, "dataStoreServices");
 
-            var commandInfo = PrepareCommand((RelationalConnection)dataStoreServices.Value.Connection);
+            var commandInfo = PrepareCommand((RelationalConnection)dataStoreServices.Service.Connection);
             var nextValue = _executor.ExecuteScalar(commandInfo.Item1.DbConnection, commandInfo.Item1.DbTransaction, commandInfo.Item2);
 
             return (long)Convert.ChangeType(nextValue, typeof(long), CultureInfo.InvariantCulture);
         }
 
         protected override async Task<long> GetNewCurrentValueAsync(
-            IProperty property, LazyRef<DataStoreServices> dataStoreServices, CancellationToken cancellationToken)
+            IProperty property, ContextService<DataStoreServices> dataStoreServices, CancellationToken cancellationToken)
         {
             Check.NotNull(property, "property");
             Check.NotNull(dataStoreServices, "dataStoreServices");
 
-            var commandInfo = PrepareCommand((RelationalConnection)dataStoreServices.Value.Connection);
+            var commandInfo = PrepareCommand((RelationalConnection)dataStoreServices.Service.Connection);
             var nextValue = await _executor
                 .ExecuteScalarAsync(commandInfo.Item1.DbConnection, commandInfo.Item1.DbTransaction, commandInfo.Item2, cancellationToken)
                 .WithCurrentCulture();

--- a/src/EntityFramework.SqlServer/Update/SqlServerBatchExecutor.cs
+++ b/src/EntityFramework.SqlServer/Update/SqlServerBatchExecutor.cs
@@ -3,8 +3,8 @@
 
 using System;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Relational.Update;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 
 namespace Microsoft.Data.Entity.SqlServer.Update
@@ -22,7 +22,7 @@ namespace Microsoft.Data.Entity.SqlServer.Update
 
         public SqlServerBatchExecutor(
             [NotNull] SqlServerTypeMapper typeMapper,
-            [NotNull] LazyRef<DbContext> context,
+            [NotNull] ContextService<DbContext> context,
             [NotNull] ILoggerFactory loggerFactory)
             : base(typeMapper, context, loggerFactory)
         {

--- a/src/EntityFramework/ChangeTracking/ChangeDetector.cs
+++ b/src/EntityFramework/ChangeTracking/ChangeDetector.cs
@@ -8,6 +8,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 
@@ -15,7 +16,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
 {
     public class ChangeDetector : IPropertyListener
     {
-        private readonly LazyRef<IModel> _model;
+        private readonly ContextService<IModel> _model;
 
         /// <summary>
         ///     This constructor is intended only for use when creating test doubles that will override members
@@ -26,7 +27,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
         {
         }
 
-        public ChangeDetector([NotNull] LazyRef<IModel> model)
+        public ChangeDetector([NotNull] ContextService<IModel> model)
         {
             Check.NotNull(model, "model");
 
@@ -240,7 +241,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
             var isPrimaryKey = property.IsPrimaryKey();
 
             // TODO: Perf: make it faster to check if the property is at the principal end or not
-            var foreignKeys = _model.Value.GetReferencingForeignKeys(property).ToList();
+            var foreignKeys = _model.Service.GetReferencingForeignKeys(property).ToList();
 
             if (isPrimaryKey || foreignKeys.Count > 0)
             {

--- a/src/EntityFramework/ChangeTracking/ValueGenerationManager.cs
+++ b/src/EntityFramework/ChangeTracking/ValueGenerationManager.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.Identity;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
@@ -13,13 +14,13 @@ namespace Microsoft.Data.Entity.ChangeTracking
 {
     public class ValueGenerationManager
     {
-        private readonly LazyRef<ValueGeneratorCache> _valueGeneratorCache;
-        private readonly LazyRef<DataStoreServices> _dataStoreServices;
+        private readonly ContextService<ValueGeneratorCache> _valueGeneratorCache;
+        private readonly ContextService<DataStoreServices> _dataStoreServices;
         private readonly ForeignKeyValuePropagator _foreignKeyValuePropagator;
 
         public ValueGenerationManager(
-            [NotNull] LazyRef<ValueGeneratorCache> valueGeneratorCache,
-            [NotNull] LazyRef<DataStoreServices> dataStoreServices,
+            [NotNull] ContextService<ValueGeneratorCache> valueGeneratorCache,
+            [NotNull] ContextService<DataStoreServices> dataStoreServices,
             [NotNull] ForeignKeyValuePropagator foreignKeyValuePropagator)
         {
             Check.NotNull(valueGeneratorCache, "valueGeneratorCache");
@@ -48,7 +49,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
                     }
                     else
                     {
-                        var valueGenerator = _valueGeneratorCache.Value.GetGenerator(property);
+                        var valueGenerator = _valueGeneratorCache.Service.GetGenerator(property);
                         var generatedValue = valueGenerator == null
                             ? null
                             : valueGenerator.Next(property, _dataStoreServices);
@@ -76,7 +77,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
                     }
                     else
                     {
-                        var valueGenerator = _valueGeneratorCache.Value.GetGenerator(property);
+                        var valueGenerator = _valueGeneratorCache.Service.GetGenerator(property);
                         var generatedValue = valueGenerator == null
                             ? null
                             : await valueGenerator.NextAsync(property, _dataStoreServices, cancellationToken);

--- a/src/EntityFramework/DbContext.cs
+++ b/src/EntityFramework/DbContext.cs
@@ -297,7 +297,7 @@ namespace Microsoft.Data.Entity
 
         public virtual Database Database
         {
-            get { return _configuration.Value.ScopedServiceProvider.GetRequiredServiceChecked<LazyRef<Database>>().Value; }
+            get { return _configuration.Value.ScopedServiceProvider.GetRequiredServiceChecked<ContextService<Database>>().Service; }
         }
 
         public virtual ChangeTracker ChangeTracker
@@ -307,7 +307,7 @@ namespace Microsoft.Data.Entity
 
         public virtual IModel Model
         {
-            get { return _configuration.Value.ScopedServiceProvider.GetRequiredServiceChecked<LazyRef<IModel>>().Value; }
+            get { return _configuration.Value.ScopedServiceProvider.GetRequiredServiceChecked<ContextService<IModel>>().Service; }
         }
 
         public virtual DbSet<TEntity> Set<TEntity>()

--- a/src/EntityFramework/EntityFramework.csproj
+++ b/src/EntityFramework/EntityFramework.csproj
@@ -75,6 +75,7 @@
     <Compile Include="ChangeTracking\ValueGenerationManager.cs" />
     <Compile Include="DbContext.cs" />
     <Compile Include="Identity\GeneratedValue.cs" />
+    <Compile Include="Infrastructure\ContextService.cs" />
     <Compile Include="Infrastructure\DbContextActivator.cs" />
     <Compile Include="DbContextOptions.cs" />
     <Compile Include="DbContextOptions`.cs" />

--- a/src/EntityFramework/Extensions/EntityServiceCollectionExtensions.cs
+++ b/src/EntityFramework/Extensions/EntityServiceCollectionExtensions.cs
@@ -69,15 +69,15 @@ namespace Microsoft.Framework.DependencyInjection
                 .AddScoped<ValueGenerationManager>()
                 .AddScoped<EntityQueryExecutor>()
                 .AddScoped<ChangeTracker>()
-                .AddScoped<LazyRef<IModel>>(DbContextConfiguration.ModelFactory)
-                .AddScoped<LazyRef<DbContext>>(DbContextConfiguration.ContextFactory)
-                .AddScoped<LazyRef<IDbContextOptions>>(DbContextConfiguration.ContextOptionsFactory)
-                .AddScoped<LazyRef<DataStoreServices>>(DataStoreServices.DataStoreServicesFactory)
-                .AddScoped<LazyRef<DataStore>>(DataStoreServices.DataStoreFactory)
-                .AddScoped<LazyRef<DataStoreConnection>>(DataStoreServices.ConnectionFactory)
-                .AddScoped<LazyRef<Database>>(DataStoreServices.DatabaseFactory)
-                .AddScoped<LazyRef<ValueGeneratorCache>>(DataStoreServices.ValueGeneratorCacheFactory)
-                .AddScoped<LazyRef<DataStoreCreator>>(DataStoreServices.DataStoreCreatorFactory);
+                .AddScoped(DbContextConfiguration.ModelFactory)
+                .AddScoped(DbContextConfiguration.ContextFactory)
+                .AddScoped(DbContextConfiguration.ContextOptionsFactory)
+                .AddScoped(DataStoreServices.DataStoreServicesFactory)
+                .AddScoped(DataStoreServices.DataStoreFactory)
+                .AddScoped(DataStoreServices.ConnectionFactory)
+                .AddScoped(DataStoreServices.DatabaseFactory)
+                .AddScoped(DataStoreServices.ValueGeneratorCacheFactory)
+                .AddScoped(DataStoreServices.DataStoreCreatorFactory);
 
             EnsureLowLevelServices(serviceCollection);
 

--- a/src/EntityFramework/Identity/BlockOfSequentialValuesGenerator.cs
+++ b/src/EntityFramework/Identity/BlockOfSequentialValuesGenerator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
@@ -43,7 +44,7 @@ namespace Microsoft.Data.Entity.Identity
             get { return _blockSize; }
         }
 
-        public virtual GeneratedValue Next(IProperty property, LazyRef<DataStoreServices> dataStoreServices)
+        public virtual GeneratedValue Next(IProperty property, ContextService<DataStoreServices> dataStoreServices)
         {
             Check.NotNull(property, "property");
             Check.NotNull(dataStoreServices, "dataStoreServices");
@@ -77,7 +78,7 @@ namespace Microsoft.Data.Entity.Identity
 
         public virtual async Task<GeneratedValue> NextAsync(
             IProperty property,
-            LazyRef<DataStoreServices> dataStoreServices,
+            ContextService<DataStoreServices> dataStoreServices,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             Check.NotNull(property, "property");
@@ -112,11 +113,11 @@ namespace Microsoft.Data.Entity.Identity
 
         protected abstract long GetNewCurrentValue(
             [NotNull] IProperty property,
-            [NotNull] LazyRef<DataStoreServices> dataStoreServices);
+            [NotNull] ContextService<DataStoreServices> dataStoreServices);
 
         protected abstract Task<long> GetNewCurrentValueAsync(
             [NotNull] IProperty property,
-            [NotNull] LazyRef<DataStoreServices> dataStoreServices,
+            [NotNull] ContextService<DataStoreServices> dataStoreServices,
             CancellationToken cancellationToken);
 
         private SequenceValue GetNextValue()

--- a/src/EntityFramework/Identity/IValueGenerator.cs
+++ b/src/EntityFramework/Identity/IValueGenerator.cs
@@ -4,9 +4,9 @@
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Identity
 {
@@ -14,11 +14,11 @@ namespace Microsoft.Data.Entity.Identity
     {
         GeneratedValue Next(
             [NotNull] IProperty property,
-            [NotNull] LazyRef<DataStoreServices> dataStoreServices);
+            [NotNull] ContextService<DataStoreServices> dataStoreServices);
 
         Task<GeneratedValue> NextAsync(
             [NotNull] IProperty property,
-            [NotNull] LazyRef<DataStoreServices> dataStoreServices,
+            [NotNull] ContextService<DataStoreServices> dataStoreServices,
             CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/EntityFramework/Identity/SimpleValueGenerator.cs
+++ b/src/EntityFramework/Identity/SimpleValueGenerator.cs
@@ -4,6 +4,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
@@ -14,7 +15,7 @@ namespace Microsoft.Data.Entity.Identity
     {
         public abstract GeneratedValue Next([NotNull] IProperty property);
 
-        public virtual GeneratedValue Next(IProperty property, LazyRef<DataStoreServices> dataStoreServices)
+        public virtual GeneratedValue Next(IProperty property, ContextService<DataStoreServices> dataStoreServices)
         {
             Check.NotNull(property, "property");
 
@@ -23,7 +24,7 @@ namespace Microsoft.Data.Entity.Identity
 
         public virtual Task<GeneratedValue> NextAsync(
             IProperty property,
-            LazyRef<DataStoreServices> dataStoreServices,
+            ContextService<DataStoreServices> dataStoreServices,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             Check.NotNull(property, "property");

--- a/src/EntityFramework/Infrastructure/ContextService.cs
+++ b/src/EntityFramework/Infrastructure/ContextService.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Utilities;
+
+namespace Microsoft.Data.Entity.Infrastructure
+{
+    /// <summary>
+    ///     Used for constructor injection of services that are dynamic based on the configuration
+    ///     of the currrently in scope <see cref="DbContext" />.
+    /// </summary>
+    /// <typeparam name="TService">The service that will be dynamically resolved.</typeparam>
+    public class ContextService<TService>
+    {
+        private readonly LazyRef<TService> _service;
+
+        public ContextService([NotNull] Func<TService> initializer)
+        {
+            Check.NotNull(initializer, "initializer");
+
+            _service = new LazyRef<TService>(initializer);
+        }
+
+        public ContextService([CanBeNull] TService service)
+        {
+            _service = new LazyRef<TService>(service);
+        }
+
+        public virtual TService Service
+        {
+            get { return _service.Value; }
+        }
+    }
+}

--- a/src/EntityFramework/Infrastructure/Database.cs
+++ b/src/EntityFramework/Infrastructure/Database.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Data.Entity.Infrastructure
 {
     public abstract class Database : IDatabaseInternals
     {
-        private readonly LazyRef<IModel> _model;
+        private readonly ContextService<IModel> _model;
         private readonly DataStoreCreator _dataStoreCreator;
         private readonly DataStoreConnection _connection;
         private readonly LazyRef<ILogger> _logger;
@@ -29,7 +29,7 @@ namespace Microsoft.Data.Entity.Infrastructure
         }
 
         protected Database(
-            [NotNull] LazyRef<IModel> model,
+            [NotNull] ContextService<IModel> model,
             [NotNull] DataStoreCreator dataStoreCreator,
             [NotNull] DataStoreConnection connection,
             [NotNull] ILoggerFactory loggerFactory)
@@ -86,7 +86,7 @@ namespace Microsoft.Data.Entity.Infrastructure
 
         protected virtual IModel Model
         {
-            get { return _model.Value; }
+            get { return _model.Service; }
         }
 
         DataStoreCreator IDatabaseInternals.DataStoreCreator

--- a/src/EntityFramework/Infrastructure/DbContextConfiguration.cs
+++ b/src/EntityFramework/Infrastructure/DbContextConfiguration.cs
@@ -90,19 +90,19 @@ namespace Microsoft.Data.Entity.Infrastructure
             get { return _dataStoreServices.Value; }
         }
 
-        public static Func<IServiceProvider, LazyRef<DbContext>> ContextFactory
+        public static Func<IServiceProvider, ContextService<DbContext>> ContextFactory
         {
-            get { return p => new LazyRef<DbContext>(() => p.GetRequiredServiceChecked<DbContextConfiguration>().Context); }
+            get { return p => new ContextService<DbContext>(() => p.GetRequiredServiceChecked<DbContextConfiguration>().Context); }
         }
 
-        public static Func<IServiceProvider, LazyRef<IModel>> ModelFactory
+        public static Func<IServiceProvider, ContextService<IModel>> ModelFactory
         {
-            get { return p => new LazyRef<IModel>(() => p.GetRequiredServiceChecked<DbContextConfiguration>().Model); }
+            get { return p => new ContextService<IModel>(() => p.GetRequiredServiceChecked<DbContextConfiguration>().Model); }
         }
 
-        public static Func<IServiceProvider, LazyRef<IDbContextOptions>> ContextOptionsFactory
+        public static Func<IServiceProvider, ContextService<IDbContextOptions>> ContextOptionsFactory
         {
-            get { return p => new LazyRef<IDbContextOptions>(() => p.GetRequiredServiceChecked<DbContextConfiguration>().ContextOptions); }
+            get { return p => new ContextService<IDbContextOptions>(() => p.GetRequiredServiceChecked<DbContextConfiguration>().ContextOptions); }
         }
 
         public virtual IServiceProvider ScopedServiceProvider

--- a/src/EntityFramework/Storage/DataStore.cs
+++ b/src/EntityFramework/Storage/DataStore.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Utilities;
@@ -18,7 +19,7 @@ namespace Microsoft.Data.Entity.Storage
     public abstract class DataStore
     {
         private readonly StateManager _stateManager;
-        private readonly LazyRef<IModel> _model;
+        private readonly ContextService<IModel> _model;
         private readonly EntityKeyFactorySource _entityKeyFactorySource;
         private readonly EntityMaterializerSource _entityMaterializerSource;
         private readonly ClrCollectionAccessorSource _collectionAccessorSource;
@@ -36,7 +37,7 @@ namespace Microsoft.Data.Entity.Storage
 
         protected DataStore(
             [NotNull] StateManager stateManager,
-            [NotNull] LazyRef<IModel> model,
+            [NotNull] ContextService<IModel> model,
             [NotNull] EntityKeyFactorySource entityKeyFactorySource,
             [NotNull] EntityMaterializerSource entityMaterializerSource,
             [NotNull] ClrCollectionAccessorSource collectionAccessorSource,
@@ -67,7 +68,7 @@ namespace Microsoft.Data.Entity.Storage
 
         public virtual IModel Model
         {
-            get { return _model.Value; }
+            get { return _model.Service; }
         }
 
         public virtual EntityKeyFactorySource EntityKeyFactorySource

--- a/src/EntityFramework/Storage/DataStoreServices.cs
+++ b/src/EntityFramework/Storage/DataStoreServices.cs
@@ -20,34 +20,34 @@ namespace Microsoft.Data.Entity.Storage
         public abstract Database Database { get; }
         public abstract IModelBuilderFactory ModelBuilderFactory { get; }
 
-        public static Func<IServiceProvider, LazyRef<DataStoreServices>> DataStoreServicesFactory
+        public static Func<IServiceProvider, ContextService<DataStoreServices>> DataStoreServicesFactory
         {
-            get { return p => new LazyRef<DataStoreServices>(() => GetStoreServices(p)); }
+            get { return p => new ContextService<DataStoreServices>(() => GetStoreServices(p)); }
         }
 
-        public static Func<IServiceProvider, LazyRef<DataStore>> DataStoreFactory
+        public static Func<IServiceProvider, ContextService<DataStore>> DataStoreFactory
         {
-            get { return p => new LazyRef<DataStore>(() => GetStoreServices(p).Store); }
+            get { return p => new ContextService<DataStore>(() => GetStoreServices(p).Store); }
         }
 
-        public static Func<IServiceProvider, LazyRef<Database>> DatabaseFactory
+        public static Func<IServiceProvider, ContextService<Database>> DatabaseFactory
         {
-            get { return p => new LazyRef<Database>(() => GetStoreServices(p).Database); }
+            get { return p => new ContextService<Database>(() => GetStoreServices(p).Database); }
         }
 
-        public static Func<IServiceProvider, LazyRef<DataStoreCreator>> DataStoreCreatorFactory
+        public static Func<IServiceProvider, ContextService<DataStoreCreator>> DataStoreCreatorFactory
         {
-            get { return p => new LazyRef<DataStoreCreator>(() => GetStoreServices(p).Creator); }
+            get { return p => new ContextService<DataStoreCreator>(() => GetStoreServices(p).Creator); }
         }
 
-        public static Func<IServiceProvider, LazyRef<ValueGeneratorCache>> ValueGeneratorCacheFactory
+        public static Func<IServiceProvider, ContextService<ValueGeneratorCache>> ValueGeneratorCacheFactory
         {
-            get { return p => new LazyRef<ValueGeneratorCache>(() => GetStoreServices(p).ValueGeneratorCache); }
+            get { return p => new ContextService<ValueGeneratorCache>(() => GetStoreServices(p).ValueGeneratorCache); }
         }
 
-        public static Func<IServiceProvider, LazyRef<DataStoreConnection>> ConnectionFactory
+        public static Func<IServiceProvider, ContextService<DataStoreConnection>> ConnectionFactory
         {
-            get { return p => new LazyRef<DataStoreConnection>(() => GetStoreServices(p).Connection); }
+            get { return p => new ContextService<DataStoreConnection>(() => GetStoreServices(p).Connection); }
         }
 
         protected static DataStoreServices GetStoreServices([NotNull] IServiceProvider serviceProvider)

--- a/src/EntityFramework/Storage/DataStoreSource`.cs
+++ b/src/EntityFramework/Storage/DataStoreSource`.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Data.Entity.Storage
         where TOptionsExtension : DbContextOptionsExtension
     {
         private readonly DbContextConfiguration _configuration;
-        private readonly LazyRef<IDbContextOptions> _options;
+        private readonly ContextService<IDbContextOptions> _options;
 
-        protected DataStoreSource([NotNull] DbContextConfiguration configuration, [NotNull] LazyRef<IDbContextOptions> options)
+        protected DataStoreSource([NotNull] DbContextConfiguration configuration, [NotNull] ContextService<IDbContextOptions> options)
         {
             Check.NotNull(configuration, "configuration");
             Check.NotNull(options, "options");
@@ -37,7 +37,7 @@ namespace Microsoft.Data.Entity.Storage
 
         public override bool IsConfigured
         {
-            get { return _options.Value.Extensions.OfType<TOptionsExtension>().Any(); }
+            get { return _options.Service.Extensions.OfType<TOptionsExtension>().Any(); }
         }
 
         public override bool IsAvailable

--- a/test/EntityFramework.AzureTableStorage.Tests/AtsBatchedDataStoreTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/AtsBatchedDataStoreTests.cs
@@ -15,7 +15,6 @@ using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Update;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Table;
@@ -148,7 +147,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests
         {
             var store = new AtsDataStore(
                 Mock.Of<StateManager>(),
-                new LazyRef<IModel>(() => null),
+                new ContextService<IModel>(() => null),
                 Mock.Of<EntityKeyFactorySource>(),
                 Mock.Of<EntityMaterializerSource>(),
                 Mock.Of<ClrCollectionAccessorSource>(),
@@ -156,7 +155,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests
                 _connection.Object,
                 new AtsQueryFactory(new AtsValueReaderFactory()),
                 new TableEntityAdapterFactory(),
-                new LazyRef<DbContext>(Mock.Of<DbContext>()),
+                new ContextService<DbContext>(Mock.Of<DbContext>()),
                 new LoggerFactory());
             return store;
         }

--- a/test/EntityFramework.AzureTableStorage.Tests/AtsDataStoreSourceTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/AtsDataStoreSourceTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Utilities;
 using Moq;
 using Xunit;
 
@@ -22,7 +21,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests
                 Mock.Of<DbContext>(),
                 DbContextConfiguration.ServiceProviderSource.Implicit);
 
-            var source = new AtsDataStoreSource(config, new LazyRef<IDbContextOptions>(options));
+            var source = new AtsDataStoreSource(config, new ContextService<IDbContextOptions>(options));
 
             Assert.False(source.IsAvailable);
 
@@ -36,7 +35,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests
         {
             Assert.Equal(
                 "AzureTableStorage", 
-                new AtsDataStoreSource(Mock.Of<DbContextConfiguration>(),  new LazyRef<IDbContextOptions>(() => null)).Name);
+                new AtsDataStoreSource(Mock.Of<DbContextConfiguration>(),  new ContextService<IDbContextOptions>(() => null)).Name);
         }
     }
 }

--- a/test/EntityFramework.AzureTableStorage.Tests/AtsDataStoreTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/AtsDataStoreTests.cs
@@ -15,7 +15,6 @@ using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Update;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Microsoft.WindowsAzure.Storage;
 using Microsoft.WindowsAzure.Storage.Table;
@@ -130,7 +129,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests
         {
             var store = new AtsDataStore(
                 Mock.Of<StateManager>(),
-                new LazyRef<IModel>(() => null),
+                new ContextService<IModel>(() => null),
                 Mock.Of<EntityKeyFactorySource>(),
                 Mock.Of<EntityMaterializerSource>(),
                 Mock.Of<ClrCollectionAccessorSource>(),
@@ -138,7 +137,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests
                 _connection.Object,
                 new AtsQueryFactory(new AtsValueReaderFactory()),
                 new TableEntityAdapterFactory(),
-                new LazyRef<DbContext>(Mock.Of<DbContext>()),
+                new ContextService<DbContext>(Mock.Of<DbContext>()),
                 new LoggerFactory());
             return store;
         }

--- a/test/EntityFramework.AzureTableStorage.Tests/AtsDatabaseTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/AtsDatabaseTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
@@ -21,7 +21,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests
             creatorMock.Setup(m => m.EnsureDeleted(model)).Returns(true);
 
             var database = new AtsDatabase(
-                new LazyRef<IModel>(() => model),
+                new ContextService<IModel>(() => model),
                 creatorMock.Object,
                 connection,
                 new LoggerFactory());

--- a/test/EntityFramework.AzureTableStorage.Tests/Extensions/AtsDatabaseExtensionTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Extensions/AtsDatabaseExtensionTests.cs
@@ -5,7 +5,6 @@ using System;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
@@ -18,7 +17,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Extensions
         public void Returns_typed_database_object()
         {
             var database = new AtsDatabase(
-                new LazyRef<IModel>(() => null),
+                new ContextService<IModel>(() => null),
                 Mock.Of<AtsDataStoreCreator>(),
                 Mock.Of<AtsConnection>(),
                 new LoggerFactory());
@@ -30,7 +29,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Extensions
         public void Throws_when_non_ats_provider_is_in_use()
         {
             var database = new ConcreteDatabase(
-                new LazyRef<IModel>(() => null),
+                new ContextService<IModel>(() => null),
                 Mock.Of<DataStoreCreator>(),
                 Mock.Of<DataStoreConnection>(),
                 new LoggerFactory());
@@ -43,7 +42,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Extensions
         private class ConcreteDatabase : Database
         {
             public ConcreteDatabase(
-                LazyRef<IModel> model,
+                ContextService<IModel> model,
                 DataStoreCreator dataStoreCreator,
                 DataStoreConnection connection,
                 ILoggerFactory loggerFactory)

--- a/test/EntityFramework.AzureTableStorage.Tests/Query/QueryGenerationTests.cs
+++ b/test/EntityFramework.AzureTableStorage.Tests/Query/QueryGenerationTests.cs
@@ -13,7 +13,6 @@ using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Query;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Tests;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.Logging;
 using Moq;
@@ -171,7 +170,7 @@ namespace Microsoft.Data.Entity.AzureTableStorage.Tests.Query
 
         private MainFromClause CreateWithEntityQueryable<T>()
         {
-            var entityQueryExecutor = new EntityQueryExecutor(new LazyRef<DbContext>(Mock.Of<DbContext>()), new LazyRef<DataStore>(() => null), new LoggerFactory());
+            var entityQueryExecutor = new EntityQueryExecutor(new ContextService<DbContext>(Mock.Of<DbContext>()), new ContextService<DataStore>(() => null), new LoggerFactory());
             var queryable = new EntityQueryable<T>(entityQueryExecutor);
             return new MainFromClause("s", typeof(T), Expression.Constant(queryable));
         }

--- a/test/EntityFramework.Commands.Tests/Migrations/MigrationScaffolderTest.cs
+++ b/test/EntityFramework.Commands.Tests/Migrations/MigrationScaffolderTest.cs
@@ -9,7 +9,6 @@ using Microsoft.Data.Entity.Migrations;
 using Microsoft.Data.Entity.Migrations.Infrastructure;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Relational.Model;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
 using Xunit;
 
@@ -23,15 +22,15 @@ namespace Microsoft.Data.Entity.Commands.Tests.Migrations
             using (var context = new Context(new Model()))
             {
                 var contextServices = ((IDbContextServices)context).ScopedServiceProvider;
-                var options = contextServices.GetRequiredService<LazyRef<IDbContextOptions>>();
-                var model = contextServices.GetRequiredService<LazyRef<IModel>>().Value;
+                var options = contextServices.GetRequiredService<ContextService<IDbContextOptions>>();
+                var model = contextServices.GetRequiredService<ContextService<IModel>>().Service;
 
                 var scaffolder
                     = new MyMigrationScaffolder(
                         context,
-                        options.Value,
+                        options.Service,
                         model,
-                        new MigrationAssembly(new LazyRef<DbContext>(context), options),
+                        new MigrationAssembly(new ContextService<DbContext>(context), options),
                         new TestModelDiffer(),
                         new CSharpMigrationCodeGenerator(
                             new CSharpModelCodeGenerator()),
@@ -48,15 +47,15 @@ namespace Microsoft.Data.Entity.Commands.Tests.Migrations
             using (var context = new Context(CreateModel()))
             {
                 var contextServices = ((IDbContextServices)context).ScopedServiceProvider;
-                var options = contextServices.GetRequiredService<LazyRef<IDbContextOptions>>();
-                var model = contextServices.GetRequiredService<LazyRef<IModel>>().Value;
+                var options = contextServices.GetRequiredService<ContextService<IDbContextOptions>>();
+                var model = contextServices.GetRequiredService<ContextService<IModel>>().Service;
 
                 var scaffolder
                     = new MyMigrationScaffolder(
                         context,
-                        options.Value,
+                        options.Service,
                         model,
-                        new MigrationAssembly(new LazyRef<DbContext>(context), options),
+                        new MigrationAssembly(new ContextService<DbContext>(context), options),
                         new TestModelDiffer(),
                         new CSharpMigrationCodeGenerator(
                             new CSharpModelCodeGenerator()),
@@ -73,15 +72,15 @@ namespace Microsoft.Data.Entity.Commands.Tests.Migrations
             using (var context = new Context(CreateModelWithForeignKeys()))
             {
                 var contextServices = ((IDbContextServices)context).ScopedServiceProvider;
-                var options = contextServices.GetRequiredService<LazyRef<IDbContextOptions>>();
-                var model = contextServices.GetRequiredService<LazyRef<IModel>>().Value;
+                var options = contextServices.GetRequiredService<ContextService<IDbContextOptions>>();
+                var model = contextServices.GetRequiredService<ContextService<IModel>>().Service;
 
                 var scaffolder
                     = new MyMigrationScaffolder(
                         context,
-                        options.Value,
+                        options.Service,
                         model,
-                        new MigrationAssembly(new LazyRef<DbContext>(context), options),
+                        new MigrationAssembly(new ContextService<DbContext>(context), options),
                         new TestModelDiffer(),
                         new CSharpMigrationCodeGenerator(
                             new CSharpModelCodeGenerator()),
@@ -98,15 +97,15 @@ namespace Microsoft.Data.Entity.Commands.Tests.Migrations
             using (var context = new Context(CreateModelWithCompositeKeys()))
             {
                 var contextServices = ((IDbContextServices)context).ScopedServiceProvider;
-                var options = contextServices.GetRequiredService<LazyRef<IDbContextOptions>>();
-                var model = contextServices.GetRequiredService<LazyRef<IModel>>().Value;
+                var options = contextServices.GetRequiredService<ContextService<IDbContextOptions>>();
+                var model = contextServices.GetRequiredService<ContextService<IModel>>().Service;
 
                 var scaffolder
                     = new MyMigrationScaffolder(
                         context,
-                        options.Value,
+                        options.Service,
                         model,
-                        new MigrationAssembly(new LazyRef<DbContext>(context), options),
+                        new MigrationAssembly(new ContextService<DbContext>(context), options),
                         new TestModelDiffer(),
                         new CSharpMigrationCodeGenerator(
                             new CSharpModelCodeGenerator()),

--- a/test/EntityFramework.FunctionalTests/ThrowingMonsterStateManager.cs
+++ b/test/EntityFramework.FunctionalTests/ThrowingMonsterStateManager.cs
@@ -6,9 +6,9 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.FunctionalTests
 {
@@ -20,8 +20,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
             StateEntrySubscriber subscriber,
             StateEntryNotifier notifier,
             ValueGenerationManager valueGeneration,
-            LazyRef<IModel> model,
-            LazyRef<DataStore> dataStore)
+            ContextService<IModel> model,
+            ContextService<DataStore> dataStore)
             : base(factory, entityKeyFactorySource, subscriber, notifier, valueGeneration, model, dataStore)
         {
         }

--- a/test/EntityFramework.InMemory.FunctionalTests/InMemoryConfigPatternsTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/InMemoryConfigPatternsTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Linq;
 using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Fallback;
 using Xunit;
@@ -444,7 +443,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             public void Test()
             {
                 Assert.IsType<DbContextOptions<InjectDifferentConfigurationsBlogContext>>(
-                    ((IDbContextServices)_context).ScopedServiceProvider.GetRequiredService<LazyRef<IDbContextOptions>>().Value);
+                    ((IDbContextServices)_context).ScopedServiceProvider.GetRequiredService<ContextService<IDbContextOptions>>().Service);
 
                 _context.Blogs.Add(new Blog { Name = "The Waffle Cart" });
                 _context.SaveChanges();
@@ -470,7 +469,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             public void Test()
             {
                 Assert.IsType<DbContextOptions<InjectDifferentConfigurationsAccountContext>>(
-                    ((IDbContextServices)_context).ScopedServiceProvider.GetRequiredService<LazyRef<IDbContextOptions>>().Value);
+                    ((IDbContextServices)_context).ScopedServiceProvider.GetRequiredService<ContextService<IDbContextOptions>>().Service);
 
                 _context.Accounts.Add(new Account { Name = "Eeky Bear" });
                 _context.SaveChanges();
@@ -542,7 +541,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             public void Test()
             {
                 Assert.IsType<DbContextOptions<InjectDifferentConfigurationsNoConstructorBlogContext>>(
-                    ((IDbContextServices)_context).ScopedServiceProvider.GetRequiredService<LazyRef<IDbContextOptions>>().Value);
+                    ((IDbContextServices)_context).ScopedServiceProvider.GetRequiredService<ContextService<IDbContextOptions>>().Service);
 
                 _context.Blogs.Add(new Blog { Name = "The Waffle Cart" });
                 _context.SaveChanges();
@@ -568,7 +567,7 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             public void Test()
             {
                 Assert.IsType<DbContextOptions<InjectDifferentConfigurationsNoConstructorAccountContext>>(
-                    ((IDbContextServices)_context).ScopedServiceProvider.GetRequiredService<LazyRef<IDbContextOptions>>().Value);
+                    ((IDbContextServices)_context).ScopedServiceProvider.GetRequiredService<ContextService<IDbContextOptions>>().Service);
 
                 _context.Accounts.Add(new Account { Name = "Eeky Bear" });
                 _context.SaveChanges();

--- a/test/EntityFramework.InMemory.Tests/InMemoryDataStoreSourceTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryDataStoreSourceTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Utilities;
 using Moq;
 using Xunit;
 
@@ -15,7 +14,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         {
             Assert.Equal(
                 typeof(InMemoryDataStore).Name, 
-                new InMemoryDataStoreSource(Mock.Of<DbContextConfiguration>(), new LazyRef<IDbContextOptions>(() => null)).Name);
+                new InMemoryDataStoreSource(Mock.Of<DbContextConfiguration>(), new ContextService<IDbContextOptions>(() => null)).Name);
         }
 
         [Fact]
@@ -27,7 +26,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             var configurationMock = new Mock<DbContextConfiguration>();
             configurationMock.Setup(m => m.ContextOptions).Returns(options);
 
-            Assert.True(new InMemoryDataStoreSource(configurationMock.Object, new LazyRef<IDbContextOptions>(options)).IsConfigured);
+            Assert.True(new InMemoryDataStoreSource(configurationMock.Object, new ContextService<IDbContextOptions>(options)).IsConfigured);
         }
 
         [Fact]
@@ -38,13 +37,13 @@ namespace Microsoft.Data.Entity.InMemory.Tests
             var configurationMock = new Mock<DbContextConfiguration>();
             configurationMock.Setup(m => m.ContextOptions).Returns(options);
 
-            Assert.False(new InMemoryDataStoreSource(configurationMock.Object, new LazyRef<IDbContextOptions>(options)).IsConfigured);
+            Assert.False(new InMemoryDataStoreSource(configurationMock.Object, new ContextService<IDbContextOptions>(options)).IsConfigured);
         }
 
         [Fact]
         public void Is_always_available()
         {
-            Assert.True(new InMemoryDataStoreSource(Mock.Of<DbContextConfiguration>(), new LazyRef<IDbContextOptions>(() => null)).IsAvailable);
+            Assert.True(new InMemoryDataStoreSource(Mock.Of<DbContextConfiguration>(), new ContextService<IDbContextOptions>(() => null)).IsAvailable);
         }
     }
 }

--- a/test/EntityFramework.InMemory.Tests/InMemoryDatabaseExtensionsTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryDatabaseExtensionsTest.cs
@@ -5,7 +5,6 @@ using System;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
@@ -18,7 +17,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         public void Returns_typed_database_object()
         {
             var database = new InMemoryDatabaseFacade(
-                new LazyRef<IModel>(() => null), 
+                new ContextService<IModel>(() => null), 
                 Mock.Of<InMemoryDataStoreCreator>(), 
                 Mock.Of<InMemoryConnection>(), 
                 new LoggerFactory());
@@ -30,7 +29,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         public void Throws_when_non_relational_provider_is_in_use()
         {
             var database = new ConcreteDatabase(
-                new LazyRef<IModel>(() => null),
+                new ContextService<IModel>(() => null),
                 Mock.Of<DataStoreCreator>(),
                 Mock.Of<DataStoreConnection>(),
                 new LoggerFactory());
@@ -43,7 +42,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         private class ConcreteDatabase : Database
         {
             public ConcreteDatabase(
-                LazyRef<IModel> model,
+                ContextService<IModel> model,
                 DataStoreCreator dataStoreCreator,
                 DataStoreConnection connection,
                 ILoggerFactory loggerFactory)

--- a/test/EntityFramework.InMemory.Tests/InMemoryValueGeneratorTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryValueGeneratorTest.cs
@@ -3,10 +3,10 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Tests;
-using Microsoft.Data.Entity.Utilities;
 using Xunit;
 
 namespace Microsoft.Data.Entity.InMemory.Tests
@@ -22,44 +22,44 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 
             var generator = new InMemoryValueGenerator();
 
-            var generatedValue = await generator.NextAsync(property, new LazyRef<DataStoreServices>(() => null));
+            var generatedValue = await generator.NextAsync(property, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(1, generatedValue.Value);
             Assert.False(generatedValue.IsTemporary);
 
-            generatedValue = await generator.NextAsync(property, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = await generator.NextAsync(property, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(2, generatedValue.Value);
             Assert.False(generatedValue.IsTemporary);
 
-            generatedValue = await generator.NextAsync(property, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = await generator.NextAsync(property, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(3, generatedValue.Value);
             Assert.False(generatedValue.IsTemporary);
 
-            generatedValue = generator.Next(property, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = generator.Next(property, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(4, generatedValue.Value);
             Assert.False(generatedValue.IsTemporary);
 
-            generatedValue = generator.Next(property, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = generator.Next(property, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(5, generatedValue.Value);
             Assert.False(generatedValue.IsTemporary);
 
-            generatedValue = generator.Next(property, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = generator.Next(property, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(6, generatedValue.Value);
             Assert.False(generatedValue.IsTemporary);
 
             generator = new InMemoryValueGenerator();
 
-            generatedValue = await generator.NextAsync(property, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = await generator.NextAsync(property, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(1, generatedValue.Value);
             Assert.False(generatedValue.IsTemporary);
 
-            generatedValue = await generator.NextAsync(property, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = await generator.NextAsync(property, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(2, generatedValue.Value);
             Assert.False(generatedValue.IsTemporary);
@@ -81,82 +81,82 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 
             var generator = new InMemoryValueGenerator();
 
-            var generatedValue = await generator.NextAsync(longProperty, new LazyRef<DataStoreServices>(() => null));
+            var generatedValue = await generator.NextAsync(longProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(1L, generatedValue.Value);
             Assert.False(generatedValue.IsTemporary);
 
-            generatedValue = await generator.NextAsync(intProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = await generator.NextAsync(intProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(2, generatedValue.Value);
             Assert.False(generatedValue.IsTemporary);
 
-            generatedValue = await generator.NextAsync(shortProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = await generator.NextAsync(shortProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal((short)3, generatedValue.Value);
             Assert.False(generatedValue.IsTemporary);
 
-            generatedValue = await generator.NextAsync(byteProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = await generator.NextAsync(byteProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal((byte)4, generatedValue.Value);
             Assert.False(generatedValue.IsTemporary);
 
-            generatedValue = await generator.NextAsync(ulongProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = await generator.NextAsync(ulongProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal((ulong)5, generatedValue.Value);
             Assert.False(generatedValue.IsTemporary);
 
-            generatedValue = await generator.NextAsync(uintProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = await generator.NextAsync(uintProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal((uint)6, generatedValue.Value);
             Assert.False(generatedValue.IsTemporary);
 
-            generatedValue = await generator.NextAsync(ushortProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = await generator.NextAsync(ushortProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal((ushort)7, generatedValue.Value);
             Assert.False(generatedValue.IsTemporary);
 
-            generatedValue = await generator.NextAsync(sbyteProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = await generator.NextAsync(sbyteProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal((sbyte)8, generatedValue.Value);
             Assert.False(generatedValue.IsTemporary);
 
-            generatedValue = generator.Next(longProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = generator.Next(longProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(9L, generatedValue.Value);
             Assert.False(generatedValue.IsTemporary);
 
-            generatedValue = generator.Next(intProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = generator.Next(intProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(10, generatedValue.Value);
             Assert.False(generatedValue.IsTemporary);
 
-            generatedValue = generator.Next(shortProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = generator.Next(shortProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal((short)11, generatedValue.Value);
             Assert.False(generatedValue.IsTemporary);
 
-            generatedValue = generator.Next(byteProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = generator.Next(byteProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal((byte)12, generatedValue.Value);
             Assert.False(generatedValue.IsTemporary);
 
-            generatedValue = generator.Next(ulongProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = generator.Next(ulongProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal((ulong)13, generatedValue.Value);
             Assert.False(generatedValue.IsTemporary);
 
-            generatedValue = generator.Next(uintProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = generator.Next(uintProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal((uint)14, generatedValue.Value);
             Assert.False(generatedValue.IsTemporary);
 
-            generatedValue = generator.Next(ushortProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = generator.Next(ushortProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal((ushort)15, generatedValue.Value);
             Assert.False(generatedValue.IsTemporary);
 
-            generatedValue = generator.Next(sbyteProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = generator.Next(sbyteProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal((sbyte)16, generatedValue.Value);
             Assert.False(generatedValue.IsTemporary);
@@ -170,10 +170,10 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 
             for (var i = 1; i < 256; i++)
             {
-                generator.Next(property, new LazyRef<DataStoreServices>(() => null));
+                generator.Next(property, new ContextService<DataStoreServices>(() => null));
             }
 
-            Assert.Throws<OverflowException>(() => generator.Next(property, new LazyRef<DataStoreServices>(() => null)));
+            Assert.Throws<OverflowException>(() => generator.Next(property, new ContextService<DataStoreServices>(() => null)));
         }
 
         private static Property CreateProperty(Type propertyType)

--- a/test/EntityFramework.Migrations.Tests/Infrastructure/HistoryRepositoryTest.cs
+++ b/test/EntityFramework.Migrations.Tests/Infrastructure/HistoryRepositoryTest.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
             {
                 var historyRepository = new HistoryRepository(
                     serviceProvider,
-                    new LazyRef<IDbContextOptions>(new DbContextOptions()),
-                    new LazyRef<DbContext>(context));
+                    new ContextService<IDbContextOptions>(new DbContextOptions()),
+                    new ContextService<DbContext>(context));
 
                 Assert.Equal("__MigrationHistory", historyRepository.TableName);
             }
@@ -45,8 +45,8 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
             {
                 var historyRepository = new HistoryRepository(
                     serviceProvider,
-                    new LazyRef<IDbContextOptions>(new DbContextOptions()),
-                    new LazyRef<DbContext>(context));
+                    new ContextService<IDbContextOptions>(new DbContextOptions()),
+                    new ContextService<DbContext>(context));
 
                 var historyModel1 = historyRepository.HistoryModel;
                 var historyModel2 = historyRepository.HistoryModel;
@@ -74,18 +74,18 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
             {
                 var historyRepository = new HistoryRepository(
                     serviceProvider,
-                    new LazyRef<IDbContextOptions>(new DbContextOptions()),
-                    new LazyRef<DbContext>(context));
+                    new ContextService<IDbContextOptions>(new DbContextOptions()),
+                    new ContextService<DbContext>(context));
 
                 using (var historyContext = historyRepository.CreateHistoryContext())
                 {
                     Assert.Same(historyRepository.HistoryModel, historyContext.Model);
 
-                    var options = ((IDbContextServices)context).ScopedServiceProvider.GetRequiredService<LazyRef<IDbContextOptions>>();
-                    var historyOptions = ((IDbContextServices)historyContext).ScopedServiceProvider.GetRequiredService<LazyRef<IDbContextOptions>>();
+                    var options = ((IDbContextServices)context).ScopedServiceProvider.GetRequiredService<ContextService<IDbContextOptions>>();
+                    var historyOptions = ((IDbContextServices)historyContext).ScopedServiceProvider.GetRequiredService<ContextService<IDbContextOptions>>();
 
-                    var extensions = options.Value.Extensions;
-                    var historyExtensions = historyOptions.Value.Extensions;
+                    var extensions = options.Service.Extensions;
+                    var historyExtensions = historyOptions.Service.Extensions;
 
                     Assert.Equal(extensions.Count, historyExtensions.Count);
 
@@ -106,8 +106,8 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
             {
                 var historyRepository = new HistoryRepository(
                     serviceProvider,
-                    new LazyRef<IDbContextOptions>(new DbContextOptions()),
-                    new LazyRef<DbContext>(context));
+                    new ContextService<IDbContextOptions>(new DbContextOptions()),
+                    new ContextService<DbContext>(context));
 
                 using (var historyContext = historyRepository.CreateHistoryContext())
                 {
@@ -144,8 +144,8 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
             {
                 var historyRepositoryMock = new Mock<HistoryRepository>(
                     serviceProvider,
-                    new LazyRef<IDbContextOptions>(new DbContextOptions()),
-                    new LazyRef<DbContext>(context))
+                    new ContextService<IDbContextOptions>(new DbContextOptions()),
+                    new ContextService<DbContext>(context))
                 { CallBase = true };
 
                 historyRepositoryMock
@@ -178,8 +178,8 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
             {
                 var historyRepository = new HistoryRepository(
                     serviceProvider,
-                    new LazyRef<IDbContextOptions>(new DbContextOptions()),
-                    new LazyRef<DbContext>(context));
+                    new ContextService<IDbContextOptions>(new DbContextOptions()),
+                    new ContextService<DbContext>(context));
 
                 var sqlStatements = historyRepository.GenerateInsertMigrationSql(
                     new MigrationInfo("000000000000001_Foo"), new DmlSqlGenerator());
@@ -200,8 +200,8 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
             {
                 var historyRepository = new Mock<HistoryRepository>(
                     serviceProvider,
-                    new LazyRef<IDbContextOptions>(new DbContextOptions()),
-                    new LazyRef<DbContext>(context))
+                    new ContextService<IDbContextOptions>(new DbContextOptions()),
+                    new ContextService<DbContext>(context))
                 { CallBase = true };
 
                 historyRepository.Protected().Setup<string>("GetContextKey").Returns("SomeContextKey");
@@ -225,8 +225,8 @@ namespace Microsoft.Data.Entity.Migrations.Tests.Infrastructure
             {
                 var historyRepository = new HistoryRepository(
                     serviceProvider,
-                    new LazyRef<IDbContextOptions>(new DbContextOptions()),
-                    new LazyRef<DbContext>(context));
+                    new ContextService<IDbContextOptions>(new DbContextOptions()),
+                    new ContextService<DbContext>(context));
 
                 var sqlStatements = historyRepository.GenerateDeleteMigrationSql(
                     new MigrationInfo("000000000000001_Foo"), new DmlSqlGenerator());

--- a/test/EntityFramework.Migrations.Tests/MigrationsDatabaseExtensionsTest.cs
+++ b/test/EntityFramework.Migrations.Tests/MigrationsDatabaseExtensionsTest.cs
@@ -6,7 +6,6 @@ using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Migrations.Infrastructure;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
@@ -19,7 +18,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         public void Returns_typed_database_object()
         {
             var database = new ConcreteMigrationsEnabledDatabase(
-                new LazyRef<IModel>(() => null),
+                new ContextService<IModel>(() => null),
                 Mock.Of<DataStoreCreator>(),
                 Mock.Of<DataStoreConnection>(),
                 Mock.Of<Migrator>(),
@@ -32,7 +31,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         public void Throws_when_non_relational_provider_is_in_use()
         {
             var database = new ConcreteDatabase(
-                new LazyRef<IModel>(() => null),
+                new ContextService<IModel>(() => null),
                 Mock.Of<DataStoreCreator>(),
                 Mock.Of<DataStoreConnection>(),
                 new LoggerFactory());
@@ -45,7 +44,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         private class ConcreteDatabase : Database
         {
             public ConcreteDatabase(
-                LazyRef<IModel> model,
+                ContextService<IModel> model,
                 DataStoreCreator dataStoreCreator,
                 DataStoreConnection connection,
                 ILoggerFactory loggerFactory)
@@ -57,7 +56,7 @@ namespace Microsoft.Data.Entity.Migrations.Tests
         private class ConcreteMigrationsEnabledDatabase : MigrationsEnabledDatabase
         {
             public ConcreteMigrationsEnabledDatabase(
-                LazyRef<IModel> model,
+                ContextService<IModel> model,
                 DataStoreCreator dataStoreCreator,
                 DataStoreConnection connection,
                 Migrator migrator,

--- a/test/EntityFramework.Migrations.Tests/TestHelperExtensions.cs
+++ b/test/EntityFramework.Migrations.Tests/TestHelperExtensions.cs
@@ -372,7 +372,7 @@ namespace Microsoft.Data.Entity.Tests
 
     public class FakeRelationalConnection : RelationalConnection
     {
-        public FakeRelationalConnection(LazyRef<IDbContextOptions> options, ILoggerFactory loggerFactory)
+        public FakeRelationalConnection(ContextService<IDbContextOptions> options, ILoggerFactory loggerFactory)
             : base(options, loggerFactory)
         {
         }
@@ -385,7 +385,7 @@ namespace Microsoft.Data.Entity.Tests
 
     public class FakeDataStoreSource : DataStoreSource<FakeDataStoreServices, FakeRelationalOptionsExtension>
     {
-        public FakeDataStoreSource(DbContextConfiguration configuration, LazyRef<IDbContextOptions> options)
+        public FakeDataStoreSource(DbContextConfiguration configuration, ContextService<IDbContextOptions> options)
             : base(configuration, options)
         {
         }
@@ -473,7 +473,7 @@ namespace Microsoft.Data.Entity.Tests
     public class FakeDatabase : MigrationsEnabledDatabase
     {
         public FakeDatabase(
-            LazyRef<IModel> model,
+            ContextService<IModel> model,
             RecordingDataStoreCreator dataStoreCreator,
             FakeRelationalConnection connection,
             TestMigrator migrator,
@@ -494,7 +494,7 @@ namespace Microsoft.Data.Entity.Tests
     {
         public FakeDataStore(
             StateManager stateManager,
-            LazyRef<IModel> model,
+            ContextService<IModel> model,
             EntityKeyFactorySource entityKeyFactorySource,
             EntityMaterializerSource entityMaterializerSource,
             ClrCollectionAccessorSource collectionAccessorSource,

--- a/test/EntityFramework.Redis.Tests/RedisDataStoreSourceTests.cs
+++ b/test/EntityFramework.Redis.Tests/RedisDataStoreSourceTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Utilities;
 using Moq;
 using Xunit;
 
@@ -22,7 +21,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
                 Mock.Of<DbContext>(),
                 DbContextConfiguration.ServiceProviderSource.Implicit);
 
-            var source = new RedisDataStoreSource(config, new LazyRef<IDbContextOptions>(options));
+            var source = new RedisDataStoreSource(config, new ContextService<IDbContextOptions>(options));
 
             Assert.False(source.IsAvailable);
 
@@ -36,7 +35,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
         {
             Assert.Equal(
                 typeof(RedisDataStore).Name,
-                new RedisDataStoreSource(Mock.Of<DbContextConfiguration>(), new LazyRef<IDbContextOptions>(() => null)).Name);
+                new RedisDataStoreSource(Mock.Of<DbContextConfiguration>(), new ContextService<IDbContextOptions>(() => null)).Name);
         }
     }
 }

--- a/test/EntityFramework.Redis.Tests/RedisDatabaseExtensionsTest.cs
+++ b/test/EntityFramework.Redis.Tests/RedisDatabaseExtensionsTest.cs
@@ -5,7 +5,6 @@ using System;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
@@ -18,7 +17,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
         public void Returns_typed_database_object()
         {
             var database = new RedisDatabase(
-                new LazyRef<IModel>(() => null),
+                new ContextService<IModel>(() => null),
                 Mock.Of<RedisDataStoreCreator>(),
                 Mock.Of<RedisConnection>(),
                 new LoggerFactory());
@@ -30,7 +29,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
         public void Throws_when_non_relational_provider_is_in_use()
         {
             var database = new ConcreteDatabase(
-                new LazyRef<IModel>(() => null),
+                new ContextService<IModel>(() => null),
                 Mock.Of<DataStoreCreator>(),
                 Mock.Of<DataStoreConnection>(),
                 new LoggerFactory());
@@ -43,7 +42,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
         private class ConcreteDatabase : Database
         {
             public ConcreteDatabase(
-                LazyRef<IModel> model,
+                ContextService<IModel> model,
                 DataStoreCreator dataStoreCreator,
                 DataStoreConnection connection,
                 ILoggerFactory loggerFactory)

--- a/test/EntityFramework.Redis.Tests/RedisDatabaseTests.cs
+++ b/test/EntityFramework.Redis.Tests/RedisDatabaseTests.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
@@ -27,7 +26,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
             configurationMock.Setup(m => m.DataStoreCreator).Returns(creatorMock.Object);
 
             var database = new RedisDatabase(
-                new LazyRef<IModel>(() => model),
+                new ContextService<IModel>(() => model),
                 creatorMock.Object,
                 connection,
                 new LoggerFactory());

--- a/test/EntityFramework.Redis.Tests/RedisSequenceValueGeneratorTest.cs
+++ b/test/EntityFramework.Redis.Tests/RedisSequenceValueGeneratorTest.cs
@@ -6,10 +6,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Tests;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.Logging;
 using Xunit;
@@ -328,14 +328,14 @@ namespace Microsoft.Data.Entity.Redis.Tests
             public sbyte SignedByte { get; set; }
         }
 
-        private LazyRef<DataStoreServices> CreateStoreServices(IServiceProvider serviceProvider = null)
+        private ContextService<DataStoreServices> CreateStoreServices(IServiceProvider serviceProvider = null)
         {
             serviceProvider = serviceProvider
                               ?? TestHelpers.CreateServiceProvider(new ServiceCollection()
                                   .AddScoped<RedisDatabase, FakeRedisDatabase>()
                                   .AddInstance(new FakeRedisSequence()));
 
-            return TestHelpers.CreateContextServices(serviceProvider, _model).GetRequiredService<LazyRef<DataStoreServices>>();
+            return TestHelpers.CreateContextServices(serviceProvider, _model).GetRequiredService<ContextService<DataStoreServices>>();
         }
 
         private class FakeRedisSequence
@@ -348,7 +348,7 @@ namespace Microsoft.Data.Entity.Redis.Tests
             private readonly FakeRedisSequence _redisSequence;
 
             public FakeRedisDatabase(
-                LazyRef<IModel> model,
+                ContextService<IModel> model,
                 RedisDataStoreCreator dataStoreCreator,
                 RedisConnection connection,
                 FakeRedisSequence redisSequence,

--- a/test/EntityFramework.Relational.Tests/RelationalConnectionTest.cs
+++ b/test/EntityFramework.Relational.Tests/RelationalConnectionTest.cs
@@ -7,7 +7,6 @@ using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Moq;
 using Moq.Protected;
@@ -324,7 +323,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
                             }))).Message);
         }
 
-        private static LazyRef<IDbContextOptions> CreateOptions(
+        private static ContextService<IDbContextOptions> CreateOptions(
             Action<FakeOptionsExtension1> configUpdater1,
             Action<FakeOptionsExtension2> configUpdater2 = null)
         {
@@ -340,12 +339,12 @@ namespace Microsoft.Data.Entity.Relational.Tests
                 contextOptions.AddOrUpdateExtension(configUpdater2);
             }
 
-            return new LazyRef<IDbContextOptions>(contextOptions);
+            return new ContextService<IDbContextOptions>(contextOptions);
         }
 
         private class FakeConnection : RelationalConnection
         {
-            public FakeConnection(LazyRef<IDbContextOptions> options)
+            public FakeConnection(ContextService<IDbContextOptions> options)
                 : base(options, new LoggerFactory())
             {
             }

--- a/test/EntityFramework.Relational.Tests/RelationalDataStoreTest.cs
+++ b/test/EntityFramework.Relational.Tests/RelationalDataStoreTest.cs
@@ -5,10 +5,10 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.Update;
 using Microsoft.Data.Entity.Tests;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.Logging;
 using Moq;
@@ -73,7 +73,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
         {
             public FakeRelationalDataStore(
                 StateManager stateManager,
-                LazyRef<IModel> model,
+                ContextService<IModel> model,
                 EntityKeyFactorySource entityKeyFactorySource,
                 EntityMaterializerSource entityMaterializerSource,
                 ClrCollectionAccessorSource collectionAccessorSource,

--- a/test/EntityFramework.Relational.Tests/RelationalDatabaseExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/RelationalDatabaseExtensionsTest.cs
@@ -5,7 +5,6 @@ using System;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
@@ -18,7 +17,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
         public void Returns_typed_database_object()
         {
             var database = new ConcreteRelationalDatabase(
-                new LazyRef<IModel>(() => null),
+                new ContextService<IModel>(() => null),
                 Mock.Of<DataStoreCreator>(),
                 Mock.Of<DataStoreConnection>(),
                 new LoggerFactory());
@@ -30,7 +29,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
         public void Throws_when_non_relational_provider_is_in_use()
         {
             var database = new ConcreteDatabase(
-                new LazyRef<IModel>(() => null),
+                new ContextService<IModel>(() => null),
                 Mock.Of<DataStoreCreator>(),
                 Mock.Of<DataStoreConnection>(),
                 new LoggerFactory());
@@ -43,7 +42,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
         private class ConcreteDatabase : Database
         {
             public ConcreteDatabase(
-                LazyRef<IModel> model,
+                ContextService<IModel> model,
                 DataStoreCreator dataStoreCreator,
                 DataStoreConnection connection,
                 ILoggerFactory loggerFactory)
@@ -55,7 +54,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
         private class ConcreteRelationalDatabase : RelationalDatabase
         {
             public ConcreteRelationalDatabase(
-                LazyRef<IModel> model,
+                ContextService<IModel> model,
                 DataStoreCreator dataStoreCreator,
                 DataStoreConnection connection,
                 ILoggerFactory loggerFactory)

--- a/test/EntityFramework.Relational.Tests/RelationalDatabaseTest.cs
+++ b/test/EntityFramework.Relational.Tests/RelationalDatabaseTest.cs
@@ -4,9 +4,9 @@
 using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
@@ -31,7 +31,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
             dbConnectionMock.SetupGet(m => m.Database).Returns("MyDb");
 
             var database = new ConcreteRelationalDatabase(
-                new LazyRef<IModel>(model),
+                new ContextService<IModel>(model),
                 creatorMock.Object,
                 connectionMock.Object,
                 new LoggerFactory());
@@ -78,7 +78,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
             dbConnectionMock.SetupGet(m => m.Database).Returns("MyDb");
 
             var database = new ConcreteRelationalDatabase(
-                new LazyRef<IModel>(model),
+                new ContextService<IModel>(model),
                 creatorMock.Object,
                 connectionMock.Object,
                 new LoggerFactory());
@@ -108,7 +108,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
         private class ConcreteRelationalDatabase : RelationalDatabase
         {
             public ConcreteRelationalDatabase(
-                LazyRef<IModel> model,
+                ContextService<IModel> model,
                 DataStoreCreator dataStoreCreator,
                 DataStoreConnection connection,
                 ILoggerFactory loggerFactory)

--- a/test/EntityFramework.Relational.Tests/Update/BatchExecutorTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/BatchExecutorTest.cs
@@ -3,9 +3,9 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Relational.Model;
 using Microsoft.Data.Entity.Relational.Update;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
@@ -75,7 +75,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         private class BatchExecutorForTest : BatchExecutor
         {
             public BatchExecutorForTest(RelationalTypeMapper typeMapper)
-                : base(typeMapper, new LazyRef<DbContext>(() => null), new LoggerFactory())
+                : base(typeMapper, new ContextService<DbContext>(() => null), new LoggerFactory())
             {
             }
 

--- a/test/EntityFramework.SQLite.Tests/SQLiteDatabaseExtensionsTest.cs
+++ b/test/EntityFramework.SQLite.Tests/SQLiteDatabaseExtensionsTest.cs
@@ -5,7 +5,6 @@ using System;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
@@ -18,7 +17,7 @@ namespace Microsoft.Data.Entity.SQLite.Tests
         public void Returns_typed_database_object()
         {
             var database = new SQLiteDatabase(
-                new LazyRef<IModel>(() => null),
+                new ContextService<IModel>(() => null),
                 Mock.Of<SQLiteDataStoreCreator>(),
                 Mock.Of<SQLiteConnection>(),
                 Mock.Of<SQLiteMigrator>(),
@@ -31,7 +30,7 @@ namespace Microsoft.Data.Entity.SQLite.Tests
         public void Throws_when_non_relational_provider_is_in_use()
         {
             var database = new ConcreteDatabase(
-                new LazyRef<IModel>(() => null),
+                new ContextService<IModel>(() => null),
                 Mock.Of<DataStoreCreator>(),
                 Mock.Of<DataStoreConnection>(),
                 new LoggerFactory());
@@ -44,7 +43,7 @@ namespace Microsoft.Data.Entity.SQLite.Tests
         private class ConcreteDatabase : Database
         {
             public ConcreteDatabase(
-                LazyRef<IModel> model,
+                ContextService<IModel> model,
                 DataStoreCreator dataStoreCreator,
                 DataStoreConnection connection,
                 ILoggerFactory loggerFactory)

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerDataStoreCreatorTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerDataStoreCreatorTest.cs
@@ -11,7 +11,6 @@ using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Fallback;
 using Xunit;
@@ -231,7 +230,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 {
                     var contextServices = ((IDbContextServices)context).ScopedServiceProvider;
 
-                    var creator = (RelationalDataStoreCreator)contextServices.GetRequiredService<LazyRef<DataStoreCreator>>().Value;
+                    var creator = (RelationalDataStoreCreator)contextServices.GetRequiredService<ContextService<DataStoreCreator>>().Service;
 
                     if (async)
                     {

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -17,7 +17,6 @@ using Microsoft.Data.Entity.Relational.FunctionalTests;
 using Microsoft.Data.Entity.SqlServer.FunctionalTests.TestModels;
 using Microsoft.Data.Entity.SqlServer.Update;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Fallback;
 using Microsoft.Framework.Logging;
@@ -86,7 +85,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                     var contextServices = ((IDbContextServices)db).ScopedServiceProvider;
 
-                    Assert.IsType<SqlStoreWithBufferReader>(contextServices.GetRequiredService<LazyRef<DataStore>>().Value);
+                    Assert.IsType<SqlStoreWithBufferReader>(contextServices.GetRequiredService<ContextService<DataStore>>().Service);
                 }
             }
         }
@@ -95,7 +94,7 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             public SqlStoreWithBufferReader(
                 StateManager stateManager,
-                LazyRef<IModel> model,
+                ContextService<IModel> model,
                 EntityKeyFactorySource entityKeyFactorySource,
                 EntityMaterializerSource entityMaterializerSource,
                 ClrCollectionAccessorSource collectionAccessorSource,

--- a/test/EntityFramework.SqlServer.Tests/SequentialGuidValueGeneratorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SequentialGuidValueGeneratorTest.cs
@@ -4,10 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Tests;
-using Microsoft.Data.Entity.Utilities;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.Tests
@@ -38,8 +38,8 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             for (var i = 0; i < 100; i++)
             {
                 var generatedValue = async
-                    ? await sequentialGuidIdentityGenerator.NextAsync(property, new LazyRef<DataStoreServices>(() => null))
-                    : sequentialGuidIdentityGenerator.Next(property, new LazyRef<DataStoreServices>(() => null));
+                    ? await sequentialGuidIdentityGenerator.NextAsync(property, new ContextService<DataStoreServices>(() => null))
+                    : sequentialGuidIdentityGenerator.Next(property, new ContextService<DataStoreServices>(() => null));
 
                 Assert.False(generatedValue.IsTemporary);
 

--- a/test/EntityFramework.SqlServer.Tests/SqlServerConnectionTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerConnectionTest.cs
@@ -3,7 +3,6 @@
 
 using System.Data.SqlClient;
 using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Xunit;
 
@@ -32,9 +31,9 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             }
         }
 
-        public static LazyRef<IDbContextOptions> CreateOptions()
+        public static ContextService<IDbContextOptions> CreateOptions()
         {
-            return new LazyRef<IDbContextOptions>(() => new DbContextOptions()
+            return new ContextService<IDbContextOptions>(() => new DbContextOptions()
                 .UseSqlServer(@"Server=(localdb)\v11.0;Database=SqlServerConnectionTest;Trusted_Connection=True;"));
         }
     }

--- a/test/EntityFramework.SqlServer.Tests/SqlServerDataStoreSourceTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerDataStoreSourceTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.Data.Entity.Infrastructure;
-using Microsoft.Data.Entity.Utilities;
 using Moq;
 using Xunit;
 
@@ -15,7 +14,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         {
             Assert.Equal(
                 typeof(SqlServerDataStore).Name, 
-                new SqlServerDataStoreSource(Mock.Of<DbContextConfiguration>(), new LazyRef<IDbContextOptions>(() => null)).Name);
+                new SqlServerDataStoreSource(Mock.Of<DbContextConfiguration>(), new ContextService<IDbContextOptions>(() => null)).Name);
         }
 
         [Fact]
@@ -27,7 +26,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             var configurationMock = new Mock<DbContextConfiguration>();
             configurationMock.Setup(m => m.ContextOptions).Returns(options);
 
-            Assert.True(new SqlServerDataStoreSource(configurationMock.Object, new LazyRef<IDbContextOptions>(options)).IsConfigured);
+            Assert.True(new SqlServerDataStoreSource(configurationMock.Object, new ContextService<IDbContextOptions>(options)).IsConfigured);
         }
 
         [Fact]
@@ -38,7 +37,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             var configurationMock = new Mock<DbContextConfiguration>();
             configurationMock.Setup(m => m.ContextOptions).Returns(options);
 
-            Assert.False(new SqlServerDataStoreSource(configurationMock.Object, new LazyRef<IDbContextOptions>(options)).IsConfigured);
+            Assert.False(new SqlServerDataStoreSource(configurationMock.Object, new ContextService<IDbContextOptions>(options)).IsConfigured);
         }
 
         [Fact]
@@ -50,7 +49,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             var configurationMock = new Mock<DbContextConfiguration>();
             configurationMock.Setup(m => m.ContextOptions).Returns(options);
 
-            Assert.True(new SqlServerDataStoreSource(configurationMock.Object, new LazyRef<IDbContextOptions>(options)).IsAvailable);
+            Assert.True(new SqlServerDataStoreSource(configurationMock.Object, new ContextService<IDbContextOptions>(options)).IsAvailable);
         }
 
         [Fact]
@@ -61,7 +60,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             var configurationMock = new Mock<DbContextConfiguration>();
             configurationMock.Setup(m => m.ContextOptions).Returns(options);
 
-            Assert.False(new SqlServerDataStoreSource(configurationMock.Object, new LazyRef<IDbContextOptions>(options)).IsAvailable);
+            Assert.False(new SqlServerDataStoreSource(configurationMock.Object, new ContextService<IDbContextOptions>(options)).IsAvailable);
         }
     }
 }

--- a/test/EntityFramework.SqlServer.Tests/SqlServerDatabaseExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerDatabaseExtensionsTest.cs
@@ -2,7 +2,6 @@ using System;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
@@ -15,7 +14,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Returns_typed_database_object()
         {
             var database = new SqlServerDatabase(
-                new LazyRef<IModel>(() => null),
+                new ContextService<IModel>(() => null),
                 Mock.Of<SqlServerDataStoreCreator>(),
                 Mock.Of<SqlServerConnection>(),
                 Mock.Of<SqlServerMigrator>(),
@@ -28,7 +27,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Throws_when_non_relational_provider_is_in_use()
         {
             var database = new ConcreteDatabase(
-                new LazyRef<IModel>(() => null),
+                new ContextService<IModel>(() => null),
                 Mock.Of<DataStoreCreator>(),
                 Mock.Of<DataStoreConnection>(),
                 new LoggerFactory());
@@ -41,7 +40,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         private class ConcreteDatabase : Database
         {
             public ConcreteDatabase(
-                LazyRef<IModel> model,
+                ContextService<IModel> model,
                 DataStoreCreator dataStoreCreator,
                 DataStoreConnection connection,
                 ILoggerFactory loggerFactory)

--- a/test/EntityFramework.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
@@ -7,11 +7,11 @@ using System.Data.Common;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Tests;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.Logging;
 using Xunit;
@@ -289,11 +289,11 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             Assert.True(checks.All(c => c));
         }
 
-        private LazyRef<DataStoreServices> CreateStoreServices(IServiceProvider serviceProvider = null)
+        private ContextService<DataStoreServices> CreateStoreServices(IServiceProvider serviceProvider = null)
         {
             serviceProvider = serviceProvider ?? TestHelpers.CreateServiceProvider();
 
-            return TestHelpers.CreateContextServices(serviceProvider, _model).GetRequiredService<LazyRef<DataStoreServices>>();
+            return TestHelpers.CreateContextServices(serviceProvider, _model).GetRequiredService<ContextService<DataStoreServices>>();
         }
 
         private class FakeSqlStatementExecutor : SqlStatementExecutor

--- a/test/EntityFramework.Tests/ChangeTracking/ChangeDetectorTest.cs
+++ b/test/EntityFramework.Tests/ChangeTracking/ChangeDetectorTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
@@ -29,7 +30,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             principalEntry.RelationshipsSnapshot[keyProperty] = 77;
             principalEntry.EntityState = EntityState.Added;
 
-            var changeDetector = new ChangeDetector(new LazyRef<IModel>(model));
+            var changeDetector = new ChangeDetector(new ContextService<IModel>(model));
 
             Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
 
@@ -58,7 +59,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             principalEntry.RelationshipsSnapshot[keyProperty] = 77;
             principalEntry.EntityState = EntityState.Added;
 
-            var changeDetector = new ChangeDetector(new LazyRef<IModel>(model));
+            var changeDetector = new ChangeDetector(new ContextService<IModel>(model));
 
             Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
 
@@ -87,7 +88,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             principalEntry.RelationshipsSnapshot[keyProperty] = -1;
             principalEntry.EntityState = EntityState.Added;
 
-            var changeDetector = new ChangeDetector(new LazyRef<IModel>(model));
+            var changeDetector = new ChangeDetector(new ContextService<IModel>(model));
 
             Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
 
@@ -116,7 +117,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             principalEntry.RelationshipsSnapshot[keyProperty] = -1;
             principalEntry.EntityState = EntityState.Added;
 
-            var changeDetector = new ChangeDetector(new LazyRef<IModel>(model));
+            var changeDetector = new ChangeDetector(new ContextService<IModel>(model));
 
             Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
 
@@ -145,7 +146,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             principalEntry.RelationshipsSnapshot[property] = "Blue";
             principalEntry.EntityState = EntityState.Added;
 
-            var changeDetector = new ChangeDetector(new LazyRef<IModel>(model));
+            var changeDetector = new ChangeDetector(new ContextService<IModel>(model));
 
             Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
 
@@ -175,7 +176,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             principalEntry.RelationshipsSnapshot[property] = "Blue";
             principalEntry.EntityState = EntityState.Added;
 
-            var changeDetector = new ChangeDetector(new LazyRef<IModel>(model));
+            var changeDetector = new ChangeDetector(new ContextService<IModel>(model));
 
             Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
 
@@ -205,7 +206,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             principalEntry.RelationshipsSnapshot[keyProperty] = 77;
             principalEntry.EntityState = EntityState.Added;
 
-            var changeDetector = new ChangeDetector(new LazyRef<IModel>(model));
+            var changeDetector = new ChangeDetector(new ContextService<IModel>(model));
 
             Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
 
@@ -234,7 +235,7 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             principalEntry.RelationshipsSnapshot[keyProperty] = 77;
             principalEntry.EntityState = EntityState.Added;
 
-            var changeDetector = new ChangeDetector(new LazyRef<IModel>(model));
+            var changeDetector = new ChangeDetector(new ContextService<IModel>(model));
 
             Assert.Same(principalEntry, stateManager.TryGetEntry(new SimpleEntityKey<int>(entityType, -1)));
 

--- a/test/EntityFramework.Tests/ContextConfigurationTest.cs
+++ b/test/EntityFramework.Tests/ContextConfigurationTest.cs
@@ -4,7 +4,6 @@
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
 using Xunit;
 
@@ -54,22 +53,22 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var contextServices = ((IDbContextServices)context).ScopedServiceProvider;
 
-                store = contextServices.GetRequiredService<LazyRef<DataStore>>().Value;
-                creator = contextServices.GetRequiredService<LazyRef<DataStoreCreator>>().Value;
-                connection = contextServices.GetRequiredService<LazyRef<DataStoreConnection>>().Value;
+                store = contextServices.GetRequiredService<ContextService<DataStore>>().Service;
+                creator = contextServices.GetRequiredService<ContextService<DataStoreCreator>>().Service;
+                connection = contextServices.GetRequiredService<ContextService<DataStoreConnection>>().Service;
 
-                Assert.Same(store, contextServices.GetRequiredService<LazyRef<DataStore>>().Value);
-                Assert.Same(creator, contextServices.GetRequiredService<LazyRef<DataStoreCreator>>().Value);
-                Assert.Same(connection, contextServices.GetRequiredService<LazyRef<DataStoreConnection>>().Value);
+                Assert.Same(store, contextServices.GetRequiredService<ContextService<DataStore>>().Service);
+                Assert.Same(creator, contextServices.GetRequiredService<ContextService<DataStoreCreator>>().Service);
+                Assert.Same(connection, contextServices.GetRequiredService<ContextService<DataStoreConnection>>().Service);
             }
 
             using (var context = new DbContext(serviceProvider))
             {
                 var contextServices = ((IDbContextServices)context).ScopedServiceProvider;
 
-                Assert.NotSame(store, contextServices.GetRequiredService<LazyRef<DataStore>>().Value);
-                Assert.NotSame(creator, contextServices.GetRequiredService<LazyRef<DataStoreCreator>>().Value);
-                Assert.NotSame(connection, contextServices.GetRequiredService<LazyRef<DataStoreConnection>>().Value);
+                Assert.NotSame(store, contextServices.GetRequiredService<ContextService<DataStore>>().Service);
+                Assert.NotSame(creator, contextServices.GetRequiredService<ContextService<DataStoreCreator>>().Service);
+                Assert.NotSame(connection, contextServices.GetRequiredService<ContextService<DataStoreConnection>>().Service);
             }
         }
 
@@ -84,22 +83,22 @@ namespace Microsoft.Data.Entity.Tests
             {
                 var contextServices = ((IDbContextServices)context).ScopedServiceProvider;
 
-                store = contextServices.GetRequiredService<LazyRef<DataStore>>().Value;
-                creator = contextServices.GetRequiredService<LazyRef<DataStoreCreator>>().Value;
-                connection = contextServices.GetRequiredService<LazyRef<DataStoreConnection>>().Value;
+                store = contextServices.GetRequiredService<ContextService<DataStore>>().Service;
+                creator = contextServices.GetRequiredService<ContextService<DataStoreCreator>>().Service;
+                connection = contextServices.GetRequiredService<ContextService<DataStoreConnection>>().Service;
 
-                Assert.Same(store, contextServices.GetRequiredService<LazyRef<DataStore>>().Value);
-                Assert.Same(creator, contextServices.GetRequiredService<LazyRef<DataStoreCreator>>().Value);
-                Assert.Same(connection, contextServices.GetRequiredService<LazyRef<DataStoreConnection>>().Value);
+                Assert.Same(store, contextServices.GetRequiredService<ContextService<DataStore>>().Service);
+                Assert.Same(creator, contextServices.GetRequiredService<ContextService<DataStoreCreator>>().Service);
+                Assert.Same(connection, contextServices.GetRequiredService<ContextService<DataStoreConnection>>().Service);
             }
 
             using (var context = new GiddyupContext())
             {
                 var contextServices = ((IDbContextServices)context).ScopedServiceProvider;
 
-                Assert.NotSame(store, contextServices.GetRequiredService<LazyRef<DataStore>>().Value);
-                Assert.NotSame(creator, contextServices.GetRequiredService<LazyRef<DataStoreCreator>>().Value);
-                Assert.NotSame(connection, contextServices.GetRequiredService<LazyRef<DataStoreConnection>>().Value);
+                Assert.NotSame(store, contextServices.GetRequiredService<ContextService<DataStore>>().Service);
+                Assert.NotSame(creator, contextServices.GetRequiredService<ContextService<DataStoreCreator>>().Service);
+                Assert.NotSame(connection, contextServices.GetRequiredService<ContextService<DataStoreConnection>>().Service);
             }
         }
 

--- a/test/EntityFramework.Tests/DatabaseTest.cs
+++ b/test/EntityFramework.Tests/DatabaseTest.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.Logging;
 using Moq;
 using Xunit;
@@ -26,7 +25,7 @@ namespace Microsoft.Data.Entity.Tests
             var connection = Mock.Of<DataStoreConnection>();
 
             var database = new ConcreteDatabase(
-                    new LazyRef<IModel>(() => model),
+                    new ContextService<IModel>(() => model),
                     creatorMock.Object,
                     connection,
                     new LoggerFactory());
@@ -51,7 +50,7 @@ namespace Microsoft.Data.Entity.Tests
             creatorMock.Setup(m => m.EnsureDeletedAsync(model, cancellationToken)).Returns(Task.FromResult(true));
 
             var database = new ConcreteDatabase(
-                    new LazyRef<IModel>(() => model),
+                    new ContextService<IModel>(() => model),
                     creatorMock.Object,
                     Mock.Of<DataStoreConnection>(),
                     new LoggerFactory());
@@ -66,7 +65,7 @@ namespace Microsoft.Data.Entity.Tests
         private class ConcreteDatabase : Database
         {
             public ConcreteDatabase(
-                LazyRef<IModel> model,
+                ContextService<IModel> model,
                 DataStoreCreator dataStoreCreator,
                 DataStoreConnection connection,
                 ILoggerFactory loggerFactory)

--- a/test/EntityFramework.Tests/DbContextTest.cs
+++ b/test/EntityFramework.Tests/DbContextTest.cs
@@ -12,7 +12,6 @@ using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.ConfigurationModel;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.DependencyInjection.Fallback;
@@ -889,7 +888,7 @@ namespace Microsoft.Data.Entity.Tests
 
                 Assert.NotNull(serviceProvider.GetRequiredService<FakeService>());
                 Assert.NotSame(serviceProvider, contextServices);
-                Assert.Equal(0, contextServices.GetRequiredService<LazyRef<IDbContextOptions>>().Value.Extensions.Count);
+                Assert.Equal(0, contextServices.GetRequiredService<ContextService<IDbContextOptions>>().Service.Extensions.Count);
             }
         }
 
@@ -909,7 +908,7 @@ namespace Microsoft.Data.Entity.Tests
             using (var context = serviceProvider.GetRequiredService<ContextWithDefaults>())
             {
                 var contextServices = ((IDbContextServices)context).ScopedServiceProvider;
-                var options = contextServices.GetRequiredService<LazyRef<IDbContextOptions>>().Value;
+                var options = contextServices.GetRequiredService<ContextService<IDbContextOptions>>().Service;
 
                 Assert.NotNull(contextServices.GetRequiredService<FakeService>());
                 Assert.Equal(1, options.Extensions.Count);
@@ -933,7 +932,7 @@ namespace Microsoft.Data.Entity.Tests
             using (var context = serviceProvider.GetRequiredService<ContextWithServiceProvider>())
             {
                 var contextServices = ((IDbContextServices)context).ScopedServiceProvider;
-                var options = contextServices.GetRequiredService<LazyRef<IDbContextOptions>>().Value;
+                var options = contextServices.GetRequiredService<ContextService<IDbContextOptions>>().Service;
 
                 Assert.NotNull(contextServices.GetRequiredService<FakeService>());
                 Assert.Equal(1, options.Extensions.Count);
@@ -957,7 +956,7 @@ namespace Microsoft.Data.Entity.Tests
             using (var context = serviceProvider.GetRequiredService<ContextWithOptions>())
             {
                 var contextServices = ((IDbContextServices)context).ScopedServiceProvider;
-                var options = contextServices.GetRequiredService<LazyRef<IDbContextOptions>>().Value;
+                var options = contextServices.GetRequiredService<ContextService<IDbContextOptions>>().Service;
 
                 Assert.NotNull(contextServices.GetRequiredService<FakeService>());
                 Assert.Equal(1, options.Extensions.Count);
@@ -1002,7 +1001,7 @@ namespace Microsoft.Data.Entity.Tests
             using (var context = serviceProvider.GetRequiredService<ContextT>())
             {
                 var contextServices = ((IDbContextServices)context).ScopedServiceProvider;
-                var contextOptions = (DbContextOptions<ContextT>)contextServices.GetRequiredService<LazyRef<IDbContextOptions>>().Value;
+                var contextOptions = (DbContextOptions<ContextT>)contextServices.GetRequiredService<ContextService<IDbContextOptions>>().Service;
 
                 Assert.NotNull(contextOptions);
                 var rawOptions = ((IDbContextOptions)contextOptions).RawOptions;
@@ -1034,7 +1033,7 @@ namespace Microsoft.Data.Entity.Tests
             using (var context = serviceProvider.GetRequiredService<ContextWithDefaults>())
             {
                 var contextServices = ((IDbContextServices)context).ScopedServiceProvider;
-                var contextOptions = (DbContextOptions<ContextWithDefaults>)contextServices.GetRequiredService<LazyRef<IDbContextOptions>>().Value;
+                var contextOptions = (DbContextOptions<ContextWithDefaults>)contextServices.GetRequiredService<ContextService<IDbContextOptions>>().Service;
 
                 Assert.NotNull(contextOptions);
                 var rawOptions = ((IDbContextOptions)contextOptions).RawOptions;

--- a/test/EntityFramework.Tests/Identity/GuidValueGeneratorTest.cs
+++ b/test/EntityFramework.Tests/Identity/GuidValueGeneratorTest.cs
@@ -5,9 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.Identity;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.Identity
@@ -39,8 +39,8 @@ namespace Microsoft.Data.Entity.Tests.Identity
             for (var i = 0; i < 100; i++)
             {
                 var generatedValue = async 
-                    ? await sequentialGuidIdentityGenerator.NextAsync(property, new LazyRef<DataStoreServices>(() => null))
-                    : sequentialGuidIdentityGenerator.Next(property, new LazyRef<DataStoreServices>(() => null));
+                    ? await sequentialGuidIdentityGenerator.NextAsync(property, new ContextService<DataStoreServices>(() => null))
+                    : sequentialGuidIdentityGenerator.Next(property, new ContextService<DataStoreServices>(() => null));
 
                 Assert.False(generatedValue.IsTemporary);
 

--- a/test/EntityFramework.Tests/Identity/SimpleValueGeneratorTest.cs
+++ b/test/EntityFramework.Tests/Identity/SimpleValueGeneratorTest.cs
@@ -3,9 +3,9 @@
 
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.Identity;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.Identity
@@ -19,7 +19,7 @@ namespace Microsoft.Data.Entity.Tests.Identity
 
             var generator = new TestValueGenerator();
 
-            var generatedValue = generator.Next(property, new LazyRef<DataStoreServices>(() => null));
+            var generatedValue = generator.Next(property, new ContextService<DataStoreServices>(() => null));
 
             Assert.Same(generator.Property, property);
 
@@ -34,7 +34,7 @@ namespace Microsoft.Data.Entity.Tests.Identity
 
             var generator = new TestValueGenerator();
 
-            var generatedValue = await generator.NextAsync(property, new LazyRef<DataStoreServices>(() => null));
+            var generatedValue = await generator.NextAsync(property, new ContextService<DataStoreServices>(() => null));
 
             Assert.Same(generator.Property, property);
 

--- a/test/EntityFramework.Tests/Identity/TemporaryValueGeneratorTest.cs
+++ b/test/EntityFramework.Tests/Identity/TemporaryValueGeneratorTest.cs
@@ -4,9 +4,9 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Data.Entity.Identity;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
-using Microsoft.Data.Entity.Utilities;
 using Xunit;
 
 namespace Microsoft.Data.Entity.Tests.Identity
@@ -22,32 +22,32 @@ namespace Microsoft.Data.Entity.Tests.Identity
 
             var generator = new TemporaryValueGenerator();
 
-            var generatedValue = await generator.NextAsync(property, new LazyRef<DataStoreServices>(() => null));
+            var generatedValue = await generator.NextAsync(property, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(-1, generatedValue.Value);
             Assert.True(generatedValue.IsTemporary);
 
-            generatedValue = await generator.NextAsync(property, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = await generator.NextAsync(property, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(-2, generatedValue.Value);
             Assert.True(generatedValue.IsTemporary);
 
-            generatedValue = await generator.NextAsync(property, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = await generator.NextAsync(property, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(-3, generatedValue.Value);
             Assert.True(generatedValue.IsTemporary);
 
-            generatedValue = generator.Next(property, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = generator.Next(property, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(-4, generatedValue.Value);
             Assert.True(generatedValue.IsTemporary);
 
-            generatedValue = generator.Next(property, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = generator.Next(property, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(-5, generatedValue.Value);
             Assert.True(generatedValue.IsTemporary);
 
-            generatedValue = generator.Next(property, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = generator.Next(property, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(-6, generatedValue.Value);
             Assert.True(generatedValue.IsTemporary);
@@ -67,62 +67,62 @@ namespace Microsoft.Data.Entity.Tests.Identity
 
             var generator = new TemporaryValueGenerator();
             
-            var generatedValue = await generator.NextAsync(longProperty, new LazyRef<DataStoreServices>(() => null));
+            var generatedValue = await generator.NextAsync(longProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(-1L, generatedValue.Value);
             Assert.True(generatedValue.IsTemporary);
 
-            generatedValue = await generator.NextAsync(intProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = await generator.NextAsync(intProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(-2, generatedValue.Value);
             Assert.True(generatedValue.IsTemporary);
 
-            generatedValue = await generator.NextAsync(shortProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = await generator.NextAsync(shortProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal((short)-3, generatedValue.Value);
             Assert.True(generatedValue.IsTemporary);
 
-            generatedValue = generator.Next(longProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = generator.Next(longProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(-4L, generatedValue.Value);
             Assert.True(generatedValue.IsTemporary);
 
-            generatedValue = generator.Next(intProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = generator.Next(intProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(-5, generatedValue.Value);
             Assert.True(generatedValue.IsTemporary);
 
-            generatedValue = generator.Next(shortProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = generator.Next(shortProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal((short)-6, generatedValue.Value);
             Assert.True(generatedValue.IsTemporary);
 
-            generatedValue = await generator.NextAsync(nullableLongProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = await generator.NextAsync(nullableLongProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(-7L, generatedValue.Value);
             Assert.True(generatedValue.IsTemporary);
 
-            generatedValue = await generator.NextAsync(nullableIntProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = await generator.NextAsync(nullableIntProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(-8, generatedValue.Value);
             Assert.True(generatedValue.IsTemporary);
 
-            generatedValue = await generator.NextAsync(nullableShortProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = await generator.NextAsync(nullableShortProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal((short)-9, generatedValue.Value);
             Assert.True(generatedValue.IsTemporary);
 
-            generatedValue = generator.Next(nullableLongProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = generator.Next(nullableLongProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(-10L, generatedValue.Value);
             Assert.True(generatedValue.IsTemporary);
 
-            generatedValue = generator.Next(nullableIntProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = generator.Next(nullableIntProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal(-11, generatedValue.Value);
             Assert.True(generatedValue.IsTemporary);
 
-            generatedValue = generator.Next(nullableShortProperty, new LazyRef<DataStoreServices>(() => null));
+            generatedValue = generator.Next(nullableShortProperty, new ContextService<DataStoreServices>(() => null));
 
             Assert.Equal((short)-12, generatedValue.Value);
             Assert.True(generatedValue.IsTemporary);


### PR DESCRIPTION
Instead of using LazyRef which is perhaps too general and fails to get across the semantics of what is going on.
