### PR TITLE
Query: Apply type facets to all arguments for string.Contains

### DIFF
--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -165,7 +165,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         protected virtual string TypedFalseLiteral => "CAST(0 AS BIT)";
 
         /// <summary>
-        /// Whether schemas should be generated when generating identifiers.
+        ///     Whether schemas should be generated when generating identifiers.
         /// </summary>
         protected virtual bool SupportsSchemas { get; } = true;
 
@@ -447,8 +447,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         /// <param name="generationAction">The generation action.</param>
         /// <param name="joinAction">An optional join action.</param>
         protected virtual void GenerateList<T>(
-            [NotNull] IReadOnlyList<T> items, 
-            [NotNull] Action<T> generationAction, 
+            [NotNull] IReadOnlyList<T> items,
+            [NotNull] Action<T> generationAction,
             [CanBeNull] Action<IRelationalCommandBuilder> joinAction = null)
         {
             Check.NotNull(items, nameof(items));
@@ -1365,6 +1365,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
             _relationalCommandBuilder.Append(functionName);
             _relationalCommandBuilder.Append("(");
+
+            if (functionName == "CHARINDEX")
+            {
+                _typeMapping = arguments.Select(InferTypeMappingFromColumn)
+                                   .FirstOrDefault(t => t != null)
+                               ?? parentTypeMapping;
+            }
 
             GenerateList(arguments);
 

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -1449,7 +1449,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       select c);
         }
 
-        [ConditionalFact(Skip = "Test does not pass. See issue#4978")]
+        [ConditionalFact]
         public virtual void Non_unicode_string_literals_is_used_for_non_unicode_column_with_concat()
         {
             using (var context = CreateContext())

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -2020,7 +2020,7 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (([g].[Nickname] = N'Marc
             AssertSql(
                 @"SELECT [c].[Name], [c].[Location]
 FROM [Cities] AS [c]
-WHERE CHARINDEX(N'Jacinto', [c].[Location]) > 0");
+WHERE CHARINDEX('Jacinto', [c].[Location]) > 0");
         }
 
         public override void Non_unicode_string_literals_is_used_for_non_unicode_column_with_concat()
@@ -2030,7 +2030,7 @@ WHERE CHARINDEX(N'Jacinto', [c].[Location]) > 0");
             AssertSql(
                 @"SELECT [c].[Name], [c].[Location]
 FROM [Cities] AS [c]
-WHERE CHARINDEX('Add', [c].[Location] + 'Added') > 0");
+WHERE CHARINDEX(N'Add', [c].[Location] + 'Added') > 0");
         }
 
         public override void Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result1()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -2618,7 +2618,7 @@ FROM [Orders] AS [o]");
 
             AssertSql(
                 @"@__NewLine_0='
-' (Size = 4000)
+' (Size = 5)
 
 SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]


### PR DESCRIPTION
Resolves #9582

This solves the issue in simple cases. For complex cases we need to visit Expression Tree and infer facets and propagate them through tree.
