### PR TITLE
Changed return type of UseSqlServer and UseInMemoryStore extensions to void

### DIFF
--- a/src/EntityFramework.InMemory/Extensions/InMemoryDbContextOptionsExtensions.cs
+++ b/src/EntityFramework.InMemory/Extensions/InMemoryDbContextOptionsExtensions.cs
@@ -12,19 +12,17 @@ namespace Microsoft.Data.Entity
 {
     public static class InMemoryDbContextOptionsExtensions
     {
-        public static DbContextOptions UseInMemoryStore([NotNull] this DbContextOptions options, bool persist = true)
+        public static void UseInMemoryStore([NotNull] this DbContextOptions options, bool persist = true)
         {
             Check.NotNull(options, "options");
 
             ((IDbContextOptions)options)
                 .AddOrUpdateExtension<InMemoryOptionsExtension>(x => x.Persist = persist);
-
-            return options;
         }
 
-        public static DbContextOptions<T> UseInMemoryStore<T>([NotNull] this DbContextOptions<T> options, bool persist = true)
+        public static void UseInMemoryStore<T>([NotNull] this DbContextOptions<T> options, bool persist = true)
         {
-            return (DbContextOptions<T>)UseInMemoryStore((DbContextOptions)options, persist);
+            UseInMemoryStore((DbContextOptions)options, persist);
         }
     }
 }

--- a/src/EntityFramework.SqlServer/Extensions/SqlServerDbContextOptionsExtensions.cs
+++ b/src/EntityFramework.SqlServer/Extensions/SqlServerDbContextOptionsExtensions.cs
@@ -13,48 +13,42 @@ namespace Microsoft.Data.Entity
 {
     public static class SqlServerDbContextOptionsExtensions
     {
-        public static DbContextOptions UseSqlServer([NotNull] this DbContextOptions options)
+        public static void UseSqlServer([NotNull] this DbContextOptions options)
         {
             Check.NotNull(options, "options");
 
             ((IDbContextOptions)options)
                 .AddOrUpdateExtension<SqlServerOptionsExtension>(x => { });
-
-            return options;
         }
 
-        public static DbContextOptions UseSqlServer([NotNull] this DbContextOptions options, [NotNull] string connectionString)
+        public static void UseSqlServer([NotNull] this DbContextOptions options, [NotNull] string connectionString)
         {
             Check.NotNull(options, "options");
             Check.NotEmpty(connectionString, "connectionString");
 
             ((IDbContextOptions)options)
                 .AddOrUpdateExtension<SqlServerOptionsExtension>(x => x.ConnectionString = connectionString);
-
-            return options;
         }
 
-        public static DbContextOptions<T> UseSqlServer<T>([NotNull] this DbContextOptions<T> options, [NotNull] string connectionString)
+        public static void UseSqlServer<T>([NotNull] this DbContextOptions<T> options, [NotNull] string connectionString)
         {
-            return (DbContextOptions<T>)UseSqlServer((DbContextOptions)options, connectionString);
+            UseSqlServer((DbContextOptions)options, connectionString);
         }
 
         // Note: Decision made to use DbConnection not SqlConnection: Issue #772
-        public static DbContextOptions UseSqlServer([NotNull] this DbContextOptions options, [NotNull] DbConnection connection)
+        public static void UseSqlServer([NotNull] this DbContextOptions options, [NotNull] DbConnection connection)
         {
             Check.NotNull(options, "options");
             Check.NotNull(connection, "connection");
 
             ((IDbContextOptions)options)
                 .AddOrUpdateExtension<SqlServerOptionsExtension>(x => x.Connection = connection);
-
-            return options;
         }
 
         // Note: Decision made to use DbConnection not SqlConnection: Issue #772
-        public static DbContextOptions<T> UseSqlServer<T>([NotNull] this DbContextOptions<T> options, [NotNull] DbConnection connection)
+        public static void UseSqlServer<T>([NotNull] this DbContextOptions<T> options, [NotNull] DbConnection connection)
         {
-            return (DbContextOptions<T>)UseSqlServer((DbContextOptions)options, connection);
+            UseSqlServer((DbContextOptions)options, connection);
         }
     }
 }

--- a/test/EntityFramework.Core.FunctionalTests/Metadata/CompiledModelTest.cs
+++ b/test/EntityFramework.Core.FunctionalTests/Metadata/CompiledModelTest.cs
@@ -140,8 +140,8 @@ namespace Microsoft.Data.Entity.FunctionalTests.Metadata
         private static void FixupTest(IModel model)
         {
             var options = new DbContextOptions()
-                .UseModel(model)
-                .UseInMemoryStore(persist: false);
+                .UseModel(model);
+            options.UseInMemoryStore(persist: false);
 
             using (var context = new DbContext(options))
             {
@@ -192,8 +192,8 @@ namespace Microsoft.Data.Entity.FunctionalTests.Metadata
         public void Navigation_fixup_happens_with_compiled_metadata_using_non_standard_collection_access()
         {
             var options = new DbContextOptions()
-                .UseModel(new _OneTwoThreeContextModel())
-                .UseInMemoryStore();
+                .UseModel(new _OneTwoThreeContextModel());
+            options.UseInMemoryStore();
 
             using (var context = new DbContext(options))
             {

--- a/test/EntityFramework.CrossStore.FunctionalTests/InMemoryCrossStoreFixture.cs
+++ b/test/EntityFramework.CrossStore.FunctionalTests/InMemoryCrossStoreFixture.cs
@@ -30,8 +30,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
         public override CrossStoreContext CreateContext(InMemoryTestStore testStore)
         {
-            var options = new DbContextOptions()
-                .UseInMemoryStore();
+            var options = new DbContextOptions();
+            options.UseInMemoryStore();
 
             return new CrossStoreContext(_serviceProvider, options);
         }

--- a/test/EntityFramework.CrossStore.FunctionalTests/SqlServerCrossStoreFixture.cs
+++ b/test/EntityFramework.CrossStore.FunctionalTests/SqlServerCrossStoreFixture.cs
@@ -30,8 +30,8 @@ namespace Microsoft.Data.Entity.FunctionalTests
 
         public override CrossStoreContext CreateContext(SqlServerTestStore testStore)
         {
-            var options = new DbContextOptions()
-                .UseSqlServer(testStore.Connection);
+            var options = new DbContextOptions();
+            options.UseSqlServer(testStore.Connection);
 
             var context = new CrossStoreContext(_serviceProvider, options);
             context.Database.EnsureCreated();

--- a/test/EntityFramework.InMemory.FunctionalTests/EntityTypeTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/EntityTypeTest.cs
@@ -35,15 +35,15 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             entityType.GetOrSetPrimaryKey(idProperty);
 
             var options = new DbContextOptions()
-                .UseModel(model)
-                .UseInMemoryStore();
+                .UseModel(model);
+            options.UseInMemoryStore();
 
             T entity;
             using (var context = new DbContext(_fixture.ServiceProvider, options))
             {
                 var stateEntry = context.ChangeTracker.StateManager.CreateNewEntry(entityType);
                 entity = (T)stateEntry.Entity;
-                
+
                 stateEntry[idProperty] = 42;
                 stateEntry[nameProperty] = "The";
 

--- a/test/EntityFramework.InMemory.FunctionalTests/InMemoryBuiltInDataTypesFixture.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/InMemoryBuiltInDataTypesFixture.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 
         public override DbContext CreateContext(InMemoryTestStore testStore)
         {
-            var options = new DbContextOptions()
-                .UseInMemoryStore();
+            var options = new DbContextOptions();
+            options.UseInMemoryStore();
 
             return new DbContext(_serviceProvider, options);
         }

--- a/test/EntityFramework.InMemory.FunctionalTests/InMemoryConfigPatternsTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/InMemoryConfigPatternsTest.cs
@@ -49,7 +49,8 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
         [Fact]
         public void Can_save_and_query_with_implicit_services_and_explicit_config()
         {
-            var options = new DbContextOptions().UseInMemoryStore();
+            var options = new DbContextOptions();
+            options.UseInMemoryStore();
 
             using (var context = new ImplicitServicesExplicitConfigBlogContext(options))
             {
@@ -130,7 +131,8 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             services.AddEntityFramework().AddInMemoryStore();
             var serviceProvider = services.BuildServiceProvider();
 
-            var options = new DbContextOptions().UseInMemoryStore();
+            var options = new DbContextOptions();
+            options.UseInMemoryStore();
 
             using (var context = new ExplicitServicesAndConfigBlogContext(serviceProvider, options))
             {
@@ -304,7 +306,8 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
         [Fact]
         public void Can_register_context_and_configuration_with_DI_container_and_have_both_injected()
         {
-            var options = new DbContextOptions().UseInMemoryStore();
+            var options = new DbContextOptions();
+            options.UseInMemoryStore();
 
             var services = new ServiceCollection();
             services.AddTransient<InjectContextAndConfigurationBlogContext>()
@@ -359,7 +362,8 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
         [Fact]
         public void Can_register_configuration_with_DI_container_and_have_it_injected()
         {
-            var options = new DbContextOptions().UseInMemoryStore(persist: false);
+            var options = new DbContextOptions();
+            options.UseInMemoryStore(persist: false);
 
             var services = new ServiceCollection();
             services.AddTransient<InjectConfigurationBlogContext>()
@@ -410,8 +414,11 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
         [Fact]
         public void Can_inject_different_configurations_into_different_contexts()
         {
-            var blogOptions = new DbContextOptions<InjectDifferentConfigurationsBlogContext>().UseInMemoryStore();
-            var accountOptions = new DbContextOptions<InjectDifferentConfigurationsAccountContext>().UseInMemoryStore();
+            var blogOptions = new DbContextOptions<InjectDifferentConfigurationsBlogContext>();
+            blogOptions.UseInMemoryStore();
+
+            var accountOptions = new DbContextOptions<InjectDifferentConfigurationsAccountContext>();
+            accountOptions.UseInMemoryStore();
 
             var services = new ServiceCollection();
             services.AddTransient<InjectDifferentConfigurationsBlogContext>()
@@ -508,8 +515,11 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
         [Fact]
         public void Can_inject_different_configurations_into_different_contexts_without_declaring_in_constructor()
         {
-            var blogOptions = new DbContextOptions<InjectDifferentConfigurationsNoConstructorBlogContext>().UseInMemoryStore();
-            var accountOptions = new DbContextOptions<InjectDifferentConfigurationsNoConstructorAccountContext>().UseInMemoryStore();
+            var blogOptions = new DbContextOptions<InjectDifferentConfigurationsNoConstructorBlogContext>();
+            blogOptions.UseInMemoryStore();
+
+            var accountOptions = new DbContextOptions<InjectDifferentConfigurationsNoConstructorAccountContext>();
+            accountOptions.UseInMemoryStore();
 
             var services = new ServiceCollection();
             services.AddTransient<InjectDifferentConfigurationsNoConstructorBlogContext>()

--- a/test/EntityFramework.InMemory.FunctionalTests/InMemoryDataStoreTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/InMemoryDataStoreTest.cs
@@ -25,8 +25,8 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
                 .BuildServiceProvider();
 
             var options = new DbContextOptions()
-                .UseModel(model)
-                .UseInMemoryStore(persist: true);
+                .UseModel(model);
+            options.UseInMemoryStore(persist: true);
 
             var customer = new Customer { Id = 42, Name = "Theon" };
 

--- a/test/EntityFramework.InMemory.FunctionalTests/InMemoryMonsterFixupTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/InMemoryMonsterFixupTest.cs
@@ -27,7 +27,10 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 
         protected override DbContextOptions CreateOptions(string databaseName)
         {
-            return new DbContextOptions().UseInMemoryStore();
+            var options = new DbContextOptions();
+            options.UseInMemoryStore();
+
+            return options;
         }
 
         protected override Task CreateAndSeedDatabase(string databaseName, Func<MonsterContext> createContext)

--- a/test/EntityFramework.InMemory.FunctionalTests/InMemoryNorthwindQueryFixture.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/InMemoryNorthwindQueryFixture.cs
@@ -24,9 +24,8 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
                     .AddTestModelSource(OnModelCreating)
                     .BuildServiceProvider();
 
-            _options
-                = new DbContextOptions()
-                    .UseInMemoryStore();
+            _options = new DbContextOptions();
+            _options.UseInMemoryStore();
 
             using (var context = CreateContext())
             {

--- a/test/EntityFramework.InMemory.FunctionalTests/MusicStoreQueryTests.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/MusicStoreQueryTests.cs
@@ -23,9 +23,8 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
                     .ServiceCollection
                     .BuildServiceProvider();
 
-            var options
-                = new DbContextOptions()
-                    .UseInMemoryStore(persist: true);
+            var options = new DbContextOptions();
+            options.UseInMemoryStore(persist: true);
 
             using (var db = new MusicStoreContext(serviceProvider, options))
             {

--- a/test/EntityFramework.InMemory.FunctionalTests/OneToOneQueryFixture.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/OneToOneQueryFixture.cs
@@ -24,10 +24,9 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
 
             var model = CreateModel();
 
-            _options
-                = new DbContextOptions()
-                    .UseModel(model)
-                    .UseInMemoryStore();
+            _options = new DbContextOptions()
+                .UseModel(model);
+            _options.UseInMemoryStore();
 
             using (var context = new DbContext(_serviceProvider, _options))
             {

--- a/test/EntityFramework.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
+++ b/test/EntityFramework.InMemory.FunctionalTests/ShadowStateUpdateTest.cs
@@ -23,8 +23,8 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             customerType.GetOrAddProperty("Name", typeof(string), shadowProperty: true);
 
             var options = new DbContextOptions()
-                .UseModel(model)
-                .UseInMemoryStore();
+                .UseModel(model);
+            options.UseInMemoryStore();
 
             using (var context = new DbContext(_fixture.ServiceProvider, options))
             {
@@ -85,8 +85,8 @@ namespace Microsoft.Data.Entity.InMemory.FunctionalTests
             customerType.GetOrAddProperty("Name", typeof(string), shadowProperty: true);
 
             var options = new DbContextOptions()
-                .UseModel(model)
-                .UseInMemoryStore();
+                .UseModel(model);
+            options.UseInMemoryStore();
 
             var customer = new Customer { Id = 42 };
 

--- a/test/EntityFramework.InMemory.Tests/InMemoryDataStoreCreatorTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryDataStoreCreatorTest.cs
@@ -83,7 +83,8 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 
         private static InMemoryDataStore CreateStore(IServiceProvider serviceProvider, bool persist)
         {
-            var options = new DbContextOptions().UseInMemoryStore(persist: persist);
+            var options = new DbContextOptions();
+            options.UseInMemoryStore(persist: persist);
 
             return TestHelpers.CreateContextServices(serviceProvider, options).GetRequiredService<InMemoryDataStore>();
         }

--- a/test/EntityFramework.InMemory.Tests/InMemoryDataStoreTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryDataStoreTest.cs
@@ -83,7 +83,8 @@ namespace Microsoft.Data.Entity.InMemory.Tests
 
         private static InMemoryDataStore CreateStore(IServiceProvider serviceProvider, bool persist)
         {
-            var options = new DbContextOptions().UseInMemoryStore(persist: persist);
+            var options = new DbContextOptions();
+            options.UseInMemoryStore(persist: persist);
 
             return TestHelpers.CreateContextServices(serviceProvider, options).GetRequiredService<InMemoryDataStore>();
         }

--- a/test/EntityFramework.InMemory.Tests/InMemoryDbContextOptionsExtensionsTest.cs
+++ b/test/EntityFramework.InMemory.Tests/InMemoryDbContextOptionsExtensionsTest.cs
@@ -13,8 +13,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         public void Can_add_extension_with_connection_string()
         {
             var options = new DbContextOptions();
-
-            options = options.UseInMemoryStore(persist: false);
+            options.UseInMemoryStore(persist: false);
 
             var extension = ((IDbContextOptions)options).Extensions.OfType<InMemoryOptionsExtension>().Single();
 
@@ -25,8 +24,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         public void Can_add_extension_with_connection_string_using_generic_options()
         {
             var options = new DbContextOptions<DbContext>();
-
-            options = options.UseInMemoryStore(persist: false);
+            options.UseInMemoryStore(persist: false);
 
             var extension = ((IDbContextOptions)options).Extensions.OfType<InMemoryOptionsExtension>().Single();
 
@@ -37,8 +35,7 @@ namespace Microsoft.Data.Entity.InMemory.Tests
         public void Can_add_extension_using_persist_true()
         {
             var options = new DbContextOptions();
-
-            options = options.UseInMemoryStore(persist: true);
+            options.UseInMemoryStore(persist: true);
 
             var extension = ((IDbContextOptions)options).Extensions.OfType<InMemoryOptionsExtension>().Single();
 

--- a/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -234,10 +234,11 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
 
         private static IServiceProvider CreateContextServices(IModel model)
         {
-            return ((IDbContextServices)new DbContext(
-                new DbContextOptions()
-                    .UseModel(model)
-                    .UseInMemoryStore(persist: false))).ScopedServiceProvider;
+            var options = new DbContextOptions()
+                .UseModel(model);
+            options.UseInMemoryStore(persist: false);
+
+            return ((IDbContextServices)new DbContext(options)).ScopedServiceProvider;
         }
 
         private static CommandBatchPreparer CreateCommandBatchPreparer(ModificationCommandBatchFactory modificationCommandBatchFactory = null)

--- a/test/EntityFramework.Relational.Tests/Update/ModificationCommandComparerTest.cs
+++ b/test/EntityFramework.Relational.Tests/Update/ModificationCommandComparerTest.cs
@@ -17,10 +17,11 @@ namespace Microsoft.Data.Entity.Relational.Tests.Update
             var model = new Entity.Metadata.Model();
             var entityType = model.AddEntityType(typeof(object));
 
-            var contextServices = ((IDbContextServices)new DbContext(
-                new DbContextOptions()
-                .UseModel(model)
-                .UseInMemoryStore(persist: false))).ScopedServiceProvider;
+            var options = new DbContextOptions()
+                .UseModel(model);
+            options.UseInMemoryStore(persist: false);
+
+            var contextServices = ((IDbContextServices)new DbContext(options)).ScopedServiceProvider;
             var stateManager = contextServices.GetRequiredService<StateManager>();
 
             var key = entityType.GetOrAddProperty("Id", typeof(int), shadowProperty: true);

--- a/test/EntityFramework.SqlServer.FunctionalTests/BatchingTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/BatchingTest.cs
@@ -18,10 +18,9 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             var modelBuilder = new ModelBuilder(new Model());
             modelBuilder.Entity<Blog>().Property(b => b.Id).GenerateValueOnAdd(generateValue: false);
 
-            var options
-                = new DbContextOptions()
-                    .UseModel(modelBuilder.Model)
-                    .UseSqlServer(_testStore.Connection);
+            var options = new DbContextOptions()
+                .UseModel(modelBuilder.Model);
+            options.UseSqlServer(_testStore.Connection);
 
             using (var context = new DbContext(_serviceProvider, options))
             {

--- a/test/EntityFramework.SqlServer.FunctionalTests/MappingQueryFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/MappingQueryFixture.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             _testDatabase = SqlServerNorthwindContext.GetSharedStoreAsync().Result;
 
             _options = new DbContextOptions()
-                .UseModel(CreateModel())
-                .UseSqlServer(_testDatabase.Connection.ConnectionString);
+                .UseModel(CreateModel());
+            _options.UseSqlServer(_testDatabase.Connection.ConnectionString);
         }
 
         public DbContext CreateContext()

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerBuiltInDataTypesFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerBuiltInDataTypesFixture.cs
@@ -30,8 +30,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
         public override DbContext CreateContext(SqlServerTestStore testStore)
         {
-            var options = new DbContextOptions()
-                .UseSqlServer(testStore.Connection);
+            var options = new DbContextOptions();
+            options.UseSqlServer(testStore.Connection);
 
             var context = new DbContext(_serviceProvider, options);
             context.Database.EnsureCreated();

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerConfigPatternsTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerConfigPatternsTest.cs
@@ -53,7 +53,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             {
                 using (await SqlServerNorthwindContext.GetSharedStoreAsync())
                 {
-                    var options = new DbContextOptions().UseSqlServer(SqlServerNorthwindContext.ConnectionString);
+                    var options = new DbContextOptions();
+                    options.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
 
                     using (var context = new NorthwindContext(options))
                     {
@@ -134,7 +135,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                     var serviceProvider = serviceCollection.BuildServiceProvider();
 
-                    var options = new DbContextOptions().UseSqlServer(SqlServerNorthwindContext.ConnectionString);
+                    var options = new DbContextOptions();
+                    options.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
 
                     using (var context = new NorthwindContext(serviceProvider, options))
                     {
@@ -342,7 +344,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             [Fact]
             public async Task Can_register_context_and_configuration_with_DI_container_and_have_both_injected()
             {
-                var options = new DbContextOptions().UseSqlServer(SqlServerNorthwindContext.ConnectionString);
+                var options = new DbContextOptions();
+                options.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
 
                 var serviceCollection = new ServiceCollection();
                 serviceCollection
@@ -404,7 +407,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
             [Fact]
             public async Task Can_register_configuration_with_DI_container_and_have_it_injected()
             {
-                var options = new DbContextOptions().UseSqlServer(SqlServerNorthwindContext.ConnectionString);
+                var options = new DbContextOptions();
+                options.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
 
                 var serviceCollection = new ServiceCollection();
                 serviceCollection
@@ -460,11 +464,14 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         public class ConstructorArgsToBuilder
         {
             [Fact]
-            public async Task Can_pass_connection_string_to_constructor_and_use_in_builder()
+            public async Task Can_pass_context_options_to_constructor_and_use_in_builder()
             {
                 using (await SqlServerNorthwindContext.GetSharedStoreAsync())
                 {
-                    using (var context = new NorthwindContext(SqlServerNorthwindContext.ConnectionString))
+                    var options = new DbContextOptions();
+                    options.UseSqlServer(SqlServerNorthwindContext.ConnectionString);
+
+                    using (var context = new NorthwindContext(options))
                     {
                         Assert.Equal(91, await context.Customers.CountAsync());
                     }
@@ -473,8 +480,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             private class NorthwindContext : DbContext
             {
-                public NorthwindContext(string connectionString)
-                    : base(new DbContextOptions().UseSqlServer(connectionString))
+                public NorthwindContext(DbContextOptions options)
+                    : base(options)
                 {
                 }
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerDataStoreCreatorTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerDataStoreCreatorTest.cs
@@ -227,7 +227,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
                 var serviceProvider = serviceCollection.BuildServiceProvider();
 
-                var options = new DbContextOptions().UseSqlServer(testDatabase.Connection.ConnectionString);
+                var options = new DbContextOptions();
+                options.UseSqlServer(testDatabase.Connection.ConnectionString);
 
                 using (var context = new BloggingContext(serviceProvider, options))
                 {
@@ -373,9 +374,12 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 .AddEntityFramework()
                 .AddSqlServer();
 
+            var options = new DbContextOptions();
+            options.UseSqlServer(testStore.Connection.ConnectionString);
+
             return ((IDbContextServices)new DbContext(
                 serviceCollection.BuildServiceProvider(),
-                new DbContextOptions().UseSqlServer(testStore.Connection.ConnectionString)))
+                options))
                 .ScopedServiceProvider;
         }
 

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -140,7 +140,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             using (var testDatabase = await SqlServerTestStore.CreateScratchAsync())
             {
-                var options = new DbContextOptions().UseSqlServer(testDatabase.Connection.ConnectionString);
+                var options = new DbContextOptions();
+                options.UseSqlServer(testDatabase.Connection.ConnectionString);
 
                 using (var db = new BloggingContext(_fixture.ServiceProvider, options))
                 {
@@ -221,7 +222,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             using (var testDatabase = await SqlServerTestStore.CreateScratchAsync())
             {
-                var options = new DbContextOptions().UseSqlServer(testDatabase.Connection.ConnectionString);
+                var options = new DbContextOptions();
+                options.UseSqlServer(testDatabase.Connection.ConnectionString);
 
                 int updatedId;
                 int deletedId;
@@ -400,7 +402,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             using (var testDatabase = await SqlServerTestStore.CreateScratchAsync())
             {
-                var options = new DbContextOptions().UseSqlServer(testDatabase.Connection.ConnectionString);
+                var options = new DbContextOptions();
+                options.UseSqlServer(testDatabase.Connection.ConnectionString);
 
                 int blog1Id;
                 int blog2Id;

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerF1Fixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerF1Fixture.cs
@@ -33,8 +33,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
         {
             return SqlServerTestStore.GetOrCreateSharedAsync(DatabaseName, async () =>
                 {
-                    var options = new DbContextOptions()
-                        .UseSqlServer(_connectionString);
+                    var options = new DbContextOptions();
+                    options.UseSqlServer(_connectionString);
 
                     using (var context = new F1Context(_serviceProvider, options))
                     {
@@ -48,9 +48,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
         public override F1Context CreateContext(SqlServerTestStore testStore)
         {
-            var options
-                = new DbContextOptions()
-                    .UseSqlServer(testStore.Connection);
+            var options = new DbContextOptions();
+            options.UseSqlServer(testStore.Connection);
 
             var context = new F1Context(_serviceProvider, options);
             context.Database.AsRelational().Connection.UseTransaction(testStore.Transaction);

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerMigrationsTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerMigrationsTest.cs
@@ -38,9 +38,12 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                     .ServiceCollection
                     .BuildServiceProvider();
 
+            var options =new DbContextOptions();
+            options.UseSqlServer(testStore.Connection.ConnectionString);
+
             return new BloggingContext(
                 serviceProvider,
-                new DbContextOptions().UseSqlServer(testStore.Connection.ConnectionString));
+                options);
         }
 
         private class BloggingContext : DbContext

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerMonsterFixupTest.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerMonsterFixupTest.cs
@@ -39,7 +39,10 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
         protected override DbContextOptions CreateOptions(string databaseName)
         {
-            return new DbContextOptions().UseSqlServer(CreateConnectionString(databaseName));
+            var options = new DbContextOptions();
+            options.UseSqlServer(CreateConnectionString(databaseName));
+
+            return options;
         }
 
         private static string CreateConnectionString(string name)

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerNorthwindQueryFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerNorthwindQueryFixture.cs
@@ -30,9 +30,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
                 .AddInstance<ILoggerFactory>(new TestSqlLoggerFactory())
                 .BuildServiceProvider();
 
-            _options
-                = new DbContextOptions()
-                    .UseSqlServer(_testStore.Connection.ConnectionString);
+            _options = new DbContextOptions();
+            _options.UseSqlServer(_testStore.Connection.ConnectionString);
         }
 
         public override NorthwindContext CreateContext()

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerOneToOneQueryFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerOneToOneQueryFixture.cs
@@ -30,8 +30,8 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
             _options
                 = new DbContextOptions()
-                    .UseModel(model)
-                    .UseSqlServer(database.Connection.ConnectionString);
+                    .UseModel(model);
+            _options.UseSqlServer(database.Connection.ConnectionString);
 
             using (var context = new DbContext(_serviceProvider, _options))
             {

--- a/test/EntityFramework.SqlServer.FunctionalTests/SqlServerTransactionFixture.cs
+++ b/test/EntityFramework.SqlServer.FunctionalTests/SqlServerTransactionFixture.cs
@@ -50,18 +50,16 @@ namespace Microsoft.Data.Entity.SqlServer.FunctionalTests
 
         public override DbContext CreateContext(SqlServerTestStore testStore)
         {
-            var options
-                = new DbContextOptions()
-                    .UseSqlServer(testStore.Connection.ConnectionString);
+            var options = new DbContextOptions();
+            options.UseSqlServer(testStore.Connection.ConnectionString);
 
             return new DbContext(_serviceProvider, options);
         }
 
         public override DbContext CreateContext(DbConnection connection)
         {
-            var options
-                = new DbContextOptions()
-                    .UseSqlServer(connection);
+            var options = new DbContextOptions();
+            options.UseSqlServer(connection);
 
             return new DbContext(_serviceProvider, options);
         }

--- a/test/EntityFramework.SqlServer.Tests/SqlServerConnectionTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerConnectionTest.cs
@@ -33,8 +33,10 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
 
         public static DbContextService<IDbContextOptions> CreateOptions()
         {
-            return new DbContextService<IDbContextOptions>(() => new DbContextOptions()
-                .UseSqlServer(@"Server=(localdb)\v11.0;Database=SqlServerConnectionTest;Trusted_Connection=True;"));
+            var options = new DbContextOptions();
+            options.UseSqlServer(@"Server=(localdb)\v11.0;Database=SqlServerConnectionTest;Trusted_Connection=True;");
+
+            return new DbContextService<IDbContextOptions>(() => options);
         }
     }
 }

--- a/test/EntityFramework.SqlServer.Tests/SqlServerDbContextOptionsExtensionsTest.cs
+++ b/test/EntityFramework.SqlServer.Tests/SqlServerDbContextOptionsExtensionsTest.cs
@@ -15,8 +15,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Can_add_extension_with_connection_string()
         {
             var options = new DbContextOptions();
-
-            options = options.UseSqlServer("Database=Crunchie");
+            options.UseSqlServer("Database=Crunchie");
 
             var extension = ((IDbContextOptions)options).Extensions.OfType<SqlServerOptionsExtension>().Single();
 
@@ -28,8 +27,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
         public void Can_add_extension_with_connection_string_using_generic_options()
         {
             var options = new DbContextOptions<DbContext>();
-
-            options = options.UseSqlServer("Database=Whisper");
+            options.UseSqlServer("Database=Whisper");
 
             var extension = ((IDbContextOptions)options).Extensions.OfType<SqlServerOptionsExtension>().Single();
 
@@ -43,7 +41,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             var options = new DbContextOptions();
             var connection = new SqlConnection();
 
-            options = options.UseSqlServer(connection);
+            options.UseSqlServer(connection);
 
             var extension = ((IDbContextOptions)options).Extensions.OfType<SqlServerOptionsExtension>().Single();
 
@@ -57,7 +55,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             var options = new DbContextOptions<DbContext>();
             var connection = new SqlConnection();
 
-            options = options.UseSqlServer(connection);
+            options.UseSqlServer(connection);
 
             var extension = ((IDbContextOptions)options).Extensions.OfType<SqlServerOptionsExtension>().Single();
 
@@ -71,7 +69,7 @@ namespace Microsoft.Data.Entity.SqlServer.Tests
             var options = new DbContextOptions();
             ((IDbContextOptions)options).RawOptions = new Dictionary<string, string> { { "ConnectionString", "Database=Crunchie" } };
 
-            options = options.UseSqlServer();
+            options.UseSqlServer();
 
             var extension = ((IDbContextOptions)options).Extensions.OfType<SqlServerOptionsExtension>().Single();
 

--- a/test/EntityFramework.SqlServer.Tests/TestHelperExtensions.cs
+++ b/test/EntityFramework.SqlServer.Tests/TestHelperExtensions.cs
@@ -15,7 +15,9 @@ namespace Microsoft.Data.Entity.Tests
 
         public static DbContextOptions UseProviderOptions(this DbContextOptions options)
         {
-            return options.UseSqlServer(new SqlConnection("Database=DummyDatabase"));
+            options.UseSqlServer(new SqlConnection("Database=DummyDatabase"));
+
+            return options;
         }
     }
 }


### PR DESCRIPTION
Changed UseSqlServer and UseInMemoryStore extension method return types. Did not modify UseModel, UseProviderOptions, or UseMigrationAssembly extensions.
@ajcvickers 
