### PR TITLE
[2.0.1] Update version.props to include suffix and set PackageId in csproj

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -9,7 +9,6 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/aspnet/EntityFramework.git</RepositoryUrl>
     <SignAssembly>True</SignAssembly>
-    <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
     <DebugType Condition="'$(Configuration)' == 'Debug' AND '$(OS)' == 'Windows_NT'">full</DebugType>
     <NoWarn>$(NoWarn);xUnit1004</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/EFCore.Tools.DotNet/EFCore.Tools.DotNet.csproj
+++ b/src/EFCore.Tools.DotNet/EFCore.Tools.DotNet.csproj
@@ -8,6 +8,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <PackageId>Microsoft.EntityFrameworkCore.Tools.DotNet</PackageId>
     <NuspecFile>$(MSBuildThisFileDirectory)$(MSBuildProjectName).nuspec</NuspecFile>
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <IncludeBuildOutput>false</IncludeBuildOutput>
@@ -30,6 +31,7 @@
     </ResolvePackageDependencies>
     <PropertyGroup>
       <NuspecProperties>
+        id=$(PackageId);
         version=$(PackageVersion);
         configuration=$(Configuration);
         runtimeFrameworkVersion=@(_PackageDefinitions-&gt;WithMetadataValue('Name', 'Microsoft.NETCore.App')-&gt;Metadata('Version'));

--- a/src/EFCore.Tools.DotNet/EFCore.Tools.DotNet.nuspec
+++ b/src/EFCore.Tools.DotNet/EFCore.Tools.DotNet.nuspec
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
-    <id>Microsoft.EntityFrameworkCore.Tools.DotNet</id>
+    <id>$id$</id>
     <version>$version$</version>
     <authors>Microsoft</authors>
     <copyright>Copyright © Microsoft Corporation</copyright>

--- a/src/EFCore.Tools/EFCore.Tools.csproj
+++ b/src/EFCore.Tools/EFCore.Tools.csproj
@@ -6,6 +6,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
+    <PackageId>Microsoft.EntityFrameworkCore.Tools</PackageId>
     <NuspecFile>$(MSBuildThisFileDirectory)$(MSBuildProjectName).nuspec</NuspecFile>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <NoPackageAnalysis>true</NoPackageAnalysis>
@@ -20,7 +21,11 @@
 
   <Target Name="SetPackageProperties" BeforeTargets="GenerateNuspec">
     <PropertyGroup>
-      <NuspecProperties>version=$(PackageVersion);configuration=$(Configuration)</NuspecProperties>
+      <NuspecProperties>
+        id=$(PackageId);
+        version=$(PackageVersion);
+        configuration=$(Configuration)
+      </NuspecProperties>
     </PropertyGroup>
   </Target>
 

--- a/src/EFCore.Tools/EFCore.Tools.nuspec
+++ b/src/EFCore.Tools/EFCore.Tools.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
-    <id>Microsoft.EntityFrameworkCore.Tools</id>
+    <id>$id$</id>
     <version>$version$</version>
     <authors>Microsoft</authors>
     <copyright>Copyright © Microsoft Corporation</copyright>

--- a/version.props
+++ b/version.props
@@ -1,6 +1,9 @@
-<!-- This file may be overwritten by automation. Only values allowed here are VersionPrefix and VersionSuffix.  -->
 <Project>
-    <PropertyGroup>
-        <VersionPrefix>2.0.1</VersionPrefix>
-    </PropertyGroup>
+  <PropertyGroup>
+    <VersionPrefix>2.0.1</VersionPrefix>
+    <VersionSuffix>rtm</VersionSuffix>
+    <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' == 'rtm' ">$(VersionPrefix)</PackageVersion>
+    <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' != 'rtm' ">$(VersionPrefix)-$(VersionSuffix)-final</PackageVersion>
+    <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Backports https://github.com/aspnet/EntityFrameworkCore/pull/9381 so repo-to-repo graph analysis works.

Set VersionSuffix on the packages produced from this branch to 2.0.1-rtm-$(BuildNumber)