### PR TITLE
Fix #9849 - Using Include with InMemory and empty database throws

### DIFF
--- a/src/EFCore/Query/ExpressionVisitors/ExpressionVisitorBase.cs
+++ b/src/EFCore/Query/ExpressionVisitors/ExpressionVisitorBase.cs
@@ -56,15 +56,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         protected override Expression VisitLambda<T>(Expression<T> node)
         {
             var newBody = Visit(node.Body);
-            var newParameters = VisitAndConvert(node.Parameters, callerName: "VisitLambda");
-
-            if (newBody == node.Body
-                && newParameters == node.Parameters)
-            {
-                return node;
-            }
-
-            return Expression.Lambda(newBody, node.Name, node.TailCall, newParameters);
+            
+            return newBody == node.Body 
+                ? node 
+                : Expression.Lambda(newBody, node.Name, node.TailCall, node.Parameters);
         }
     }
 }

--- a/src/EFCore/Query/ExpressionVisitors/Internal/DefaultQueryExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/DefaultQueryExpressionVisitor.cs
@@ -66,8 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         /// </summary>
         protected override Expression VisitParameter(ParameterExpression node)
         {
-            if (node.Name
-                .StartsWith(CompiledQueryCache.CompiledQueryParameterPrefix, StringComparison.Ordinal))
+            if (node.Name.StartsWith(CompiledQueryCache.CompiledQueryParameterPrefix, StringComparison.Ordinal))
             {
                 return Expression.Call(
                     GetParameterValueMethodInfo.MakeGenericMethod(node.Type),
@@ -84,8 +83,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         /// </summary>
         protected override Expression VisitExtension(Expression node)
         {
-            var nullConditionalExpression = node as NullConditionalExpression;
-            if (nullConditionalExpression != null)
+            if (node is NullConditionalExpression nullConditionalExpression)
             {
                 var newCaller = Visit(nullConditionalExpression.Caller);
                 var newAccessOperation = Visit(nullConditionalExpression.AccessOperation);

--- a/test/EFCore.InMemory.FunctionalTests/Query/QueryBugsInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/QueryBugsInMemoryTest.cs
@@ -18,6 +18,134 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     {
+        #region Bug9849
+
+        [Fact]
+        public void Include_throw_when_empty_9849()
+        {
+            using (CreateScratch<DatabaseContext>(_ => { }, "9849"))
+            {
+                using (var context = new DatabaseContext())
+                {
+                    var results = context.VehicleInspections.Include(_ => _.Motors).ToList();
+
+                    Assert.Empty(results);
+                }
+            }
+        }
+
+        [Fact]
+        public void Include_throw_when_empty_9849_2()
+        {
+            using (CreateScratch<DatabaseContext>(_ => { }, "9849"))
+            {
+                using (var context = new DatabaseContext())
+                {
+                    var results = context.VehicleInspections.Include(_foo => _foo.Motors).ToList();
+
+                    Assert.Empty(results);
+                }
+            }
+        }
+
+        [Fact]
+        public void Include_throw_when_empty_9849_3()
+        {
+            using (CreateScratch<DatabaseContext>(_ => { }, "9849"))
+            {
+                using (var context = new DatabaseContext())
+                {
+                    var results = context.VehicleInspections.Include(__ => __.Motors).ToList();
+
+                    Assert.Empty(results);
+                }
+            }
+        }
+
+        [Fact]
+        public void Include_throw_when_empty_9849_4()
+        {
+            using (CreateScratch<DatabaseContext>(_ => { }, "9849"))
+            {
+                using (var context = new DatabaseContext())
+                {
+                    var results = context.VehicleInspections.Include(___ => ___.Motors).ToList();
+
+                    Assert.Empty(results);
+                }
+            }
+        }
+
+        [Fact]
+        public void Include_throw_when_empty_9849_5()
+        {
+            using (CreateScratch<DatabaseContext>(_ => { }, "9849"))
+            {
+                using (var context = new DatabaseContext())
+                {
+                    var results
+                        = (from _ in context.VehicleInspections
+                           join _f in context.Motors on _.Id equals _f.Id
+                           join __ in context.VehicleInspections on _f.Id equals __.Id
+                           select _).ToList();
+
+                    Assert.Empty(results);
+                }
+            }
+        }
+
+        [Fact]
+        public void Include_throw_when_empty_9849_6()
+        {
+            using (CreateScratch<DatabaseContext>(_ => { }, "9849"))
+            {
+                using (var context = new DatabaseContext())
+                {
+                    var _ = 0L;
+                    var __ = 0L;
+                    var _f = 0L;
+
+                    var results
+                        = (from v in context.VehicleInspections
+                           where v.Id == _ || v.Id == __ || v.Id == _f
+                           select _).ToList();
+
+                    Assert.Empty(results);
+                }
+            }
+        }
+
+        public class DatabaseContext : DbContext
+        {
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.UseInMemoryDatabase("9849");
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                var builder = modelBuilder.Entity<VehicleInspection>();
+
+                builder.HasMany(i => i.Motors).WithOne(a => a.Inspection).HasForeignKey(i => i.VehicleInspectionId);
+            }
+
+            public DbSet<VehicleInspection> VehicleInspections { get; set; }
+            public DbSet<Motor> Motors { get; set; }
+        }
+
+        public class VehicleInspection
+        {
+            public long Id { get; set; }
+            public ICollection<Motor> Motors { get; set; } = new HashSet<Motor>();
+        }
+
+        public class Motor
+        {
+            public long Id { get; set; }
+            public long VehicleInspectionId { get; set; }
+            public VehicleInspection Inspection { get; set; }
+        }
+
+        #endregion
+
         #region Bug3595
 
         [Fact]


### PR DESCRIPTION
Tweak ExpressionVisitorBase to not visit parameters during VisitLambda.
