### PR TITLE
Fix #9433 - Using pooling for multiple DbContexts causes exception

### DIFF
--- a/src/EFCore/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EFCore/EntityFrameworkServiceCollectionExtensions.cs
@@ -164,8 +164,8 @@ namespace Microsoft.Extensions.DependencyInjection
                     },
                 ServiceLifetime.Singleton);
 
-            serviceCollection.TryAddSingleton<DbContextPool<TContext>>();
-            serviceCollection.AddScoped(p => p.GetService<DbContextPool<TContext>>().Rent());
+            serviceCollection.TryAddSingleton(sp => new DbContextPool<TContext>(sp.GetService<DbContextOptions<TContext>>()));
+            serviceCollection.AddScoped(sp => sp.GetService<DbContextPool<TContext>>().Rent());
 
             return serviceCollection;
         }

--- a/src/EFCore/Internal/DbContextPool.cs
+++ b/src/EFCore/Internal/DbContextPool.cs
@@ -30,12 +30,11 @@ namespace Microsoft.EntityFrameworkCore.Internal
         private int _count;
 
         private DbContextPoolConfigurationSnapshot _configurationSnapshot;
-
+        
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        // ReSharper disable once SuggestBaseTypeForParameter
         public DbContextPool([NotNull] DbContextOptions options)
         {
             _maxSize = options.FindExtension<CoreOptionsExtension>()?.MaxPoolSize ?? DefaultPoolSize;

--- a/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
@@ -29,6 +29,9 @@ namespace Microsoft.EntityFrameworkCore
                 .AddDbContextPool<TContext>(
                     ob => ob.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString),
                     poolSize)
+                .AddDbContextPool<SecondContext>(
+                    ob => ob.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString),
+                    poolSize)
                 .BuildServiceProvider();
 
         private class PooledContext : DbContext
@@ -71,6 +74,14 @@ namespace Microsoft.EntityFrameworkCore
             {
                 public string CustomerId { get; set; }
                 public string CompanyName { get; set; }
+            }
+        }
+
+        private class SecondContext : DbContext
+        {
+            public SecondContext(DbContextOptions options)
+                : base(options)
+            {
             }
         }
 
@@ -165,12 +176,15 @@ namespace Microsoft.EntityFrameworkCore
             var serviceScope1 = serviceProvider.CreateScope();
 
             var context1 = serviceScope1.ServiceProvider.GetService<PooledContext>();
+            var secondContext1 = serviceScope1.ServiceProvider.GetService<SecondContext>();
 
             var serviceScope2 = serviceProvider.CreateScope();
 
             var context2 = serviceScope2.ServiceProvider.GetService<PooledContext>();
+            var secondContext2 = serviceScope2.ServiceProvider.GetService<SecondContext>();
 
             Assert.NotSame(context1, context2);
+            Assert.NotSame(secondContext1, secondContext2);
 
             serviceScope1.Dispose();
             serviceScope2.Dispose();
@@ -178,14 +192,18 @@ namespace Microsoft.EntityFrameworkCore
             var serviceScope3 = serviceProvider.CreateScope();
 
             var context3 = serviceScope3.ServiceProvider.GetService<PooledContext>();
+            var secondContext3 = serviceScope3.ServiceProvider.GetService<SecondContext>();
 
             Assert.Same(context1, context3);
+            Assert.Same(secondContext1, secondContext3);
 
             var serviceScope4 = serviceProvider.CreateScope();
 
             var context4 = serviceScope4.ServiceProvider.GetService<PooledContext>();
+            var secondContext4 = serviceScope4.ServiceProvider.GetService<SecondContext>();
 
             Assert.Same(context2, context4);
+            Assert.Same(secondContext2, secondContext4);
         }
 
         [Fact]


### PR DESCRIPTION
- Adds missing DbContextOptions generic parameter.

