### PR TITLE
Allow a global (app-domain) in-memory store

### DIFF
--- a/src/EFCore.InMemory/Extensions/InMemoryServiceCollectionExtensions.cs
+++ b/src/EFCore.InMemory/Extensions/InMemoryServiceCollectionExtensions.cs
@@ -66,8 +66,10 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAdd<IEntityQueryModelVisitorFactory, InMemoryQueryModelVisitorFactory>()
                 .TryAdd<IEntityQueryableExpressionVisitorFactory, InMemoryEntityQueryableExpressionVisitorFactory>()
                 .TryAdd<IEvaluatableExpressionFilter, EvaluatableExpressionFilter>()
+                .TryAdd<ISingletonOptions, IInMemorySingletonOptions>(p => p.GetService<IInMemorySingletonOptions>())
                 .TryAddProviderSpecificServices(
                     b => b
+                        .TryAddSingleton<IInMemorySingletonOptions, InMemorySingletonOptions>()
                         .TryAddSingleton<IInMemoryStoreCache, InMemoryStoreCache>()
                         .TryAddSingleton<IInMemoryTableFactory, InMemoryTableFactory>()
                         .TryAddScoped<IInMemoryDatabase, InMemoryDatabase>()

--- a/src/EFCore.InMemory/Infrastructure/Internal/IInMemorySingletonOptions.cs
+++ b/src/EFCore.InMemory/Infrastructure/Internal/IInMemorySingletonOptions.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public interface IInMemorySingletonOptions : ISingletonOptions
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        bool UseGlobalDatabase { get; }
+    }
+}

--- a/src/EFCore.InMemory/Infrastructure/Internal/InMemoryOptionsExtension.cs
+++ b/src/EFCore.InMemory/Infrastructure/Internal/InMemoryOptionsExtension.cs
@@ -15,6 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal
     public class InMemoryOptionsExtension : IDbContextOptionsExtension
     {
         private string _storeName;
+        private bool _useGlobalDatabase;
         private string _logFragment;
 
         /// <summary>
@@ -63,6 +64,25 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public virtual bool UseGlobalDatabase => _useGlobalDatabase;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual InMemoryOptionsExtension WithGlobalDatabase(bool useGlobalDatabase = true)
+        {
+            var clone = Clone();
+
+            clone._useGlobalDatabase = useGlobalDatabase;
+
+            return clone;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual bool ApplyServices(IServiceCollection services)
         {
             Check.NotNull(services, nameof(services));
@@ -76,7 +96,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual long GetServiceProviderHashCode() => 0;
+        public virtual long GetServiceProviderHashCode() => _useGlobalDatabase.GetHashCode();
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.InMemory/Infrastructure/Internal/InMemorySingletonOptions.cs
+++ b/src/EFCore.InMemory/Infrastructure/Internal/InMemorySingletonOptions.cs
@@ -1,0 +1,53 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class InMemorySingletonOptions : IInMemorySingletonOptions
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void Initialize(IDbContextOptions options)
+        {
+            var inMemoryOptions = options.FindExtension<InMemoryOptionsExtension>();
+
+            if (inMemoryOptions != null)
+            {
+                UseGlobalDatabase = inMemoryOptions.UseGlobalDatabase;
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void Validate(IDbContextOptions options)
+        {
+            var inMemoryOptions = options.FindExtension<InMemoryOptionsExtension>();
+
+            if (inMemoryOptions != null
+                && UseGlobalDatabase != inMemoryOptions.UseGlobalDatabase)
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.SingletonOptionChanged(
+                        nameof(InMemoryDbContextOptionsExtensions.UseInMemoryDatabase),
+                        nameof(DbContextOptionsBuilder.UseInternalServiceProvider)));
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual bool UseGlobalDatabase { get; private set; }
+    }
+}

--- a/test/EFCore.InMemory.FunctionalTests/GlobalDatabaseTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/GlobalDatabaseTest.cs
@@ -1,0 +1,166 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class GlobalDatabaseTest
+    {
+        [Fact]
+        public void Different_stores_are_used_when_options_force_different_internal_service_provider()
+        {
+            using (var context = new BooFooContext(
+                new DbContextOptionsBuilder()
+                    .UseInMemoryDatabase(nameof(BooFooContext))
+                    .Options))
+            {
+                context.Add(new Foo());
+                context.SaveChanges();
+            }
+
+            using (var context = new BooFooContext(
+                new DbContextOptionsBuilder()
+                    .UseInMemoryDatabase(nameof(BooFooContext))
+                    .EnableSensitiveDataLogging()
+                    .Options))
+            {
+                Assert.Empty(context.Foos.ToList());
+            }
+        }
+
+        [Fact]
+        public void Different_stores_are_used_when_AddDbContext_force_different_internal_service_provider()
+        {
+            using (var context = new BooFooContext(
+                new DbContextOptionsBuilder()
+                    .UseInMemoryDatabase(nameof(BooFooContext))
+                    .Options))
+            {
+                context.Add(new Foo());
+                context.SaveChanges();
+            }
+
+            var serviceProvider = new ServiceCollection()
+                .AddDbContext<BooFooContext>(
+                    b => b.UseInMemoryDatabase(nameof(BooFooContext)))
+                .BuildServiceProvider();
+
+            using (var scope = serviceProvider.CreateScope())
+            {
+                var context = scope.ServiceProvider.GetService<BooFooContext>();
+                Assert.Empty(context.Foos.ToList());
+            }
+        }
+
+        [Fact]
+        public void Global_store_can_be_used_when_options_force_different_internal_service_provider()
+        {
+            using (var context = new BooFooContext(
+                new DbContextOptionsBuilder()
+                    .UseInMemoryDatabase(nameof(BooFooContext), useGlobalDatabase: true)
+                    .Options))
+            {
+                context.Add(new Foo());
+                context.SaveChanges();
+            }
+
+            using (var context = new BooFooContext(
+                new DbContextOptionsBuilder()
+                    .UseInMemoryDatabase(nameof(BooFooContext), useGlobalDatabase: true)
+                    .EnableSensitiveDataLogging()
+                    .Options))
+            {
+                Assert.Equal(1, context.Foos.Count());
+            }
+        }
+
+        [Fact]
+        public void Global_store_can_be_used_when_AddDbContext_force_different_internal_service_provider()
+        {
+            using (var context = new BooFooContext(
+                new DbContextOptionsBuilder()
+                    .UseInMemoryDatabase(nameof(BooFooContext), useGlobalDatabase: true)
+                    .Options))
+            {
+                context.Add(new Boo());
+                context.SaveChanges();
+            }
+
+            var serviceProvider = new ServiceCollection()
+                .AddDbContext<BooFooContext>(
+                    b => b.UseInMemoryDatabase(nameof(BooFooContext), useGlobalDatabase: true))
+                .BuildServiceProvider();
+
+            using (var scope = serviceProvider.CreateScope())
+            {
+                var context = scope.ServiceProvider.GetService<BooFooContext>();
+                Assert.Equal(1, context.Boos.Count());
+            }
+        }
+
+        [Fact]
+        public void Throws_changing_global_store_in_OnConfiguring_when_UseInternalServiceProvider()
+        {
+            using (var context = new ChangeSdlCacheContext(false))
+            {
+                _ = context.Model;
+            }
+
+            using (var context = new ChangeSdlCacheContext(true))
+            {
+                Assert.Equal(
+                    CoreStrings.SingletonOptionChanged(
+                        nameof(InMemoryDbContextOptionsExtensions.UseInMemoryDatabase),
+                        nameof(DbContextOptionsBuilder.UseInternalServiceProvider)),
+                    Assert.Throws<InvalidOperationException>(() => context.Model).Message);
+            }
+        }
+
+        private class ChangeSdlCacheContext : DbContext
+        {
+            private static readonly IServiceProvider _serviceProvider
+                = new ServiceCollection()
+                    .AddEntityFrameworkInMemoryDatabase()
+                    .BuildServiceProvider();
+
+            private readonly bool _on;
+
+            public ChangeSdlCacheContext(bool on)
+            {
+                _on = on;
+            }
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder
+                    .UseInternalServiceProvider(_serviceProvider)
+                    .UseInMemoryDatabase(nameof(ChangeSdlCacheContext), _on);
+        }
+
+
+        private class BooFooContext : DbContext
+        {
+            public BooFooContext(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            public DbSet<Foo> Foos { get; set; }
+            public DbSet<Boo> Boos { get; set; }
+        }
+
+        private class Foo
+        {
+            public int Id { get; set; }
+        }
+
+        private class Boo
+        {
+            public int Id { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Issue #9613

The internal service provider created by AddDbContext is typically different than the one created when `new` is used. This is because AddDbContext automatically sets ILoggerFactory, etc. from the application service provider, while `new` does not have access to this and so uses a different ILoggerFactory. The same thing can happen with other 'singleton options' like EnableSensitiveDataLogging.

For the in-memory database, this has two consequences:
* Since the store is rooted in the service provider, a new store is created when a situation like above forces a new internal service provider
* Since the store uses `IEntityType` instances to key its table dictionary, these instances must come from the same model to match, which is typically not the case when the model is built twice; once for each service provider

This fix adds a new flag to UseInMemoryDatabase such that the database will really be created globally (i.e. once per app domain) and entity type names are uses as keys instead of IEntityType instances. This could result in memory leaks, but this can be mitigated by seeding with well-known for the test, and/or calling EnsureDeleted appropriately to clean out the data.