### PR TITLE
Update appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,9 +14,9 @@ branches:
     - master
     - release
     - dev
-    - /^rel\/.*/
-    - /^feature\/.*/
-    - /^(.*\/)?ci-.*$/
+    - /rel\/.*/
+    - /feature\/.*/
+    - /(.*\/)?ci-.*$/
 environment:
   global:
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true


### PR DESCRIPTION
Fix regular expression used for branch matching

It seems that appveyor is not building any branches matched by regex for us. Probably seems like our regex was incorrect. This change may not work but testing it out.

I will merge PR if appveyor/travis passes.
