### PR TITLE
Fix Identity for shared columns

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsOwnedQueryRelationalFixtureBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/ComplexNavigationsOwnedQueryRelationalFixtureBase.cs
@@ -45,7 +45,6 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
             => base.AddOptions(builder).ConfigureWarnings(
-                c => c
-                    .Log(RelationalEventId.QueryClientEvaluationWarning));
+                c => c.Log(RelationalEventId.QueryClientEvaluationWarning));
     }
 }

--- a/src/EFCore.Relational/Metadata/Internal/PropertyExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/PropertyExtensions.cs
@@ -1,0 +1,59 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     Extension methods for <see cref="IProperty" /> for relational database metadata.
+    /// </summary>
+    public static class PropertyExtensions
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static IProperty FindSharedTablePrincipalPrimaryKeyProperty([NotNull] this IProperty property)
+        {
+            var linkingRelationship = property.FindSharedTableLink();
+            return linkingRelationship?.PrincipalKey.Properties[linkingRelationship.Properties.IndexOf(property)];
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static IForeignKey FindSharedTableLink([NotNull] this IProperty property)
+        {
+            var pk = property.GetContainingPrimaryKey();
+            if (pk == null)
+            {
+                return null;
+            }
+
+            var entityType = property.DeclaringEntityType;
+
+            foreach (var fk in entityType.FindForeignKeys(pk.Properties))
+            {
+                if (!fk.PrincipalKey.IsPrimaryKey()
+                    || fk.PrincipalEntityType == fk.DeclaringEntityType)
+                {
+                    continue;
+                }
+
+                var principalEntityType = fk.PrincipalEntityType;
+                var entityTypeAnnotations = fk.DeclaringEntityType.Relational();
+                var principalTypeAnnotations = principalEntityType.Relational();
+                if (entityTypeAnnotations.TableName == principalTypeAnnotations.TableName
+                    && entityTypeAnnotations.Schema == principalTypeAnnotations.Schema)
+                {
+                    return fk;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/EFCore.Relational/Metadata/RelationalPropertyAnnotations.cs
+++ b/src/EFCore.Relational/Metadata/RelationalPropertyAnnotations.cs
@@ -93,67 +93,49 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
         private string GetDefaultColumnName()
         {
-            var entityType = Property.DeclaringEntityType;
-            var pk = Property.GetContainingPrimaryKey();
-            if (pk != null)
+            var sharedTablePrincipalPrimaryKeyProperty = Property.FindSharedTablePrincipalPrimaryKeyProperty();
+            if (sharedTablePrincipalPrimaryKeyProperty != null)
             {
-                foreach (var fk in entityType.FindForeignKeys(pk.Properties))
-                {
-                    if (!fk.PrincipalKey.IsPrimaryKey()
-                        || fk.PrincipalKey == pk)
-                    {
-                        continue;
-                    }
-
-                    var principalEntityType = fk.PrincipalEntityType;
-                    var entityTypeAnnotations = GetAnnotations(entityType);
-                    var principalTypeAnnotations = GetAnnotations(principalEntityType);
-                    if (entityTypeAnnotations.TableName == principalTypeAnnotations.TableName
-                        && entityTypeAnnotations.Schema == principalTypeAnnotations.Schema)
-                    {
-                        return GetAnnotations(principalEntityType.FindPrimaryKey().Properties[pk.IndexOf(Property)]).ColumnName;
-                    }
-                }
+                return GetAnnotations(sharedTablePrincipalPrimaryKeyProperty).ColumnName;
             }
-            else
+
+            var entityType = Property.DeclaringEntityType;
+            StringBuilder builder = null;
+            do
             {
-                StringBuilder builder = null;
-                do
+                var ownership = entityType.GetForeignKeys().SingleOrDefault(fk => fk.IsOwnership);
+                if (ownership == null)
                 {
-                    var ownership = entityType.GetForeignKeys().SingleOrDefault(fk => fk.IsOwnership);
-                    if (ownership == null)
+                    entityType = null;
+                }
+                else
+                {
+                    var ownerType = ownership.PrincipalEntityType;
+                    var entityTypeAnnotations = GetAnnotations(entityType);
+                    var ownerTypeAnnotations = GetAnnotations(ownerType);
+                    if (entityTypeAnnotations.TableName == ownerTypeAnnotations.TableName
+                        && entityTypeAnnotations.Schema == ownerTypeAnnotations.Schema)
                     {
-                        entityType = null;
+                        if (builder == null)
+                        {
+                            builder = new StringBuilder();
+                        }
+                        builder.Insert(0, "_");
+                        builder.Insert(0, ownership.PrincipalToDependent.Name);
+                        entityType = ownerType;
                     }
                     else
                     {
-                        var ownerType = ownership.PrincipalEntityType;
-                        var entityTypeAnnotations = GetAnnotations(entityType);
-                        var ownerTypeAnnotations = GetAnnotations(ownerType);
-                        if (entityTypeAnnotations.TableName == ownerTypeAnnotations.TableName
-                            && entityTypeAnnotations.Schema == ownerTypeAnnotations.Schema)
-                        {
-                            if (builder == null)
-                            {
-                                builder = new StringBuilder();
-                            }
-                            builder.Insert(0, "_");
-                            builder.Insert(0, ownership.PrincipalToDependent.Name);
-                            entityType = ownerType;
-                        }
-                        else
-                        {
-                            entityType = null;
-                        }
+                        entityType = null;
                     }
                 }
-                while (entityType != null);
+            }
+            while (entityType != null);
 
-                if (builder != null)
-                {
-                    builder.Append(Property.Name);
-                    return builder.ToString();
-                }
+            if (builder != null)
+            {
+                builder.Append(Property.Name);
+                return builder.ToString();
             }
 
             return Property.Name;

--- a/src/EFCore.Relational/Metadata/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Metadata/RelationalPropertyExtensions.cs
@@ -37,14 +37,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                 return false;
             }
 
-            var pk = property.DeclaringEntityType.FindPrimaryKey();
-            return pk != null
-                   && property.DeclaringEntityType.FindForeignKeys(pk.Properties)
-                       .Any(
-                           fk => fk.PrincipalKey.IsPrimaryKey()
-                                 && fk.PrincipalEntityType.BaseType != null
-                                 && fk.DeclaringEntityType.Relational().TableName == fk.PrincipalEntityType.Relational().TableName
-                                 && fk.DeclaringEntityType.Relational().Schema == fk.PrincipalEntityType.Relational().Schema);
+            return property.DeclaringEntityType.FindPrimaryKey()?.Properties.First()
+                ?.FindSharedTableLink()?.PrincipalEntityType.BaseType != null;
         }
     }
 }

--- a/src/EFCore.SqlServer/Metadata/SqlServerPropertyAnnotations.cs
+++ b/src/EFCore.SqlServer/Metadata/SqlServerPropertyAnnotations.cs
@@ -133,11 +133,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
             var relationalProperty = Property.Relational();
             if (!fallbackToModel
-                || Property.ValueGenerated != ValueGenerated.OnAdd
                 || relationalProperty.DefaultValue != null
                 || relationalProperty.DefaultValueSql != null
                 || relationalProperty.ComputedColumnSql != null)
             {
+                return null;
+            }
+
+            if (Property.ValueGenerated != ValueGenerated.OnAdd)
+            {
+                var sharedTablePrincipalPrimaryKeyProperty = Property.FindSharedTablePrincipalPrimaryKeyProperty();
+                if (sharedTablePrincipalPrimaryKeyProperty != null
+                    && sharedTablePrincipalPrimaryKeyProperty.SqlServer().ValueGenerationStrategy == SqlServerValueGenerationStrategy.IdentityColumn)
+                {
+                    return SqlServerValueGenerationStrategy.IdentityColumn;
+                }
+
                 return null;
             }
 

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -279,6 +279,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
                     SqlServerEventId.ForeignKeyTableMissingWarning,
                     _resourceManager.GetString("LogForeignKeyTableNotInSelectionSet")));
 
+        /// <summary>
+        ///     '{entityType1}.{property1}' and '{entityType2}.{property2}' are both mapped to column '{columnName}' in '{table}' but are configured with different value generation strategies.
+        /// </summary>
+        public static string DuplicateColumnNameValueGenerationStrategyMismatch([CanBeNull] object entityType1, [CanBeNull] object property1, [CanBeNull] object entityType2, [CanBeNull] object property2, [CanBeNull] object columnName, [CanBeNull] object table)
+            => string.Format(
+                GetString("DuplicateColumnNameValueGenerationStrategyMismatch", nameof(entityType1), nameof(property1), nameof(entityType2), nameof(property2), nameof(columnName), nameof(table)),
+                entityType1, property1, entityType2, property2, columnName, table);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -214,4 +214,7 @@
     <value>Foreign key {fkName} is defined on table {tableName} which is not included in the selection set. Skipping.</value>
     <comment>Debug SqlServerEventId.ForeignKeyTableMissingWarning string string</comment>
   </data>
+  <data name="DuplicateColumnNameValueGenerationStrategyMismatch" xml:space="preserve">
+    <value>'{entityType1}.{property1}' and '{entityType2}.{property2}' are both mapped to column '{columnName}' in '{table}' but are configured with different value generation strategies.</value>
+  </data>
 </root>

--- a/src/EFCore/Internal/EnumerableExtensions.cs
+++ b/src/EFCore/Internal/EnumerableExtensions.cs
@@ -122,5 +122,28 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
             return true;
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static int IndexOf<T>([NotNull] this IEnumerable<T> source, [NotNull] T item)
+            => source.Select((x, index) =>
+                EqualityComparer<T>.Default.Equals(item, x) ? index : -1)
+                .FirstOr(x => x != -1, -1);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static T FirstOr<T>([NotNull] this IEnumerable<T> source, [NotNull] T alternate)
+            => source.DefaultIfEmpty(alternate).First();
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static T FirstOr<T>([NotNull] this IEnumerable<T> source, [NotNull] Func<T, bool> predicate, [NotNull] T alternate)
+            => source.Where(predicate).FirstOr(alternate);
     }
 }

--- a/test/EFCore.Relational.Tests/RelationalModelValidatorTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalModelValidatorTest.cs
@@ -14,6 +14,7 @@ using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore
 {
     public class RelationalModelValidatorTest : ModelValidatorTest
@@ -764,6 +765,8 @@ namespace Microsoft.EntityFrameworkCore
 
             [NotMapped]
             public string Type { get; set; }
+
+            public int Identity { get; set; }
         }
 
         protected class Dog : Animal
@@ -772,6 +775,8 @@ namespace Microsoft.EntityFrameworkCore
 
             [NotMapped]
             public int Type { get; set; }
+
+            public int Identity { get; set; }
         }
 
         protected class Person


### PR DESCRIPTION
Default to the principal value generation strategy for the primary key columns for entity types sharing the same table.

Validate that properties sharing the same column have the same value generation strategy.

Fixes #9652