### PR TITLE
[2.0.1] - Fix #9570 - Exception in Client vs. Server Evaluation with async/await in EF Core 2.0.0

### DIFF
--- a/src/EFCore.Specification.Tests/Query/AsyncQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncQueryTestBase.cs
@@ -24,6 +24,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         where TFixture : NorthwindQueryFixtureBase, new()
     {
         [ConditionalFact]
+        public virtual async Task Projection_when_client_evald_subquery()
+        {
+            await AssertQuery<Customer>(
+                cs => cs.Select(c => string.Join(", ", c.Orders.Select(o => o.CustomerID))));
+        }
+
+        [ConditionalFact]
         public virtual async Task ToArray_on_nav_subquery_in_projection()
         {
             using (var context = CreateContext())

--- a/src/EFCore.Specification.Tests/Query/QueryTestBase.Select.cs
+++ b/src/EFCore.Specification.Tests/Query/QueryTestBase.Select.cs
@@ -42,6 +42,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void Projection_when_client_evald_subquery()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Select(c => string.Join(", ", c.Orders.Select(o => o.CustomerID))));
+        }
+        
+        [ConditionalFact]
         public virtual void Project_to_object_array()
         {
             AssertQuery<Employee>(


### PR DESCRIPTION
Two issues:

1) CollectionNavigationSetOperatorSubqueryInjector would incorrectly introduce MaterializeCollectionNavigation calls around
subqueries. Fix is to reset the ShouldInject flag when visiting subqueries.
2) After fixing 1, we would deadlock due to blocking on the subquery call. Extended task lifting to deal with this case.

