### PR TITLE
Fix #1070 - .Include() order causes Queries to fail.

### DIFF
--- a/src/EntityFramework.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EntityFramework.Relational/Query/Expressions/SelectExpression.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Data.Entity.Relational.Query.Expressions
         {
             Check.NotNull(querySource, "querySource");
 
-            return _tables.Single(t => t.QuerySource == querySource);
+            return _tables.First(t => t.QuerySource == querySource);
         }
 
         public virtual bool IsDistinct

--- a/src/EntityFramework/ChangeTracking/StateManager.cs
+++ b/src/EntityFramework/ChangeTracking/StateManager.cs
@@ -11,6 +11,7 @@ using Microsoft.Data.Entity.Internal;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Utilities;
+using System.Diagnostics;
 
 namespace Microsoft.Data.Entity.ChangeTracking
 {
@@ -330,6 +331,7 @@ namespace Microsoft.Data.Entity.ChangeTracking
                          && principalKeyValue.Equals(e.GetDependentKeyValue(foreignKey)));
         }
 
+        [DebuggerStepThrough]
         public virtual int SaveChanges()
         {
             var entriesToSave = StateEntries

--- a/src/EntityFramework/DbContext.cs
+++ b/src/EntityFramework/DbContext.cs
@@ -14,6 +14,7 @@ using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
 using Microsoft.Framework.Logging;
 using Microsoft.Framework.OptionsModel;
+using System.Diagnostics;
 
 namespace Microsoft.Data.Entity
 {
@@ -190,6 +191,7 @@ namespace Microsoft.Data.Entity
         {
         }
 
+        [DebuggerStepThrough]
         public virtual int SaveChanges()
         {
             var stateManager = GetStateManager();

--- a/test/EntityFramework.FunctionalTests/IncludeOneToOneTestBase.cs
+++ b/test/EntityFramework.FunctionalTests/IncludeOneToOneTestBase.cs
@@ -15,7 +15,23 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 var people
                     = context.Set<Person>()
-                        .Include(c => c.Address)
+                        .Include(p => p.Address)
+                        .ToList();
+
+                Assert.Equal(3, people.Count);
+                Assert.True(people.All(p => p.Address != null));
+                Assert.Equal(3 + 3, context.ChangeTracker.Entries().Count());
+            }
+        }
+
+        [Fact]
+        public virtual void Include_address_shadow()
+        {
+            using (var context = CreateContext())
+            {
+                var people
+                    = context.Set<Person2>()
+                        .Include(p => p.Address)
                         .ToList();
 
                 Assert.Equal(3, people.Count);
@@ -31,7 +47,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 var people
                     = context.Set<Person>()
-                        .Include(c => c.Address)
+                        .Include(p => p.Address)
                         .AsNoTracking()
                         .ToList();
 
@@ -48,7 +64,23 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 var addresses
                     = context.Set<Address>()
-                        .Include(c => c.Resident)
+                        .Include(a => a.Resident)
+                        .ToList();
+
+                Assert.Equal(3, addresses.Count);
+                Assert.True(addresses.All(p => p.Resident != null));
+                Assert.Equal(3 + 3, context.ChangeTracker.Entries().Count());
+            }
+        }
+
+        [Fact]
+        public virtual void Include_person_shadow()
+        {
+            using (var context = CreateContext())
+            {
+                var addresses
+                    = context.Set<Address2>()
+                        .Include(a => a.Resident)
                         .ToList();
 
                 Assert.Equal(3, addresses.Count);
@@ -64,7 +96,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
             {
                 var addresses
                     = context.Set<Address>()
-                        .Include(c => c.Resident)
+                        .Include(a => a.Resident)
                         .AsNoTracking()
                         .ToList();
 
@@ -85,7 +117,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                 var people
                     = context.Set<Person>()
-                        .Include(c => c.Address)
+                        .Include(p => p.Address)
                         .ToList();
 
                 Assert.Equal(3, people.Count);
@@ -106,7 +138,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
                 var addresses
                     = context.Set<Address>()
-                        .Include(c => c.Resident)
+                        .Include(a => a.Resident)
                         .ToList();
 
                 Assert.Equal(3, addresses.Count);

--- a/test/EntityFramework.FunctionalTests/IncludeTestBase.cs
+++ b/test/EntityFramework.FunctionalTests/IncludeTestBase.cs
@@ -30,6 +30,36 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
+        public virtual void Include_collection_and_reference()
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = context.Set<Order>()
+                        .Include(o => o.OrderDetails)
+                        .Include(o => o.Customer)
+                        .ToList();
+
+                Assert.Equal(830, orders.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Include_reference_and_collection()
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = context.Set<Order>()
+                        .Include(o => o.Customer)
+                        .Include(o => o.OrderDetails)
+                        .ToList();
+
+                Assert.Equal(830, orders.Count);
+            }
+        }
+
+        [Fact]
         public virtual void Include_multi_level()
         {
             Assert.Throws<NotImplementedException>(() =>
@@ -150,7 +180,26 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 Assert.Equal(830 + 89, context.ChangeTracker.Entries().Count());
             }
         }
-        
+
+        [Fact]
+        public virtual void Include_multiple_references()
+        {
+            using (var context = CreateContext())
+            {
+                var orderDetails
+                    = context.Set<OrderDetail>()
+                        .Include(o => o.Order)
+                        .Include(o => o.Product)
+                        .ToList();
+
+                Assert.True(orderDetails.Count > 0);
+                Assert.True(orderDetails.All(o => o.Order != null));
+                Assert.True(orderDetails.All(o => o.Product != null));
+                Assert.Equal(830, orderDetails.Select(o => o.Order).Distinct().Count());
+                Assert.True(orderDetails.Select(o => o.Product).Distinct().Any());
+            }
+        }
+
         [Fact]
         public virtual void Include_reference_alias_generation()
         {
@@ -434,7 +483,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
-        public virtual void Include_multiple_collection()
+        public virtual void Include_duplicate_collection()
         {
             using (var context = CreateContext())
             {
@@ -461,7 +510,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
-        public virtual void Include_multiple_reference()
+        public virtual void Include_duplicate_reference()
         {
             using (var context = CreateContext())
             {
@@ -488,7 +537,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
-        public virtual void Include_multiple_reference2()
+        public virtual void Include_duplicate_reference2()
         {
             using (var context = CreateContext())
             {
@@ -513,7 +562,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
-        public virtual void Include_multiple_reference3()
+        public virtual void Include_duplicate_reference3()
         {
             using (var context = CreateContext())
             {
@@ -538,7 +587,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
-        public virtual void Include_multiple_collection_result_operator()
+        public virtual void Include_duplicate_collection_result_operator()
         {
             using (var context = CreateContext())
             {
@@ -566,7 +615,7 @@ namespace Microsoft.Data.Entity.FunctionalTests
         }
 
         [Fact]
-        public virtual void Include_multiple_collection_result_operator2()
+        public virtual void Include_duplicate_collection_result_operator2()
         {
             using (var context = CreateContext())
             {

--- a/test/EntityFramework.FunctionalTests/OneToOneQueryFixtureBase.cs
+++ b/test/EntityFramework.FunctionalTests/OneToOneQueryFixtureBase.cs
@@ -16,7 +16,16 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 .Entity<Person>(
                     e => e.OneToOne(p => p.Address, a => a.Resident));
 
-            modelBuilder.Entity<Address>();
+            // TODO: Bug #1116
+            modelBuilder.Entity<Address>().Property(a => a.Id).GenerateValueOnAdd(false);
+
+            // TODO: Bugs #1123, #1124, #1125
+            modelBuilder.Entity<Address2>().Property<int>("PersonId");
+
+            modelBuilder
+                .Entity<Person2>(
+                    e => e.OneToOne(p => p.Address, a => a.Resident)
+                        .ForeignKey(typeof(Address2), "PersonId"));
 
             return model;
         }
@@ -45,6 +54,28 @@ namespace Microsoft.Data.Entity.FunctionalTests
                     }
                 );
 
+            var address21 = new Address2 { Id = "1", Street = "3 Dragons Way", City = "Meereen" };
+            var address22 = new Address2 { Id = "2", Street = "42 Castle Black", City = "The Wall" };
+            var address23 = new Address2 { Id = "3", Street = "House of Black and White", City = "Braavos" };
+
+            context.Set<Person2>().AddRange(
+                new[]
+                    {
+                        new Person2 { Name = "Daenerys Targaryen", Address = address21 },
+                        new Person2 { Name = "John Snow", Address = address22 },
+                        new Person2 { Name = "Arya Stark", Address = address23 }
+                    }
+                );
+
+            context.Set<Address2>().AddRange(
+                new[]
+                    {
+                        address21,
+                        address22,
+                        address23
+                    }
+                );
+
             context.SaveChanges();
         }
     }
@@ -62,5 +93,20 @@ namespace Microsoft.Data.Entity.FunctionalTests
         public string Street { get; set; }
         public string City { get; set; }
         public Person Resident { get; set; }
+    }
+
+    public class Person2
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public Address2 Address { get; set; }
+    }
+
+    public class Address2
+    {
+        public string Id { get; set; }
+        public string Street { get; set; }
+        public string City { get; set; }
+        public Person2 Resident { get; set; }
     }
 }

--- a/test/EntityFramework.InMemory.FunctionalTests/EntityFramework.InMemory.FunctionalTests.csproj
+++ b/test/EntityFramework.InMemory.FunctionalTests/EntityFramework.InMemory.FunctionalTests.csproj
@@ -73,7 +73,7 @@
     <Compile Include="InMemoryTestStore.cs" />
     <Compile Include="InMemoryBuiltInDataTypesFixture.cs" />
     <Compile Include="InMemoryBuiltInDataTypesTest.cs" />
-    <Compile Include="IncludeOneToOneTest.cs" />
+    <Compile Include="InMemoryIncludeOneToOneTest.cs" />
     <Compile Include="MusicStoreQueryTests.cs" />
     <Compile Include="CompositeKeyEndToEndTest.cs" />
     <Compile Include="GuidValueGeneratorEndToEndTest.cs" />

--- a/test/EntityFramework.InMemory.FunctionalTests/InMemoryIncludeOneToOneTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/InMemoryIncludeOneToOneTest.cs
@@ -6,11 +6,11 @@ using Xunit;
 
 namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 {
-    public class IncludeOneToOneTest : IncludeOneToOneTestBase, IClassFixture<OneToOneQueryFixture>
+    public class InMemoryIncludeOneToOneTest : IncludeOneToOneTestBase, IClassFixture<OneToOneQueryFixture>
     {
         private readonly OneToOneQueryFixture _fixture;
 
-        public IncludeOneToOneTest(OneToOneQueryFixture fixture)
+        public InMemoryIncludeOneToOneTest(OneToOneQueryFixture fixture)
         {
             _fixture = fixture;
         }

--- a/test/EntityFramework.SQLite.FunctionalTests/EntityFramework.SQLite.FunctionalTests.csproj
+++ b/test/EntityFramework.SQLite.FunctionalTests/EntityFramework.SQLite.FunctionalTests.csproj
@@ -85,6 +85,8 @@
     <Compile Include="SqLiteTestStore.cs" />
     <Compile Include="SqLiteTransactionFixture.cs" />
     <Compile Include="SqLiteTransactionTests.cs" />
+    <Compile Include="SqlLiteIncludeOneToOneTest.cs" />
+    <Compile Include="SqLiteOneToOneQueryFixture.cs" />
     <Compile Include="TestModels\SQLiteNorthwindContext.cs" />
     <None Include="northwind.db">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/test/EntityFramework.SQLite.FunctionalTests/SqLiteIncludeTest.cs
+++ b/test/EntityFramework.SQLite.FunctionalTests/SqLiteIncludeTest.cs
@@ -279,9 +279,9 @@ ORDER BY ""c"".""CustomerID""",
                 TestSqlLoggerFactory.Sql);
         }
 
-        public override void Include_multiple_collection()
+        public override void Include_duplicate_collection()
         {
-            base.Include_multiple_collection();
+            base.Include_duplicate_collection();
 
             Assert.Equal(
                 @"SELECT ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""CustomerID"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
@@ -323,9 +323,9 @@ LIMIT @p0 OFFSET @p0",
                 TestSqlLoggerFactory.Sql);
         }
 
-        public override void Include_multiple_collection_result_operator()
+        public override void Include_duplicate_collection_result_operator()
         {
-            base.Include_multiple_collection_result_operator();
+            base.Include_duplicate_collection_result_operator();
 
             Assert.Equal(
                 @"SELECT ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""CustomerID"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
@@ -412,9 +412,9 @@ FROM ""Customers"" AS ""c""",
                 TestSqlLoggerFactory.Sql);
         }
 
-        public override void Include_multiple_collection_result_operator2()
+        public override void Include_duplicate_collection_result_operator2()
         {
-            base.Include_multiple_collection_result_operator2();
+            base.Include_duplicate_collection_result_operator2();
 
             Assert.Equal(
                 @"SELECT ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""CustomerID"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
@@ -449,9 +449,9 @@ LEFT JOIN ""Customers"" AS ""c"" ON ""o"".""CustomerID"" = ""c"".""CustomerID"""
                 TestSqlLoggerFactory.Sql);
         }
 
-        public override void Include_multiple_reference()
+        public override void Include_duplicate_reference()
         {
-            base.Include_multiple_reference();
+            base.Include_duplicate_reference();
 
             Assert.Equal(
                 @"SELECT ""o"".""CustomerID"", ""o"".""OrderDate"", ""o"".""OrderID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""CustomerID"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
@@ -474,9 +474,9 @@ LIMIT @p0 OFFSET @p0",
                 TestSqlLoggerFactory.Sql);
         }
 
-        public override void Include_multiple_reference2()
+        public override void Include_duplicate_reference2()
         {
-            base.Include_multiple_reference2();
+            base.Include_duplicate_reference2();
 
             Assert.Equal(
                 @"SELECT ""o"".""CustomerID"", ""o"".""OrderDate"", ""o"".""OrderID"", ""c"".""Address"", ""c"".""City"", ""c"".""CompanyName"", ""c"".""ContactName"", ""c"".""ContactTitle"", ""c"".""Country"", ""c"".""CustomerID"", ""c"".""Fax"", ""c"".""Phone"", ""c"".""PostalCode"", ""c"".""Region""
@@ -497,9 +497,9 @@ LIMIT @p0 OFFSET @p0",
                 TestSqlLoggerFactory.Sql);
         }
 
-        public override void Include_multiple_reference3()
+        public override void Include_duplicate_reference3()
         {
-            base.Include_multiple_reference3();
+            base.Include_duplicate_reference3();
 
             Assert.Equal(
                 @"SELECT ""o"".""CustomerID"", ""o"".""OrderDate"", ""o"".""OrderID""

--- a/test/EntityFramework.SQLite.FunctionalTests/SqLiteOneToOneQueryFixture.cs
+++ b/test/EntityFramework.SQLite.FunctionalTests/SqLiteOneToOneQueryFixture.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
+using Microsoft.Framework.Logging;
+using Microsoft.Data.Entity.Relational.FunctionalTests;
+
+namespace Microsoft.Data.Entity.SQLite.FunctionalTests
+{
+    public class SQLiteOneToOneQueryFixture : OneToOneQueryFixtureBase
+    {
+        private readonly DbContextOptions _options;
+        private readonly IServiceProvider _serviceProvider;
+
+        public SQLiteOneToOneQueryFixture()
+        {
+            _serviceProvider
+                = new ServiceCollection()
+                    .AddEntityFramework()
+                    .AddSQLite()
+                    .ServiceCollection
+                    .AddInstance<ILoggerFactory>(new TestSqlLoggerFactory())
+                    .BuildServiceProvider();
+
+            var model = CreateModel();
+            var database = SqLiteTestStore.CreateScratchAsync().Result;
+
+            _options
+                = new DbContextOptions()
+                    .UseModel(model)
+                    .UseSQLite(database.Connection.ConnectionString);
+            
+            using (var context = new DbContext(_serviceProvider, _options))
+            {
+                context.Database.EnsureCreated();
+
+                AddTestData(context);
+            }
+        }
+
+        public DbContext CreateContext()
+        {
+            return new DbContext(_serviceProvider, _options);
+        }
+    }
+}

--- a/test/EntityFramework.SQLite.FunctionalTests/SqlLiteIncludeOneToOneTest.cs
+++ b/test/EntityFramework.SQLite.FunctionalTests/SqlLiteIncludeOneToOneTest.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.Relational.FunctionalTests;
+using Xunit;
+using System.Linq;
+
+namespace Microsoft.Data.Entity.SQLite.FunctionalTests
+{
+    // TODO: Blocked by #1127
+    internal class SQLiteIncludeOneToOneTest : IncludeOneToOneTestBase, IClassFixture<SQLiteOneToOneQueryFixture>
+    {
+        public override void Include_person()
+        {
+            base.Include_person();
+
+            Assert.Equal(
+                @"SELECT ""a"".""City"", ""a"".""Id"", ""a"".""Street"", ""p"".""Id"", ""p"".""Name""
+FROM ""Address"" AS ""a""
+INNER JOIN ""Person"" AS ""p"" ON ""a"".""Id"" = ""p"".""Id""",
+                Sql);
+        }
+
+        public override void Include_person_shadow()
+        {
+            base.Include_person_shadow();
+
+            Assert.Equal(
+                @"SELECT ""a"".""City"", ""a"".""Id"", ""a"".""PersonId"", ""a"".""Street"", ""p"".""Id"", ""p"".""Name""
+FROM ""Address2"" AS ""a""
+INNER JOIN ""Person2"" AS ""p"" ON ""a"".""PersonId"" = ""p"".""Id""",
+                Sql);
+        }
+
+        public override void Include_address()
+        {
+            base.Include_address();
+
+            Assert.Equal(
+                @"SELECT ""p"".""Id"", ""p"".""Name"", ""a"".""City"", ""a"".""Id"", ""a"".""Street""
+FROM ""Person"" AS ""p""
+INNER JOIN ""Address"" AS ""a"" ON ""a"".""Id"" = ""p"".""Id""",
+                Sql);
+        }
+
+        public override void Include_address_shadow()
+        {
+            base.Include_address_shadow();
+
+            Assert.Equal(
+                @"SELECT ""p"".""Id"", ""p"".""Name"", ""a"".""City"", ""a"".""Id"", ""a"".""PersonId"", ""a"".""Street""
+FROM ""Person2"" AS ""p""
+INNER JOIN ""Address2"" AS ""a"" ON ""a"".""PersonId"" = ""p"".""Id""",
+                Sql);
+        }
+
+        private readonly SQLiteOneToOneQueryFixture _fixture;
+
+        public SQLiteIncludeOneToOneTest(SQLiteOneToOneQueryFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        protected override DbContext CreateContext()
+        {
+            return _fixture.CreateContext();
+        }
+
+        private static string Sql
+        {
+            get { return TestSqlLoggerFactory.SqlStatements.Last(); }
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
+++ b/test/EntityFramework.SqlServer.FunctionalTests/EntityFramework.SqlServer.FunctionalTests.csproj
@@ -73,6 +73,8 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="SqlServerIncludeOneToOneTest.cs" />
+    <Compile Include="SqlServerOneToOneQueryFixture.cs" />
     <Compile Include="SqlServerBuiltInDataTypesFixture.cs" />
     <Compile Include="SqlServerBuiltInDataTypesTest.cs" />
     <Compile Include="BatchingTest.cs" />

--- a/test/EntityFramework.SqlServer.FunctionalTests/MappingQueryFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/MappingQueryFixture.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             _serviceProvider = new ServiceCollection()
                 .AddEntityFramework()
-                .AddSqlServer().ServiceCollection
+                .AddSqlServer()
+                .ServiceCollection
                 .AddInstance<ILoggerFactory>(new TestSqlLoggerFactory())
                 .BuildServiceProvider();
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerIncludeOneToOneTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerIncludeOneToOneTest.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Data.Entity.Relational.FunctionalTests;
+using Xunit;
+using System.Linq;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public class SqlServerIncludeOneToOneTest : IncludeOneToOneTestBase, IClassFixture<SqlServerOneToOneQueryFixture>
+    {
+        public override void Include_person()
+        {
+            base.Include_person();
+
+            Assert.Equal(
+                @"SELECT [a].[City], [a].[Id], [a].[Street], [p].[Id], [p].[Name]
+FROM [Address] AS [a]
+INNER JOIN [Person] AS [p] ON [a].[Id] = [p].[Id]",
+                Sql);
+        }
+
+        public override void Include_person_shadow()
+        {
+            base.Include_person_shadow();
+
+            Assert.Equal(
+                @"SELECT [a].[City], [a].[Id], [a].[PersonId], [a].[Street], [p].[Id], [p].[Name]
+FROM [Address2] AS [a]
+INNER JOIN [Person2] AS [p] ON [a].[PersonId] = [p].[Id]",
+                Sql);
+        }
+
+        public override void Include_address()
+        {
+            base.Include_address();
+
+            Assert.Equal(
+                @"SELECT [p].[Id], [p].[Name], [a].[City], [a].[Id], [a].[Street]
+FROM [Person] AS [p]
+INNER JOIN [Address] AS [a] ON [a].[Id] = [p].[Id]",
+                Sql);
+        }
+
+        public override void Include_address_shadow()
+        {
+            base.Include_address_shadow();
+
+            Assert.Equal(
+                @"SELECT [p].[Id], [p].[Name], [a].[City], [a].[Id], [a].[PersonId], [a].[Street]
+FROM [Person2] AS [p]
+INNER JOIN [Address2] AS [a] ON [a].[PersonId] = [p].[Id]",
+                Sql);
+        }
+
+        private readonly SqlServerOneToOneQueryFixture _fixture;
+
+        public SqlServerIncludeOneToOneTest(SqlServerOneToOneQueryFixture fixture)
+        {
+            _fixture = fixture;
+        }
+
+        protected override DbContext CreateContext()
+        {
+            return _fixture.CreateContext();
+        }
+
+        private static string Sql
+        {
+            get { return TestSqlLoggerFactory.SqlStatements.Last(); }
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerIncludeTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerIncludeTest.cs
@@ -28,6 +28,26 @@ ORDER BY [c].[CustomerID]",
                 Sql);
         }
 
+        public override void Include_reference_and_collection()
+        {
+            base.Include_reference_and_collection();
+
+            Assert.Equal(
+                @"SELECT [o].[CustomerID], [o].[OrderDate], [o].[OrderID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+ORDER BY [o].[OrderID]
+
+SELECT [o0].[Discount], [o0].[OrderID], [o0].[ProductID], [o0].[Quantity], [o0].[UnitPrice]
+FROM [Order Details] AS [o0]
+INNER JOIN (
+    SELECT DISTINCT [o].[OrderID]
+    FROM [Orders] AS [o]
+) AS [o] ON [o0].[OrderID] = [o].[OrderID]
+ORDER BY [o].[OrderID]",
+                Sql);
+        }
+
         public override void Include_collection_alias_generation()
         {
             base.Include_collection_alias_generation();
@@ -291,9 +311,9 @@ ORDER BY [c].[CustomerID]",
                 Sql);
         }
 
-        public override void Include_multiple_collection()
+        public override void Include_duplicate_collection()
         {
-            base.Include_multiple_collection();
+            base.Include_duplicate_collection();
 
             Assert.Equal(
                 @"SELECT TOP(@p0) [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
@@ -330,9 +350,9 @@ ORDER BY [c].[CustomerID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY",
                 Sql);
         }
 
-        public override void Include_multiple_collection_result_operator()
+        public override void Include_duplicate_collection_result_operator()
         {
-            base.Include_multiple_collection_result_operator();
+            base.Include_duplicate_collection_result_operator();
 
             Assert.Equal(
                 @"SELECT TOP(@p0) [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
@@ -414,9 +434,9 @@ FROM [Customers] AS [c]",
                 Sql);
         }
 
-        public override void Include_multiple_collection_result_operator2()
+        public override void Include_duplicate_collection_result_operator2()
         {
-            base.Include_multiple_collection_result_operator2();
+            base.Include_duplicate_collection_result_operator2();
 
             Assert.Equal(
                 @"SELECT TOP(@p0) [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
@@ -448,6 +468,18 @@ LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]",
                 Sql);
         }
 
+        public override void Include_multiple_references()
+        {
+            base.Include_multiple_references();
+
+            Assert.Equal(
+                @"SELECT [o].[Discount], [o].[OrderID], [o].[ProductID], [o].[Quantity], [o].[UnitPrice], [o0].[CustomerID], [o0].[OrderDate], [o0].[OrderID], [p].[Discontinued], [p].[ProductID], [p].[ProductName]
+FROM [Order Details] AS [o]
+INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]
+INNER JOIN [Products] AS [p] ON [o].[ProductID] = [p].[ProductID]",
+                Sql);
+        }
+
         public override void Include_reference_alias_generation()
         {
             base.Include_reference_alias_generation();
@@ -459,9 +491,9 @@ INNER JOIN [Orders] AS [o0] ON [o].[OrderID] = [o0].[OrderID]",
                 Sql);
         }
 
-        public override void Include_multiple_reference()
+        public override void Include_duplicate_reference()
         {
-            base.Include_multiple_reference();
+            base.Include_duplicate_reference();
 
             Assert.Equal(
                 @"SELECT TOP(@p0) [o].[CustomerID], [o].[OrderDate], [o].[OrderID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
@@ -481,9 +513,9 @@ ORDER BY [o].[CustomerID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY",
                 Sql);
         }
 
-        public override void Include_multiple_reference2()
+        public override void Include_duplicate_reference2()
         {
-            base.Include_multiple_reference2();
+            base.Include_duplicate_reference2();
 
             Assert.Equal(
                 @"SELECT TOP(@p0) [o].[CustomerID], [o].[OrderDate], [o].[OrderID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[CustomerID], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
@@ -501,9 +533,9 @@ ORDER BY [o].[OrderID] OFFSET @p0 ROWS FETCH NEXT @p0 ROWS ONLY",
                 Sql);
         }
 
-        public override void Include_multiple_reference3()
+        public override void Include_duplicate_reference3()
         {
-            base.Include_multiple_reference3();
+            base.Include_duplicate_reference3();
 
             Assert.Equal(
                 @"SELECT TOP(@p0) [o].[CustomerID], [o].[OrderDate], [o].[OrderID]

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerOneToOneQueryFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerOneToOneQueryFixture.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.Data.Entity.FunctionalTests;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
+using Microsoft.Framework.Logging;
+using Microsoft.Data.Entity.Relational.FunctionalTests;
+
+namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
+{
+    public class SqlServerOneToOneQueryFixture : OneToOneQueryFixtureBase
+    {
+        private readonly DbContextOptions _options;
+        private readonly IServiceProvider _serviceProvider;
+
+        public SqlServerOneToOneQueryFixture()
+        {
+            _serviceProvider
+                = new ServiceCollection()
+                    .AddEntityFramework()
+                    .AddSqlServer()
+                    .ServiceCollection
+                    .AddInstance<ILoggerFactory>(new TestSqlLoggerFactory())
+                    .BuildServiceProvider();
+
+            var model = CreateModel();
+            var database = SqlServerTestStore.CreateScratchAsync().Result;
+
+            _options
+                = new DbContextOptions()
+                    .UseModel(model)
+                    .UseSqlServer(database.Connection.ConnectionString);
+            
+            using (var context = new DbContext(_serviceProvider, _options))
+            {
+                context.Database.EnsureCreated();
+
+                AddTestData(context);
+            }
+        }
+
+        public DbContext CreateContext()
+        {
+            return new DbContext(_serviceProvider, _options);
+        }
+    }
+}


### PR DESCRIPTION
- Ensure that collection includes run first so that sub-queries use the original top-level query.
