### PR TITLE
Improving fix for #9038 - NullReferenceException when using TPH Inheritance

### DIFF
--- a/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTreeNode.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTreeNode.cs
@@ -303,10 +303,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         Expression.Block(
                             blockType,
                             blockExpressions),
-                        blockType == typeof(Task) 
-                            && (!AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Query.UseLegacyAsyncInclude", out var isEnabled) || !isEnabled)
-                            ? Expression.Constant(Task.CompletedTask)
-                            : (Expression)Expression.Default(blockType),
+                        Expression.Default(blockType),
                         blockType);
             }
 

--- a/src/EFCore/Query/Internal/IncludeCompiler.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.cs
@@ -220,7 +220,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         {
             if (entity != null)
             {
-                await fixup(queryContext, entity, included, cancellationToken);
+                var fixupTask = fixup(queryContext, entity, included, cancellationToken);
+                if (AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Query.UseLegacyAsyncInclude", out var isEnabled) && isEnabled
+                    || fixupTask != null)
+                {
+                    await fixupTask;
+                }
             }
 
             return entity;


### PR DESCRIPTION
Instead of modifying the Task that we return from the problematic query, we are checking if the resulting fixup Task is null and only await on it if it's not.