### PR TITLE
Use TryAdd in AddXxx methods to only add services if not already present.

### DIFF
--- a/src/EntityFramework.InMemory/Extensions/InMemoryEntityServicesBuilderExtensions.cs
+++ b/src/EntityFramework.InMemory/Extensions/InMemoryEntityServicesBuilderExtensions.cs
@@ -19,16 +19,17 @@ namespace Microsoft.Framework.DependencyInjection
             Check.NotNull(builder, "builder");
 
             builder.ServiceCollection
-                .AddSingleton<InMemoryValueGeneratorCache>()
-                .AddSingleton<InMemoryValueGeneratorSelector>()
-                .AddSingleton<SimpleValueGeneratorFactory<InMemoryValueGenerator>>()
-                .AddSingleton<InMemoryDatabase>()
                 .AddScoped<DataStoreSource, InMemoryDataStoreSource>()
-                .AddScoped<InMemoryDataStoreServices>()
-                .AddScoped<InMemoryDatabaseFacade>()
-                .AddScoped<InMemoryDataStore>()
-                .AddScoped<InMemoryConnection>()
-                .AddScoped<InMemoryDataStoreCreator>();
+                .TryAdd(new ServiceCollection()
+                    .AddSingleton<InMemoryValueGeneratorCache>()
+                    .AddSingleton<InMemoryValueGeneratorSelector>()
+                    .AddSingleton<SimpleValueGeneratorFactory<InMemoryValueGenerator>>()
+                    .AddSingleton<InMemoryDatabase>()
+                    .AddScoped<InMemoryDataStoreServices>()
+                    .AddScoped<InMemoryDatabaseFacade>()
+                    .AddScoped<InMemoryDataStore>()
+                    .AddScoped<InMemoryConnection>()
+                    .AddScoped<InMemoryDataStoreCreator>());
 
             return builder;
         }

--- a/src/EntityFramework.Migrations/MigrationsEntityServicesBuilderExtensions.cs
+++ b/src/EntityFramework.Migrations/MigrationsEntityServicesBuilderExtensions.cs
@@ -17,9 +17,10 @@ namespace Microsoft.Data.Entity.Migrations
 
             builder
                 .AddRelational().ServiceCollection
-                .AddScoped<MigrationAssembly>()
-                .AddScoped<HistoryRepository>()
-                .AddScoped(MigrationsDataStoreServices.MigratorFactory);
+                .TryAdd(new ServiceCollection()
+                    .AddScoped<MigrationAssembly>()
+                    .AddScoped<HistoryRepository>()
+                    .AddScoped(MigrationsDataStoreServices.MigratorFactory));
 
             return builder;
         }

--- a/src/EntityFramework.Relational/RelationalEntityServicesBuilderExtensions.cs
+++ b/src/EntityFramework.Relational/RelationalEntityServicesBuilderExtensions.cs
@@ -18,11 +18,11 @@ namespace Microsoft.Data.Entity.Relational
         {
             Check.NotNull(builder, "builder");
 
-            builder.ServiceCollection
+            builder.ServiceCollection.TryAdd(new ServiceCollection()
                 .AddSingleton<RelationalObjectArrayValueReaderFactory>()
                 .AddSingleton<RelationalTypedValueReaderFactory>()
                 .AddSingleton<ParameterNameGeneratorFactory>()
-                .AddSingleton<ModificationCommandComparer>();
+                .AddSingleton<ModificationCommandComparer>());
 
             return builder;
         }

--- a/src/EntityFramework.SqlServer/Extensions/SqlServerEntityServicesBuilderExtensions.cs
+++ b/src/EntityFramework.SqlServer/Extensions/SqlServerEntityServicesBuilderExtensions.cs
@@ -4,7 +4,7 @@
 using JetBrains.Annotations;
 using Microsoft.Data.Entity;
 using Microsoft.Data.Entity.Identity;
-using Microsoft.Data.Entity.Migrations.Infrastructure;
+using Microsoft.Data.Entity.Migrations;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.SqlServer;
 using Microsoft.Data.Entity.SqlServer.Metadata;
@@ -22,31 +22,30 @@ namespace Microsoft.Framework.DependencyInjection
         {
             Check.NotNull(builder, "builder");
 
-            builder.AddRelational().ServiceCollection
-                .AddSingleton<SqlServerValueGeneratorCache>()
-                .AddSingleton<SqlServerValueGeneratorSelector>()
-                .AddSingleton<SimpleValueGeneratorFactory<SequentialGuidValueGenerator>>()
-                .AddSingleton<SqlServerSequenceValueGeneratorFactory>()
-                .AddSingleton<SqlServerSqlGenerator>()
-                .AddSingleton<SqlStatementExecutor>()
-                .AddSingleton<SqlServerTypeMapper>()
-                .AddSingleton<SqlServerModificationCommandBatchFactory>()
-                .AddSingleton<SqlServerCommandBatchPreparer>()
-                .AddSingleton<SqlServerMetadataExtensionProvider>()
-                .AddSingleton<SqlServerMigrationOperationFactory>()
-                .AddScoped<SqlServerBatchExecutor>()
+            builder.AddMigrations().ServiceCollection
                 .AddScoped<DataStoreSource, SqlServerDataStoreSource>()
-                .AddScoped<SqlServerDataStoreServices>()
-                .AddScoped<SqlServerDataStore>()
-                .AddScoped<SqlServerConnection>()                
-                .AddScoped<SqlServerMigrationOperationProcessor>()
-                .AddScoped<SqlServerModelDiffer>()
-                .AddScoped<SqlServerDatabase>()
-                .AddScoped<SqlServerMigrationOperationSqlGeneratorFactory>()
-                .AddScoped<SqlServerDataStoreCreator>()
-                .AddScoped<MigrationAssembly>()
-                .AddScoped<HistoryRepository>()
-                .AddScoped<SqlServerMigrator>();
+                .TryAdd(new ServiceCollection()
+                    .AddSingleton<SqlServerValueGeneratorCache>()
+                    .AddSingleton<SqlServerValueGeneratorSelector>()
+                    .AddSingleton<SimpleValueGeneratorFactory<SequentialGuidValueGenerator>>()
+                    .AddSingleton<SqlServerSequenceValueGeneratorFactory>()
+                    .AddSingleton<SqlServerSqlGenerator>()
+                    .AddSingleton<SqlStatementExecutor>()
+                    .AddSingleton<SqlServerTypeMapper>()
+                    .AddSingleton<SqlServerModificationCommandBatchFactory>()
+                    .AddSingleton<SqlServerCommandBatchPreparer>()
+                    .AddSingleton<SqlServerMetadataExtensionProvider>()
+                    .AddSingleton<SqlServerMigrationOperationFactory>()
+                    .AddScoped<SqlServerBatchExecutor>()
+                    .AddScoped<SqlServerDataStoreServices>()
+                    .AddScoped<SqlServerDataStore>()
+                    .AddScoped<SqlServerConnection>()
+                    .AddScoped<SqlServerMigrationOperationProcessor>()
+                    .AddScoped<SqlServerModelDiffer>()
+                    .AddScoped<SqlServerDatabase>()
+                    .AddScoped<SqlServerMigrationOperationSqlGeneratorFactory>()
+                    .AddScoped<SqlServerDataStoreCreator>()
+                    .AddScoped<SqlServerMigrator>());
 
             return builder;
         }

--- a/src/EntityFramework.SqlServer/SqlServerDataStore.cs
+++ b/src/EntityFramework.SqlServer/SqlServerDataStore.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking;
 using Microsoft.Data.Entity.Infrastructure;
@@ -18,6 +19,15 @@ namespace Microsoft.Data.Entity.SqlServer
 {
     public class SqlServerDataStore : RelationalDataStore
     {
+        /// <summary>
+        ///     This constructor is intended only for use when creating test doubles that will override members
+        ///     with mocked or faked behavior. Use of this constructor for other purposes may result in unexpected
+        ///     behavior including but not limited to throwing <see cref="NullReferenceException" />.
+        /// </summary>
+        protected SqlServerDataStore()
+        {
+        }
+
         public SqlServerDataStore(
             [NotNull] StateManager stateManager,
             [NotNull] DbContextService<IModel> model,

--- a/test/EntityFramework.InMemory.Tests/InMemoryEntityServicesBuilderExtensionsTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryEntityServicesBuilderExtensionsTest.cs
@@ -6,6 +6,7 @@ using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Tests;
 using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
 using Xunit;
 
 namespace Microsoft.Data.Entity.InMemory.Tests
@@ -32,6 +33,23 @@ namespace Microsoft.Data.Entity.InMemory.Tests
                 Assert.NotNull(scopedProvider.GetRequiredService<InMemoryDataStore>());
                 Assert.NotNull(scopedProvider.GetRequiredService<DataStoreSource>());
             }
+        }
+
+        [Fact]
+        public void AddInMemoryStore_does_not_replace_services_already_registered()
+        {
+            var services = new ServiceCollection()
+                .AddSingleton<InMemoryDataStore, FakeInMemoryDataStore>();
+
+            services.AddEntityFramework().AddInMemoryStore();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            Assert.IsType<FakeInMemoryDataStore>(serviceProvider.GetRequiredService<InMemoryDataStore>());
+        }
+
+        private class FakeInMemoryDataStore : InMemoryDataStore
+        {
         }
     }
 }

--- a/test/EntityFramework.Migrations.Tests/EntityFramework.Migrations.Tests.csproj
+++ b/test/EntityFramework.Migrations.Tests/EntityFramework.Migrations.Tests.csproj
@@ -88,6 +88,7 @@
     <Compile Include="MigrationOperationFactoryTest.cs" />
     <Compile Include="MigrationOperationSqlGeneratorTest.cs" />
     <Compile Include="MigrationsDatabaseExtensionsTest.cs" />
+    <Compile Include="MigrationsEntityServicesBuilderExtensionsTest.cs" />
     <Compile Include="MigrationTest.cs" />
     <Compile Include="ModelDifferTest.cs" />
     <Compile Include="Builders\ColumnBuilderTest.cs" />

--- a/test/EntityFramework.Migrations.Tests/MigrationsEntityServicesBuilderExtensionsTest.cs
+++ b/test/EntityFramework.Migrations.Tests/MigrationsEntityServicesBuilderExtensionsTest.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Migrations.Infrastructure;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Migrations.Tests
+{
+    public class MigrationsEntityServicesBuilderExtensionsTest
+    {
+        [Fact]
+        public void AddMigrations_does_not_replace_services_already_registered()
+        {
+            var services = new ServiceCollection()
+                .AddSingleton<MigrationAssembly, FakeMigrationAssembly>();
+
+            services.AddEntityFramework().AddMigrations();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            Assert.IsType<FakeMigrationAssembly>(serviceProvider.GetRequiredService<MigrationAssembly>());
+        }
+
+        private class FakeMigrationAssembly : MigrationAssembly
+        {
+        }
+    }
+}

--- a/test/EntityFramework.Redis.Tests/RedisEntityServicesBuilderExtensionsTest.cs
+++ b/test/EntityFramework.Redis.Tests/RedisEntityServicesBuilderExtensionsTest.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Redis.Tests
+{
+    public class RedisEntityServicesBuilderExtensionsTest
+    {
+        [Fact]
+        public void AddRedis_does_not_replace_services_already_registered()
+        {
+            var services = new ServiceCollection()
+                .AddSingleton<RedisDataStore, FakeRedisDataStore>();
+
+            services.AddEntityFramework().AddRedis();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            Assert.IsType<FakeRedisDataStore>(serviceProvider.GetRequiredService<RedisDataStore>());
+        }
+
+        private class FakeRedisDataStore : RedisDataStore
+        {
+        }
+    }
+}

--- a/test/EntityFramework.Relational.Tests/EntityFramework.Relational.Tests.csproj
+++ b/test/EntityFramework.Relational.Tests/EntityFramework.Relational.Tests.csproj
@@ -86,6 +86,7 @@
     <Compile Include="RelationalDatabaseExtensionsTest.cs" />
     <Compile Include="RelationalDatabaseTest.cs" />
     <Compile Include="RelationalDataStoreTest.cs" />
+    <Compile Include="RelationalEntityServicesBuilderExtensionsTest.cs" />
     <Compile Include="RelationalObjectArrayValueReaderFactoryTest.cs" />
     <Compile Include="RelationalObjectArrayValueReaderTest.cs" />
     <Compile Include="RelationalTypedValueReaderFactoryTest.cs" />

--- a/test/EntityFramework.Relational.Tests/RelationalEntityServicesBuilderExtensionsTest.cs
+++ b/test/EntityFramework.Relational.Tests/RelationalEntityServicesBuilderExtensionsTest.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Relational.Update;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Relational.Tests
+{
+    public class RelationalEntityServicesBuilderExtensionsTest
+    {
+        [Fact]
+        public void AddRelational_does_not_replace_services_already_registered()
+        {
+            var services = new ServiceCollection()
+                .AddSingleton<ModificationCommandComparer, FakeModificationCommandComparer>();
+
+            services.AddEntityFramework().AddRelational();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            Assert.IsType<FakeModificationCommandComparer>(serviceProvider.GetRequiredService<ModificationCommandComparer>());
+        }
+
+        private class FakeModificationCommandComparer : ModificationCommandComparer
+        {
+        }
+    }
+}

--- a/test/EntityFramework.SQLite.Tests/SqliteEntityServicesBuilderExtensionsTest.cs
+++ b/test/EntityFramework.SQLite.Tests/SqliteEntityServicesBuilderExtensionsTest.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Sqlite.Tests
+{
+    public class SqliteEntityServicesBuilderExtensionsTest
+    {
+        [Fact]
+        public void AddSqlite_does_not_replace_services_already_registered()
+        {
+            var services = new ServiceCollection()
+                .AddSingleton<SqliteDataStore, FakeSqliteDataStore>();
+
+            services.AddEntityFramework().AddSqlite();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            Assert.IsType<FakeSqliteDataStore>(serviceProvider.GetRequiredService<SqliteDataStore>());
+        }
+
+        private class FakeSqliteDataStore : SqliteDataStore
+        {
+        }
+    }
+}

--- a/test/EntityFramework.SqlServer.Tests/SqlServerEntityServicesBuilderExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerEntityServicesBuilderExtensionsTest.cs
@@ -12,6 +12,7 @@ using Microsoft.Data.Entity.Storage;
 using Microsoft.Data.Entity.Tests;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
 using Xunit;
 
 namespace Microsoft.Data.Entity.SqlServer.Tests
@@ -141,6 +142,23 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             Assert.NotSame(sqlServerMigrator, scopedProvider.GetService<SqlServerMigrator>());
 
             context.Dispose();
+        }
+
+        [Fact]
+        public void AddSqlServer_does_not_replace_services_already_registered()
+        {
+            var services = new ServiceCollection()
+                .AddSingleton<SqlServerDataStore, FakeSqlServerDataStore>();
+
+            services.AddEntityFramework().AddSqlServer();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            Assert.IsType<FakeSqlServerDataStore>(serviceProvider.GetRequiredService<SqlServerDataStore>());
+        }
+
+        private class FakeSqlServerDataStore : SqlServerDataStore
+        {
         }
     }
 }

--- a/test/EntityFramework.Tests/EntityFramework.Tests.csproj
+++ b/test/EntityFramework.Tests/EntityFramework.Tests.csproj
@@ -83,6 +83,7 @@
     <Compile Include="DefaultModelSourceTest.cs" />
     <Compile Include="DbContextOptionsTest.cs" />
     <Compile Include="EntitySetFinderTest.cs" />
+    <Compile Include="Extensions\EntityServiceCollectionExtensionsTest.cs" />
     <Compile Include="Extensions\ServiceProviderExtensionsTest.cs" />
     <Compile Include="Extensions\TaskExtensionsTest.cs" />
     <Compile Include="Identity\ForeignKeyValuePropagatorTest.cs" />

--- a/test/EntityFramework.Tests/Extensions/EntityServiceCollectionExtensionsTest.cs
+++ b/test/EntityFramework.Tests/Extensions/EntityServiceCollectionExtensionsTest.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.Data.Entity.Infrastructure;
+using Microsoft.Framework.DependencyInjection;
+using Microsoft.Framework.DependencyInjection.Fallback;
+using Xunit;
+
+namespace Microsoft.Data.Entity.Tests
+{
+    public class EntityServiceCollectionExtensionsTest
+    {
+        [Fact]
+        public void AddEntityFramework_does_not_replace_services_already_registered()
+        {
+            var services = new ServiceCollection()
+                .AddSingleton<DbSetSource, FakeDbSetSource>();
+
+            services.AddEntityFramework();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            Assert.IsType<FakeDbSetSource>(serviceProvider.GetRequiredService<DbSetSource>());
+        }
+
+        private class FakeDbSetSource : DbSetSource
+        {
+        }
+    }
+}


### PR DESCRIPTION
Issue #956 and also see pull request #1129.

This change updates all of our AddXxx methods to use TryAdd when adding to the service collection such that only services that are not already registered will be registered. This also means that the code we had to check the service collection for "hosting" services is no longer needed.

Note that services for which it is expected that multiple instances can be registered (e.g. listeners and data sources) must not use TryAdd since otherwise only the first registered will be used.
