### PR TITLE
Query: Tuples are not translatable to Sql. Client Eval them

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -907,7 +907,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                     || fromExpression.NodeType == ExpressionType.NewArrayInit)
                 {
                     var containsItem = Visit(contains.Item)?.RemoveConvert();
-                    if (containsItem != null)
+                    if (containsItem != null && !containsItem.Type.Equals(typeof(Expression[])))
                     {
                         return new InExpression(containsItem, new[] { fromExpression });
                     }

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
@@ -866,6 +866,34 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void Contains_with_local_tuple_array_closure()
+        {
+            var ids = new[] { Tuple.Create(1, 2), Tuple.Create(10248, 11) };
+
+            AssertQuery<OrderDetail>(
+                od => od.Where(o => ids.Contains(new Tuple<int, int>(o.OrderID, o.ProductID))), entryCount: 1);
+
+            ids = new[] { Tuple.Create(1, 2) };
+
+            AssertQuery<OrderDetail>(
+                od => od.Where(o => ids.Contains(new Tuple<int, int>(o.OrderID, o.ProductID))));
+        }
+
+        [ConditionalFact]
+        public virtual void Contains_with_local_anonymous_type_array_closure()
+        {
+            var ids = new[] { new { Id1 = 1, Id2 = 2 }, new { Id1 = 10248, Id2 = 11 } };
+
+            AssertQuery<OrderDetail>(
+                od => od.Where(o => ids.Contains(new { Id1 = o.OrderID, Id2 = o.ProductID})), entryCount: 1);
+
+            ids = new[] { new { Id1 = 1, Id2 = 2 } };
+
+            AssertQuery<OrderDetail>(
+                od => od.Where(o => ids.Contains(new { Id1 = o.OrderID, Id2 = o.ProductID })));
+        }
+
+        [ConditionalFact]
         public virtual void OfType_Select()
         {
             using (var context = CreateContext())

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
@@ -823,7 +823,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (cs, es) =>
                     from c in cs
                     from e in es
-                    // ReSharper disable ArrangeRedundantParentheses
+                        // ReSharper disable ArrangeRedundantParentheses
                     where (c.City == "London" && c.Country == "UK")
                           && (e.City == "London" && e.Country == "UK")
                     select new { c, e },
@@ -1210,10 +1210,47 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
-        public virtual void Where_compare_constructed()
+        public virtual void Where_compare_tuple_constructed_equal()
         {
             AssertQuery<Customer>(
-                cs => cs.Where(c => new { x = c.City } == new { x = "London" }));
+                cs => cs.Where(c => new Tuple<string>(c.City) == new Tuple<string>("London")));
+        }
+
+        [ConditionalFact]
+        public virtual void Where_compare_tuple_constructed_multi_value_equal()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Where(c => new Tuple<string, string> (c.City, c.Country) == new Tuple<string, string>("London", "UK")));
+        }
+
+        [ConditionalFact]
+        public virtual void Where_compare_tuple_constructed_multi_value_not_equal()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Where(c => new Tuple<string, string>(c.City, c.Country) != new Tuple<string, string>("London", "UK")),
+                entryCount: 91);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_compare_tuple_create_constructed_equal()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Where(c => Tuple.Create(c.City) == Tuple.Create("London")));
+        }
+
+        [ConditionalFact]
+        public virtual void Where_compare_tuple_create_constructed_multi_value_equal()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Where(c => Tuple.Create(c.City, c.Country) == Tuple.Create("London", "UK")));
+        }
+
+        [ConditionalFact]
+        public virtual void Where_compare_tuple_create_constructed_multi_value_not_equal()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Where(c => Tuple.Create(c.City, c.Country) != Tuple.Create("London", "UK")),
+                entryCount: 91);
         }
 
         [ConditionalFact]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
@@ -886,6 +886,30 @@ SELECT CASE
 END");
         }
 
+        public override void Contains_with_local_tuple_array_closure()
+        {
+            base.Contains_with_local_tuple_array_closure();
+
+            AssertSql(
+                @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]",
+                //
+                @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]");
+        }
+
+        public override void Contains_with_local_anonymous_type_array_closure()
+        {
+            base.Contains_with_local_anonymous_type_array_closure();
+
+            AssertSql(
+                @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]",
+                //
+                @"SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
+FROM [Order Details] AS [o]");
+        }
+
         public override void OfType_Select()
         {
             base.OfType_Select();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
@@ -1296,9 +1296,54 @@ FROM [Customers] AS [c]");
 FROM [Customers] AS [c]");
         }
 
-        public override void Where_compare_constructed()
+        public override void Where_compare_tuple_constructed_equal()
         {
-            base.Where_compare_constructed();
+            base.Where_compare_tuple_constructed_equal();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+        }
+
+        public override void Where_compare_tuple_constructed_multi_value_equal()
+        {
+            base.Where_compare_tuple_constructed_multi_value_equal();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+        }
+
+        public override void Where_compare_tuple_constructed_multi_value_not_equal()
+        {
+            base.Where_compare_tuple_constructed_multi_value_not_equal();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+        }
+
+        public override void Where_compare_tuple_create_constructed_equal()
+        {
+            base.Where_compare_tuple_create_constructed_equal();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+        }
+
+        public override void Where_compare_tuple_create_constructed_multi_value_equal()
+        {
+            base.Where_compare_tuple_create_constructed_multi_value_equal();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+        }
+
+        public override void Where_compare_tuple_create_constructed_multi_value_not_equal()
+        {
+            base.Where_compare_tuple_create_constructed_multi_value_not_equal();
 
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]


### PR DESCRIPTION
Fixes #9424
