### PR TITLE
adding (client side) support for Contains operator in query

### DIFF
--- a/src/EntityFramework.Core/Query/AsyncLinqOperatorProvider.cs
+++ b/src/EntityFramework.Core/Query/AsyncLinqOperatorProvider.cs
@@ -262,6 +262,7 @@ namespace Microsoft.Data.Entity.Query
         private static readonly MethodInfo _all = GetMethod("All", 1);
         private static readonly MethodInfo _cast = GetMethod("Cast");
         private static readonly MethodInfo _count = GetMethod("Count");
+        private static readonly MethodInfo _contains = GetMethod("Contains", 1);
         private static readonly MethodInfo _defaultIfEmpty = GetMethod("DefaultIfEmpty");
         private static readonly MethodInfo _defaultIfEmptyArg = GetMethod("DefaultIfEmpty", 1);
         private static readonly MethodInfo _distinct = GetMethod("Distinct");
@@ -288,6 +289,11 @@ namespace Microsoft.Data.Entity.Query
         public virtual MethodInfo Count
         {
             get { return _count; }
+        }
+
+        public virtual MethodInfo Contains
+        {
+            get { return _contains; }
         }
 
         public virtual MethodInfo DefaultIfEmpty

--- a/src/EntityFramework.Core/Query/ILinqOperatorProvider.cs
+++ b/src/EntityFramework.Core/Query/ILinqOperatorProvider.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Data.Entity.Query
         MethodInfo All { get; }
         MethodInfo Cast { get; }
         MethodInfo Count { get; }
+        MethodInfo Contains { get; }
         MethodInfo DefaultIfEmpty { get; }
         MethodInfo DefaultIfEmptyArg { get; }
         MethodInfo Distinct { get; }

--- a/src/EntityFramework.Core/Query/LinqOperatorProvider.cs
+++ b/src/EntityFramework.Core/Query/LinqOperatorProvider.cs
@@ -214,6 +214,7 @@ namespace Microsoft.Data.Entity.Query
         private static readonly MethodInfo _all = GetMethod("All", 1);
         private static readonly MethodInfo _cast = GetMethod("Cast");
         private static readonly MethodInfo _count = GetMethod("Count");
+        private static readonly MethodInfo _contains = GetMethod("Contains", 1);
         private static readonly MethodInfo _defaultIfEmpty = GetMethod("DefaultIfEmpty");
         private static readonly MethodInfo _defaultIfEmptyArg = GetMethod("DefaultIfEmpty", 1);
         private static readonly MethodInfo _distinct = GetMethod("Distinct");
@@ -238,6 +239,11 @@ namespace Microsoft.Data.Entity.Query
         public virtual MethodInfo Count
         {
             get { return _count; }
+        }
+
+        public virtual MethodInfo Contains
+        {
+            get { return _contains; }
         }
 
         public virtual MethodInfo DefaultIfEmpty

--- a/src/EntityFramework.Core/Query/ResultOperatorHandler.cs
+++ b/src/EntityFramework.Core/Query/ResultOperatorHandler.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Data.Entity.Query
                     { typeof(AverageResultOperator), (v, _, __) => HandleAverage(v) },
                     { typeof(CastResultOperator), (v, r, __) => HandleCast(v, (CastResultOperator)r) },
                     { typeof(CountResultOperator), (v, _, __) => HandleCount(v) },
+                    { typeof(ContainsResultOperator), (v, r, q) => HandleContains(v, (ContainsResultOperator)r, q) },
                     { typeof(DefaultIfEmptyResultOperator), (v, r, q) => HandleDefaultIfEmpty(v, (DefaultIfEmptyResultOperator)r, q) },
                     { typeof(DistinctResultOperator), (v, _, __) => HandleDistinct(v) },
                     { typeof(FirstResultOperator), (v, r, __) => HandleFirst(v, (ChoiceResultOperatorBase)r) },
@@ -110,6 +111,23 @@ namespace Microsoft.Data.Entity.Query
                 entityQueryModelVisitor.LinqOperatorProvider
                     .Count.MakeGenericMethod(entityQueryModelVisitor.StreamedSequenceInfo.ResultItemType),
                 entityQueryModelVisitor.Expression);
+        }
+
+        private static Expression HandleContains(
+            EntityQueryModelVisitor entityQueryModelVisitor, 
+            ContainsResultOperator containsResultOperator,
+            QueryModel queryModel)
+        {
+            var item = entityQueryModelVisitor
+                .ReplaceClauseReferences(
+                    containsResultOperator.Item,
+                    queryModel.MainFromClause);
+
+            return CallWithPossibleCancellationToken(
+                entityQueryModelVisitor.LinqOperatorProvider.Contains
+                    .MakeGenericMethod(entityQueryModelVisitor.StreamedSequenceInfo.ResultItemType),
+                entityQueryModelVisitor.Expression,
+                item);
         }
 
         private static Expression HandleDefaultIfEmpty(

--- a/test/EntityFramework.Core.FunctionalTests/AsyncQueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/AsyncQueryTestBase.cs
@@ -1643,6 +1643,13 @@ namespace Microsoft.Data.Entity.FunctionalTests
             await AssertQuery<Customer>(cs => cs.Where(c => c.ContactName.EndsWith(LocalMethod2())));
         }
 
+        [Fact]
+        public virtual async Task Contains_top_level()
+        {
+            await AssertQuery<Customer>(cs =>
+                cs.Select(c => c.CustomerID).ContainsAsync("ALFKI"));
+        }
+
         private static string LocalMethod1()
         {
             return "M";

--- a/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
+++ b/test/EntityFramework.Core.FunctionalTests/QueryTestBase.cs
@@ -1905,6 +1905,28 @@ namespace Microsoft.Data.Entity.FunctionalTests
                 select new { c.ContactName, o });
         }
 
+        [Fact]
+        public void Contains_with_subquery()
+        {
+            AssertQuery<Customer, Order>((cs, os) =>
+                cs.Where(c => os.Select(o => o.CustomerID).Contains(c.CustomerID)));
+        }
+
+        [Fact]
+        public void Contains_with_local_collection()
+        {
+            string[] ids = new[] { "ABCDE", "ALFKI" };
+            AssertQuery<Customer>(cs =>
+                cs.Where(c => ids.Contains(c.CustomerID)), stateEntryCount: 1);
+        }
+
+        [Fact]
+        public void Contains_top_level()
+        {
+            AssertQuery<Customer>(cs => 
+                cs.Select(c => c.CustomerID).Contains("ALFKI"));
+        }
+
         protected NorthwindContext CreateContext()
         {
             return Fixture.CreateContext();


### PR DESCRIPTION
Partial fix to:
https://github.com/aspnet/EntityFramework/issues/1243

This checkin only enables client-side evaluation of Contains method.

@divega @AndriySvyryd @ajcvickers @lukewaters 
