### PR TITLE
Allow passing a root for in-memory databases

### DIFF
--- a/src/EFCore.InMemory/Extensions/InMemoryServiceCollectionExtensions.cs
+++ b/src/EFCore.InMemory/Extensions/InMemoryServiceCollectionExtensions.cs
@@ -66,8 +66,10 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAdd<IEntityQueryModelVisitorFactory, InMemoryQueryModelVisitorFactory>()
                 .TryAdd<IEntityQueryableExpressionVisitorFactory, InMemoryEntityQueryableExpressionVisitorFactory>()
                 .TryAdd<IEvaluatableExpressionFilter, EvaluatableExpressionFilter>()
+                .TryAdd<ISingletonOptions, IInMemorySingletonOptions>(p => p.GetService<IInMemorySingletonOptions>())
                 .TryAddProviderSpecificServices(
                     b => b
+                        .TryAddSingleton<IInMemorySingletonOptions, InMemorySingletonOptions>()
                         .TryAddSingleton<IInMemoryStoreCache, InMemoryStoreCache>()
                         .TryAddSingleton<IInMemoryTableFactory, InMemoryTableFactory>()
                         .TryAddScoped<IInMemoryDatabase, InMemoryDatabase>()

--- a/src/EFCore.InMemory/Infrastructure/Internal/IInMemorySingletonOptions.cs
+++ b/src/EFCore.InMemory/Infrastructure/Internal/IInMemorySingletonOptions.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public interface IInMemorySingletonOptions : ISingletonOptions
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        InMemoryDatabaseRoot DatabaseRoot { get; }
+    }
+}

--- a/src/EFCore.InMemory/Infrastructure/Internal/InMemoryOptionsExtension.cs
+++ b/src/EFCore.InMemory/Infrastructure/Internal/InMemoryOptionsExtension.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -15,6 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal
     public class InMemoryOptionsExtension : IDbContextOptionsExtension
     {
         private string _storeName;
+        private InMemoryDatabaseRoot _databaseRoot;
         private string _logFragment;
 
         /// <summary>
@@ -32,6 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal
         protected InMemoryOptionsExtension([NotNull] InMemoryOptionsExtension copyFrom)
         {
             _storeName = copyFrom._storeName;
+            _databaseRoot = copyFrom._databaseRoot;
         }
 
         /// <summary>
@@ -63,6 +66,25 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public virtual InMemoryDatabaseRoot DatabaseRoot => _databaseRoot;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual InMemoryOptionsExtension WithDatabaseRoot([NotNull] InMemoryDatabaseRoot databaseRoot)
+        {
+            var clone = Clone();
+
+            clone._databaseRoot = databaseRoot;
+
+            return clone;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual bool ApplyServices(IServiceCollection services)
         {
             Check.NotNull(services, nameof(services));
@@ -76,7 +98,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual long GetServiceProviderHashCode() => 0;
+        public virtual long GetServiceProviderHashCode() => _databaseRoot?.GetHashCode() ?? 0L;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.InMemory/Infrastructure/Internal/InMemorySingletonOptions.cs
+++ b/src/EFCore.InMemory/Infrastructure/Internal/InMemorySingletonOptions.cs
@@ -1,0 +1,54 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class InMemorySingletonOptions : IInMemorySingletonOptions
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void Initialize(IDbContextOptions options)
+        {
+            var inMemoryOptions = options.FindExtension<InMemoryOptionsExtension>();
+
+            if (inMemoryOptions != null)
+            {
+                DatabaseRoot = inMemoryOptions.DatabaseRoot;
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void Validate(IDbContextOptions options)
+        {
+            var inMemoryOptions = options.FindExtension<InMemoryOptionsExtension>();
+
+            if (inMemoryOptions != null
+                && DatabaseRoot != inMemoryOptions.DatabaseRoot)
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.SingletonOptionChanged(
+                        nameof(InMemoryDbContextOptionsExtensions.UseInMemoryDatabase),
+                        nameof(DbContextOptionsBuilder.UseInternalServiceProvider)));
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual InMemoryDatabaseRoot DatabaseRoot { get; private set; }
+    }
+}

--- a/src/EFCore.InMemory/Storage/InMemoryDatabaseRoot.cs
+++ b/src/EFCore.InMemory/Storage/InMemoryDatabaseRoot.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    /// <summary>
+    ///     Acts as a root for all in-memory databases such that they will be available
+    ///     across context instances and service providers as long as the same instance
+    ///     of this type is passed to
+    ///     <see
+    ///         cref="InMemoryDbContextOptionsExtensions.UseInMemoryDatabase{TContext}(DbContextOptionsBuilder{TContext},string,System.Action{Infrastructure.InMemoryDbContextOptionsBuilder})" />
+    /// </summary>
+    public sealed class InMemoryDatabaseRoot
+    {
+        /// <summary>
+        ///     Entity Framework code will set this instance as needed. It should be considered opaque to
+        ///     application code. The type of object may change at any time.
+        /// </summary>
+        public object Instance;
+    }
+}

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryStoreCache.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryStoreCache.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Threading;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
 {
@@ -15,18 +16,43 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
     public class InMemoryStoreCache : IInMemoryStoreCache
     {
         private readonly IInMemoryTableFactory _tableFactory;
-
-        private readonly Lazy<ConcurrentDictionary<string, IInMemoryStore>> _namedStores
-            = new Lazy<ConcurrentDictionary<string, IInMemoryStore>>(
-                () => new ConcurrentDictionary<string, IInMemoryStore>(), LazyThreadSafetyMode.PublicationOnly);
+        private readonly bool _useNameMatching;
+        private readonly ConcurrentDictionary<string, IInMemoryStore> _namedStores;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        [Obsolete("Use the constructor that also accepts options.")]
         public InMemoryStoreCache([NotNull] IInMemoryTableFactory tableFactory)
+            : this(tableFactory, null)
+        {
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public InMemoryStoreCache(
+            [NotNull] IInMemoryTableFactory tableFactory, 
+            [CanBeNull] IInMemorySingletonOptions options)
         {
             _tableFactory = tableFactory;
+
+            if (options?.DatabaseRoot != null)
+            {
+                _useNameMatching = true;
+
+                LazyInitializer.EnsureInitialized(
+                    ref options.DatabaseRoot.Instance,
+                    () => new ConcurrentDictionary<string, IInMemoryStore>());
+
+                _namedStores = (ConcurrentDictionary<string, IInMemoryStore>)options.DatabaseRoot.Instance;
+            }
+            else
+            {
+                _namedStores = new ConcurrentDictionary<string, IInMemoryStore>();
+            }
         }
 
         /// <summary>
@@ -34,6 +60,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual IInMemoryStore GetStore(string name)
-            => _namedStores.Value.GetOrAdd(name, n => new InMemoryStore(_tableFactory));
+            => _namedStores.GetOrAdd(name, n => new InMemoryStore(_tableFactory, _useNameMatching));
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/GlobalDatabaseTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/GlobalDatabaseTest.cs
@@ -1,0 +1,168 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class GlobalDatabaseTest
+    {
+        private static readonly InMemoryDatabaseRoot _databaseRoot = new InMemoryDatabaseRoot();
+
+        [Fact]
+        public void Different_stores_are_used_when_options_force_different_internal_service_provider()
+        {
+            using (var context = new BooFooContext(
+                new DbContextOptionsBuilder()
+                    .UseInMemoryDatabase(nameof(BooFooContext))
+                    .Options))
+            {
+                context.Add(new Foo());
+                context.SaveChanges();
+            }
+
+            using (var context = new BooFooContext(
+                new DbContextOptionsBuilder()
+                    .UseInMemoryDatabase(nameof(BooFooContext))
+                    .EnableSensitiveDataLogging()
+                    .Options))
+            {
+                Assert.Empty(context.Foos.ToList());
+            }
+        }
+
+        [Fact]
+        public void Different_stores_are_used_when_AddDbContext_force_different_internal_service_provider()
+        {
+            using (var context = new BooFooContext(
+                new DbContextOptionsBuilder()
+                    .UseInMemoryDatabase(nameof(BooFooContext))
+                    .Options))
+            {
+                context.Add(new Foo());
+                context.SaveChanges();
+            }
+
+            var serviceProvider = new ServiceCollection()
+                .AddDbContext<BooFooContext>(
+                    b => b.UseInMemoryDatabase(nameof(BooFooContext)))
+                .BuildServiceProvider();
+
+            using (var scope = serviceProvider.CreateScope())
+            {
+                var context = scope.ServiceProvider.GetService<BooFooContext>();
+                Assert.Empty(context.Foos.ToList());
+            }
+        }
+
+        [Fact]
+        public void Global_store_can_be_used_when_options_force_different_internal_service_provider()
+        {
+            using (var context = new BooFooContext(
+                new DbContextOptionsBuilder()
+                    .UseInMemoryDatabase(nameof(BooFooContext), _databaseRoot)
+                    .Options))
+            {
+                context.Add(new Foo());
+                context.SaveChanges();
+            }
+
+            using (var context = new BooFooContext(
+                new DbContextOptionsBuilder()
+                    .UseInMemoryDatabase(nameof(BooFooContext), _databaseRoot)
+                    .EnableSensitiveDataLogging()
+                    .Options))
+            {
+                Assert.Equal(1, context.Foos.Count());
+            }
+        }
+
+        [Fact]
+        public void Global_store_can_be_used_when_AddDbContext_force_different_internal_service_provider()
+        {
+            using (var context = new BooFooContext(
+                new DbContextOptionsBuilder()
+                    .UseInMemoryDatabase(nameof(BooFooContext), _databaseRoot)
+                    .Options))
+            {
+                context.Add(new Boo());
+                context.SaveChanges();
+            }
+
+            var serviceProvider = new ServiceCollection()
+                .AddDbContext<BooFooContext>(
+                    b => b.UseInMemoryDatabase(nameof(BooFooContext), _databaseRoot))
+                .BuildServiceProvider();
+
+            using (var scope = serviceProvider.CreateScope())
+            {
+                var context = scope.ServiceProvider.GetService<BooFooContext>();
+                Assert.Equal(1, context.Boos.Count());
+            }
+        }
+
+        [Fact]
+        public void Throws_changing_global_store_in_OnConfiguring_when_UseInternalServiceProvider()
+        {
+            using (var context = new ChangeSdlCacheContext(false))
+            {
+                _ = context.Model;
+            }
+
+            using (var context = new ChangeSdlCacheContext(true))
+            {
+                Assert.Equal(
+                    CoreStrings.SingletonOptionChanged(
+                        nameof(InMemoryDbContextOptionsExtensions.UseInMemoryDatabase),
+                        nameof(DbContextOptionsBuilder.UseInternalServiceProvider)),
+                    Assert.Throws<InvalidOperationException>(() => context.Model).Message);
+            }
+        }
+
+        private class ChangeSdlCacheContext : DbContext
+        {
+            private static readonly IServiceProvider _serviceProvider
+                = new ServiceCollection()
+                    .AddEntityFrameworkInMemoryDatabase()
+                    .BuildServiceProvider();
+
+            private readonly bool _on;
+
+            public ChangeSdlCacheContext(bool on)
+            {
+                _on = on;
+            }
+
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder
+                    .UseInternalServiceProvider(_serviceProvider)
+                    .UseInMemoryDatabase(nameof(ChangeSdlCacheContext), _on ? _databaseRoot : null);
+        }
+
+        private class BooFooContext : DbContext
+        {
+            public BooFooContext(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            public DbSet<Foo> Foos { get; set; }
+            public DbSet<Boo> Boos { get; set; }
+        }
+
+        private class Foo
+        {
+            public int Id { get; set; }
+        }
+
+        private class Boo
+        {
+            public int Id { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Alternate fix for issue #9613

The internal service provider created by AddDbContext is typically different than the one created when `new` is used. This is because AddDbContext automatically sets ILoggerFactory, etc. from the application service provider, while `new` does not have access to this and so uses a different ILoggerFactory. The same thing can happen with other 'singleton options' like EnableSensitiveDataLogging.

For the in-memory database, this has two consequences:
* Since the store is rooted in the service provider, a new store is created when a situation like above forces a new internal service provider
* Since the store uses `IEntityType` instances to key its table dictionary, these instances must come from the same model to match, which is typically not the case when the model is built twice; once for each service provider

This fix adds a new object that can be passed to UseInMemoryDatabase such that the database can be rooted globally, however the application wishes. Entity type names are uses as keys instead of IEntityType instances.
