### PR TITLE
Make state change to Deleted always result in Deleted state

### DIFF
--- a/src/EntityFramework.Core/ChangeTracking/StateEntry.cs
+++ b/src/EntityFramework.Core/ChangeTracking/StateEntry.cs
@@ -176,14 +176,6 @@ namespace Microsoft.Data.Entity.ChangeTracking
                 return;
             }
 
-            // An Added entity does not yet exist in the database. If it is then marked as deleted there is
-            // nothing to delete because it was not yet inserted, so just make sure it doesn't get inserted.
-            if (oldState == EntityState.Added
-                && newState == EntityState.Deleted)
-            {
-                newState = EntityState.Unknown;
-            }
-
             if (newState == EntityState.Unchanged)
             {
                 _stateData.FlagAllProperties(EntityType.Properties.Count(), isFlagged: false);

--- a/src/EntityFramework.Core/DbContext.cs
+++ b/src/EntityFramework.Core/DbContext.cs
@@ -303,7 +303,12 @@ namespace Microsoft.Data.Entity
         {
             Check.NotNull(entity, "entity");
 
-            return SetEntityState(entity, EntityState.Deleted);
+            // An Added entity does not yet exist in the database. If it is then marked as deleted there is
+            // nothing to delete because it was not yet inserted, so just make sure it doesn't get inserted.
+            return SetEntityState(
+                entity, Entry(entity).State == EntityState.Added
+                    ? EntityState.Unknown
+                    : EntityState.Deleted);
         }
 
         private EntityEntry<TEntity> SetEntityState<TEntity>(TEntity entity, EntityState entityState)
@@ -354,7 +359,12 @@ namespace Microsoft.Data.Entity
         {
             Check.NotNull(entity, "entity");
 
-            return SetEntityState(entity, EntityState.Deleted);
+            // An Added entity does not yet exist in the database. If it is then marked as deleted there is
+            // nothing to delete because it was not yet inserted, so just make sure it doesn't get inserted.
+            return SetEntityState(
+                entity, Entry(entity).State == EntityState.Added
+                    ? EntityState.Unknown
+                    : EntityState.Deleted);
         }
 
         private EntityEntry SetEntityState(object entity, EntityState entityState)
@@ -416,7 +426,19 @@ namespace Microsoft.Data.Entity
         {
             Check.NotNull(entities, "entities");
 
-            return SetEntityStates(entities, EntityState.Deleted);
+            var entries = GetOrCreateEntries(entities);
+
+            // An Added entity does not yet exist in the database. If it is then marked as deleted there is
+            // nothing to delete because it was not yet inserted, so just make sure it doesn't get inserted.
+            foreach (var entry in entries)
+            {
+                entry.SetState(
+                    entry.State == EntityState.Added
+                        ? EntityState.Unknown
+                        : EntityState.Deleted);
+            }
+
+            return entries;
         }
 
         private List<EntityEntry<TEntity>> SetEntityStates<TEntity>(TEntity[] entities, EntityState entityState)
@@ -488,7 +510,19 @@ namespace Microsoft.Data.Entity
         {
             Check.NotNull(entities, "entities");
 
-            return SetEntityStates(entities, EntityState.Deleted);
+            var entries = GetOrCreateEntries(entities);
+
+            // An Added entity does not yet exist in the database. If it is then marked as deleted there is
+            // nothing to delete because it was not yet inserted, so just make sure it doesn't get inserted.
+            foreach (var entry in entries)
+            {
+                entry.SetState(
+                    entry.State == EntityState.Added
+                        ? EntityState.Unknown
+                        : EntityState.Deleted);
+            }
+
+            return entries;
         }
 
         private List<EntityEntry> SetEntityStates(object[] entities, EntityState entityState)

--- a/test/EntityFramework.Core.Tests/ChangeTracking/EntityEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/EntityEntryTest.cs
@@ -83,6 +83,69 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
         }
 
         [Fact]
+        public void Can_use_entry_to_change_state_to_Added()
+        {
+            ChangeStateOnEntry(EntityState.Unknown, EntityState.Added);
+            ChangeStateOnEntry(EntityState.Unchanged, EntityState.Added);
+            ChangeStateOnEntry(EntityState.Deleted, EntityState.Added);
+            ChangeStateOnEntry(EntityState.Modified, EntityState.Added);
+            ChangeStateOnEntry(EntityState.Added, EntityState.Added);
+        }
+
+        [Fact]
+        public void Can_use_entry_to_change_state_to_Unchanged()
+        {
+            ChangeStateOnEntry(EntityState.Unknown, EntityState.Unchanged);
+            ChangeStateOnEntry(EntityState.Unchanged, EntityState.Unchanged);
+            ChangeStateOnEntry(EntityState.Deleted, EntityState.Unchanged);
+            ChangeStateOnEntry(EntityState.Modified, EntityState.Unchanged);
+            ChangeStateOnEntry(EntityState.Added, EntityState.Unchanged);
+        }
+
+        [Fact]
+        public void Can_use_entry_to_change_state_to_Modified()
+        {
+            ChangeStateOnEntry(EntityState.Unknown, EntityState.Modified);
+            ChangeStateOnEntry(EntityState.Unchanged, EntityState.Modified);
+            ChangeStateOnEntry(EntityState.Deleted, EntityState.Modified);
+            ChangeStateOnEntry(EntityState.Modified, EntityState.Modified);
+            ChangeStateOnEntry(EntityState.Added, EntityState.Modified);
+        }
+
+        [Fact]
+        public void Can_use_entry_to_change_state_to_Deleted()
+        {
+            ChangeStateOnEntry(EntityState.Unknown, EntityState.Deleted);
+            ChangeStateOnEntry(EntityState.Unchanged, EntityState.Deleted);
+            ChangeStateOnEntry(EntityState.Deleted, EntityState.Deleted);
+            ChangeStateOnEntry(EntityState.Modified, EntityState.Deleted);
+            ChangeStateOnEntry(EntityState.Added, EntityState.Deleted);
+        }
+
+        [Fact]
+        public void Can_use_entry_to_change_state_to_Unknown()
+        {
+            ChangeStateOnEntry(EntityState.Unknown, EntityState.Unknown);
+            ChangeStateOnEntry(EntityState.Unchanged, EntityState.Unknown);
+            ChangeStateOnEntry(EntityState.Deleted, EntityState.Unknown);
+            ChangeStateOnEntry(EntityState.Modified, EntityState.Unknown);
+            ChangeStateOnEntry(EntityState.Added, EntityState.Unknown);
+        }
+
+        private void ChangeStateOnEntry(EntityState initialState, EntityState expectedState)
+        {
+            using (var context = new FreezerContext())
+            {
+                var entry = context.Add(new Chunky());
+
+                entry.SetState(initialState);
+                entry.SetState(expectedState);
+
+                Assert.Equal(expectedState, entry.State);
+            }
+        }
+
+        [Fact]
         public void Can_get_property_entry_by_name()
         {
             using (var context = new FreezerContext())

--- a/test/EntityFramework.Core.Tests/ChangeTracking/StateEntryTest.cs
+++ b/test/EntityFramework.Core.Tests/ChangeTracking/StateEntryTest.cs
@@ -54,8 +54,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             Assert.DoesNotContain(entry, contextServices.GetRequiredService<StateManager>().StateEntries);
         }
 
-        [Fact] // GitHub #251
-        public void Changing_state_from_Added_to_Deleted_causes_entity_to_stop_tracking()
+        [Fact] // GitHub #251, #1247
+        public void Changing_state_from_Added_to_Deleted_does_what_you_ask()
         {
             var model = BuildModel();
             var entityType = model.GetEntityType(typeof(SomeEntity).FullName);
@@ -69,8 +69,8 @@ namespace Microsoft.Data.Entity.Tests.ChangeTracking
             entry.SetEntityState(EntityState.Added);
             entry.SetEntityState(EntityState.Deleted);
 
-            Assert.Equal(EntityState.Unknown, entry.EntityState);
-            Assert.DoesNotContain(entry, contextServices.GetRequiredService<StateManager>().StateEntries);
+            Assert.Equal(EntityState.Deleted, entry.EntityState);
+            Assert.Contains(entry, contextServices.GetRequiredService<StateManager>().StateEntries);
         }
 
         [Fact]


### PR DESCRIPTION
Issue #1247. Calling Remove for and Added entity still resulted in the Detached (Unknown) state, but now setting the state to Deleted does result in the Deleted state.

The only place where setting a state may result in a different state is when attempting to set to Unchanged with an FK that is inconsistent. See #1246.
