### PR TITLE
RevEng: More internal refactoring

### DIFF
--- a/src/EFCore.Design/Design/Internal/DatabaseOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DatabaseOperations.cs
@@ -65,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
 
             var services = _servicesBuilder.Build(provider);
 
-            var generator = services.GetRequiredService<IModelScaffolder>();
+            var generator = services.GetRequiredService<IReverseEngineerScaffolder>();
 
             return generator.Generate(
                 connectionString,

--- a/src/EFCore.Design/Scaffolding/Internal/IReverseEngineerScaffolder.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/IReverseEngineerScaffolder.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IModelScaffolder
+    public interface IReverseEngineerScaffolder
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Design/Scaffolding/Internal/IScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/IScaffoldingModelFactory.cs
@@ -1,9 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
 
 namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 {
@@ -17,6 +17,6 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        IModel Create([NotNull] string connectionString, [NotNull] IEnumerable<string> tables, [NotNull] IEnumerable<string> schemas, bool useDatabaseNames);
+        IModel Create([NotNull] DatabaseModel databaseModel, bool useDatabaseNames);
     }
 }

--- a/src/EFCore.Design/Scaffolding/Internal/ReverseEngineerScaffolder.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/ReverseEngineerScaffolder.cs
@@ -18,8 +18,9 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class ModelScaffolder : IModelScaffolder
+    public class ReverseEngineerScaffolder : IReverseEngineerScaffolder
     {
+        private readonly IDatabaseModelFactory _databaseModelFactory;
         private readonly IScaffoldingModelFactory _factory;
         private readonly ICSharpUtilities _cSharpUtilities;
         private static readonly char[] _directorySeparatorChars = { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar };
@@ -30,14 +31,17 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public ModelScaffolder(
+        public ReverseEngineerScaffolder(
+            [NotNull] IDatabaseModelFactory databaseModelFactory,
             [NotNull] IScaffoldingModelFactory scaffoldingModelFactory,
             [NotNull] IScaffoldingCodeGenerator scaffoldingCodeGenerator,
             [NotNull] ICSharpUtilities cSharpUtilities)
         {
+            Check.NotNull(databaseModelFactory, nameof(databaseModelFactory));
             Check.NotNull(scaffoldingModelFactory, nameof(scaffoldingModelFactory));
             Check.NotNull(scaffoldingCodeGenerator, nameof(scaffoldingCodeGenerator));
 
+            _databaseModelFactory = databaseModelFactory;
             _factory = scaffoldingModelFactory;
             ScaffoldingCodeGenerator = scaffoldingCodeGenerator;
             _cSharpUtilities = cSharpUtilities;
@@ -79,7 +83,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                     DesignStrings.ContextClassNotValidCSharpIdentifier(contextName));
             }
 
-            var model = _factory.Create(connectionString, tables, schemas, useDatabaseNames);
+            var databaseModel = _databaseModelFactory.Create(connectionString, tables, schemas);
+            var model = _factory.Create(databaseModel, useDatabaseNames);
 
             if (model == null)
             {

--- a/src/EFCore.Design/Scaffolding/Internal/ScaffoldingServiceCollectionExtensions.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/ScaffoldingServiceCollectionExtensions.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 .AddSingleton<AnnotationCodeGeneratorDependencies>()
                 .AddSingleton<IFileService, FileSystemFileService>()
                 .AddSingleton<RelationalTypeMapperDependencies>()
-                .AddSingleton<IModelScaffolder, ModelScaffolder>()
+                .AddSingleton<IReverseEngineerScaffolder, ReverseEngineerScaffolder>()
                 .AddSingleton<ICandidateNamingService, CandidateNamingService>()
                 .AddSingleton<IPluralizer, NullPluralizer>()
                 .AddSingleton<ICSharpUtilities, CSharpUtilities>()

--- a/src/EFCore.Design/Scaffolding/Internal/ScaffoldingTypeMapper.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/ScaffoldingTypeMapper.cs
@@ -14,6 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
     /// </summary>
     public class ScaffoldingTypeMapper : IScaffoldingTypeMapper
     {
+        private readonly IRelationalTypeMapper _typeMapper;
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
@@ -22,14 +24,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         {
             Check.NotNull(typeMapper, nameof(typeMapper));
 
-            TypeMapper = typeMapper;
+            _typeMapper = typeMapper;
         }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        protected virtual IRelationalTypeMapper TypeMapper { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -43,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             // This is because certain providers can have no type specified as a default type e.g. SQLite
             Check.NotNull(storeType, nameof(storeType));
 
-            var mapping = TypeMapper.FindMapping(storeType);
+            var mapping = _typeMapper.FindMapping(storeType);
             if (mapping == null)
             {
                 return null;
@@ -54,42 +50,42 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             int? scaffoldMaxLength = null;
 
             if (mapping.ClrType == typeof(byte[])
-                && TypeMapper.ByteArrayMapper != null)
+                && _typeMapper.ByteArrayMapper != null)
             {
                 // Check for inference
-                var byteArrayMapping = TypeMapper.ByteArrayMapper.FindMapping(rowVersion, keyOrIndex, mapping.Size);
+                var byteArrayMapping = _typeMapper.ByteArrayMapper.FindMapping(rowVersion, keyOrIndex, mapping.Size);
 
                 if (byteArrayMapping.StoreType.Equals(storeType, StringComparison.OrdinalIgnoreCase))
                 {
                     canInfer = true;
 
                     // Check for size
-                    var sizedMapping = TypeMapper.ByteArrayMapper.FindMapping(rowVersion, keyOrIndex, size: null);
+                    var sizedMapping = _typeMapper.ByteArrayMapper.FindMapping(rowVersion, keyOrIndex, size: null);
                     scaffoldMaxLength = sizedMapping.Size != byteArrayMapping.Size ? byteArrayMapping.Size : null;
                 }
             }
             else if (mapping.ClrType == typeof(string)
-                     && TypeMapper.StringMapper != null)
+                     && _typeMapper.StringMapper != null)
             {
                 // Check for inference
-                var stringMapping = TypeMapper.StringMapper.FindMapping(mapping.IsUnicode, keyOrIndex, mapping.Size);
+                var stringMapping = _typeMapper.StringMapper.FindMapping(mapping.IsUnicode, keyOrIndex, mapping.Size);
 
                 if (stringMapping.StoreType.Equals(storeType, StringComparison.OrdinalIgnoreCase))
                 {
                     canInfer = true;
 
                     // Check for unicode
-                    var unicodeMapping = TypeMapper.StringMapper.FindMapping(unicode: true, keyOrIndex: keyOrIndex, maxLength: mapping.Size);
+                    var unicodeMapping = _typeMapper.StringMapper.FindMapping(unicode: true, keyOrIndex: keyOrIndex, maxLength: mapping.Size);
                     scaffoldUnicode = unicodeMapping.IsUnicode != stringMapping.IsUnicode ? (bool?)stringMapping.IsUnicode : null;
 
                     // Check for size
-                    var sizedMapping = TypeMapper.StringMapper.FindMapping(mapping.IsUnicode, keyOrIndex, maxLength: null);
+                    var sizedMapping = _typeMapper.StringMapper.FindMapping(mapping.IsUnicode, keyOrIndex, maxLength: null);
                     scaffoldMaxLength = sizedMapping.Size != stringMapping.Size ? stringMapping.Size : null;
                 }
             }
             else
             {
-                var defaultMapping = TypeMapper.GetMapping(mapping.ClrType);
+                var defaultMapping = _typeMapper.GetMapping(mapping.ClrType);
 
                 if (defaultMapping.StoreType.Equals(storeType, StringComparison.OrdinalIgnoreCase))
                 {

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
@@ -1119,7 +1119,7 @@ namespace Microsoft.EntityFrameworkCore
 
     public class FakeScaffoldingModelFactory : RelationalScaffoldingModelFactory
     {
-        public IModel Create(DatabaseModel databaseModel, bool useDatabaseNames = false)
+        public override IModel Create(DatabaseModel databaseModel, bool useDatabaseNames = false)
         {
             foreach (var sequence in databaseModel.Sequences)
             {
@@ -1156,7 +1156,7 @@ namespace Microsoft.EntityFrameworkCore
                 }
             }
 
-            return CreateFromDatabaseModel(databaseModel, useDatabaseNames);
+            return base.Create(databaseModel, useDatabaseNames);
         }
 
         public FakeScaffoldingModelFactory(
@@ -1170,8 +1170,6 @@ namespace Microsoft.EntityFrameworkCore
             [NotNull] IPluralizer pluralizer)
             : base(
                 reporter,
-                new SqlServerTypeMapper(new RelationalTypeMapperDependencies()),
-                new FakeDatabaseModelFactory(),
                 new CandidateNamingService(),
                 pluralizer,
                 new CSharpUtilities(),

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ReverseEngineeringConfigurationTests.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ReverseEngineeringConfigurationTests.cs
@@ -27,7 +27,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         private void ValidateContextNameInReverseEngineerGenerator(string contextName)
         {
             var cSharpUtilities = new CSharpUtilities();
-            var reverseEngineer = new ModelScaffolder(
+            var reverseEngineer = new ReverseEngineerScaffolder(
+                new FakeDatabaseModelFactory(),
                 new FakeScaffoldingModelFactory(new TestOperationReporter()),
                 new CSharpScaffoldingGenerator(
                     new InMemoryFileService(),


### PR DESCRIPTION
Changes:
- Rename ModelScaffolder to ReverseEngineeringScaffolder
- Decouple RelationalScaffoldingModelFactory from IDatabaseModelFactory
- Remove IRelationalTypeMapper dependency in RelationalScaffoldingModelFactory
- Remove protected dependency properties on internal services

Part of #8853