### PR TITLE
Fix #9825 - Access to context bound variable can be optimized out

### DIFF
--- a/src/EFCore.Specification.Tests/Query/AsyncSimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncSimpleQueryTestBase.cs
@@ -722,17 +722,18 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
-        public virtual async Task Where_nested_field_access_closure_via_query_cache_error_null()
+        public virtual async Task Where_nested_field_access_closure_via_query_cache_null()
         {
             var city = new City();
 
             using (var context = CreateContext())
             {
-                await Assert.ThrowsAsync<InvalidOperationException>(
-                    async () =>
-                        await context.Set<Customer>()
-                            .Where(c => c.City == city.Nested.InstanceFieldValue)
-                            .ToListAsync());
+                var results
+                    = await context.Set<Customer>()
+                        .Where(c => c.City == city.Nested.InstanceFieldValue)
+                        .ToListAsync();
+
+                Assert.Equal(0, results.Count);
             }
         }
 

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
@@ -216,17 +216,18 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
-        public virtual void Where_nested_field_access_closure_via_query_cache_error_null()
+        public virtual void Where_nested_field_access_closure_via_query_cache_null()
         {
             var city = new City();
 
             using (var context = CreateContext())
             {
-                Assert.Throws<InvalidOperationException>(
-                    () =>
-                        context.Set<Customer>()
-                            .Where(c => c.City == city.Nested.InstanceFieldValue)
-                            .ToList());
+                var results =
+                    context.Set<Customer>()
+                        .Where(c => c.City == city.Nested.InstanceFieldValue)
+                        .ToList();
+
+                Assert.Equal(0, results.Count);
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -13,7 +13,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public NullSemanticsQuerySqlServerTest(NullSemanticsQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         public override void Compare_bool_with_bool_equal()
@@ -993,9 +994,11 @@ WHERE [e].[NullableBoolA] = @__prm_0");
             base.Where_equal_using_relational_null_semantics_complex_with_parameter();
 
             AssertSql(
-                @"SELECT [e].[Id]
+                @"@__prm_0='False'
+
+SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableBoolA] = [e].[NullableBoolB]");
+WHERE ([e].[NullableBoolA] = [e].[NullableBoolB]) OR (@__prm_0 = 1)");
         }
 
         public override void Where_not_equal_using_relational_null_semantics()
@@ -1025,9 +1028,11 @@ WHERE [e].[NullableBoolA] <> @__prm_0");
             base.Where_not_equal_using_relational_null_semantics_complex_with_parameter();
 
             AssertSql(
-                @"SELECT [e].[Id]
+                @"@__prm_0='False'
+
+SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableBoolA] <> [e].[NullableBoolB]");
+WHERE ([e].[NullableBoolA] <> [e].[NullableBoolB]) OR (@__prm_0 = 1)");
         }
 
         public override void Where_comparison_null_constant_and_null_parameter()
@@ -1084,9 +1089,11 @@ FROM [Entities1] AS [e]");
             base.Where_comparison_null_semantics_optimization_works_with_complex_predicates();
 
             AssertSql(
-                @"SELECT [e].[Id]
+                @"@__prm_0='' (Size = 4000) (DbType = String)
+
+SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE [e].[NullableStringA] IS NULL");
+WHERE @__prm_0 IS NULL AND [e].[NullableStringA] IS NULL");
         }
 
         public override void Switching_null_semantics_produces_different_cache_entry()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -26,11 +26,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             base.Shaper_command_caching_when_parameter_names_different();
 
             AssertSql(
-                @"SELECT COUNT(*)
+                @"SELECT [e].[CustomerID]
 FROM [Customers] AS [e]
 WHERE [e].[CustomerID] = N'ALFKI'",
                 //
-                @"SELECT COUNT(*)
+                @"SELECT [e].[CustomerID]
 FROM [Customers] AS [e]
 WHERE [e].[CustomerID] = N'ALFKI'");
         }
@@ -2866,16 +2866,19 @@ ORDER BY [c].[CustomerID]");
             base.Parameter_extraction_short_circuits_1();
 
             AssertSql(
-                @"@__dateFilter_Value_Month_0='7'
-@__dateFilter_Value_Year_1='1996'
+                @"@__dateFilter_0='1996-07-15T00:00:00' (Nullable = true)
+@__dateFilter_Value_Month_1='7'
+@__dateFilter_Value_Year_2='1996'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[OrderID] < 10400) AND (([o].[OrderDate] IS NOT NULL AND (DATEPART(month, [o].[OrderDate]) = @__dateFilter_Value_Month_0)) AND (DATEPART(year, [o].[OrderDate]) = @__dateFilter_Value_Year_1))",
+WHERE ([o].[OrderID] < 10400) AND (@__dateFilter_0 IS NULL OR (([o].[OrderDate] IS NOT NULL AND (DATEPART(month, [o].[OrderDate]) = @__dateFilter_Value_Month_1)) AND (DATEPART(year, [o].[OrderDate]) = @__dateFilter_Value_Year_2)))",
                 //
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+                @"@__dateFilter_0='' (DbType = DateTime2)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderID] < 10400");
+WHERE ([o].[OrderID] < 10400) AND (@__dateFilter_0 IS NULL OR (([o].[OrderDate] IS NOT NULL AND DATEPART(month, [o].[OrderDate]) IS NULL) AND DATEPART(year, [o].[OrderDate]) IS NULL))");
         }
 
         public override void Parameter_extraction_short_circuits_2()
@@ -2883,16 +2886,19 @@ WHERE [o].[OrderID] < 10400");
             base.Parameter_extraction_short_circuits_2();
 
             AssertSql(
-                @"@__dateFilter_Value_Month_0='7'
-@__dateFilter_Value_Year_1='1996'
+                @"@__dateFilter_HasValue_0='True'
+@__dateFilter_Value_Month_1='7'
+@__dateFilter_Value_Year_2='1996'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[OrderID] < 10400) AND (([o].[OrderDate] IS NOT NULL AND (DATEPART(month, [o].[OrderDate]) = @__dateFilter_Value_Month_0)) AND (DATEPART(year, [o].[OrderDate]) = @__dateFilter_Value_Year_1))",
+WHERE (([o].[OrderID] < 10400) AND (@__dateFilter_HasValue_0 = 1)) AND (([o].[OrderDate] IS NOT NULL AND (DATEPART(month, [o].[OrderDate]) = @__dateFilter_Value_Month_1)) AND (DATEPART(year, [o].[OrderDate]) = @__dateFilter_Value_Year_2))",
                 //
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+                @"@__dateFilter_HasValue_0='False'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE 0 = 1");
+WHERE (([o].[OrderID] < 10400) AND (@__dateFilter_HasValue_0 = 1)) AND (([o].[OrderDate] IS NOT NULL AND DATEPART(month, [o].[OrderDate]) IS NULL) AND DATEPART(year, [o].[OrderDate]) IS NULL)");
         }
 
         public override void Parameter_extraction_short_circuits_3()
@@ -2900,15 +2906,19 @@ WHERE 0 = 1");
             base.Parameter_extraction_short_circuits_3();
 
             AssertSql(
-                @"@__dateFilter_Value_Month_0='7'
-@__dateFilter_Value_Year_1='1996'
+                @"@__dateFilter_0='1996-07-15T00:00:00' (Nullable = true)
+@__dateFilter_Value_Month_1='7'
+@__dateFilter_Value_Year_2='1996'
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE ([o].[OrderID] < 10400) OR (([o].[OrderDate] IS NOT NULL AND (DATEPART(month, [o].[OrderDate]) = @__dateFilter_Value_Month_0)) AND (DATEPART(year, [o].[OrderDate]) = @__dateFilter_Value_Year_1))",
+WHERE (([o].[OrderID] < 10400) OR @__dateFilter_0 IS NULL) OR (([o].[OrderDate] IS NOT NULL AND (DATEPART(month, [o].[OrderDate]) = @__dateFilter_Value_Month_1)) AND (DATEPART(year, [o].[OrderDate]) = @__dateFilter_Value_Year_2))",
                 //
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
-FROM [Orders] AS [o]");
+                @"@__dateFilter_0='' (DbType = DateTime2)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE (([o].[OrderID] < 10400) OR @__dateFilter_0 IS NULL) OR (([o].[OrderDate] IS NOT NULL AND DATEPART(month, [o].[OrderDate]) IS NULL) AND DATEPART(year, [o].[OrderDate]) IS NULL)");
         }
 
         public override void Subquery_member_pushdown_does_not_change_original_subquery_model()


### PR DESCRIPTION
Replaced short-circuiting optimization in ParameterExtractingExpressionVisitor with cheap null compensation handling. The main advantages to this approach are:  

1) No more query cache fragmentation - short circuiting would produce multiple entries in query cache. 
2) Simpler: Less logic/rewriting inside parameter extraction.


