### PR TITLE
Remove sample NuGet.config

### DIFF
--- a/samples/OracleProvider/NuGet.config
+++ b/samples/OracleProvider/NuGet.config
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="AspNetCore" value="https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json" />
-    <add key="AspNetCoreTools" value="https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json" />
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
This should solve the failure on Universe. The problem was that while the top level `NuGet.config` was getting edited to include the artifacts folder this one was not. The two appeared to be the same.