### PR TITLE
[1.1.3] Fix to #8862 - The multi-part identifier "ts.Id" could not be bound

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/Microsoft.EntityFrameworkCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -736,8 +736,23 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 return null;
             }
 
-            return binder(queryModelVisitor)
-                   ?? TryBindParentExpression(queryModelVisitor.ParentQueryModelVisitor, binder);
+            var result = binder(queryModelVisitor);
+            if (result != null)
+            {
+                return result;
+            }
+
+            var oldQueryModelStreamedDataInfo = CurrentQueryModelStreamedDataInfo;
+            CurrentQueryModelStreamedDataInfo = queryModelVisitor.QueryModelOutputDataInfo;
+
+            try
+            {
+                return TryBindParentExpression(queryModelVisitor.ParentQueryModelVisitor, binder);
+            }
+            finally
+            {
+                CurrentQueryModelStreamedDataInfo = oldQueryModelStreamedDataInfo;
+            }
         }
 
         private AliasExpression CreateAliasedColumnExpression(

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/QuerySqlServerTest.cs
@@ -6644,6 +6644,61 @@ END",
                 Sql);
         }
 
+        public override void Complex_nested_query_doesnt_try_binding_to_grandparent_when_parent_returns_complex_result()
+        {
+            base.Complex_nested_query_doesnt_try_binding_to_grandparent_when_parent_returns_complex_result();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'
+
+@_outer_CustomerID2: ALFKI (Size = 4000)
+@_outer_CustomerID: ALFKI (Size = 450)
+
+SELECT @_outer_CustomerID2
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+
+SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
+FROM [Orders] AS [o2]
+
+SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
+FROM [Orders] AS [o2]
+
+SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
+FROM [Orders] AS [o2]
+
+SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
+FROM [Orders] AS [o2]
+
+SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
+FROM [Orders] AS [o2]
+
+SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
+FROM [Orders] AS [o2]",
+                Sql);
+        }
+
+        public override void Complex_nested_query_properly_binds_to_grandparent_when_parent_returns_scalar_result()
+        {
+            base.Complex_nested_query_properly_binds_to_grandparent_when_parent_returns_scalar_result();
+
+            Assert.Equal(
+                @"SELECT [c].[CustomerID], (
+    SELECT COUNT(*)
+    FROM [Orders] AS [o1]
+    WHERE ((
+        SELECT COUNT(*)
+        FROM [Orders] AS [o2]
+        WHERE [c].[CustomerID] = [o2].[CustomerID]
+    ) > 0) AND ([c].[CustomerID] = [o1].[CustomerID])
+)
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'",
+                Sql);
+        }
+
         private const string FileLineEnding = @"
 ";
 


### PR DESCRIPTION
When we try to bind to parent query model we keep track of the current model output data info. However when recursive binding is required (i.e. binding to grandparent) we were not storing the output data of the parent, but still using the output data info of the child. This caused problems when the parent output data info doesn't allow for the binding to its parent - we would still try to perform the binding because we took the incorrect output data info into account.

Fix is to store the correct output data info in the variable before recursively trying to call TryBindParentExpression.