### PR TITLE
[2.0.1] Update the fix for #9038 to make it more robust against multi-collection includes

### DIFF
--- a/src/EFCore/Query/Internal/IncludeCompiler.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.cs
@@ -220,12 +220,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         {
             if (entity != null)
             {
-                var fixupTask = fixup(queryContext, entity, included, cancellationToken);
-                if (AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue9038", out var isEnabled) && isEnabled
-                    || fixupTask != null)
-                {
-                    await fixupTask;
-                }
+                await fixup(queryContext, entity, included, cancellationToken);
             }
 
             return entity;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -2171,7 +2171,7 @@ ORDER BY [t].[Id]");
         #region Bug9038
 
         [Fact]
-        public virtual async Task Repro9038()
+        public virtual async Task Include_collection_optional_reference_collection_9038()
         {
             using (CreateDatabase9038())
             {
@@ -2185,6 +2185,26 @@ ORDER BY [t].[Id]");
 
                     Assert.Equal(2, result.Count);
                     Assert.Equal(true, result.All(r => r.Students.Any()));
+                }
+            }
+        }
+
+        [Fact]
+        public async Task Include_optional_reference_collection_another_collection()
+        {
+            using (CreateDatabase9038())
+            {
+                using (var context = new MyContext9038(_options))
+                {
+                    var result = await context.Set<PersonTeacher9038>()
+                        .Include(m => m.Family.Members)
+                        .Include(m => m.Students)
+                        .ToListAsync();
+
+                    Assert.Equal(2, result.Count);
+                    Assert.True(result.All(r => r.Students.Any()));
+                    Assert.Null(result.Single(t => t.Name == "Ms. Frizzle").Family);
+                    Assert.NotNull(result.Single(t => t.Name == "Mr. Garrison").Family);
                 }
             }
         }


### PR DESCRIPTION
When there are multiple collections being included then we have single fixup task with AwaitMany function which would wait each of the include task. If one of the collection include is after optional reference navigation then only that task in AwaitMany would be null and not whole fixup task.
