### PR TITLE
Ensure .NET Core 1.1.2 is installed for the benchmarks project

### DIFF
--- a/benchmarks/EFCore.Benchmarks.EFCore1/EFCore.Benchmarks.EFCore1.csproj
+++ b/benchmarks/EFCore.Benchmarks.EFCore1/EFCore.Benchmarks.EFCore1.csproj
@@ -7,6 +7,8 @@
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">netcoreapp1.1</TargetFrameworks>
     <RootNamespace>Microsoft.EntityFrameworkCore.Benchmarks.EFCore1</RootNamespace>
     <OutputType>Exe</OutputType>
+    <!-- Sets the exact version of Microsoft.NETCore.App to be used -->
+    <RuntimeFrameworkVersion Condition="'$(TargetFramework)' == 'netcoreapp1.1'">1.1.2</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/repo.props
+++ b/build/repo.props
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <!-- Used in the EFCore1 benchmarks project -->
-    <DotNetCoreRuntime Include="1.1.2" />
+    <!-- Only required when preparing to run the EFCore1 benchmarks project -->
+    <DotNetCoreRuntime Include="1.1.2" Condition=" '$(IsBuildingBenchmarks)' == 'true' " />
 
     <ExcludeFromTest Include="$(RepositoryRoot)test\EFCore.Benchmarks.EFCore\*.csproj" />
     <ExcludeFromTest Include="$(RepositoryRoot)test\EFCore.SqlServer.FunctionalTests\*.csproj" Condition="'$(TRAVIS)' == 'true'" />

--- a/build/repo.props
+++ b/build/repo.props
@@ -5,6 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Used in the EFCore1 benchmarks project -->
+    <DotNetCoreRuntime Include="1.1.2" />
+
     <ExcludeFromTest Include="$(RepositoryRoot)test\EFCore.Benchmarks.EFCore\*.csproj" />
     <ExcludeFromTest Include="$(RepositoryRoot)test\EFCore.SqlServer.FunctionalTests\*.csproj" Condition="'$(TRAVIS)' == 'true'" />
     <ExcludeFromTest Include="$(RepositoryRoot)test\EFCore.SqlServer.Design.FunctionalTests\*.csproj" Condition="'$(TRAVIS)' == 'true'" />


### PR DESCRIPTION
Pretty soon, we will stop installing .NET Core 1.1 and 1.0 by default in the dev branch of KoreBuild. EFCore1 benchmarks still uses netcoreapp1.1. This specifies the required dependency on .NET Core 1.1.2 so it can be installed by KoreBuild.

Usage: to ensure all runtimes are installed, execute `build.sh /t:InstallDotnet`.

cref https://github.com/aspnet/BuildTools/issues/347