### PR TITLE
Query: Fix leaking data readers when query throws exception

### DIFF
--- a/src/EFCore.Specification.Tests/ConcurrencyDetectorTestBase.cs
+++ b/src/EFCore.Specification.Tests/ConcurrencyDetectorTestBase.cs
@@ -74,6 +74,74 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [Fact]
+        public virtual Task First_logs_concurrent_access_nonasync()
+        {
+            return ConcurrencyDetectorTest(
+                c =>
+                {
+                    var result = c.Products.First();
+                    return Task.FromResult(false);
+                });
+        }
+
+        [Fact]
+        public virtual Task First_logs_concurrent_access_async()
+        {
+            return ConcurrencyDetectorTest(c => c.Products.FirstAsync());
+        }
+
+        [Fact]
+        public virtual Task Last_logs_concurrent_access_nonasync()
+        {
+            return ConcurrencyDetectorTest(
+                c =>
+                {
+                    var result = c.Products.Last();
+                    return Task.FromResult(false);
+                });
+        }
+
+        [Fact]
+        public virtual Task Last_logs_concurrent_access_async()
+        {
+            return ConcurrencyDetectorTest(c => c.Products.LastAsync());
+        }
+
+        [Fact]
+        public virtual Task Single_logs_concurrent_access_nonasync()
+        {
+            return ConcurrencyDetectorTest(
+                c =>
+                {
+                    var result = c.Products.Single(p => p.ProductID == 1);
+                    return Task.FromResult(false);
+                });
+        }
+
+        [Fact]
+        public virtual Task Single_logs_concurrent_access_async()
+        {
+            return ConcurrencyDetectorTest(c => c.Products.SingleAsync(p => p.ProductID == 1));
+        }
+
+        [Fact]
+        public virtual Task Any_logs_concurrent_access_nonasync()
+        {
+            return ConcurrencyDetectorTest(
+                c =>
+                {
+                    var result = c.Products.Any(p => p.ProductID < 10);
+                    return Task.FromResult(false);
+                });
+        }
+
+        [Fact]
+        public virtual Task Any_logs_concurrent_access_async()
+        {
+            return ConcurrencyDetectorTest(c => c.Products.AnyAsync(p => p.ProductID < 10));
+        }
+
+        [Fact]
         public virtual Task ToList_logs_concurrent_access_nonasync()
         {
             return ConcurrencyDetectorTest(

--- a/test/EFCore.SqlServer.FunctionalTests/ConcurrencyDetectorSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ConcurrencyDetectorSqlServerTest.cs
@@ -1,8 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -11,6 +15,13 @@ namespace Microsoft.EntityFrameworkCore
         public ConcurrencyDetectorSqlServerTest(NorthwindQuerySqlServerFixture<NoopModelCustomizer> fixture)
             : base(fixture)
         {
+        }
+
+        protected override async Task ConcurrencyDetectorTest(Func<NorthwindContext, Task> test)
+        {
+            await base.ConcurrencyDetectorTest(test);
+
+            Assert.Empty(Fixture.TestSqlLoggerFactory.SqlStatements);
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -2343,7 +2343,7 @@ BEGIN
             Action<TContext> contextInitializer)
             where TContext : DbContext, IDisposable
         {
-            var testStore = SqlServerTestStore.CreateInitialized("QueryBugsTest");
+            var testStore = SqlServerTestStore.CreateInitialized("QueryBugsTest", multipleActiveResultSets: true);
 
             _options = Fixture.CreateOptions(testStore);
 

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
@@ -435,7 +435,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         {
             var builder = new SqlConnectionStringBuilder(TestEnvironment.DefaultConnection)
             {
-                MultipleActiveResultSets = multipleActiveResultSets ?? true, // #9404
+                MultipleActiveResultSets = multipleActiveResultSets ?? new Random().Next(0, 2) == 1,
                 InitialCatalog = name
             };
             if (fileName != null)


### PR DESCRIPTION
Leaks
- If Query fails while enumerating we leak data reader
- If DataReader disposing logger fails we leak data reader
  - Dispose reader before logging message
- If sync query throws due to concurrency check we leak data reader
  - Make enumerator creation more lazy by moving it inside concurrency detector check
  - If query is not run due to concurrency then no data readers will be created

Extend fix for #9074 to sync pipeline - sync queries do not create inner enumerator until needed

Fix issue #9404
QueryBugsTest need MARS=true because of running queries in parallel (using different contexts)
Introduce random MARS settings