### PR TITLE
Fix to issue 1220 - Queries with join and count (or other result operators) were broken.

### DIFF
--- a/src/EntityFramework.Relational/Query/RelationalResultOperatorHandler.cs
+++ b/src/EntityFramework.Relational/Query/RelationalResultOperatorHandler.cs
@@ -300,10 +300,14 @@ namespace Microsoft.Data.Entity.Relational.Query
 
         private static Expression TransformClientExpression<TResult>(HandlerContext handlerContext)
         {
-            return new ResultTransformingExpressionTreeVisitor<TResult>(
-                handlerContext.QueryModel.MainFromClause,
-                handlerContext.QueryModelVisitor.QueryCompilationContext)
-                .VisitExpression(handlerContext.QueryModelVisitor.Expression);
+            var querySource = handlerContext.QueryModel.BodyClauses.OfType<IQuerySource>().LastOrDefault() ??
+                              handlerContext.QueryModel.MainFromClause;
+
+            var visitor = new ResultTransformingExpressionTreeVisitor<TResult>(
+                querySource,
+                handlerContext.QueryModelVisitor.QueryCompilationContext);
+
+            return visitor.VisitExpression(handlerContext.QueryModelVisitor.Expression);
         }
     }
 }

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerQueryTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerQueryTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Data.SqlClient;
 using System.Linq;
 using Microsoft.Data.Entity.FunctionalTests;
 using Microsoft.Data.Entity.FunctionalTests.TestModels.Northwind;
@@ -723,6 +724,30 @@ CROSS JOIN [Employees] AS [e3]",
                 Sql);
         }
 
+        public override void SelectMany_Count()
+        {
+            base.SelectMany_Count();
+
+            Assert.Equal(
+                @"SELECT COUNT(*)
+FROM [Customers] AS [c]
+CROSS JOIN [Orders] AS [o]", Sql);
+        }
+
+        public override void SelectMany_OrderBy_ThenBy_Any()
+        {
+            base.SelectMany_OrderBy_ThenBy_Any();
+
+            Assert.Equal(
+                @"SELECT CASE WHEN (
+    EXISTS (
+        SELECT 1
+        FROM [Customers] AS [c]
+        CROSS JOIN [Orders] AS [o]
+    )
+) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END", Sql);
+        }
+
         public override void Join_customers_orders_projection()
         {
             base.Join_customers_orders_projection();
@@ -779,6 +804,39 @@ FROM [Customers] AS [c]
 INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 CROSS JOIN [Employees] AS [e]",
                 Sql);
+        }
+
+        public override void Join_Where_Count()
+        {
+            base.Join_Where_Count();
+
+            Assert.Equal(
+                @"SELECT COUNT(*)
+FROM [Customers] AS [c]
+INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [c].[CustomerID] = @p0", Sql);
+        }
+
+        public override void Join_OrderBy_Count()
+        {
+            //// issue 1251
+            Assert.Throws<SqlException>(() => base.Join_OrderBy_Count());
+        }
+
+        public override void Multiple_joins_Where_Order_Any()
+        {
+            base.Multiple_joins_Where_Order_Any();
+
+            Assert.Equal(
+                @"SELECT CASE WHEN (
+    EXISTS (
+        SELECT 1
+        FROM [Customers] AS [c]
+        INNER JOIN [Orders] AS [or] ON [c].[CustomerID] = [or].[CustomerID]
+        INNER JOIN [Order Details] AS [od] ON [or].[OrderID] = [od].[OrderID]
+        WHERE [c].[City] = @p0
+    )
+) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END", Sql);
         }
 
         public override void GroupBy_Distinct()
@@ -939,6 +997,20 @@ ORDER BY [e].[Title], [e].[EmployeeID]",
                 @"SELECT [c].[City]
 FROM [Customers] AS [c]
 ORDER BY [c].[Country], [c].[CustomerID]",
+                Sql);
+        }
+
+        public override void OrderBy_ThenBy_Any()
+        {
+            base.OrderBy_ThenBy_Any();
+
+            Assert.Equal(
+                @"SELECT CASE WHEN (
+    EXISTS (
+        SELECT 1
+        FROM [Customers] AS [c]
+    )
+) THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT) END",
                 Sql);
         }
 


### PR DESCRIPTION
Problem was in the result operator translation, where we tried prune CreateValueReader and CreateEntity calls - replace it with the reader that we get from the database query. We should remove the first (outermost) occurrence of CreateValueReader/CreateEntity, but instead we were removing the innermost one. Reason for that is that we were matching it based on source scope that was passed to the visitor and we were passing the incorrect one. Fix is to pass the correct query scope (i.e. one that would match the outermost CreateValueReader/CreateEntity node).

@ajcvickers @AndriySvyryd @divega 
