### PR TITLE
[2.0.1/TINY] Fix to #9038 - NullReferenceException when using TPH Inheritance

### DIFF
--- a/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTreeNode.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTreeNode.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Extensions.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -302,7 +303,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         Expression.Block(
                             blockType,
                             blockExpressions),
-                        Expression.Default(blockType),
+                        blockType == typeof(Task)
+                            ? Expression.Constant(Task.CompletedTask)
+                            : (Expression)Expression.Default(blockType),
                         blockType);
             }
 


### PR DESCRIPTION
Problem was that for the fixup for _IncludeAsync method would sometimes return default(Task) (i.e. null) if there was nothing to include. This breaks the async pattern, which is expecting a Task. Fix is to return Task.CompletedTask instead.