### PR TITLE
Query: Include: Adds an optimized collection include client join predicate code path.

### DIFF
--- a/EFCore.Runtime.sln.DotSettings
+++ b/EFCore.Runtime.sln.DotSettings
@@ -1,0 +1,6 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=D44E9AA0167CE64B866A64486B319AB0/AbsolutePath/@EntryValue">C:\dev\github\aspnet\EntityFramework\EFCore.sln.DotSettings</s:String>
+	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=D44E9AA0167CE64B866A64486B319AB0/RelativePath/@EntryValue">..\EFCore.sln.DotSettings</s:String>
+	<s:Boolean x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=D44E9AA0167CE64B866A64486B319AB0/@KeyIndexDefined">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=FileD44E9AA0167CE64B866A64486B319AB0/@KeyIndexDefined">True</s:Boolean>
+	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=FileD44E9AA0167CE64B866A64486B319AB0/RelativePriority/@EntryValue">1</s:Double></wpf:ResourceDictionary>

--- a/src/EFCore/Query/Internal/IQueryBuffer.cs
+++ b/src/EFCore/Query/Internal/IQueryBuffer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        void IncludeCollection(
+        void IncludeCollection<TEntity, TRelated>(
             int includeId,
             [NotNull] INavigation navigation,
             [CanBeNull] INavigation inverseNavigation,
@@ -63,14 +63,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             [NotNull] IClrCollectionAccessor clrCollectionAccessor,
             [CanBeNull] IClrPropertySetter inverseClrPropertySetter,
             bool tracking,
-            [NotNull] object instance,
-            [NotNull] Func<IEnumerable<object>> valuesFactory);
+            [NotNull] TEntity instance,
+            [NotNull] Func<IEnumerable<TRelated>> valuesFactory,
+            [CanBeNull] Func<TEntity, TRelated, bool> joinPredicate);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        Task IncludeCollectionAsync(
+        Task IncludeCollectionAsync<TEntity, TRelated>(
             int includeId,
             [NotNull] INavigation navigation,
             [CanBeNull] INavigation inverseNavigation,
@@ -78,8 +79,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             [NotNull] IClrCollectionAccessor clrCollectionAccessor,
             [CanBeNull] IClrPropertySetter inverseClrPropertySetter,
             bool tracking,
-            [NotNull] object instance,
-            [NotNull] Func<IAsyncEnumerable<object>> valuesFactory,
+            [NotNull] TEntity instance,
+            [NotNull] Func<IAsyncEnumerable<TRelated>> valuesFactory,
+            [CanBeNull] Func<TEntity, TRelated, bool> joinPredicate,
             CancellationToken cancellationToken);
     }
 }

--- a/src/EFCore/Query/Internal/IncludeCompiler.CollectionQueryModelRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.CollectionQueryModelRewritingExpressionVisitor.cs
@@ -70,8 +70,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                     var newArguments = methodCallExpression.Arguments.ToArray();
 
-                    Expression newLambdaExpression
-                        = Expression.Lambda<Func<IEnumerable<object>>>(subQueryExpression);
+                    Expression newLambdaExpression = Expression.Lambda(subQueryExpression);
 
                     if (convertExpression != null)
                     {


### PR DESCRIPTION
- Avoids the use of IIncludeKeyComparer and ValueBuffers when neither of the entity types involved have any shadow key properties.
- Introduces breaking changes in IQueryBuffer

TBD: Update breaking changes log.