### PR TITLE
Fix DataReaderDisposing null connection inconsistency

### DIFF
--- a/src/EFCore.Relational/Storage/RelationalDataReader.cs
+++ b/src/EFCore.Relational/Storage/RelationalDataReader.cs
@@ -45,12 +45,13 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="commandId"> A correlation ID that identifies the <see cref="DbCommand" /> instance being used. </param>
         /// <param name="logger"> The diagnostic source. </param>
         public RelationalDataReader(
-            [CanBeNull] IRelationalConnection connection,
+            [NotNull] IRelationalConnection connection,
             [NotNull] DbCommand command,
             [NotNull] DbDataReader reader,
             Guid commandId,
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
         {
+            Check.NotNull(connection, nameof(connection));
             Check.NotNull(command, nameof(command));
             Check.NotNull(reader, nameof(reader));
             Check.NotNull(logger, nameof(logger));
@@ -68,6 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        [Obsolete("Use other constructor for testing.")]
         protected RelationalDataReader([NotNull] DbDataReader reader)
         {
             // For testing
@@ -80,6 +82,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        [Obsolete("Use other constructor for testing, passing in a fake connection.")]
         protected RelationalDataReader(
             [NotNull] DbCommand command,
             [NotNull] DbDataReader reader,
@@ -134,11 +137,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 _reader.Dispose();
                 _command.Parameters.Clear();
                 _command.Dispose();
-                _connection?.Close();
+                _connection.Close();
 
                 _logger.DataReaderDisposing(
-                    // ReSharper disable once AssignNullToNotNullAttribute
-                    // TODO: See issue#9456
                     _connection,
                     _command,
                     _reader,

--- a/test/EFCore.Sqlite.FunctionalTests/Query/BadDataSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/BadDataSqliteTest.cs
@@ -4,11 +4,15 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Data;
 using System.Data.Common;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
@@ -205,7 +209,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             DbCommand command,
                             object[] values,
                             IDiagnosticsLogger<DbLoggerCategory.Database.Command> logger)
-                            : base(command, new BadDataDataReader(values), logger)
+                            : base(new FakeConnection(), command, new BadDataDataReader(values), Guid.NewGuid(), logger)
                         {
                         }
 
@@ -351,6 +355,31 @@ namespace Microsoft.EntityFrameworkCore.Query
             badDataCommandBuilderFactory.Values = values;
 
             return context;
+        }
+
+        private class FakeConnection : IRelationalConnection
+        {
+            public void ResetState() { }
+            public IDbContextTransaction BeginTransaction() => throw new NotImplementedException();
+            public Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = default(CancellationToken)) => throw new NotImplementedException();
+            public void CommitTransaction() { }
+            public void RollbackTransaction() { }
+            public IDbContextTransaction CurrentTransaction => throw new NotImplementedException();
+            public SemaphoreSlim Semaphore { get; }
+            public void RegisterBufferable(IBufferable bufferable) { }
+            public Task RegisterBufferableAsync(IBufferable bufferable, CancellationToken cancellationToken) => throw new NotImplementedException();
+            public string ConnectionString { get; }
+            public DbConnection DbConnection { get; }
+            public Guid ConnectionId { get; }
+            public int? CommandTimeout { get; set; }
+            public bool Open(bool errorsExpected = false) => true;
+            public Task<bool> OpenAsync(CancellationToken cancellationToken, bool errorsExpected = false) => throw new NotImplementedException();
+            public bool Close() => true;
+            public bool IsMultipleActiveResultSetsEnabled { get; }
+            public IDbContextTransaction BeginTransaction(IsolationLevel isolationLevel) => throw new NotImplementedException();
+            public Task<IDbContextTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default(CancellationToken)) => throw new NotImplementedException();
+            public IDbContextTransaction UseTransaction(DbTransaction transaction) => throw new NotImplementedException();
+            public void Dispose() {}
         }
 
         public class BadDataSqliteFixture : NorthwindQuerySqliteFixture<NoopModelCustomizer>


### PR DESCRIPTION
Connection was required to be null except for some unit test scenarios, so fixed those and added NotNull.

Issue #9456 
