### PR TITLE
RevEng: Generate names of entity types case insensitive

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpUniqueNamer.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpUniqueNamer.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
     /// </summary>
     public class CSharpUniqueNamer<T> : CSharpNamer<T>
     {
-        private readonly HashSet<string> _usedNames = new HashSet<string>();
+        private readonly HashSet<string> _usedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
@@ -82,6 +82,31 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [Fact]
+        public void Creates_entity_types_case_insensitive()
+        {
+            var info = new DatabaseModel
+            {
+                Tables =
+                {
+                    new DatabaseTable
+                    {
+                        Name = "TestTable",
+                        Columns = { IdColumn },
+                        PrimaryKey = IdPrimaryKey
+                    },
+                    new DatabaseTable
+                    {
+                        Name = "TESTTABLE",
+                        Columns = { IdColumn },
+                        PrimaryKey = IdPrimaryKey
+                    }
+                }
+            };
+            var model = _factory.Create(info);
+            Assert.Equal(2, model.GetEntityTypes().Select(et => et.Name).Distinct(StringComparer.OrdinalIgnoreCase).Count());
+        }
+
+        [Fact]
         public void Loads_column_types()
         {
             var info = new DatabaseModel


### PR DESCRIPTION
Windows file system consider file names case insensitive so entity types with same name different casing would end up overwriting other in same file
Resolves #9257
