### PR TITLE
Make database creation for SQL Server more resilient to failures

### DIFF
--- a/src/EntityFramework.SqlServer/SqlServerDataStoreCreator.cs
+++ b/src/EntityFramework.SqlServer/SqlServerDataStoreCreator.cs
@@ -54,6 +54,8 @@ namespace Microsoft.Data.Entity.SqlServer
                 _statementExecutor.ExecuteNonQuery(masterConnection, null, CreateCreateOperations());
                 ClearPool();
             }
+
+            Exists(retryOnNotExists: true);
         }
 
         public override async Task CreateAsync(CancellationToken cancellationToken = default(CancellationToken))
@@ -65,6 +67,8 @@ namespace Microsoft.Data.Entity.SqlServer
                     .WithCurrentCulture();
                 ClearPool();
             }
+
+            await ExistsAsync(retryOnNotExists: true, cancellationToken: cancellationToken).WithCurrentCulture();
         }
 
         public override void CreateTables(IModel model)
@@ -117,6 +121,11 @@ namespace Microsoft.Data.Entity.SqlServer
 
         public override bool Exists()
         {
+            return Exists(retryOnNotExists: false);
+        }
+
+        private bool Exists(bool retryOnNotExists)
+        {
             var retryCount = 0;
             while (true)
             {
@@ -128,12 +137,12 @@ namespace Microsoft.Data.Entity.SqlServer
                 }
                 catch (SqlException e)
                 {
-                    if (IsDoesNotExist(e))
+                    if (!retryOnNotExists && IsDoesNotExist(e))
                     {
                         return false;
                     }
 
-                    if (!RetryOnNoProcessOnEndOfPipe(e, ref retryCount))
+                    if (!RetryOnExistsFailure(e, ref retryCount))
                     {
                         throw;
                     }
@@ -141,7 +150,12 @@ namespace Microsoft.Data.Entity.SqlServer
             }
         }
 
-        public override async Task<bool> ExistsAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public override Task<bool> ExistsAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return ExistsAsync(retryOnNotExists: false, cancellationToken: cancellationToken);
+        }
+
+        private async Task<bool> ExistsAsync(bool retryOnNotExists, CancellationToken cancellationToken)
         {
             var retryCount = 0;
             while (true)
@@ -154,12 +168,12 @@ namespace Microsoft.Data.Entity.SqlServer
                 }
                 catch (SqlException e)
                 {
-                    if (IsDoesNotExist(e))
+                    if (!retryOnNotExists && IsDoesNotExist(e))
                     {
                         return false;
                     }
 
-                    if (!RetryOnNoProcessOnEndOfPipe(e, ref retryCount))
+                    if (!RetryOnExistsFailure(e, ref retryCount))
                     {
                         throw;
                     }
@@ -169,26 +183,32 @@ namespace Microsoft.Data.Entity.SqlServer
 
         private static bool IsDoesNotExist(SqlException exception)
         {
-            // TODO Explore if there are important scenarios where this could give a false negative
-            // Login failed is thrown when database does not exist
-            // Issue #776
+            // Login failed is thrown when database does not exist (See Issue #776)
             return exception.Number == 4060;
         }
 
-        private bool RetryOnNoProcessOnEndOfPipe(SqlException exception, ref int retryCount)
+        // See Issue #985
+        private bool RetryOnExistsFailure(SqlException exception, ref int retryCount)
         {
-            // This is to handle the case where Open throws:
-            //   System.Data.SqlClient.SqlException : A connection was successfully established with the
+            // This is to handle the case where Open throws (Number 233):
+            //   System.Data.SqlClient.SqlException: A connection was successfully established with the
             //   server, but then an error occurred during the login process. (provider: Named Pipes
             //   Provider, error: 0 - No process is on the other end of the pipe.)
             // It appears that this happens when the database has just been created but has not yet finished
             // opening or is auto-closing when using the AUTO_CLOSE option. The workaround is to flush the pool
             // for the connection and then retry the Open call.
-            if (exception.Number == 233
-                && retryCount++ < 3)
+            // Also handling (Number -2):
+            //   System.Data.SqlClient.SqlException: Connection Timeout Expired.  The timeout period elapsed while
+            //   attempting to consume the pre-login handshake acknowledgement.  This could be because the pre-login
+            //   handshake failed or the server was unable to respond back in time.
+            // And (Number 4060):
+            //   System.Data.SqlClient.SqlException: Cannot open database "X" requested by the login. The
+            //   login failed.
+            if ((exception.Number == 233 || exception.Number == -2 || exception.Number == 4060)
+                && ++retryCount < 30)
             {
                 ClearPool();
-                Thread.Sleep(10);
+                Thread.Sleep(100);
                 return true;
             }
             return false;

--- a/test/EntityFramework.SqlServer.Tests/EntityFramework.SqlServer.Tests.csproj
+++ b/test/EntityFramework.SqlServer.Tests/EntityFramework.SqlServer.Tests.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Metadata\SqlServerMetadataExtensionsTest.cs" />
     <Compile Include="SequentialGuidValueGeneratorTest.cs" />
     <Compile Include="..\EntityFramework.Relational.Tests\SqlGeneratorTestBase.cs" />
+    <Compile Include="SqlServerDataStoreCreatorTest.cs" />
     <Compile Include="SqlServerDbContextOptionsExtensionsTest.cs" />
     <Compile Include="SqlServerDatabaseExtensionsTest.cs" />
     <Compile Include="SqlServerMigrationOperationPreProcessorTest.cs" />

--- a/test/EntityFramework.SqlServer.Tests/SqlServerDataStoreCreatorTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerDataStoreCreatorTest.cs
@@ -1,0 +1,187 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Data.SqlClient;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Data.Entity.Relational;
+using Microsoft.Data.Entity.Tests;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.Logging;
+using Xunit;
+
+namespace Microsoft.Data.Entity.SqlServer.Tests
+{
+    public class SqlServerDataStoreCreatorTest
+    {
+        [Fact]
+        public async Task Create_checks_for_existence_and_retries_if_no_proccess_until_it_passes()
+        {
+            await Create_checks_for_existence_and_retries_until_it_passes(233, async: false);
+        }
+
+        [Fact]
+        public async Task Create_checks_for_existence_and_retries_if_timeout_until_it_passes()
+        {
+            await Create_checks_for_existence_and_retries_until_it_passes(-2, async: false);
+        }
+
+        [Fact]
+        public async Task Create_checks_for_existence_and_retries_if_cannot_open_until_it_passes()
+        {
+            await Create_checks_for_existence_and_retries_until_it_passes(4060, async: false);
+        }
+
+        [Fact]
+        public async Task CreateAsync_checks_for_existence_and_retries_if_no_proccess_until_it_passes()
+        {
+            await Create_checks_for_existence_and_retries_until_it_passes(233, async: true);
+        }
+
+        [Fact]
+        public async Task CreateAsync_checks_for_existence_and_retries_if_timeout_until_it_passes()
+        {
+            await Create_checks_for_existence_and_retries_until_it_passes(-2, async: true);
+        }
+
+        [Fact]
+        public async Task CreateAsync_checks_for_existence_and_retries_if_cannot_open_until_it_passes()
+        {
+            await Create_checks_for_existence_and_retries_until_it_passes(4060, async: true);
+        }
+
+        private async Task Create_checks_for_existence_and_retries_until_it_passes(int errorNumber, bool async)
+        {
+            var customServices = new ServiceCollection()
+                .AddScoped<SqlServerConnection, FakeSqlServerConnection>()
+                .AddScoped<SqlStatementExecutor, FakeSqlStatementExecutor>();
+
+            var contextServices = TestHelpers.CreateContextServices(customServices);
+
+            var connection = (FakeSqlServerConnection)contextServices.GetRequiredService<SqlServerConnection>();
+
+            connection.ErrorNumber = errorNumber;
+            connection.FailAfter = 5;
+
+            var creator = contextServices.GetRequiredService<SqlServerDataStoreCreator>();
+
+            if (async)
+            {
+                await creator.CreateAsync();
+            }
+            else
+            {
+                creator.Create();
+            }
+
+            Assert.Equal(5, connection.OpenCount);
+        }
+
+        [Fact]
+        public async Task Create_checks_for_existence_and_ultimately_gives_up_waiting()
+        {
+            await Create_checks_for_existence_and_ultimately_gives_up_waiting_test(async: false);
+        }
+
+        [Fact]
+        public async Task CreateAsync_checks_for_existence_and_ultimately_gives_up_waiting()
+        {
+            await Create_checks_for_existence_and_ultimately_gives_up_waiting_test(async: true);
+        }
+
+        private async Task Create_checks_for_existence_and_ultimately_gives_up_waiting_test(bool async)
+        {
+            var customServices = new ServiceCollection()
+                .AddScoped<SqlServerConnection, FakeSqlServerConnection>()
+                .AddScoped<SqlStatementExecutor, FakeSqlStatementExecutor>();
+
+            var contextServices = TestHelpers.CreateContextServices(customServices);
+
+            var connection = (FakeSqlServerConnection)contextServices.GetRequiredService<SqlServerConnection>();
+
+            connection.ErrorNumber = 233;
+            connection.FailAfter = 100;
+
+            var creator = contextServices.GetRequiredService<SqlServerDataStoreCreator>();
+
+            if (async)
+            {
+                await Assert.ThrowsAsync<SqlException>(async () => await creator.CreateAsync());
+            }
+            else
+            {
+                Assert.Throws<SqlException>(() => creator.Create());
+            }
+        }
+
+        private class FakeSqlServerConnection : SqlServerConnection
+        {
+            public FakeSqlServerConnection(DbContextService<IDbContextOptions> options, ILoggerFactory loggerFactory)
+                : base(options, loggerFactory)
+            {
+            }
+
+            public int ErrorNumber { get; set; }
+            public int FailAfter { get; set; }
+            public int OpenCount { get; set; }
+
+            public override void Open()
+            {
+                if (++OpenCount < FailAfter)
+                {
+                    throw CreateSqlException(ErrorNumber);
+                }
+            }
+
+            public override Task OpenAsync(CancellationToken cancellationToken = new CancellationToken())
+            {
+                if (++OpenCount < FailAfter)
+                {
+                    throw CreateSqlException(ErrorNumber);
+                }
+
+                return Task.FromResult(0);
+            }
+        }
+
+        private class FakeSqlStatementExecutor : SqlStatementExecutor
+        {
+            public FakeSqlStatementExecutor(ILoggerFactory loggerFactory)
+                : base(loggerFactory)
+            {
+            }
+
+            public override void ExecuteNonQuery(DbConnection connection, DbTransaction transaction, IEnumerable<SqlBatch> sqlBatches)
+            {
+            }
+
+            public override Task ExecuteNonQueryAsync(DbConnection connection, DbTransaction transaction, IEnumerable<SqlBatch> sqlBatches, CancellationToken cancellationToken = new CancellationToken())
+            {
+                return Task.FromResult(0);
+            }
+        }
+
+        private static SqlException CreateSqlException(int number)
+        {
+            var error = (SqlError)Activator.CreateInstance(
+                typeof(SqlError), BindingFlags.Instance | BindingFlags.NonPublic, null,
+                new object[] { number, (byte)0, (byte)0, "Server", "ErrorMessage", "Procedure", 0 }, null);
+
+            var errors = (SqlErrorCollection)Activator.CreateInstance(
+                typeof(SqlErrorCollection), BindingFlags.Instance | BindingFlags.NonPublic, null,
+                null, null);
+
+            typeof(SqlErrorCollection).GetTypeInfo().GetRuntimeMethods().Single(m => m.Name == "Add").Invoke(errors, new object[] { error });
+
+            return (SqlException)Activator.CreateInstance(
+                typeof(SqlException), BindingFlags.Instance | BindingFlags.NonPublic, null,
+                new object[] { "Bang!", errors, null, Guid.NewGuid() }, null);
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.Tests/TestHelperExtensions.cs
+++ b/test/EntityFramework.SqlServer.Tests/TestHelperExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Data.Entity.Tests
 
         public static DbContextOptions UseProviderOptions(this DbContextOptions options)
         {
-            return options.UseSqlServer(new SqlConnection());
+            return options.UseSqlServer(new SqlConnection("Database=DummyDatabase"));
         }
     }
 }


### PR DESCRIPTION
Issue #985. The change here is to call the equivalent of Exists always immediately after creating the database. If this fails with one of the "transient" errors that we have encountered, then sleep for a bit and retry the exists check. Repeat until it passes or until we've waited so long we just give up.

Also made a similar change in the test code used to create databases since it doesn't use the EF mechanisms.

Currently executing a squence of Migrations operations to create a database will not use this mechanism--will file a bug on this.
