### PR TITLE
Patch: Make Event ID values smaller so they will work with Windows EventLog

### DIFF
--- a/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.EntityFrameworkCore.Diagnostics
@@ -67,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         }
 
         private static readonly string _connectionPrefix = DbLoggerCategory.Database.Connection.Name + ".";
-        private static EventId MakeConnectionId(Id id) => new EventId((int)id, _connectionPrefix + id);
+        private static EventId MakeConnectionId(Id id) => EventIdFactory.Create((int)id, _connectionPrefix + id);
 
         /// <summary>
         ///     <para>
@@ -135,7 +137,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static readonly EventId ConnectionError = MakeConnectionId(Id.ConnectionError);
 
         private static readonly string _sqlPrefix = DbLoggerCategory.Database.Command.Name + ".";
-        private static EventId MakeCommandId(Id id) => new EventId((int)id, _sqlPrefix + id);
+        private static EventId MakeCommandId(Id id) => EventIdFactory.Create((int)id, _sqlPrefix + id);
 
         /// <summary>
         ///     <para>
@@ -177,7 +179,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static readonly EventId CommandError = MakeCommandId(Id.CommandError);
 
         private static readonly string _transactionPrefix = DbLoggerCategory.Database.Transaction.Name + ".";
-        private static EventId MakeTransactionId(Id id) => new EventId((int)id, _transactionPrefix + id);
+        private static EventId MakeTransactionId(Id id) => EventIdFactory.Create((int)id, _transactionPrefix + id);
 
         /// <summary>
         ///     <para>
@@ -284,7 +286,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static readonly EventId DataReaderDisposing = MakeCommandId(Id.DataReaderDisposing);
 
         private static readonly string _migrationsPrefix = DbLoggerCategory.Migrations.Name + ".";
-        private static EventId MakeMigrationsId(Id id) => new EventId((int)id, _migrationsPrefix + id);
+        private static EventId MakeMigrationsId(Id id) => EventIdFactory.Create((int)id, _migrationsPrefix + id);
 
         /// <summary>
         ///     <para>
@@ -379,7 +381,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static readonly EventId MigrationsNotFound = MakeMigrationsId(Id.MigrationsNotFound);
 
         private static readonly string _queryPrefix = DbLoggerCategory.Query.Name + ".";
-        private static EventId MakeQueryId(Id id) => new EventId((int)id, _queryPrefix + id);
+        private static EventId MakeQueryId(Id id) => EventIdFactory.Create((int)id, _queryPrefix + id);
 
         /// <summary>
         ///     <para>
@@ -418,7 +420,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static readonly EventId QueryPossibleExceptionWithAggregateOperator = MakeQueryId(Id.QueryPossibleExceptionWithAggregateOperator);
 
         private static readonly string _validationPrefix = DbLoggerCategory.Model.Validation.Name + ".";
-        private static EventId MakeValidationId(Id id) => new EventId((int)id, _validationPrefix + id);
+        private static EventId MakeValidationId(Id id) => EventIdFactory.Create((int)id, _validationPrefix + id);
 
         /// <summary>
         ///     <para>
@@ -445,5 +447,37 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     </para>
         /// </summary>
         public static readonly EventId BoolWithDefaultWarning = MakeValidationId(Id.BoolWithDefaultWarning);
+
+        private static class EventIdFactory
+        {
+            public static EventId Create(int id, string name)
+            {
+                if (AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Diagnostics.UseLegacyEventIds", out var isEnabled)
+                    && isEnabled)
+                {
+                    if (id >= CoreEventId.ProviderDesignBaseId)
+                    {
+                        id = MassageId(id, CoreEventId.ProviderDesignBaseId);
+                    }
+                    else if (id >= CoreEventId.ProviderBaseId)
+                    {
+                        id = MassageId(id, CoreEventId.ProviderBaseId);
+                    }
+                    else if (id >= CoreEventId.RelationalBaseId)
+                    {
+                        id = MassageId(id, CoreEventId.RelationalBaseId);
+                    }
+                    else if (id >= CoreEventId.CoreBaseId)
+                    {
+                        id = MassageId(id, CoreEventId.CoreBaseId);
+                    }
+                }
+
+                return new EventId(id, name);
+            }
+
+            private static int MassageId(int id, int baseId) => (id - baseId) + (baseId * 10);
+        }
+
     }
 }

--- a/src/EFCore.Specification.Tests/TestHelpers.cs
+++ b/src/EFCore.Specification.Tests/TestHelpers.cs
@@ -79,8 +79,16 @@ namespace Microsoft.EntityFrameworkCore
         public void TestEventLogging(
             Type eventIdType,
             Type loggerExtensionsType,
-            IDictionary<Type, Func<object>> fakeFactories)
+            IDictionary<Type, Func<object>> fakeFactories,
+            bool useLegacyIds = false)
         {
+            if (useLegacyIds)
+            {
+                // Note that we can't run the test in both modes at once because EventIds are cached.
+                // If making a change to the quirk behavior, change the default of useLegacyIds to true and re-run all tests.
+                AppContext.SetSwitch("Microsoft.EntityFrameworkCore.Diagnostics.UseLegacyEventIds", true);
+            }
+
             var eventIdFields = eventIdType.GetTypeInfo()
                 .DeclaredFields
                 .Where(p => p.FieldType == typeof(EventId))
@@ -112,6 +120,15 @@ namespace Microsoft.EntityFrameworkCore
                 }
 
                 var eventId = (EventId)eventIdField.GetValue(null);
+
+                if (useLegacyIds)
+                {
+                    Assert.InRange(eventId.Id, CoreEventId.CoreBaseId * 10, int.MaxValue);
+                }
+                else
+                {
+                    Assert.InRange(eventId.Id, CoreEventId.CoreBaseId, ushort.MaxValue);
+                }
 
                 var categoryName = Activator.CreateInstance(category).ToString();
                 Assert.Equal(categoryName + "." + eventName, eventId.Name);

--- a/src/EFCore.SqlServer/Diagnostics/SqlServerEventId.cs
+++ b/src/EFCore.SqlServer/Diagnostics/SqlServerEventId.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.EntityFrameworkCore.Diagnostics
@@ -54,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         }
 
         private static readonly string _validationPrefix = DbLoggerCategory.Model.Validation.Name + ".";
-        private static EventId MakeValidationId(Id id) => new EventId((int)id, _validationPrefix + id);
+        private static EventId MakeValidationId(Id id) => EventIdFactory.Create((int)id, _validationPrefix + id);
 
         /// <summary>
         ///     <para>
@@ -83,7 +85,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static readonly EventId ByteIdentityColumnWarning = MakeValidationId(Id.ByteIdentityColumnWarning);
 
         private static readonly string _scaffoldingPrefix = DbLoggerCategory.Scaffolding.Name + ".";
-        private static EventId MakeScaffoldingId(Id id) => new EventId((int)id, _scaffoldingPrefix + id);
+        private static EventId MakeScaffoldingId(Id id) => EventIdFactory.Create((int)id, _scaffoldingPrefix + id);
 
         /// <summary>
         ///     A column was found.
@@ -222,5 +224,36 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId SequenceFound = MakeScaffoldingId(Id.SequenceFound);
+        private static class EventIdFactory
+        {
+            public static EventId Create(int id, string name)
+            {
+                if (AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Diagnostics.UseLegacyEventIds", out var isEnabled)
+                    && isEnabled)
+                {
+                    if (id >= CoreEventId.ProviderDesignBaseId)
+                    {
+                        id = MassageId(id, CoreEventId.ProviderDesignBaseId);
+                    }
+                    else if (id >= CoreEventId.ProviderBaseId)
+                    {
+                        id = MassageId(id, CoreEventId.ProviderBaseId);
+                    }
+                    else if (id >= CoreEventId.RelationalBaseId)
+                    {
+                        id = MassageId(id, CoreEventId.RelationalBaseId);
+                    }
+                    else if (id >= CoreEventId.CoreBaseId)
+                    {
+                        id = MassageId(id, CoreEventId.CoreBaseId);
+                    }
+                }
+
+                return new EventId(id, name);
+            }
+
+            private static int MassageId(int id, int baseId) => (id - baseId) + (baseId * 10);
+        }
+
     }
 }

--- a/src/EFCore.Sqlite.Core/Diagnostics/SqliteEventId.cs
+++ b/src/EFCore.Sqlite.Core/Diagnostics/SqliteEventId.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.EntityFrameworkCore.Diagnostics
@@ -41,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         }
 
         private static readonly string _validationPrefix = DbLoggerCategory.Model.Validation.Name + ".";
-        private static EventId MakeValidationId(Id id) => new EventId((int)id, _validationPrefix + id);
+        private static EventId MakeValidationId(Id id) => EventIdFactory.Create((int)id, _validationPrefix + id);
 
         /// <summary>
         ///     <para>
@@ -70,7 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static readonly EventId SequenceConfiguredWarning = MakeValidationId(Id.SequenceConfiguredWarning);
 
         private static readonly string _scaffoldingPrefix = DbLoggerCategory.Scaffolding.Name + ".";
-        private static EventId MakeScaffoldingId(Id id) => new EventId((int)id, _scaffoldingPrefix + id);
+        private static EventId MakeScaffoldingId(Id id) => EventIdFactory.Create((int)id, _scaffoldingPrefix + id);
 
         /// <summary>
         ///     A column was found.
@@ -131,5 +133,35 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId UniqueConstraintFound = MakeScaffoldingId(Id.UniqueConstraintFound);
+        private static class EventIdFactory
+        {
+            public static EventId Create(int id, string name)
+            {
+                if (AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Diagnostics.UseLegacyEventIds", out var isEnabled)
+                    && isEnabled)
+                {
+                    if (id >= CoreEventId.ProviderDesignBaseId)
+                    {
+                        id = MassageId(id, CoreEventId.ProviderDesignBaseId);
+                    }
+                    else if (id >= CoreEventId.ProviderBaseId)
+                    {
+                        id = MassageId(id, CoreEventId.ProviderBaseId);
+                    }
+                    else if (id >= CoreEventId.RelationalBaseId)
+                    {
+                        id = MassageId(id, CoreEventId.RelationalBaseId);
+                    }
+                    else if (id >= CoreEventId.CoreBaseId)
+                    {
+                        id = MassageId(id, CoreEventId.CoreBaseId);
+                    }
+                }
+
+                return new EventId(id, name);
+            }
+
+            private static int MassageId(int id, int baseId) => (id - baseId) + (baseId * 10);
+        }
     }
 }

--- a/src/EFCore/Diagnostics/CoreEventId.cs
+++ b/src/EFCore/Diagnostics/CoreEventId.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
+using Microsoft.EntityFrameworkCore.Diagnostics.Internal;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.EntityFrameworkCore.Diagnostics
@@ -19,24 +21,36 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
     public static class CoreEventId
     {
         /// <summary>
+        ///     <para>
+        ///         The name of the switch to use with <see cref="AppContext.SetSwitch"/> to use the event ID numbers
+        ///         that were shipped with EF Core 2.0.0. These IDs are too big for use in Windows EventLog, so smaller 
+        ///         numbers were used starting with EF Core 2.0.1.
+        ///     </para>
+        ///     <para>
+        ///         Only set this switch if a tool was compiled against 2.0.0 and is explicitly using the legacy IDs.
+        ///     </para>
+        /// </summary>
+        internal const string UseLegacyEventIdsSwitch = "Microsoft.EntityFrameworkCore.Diagnostics.UseLegacyEventIds";
+
+        /// <summary>
         ///     The lower-bound for event IDs used by any Entity Framework or provider code.
         /// </summary>
-        public const int CoreBaseId = 100000;
+        public const int CoreBaseId = 10000;
 
         /// <summary>
         ///     The lower-bound for event IDs used by any relational database provider.
         /// </summary>
-        public const int RelationalBaseId = 200000;
+        public const int RelationalBaseId = 20000;
 
         /// <summary>
         ///     The lower-bound for event IDs used only by database providers.
         /// </summary>
-        public const int ProviderBaseId = 300000;
+        public const int ProviderBaseId = 30000;
 
         /// <summary>
         ///     The lower-bound for event IDs used only by database provider design-time and tooling.
         /// </summary>
-        public const int ProviderDesignBaseId = 350000;
+        public const int ProviderDesignBaseId = 35000;
 
         // Warning: These values must not change between releases.
         // Only add new values to the end of sections, never in the middle.
@@ -59,7 +73,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             PossibleUnintendedCollectionNavigationNullComparisonWarning,
             PossibleUnintendedReferenceComparisonWarning,
 
-            // Infrastucture events
+            // Infrastructure events
             SensitiveDataLoggingEnabledWarning = CoreBaseId + 400,
             ServiceProviderCreated,
             ManyServiceProvidersCreatedWarning,
@@ -67,7 +81,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         }
 
         private static readonly string _updatePrefix = DbLoggerCategory.Update.Name + ".";
-        private static EventId MakeUpdateId(Id id) => new EventId((int)id, _updatePrefix + id);
+        private static EventId MakeUpdateId(Id id) => EventIdFactory.Create((int)id, _updatePrefix + id);
 
         /// <summary>
         ///     <para>
@@ -89,7 +103,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         public static readonly EventId DuplicateDependentEntityTypeInstanceWarning = MakeUpdateId(Id.DuplicateDependentEntityTypeInstanceWarning);
 
         private static readonly string _queryPrefix = DbLoggerCategory.Query.Name + ".";
-        private static EventId MakeQueryId(Id id) => new EventId((int)id, _queryPrefix + id);
+        private static EventId MakeQueryId(Id id) => EventIdFactory.Create((int)id, _queryPrefix + id);
 
         /// <summary>
         ///     <para>
@@ -224,7 +238,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             = MakeQueryId(Id.PossibleUnintendedReferenceComparisonWarning);
 
         private static readonly string _infraPrefix = DbLoggerCategory.Infrastructure.Name + ".";
-        private static EventId MakeInfraId(Id id) => new EventId((int)id, _infraPrefix + id);
+        private static EventId MakeInfraId(Id id) => EventIdFactory.Create((int)id, _infraPrefix + id);
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/Diagnostics/Internal/EventIdFactory.cs
+++ b/src/EFCore/Diagnostics/Internal/EventIdFactory.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    internal class EventIdFactory
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static EventId Create(int id, [NotNull] string name)
+        {
+            if (AppContext.TryGetSwitch(CoreEventId.UseLegacyEventIdsSwitch, out var isEnabled)
+                && isEnabled)
+            {
+                if (id >= CoreEventId.ProviderDesignBaseId)
+                {
+                    id = MassageId(id, CoreEventId.ProviderDesignBaseId);
+                }
+                else if (id >= CoreEventId.ProviderBaseId)
+                {
+                    id = MassageId(id, CoreEventId.ProviderBaseId);
+                }
+                else if (id >= CoreEventId.RelationalBaseId)
+                {
+                    id = MassageId(id, CoreEventId.RelationalBaseId);
+                }
+                else if (id >= CoreEventId.CoreBaseId)
+                {
+                    id = MassageId(id, CoreEventId.CoreBaseId);
+                }
+            }
+
+            return new EventId(id, name);
+        }
+
+        private static int MassageId(int id, int baseId) => (id - baseId) + (baseId * 10);
+    }
+}

--- a/src/EFCore/breakingchanges.netcore.json
+++ b/src/EFCore/breakingchanges.netcore.json
@@ -1,0 +1,22 @@
+  [
+    {
+      "TypeId": "public static class Microsoft.EntityFrameworkCore.Diagnostics.CoreEventId",
+      "MemberId": "public const System.Int32 CoreBaseId = 100000",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public static class Microsoft.EntityFrameworkCore.Diagnostics.CoreEventId",
+      "MemberId": "public const System.Int32 ProviderBaseId = 300000",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public static class Microsoft.EntityFrameworkCore.Diagnostics.CoreEventId",
+      "MemberId": "public const System.Int32 ProviderDesignBaseId = 350000",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public static class Microsoft.EntityFrameworkCore.Diagnostics.CoreEventId",
+      "MemberId": "public const System.Int32 RelationalBaseId = 200000",
+      "Kind": "Removal"
+    }
+  ]

--- a/test/EFCore.SqlServer.Tests/SqlServerEventIdTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerEventIdTest.cs
@@ -32,18 +32,5 @@ namespace Microsoft.EntityFrameworkCore
                 typeof(SqlServerLoggerExtensions),
                 fakeFactories);
         }
-
-        private class FakeSequence : ISequence
-        {
-            public string Name => "SequenceName";
-            public string Schema => throw new NotImplementedException();
-            public long StartValue => throw new NotImplementedException();
-            public int IncrementBy => throw new NotImplementedException();
-            public long? MinValue => throw new NotImplementedException();
-            public long? MaxValue => throw new NotImplementedException();
-            public Type ClrType => throw new NotImplementedException();
-            public IModel Model => throw new NotImplementedException();
-            public bool IsCyclic => throw new NotImplementedException();
-        }
     }
 }


### PR DESCRIPTION
Issue #9437

All values now fit in a 16-bit unsigned int. There is a Quirks mode to switch back to the 2.0.0 RTM values.
