### PR TITLE
Query: Fix for projecting out bool values with ternary expression throws

### DIFF
--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -165,7 +165,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         protected virtual string TypedFalseLiteral => "CAST(0 AS BIT)";
 
         /// <summary>
-        /// Whether schemas should be generated when generating identifiers.
+        ///     Whether schemas should be generated when generating identifiers.
         /// </summary>
         protected virtual bool SupportsSchemas { get; } = true;
 
@@ -447,8 +447,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         /// <param name="generationAction">The generation action.</param>
         /// <param name="joinAction">An optional join action.</param>
         protected virtual void GenerateList<T>(
-            [NotNull] IReadOnlyList<T> items, 
-            [NotNull] Action<T> generationAction, 
+            [NotNull] IReadOnlyList<T> items,
+            [NotNull] Action<T> generationAction,
             [CanBeNull] Action<IRelationalCommandBuilder> joinAction = null)
         {
             Check.NotNull(items, nameof(items));
@@ -1066,8 +1066,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                 _relationalCommandBuilder.AppendLine();
                 _relationalCommandBuilder.Append("THEN ");
 
-                if (conditionalExpression.IfTrue is ConstantExpression constantIfTrue
-                    && constantIfTrue.Type == typeof(bool))
+                if (conditionalExpression.IfTrue.RemoveConvert() is ConstantExpression constantIfTrue
+                    && constantIfTrue.Value != null
+                    && constantIfTrue.Type.UnwrapNullableType() == typeof(bool))
                 {
                     _relationalCommandBuilder.Append((bool)constantIfTrue.Value ? TypedTrueLiteral : TypedFalseLiteral);
                 }
@@ -1078,8 +1079,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
                 _relationalCommandBuilder.Append(" ELSE ");
 
-                if (conditionalExpression.IfFalse is ConstantExpression constantIfFalse
-                    && constantIfFalse.Type == typeof(bool))
+                if (conditionalExpression.IfFalse.RemoveConvert() is ConstantExpression constantIfFalse
+                    && constantIfFalse.Value != null
+                    && constantIfFalse.Type.UnwrapNullableType() == typeof(bool))
                 {
                     _relationalCommandBuilder.Append((bool)constantIfFalse.Value ? TypedTrueLiteral : TypedFalseLiteral);
                 }

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -3049,6 +3049,20 @@ namespace Microsoft.EntityFrameworkCore.Query
                         }).Message);
         }
 
+        [ConditionalFact]
+        public virtual void Projecting_nullable_bool_in_conditional_works()
+        {
+            AssertQuery<CogTag>(
+                cgs =>
+                    cgs.Select(
+                        cg =>
+                            new
+                            {
+                                Prop = cg.Gear != null ? cg.Gear.HasSoulPatch : false
+                            }),
+                e => e.Prop);
+        }
+
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();
 
         protected virtual void ClearLog()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -4192,6 +4192,23 @@ INNER JOIN (
 ORDER BY [t1].[Nickname], [t1].[SquadId], [t1].[Id]");
         }
 
+        public override void Projecting_nullable_bool_in_conditional_works()
+        {
+            base.Projecting_nullable_bool_in_conditional_works();
+
+            AssertSql(
+                @"SELECT CASE
+    WHEN [cg].[GearNickName] IS NOT NULL OR [cg].[GearSquadId] IS NOT NULL
+    THEN [t].[HasSoulPatch] ELSE CAST(0 AS BIT)
+END AS [Prop]
+FROM [Tags] AS [cg]
+LEFT JOIN (
+    SELECT [cg.Gear].*
+    FROM [Gears] AS [cg.Gear]
+    WHERE [cg.Gear].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON ([cg].[GearNickName] = [t].[Nickname]) AND ([cg].[GearSquadId] = [t].[SquadId])");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Issue: When generating conditional expression we generated typed literal for true/false but that was not happening for nullable bools inside converts. Hence whole expression was getting upcasted to int type causing InvalidCastException


Resolves #9818

