### PR TITLE
[2.0.1] - Fix #9551 - Expression of type 'System.Object' cannot be used for parameter of type 'Microsoft.EntityFrameworkCore.Metadata.IEntityType'

### DIFF
--- a/src/EFCore.Specification.Tests/Query/ComplexNavigationsOwnedQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/ComplexNavigationsOwnedQueryTestBase.cs
@@ -374,6 +374,22 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
         }
 
+        public override void Include_collection_with_groupby_in_subquery()
+        {
+        }
+
+        public override void Multi_include_with_groupby_in_subquery()
+        {
+        }
+
+        public override void Include_collection_with_groupby_in_subquery_and_filter_before_groupby()
+        {
+        }
+
+        public override void Include_collection_with_groupby_in_subquery_and_filter_after_groupby()
+        {
+        }
+
         protected override IQueryable<Level1> GetExpectedLevelOne()
             => ComplexNavigationsData.SplitLevelOnes.AsQueryable();
 

--- a/src/EFCore.Specification.Tests/Query/IncludeTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/IncludeTestBase.cs
@@ -3132,6 +3132,558 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual void Include_collection_GroupBy_Select(bool useString)
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = useString
+                        ? context.Orders
+                            .Where(o => o.OrderID == 10248)
+                            .Include("OrderDetails")
+                            .GroupBy(e => e.OrderID)
+                            .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                            .ToList()
+                        : context.Orders
+                            .Where(o => o.OrderID == 10248)
+                            .Include(o => o.OrderDetails)
+                            .GroupBy(e => e.OrderID)
+                            .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                            .ToList();
+
+                foreach (var order in orders)
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        orderDetailsLoaded: true,
+                        productLoaded: false,
+                        customerLoaded: false,
+                        ordersLoaded: false);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual void Include_reference_GroupBy_Select(bool useString)
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = useString
+                        ? context.Orders
+                            .Where(o => o.OrderID == 10248)
+                            .Include("Customer")
+                            .GroupBy(e => e.OrderID)
+                            .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                            .ToList()
+                        : context.Orders
+                            .Where(o => o.OrderID == 10248)
+                            .Include(o => o.Customer)
+                            .GroupBy(e => e.OrderID)
+                            .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                            .ToList();
+
+                foreach (var order in orders)
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        orderDetailsLoaded: false,
+                        productLoaded: false,
+                        customerLoaded: true,
+                        ordersLoaded: false);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual void Include_collection_Join_GroupBy_Select(bool useString)
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = useString
+                        ? context.Orders
+                            .Where(o => o.OrderID == 10248)
+                            .Include("OrderDetails")
+                            .Join(context.OrderDetails,
+                                o => o.OrderID,
+                                od => od.OrderID,
+                                (o, od) => o)
+                            .GroupBy(e => e.OrderID)
+                            .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                            .ToList()
+                        : context.Orders
+                            .Where(o => o.OrderID == 10248)
+                            .Include(o => o.OrderDetails)
+                            .Join(context.OrderDetails,
+                                o => o.OrderID,
+                                od => od.OrderID,
+                                (o, od) => o)
+                            .GroupBy(e => e.OrderID)
+                            .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                            .ToList();
+
+                foreach (var order in orders)
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        orderDetailsLoaded: true,
+                        productLoaded: false,
+                        customerLoaded: false,
+                        ordersLoaded: false);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual void Include_reference_Join_GroupBy_Select(bool useString)
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = useString
+                        ? context.Orders
+                            .Where(o => o.OrderID == 10248)
+                            .Include("Customer")
+                            .Join(context.OrderDetails,
+                                o => o.OrderID,
+                                od => od.OrderID,
+                                (o, od) => o)
+                            .GroupBy(e => e.OrderID)
+                            .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                            .ToList()
+                        : context.Orders
+                            .Where(o => o.OrderID == 10248)
+                            .Include(o => o.Customer)
+                            .Join(context.OrderDetails,
+                                o => o.OrderID,
+                                od => od.OrderID,
+                                (o, od) => o)
+                            .GroupBy(e => e.OrderID)
+                            .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                            .ToList();
+
+                foreach (var order in orders)
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        orderDetailsLoaded: false,
+                        productLoaded: false,
+                        customerLoaded: true,
+                        ordersLoaded: false);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual void Join_Include_collection_GroupBy_Select(bool useString)
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = useString
+                        ? context.OrderDetails
+                            .Where(od => od.OrderID == 10248)
+                            .Join(
+                                context.Orders.Include("OrderDetails"),
+                                od => od.OrderID,
+                                o => o.OrderID,
+                                (od, o) => o)
+                            .GroupBy(e => e.OrderID)
+                            .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                            .ToList()
+                        : context.OrderDetails
+                            .Where(od => od.OrderID == 10248)
+                            .Join(
+                                context.Orders.Include(o => o.OrderDetails),
+                                od => od.OrderID,
+                                o => o.OrderID,
+                                (od, o) => o)
+                            .GroupBy(e => e.OrderID)
+                            .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                            .ToList();
+
+                foreach (var order in orders)
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        orderDetailsLoaded: true,
+                        productLoaded: false,
+                        customerLoaded: false,
+                        ordersLoaded: false);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual void Join_Include_reference_GroupBy_Select(bool useString)
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = useString
+                        ? context.OrderDetails
+                            .Join(
+                                context.Orders.Include("Customer"),
+                                od => od.OrderID,
+                                o => o.OrderID,
+                                (od, o) => o)
+                            .GroupBy(e => e.OrderID)
+                            .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                            .ToList()
+                        : context.OrderDetails
+                            .Join(
+                                context.Orders.Include(o => o.Customer),
+                                od => od.OrderID,
+                                o => o.OrderID,
+                                (od, o) => o)
+                            .GroupBy(e => e.OrderID)
+                            .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                            .ToList();
+
+                foreach (var order in orders)
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        orderDetailsLoaded: false,
+                        productLoaded: false,
+                        customerLoaded: true,
+                        ordersLoaded: false);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual void Include_collection_GroupJoin_GroupBy_Select(bool useString)
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = useString
+                        ? context.Orders
+                            .Where(o => o.OrderID == 10248)
+                            .Include("OrderDetails")
+                            .GroupJoin(context.OrderDetails,
+                                o => o.OrderID,
+                                od => od.OrderID,
+                                (o, od) => o)
+                            .GroupBy(e => e.OrderID)
+                            .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                            .ToList()
+                        : context.Orders
+                            .Where(o => o.OrderID == 10248)
+                            .Include(o => o.OrderDetails)
+                            .GroupJoin(context.OrderDetails,
+                                o => o.OrderID,
+                                od => od.OrderID,
+                                (o, od) => o)
+                            .GroupBy(e => e.OrderID)
+                            .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                            .ToList();
+
+                foreach (var order in orders)
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        orderDetailsLoaded: true,
+                        productLoaded: false,
+                        customerLoaded: false,
+                        ordersLoaded: false);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual void Include_reference_GroupJoin_GroupBy_Select(bool useString)
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = useString
+                        ? context.Orders
+                            .Where(o => o.OrderID == 10248)
+                            .Include("Customer")
+                            .GroupJoin(context.OrderDetails,
+                                o => o.OrderID,
+                                od => od.OrderID,
+                                (o, od) => o)
+                            .GroupBy(e => e.OrderID)
+                            .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                            .ToList()
+                        : context.Orders
+                            .Where(o => o.OrderID == 10248)
+                            .Include(o => o.Customer)
+                            .GroupJoin(context.OrderDetails,
+                                o => o.OrderID,
+                                od => od.OrderID,
+                                (o, od) => o)
+                            .GroupBy(e => e.OrderID)
+                            .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                            .ToList();
+
+                foreach (var order in orders)
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        orderDetailsLoaded: false,
+                        productLoaded: false,
+                        customerLoaded: true,
+                        ordersLoaded: false);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual void GroupJoin_Include_collection_GroupBy_Select(bool useString)
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = useString
+                        ? context.OrderDetails
+                            .Where(od => od.OrderID == 10248)
+                            .GroupJoin(
+                                context.Orders.Include("OrderDetails"),
+                                od => od.OrderID,
+                                o => o.OrderID,
+                                (od, o) => o.OrderBy(o1 => o1.OrderID).FirstOrDefault())
+                            .GroupBy(e => e.OrderID)
+                            .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                            .ToList()
+                        : context.OrderDetails
+                            .Where(od => od.OrderID == 10248)
+                            .GroupJoin(
+                                context.Orders.Include(o => o.OrderDetails),
+                                od => od.OrderID,
+                                o => o.OrderID,
+                                (od, o) => o.OrderBy(o1 => o1.OrderID).FirstOrDefault())
+                            .GroupBy(e => e.OrderID)
+                            .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                            .ToList();
+
+                foreach (var order in orders)
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        orderDetailsLoaded: true,
+                        productLoaded: false,
+                        customerLoaded: false,
+                        ordersLoaded: false);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual void GroupJoin_Include_reference_GroupBy_Select(bool useString)
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = useString
+                        ? context.OrderDetails
+                            .Where(od => od.OrderID == 10248)
+                            .GroupJoin(
+                                context.Orders.Include("Customer"),
+                                od => od.OrderID,
+                                o => o.OrderID,
+                                (od, o) => o.OrderBy(o1 => o1.OrderID).FirstOrDefault())
+                            .GroupBy(e => e.OrderID)
+                            .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                            .ToList()
+                        : context.OrderDetails
+                            .Where(od => od.OrderID == 10248)
+                            .GroupJoin(
+                                context.Orders.Include(o => o.Customer),
+                                od => od.OrderID,
+                                o => o.OrderID,
+                                (od, o) => o.OrderBy(o1 => o1.OrderID).FirstOrDefault())
+                            .GroupBy(e => e.OrderID)
+                            .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                            .ToList();
+
+                foreach (var order in orders)
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        orderDetailsLoaded: false,
+                        productLoaded: false,
+                        customerLoaded: true,
+                        ordersLoaded: false);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual void Include_collection_SelectMany_GroupBy_Select(bool useString)
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = useString
+                        ? (from o in context.Orders.Include("OrderDetails").Where(o => o.OrderID == 10248)
+                           from od in context.OrderDetails
+                           select o)
+                        .GroupBy(e => e.OrderID)
+                        .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                        .ToList()
+                        : (from o in context.Orders.Include(o => o.OrderDetails).Where(o => o.OrderID == 10248)
+                           from od in context.OrderDetails
+                           select o)
+                        .GroupBy(e => e.OrderID)
+                        .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                        .ToList();
+
+                foreach (var order in orders)
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        orderDetailsLoaded: true,
+                        productLoaded: false,
+                        customerLoaded: false,
+                        ordersLoaded: false);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual void Include_reference_SelectMany_GroupBy_Select(bool useString)
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = useString
+                        ? (from o in context.Orders.Include("Customer").Where(o => o.OrderID == 10248)
+                           from od in context.OrderDetails
+                           select o)
+                        .GroupBy(e => e.OrderID)
+                        .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                        .ToList()
+                        : (from o in context.Orders.Include(o => o.Customer).Where(o => o.OrderID == 10248)
+                           from od in context.OrderDetails
+                           select o)
+                        .GroupBy(e => e.OrderID)
+                        .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                        .ToList();
+
+                foreach (var order in orders)
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        orderDetailsLoaded: false,
+                        productLoaded: false,
+                        customerLoaded: true,
+                        ordersLoaded: false);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual void SelectMany_Include_collection_GroupBy_Select(bool useString)
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = useString
+                        ? (from od in context.OrderDetails.Where(od => od.OrderID == 10248)
+                           from o in context.Orders.Include("OrderDetails")
+                           select o)
+                        .GroupBy(e => e.OrderID)
+                        .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                        .ToList()
+                        : (from od in context.OrderDetails.Where(od => od.OrderID == 10248)
+                           from o in context.Orders.Include(o => o.OrderDetails)
+                           select o)
+                        .GroupBy(e => e.OrderID)
+                        .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                        .ToList();
+
+                foreach (var order in orders)
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        orderDetailsLoaded: true,
+                        productLoaded: false,
+                        customerLoaded: false,
+                        ordersLoaded: false);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual void SelectMany_Include_reference_GroupBy_Select(bool useString)
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = useString
+                        ? (from od in context.OrderDetails.Where(od => od.OrderID == 10248)
+                           from o in context.Orders.Include("Customer")
+                           select o)
+                        .GroupBy(e => e.OrderID)
+                        .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                        .ToList()
+                        : (from od in context.OrderDetails.Where(od => od.OrderID == 10248)
+                           from o in context.Orders.Include(o => o.Customer)
+                           select o)
+                        .GroupBy(e => e.OrderID)
+                        .Select(e => e.OrderBy(o => o.OrderID).FirstOrDefault())
+                        .ToList();
+
+                foreach (var order in orders)
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        orderDetailsLoaded: false,
+                        productLoaded: false,
+                        customerLoaded: true,
+                        ordersLoaded: false);
+                }
+            }
+        }
+
         private static void CheckIsLoaded(
             NorthwindContext context,
             Customer customer,

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -291,7 +291,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             navigationRewritingExpressionVisitor.Rewrite(queryModel, parentQueryModel: null);
 
-            includeCompiler.RewriteCollectionQueries(queryModel);
+            includeCompiler.RewriteCollectionQueries();
 
             includeCompiler.LogIgnoredIncludes();
 

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -291,7 +291,15 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             navigationRewritingExpressionVisitor.Rewrite(queryModel, parentQueryModel: null);
 
-            includeCompiler.RewriteCollectionQueries();
+            if (AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue9551", out var isEnabled)
+                && isEnabled)
+            {
+                includeCompiler.RewriteCollectionQueries(queryModel);
+            }
+            else
+            {
+                includeCompiler.RewriteCollectionQueries();
+            }
 
             includeCompiler.LogIgnoredIncludes();
 

--- a/src/EFCore/Query/ExpressionVisitors/Internal/QuerySourceTracingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/QuerySourceTracingExpressionVisitor.cs
@@ -10,6 +10,7 @@ using Remotion.Linq;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.Expressions;
 using Remotion.Linq.Clauses.ResultOperators;
+using System;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 {
@@ -106,6 +107,12 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         /// </summary>
         protected override Expression VisitSubQuery(SubQueryExpression subQueryExpression)
         {
+            if (AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue9551", out var isEnabled)
+                && isEnabled)
+            {
+                return base.VisitSubQuery(subQueryExpression);
+            }
+
             if (_reachable)
             {
                 return subQueryExpression;

--- a/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTree.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTree.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Remotion.Linq;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.Expressions;
+using System;
 
 namespace Microsoft.EntityFrameworkCore.Query.Internal
 {
@@ -34,16 +35,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 if (querySourceReferenceExpression.ReferencedQuerySource is GroupJoinClause groupJoinClause)
                 {
-                    if (queryModel.GetOutputExpression() is SubQueryExpression subQueryExpression
-                        && subQueryExpression.QueryModel.SelectClause.Selector is QuerySourceReferenceExpression qsre
-                        && (qsre.ReferencedQuerySource as MainFromClause)?.FromExpression == QuerySourceReferenceExpression)
+                    if (AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue9551", out var isEnabled)
+                        && isEnabled)
                     {
-                        querySourceReferenceExpression = qsre;
-                        queryModel = subQueryExpression.QueryModel;
-                    }
-                    else
-                    {
-                        // We expand GJs to 'from e in [g] select e' so we can rewrite the projector
+                        // GJs expand to 'from e in [g] select e' so we can rewrite the projector
 
                         var joinClause = groupJoinClause.JoinClause;
 
@@ -61,6 +56,37 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                             queryModel, QuerySourceReferenceExpression, new SubQueryExpression(subQueryModel));
 
                         queryModel = subQueryModel;
+                    }
+                    else
+                    {
+                        if (queryModel.GetOutputExpression() is SubQueryExpression subQueryExpression
+                            && subQueryExpression.QueryModel.SelectClause.Selector is QuerySourceReferenceExpression qsre
+                            && (qsre.ReferencedQuerySource as MainFromClause)?.FromExpression == QuerySourceReferenceExpression)
+                        {
+                            querySourceReferenceExpression = qsre;
+                            queryModel = subQueryExpression.QueryModel;
+                        }
+                        else
+                        {
+                            // We expand GJs to 'from e in [g] select e' so we can rewrite the projector
+
+                            var joinClause = groupJoinClause.JoinClause;
+
+                            var mainFromClause
+                                = new MainFromClause(joinClause.ItemName, joinClause.ItemType, QuerySourceReferenceExpression);
+
+                            querySourceReferenceExpression = new QuerySourceReferenceExpression(mainFromClause);
+
+                            var subQueryModel
+                                = new QueryModel(
+                                    mainFromClause,
+                                    new SelectClause(querySourceReferenceExpression));
+
+                            ApplyIncludeExpressionsToQueryModel(
+                                queryModel, QuerySourceReferenceExpression, new SubQueryExpression(subQueryModel));
+
+                            queryModel = subQueryModel;
+                        }
                     }
                 }
 

--- a/test/EFCore.InMemory.FunctionalTests/Query/ComplexNavigationsQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/ComplexNavigationsQueryInMemoryTest.cs
@@ -19,5 +19,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             base.Nested_group_join_with_take();
         }
+
+        [ConditionalFact(Skip = " issue #9591")]
+        public override void Multi_include_with_groupby_in_subquery()
+        {
+            base.Multi_include_with_groupby_in_subquery();
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryLoggingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryLoggingSqlServerTest.cs
@@ -91,6 +91,54 @@ select [c]).Include(""Orders"")'
             }
         }
 
+        [Fact]
+        public virtual void Concat_Include_collection_ignored()
+        {
+            using (var context = CreateContext())
+            {
+                var orders = context.Orders
+                    .Where(o => o.OrderID < 10250)
+                    .Concat(context.Orders.Where(o => o.CustomerID == "ALFKI"))
+                    .Include(o => o.OrderDetails)
+                    .ToList();
+
+                Assert.NotNull(orders);
+                Assert.Contains(CoreStrings.LogIgnoredInclude.GenerateMessage("[o].OrderDetails"), _fixture.TestSqlLoggerFactory.Log);
+            }
+        }
+
+        [Fact]
+        public virtual void Union_Include_collection_ignored()
+        {
+            using (var context = CreateContext())
+            {
+                var orders = context.Orders
+                    .Where(o => o.OrderID < 10250)
+                    .Union(context.Orders.Where(o => o.CustomerID == "ALFKI"))
+                    .Include(o => o.OrderDetails)
+                    .ToList();
+
+                Assert.NotNull(orders);
+                Assert.Contains(CoreStrings.LogIgnoredInclude.GenerateMessage("[o].OrderDetails"), _fixture.TestSqlLoggerFactory.Log);
+            }
+        }
+
+        [Fact]
+        public virtual void GroupBy_Include_collection_ignored()
+        {
+            using (var context = CreateContext())
+            {
+                var orders = context.Orders
+                    .GroupBy(o => o.OrderID)
+                    .Select(g => g.OrderBy(o => o.OrderID).FirstOrDefault())
+                    .Include(o => o.OrderDetails)
+                    .ToList();
+
+                Assert.NotNull(orders);
+                Assert.Contains(CoreStrings.LogIgnoredInclude.GenerateMessage("{from Order o in [g] orderby [o].OrderID asc select [o] => FirstOrDefault()}.OrderDetails"), _fixture.TestSqlLoggerFactory.Log);
+            }
+        }
+
         private readonly NorthwindQuerySqlServerFixture _fixture;
 
         public QueryLoggingSqlServerTest(NorthwindQuerySqlServerFixture fixture)


### PR DESCRIPTION
- Modify QuerySourceTracingExpressionVisitor so that it can return the "deepest" GroupBy QueryModel if one exists.
- Update the Include compiler to target the correct QueryModel when GroupBy is in play.

