### PR TITLE
Query: Unwrap AliasExpression while adding orderby to projection in R…

### DIFF
--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -3975,5 +3975,19 @@ namespace Microsoft.EntityFrameworkCore.Query
                         OuterOrders = c.Orders.Count(o => c.Orders.Count() > 0)
                     }));
         }
+
+        [ConditionalFact]
+        public virtual void OrderBy_Dto_projection_skip_take()
+        {
+            AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.CustomerID)
+                    .Select(c => new
+                    {
+                        Id = c.CustomerID
+                    })
+                    .Skip(5)
+                    .Take(10),
+                elementSorter: e => e.Id);
+        }
     }
 }

--- a/src/EFCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
+++ b/src/EFCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
@@ -177,7 +177,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
 
                 var innerRowNumberExpression = new AliasExpression(
                     RowNumberColumnName + (_counter != 0 ? $"{_counter}" : ""),
-                    new RowNumberExpression(subQuery.OrderBy));
+                    new RowNumberExpression(subQuery.OrderBy
+                        .Select(o => new Ordering(
+                            o.Expression is AliasExpression ae ? ae.Expression : o.Expression,
+                            o.OrderingDirection))
+                        .ToList()));
 
                 _counter++;
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/RowNumberPagingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/RowNumberPagingTest.cs
@@ -855,6 +855,22 @@ FROM (
 ) AS [t]");
         }
 
+        public override void OrderBy_Dto_projection_skip_take()
+        {
+            base.OrderBy_Dto_projection_skip_take();
+
+            AssertSql(
+                @"@__p_0='5'
+@__p_1='10'
+
+SELECT [t].[Id]
+FROM (
+    SELECT [c].[CustomerID] AS [Id], ROW_NUMBER() OVER(ORDER BY [c].[CustomerID]) AS [__RowNumber__]
+    FROM [Customers] AS [c]
+) AS [t]
+WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_1))");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -4295,6 +4295,20 @@ FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = N'ALFKI'");
         }
 
+        public override void OrderBy_Dto_projection_skip_take()
+        {
+            base.OrderBy_Dto_projection_skip_take();
+
+            AssertSql(
+                @"@__p_0='5'
+@__p_1='10'
+
+SELECT [c].[CustomerID] AS [Id]
+FROM [Customers] AS [c]
+ORDER BY [Id]
+OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
…owNumberPagingExpressionVisitor

Issue: When converting OFFSET to RowNumber we move order by to projection. OrderBy allows refering to projection by their alias but in projection you cannot refer to another projection by its alias
Solution: We need to unwrap the alias expression in order by when adding to projection so projection expression will print inner expression rather than the alias

Resolves #9535
