### PR TITLE
Recover connection state counting after external close

### DIFF
--- a/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
@@ -77,6 +77,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(IMemberTranslator), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(ICompositeMethodCallTranslator), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IQuerySqlGeneratorFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
+                { typeof(IRelationalTransactionFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(ICommandBatchPreparer), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IModificationCommandBatchFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IMigrationsModelDiffer), new ServiceCharacteristics(ServiceLifetime.Scoped) },
@@ -162,6 +163,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<ISqlTranslatingExpressionVisitorFactory, SqlTranslatingExpressionVisitorFactory>();
             TryAdd<INamedConnectionStringResolver, NamedConnectionStringResolver>();
             TryAdd<IEvaluatableExpressionFilter, RelationalEvaluatableExpressionFilter>();
+            TryAdd<IRelationalTransactionFactory, RelationalTransactionFactory>();
 
             ServiceCollectionMap.GetInfrastructure()
                 .AddDependencySingleton<RelationalCompositeMemberTranslatorDependencies>()
@@ -179,6 +181,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 .AddDependencySingleton<SelectExpressionDependencies>()
                 .AddDependencySingleton<RelationalValueBufferFactoryDependencies>()
                 .AddDependencySingleton<RelationalProjectionExpressionVisitorDependencies>()
+                .AddDependencySingleton<RelationalTransactionFactoryDependencies>()
                 .AddDependencyScoped<RelationalConventionSetBuilderDependencies>()
                 .AddDependencyScoped<RelationalDatabaseCreatorDependencies>()
                 .AddDependencyScoped<HistoryRepositoryDependencies>()

--- a/src/EFCore.Relational/Storage/IRelationalTransactionFactory.cs
+++ b/src/EFCore.Relational/Storage/IRelationalTransactionFactory.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Data.Common;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    /// <summary>
+    ///     <para>
+    ///         A factory for creating <see cref="RelationalTransaction" /> instances.
+    ///     </para>
+    ///     <para>
+    ///         This type is typically used by database providers It is generally not used in application code.
+    ///     </para>
+    /// </summary>
+    public interface IRelationalTransactionFactory
+    {
+        /// <summary>
+        ///     Creates a <see cref="RelationalTransaction" /> instance.
+        /// </summary>
+        /// <param name="connection"> The connection to the database. </param>
+        /// <param name="transaction"> The underlying <see cref="DbTransaction" />. </param>
+        /// <param name="logger"> The logger to write to. </param>
+        /// <param name="transactionOwned">
+        ///     A value indicating whether the transaction is owned by this class (i.e. if it can be disposed when this class is disposed).
+        /// </param>
+        /// <returns> A new <see cref="RelationalTransaction" /> instance. </returns>
+        RelationalTransaction Create(
+            [NotNull] IRelationalConnection connection,
+            [NotNull] DbTransaction transaction,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> logger,
+            bool transactionOwned);
+    }
+}

--- a/src/EFCore.Relational/Storage/RelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnection.cs
@@ -241,7 +241,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var dbTransaction = DbConnection.BeginTransaction(isolationLevel);
 
             CurrentTransaction
-                = new RelationalTransaction(
+                = Dependencies.RelationalTransactionFactory.Create(
                     this,
                     dbTransaction,
                     Dependencies.TransactionLogger,
@@ -275,7 +275,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
                 Open();
 
-                CurrentTransaction = new RelationalTransaction(
+                CurrentTransaction = Dependencies.RelationalTransactionFactory.Create(
                     this,
                     transaction,
                     Dependencies.TransactionLogger,
@@ -339,10 +339,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 wasOpened = true;
                 ClearTransactions();
             }
-            else
-            {
-                _openedCount++;
-            }
+
+            _openedCount++;
 
             HandleAmbientTransactions();
 
@@ -375,10 +373,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 wasOpened = true;
                 ClearTransactions();
             }
-            else
-            {
-                _openedCount++;
-            }
+
+            _openedCount++;
 
             HandleAmbientTransactions();
 
@@ -388,7 +384,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         private void ClearTransactions()
         {
             var previousOpenedCount = _openedCount;
-            _openedCount++;
+            _openedCount += 2;
             CurrentTransaction?.Dispose();
             CurrentTransaction = null;
             EnlistedTransaction = null;
@@ -436,7 +432,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
             if (_openedCount == 0)
             {
                 _openedInternally = true;
-                _openedCount++;
             }
         }
 
@@ -476,7 +471,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
             if (_openedCount == 0)
             {
                 _openedInternally = true;
-                _openedCount++;
             }
         }
 

--- a/src/EFCore.Relational/Storage/RelationalConnectionDependencies.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnectionDependencies.cs
@@ -45,21 +45,25 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="transactionLogger"> The logger to which transaction messages will be written. </param>
         /// <param name="connectionLogger"> The logger to which connection messages will be written. </param>
         /// <param name="connectionStringResolver"> A service for resolving a connection string from a name. </param>
+        /// <param name="relationalTransactionFactory"> A service for creating <see cref="RelationalTransaction"/> instances. </param>
         public RelationalConnectionDependencies(
             [NotNull] IDbContextOptions contextOptions,
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> transactionLogger,
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Connection> connectionLogger,
-            [NotNull] INamedConnectionStringResolver connectionStringResolver)
+            [NotNull] INamedConnectionStringResolver connectionStringResolver,
+            [NotNull] IRelationalTransactionFactory relationalTransactionFactory)
         {
             Check.NotNull(contextOptions, nameof(contextOptions));
             Check.NotNull(transactionLogger, nameof(transactionLogger));
             Check.NotNull(connectionLogger, nameof(connectionLogger));
             Check.NotNull(connectionStringResolver, nameof(connectionStringResolver));
+            Check.NotNull(relationalTransactionFactory, nameof(relationalTransactionFactory));
 
             ContextOptions = contextOptions;
             TransactionLogger = transactionLogger;
             ConnectionLogger = connectionLogger;
             ConnectionStringResolver = connectionStringResolver;
+            RelationalTransactionFactory = relationalTransactionFactory;
         }
 
         /// <summary>
@@ -83,6 +87,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public INamedConnectionStringResolver ConnectionStringResolver { get; }
 
         /// <summary>
+        ///     A service for creating <see cref="RelationalTransaction"/> instances.
+        /// </summary>
+        public IRelationalTransactionFactory RelationalTransactionFactory { get; }
+
+        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="contextOptions">
@@ -90,7 +99,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public RelationalConnectionDependencies With([NotNull] IDbContextOptions contextOptions)
-            => new RelationalConnectionDependencies(contextOptions, TransactionLogger, ConnectionLogger, ConnectionStringResolver);
+            => new RelationalConnectionDependencies(contextOptions, TransactionLogger, ConnectionLogger, ConnectionStringResolver, RelationalTransactionFactory);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -100,7 +109,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public RelationalConnectionDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Connection> connectionLogger)
-            => new RelationalConnectionDependencies(ContextOptions, TransactionLogger, connectionLogger, ConnectionStringResolver);
+            => new RelationalConnectionDependencies(ContextOptions, TransactionLogger, connectionLogger, ConnectionStringResolver, RelationalTransactionFactory);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -110,7 +119,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public RelationalConnectionDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> transactionLogger)
-            => new RelationalConnectionDependencies(ContextOptions, transactionLogger, ConnectionLogger, ConnectionStringResolver);
+            => new RelationalConnectionDependencies(ContextOptions, transactionLogger, ConnectionLogger, ConnectionStringResolver, RelationalTransactionFactory);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -120,6 +129,17 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public RelationalConnectionDependencies With([NotNull] INamedConnectionStringResolver connectionStringResolver)
-            => new RelationalConnectionDependencies(ContextOptions, TransactionLogger, ConnectionLogger, connectionStringResolver);
+            => new RelationalConnectionDependencies(ContextOptions, TransactionLogger, ConnectionLogger, connectionStringResolver, RelationalTransactionFactory);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="relationalTransactionFactory">
+        ///     A replacement for the current dependency of this type.
+        /// </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public RelationalConnectionDependencies With([NotNull] IRelationalTransactionFactory relationalTransactionFactory)
+            => new RelationalConnectionDependencies(ContextOptions, TransactionLogger, ConnectionLogger, ConnectionStringResolver, relationalTransactionFactory);
+
     }
 }

--- a/src/EFCore.Relational/Storage/RelationalTransactionFactory.cs
+++ b/src/EFCore.Relational/Storage/RelationalTransactionFactory.cs
@@ -1,0 +1,54 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Data.Common;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    /// <summary>
+    ///     <para>
+    ///         A factory for creating <see cref="RelationalTransaction" /> instances.
+    ///     </para>
+    ///     <para>
+    ///         This type is typically used by database providers It is generally not used in application code.
+    ///     </para>
+    /// </summary>
+    public class RelationalTransactionFactory : IRelationalTransactionFactory
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="RelationalTransactionFactory" /> class.
+        /// </summary>
+        /// <param name="dependencies"> Parameter object containing dependencies for this service. </param>
+        public RelationalTransactionFactory([NotNull] RelationalTransactionFactoryDependencies dependencies)
+        {
+            Check.NotNull(dependencies, nameof(dependencies));
+
+            Dependencies = dependencies;
+        }
+
+        /// <summary>
+        ///     Parameter object containing dependencies for this service.
+        /// </summary>
+        protected virtual RelationalTransactionFactoryDependencies Dependencies { get; }
+
+        /// <summary>
+        ///     Creates a <see cref="RelationalTransaction" /> instance.
+        /// </summary>
+        /// <param name="connection"> The connection to the database. </param>
+        /// <param name="transaction"> The underlying <see cref="DbTransaction" />. </param>
+        /// <param name="logger"> The logger to write to. </param>
+        /// <param name="transactionOwned">
+        ///     A value indicating whether the transaction is owned by this class (i.e. if it can be disposed when this class is disposed).
+        /// </param>
+        /// <returns> A new <see cref="RelationalTransaction" /> instance. </returns>
+        public virtual RelationalTransaction Create(
+            IRelationalConnection connection,
+            DbTransaction transaction,
+            IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> logger,
+            bool transactionOwned)
+            => new RelationalTransaction(connection, transaction, logger, transactionOwned);
+    }
+}

--- a/src/EFCore.Relational/Storage/RelationalTransactionFactoryDependencies.cs
+++ b/src/EFCore.Relational/Storage/RelationalTransactionFactoryDependencies.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    /// <summary>
+    ///     <para>
+    ///         Service dependencies parameter class for <see cref="RelationalTransactionFactory" />.
+    ///     </para>
+    ///     <para>
+    ///         This type is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
+    /// </summary>
+    public sealed class RelationalTransactionFactoryDependencies
+    {
+    }
+}

--- a/src/EFCore.Relational/breakingchanges.netcore.json
+++ b/src/EFCore.Relational/breakingchanges.netcore.json
@@ -20,5 +20,10 @@
       "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Update.UpdateSqlGeneratorDependencies",
       "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper sqlGenerationHelper)",
       "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Storage.RelationalConnectionDependencies",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptions contextOptions, Microsoft.EntityFrameworkCore.Diagnostics.IDiagnosticsLogger<Microsoft.EntityFrameworkCore.DbLoggerCategory+Database+Transaction> transactionLogger, Microsoft.EntityFrameworkCore.Diagnostics.IDiagnosticsLogger<Microsoft.EntityFrameworkCore.DbLoggerCategory+Database+Connection> connectionLogger, Microsoft.EntityFrameworkCore.Storage.Internal.INamedConnectionStringResolver connectionStringResolver)",
+      "Kind": "Removal"
     }
   ]

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
@@ -30,7 +30,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
                         new LoggerFactory(),
                         new LoggingOptions(),
                         new DiagnosticListener("FakeDiagnosticListener")),
-                    new NamedConnectionStringResolver(options)))
+                    new NamedConnectionStringResolver(options),
+                    new RelationalTransactionFactory(new RelationalTransactionFactoryDependencies())))
         {
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestRelationalCommandBuilderFactory.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestRelationalCommandBuilderFactory.cs
@@ -132,6 +132,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 if (errorNumber.HasValue)
                 {
                     connection.DbConnection.Close();
+                    result.Dispose(); // Normally, in non-test case, reader is disposed by using in caller code
                     throw SqlExceptionFactory.CreateSqlException(errorNumber.Value);
                 }
                 return result;
@@ -146,6 +147,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 if (errorNumber.HasValue)
                 {
                     connection.DbConnection.Close();
+                    result.Dispose(); // Normally, in non-test case, reader is disposed by using in caller code
                     throw SqlExceptionFactory.CreateSqlException(errorNumber.Value);
                 }
                 return result;

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestSqlServerConnection.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestSqlServerConnection.cs
@@ -1,30 +1,21 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.Common;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities
 {
-    public class TestSqlServerConnection : ISqlServerConnection
+    public class TestSqlServerConnection : SqlServerConnection
     {
-        private readonly ISqlServerConnection _realConnection;
-
         public TestSqlServerConnection(RelationalConnectionDependencies dependencies)
-            : this(new SqlServerConnection(dependencies))
+            : base(dependencies)
         {
         }
-
-        protected TestSqlServerConnection(ISqlServerConnection connection)
-            => _realConnection = connection;
 
         public int ErrorNumber { get; set; } = -2;
         public Queue<bool?> OpenFailures { get; } = new Queue<bool?>();
@@ -33,50 +24,23 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public Queue<bool?> ExecutionFailures { get; } = new Queue<bool?>();
         public int ExecutionCount { get; set; }
 
-        public virtual string ConnectionString => _realConnection.ConnectionString;
-        public virtual DbConnection DbConnection => _realConnection.DbConnection;
-
-        public virtual int? CommandTimeout
-        {
-            get => _realConnection.CommandTimeout;
-            set => _realConnection.CommandTimeout = value;
-        }
-
-        public virtual IDbContextTransaction CurrentTransaction { get; private set; }
-        public System.Transactions.Transaction EnlistedTransaction { get; }
-        public void EnlistTransaction(System.Transactions.Transaction transaction)
-        {
-            throw new NotImplementedException();
-        }
-
-        public SemaphoreSlim Semaphore => new SemaphoreSlim(1);
-
-        public void RegisterBufferable(IBufferable bufferable)
-        {
-        }
-
-        public Task RegisterBufferableAsync(IBufferable bufferable, CancellationToken cancellationToken)
-            => Task.CompletedTask;
-
-        public virtual bool IsMultipleActiveResultSetsEnabled => _realConnection.IsMultipleActiveResultSetsEnabled;
-
-        public virtual bool Open(bool errorsExpected = false)
+        public override bool Open(bool errorsExpected = false)
         {
             PreOpen();
 
-            return _realConnection.Open(errorsExpected);
+            return base.Open(errorsExpected);
         }
 
-        public virtual Task<bool> OpenAsync(CancellationToken cancellationToken, bool errorsExpected = false)
+        public override Task<bool> OpenAsync(CancellationToken cancellationToken, bool errorsExpected = false)
         {
             PreOpen();
 
-            return _realConnection.OpenAsync(cancellationToken, errorsExpected);
+            return base.OpenAsync(cancellationToken, errorsExpected);
         }
 
         private void PreOpen()
         {
-            if (_realConnection.DbConnection.State == ConnectionState.Open)
+            if (DbConnection.State == ConnectionState.Open)
             {
                 return;
             }
@@ -86,65 +50,13 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             {
                 return;
             }
+
             var fail = OpenFailures.Dequeue();
+
             if (fail.HasValue)
             {
                 throw SqlExceptionFactory.CreateSqlException(ErrorNumber);
             }
         }
-
-        public virtual bool Close() => _realConnection.Close();
-
-        public virtual IDbContextTransaction BeginTransaction()
-            => BeginTransaction(IsolationLevel.Unspecified);
-
-        public virtual Task<IDbContextTransaction> BeginTransactionAsync(CancellationToken cancellationToken = new CancellationToken())
-            => BeginTransactionAsync(IsolationLevel.Unspecified, cancellationToken);
-
-        public virtual IDbContextTransaction BeginTransaction(IsolationLevel isolationLevel)
-        {
-            Open();
-            CurrentTransaction = new TestRelationalTransaction(this, _realConnection.BeginTransaction(isolationLevel));
-            return CurrentTransaction;
-        }
-
-        public virtual async Task<IDbContextTransaction> BeginTransactionAsync(
-            IsolationLevel isolationLevel, CancellationToken cancellationToken = new CancellationToken())
-        {
-            await OpenAsync(cancellationToken: cancellationToken);
-            CurrentTransaction = new TestRelationalTransaction(this, await _realConnection.BeginTransactionAsync(isolationLevel, cancellationToken));
-            return CurrentTransaction;
-        }
-
-        public IDbContextTransaction UseTransaction(DbTransaction transaction)
-        {
-            var realTransaction = _realConnection.UseTransaction(transaction);
-            if (realTransaction == null)
-            {
-                CurrentTransaction = null;
-                return null;
-            }
-
-            Open();
-            CurrentTransaction = new TestRelationalTransaction(this, realTransaction);
-            return CurrentTransaction;
-        }
-
-        public void CommitTransaction() => CurrentTransaction.Commit();
-
-        public void RollbackTransaction() => CurrentTransaction.Rollback();
-
-        void IResettableService.ResetState() => Dispose();
-
-        public void Dispose()
-        {
-            CurrentTransaction?.Dispose();
-
-            _realConnection.Dispose();
-        }
-
-        public ISqlServerConnection CreateMasterConnection() => new TestSqlServerConnection(_realConnection.CreateMasterConnection());
-
-        public Guid ConnectionId { get; } = Guid.NewGuid();
     }
 }

--- a/test/EFCore.SqlServer.Tests/SqlServerConnectionTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerConnectionTest.cs
@@ -88,7 +88,8 @@ namespace Microsoft.EntityFrameworkCore
                     new LoggerFactory(),
                     new LoggingOptions(),
                     new DiagnosticListener("FakeDiagnosticListener")),
-                new NamedConnectionStringResolver(options));
+                new NamedConnectionStringResolver(options),
+                new RelationalTransactionFactory(new RelationalTransactionFactoryDependencies()));
         }
     }
 }


### PR DESCRIPTION
Issue #9524

The issue here was the reference count was not kept correctly if the connection was closed externally when it was not expected to be. The fix is to keep the count correct in this case.