### PR TITLE
Fix #9741 - AddDbContextPool in asp.net core System.InvalidOperationException

### DIFF
--- a/src/EFCore/Internal/DbContextPool.cs
+++ b/src/EFCore/Internal/DbContextPool.cs
@@ -81,9 +81,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// </summary>
         public virtual TContext Rent()
         {
-            TContext context;
-
-            if (_pool.TryDequeue(out context))
+            if (_pool.TryDequeue(out var context))
             {
                 Interlocked.Decrement(ref _count);
 
@@ -141,8 +139,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         {
             _maxSize = 0;
 
-            TContext context;
-            while (_pool.TryDequeue(out context))
+            while (_pool.TryDequeue(out var context))
             {
                 context.Dispose();
             }


### PR DESCRIPTION
Problem: Pooling was not resilient to multiple DbContext.Dispose calls, which meant that a context instance could incorrectly be returned to the pool twice.
Solution: Adds a DbContext async local to track which "context" (e.g. request scope) owns the context and use it to ensure a single return to the pool.
