### PR TITLE
Query: Fix for CompiledQuery with closure variable evaluating to null throws

### DIFF
--- a/src/EFCore.Specification.Tests/Query/CompiledQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/CompiledQueryTestBase.cs
@@ -251,6 +251,21 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void Query_with_closure_null()
+        {
+            string customerID = null;
+
+            var query = EF.CompileQuery(
+                (NorthwindContext context)
+                    => context.Customers.Where(c => c.CustomerID == customerID));
+
+            using (var context = CreateContext())
+            {
+                Assert.Null(query(context).FirstOrDefault());
+            }
+        }
+
+        [ConditionalFact]
         public virtual async Task DbSet_query_async()
         {
             var query = EF.CompileAsyncQuery((NorthwindContext context) => context.Customers);
@@ -424,6 +439,21 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 Assert.Equal("ALFKI", (await query(context).ToListAsync()).First().CustomerID);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual async Task Query_with_closure_async_null()
+        {
+            string customerID = null;
+
+            var query = EF.CompileAsyncQuery(
+                (NorthwindContext context)
+                    => context.Customers.Where(c => c.CustomerID == customerID));
+
+            using (var context = CreateContext())
+            {
+                Assert.Empty(await query(context).ToListAsync());
             }
         }
 

--- a/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
@@ -367,7 +367,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                 if (!_parameterize)
                 {
-                    return Expression.Constant(parameterValue);
+                    return Expression.Constant(parameterValue, expression.Type);
                 }
             }
 


### PR DESCRIPTION
Issue: In CompiledQuery, since closure variables are not modified after compilation we capture the values of closure variables as constants rather than parameters. Though the logic to create constant expression was faulty when the value is null.

Resolves #9844
