### PR TITLE
Remove direct coupling with IConfiguration

### DIFF
--- a/src/EntityFramework.Core/Infrastructure/DbContextOptionsParser.cs
+++ b/src/EntityFramework.Core/Infrastructure/DbContextOptionsParser.cs
@@ -37,10 +37,10 @@ namespace Microsoft.Data.Entity.Infrastructure
             var options = currentOptions.ToDictionary(i => i.Key, i => i.Value, StringComparer.OrdinalIgnoreCase);
 
             ReadRawOptions(options, configuration, string.Concat(
-                EntityFrameworkKey, Constants.KeyDelimiter, contextType.Name));
+                EntityFrameworkKey, Constants.KeyDelimiter, contextType.Name), string.Empty);
 
             ReadRawOptions(options, configuration, string.Concat(
-                EntityFrameworkKey, Constants.KeyDelimiter, contextType.FullName));
+                EntityFrameworkKey, Constants.KeyDelimiter, contextType.FullName), string.Empty);
 
             return options;
         }
@@ -48,24 +48,28 @@ namespace Microsoft.Data.Entity.Infrastructure
         private static void ReadRawOptions(
             Dictionary<string, string> options,
             IConfiguration configuration,
-            string contextKey)
+            string contextKey,
+            string keyPrefix)
         {
             foreach (var pair in configuration.GetSubKeys(contextKey))
             {
                 string value;
+                var key = pair.Key;
                 if (!pair.Value.TryGet(null, out value))
                 {
+                    ReadRawOptions(options, configuration,
+                        string.Concat(contextKey, Constants.KeyDelimiter, key),
+                        string.Concat(keyPrefix, key, Constants.KeyDelimiter));
                     continue;
                 }
 
-                var key = pair.Key;
                 if (key.EndsWith(KeySuffix, StringComparison.Ordinal)
                     && configuration.TryGet(value, out value))
                 {
                     key = key.Substring(0, key.Length - KeySuffix.Length);
                 }
 
-                options[key] = value;
+                options[string.Concat(keyPrefix, key)] = value;
             }
         }
     }

--- a/src/EntityFramework.Relational/RelationalOptionsExtension.cs
+++ b/src/EntityFramework.Relational/RelationalOptionsExtension.cs
@@ -51,8 +51,6 @@ namespace Microsoft.Data.Entity.Relational
             {
                 rawOptions.TryGetValue(ConnectionStringKey, out _connectionString);
             }
-
-            // TODO: Read other options.
         }
 
         public static RelationalOptionsExtension Extract([NotNull] IDbContextOptions options)

--- a/src/EntityFramework.Relational/Update/CommandBatchPreparer.cs
+++ b/src/EntityFramework.Relational/Update/CommandBatchPreparer.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.Data.Entity.ChangeTracking;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.Metadata;
 using Microsoft.Data.Entity.Utilities;
@@ -41,7 +42,7 @@ namespace Microsoft.Data.Entity.Relational.Update
             _modificationCommandComparer = modificationCommandComparer;
         }
 
-        public virtual IEnumerable<ModificationCommandBatch> BatchCommands([NotNull] IReadOnlyList<StateEntry> stateEntries)
+        public virtual IEnumerable<ModificationCommandBatch> BatchCommands([NotNull] IReadOnlyList<StateEntry> stateEntries, [NotNull] IDbContextOptions options)
         {
             Check.NotNull(stateEntries, "stateEntries");
 
@@ -53,13 +54,13 @@ namespace Microsoft.Data.Entity.Relational.Update
             {
                 independentCommandSet.Sort(_modificationCommandComparer);
 
-                var batch = _modificationCommandBatchFactory.Create();
+                var batch = _modificationCommandBatchFactory.Create(options);
                 foreach (var modificationCommand in independentCommandSet)
                 {
                     if (!_modificationCommandBatchFactory.AddCommand(batch, modificationCommand))
                     {
                         yield return batch;
-                        batch = _modificationCommandBatchFactory.Create();
+                        batch = _modificationCommandBatchFactory.Create(options);
                         _modificationCommandBatchFactory.AddCommand(batch, modificationCommand);
                     }
                 }

--- a/src/EntityFramework.Relational/Update/ModificationCommandBatchFactory.cs
+++ b/src/EntityFramework.Relational/Update/ModificationCommandBatchFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Utilities;
 
 namespace Microsoft.Data.Entity.Relational.Update
@@ -33,7 +34,7 @@ namespace Microsoft.Data.Entity.Relational.Update
             get { return _sqlGenerator; }
         }
 
-        public abstract ModificationCommandBatch Create();
+        public abstract ModificationCommandBatch Create([NotNull] IDbContextOptions options);
 
         public virtual bool AddCommand(
             [NotNull] ModificationCommandBatch modificationCommandBatch,

--- a/src/EntityFramework.SqlServer/SqlServerDataStore.cs
+++ b/src/EntityFramework.SqlServer/SqlServerDataStore.cs
@@ -38,9 +38,10 @@ namespace Microsoft.Data.Entity.SqlServer
             [NotNull] SqlServerConnection connection,
             [NotNull] SqlServerCommandBatchPreparer batchPreparer,
             [NotNull] SqlServerBatchExecutor batchExecutor,
+            [NotNull] DbContextService<IDbContextOptions> options,
             [NotNull] ILoggerFactory loggerFactory)
             : base(stateManager, model, entityKeyFactorySource, entityMaterializerSource,
-                collectionAccessorSource, propertySetterSource, connection, batchPreparer, batchExecutor, loggerFactory)
+                collectionAccessorSource, propertySetterSource, connection, batchPreparer, batchExecutor, options, loggerFactory)
         {
         }
 

--- a/src/EntityFramework.SqlServer/SqlServerOptionsExtension.cs
+++ b/src/EntityFramework.SqlServer/SqlServerOptionsExtension.cs
@@ -1,6 +1,11 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Relational;
 using Microsoft.Data.Entity.Utilities;
 using Microsoft.Framework.DependencyInjection;
@@ -9,6 +14,42 @@ namespace Microsoft.Data.Entity.SqlServer
 {
     public class SqlServerOptionsExtension : RelationalOptionsExtension
     {
+        private const string ProviderPrefix = "SqlServer";
+        private const string MaxBatchSizeKey = "MaxBatchSize";
+
+        private int? _maxBatchSize;
+
+        public virtual int? MaxBatchSize
+        {
+            get { return _maxBatchSize; }
+
+            [param:CanBeNull]
+            set
+            {
+                _maxBatchSize = value;
+            }
+
+        }
+
+        protected override void Configure(IReadOnlyDictionary<string, string> rawOptions)
+        {
+            base.Configure(rawOptions);
+            if (!_maxBatchSize.HasValue)
+            {
+                var MaxBatchSizeConfigurationKey = ProviderPrefix + ":" + MaxBatchSizeKey;
+                string maxBatchSizeString;
+                if (rawOptions.TryGetValue(MaxBatchSizeConfigurationKey, out maxBatchSizeString))
+                {
+                    int maxBatchSizeInt;
+                    if (!Int32.TryParse(maxBatchSizeString, out maxBatchSizeInt))
+                    {
+                        throw new InvalidOperationException(Strings.IntegerConfigurationValueFormatError(MaxBatchSizeConfigurationKey, maxBatchSizeString));
+                    }
+                    _maxBatchSize = maxBatchSizeInt;
+                }
+            }
+        }
+
         protected override void ApplyServices(EntityServicesBuilder builder)
         {
             Check.NotNull(builder, "builder");

--- a/test/EntityFramework.Core.Tests/DbContextOptionsParserTest.cs
+++ b/test/EntityFramework.Core.Tests/DbContextOptionsParserTest.cs
@@ -196,7 +196,8 @@ namespace Microsoft.Data.Entity.Tests
         }
 
         [Fact]
-        public void Key_searching_is_case_insensitive() {
+        public void Key_searching_is_case_insensitive()
+        {
             var config = new Configuration
                 {
                     new MemoryConfigurationSource
@@ -211,5 +212,208 @@ namespace Microsoft.Data.Entity.Tests
             Assert.Equal("MyConnectionString", rawOptions["ConnectionString"]);
         }
 
+        [Fact]
+        public void Nested_keys_are_read_using_context_name()
+        {
+            var config = new Configuration
+                {
+                    new MemoryConfigurationSource
+                        {
+                            { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "MyConnectionString" },
+                            { "EntityFramework:" + typeof(MyContext).Name + ":SqlServer:MaxBatchSize", "1" },
+                            { "EntityFramework:" + typeof(MyContext).Name + ":SqlServer:AnotherSqlServerOption", "SqlServerOptionValue" },
+                            { "EntityFramework:" + typeof(MyContext).Name + ":SomeProvider:ProviderSpecificOption", "OptionValue" },
+                            { "EntityFramework:" + typeof(MyContext).Name + ":Level1:Level2:Level3", "NestedLevelValue" }
+                        }
+                };
+
+            var rawOptions = new DbContextOptionsParser().ReadRawOptions(config, typeof(MyContext), new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+
+            Assert.Equal(5, rawOptions.Count);
+            Assert.Equal("MyConnectionString", rawOptions["ConnectionString"]);
+            Assert.Equal("1", rawOptions["SqlServer:MaxBatchSize"]);
+            Assert.Equal("SqlServerOptionValue", rawOptions["SqlServer:AnotherSqlServerOption"]);
+            Assert.Equal("OptionValue", rawOptions["SomeProvider:ProviderSpecificOption"]);
+            Assert.Equal("NestedLevelValue", rawOptions["Level1:Level2:Level3"]);
+        }
+
+        [Fact]
+        public void Nested_keys_are_read_using_context_full_name()
+        {
+            var config = new Configuration
+                {
+                    new MemoryConfigurationSource
+                        {
+                            { "EntityFramework:" + typeof(MyContext).FullName + ":ConnectionString", "MyConnectionString" },
+                            { "EntityFramework:" + typeof(MyContext).FullName + ":SqlServer:MaxBatchSize", "1" },
+                            { "EntityFramework:" + typeof(MyContext).FullName + ":SqlServer:AnotherSqlServerOption", "SqlServerOptionValue" },
+                            { "EntityFramework:" + typeof(MyContext).FullName + ":SomeProvider:ProviderSpecificOption", "OptionValue" },
+                            { "EntityFramework:" + typeof(MyContext).FullName + ":Level1:Level2:Level3", "NestedLevelValue" }
+                        }
+                };
+
+            var rawOptions = new DbContextOptionsParser().ReadRawOptions(config, typeof(MyContext), new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+
+            Assert.Equal(5, rawOptions.Count);
+            Assert.Equal("MyConnectionString", rawOptions["ConnectionString"]);
+            Assert.Equal("1", rawOptions["SqlServer:MaxBatchSize"]);
+            Assert.Equal("SqlServerOptionValue", rawOptions["SqlServer:AnotherSqlServerOption"]);
+            Assert.Equal("OptionValue", rawOptions["SomeProvider:ProviderSpecificOption"]);
+            Assert.Equal("NestedLevelValue", rawOptions["Level1:Level2:Level3"]);
+        }
+
+        [Fact]
+        public void Nested_keys_are_read_using_context_name_generic()
+        {
+            var config = new Configuration
+                {
+                    new MemoryConfigurationSource
+                        {
+                            { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "MyConnectionString" },
+                            { "EntityFramework:" + typeof(MyContext).Name + ":SqlServer:MaxBatchSize", "1" },
+                            { "EntityFramework:" + typeof(MyContext).Name + ":SqlServer:AnotherSqlServerOption", "SqlServerOptionValue" },
+                            { "EntityFramework:" + typeof(MyContext).Name + ":SomeProvider:ProviderSpecificOption", "OptionValue" },
+                            { "EntityFramework:" + typeof(MyContext).Name + ":Level1:Level2:Level3", "NestedLevelValue" }
+                        }
+                };
+
+            var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+
+            Assert.Equal(5, rawOptions.Count);
+            Assert.Equal("MyConnectionString", rawOptions["ConnectionString"]);
+            Assert.Equal("1", rawOptions["SqlServer:MaxBatchSize"]);
+            Assert.Equal("SqlServerOptionValue", rawOptions["SqlServer:AnotherSqlServerOption"]);
+            Assert.Equal("OptionValue", rawOptions["SomeProvider:ProviderSpecificOption"]);
+            Assert.Equal("NestedLevelValue", rawOptions["Level1:Level2:Level3"]);
+        }
+
+        [Fact]
+        public void Nested_keys_are_read_using_context_full_name_generic()
+        {
+            var config = new Configuration
+                {
+                    new MemoryConfigurationSource
+                        {
+                            { "EntityFramework:" + typeof(MyContext).FullName + ":ConnectionString", "MyConnectionString" },
+                            { "EntityFramework:" + typeof(MyContext).FullName + ":SqlServer:MaxBatchSize", "1" },
+                            { "EntityFramework:" + typeof(MyContext).FullName + ":SqlServer:AnotherSqlServerOption", "SqlServerOptionValue" },
+                            { "EntityFramework:" + typeof(MyContext).FullName + ":SomeProvider:ProviderSpecificOption", "OptionValue" },
+                            { "EntityFramework:" + typeof(MyContext).FullName + ":Level1:Level2:Level3", "NestedLevelValue" }
+                        }
+                };
+
+            var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+
+            Assert.Equal(5, rawOptions.Count);
+            Assert.Equal("MyConnectionString", rawOptions["ConnectionString"]);
+            Assert.Equal("1", rawOptions["SqlServer:MaxBatchSize"]);
+            Assert.Equal("SqlServerOptionValue", rawOptions["SqlServer:AnotherSqlServerOption"]);
+            Assert.Equal("OptionValue", rawOptions["SomeProvider:ProviderSpecificOption"]);
+            Assert.Equal("NestedLevelValue", rawOptions["Level1:Level2:Level3"]);
+        }
+
+        [Fact]
+        public void Nested_indirect_keys_are_read_using_context_name()
+        {
+            var config = new Configuration
+                {
+                    new MemoryConfigurationSource
+                        {
+                            { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "MyConnectionString" },
+                            { "EntityFramework:" + typeof(MyContext).Name + ":SqlServer:MaxBatchSizeKey", "Data:SqlServer:MaxBatchSize" },
+                            { "EntityFramework:" + typeof(MyContext).Name + ":SqlServer:AnotherSqlServerOption", "SqlServerOptionValue" },
+                            { "EntityFramework:" + typeof(MyContext).Name + ":SomeProvider:ProviderSpecificOption", "OptionValue" },
+                            { "EntityFramework:" + typeof(MyContext).Name + ":Level1:Level2:Level3", "NestedLevelValue" },
+                            { "Data:SqlServer:MaxBatchSize", "1" }
+                        }
+                };
+
+            var rawOptions = new DbContextOptionsParser().ReadRawOptions(config, typeof(MyContext), new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+
+            Assert.Equal(5, rawOptions.Count);
+            Assert.Equal("MyConnectionString", rawOptions["ConnectionString"]);
+            Assert.Equal("1", rawOptions["SqlServer:MaxBatchSize"]);
+            Assert.Equal("SqlServerOptionValue", rawOptions["SqlServer:AnotherSqlServerOption"]);
+            Assert.Equal("OptionValue", rawOptions["SomeProvider:ProviderSpecificOption"]);
+            Assert.Equal("NestedLevelValue", rawOptions["Level1:Level2:Level3"]);
+        }
+
+        [Fact]
+        public void Nested_indirect_keys_are_read_using_context_full_name()
+        {
+            var config = new Configuration
+                {
+                    new MemoryConfigurationSource
+                        {
+                            { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "MyConnectionString" },
+                            { "EntityFramework:" + typeof(MyContext).Name + ":SqlServer:MaxBatchSizeKey", "Data:SqlServer:MaxBatchSize" },
+                            { "EntityFramework:" + typeof(MyContext).Name + ":SqlServer:AnotherSqlServerOption", "SqlServerOptionValue" },
+                            { "EntityFramework:" + typeof(MyContext).Name + ":SomeProvider:ProviderSpecificOption", "OptionValue" },
+                            { "EntityFramework:" + typeof(MyContext).Name + ":Level1:Level2:Level3", "NestedLevelValue" },
+                            { "Data:SqlServer:MaxBatchSize", "1" }
+                        }
+                };
+
+            var rawOptions = new DbContextOptionsParser().ReadRawOptions(config, typeof(MyContext), new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+
+            Assert.Equal(5, rawOptions.Count);
+            Assert.Equal("MyConnectionString", rawOptions["ConnectionString"]);
+            Assert.Equal("1", rawOptions["SqlServer:MaxBatchSize"]);
+            Assert.Equal("SqlServerOptionValue", rawOptions["SqlServer:AnotherSqlServerOption"]);
+            Assert.Equal("OptionValue", rawOptions["SomeProvider:ProviderSpecificOption"]);
+            Assert.Equal("NestedLevelValue", rawOptions["Level1:Level2:Level3"]);
+        }
+
+        [Fact]
+        public void Nested_indirect_keys_are_read_using_context_name_generic()
+        {
+            var config = new Configuration
+                {
+                    new MemoryConfigurationSource
+                        {
+                            { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "MyConnectionString" },
+                            { "EntityFramework:" + typeof(MyContext).Name + ":SqlServer:MaxBatchSizeKey", "Data:SqlServer:MaxBatchSize" },
+                            { "EntityFramework:" + typeof(MyContext).Name + ":SqlServer:AnotherSqlServerOption", "SqlServerOptionValue" },
+                            { "EntityFramework:" + typeof(MyContext).Name + ":SomeProvider:ProviderSpecificOption", "OptionValue" },
+                            { "EntityFramework:" + typeof(MyContext).Name + ":Level1:Level2:Level3", "NestedLevelValue" },
+                            { "Data:SqlServer:MaxBatchSize", "1" }
+                        }
+                };
+
+            var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+
+            Assert.Equal(5, rawOptions.Count);
+            Assert.Equal("MyConnectionString", rawOptions["ConnectionString"]);
+            Assert.Equal("1", rawOptions["SqlServer:MaxBatchSize"]);
+            Assert.Equal("SqlServerOptionValue", rawOptions["SqlServer:AnotherSqlServerOption"]);
+            Assert.Equal("OptionValue", rawOptions["SomeProvider:ProviderSpecificOption"]);
+            Assert.Equal("NestedLevelValue", rawOptions["Level1:Level2:Level3"]);
+        }
+
+        [Fact]
+        public void Nested_indirect_keys_are_read_using_context_full_name_generic()
+        {
+            var config = new Configuration
+                {
+                    new MemoryConfigurationSource
+                        {
+                            { "EntityFramework:" + typeof(MyContext).Name + ":ConnectionString", "MyConnectionString" },
+                            { "EntityFramework:" + typeof(MyContext).Name + ":SqlServer:MaxBatchSizeKey", "Data:SqlServer:MaxBatchSize" },
+                            { "EntityFramework:" + typeof(MyContext).Name + ":SqlServer:AnotherSqlServerOption", "SqlServerOptionValue" },
+                            { "EntityFramework:" + typeof(MyContext).Name + ":SomeProvider:ProviderSpecificOption", "OptionValue" },
+                            { "EntityFramework:" + typeof(MyContext).Name + ":Level1:Level2:Level3", "NestedLevelValue" },
+                            { "Data:SqlServer:MaxBatchSize", "1" }
+                        }
+                };
+
+            var rawOptions = new DbContextOptionsParser().ReadRawOptions<MyContext>(config, new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+
+            Assert.Equal(5, rawOptions.Count);
+            Assert.Equal("MyConnectionString", rawOptions["ConnectionString"]);
+            Assert.Equal("1", rawOptions["SqlServer:MaxBatchSize"]);
+            Assert.Equal("SqlServerOptionValue", rawOptions["SqlServer:AnotherSqlServerOption"]);
+            Assert.Equal("OptionValue", rawOptions["SomeProvider:ProviderSpecificOption"]);
+            Assert.Equal("NestedLevelValue", rawOptions["Level1:Level2:Level3"]);
+        }
     }
 }

--- a/test/EntityFramework.Microbenchmarks/CudPerf/CudTests.cs
+++ b/test/EntityFramework.Microbenchmarks/CudPerf/CudTests.cs
@@ -24,15 +24,13 @@ namespace EntityFramework.Microbenchmarks.CudPerf
         public static IServiceProvider CreateServiceProvider(Configuration configuration)
         {
             var services = new ServiceCollection();
-            services.AddEntityFramework().AddSqlServer();
-            services.AddInstance<IConfiguration>(configuration);
+            services.AddEntityFramework(configuration).AddDbContext<CudContext>().AddSqlServer();
             return services.BuildServiceProvider();
         }
 
         public static CudContext CreateContext(string connectionString)
         {
-            var options = new DbContextOptions();
-            return new CudContext(connectionString, _serviceProvider, options);
+            return new CudContext(connectionString, _serviceProvider);
         }
 
         public void Setup()

--- a/test/EntityFramework.Microbenchmarks/CudPerf/Model/CudContext.cs
+++ b/test/EntityFramework.Microbenchmarks/CudPerf/Model/CudContext.cs
@@ -12,8 +12,8 @@ namespace EntityFramework.Microbenchmarks.CudPerf.Model
     {
         private readonly string _connectionString;
 
-        public CudContext(string connectionString, IServiceProvider serviceProvider, DbContextOptions options)
-            : base(serviceProvider, options)
+        public CudContext(string connectionString, IServiceProvider serviceProvider)
+            : base(serviceProvider)
         {
             _connectionString = connectionString;
         }

--- a/test/EntityFramework.Microbenchmarks/LocalConfig.json
+++ b/test/EntityFramework.Microbenchmarks/LocalConfig.json
@@ -1,6 +1,6 @@
 ﻿{
     "Data": {
-        "DefaultDataSource": { 
+        "DefaultDataSource": {
             "DataSource": "(localdb)\\MSSQLLocalDB"
         },
         "DefaultConnection": {
@@ -9,9 +9,13 @@
         "TcpIpConnection": {
             "Connectionstring": "Data Source={0};Integrated Security=True;MultipleActiveResultSets=true;Network Library=dbmssocn;"
         },
-        "SqlServer": {
-            "MaxBatchSize": "1"
-        },
         "RunPerfTests": "false"
+    },
+    "EntityFramework": {
+        "CudContext": {
+            "SqlServer": {
+                "MaxBatchSize": "1"
+            }
+        }
     }
 }

--- a/test/EntityFramework.Migrations.Tests/TestHelperExtensions.cs
+++ b/test/EntityFramework.Migrations.Tests/TestHelperExtensions.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Data.Entity.Tests
     }
 
     public class FakeMigrationOperationProcessor : MigrationOperationProcessor
-    {     
+    {
     }
 
     public class FakeModelDiffer : ModelDiffer
@@ -509,9 +509,10 @@ namespace Microsoft.Data.Entity.Tests
             FakeRelationalConnection connection,
             FakeCommandBatchPreparer batchPreparer,
             BatchExecutor batchExecutor,
+            DbContextService<IDbContextOptions> options,
             ILoggerFactory loggerFactory)
             : base(stateManager, model, entityKeyFactorySource, entityMaterializerSource,
-                collectionAccessorSource, propertySetterSource, connection, batchPreparer, batchExecutor, loggerFactory)
+                collectionAccessorSource, propertySetterSource, connection, batchPreparer, batchExecutor, options, loggerFactory)
         {
         }
     }

--- a/test/EntityFramework.Relational.Tests/RelationalDataStoreTest.cs
+++ b/test/EntityFramework.Relational.Tests/RelationalDataStoreTest.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
 
             await relationalDataStore.SaveChangesAsync(stateEntries, cancellationToken);
 
-            commandBatchPreparerMock.Verify(c => c.BatchCommands(stateEntries));
+            commandBatchPreparerMock.Verify(c => c.BatchCommands(stateEntries, relationalDataStore.DbContextOptions));
             batchExecutorMock.Verify(be => be.ExecuteAsync(It.IsAny<IEnumerable<ModificationCommandBatch>>(), relationalConnectionMock.Object, cancellationToken));
         }
 
@@ -65,7 +65,7 @@ namespace Microsoft.Data.Entity.Relational.Tests
 
             relationalDataStore.SaveChanges(stateEntries);
 
-            commandBatchPreparerMock.Verify(c => c.BatchCommands(stateEntries));
+            commandBatchPreparerMock.Verify(c => c.BatchCommands(stateEntries, relationalDataStore.DbContextOptions));
             batchExecutorMock.Verify(be => be.Execute(It.IsAny<IEnumerable<ModificationCommandBatch>>(), relationalConnectionMock.Object));
         }
 
@@ -81,9 +81,10 @@ namespace Microsoft.Data.Entity.Relational.Tests
                 RelationalConnection connection,
                 CommandBatchPreparer batchPreparer,
                 BatchExecutor batchExecutor,
+                DbContextService<IDbContextOptions> options,
                 ILoggerFactory loggerFactory)
                 : base(stateManager, model, entityKeyFactorySource, entityMaterializerSource,
-                    collectionAccessorSource, propertySetterSource, connection, batchPreparer, batchExecutor, loggerFactory)
+                    collectionAccessorSource, propertySetterSource, connection, batchPreparer, batchExecutor, options, loggerFactory)
             {
             }
         }

--- a/test/EntityFramework.Relational.Tests/Update/ModificationCommandBatchFactoryTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ModificationCommandBatchFactoryTest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using JetBrains.Annotations;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Data.Entity.Metadata;
 using Microsoft.Data.Entity.Relational.Metadata;
 using Microsoft.Data.Entity.Relational.Update;
@@ -16,9 +18,10 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
         {
             var factory = new TestModificationCommandBatchFactory(
                 new Mock<SqlGenerator>().Object);
+            var options = new Mock<IDbContextOptions>().Object;
 
-            var firstBatch = factory.Create();
-            var secondBatch = factory.Create();
+            var firstBatch = factory.Create(options);
+            var secondBatch = factory.Create(options);
 
             Assert.NotNull(firstBatch);
             Assert.NotNull(secondBatch);
@@ -46,7 +49,7 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             {
             }
 
-            public override ModificationCommandBatch Create()
+            public override ModificationCommandBatch Create([NotNull] IDbContextOptions options)
             {
                 return new TestModificationCommandBatch(SqlGenerator);
             }

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -102,9 +102,10 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 SqlServerConnection connection,
                 SqlServerCommandBatchPreparer batchPreparer,
                 SqlServerBatchExecutor batchExecutor,
+                DbContextService<IDbContextOptions> options,
                 ILoggerFactory loggerFactory)
                 : base(stateManager, model, entityKeyFactorySource, entityMaterializerSource,
-                    collectionAccessorSource, propertySetterSource, connection, batchPreparer, batchExecutor, loggerFactory)
+                    collectionAccessorSource, propertySetterSource, connection, batchPreparer, batchExecutor, options, loggerFactory)
             {
             }
 

--- a/test/EntityFramework.SqlServer.Tests/SqlServerOptionsExtensionTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerOptionsExtensionTest.cs
@@ -1,9 +1,12 @@
 // Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using System.Data.Common;
 using System.Linq;
 using System.Reflection;
+using Microsoft.Data.Entity.Infrastructure;
 using Microsoft.Framework.DependencyInjection;
 using Moq;
 using Xunit;
@@ -33,13 +36,50 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
             Assert.Null(configuration.Connection);
             Assert.Null(configuration.ConnectionString);
+            Assert.Null(configuration.MaxBatchSize);
 
             var connection = Mock.Of<DbConnection>();
             configuration.Connection = connection;
             configuration.ConnectionString = "Fraggle=Rock";
+            configuration.MaxBatchSize = 1;
 
             Assert.Same(connection, configuration.Connection);
             Assert.Equal("Fraggle=Rock", configuration.ConnectionString);
+            Assert.Equal(1, configuration.MaxBatchSize);
+        }
+
+        [Fact]
+        public void Configures_max_batch_size_specified_in_dbContext_options()
+        {
+            IDbContextOptions options = new DbContextOptions();
+            options.RawOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { "SqlServer:MaxBatchSize", "1" } };
+            options.AddExtension(new SqlServerOptionsExtension());
+
+            var optionsExtension = options.Extensions.OfType<SqlServerOptionsExtension>().First();
+
+            Assert.Equal(1, optionsExtension.MaxBatchSize);
+        }
+
+        [Fact]
+        public void MaxBatchSize_in_sqlServerOptionsExtension_is_optional()
+        {
+            IDbContextOptions options = new DbContextOptions();
+            options.RawOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            options.AddExtension(new SqlServerOptionsExtension());
+
+            var optionsExtension = options.Extensions.OfType<SqlServerOptionsExtension>().First();
+
+            Assert.Null(optionsExtension.MaxBatchSize);
+        }
+
+        [Fact]
+        public void Throws_on_invalid_MaxBatchSize_specified_in_dbContextOptions()
+        {
+            IDbContextOptions options = new DbContextOptions();
+            options.RawOptions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase) { { "SqlServer:MaxBatchSize", "one" } };
+
+            Assert.Equal(Strings.IntegerConfigurationValueFormatError("SqlServer:MaxBatchSize", "one"),
+                Assert.Throws<InvalidOperationException>(() => options.AddExtension(new SqlServerOptionsExtension())).Message);
         }
     }
 }


### PR DESCRIPTION
Read all options in IConfiguration stored under key "EntityFramework:ContextName" in DbContextOptions.
Get ConnectionString & SqlServer:MaxBatchSize from DbContextOptions removing coupling with IConfiguration.
