### PR TITLE
Splitting DbSet operations and SaveChanges in perf tests

### DIFF
--- a/test/EntityFramework.Microbenchmarks.EF6/ChangeTracker/DbSetOperationTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/ChangeTracker/DbSetOperationTests.cs
@@ -1,0 +1,207 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using EntityFramework.Microbenchmarks.Core;
+using EntityFramework.Microbenchmarks.EF6.Models.Orders;
+using System;
+using System.Data.Entity;
+using System.Linq;
+using Xunit;
+
+namespace EntityFramework.Microbenchmarks.EF6.ChangeTracker
+{
+    public class DbSetOperationTests
+    {
+        private static string _connectionString = String.Format(@"Server={0};Database=Perf_ChangeTracker_DbSetOperation;Integrated Security=True;MultipleActiveResultSets=true;", TestConfig.Instance.DataSource);
+
+        [Fact]
+        public void Add()
+        {
+            new TestDefinition
+            {
+                TestName = "ChangeTracker_DbSetOperation_Add_EF6",
+                IterationCount = 100,
+                WarmupCount = 5,
+                RunWithCollector = collector =>
+                {
+                    using (var context = new OrdersContext(_connectionString))
+                    {
+                        var customers = new Customer[1000];
+                        for (int i = 0; i < customers.Length; i++)
+                        {
+                            customers[i] = new Customer { Name = "Customer " + i };
+                        }
+
+                        using (collector.Start())
+                        {
+                            foreach (var customer in customers)
+                            {
+                                context.Customers.Add(customer);
+                            }
+                        }
+                    }
+                }
+            }.RunTest();
+        }
+
+        [Fact]
+        public void AddCollection()
+        {
+            new TestDefinition
+            {
+                TestName = "ChangeTracker_DbSetOperation_AddCollection_EF6",
+                IterationCount = 100,
+                WarmupCount = 5,
+                RunWithCollector = collector =>
+                {
+                    using (var context = new OrdersContext(_connectionString))
+                    {
+                        var customers = new Customer[1000];
+                        for (int i = 0; i < customers.Length; i++)
+                        {
+                            customers[i] = new Customer { Name = "Customer " + i };
+                        }
+
+                        using (collector.Start())
+                        {
+                            context.Customers.AddRange(customers);
+                        }
+                    }
+                }
+            }.RunTest();
+        }
+
+        [Fact]
+        public void Attach()
+        {
+            new TestDefinition
+            {
+                TestName = "ChangeTracker_DbSetOperation_Attach_EF6",
+                IterationCount = 100,
+                WarmupCount = 5,
+                Setup = EnsureDatabaseSetup,
+                RunWithCollector = collector =>
+                {
+                    using (var context = new OrdersContext(_connectionString))
+                    {
+                        var customers = GetAllCustomersFromDatabase();
+                        Assert.Equal(1000, customers.Length);
+
+                        using (collector.Start())
+                        {
+                            foreach (var customer in customers)
+                            {
+                                context.Customers.Attach(customer);
+                            }
+                        }
+                    }
+                }
+            }.RunTest();
+        }
+
+        // Note: AttachCollection() not implemented because there is no
+        //       API for bulk attach in EF6.x
+
+        [Fact]
+        public void Remove()
+        {
+            new TestDefinition
+            {
+                TestName = "ChangeTracker_DbSetOperation_Remove_EF6",
+                IterationCount = 100,
+                WarmupCount = 5,
+                Setup = EnsureDatabaseSetup,
+                RunWithCollector = collector =>
+                {
+                    using (var context = new OrdersContext(_connectionString))
+                    {
+                        var customers = context.Customers.ToArray();
+                        Assert.Equal(1000, customers.Length);
+
+                        using (collector.Start())
+                        {
+                            foreach (var customer in customers)
+                            {
+                                context.Customers.Remove(customer);
+                            }
+                        }
+                    }
+                }
+            }.RunTest();
+        }
+
+        [Fact]
+        public void RemoveCollection()
+        {
+            new TestDefinition
+            {
+                TestName = "ChangeTracker_DbSetOperation_RemoveCollection_EF6",
+                IterationCount = 100,
+                WarmupCount = 5,
+                Setup = EnsureDatabaseSetup,
+                RunWithCollector = collector =>
+                {
+                    using (var context = new OrdersContext(_connectionString))
+                    {
+                        var customers = context.Customers.ToArray();
+                        Assert.Equal(1000, customers.Length);
+
+                        using (collector.Start())
+                        {
+                            context.Customers.RemoveRange(customers);
+                        }
+                    }
+                }
+            }.RunTest();
+        }
+
+        [Fact]
+        public void Update()
+        {
+            new TestDefinition
+            {
+                TestName = "ChangeTracker_DbSetOperation_Update_EF6",
+                IterationCount = 100,
+                WarmupCount = 5,
+                Setup = EnsureDatabaseSetup,
+                RunWithCollector = collector =>
+                {
+                    using (var context = new OrdersContext(_connectionString))
+                    {
+                        var customers = GetAllCustomersFromDatabase();
+                        Assert.Equal(1000, customers.Length);
+
+                        using (collector.Start())
+                        {
+                            foreach (var customer in customers)
+                            {
+                                context.Entry(customer).State = EntityState.Modified;
+                            }
+                        }
+                    }
+                }
+            }.RunTest();
+        }
+
+        // Note: UpdateCollection() not implemented because there is no
+        //       API for bulk update in EF6.x
+
+        private static Customer[] GetAllCustomersFromDatabase()
+        {
+            using (var context = new OrdersContext(_connectionString))
+            {
+                return context.Customers.ToArray();
+            }
+        }
+
+        private static void EnsureDatabaseSetup()
+        {
+            OrdersSeedData.EnsureCreated(
+                _connectionString,
+                productCount: 0,
+                customerCount: 1000,
+                ordersPerCustomer: 0,
+                linesPerOrder: 0);
+        }
+    }
+}

--- a/test/EntityFramework.Microbenchmarks.EF6/EntityFramework.Microbenchmarks.EF6.csproj
+++ b/test/EntityFramework.Microbenchmarks.EF6/EntityFramework.Microbenchmarks.EF6.csproj
@@ -55,6 +55,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ChangeTracker\DbSetOperationTests.cs" />
     <Compile Include="ChangeTracker\FixupTests.cs" />
     <Compile Include="Models\Orders\Customer.cs" />
     <Compile Include="Models\Orders\OrdersContext.cs" />

--- a/test/EntityFramework.Microbenchmarks.EF6/UpdatePipeline/SimpleUpdatePipelineTests.cs
+++ b/test/EntityFramework.Microbenchmarks.EF6/UpdatePipeline/SimpleUpdatePipelineTests.cs
@@ -33,22 +33,14 @@ namespace EntityFramework.Microbenchmarks.EF6.UpdatePipeline
             {
                 using (context.Database.BeginTransaction())
                 {
-                    var customers = new List<Customer>();
                     for (int i = 0; i < 1000; i++)
                     {
-                        customers.Add(new Customer { Name = "Test Customer" });
+                        context.Customers.Add(new Customer { Name = "New Customer " + i });
                     }
 
-                    int records;
-                    using (collector.Start())
-                    {
-                        foreach (var customer in customers)
-                        {
-                            context.Customers.Add(customer);
-                        }
-
-                        records = context.SaveChanges();
-                    }
+                    collector.Start();
+                    var records = context.SaveChanges();
+                    collector.Stop();
 
                     Assert.Equal(1000, records);
                 }
@@ -74,18 +66,14 @@ namespace EntityFramework.Microbenchmarks.EF6.UpdatePipeline
             {
                 using (context.Database.BeginTransaction())
                 {
-                    int records;
-                    var customers = context.Customers.ToList();
-                    using (collector.Start())
+                    foreach (var customer in context.Customers)
                     {
-
-                        foreach (var customer in customers)
-                        {
-                            customer.Name += " Modified";
-                        }
-
-                        records = context.SaveChanges();
+                        customer.Name += " Modified";
                     }
+
+                    collector.Start();
+                    var records = context.SaveChanges();
+                    collector.Stop();
 
                     Assert.Equal(1000, records);
                 }
@@ -111,17 +99,14 @@ namespace EntityFramework.Microbenchmarks.EF6.UpdatePipeline
             {
                 using (context.Database.BeginTransaction())
                 {
-                    int records;
-                    var customers = context.Customers.ToList();
-                    using (collector.Start())
+                    foreach (var customer in context.Customers)
                     {
-                        foreach (var customer in customers)
-                        {
-                            context.Customers.Remove(customer);
-                        }
-
-                        records = context.SaveChanges();
+                        context.Customers.Remove(customer);
                     }
+
+                    collector.Start();
+                    var records = context.SaveChanges();
+                    collector.Stop();
 
                     Assert.Equal(1000, records);
                 }
@@ -147,34 +132,26 @@ namespace EntityFramework.Microbenchmarks.EF6.UpdatePipeline
             {
                 using (context.Database.BeginTransaction())
                 {
-                    int records;
                     var customers = context.Customers.ToArray();
-                    var newCustomers = new List<Customer>();
 
                     for (int i = 0; i < 333; i++)
                     {
-                        newCustomers.Add(new Customer { Name = "Test Customer" });
+                        context.Customers.Add(new Customer { Name = "New Customer " + i });
                     }
 
-                    using (collector.Start())
+                    for (int i = 0; i < 1000; i += 3)
                     {
-                        for (int i = 0; i < 1000; i += 3)
-                        {
-                            context.Customers.Remove(customers[i]);
-                        }
-
-                        for (int i = 1; i < 1000; i += 3)
-                        {
-                            customers[i].Name += " Modified";
-                        }
-
-                        foreach (var customer in newCustomers)
-                        {
-                            context.Customers.Add(customer);
-                        }
-
-                        records = context.SaveChanges();
+                        context.Customers.Remove(customers[i]);
                     }
+
+                    for (int i = 1; i < 1000; i += 3)
+                    {
+                        customers[i].Name += " Modified";
+                    }
+
+                    collector.Start();
+                    var records = context.SaveChanges();
+                    collector.Stop();
 
                     Assert.Equal(1000, records);
                 }

--- a/test/EntityFramework.Microbenchmarks/ChangeTracker/DbSetOperationTests.cs
+++ b/test/EntityFramework.Microbenchmarks/ChangeTracker/DbSetOperationTests.cs
@@ -1,0 +1,250 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using EntityFramework.Microbenchmarks.Core;
+using EntityFramework.Microbenchmarks.Models.Orders;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace EntityFramework.Microbenchmarks.ChangeTracker
+{
+    public class DbSetOperationTests
+    {
+        private static string _connectionString = String.Format(@"Server={0};Database=Perf_ChangeTracker_DbSetOperation;Integrated Security=True;MultipleActiveResultSets=true;", TestConfig.Instance.DataSource);
+
+        [Fact]
+        public void Add()
+        {
+            new TestDefinition
+            {
+                TestName = "ChangeTracker_DbSetOperation_Add",
+                IterationCount = 100,
+                WarmupCount = 5,
+                RunWithCollector = collector =>
+                {
+                    using (var context = new OrdersContext(_connectionString))
+                    {
+                        var customers = new Customer[1000];
+                        for (int i = 0; i < customers.Length; i++)
+                        {
+                            customers[i] = new Customer { Name = "Customer " + i };
+                        }
+
+                        using (collector.Start())
+                        {
+                            foreach (var customer in customers)
+                            {
+                                context.Customers.Add(customer);
+                            }
+                        }
+                    }
+                }
+            }.RunTest();
+        }
+
+        [Fact]
+        public void AddCollection()
+        {
+            new TestDefinition
+            {
+                TestName = "ChangeTracker_DbSetOperation_AddCollection",
+                IterationCount = 100,
+                WarmupCount = 5,
+                RunWithCollector = collector =>
+                {
+                    using (var context = new OrdersContext(_connectionString))
+                    {
+                        var customers = new Customer[1000];
+                        for (int i = 0; i < customers.Length; i++)
+                        {
+                            customers[i] = new Customer { Name = "Customer " + i };
+                        }
+
+                        using (collector.Start())
+                        {
+                            context.Customers.Add(customers);
+                        }
+                    }
+                }
+            }.RunTest();
+        }
+
+        [Fact]
+        public void Attach()
+        {
+            new TestDefinition
+            {
+                TestName = "ChangeTracker_DbSetOperation_Attach",
+                IterationCount = 100,
+                WarmupCount = 5,
+                Setup = EnsureDatabaseSetup,
+                RunWithCollector = collector =>
+                {
+                    using (var context = new OrdersContext(_connectionString))
+                    {
+                        var customers = GetAllCustomersFromDatabase();
+                        Assert.Equal(1000, customers.Length);
+
+                        using (collector.Start())
+                        {
+                            foreach (var customer in customers)
+                            {
+                                context.Customers.Attach(customer);
+                            }
+                        }
+                    }
+                }
+            }.RunTest();
+        }
+
+        [Fact]
+        public void AttachCollection()
+        {
+            new TestDefinition
+            {
+                TestName = "ChangeTracker_DbSetOperation_AttachCollection",
+                IterationCount = 100,
+                WarmupCount = 5,
+                Setup = EnsureDatabaseSetup,
+                RunWithCollector = collector =>
+                {
+                    using (var context = new OrdersContext(_connectionString))
+                    {
+                        var customers = GetAllCustomersFromDatabase();
+                        Assert.Equal(1000, customers.Length);
+
+                        using (collector.Start())
+                        {
+                            context.Customers.Attach(customers);
+                        }
+                    }
+                }
+            }.RunTest();
+        }
+
+        [Fact]
+        public void Remove()
+        {
+            new TestDefinition
+            {
+                TestName = "ChangeTracker_DbSetOperation_Remove",
+                IterationCount = 100,
+                WarmupCount = 5,
+                Setup = EnsureDatabaseSetup,
+                RunWithCollector = collector =>
+                {
+                    using (var context = new OrdersContext(_connectionString))
+                    {
+                        var customers = context.Customers.ToArray();
+                        Assert.Equal(1000, customers.Length);
+
+                        using (collector.Start())
+                        {
+                            foreach (var customer in customers)
+                            {
+                                context.Customers.Remove(customer);
+                            }
+                        }
+                    }
+                }
+            }.RunTest();
+        }
+
+        [Fact]
+        public void RemoveCollection()
+        {
+            new TestDefinition
+            {
+                TestName = "ChangeTracker_DbSetOperation_RemoveCollection",
+                IterationCount = 100,
+                WarmupCount = 5,
+                Setup = EnsureDatabaseSetup,
+                RunWithCollector = collector =>
+                {
+                    using (var context = new OrdersContext(_connectionString))
+                    {
+                        var customers = context.Customers.ToArray();
+                        Assert.Equal(1000, customers.Length);
+
+                        using (collector.Start())
+                        {
+                            context.Customers.Remove(customers);
+                        }
+                    }
+                }
+            }.RunTest();
+        }
+
+        [Fact]
+        public void Update()
+        {
+            new TestDefinition
+            {
+                TestName = "ChangeTracker_DbSetOperation_Update",
+                IterationCount = 100,
+                WarmupCount = 5,
+                Setup = EnsureDatabaseSetup,
+                RunWithCollector = collector =>
+                {
+                    using (var context = new OrdersContext(_connectionString))
+                    {
+                        var customers = GetAllCustomersFromDatabase();
+                        Assert.Equal(1000, customers.Length);
+
+                        using (collector.Start())
+                        {
+                            foreach (var customer in customers)
+                            {
+                                context.Customers.Update(customer);
+                            }
+                        }
+                    }
+                }
+            }.RunTest();
+        }
+
+        [Fact]
+        public void UpdateCollection()
+        {
+            new TestDefinition
+            {
+                TestName = "ChangeTracker_DbSetOperation_UpdateCollection",
+                IterationCount = 100,
+                WarmupCount = 5,
+                Setup = EnsureDatabaseSetup,
+                RunWithCollector = collector =>
+                {
+                    using (var context = new OrdersContext(_connectionString))
+                    {
+                        var customers = GetAllCustomersFromDatabase();
+                        Assert.Equal(1000, customers.Length);
+
+                        using (collector.Start())
+                        {
+                            context.Customers.Update(customers);
+                        }
+                    }
+                }
+            }.RunTest();
+        }
+
+        private static Customer[] GetAllCustomersFromDatabase()
+        {
+            using (var context = new OrdersContext(_connectionString))
+            {
+                return context.Customers.ToArray();
+            }
+        }
+
+        private static void EnsureDatabaseSetup()
+        {
+            OrdersSeedData.EnsureCreated(
+                _connectionString,
+                productCount: 0,
+                customerCount: 1000,
+                ordersPerCustomer: 0,
+                linesPerOrder: 0);
+        }
+    }
+}

--- a/test/EntityFramework.Microbenchmarks/EntityFramework.Microbenchmarks.csproj
+++ b/test/EntityFramework.Microbenchmarks/EntityFramework.Microbenchmarks.csproj
@@ -85,6 +85,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ChangeTracker\DbSetOperationTests.cs" />
     <Compile Include="ChangeTracker\FixupTests.cs" />
     <Compile Include="Core\PerformanceCaseResult.cs" />
     <Compile Include="Core\Extensions.cs" />


### PR DESCRIPTION
Changes:
- Scoping collection in UpdatePipeline tests to just cover SaveChanges
- Adding tests that target DbSet.Add/Remove/Attach/Update
