### PR TITLE
Restore GetAwaiter behavior of TaskBlockingExpressionVisitor.

### DIFF
--- a/src/EFCore/Query/ExpressionVisitors/Internal/TaskBlockingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/TaskBlockingExpressionVisitor.cs
@@ -4,6 +4,7 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 {
@@ -26,11 +27,20 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 if (typeInfo.IsGenericType
                     && typeInfo.GetGenericTypeDefinition() == typeof(Task<>))
                 {
-                    return Expression.Property(expression, nameof(Task<object>.Result));
+                    return Expression.Call(
+                        ResultMethodInfo.MakeGenericMethod(typeInfo.GenericTypeArguments[0]),
+                        expression);
                 }
             }
 
             return expression;
         }
+
+        internal static MethodInfo ResultMethodInfo { get; }
+            = typeof(TaskBlockingExpressionVisitor).GetTypeInfo()
+                .GetDeclaredMethod(nameof(Result));
+
+        [UsedImplicitly]
+        private static T Result<T>(Task<T> task) => task.GetAwaiter().GetResult();
     }
 }

--- a/src/EFCore/Query/ExpressionVisitors/Internal/TaskLiftingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/TaskLiftingExpressionVisitor.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Extensions.Internal;
 using Remotion.Linq.Parsing;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
@@ -148,6 +149,38 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             }
 
             return base.VisitMember(memberExpression);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+        {
+            if (methodCallExpression.Method
+                .MethodIsClosedFormOf(TaskBlockingExpressionVisitor.ResultMethodInfo))
+            {
+                _taskExpressions.Add(
+                    Expression.Lambda<Func<Task<object>>>(
+                        Expression.Call(
+                            _toObjectTask.MakeGenericMethod(
+                                methodCallExpression.Method.ReturnType),
+                            methodCallExpression.Arguments[0])));
+
+                if (CancellationTokenParameter == null)
+                {
+                    Visit(methodCallExpression.Arguments[0]);
+                }
+
+                return
+                    Expression.Convert(
+                        Expression.ArrayAccess(
+                            _resultsParameter,
+                            Expression.Constant(_taskExpressions.Count - 1)),
+                        methodCallExpression.Method.ReturnType);
+            }
+
+            return base.VisitMethodCall(methodCallExpression);
         }
 
         // Prune nodes


### PR DESCRIPTION
And corresponding changes to task lifting and Include compiler.