### PR TITLE
[2.0.1] Query: Fix for Access to context bound variable can be optimized out

### DIFF
--- a/src/EFCore.Specification.Tests/Query/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/QueryTestBase.cs
@@ -3127,6 +3127,25 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void Parameter_extraction_can_throw_exception_from_user_code_2()
+        {
+            using (var context = CreateContext())
+            {
+                DateTime? dateFilter = null;
+
+                Assert.Throws<InvalidOperationException>(
+                    () =>
+                        context.Orders
+                            .Where(
+                                o => (o.OrderID < 10400)
+                                     && ((o.OrderDate.HasValue
+                                          && o.OrderDate.Value.Month == dateFilter.Value.Month
+                                          && o.OrderDate.Value.Year == dateFilter.Value.Year)))
+                            .ToList());
+            }
+        }
+
+        [ConditionalFact]
         public virtual void Subquery_member_pushdown_does_not_change_original_subquery_model()
         {
             AssertQuery<Order, Customer>(

--- a/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
@@ -20,6 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
     public class ParameterExtractingExpressionVisitor : ExpressionVisitor
     {
         private static readonly TypeInfo _queryableTypeInfo = typeof(IQueryable).GetTypeInfo();
+        private static ContextParameterReplacingExpressionVisitor _contextParameterReplacingExpressionVisitor;
 
         private readonly IEvaluatableExpressionFilter _evaluatableExpressionFilter;
         private readonly IParameterValues _parameterValues;
@@ -31,6 +32,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         private PartialEvaluationInfo _partialEvaluationInfo;
 
         private bool _inLambda;
+
+        private static bool QuirkEnabled => AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue9825", out var enabled) && enabled;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -48,6 +51,12 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             _logger = logger;
             _parameterize = parameterize;
             _generateContextAccessors = generateContextAccessors;
+
+            if (_generateContextAccessors
+                && !QuirkEnabled)
+            {
+                _contextParameterReplacingExpressionVisitor = new ContextParameterReplacingExpressionVisitor();
+            }
         }
 
         /// <summary>
@@ -352,30 +361,48 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         {
             var parameterValue = Evaluate(expression, out var parameterName);
 
-            if (parameterValue is Expression valueExpression)
+            if (QuirkEnabled)
             {
-                return ExtractParameters(valueExpression);
-            }
-
-            if (!_parameterize)
-            {
-                if (_generateContextAccessors
-                    && expression is MemberExpression memberExpression
-                    && memberExpression.Expression != null
-                    && typeof(DbContext).GetTypeInfo()
-                        .IsAssignableFrom(memberExpression.Expression.Type.GetTypeInfo()))
+                if (parameterValue is Expression valueExpression)
                 {
-                    var contextParameterExpression
-                        = Expression.Parameter(memberExpression.Expression.Type, "context");
-
-                    parameterValue
-                        = Expression.Lambda(
-                            memberExpression.Update(contextParameterExpression),
-                            contextParameterExpression);
+                    return ExtractParameters(valueExpression);
                 }
-                else
+
+                if (!_parameterize)
                 {
-                    return Expression.Constant(parameterValue);
+                    if (_generateContextAccessors
+                        && expression is MemberExpression memberExpression
+                        && memberExpression.Expression != null
+                        && typeof(DbContext).GetTypeInfo()
+                            .IsAssignableFrom(memberExpression.Expression.Type.GetTypeInfo()))
+                    {
+                        var contextParameterExpression
+                            = Expression.Parameter(memberExpression.Expression.Type, "context");
+
+                        parameterValue
+                            = Expression.Lambda(
+                                memberExpression.Update(contextParameterExpression),
+                                contextParameterExpression);
+                    }
+                    else
+                    {
+                        return Expression.Constant(parameterValue);
+                    }
+                }
+            }
+            else
+            {
+                if (!_generateContextAccessors)
+                {
+                    if (parameterValue is Expression valueExpression)
+                    {
+                        return ExtractParameters(valueExpression);
+                    }
+
+                    if (!_parameterize)
+                    {
+                        return Expression.Constant(parameterValue);
+                    }
                 }
             }
 
@@ -403,6 +430,22 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             return Expression.Parameter(expression.Type, parameterName);
         }
 
+        private sealed class ContextParameterReplacingExpressionVisitor : ExpressionVisitor
+        {
+            public ParameterExpression ContextParameterExpression;
+
+            protected override Expression VisitConstant(ConstantExpression constantExpression)
+            {
+                if (typeof(DbContext).GetTypeInfo()
+                    .IsAssignableFrom(constantExpression.Type.GetTypeInfo()))
+                {
+                    return ContextParameterExpression ?? (ContextParameterExpression = Expression.Parameter(constantExpression.Type, "context"));
+                }
+
+                return constantExpression;
+            }
+        }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
@@ -414,6 +457,25 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             if (expression == null)
             {
                 return null;
+            }
+
+            if (!QuirkEnabled)
+            {
+                if (_generateContextAccessors)
+                {
+                    var newExpression = _contextParameterReplacingExpressionVisitor.Visit(expression);
+
+                    if (newExpression != expression)
+                    {
+                        parameterName = newExpression is MemberExpression memberExpression
+                            ? memberExpression.Member.Name
+                            : "_queryFilter";
+
+                        return Expression.Lambda(
+                            newExpression,
+                            _contextParameterReplacingExpressionVisitor.ContextParameterExpression);
+                    }
+                }
             }
 
             // ReSharper disable once SwitchStatementMissingSomeCases

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FiltersSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FiltersSqlServerTest.cs
@@ -217,7 +217,7 @@ WHERE (([c].[CompanyName] LIKE @__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyNa
         [ConditionalFact]
         public void FromSql_is_composed()
         {
-            using (var context = Fixture.CreateContext())
+            using (var context = Fixture.CreateContext(enableFilters: true))
             {
                 var results = context.Customers.FromSql("select * from Customers").ToList();
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -12,7 +12,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public NullSemanticsQuerySqlServerTest(NullSemanticsQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         public override void Compare_bool_with_bool_equal()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QuerySqlServerTest.cs
@@ -30,7 +30,7 @@ WHERE [e].[CustomerID] = N'ALFKI'",
                 //
                 @"SELECT COUNT(*)
 FROM [Customers] AS [e]
-WHERE [e].[CustomerID] = N'ALFKI'");            
+WHERE [e].[CustomerID] = N'ALFKI'");
         }
 
         public override void Lifting_when_subquery_nested_order_by_anonymous()


### PR DESCRIPTION
**Take 3**

Issue:
We adopted short-circuiting logic in logical expression due to possible exceptions (which compiler would never throw in memory). This works correctly for general cases because the expression tree would have current value of closure variable hence evaluating to correct thing.
When it comes to QueryFilter, the filter has closure member access on context instance which was used during OnModelCreating which may have stale value of context closure variables. We parametrize such closure variables and insert their values through parameters when running query. But if such closure variable is used in complex expression which can short-circuit then we would be using wrong value for short-circuit (by this point we haven't inserted correct value from current context instance) hence generating incorrect query model. The other cause for it is QueryCache has only 1 entry for all the possible values of context bound variables in filter.

Solution:
Since evaluating filter with context bound variables with different value may not always generate a re-usable query model for all values of variables, whenever we get an expression to evaluate during funcletizing query filter, we replace context, with context parameter (which would be injected later) and return this expression without evaluating anything in-memory. Any exception to be thrown from evaluation of context bound variables will be thrown when actual parameter value will be calculated while running query.

Resolves #9825
