### PR TITLE
[2.0.1] Don't use IProperty.Relational().ColumnType when we want only explicitly configured values

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -505,7 +505,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                     lines.Add($".{nameof(RelationalPropertyBuilderExtensions.HasColumnName)}({_cSharpUtilities.DelimitString(columnName)})");
                 }
 
-                var columnType = property.Relational().ColumnType;
+                var columnType = property.GetConfiguredColumnType();
 
                 if (columnType != null)
                 {

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
@@ -198,7 +198,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         private void GenerateColumnAttribute(IProperty property)
         {
             var columnName = property.Relational().ColumnName;
-            var columnType = property.Relational().ColumnType;
+            var columnType = property.GetConfiguredColumnType();
 
             var delimitedColumnName = columnName != null && columnName != property.Name ? CSharpUtilities.DelimitString(columnName) : null;
             var delimitedColumnType = columnType != null ? CSharpUtilities.DelimitString(columnType) : null;

--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -129,7 +129,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             {
                 foreach (var property in entityType.GetDeclaredProperties())
                 {
-                    var dataType = property.Relational().ColumnType;
+                    var dataType = property.GetConfiguredColumnType();
                     if (dataType != null)
                     {
                         TypeMapper.ValidateTypeName(dataType);

--- a/src/EFCore.Relational/Internal/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Internal/RelationalPropertyExtensions.cs
@@ -20,5 +20,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// </summary>
         public static string FormatColumns([NotNull] this IEnumerable<IProperty> properties)
             => "{" + string.Join(", ", properties.Select(p => "'" + p.Relational().ColumnName + "'")) + "}";
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string GetConfiguredColumnType([NotNull] this IProperty property)
+            => (string)property[RelationalAnnotationNames.ColumnType];
     }
 }

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -592,7 +592,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                            && s.GetMaxLength() == t.GetMaxLength()
                            && s.IsColumnNullable() == t.IsColumnNullable()
                            && s.IsUnicode() == t.IsUnicode()
-                           && sAnnotations.ColumnType == tAnnotations.ColumnType
+                           && s.GetConfiguredColumnType() == t.GetConfiguredColumnType()
                            && sAnnotations.ComputedColumnSql == tAnnotations.ComputedColumnSql
                            && Equals(sAnnotations.DefaultValue, tAnnotations.DefaultValue)
                            && sAnnotations.DefaultValueSql == tAnnotations.DefaultValueSql;
@@ -712,7 +712,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             bool inline = false)
         {
             columnOperation.ClrType = property.ClrType.UnwrapNullableType().UnwrapEnumType();
-            columnOperation.ColumnType = annotations.ColumnType;
+            columnOperation.ColumnType = property.GetConfiguredColumnType();
             columnOperation.MaxLength = property.GetMaxLength();
             columnOperation.IsUnicode = property.IsUnicode();
             columnOperation.IsRowVersion = property.ClrType == typeof(byte[])


### PR DESCRIPTION
Fixes #9344