### PR TITLE
Query: When we PushDownSubquery update aliases of ordering expressions

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -1012,15 +1012,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                         break;
                     }
 
-                    if (sqlOrderingExpression.IsComparisonOperation()
-                        || sqlOrderingExpression.IsLogicalOperation())
-                    {
-                        sqlOrderingExpression = Expression.Condition(
-                            sqlOrderingExpression,
-                            Expression.Constant(true, typeof(bool)),
-                            Expression.Constant(false, typeof(bool)));
-                    }
-
                     orderings.Add(
                         new Ordering(
                             sqlOrderingExpression,

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
@@ -14,7 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public SimpleQuerySqliteTest(NorthwindQuerySqliteFixture<NoopModelCustomizer> fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         public override void Take_Skip()


### PR DESCRIPTION
Issue: Since OrderBy comes after Projection, for smaller sql, we refer to ordering as alias when it is present in projection. When we pushdown a subquery, we generate unique alias for each projection. This can cause change of alias for existing alias expression which may be referred by ordering. So even though ordering expression is correct one but since we only print out alias it may cause change of the expression actually used.

Fix: When pushing down subquery, we need to account for already aliased expression being in orderby. Hence we would store a map so that we can track change of expression and update orderby accordingly

Test: Due to #9742 added test in QueryBugsTest

Resolves #9735
