### PR TITLE
Fix #9128: Projection with nested projection hangs/does not complete in 2.0 Preview 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -291,3 +291,4 @@ __pycache__/
 *.btm.cs
 *.odx.cs
 *.xsd.cs
+korebuild-lock.txt

--- a/src/EFCore.Specification.Tests/Query/AsyncQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncQueryTestBase.cs
@@ -24,21 +24,69 @@ namespace Microsoft.EntityFrameworkCore.Query
         where TFixture : NorthwindQueryFixtureBase, new()
     {
         [ConditionalFact]
-        public virtual async Task ToList_on_nav_in_projection_is_async()
+        public virtual async Task ToArray_on_nav_subquery_in_projection()
         {
             using (var context = CreateContext())
             {
                 var results
-                    = await context.Customers
-                        .Where(c => c.CustomerID == "ALFKI")
-                        .Select(c => new
+                    = await context.Customers.Select(c => new
                         {
-                            c,
-                            Orders = ((IAsyncEnumerable<Order>)(from o in c.Orders select o)).ToList().Result
+                            Orders = c.Orders.ToArray()
                         })
                         .ToListAsync();
 
-                Assert.Equal(1, results.Count);
+                Assert.Equal(830, results.SelectMany(a => a.Orders).ToList().Count);
+            }
+        }
+        [ConditionalFact]
+        public virtual async Task ToArray_on_nav_subquery_in_projection_nested()
+        {
+            using (var context = CreateContext())
+            {
+                var results
+                    = await context.Customers.Select(c => new
+                        {
+                            Orders = c.Orders.Select(o => new
+                            {
+                                OrderDetails = o.OrderDetails.ToArray()
+                            })
+                            .ToArray()
+                        })
+                        .ToListAsync();
+
+                Assert.Equal(2155, results.SelectMany(a => a.Orders.SelectMany(o => o.OrderDetails)).ToList().Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual async Task ToList_on_nav_subquery_in_projection()
+        {
+            using (var context = CreateContext())
+            {
+                var results
+                    = await context.Customers.Select(c => new
+                    {
+                        Orders = c.Orders.ToList()
+                    })
+                    .ToListAsync();
+
+                Assert.Equal(830, results.SelectMany(a => a.Orders).ToList().Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual async Task Average_on_nav_subquery_in_projection()
+        {
+            using (var context = CreateContext())
+            {
+                var results
+                    = await context.Customers.Select(c => new
+                        {
+                            Ave = c.Orders.Average(o => o.Freight)
+                        })
+                        .ToListAsync();
+
+                Assert.Equal(91, results.ToList().Count);
             }
         }
 

--- a/src/EFCore/Query/ExpressionVisitors/Internal/TaskBlockingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/TaskBlockingExpressionVisitor.cs
@@ -4,7 +4,6 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 {
@@ -25,22 +24,13 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 var typeInfo = expression.Type.GetTypeInfo();
 
                 if (typeInfo.IsGenericType
-                    && (typeInfo.GetGenericTypeDefinition() == typeof(Task<>)))
+                    && typeInfo.GetGenericTypeDefinition() == typeof(Task<>))
                 {
-                    return Expression.Call(
-                        _resultMethodInfo.MakeGenericMethod(typeInfo.GenericTypeArguments[0]),
-                        expression);
+                    return Expression.Property(expression, nameof(Task<object>.Result));
                 }
             }
 
             return expression;
         }
-
-        private static readonly MethodInfo _resultMethodInfo
-            = typeof(TaskBlockingExpressionVisitor).GetTypeInfo()
-                .GetDeclaredMethod(nameof(Result));
-
-        [UsedImplicitly]
-        private static T Result<T>(Task<T> task) => task.GetAwaiter().GetResult();
     }
 }

--- a/src/EFCore/Query/ExpressionVisitors/ProjectionExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/ProjectionExpressionVisitor.cs
@@ -6,7 +6,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Extensions.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Remotion.Linq.Clauses.Expressions;
@@ -25,8 +30,99 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         public ProjectionExpressionVisitor([NotNull] EntityQueryModelVisitor entityQueryModelVisitor)
             : base(Check.NotNull(entityQueryModelVisitor, nameof(entityQueryModelVisitor)))
         {
+        }       
+        
+        /// <summary>
+        ///     Visits the children of the <see cref="T:System.Linq.Expressions.MethodCallExpression"></see>.
+        /// </summary>
+        /// <param name="methodCallExpression">The expression to visit.</param>
+        /// <returns>
+        ///     The modified expression, if it or any subexpression was modified; otherwise, returns the original expression.
+        /// </returns>
+        protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+        {
+            var newExpression = base.VisitMethodCall(methodCallExpression);
+
+            switch (newExpression)
+            {
+                case MethodCallExpression newMethodCallExpression
+                when newMethodCallExpression.Arguments.Count > 0
+                     && newMethodCallExpression.Arguments[0] is MethodCallExpression innerMethodCallExpression
+                     && innerMethodCallExpression.Method.MethodIsClosedFormOf(QueryModelVisitor.LinqOperatorProvider.ToEnumerable)
+                     && TryFindAsyncMethod(newMethodCallExpression.Method.Name, out var asyncMethodInfo):
+                {
+                    // Transforms a sync method inside an async projector into the corresponding async version (if one exists).
+                    // We call .Result here so that the types still line up (we remove the .Result in TaskLiftingExpressionVisitor).
+
+                    return
+                        Expression.Property(
+                            ResultOperatorHandler.CallWithPossibleCancellationToken(
+                                asyncMethodInfo.MakeGenericMethod(
+                                    newMethodCallExpression.Method.GetGenericArguments()),
+                                innerMethodCallExpression.Arguments.ToArray()),
+                            nameof(Task<object>.Result));
+                }
+                case MethodCallExpression newMethodCallExpression2
+                when newMethodCallExpression2.Method
+                         .MethodIsClosedFormOf(CollectionNavigationSubqueryInjector.MaterializeCollectionNavigationMethodInfo)
+                     && newMethodCallExpression2.Arguments[1] is MethodCallExpression innerMethodCallExpression2
+                     && innerMethodCallExpression2.Method.MethodIsClosedFormOf(QueryModelVisitor.LinqOperatorProvider.ToQueryable):
+                {
+                    // Transforms a sync method inside a MaterializeCollectionNavigation call into a corresponding async version.
+                    // We call .Result here so that the types still line up (we remove the .Result in TaskLiftingExpressionVisitor).
+
+                    return
+                        innerMethodCallExpression2.Arguments[0].Type.IsGenericType
+                        && innerMethodCallExpression2.Arguments[0].Type.GetGenericTypeDefinition() == typeof(IAsyncEnumerable<>)
+                            ? (Expression) Expression.Property(
+                                ResultOperatorHandler.CallWithPossibleCancellationToken(
+                                    MaterializeCollectionNavigationAsyncMethodInfo.MakeGenericMethod(
+                                        newMethodCallExpression2.Method.GetGenericArguments()[0]),
+                                    newMethodCallExpression2.Arguments[0],
+                                    innerMethodCallExpression2.Arguments[0]),
+                                nameof(Task<object>.Result))
+                            : Expression.Call(
+                                newMethodCallExpression2.Method,
+                                newMethodCallExpression2.Arguments[0],
+                                innerMethodCallExpression2.Arguments[0]);
+                }
+            }
+
+            return newExpression;
         }
 
+        private static readonly MethodInfo MaterializeCollectionNavigationAsyncMethodInfo
+            = typeof(ProjectionExpressionVisitor).GetTypeInfo()
+                .GetDeclaredMethod(nameof(MaterializeCollectionNavigationAsync));
+
+        [UsedImplicitly]
+        private static async Task<ICollection<TEntity>> MaterializeCollectionNavigationAsync<TEntity>(
+            INavigation navigation,
+            IAsyncEnumerable<object> elements)
+        {
+            var collection = (ICollection<TEntity>) navigation.GetCollectionAccessor().Create();
+
+            await elements.ForEachAsync(e => collection.Add((TEntity) e));
+
+            return collection;
+        }
+
+        private static bool TryFindAsyncMethod(string methodName, out MethodInfo asyncMethodInfo)
+        {
+            var candidateMethods
+                = typeof(AsyncEnumerable).GetTypeInfo().GetDeclaredMethods(methodName)
+                    .Where(mi =>
+                        mi.ReturnType.IsConstructedGenericType
+                        && mi.ReturnType.GetGenericTypeDefinition() == typeof(Task<>)
+                        && mi.GetParameters().Length > 0
+                        && mi.GetParameters().Last().ParameterType == typeof(CancellationToken))
+                    .ToList();
+
+            asyncMethodInfo = candidateMethods.Count == 1 ? candidateMethods[0] : null;
+
+            return asyncMethodInfo != null;
+        }
+        
         /// <summary>
         ///     Visit a subquery.
         /// </summary>

--- a/test/EFCore.InMemory.FunctionalTests/Query/AsyncQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/AsyncQueryInMemoryTest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Threading.Tasks;
-
 namespace Microsoft.EntityFrameworkCore.Query
 {
     public class AsyncQueryInMemoryTest : AsyncQueryTestBase<NorthwindQueryInMemoryFixture>
@@ -10,13 +8,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         public AsyncQueryInMemoryTest(NorthwindQueryInMemoryFixture fixture)
             : base(fixture)
         {
-        }
-
-        public override Task ToList_on_nav_in_projection_is_async()
-        {
-            // Not valid for in-memory.
-
-            return null;
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AsyncQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AsyncQuerySqlServerTest.cs
@@ -27,40 +27,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
-        public override async Task ToList_on_nav_in_projection_is_async()
-        {
-            await base.ToList_on_nav_in_projection_is_async();
-
-            Assert.Contains(
-                @"_SelectAsync(
-            source: IAsyncEnumerable<Customer> _ShapedQuery(
-                queryContext: queryContext, 
-                shaperCommandContext: SelectExpression: 
-                    SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-                    FROM [Customers] AS [c]
-                    WHERE [c].[CustomerID] = N'ALFKI', 
-                shaper: BufferedEntityShaper<Customer>), 
-            selector: (Customer c | CancellationToken ct) => Task<<>f__AnonymousType17<Customer, List<Order>>> _ExecuteAsync(
-                taskFactories: new Func<Task<object>>[]{ () => Task<object> _ToObjectTask(Task<List<Order>> ToList((IAsyncEnumerable<Order>)EnumerableAdapter<Order> _ToEnumerable(IAsyncEnumerable<Order> _InjectParameters(
-                                    queryContext: queryContext, 
-                                    source: IAsyncEnumerable<Order> _ShapedQuery(
-                                        queryContext: queryContext, 
-                                        shaperCommandContext: SelectExpression: 
-                                            SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-                                            FROM [Orders] AS [o]
-                                            WHERE @_outer_CustomerID = [o].[CustomerID], 
-                                        shaper: BufferedEntityShaper<Order>), 
-                                    parameterNames: new string[]{ ""_outer_CustomerID"" }, 
-                                    parameterValues: new object[]{ string GetValueFromEntity(
-                                            clrPropertyGetter: ClrPropertyGetter<Customer, string>, 
-                                            entity: c) })))) }, 
-                selector: (Object[] results) => new <>f__AnonymousType17<Customer, List<Order>>(
-                    c, 
-                    (List<Order>)results[0]
-                )))",
-                Fixture.TestSqlLoggerFactory.Log);
-        }
-
         [ConditionalFact]
         public async Task Query_compiler_concurrency()
         {


### PR DESCRIPTION
Removes blocking by making async projections fully async even when nested queries are using sync operators.
