### PR TITLE
Query: Fix for incorrect QueryCache hit when chaining a streaming N+1 query

### DIFF
--- a/src/EFCore.Specification.Tests/Query/AsyncSimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncSimpleQueryTestBase.cs
@@ -173,7 +173,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             })
                         .ToList();
 
-                Assert.Equal(546, results.SelectMany(r => r.Orders).ToList().Count);
+                Assert.Equal(830, results.SelectMany(r => r.Orders).ToList().Count);
             }
         }
 

--- a/src/EFCore/Query/Internal/ExpressionEqualityComparer.cs
+++ b/src/EFCore/Query/Internal/ExpressionEqualityComparer.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
 
 // ReSharper disable SwitchStatementMissingSomeCases
@@ -434,8 +435,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     return false; // EnumerableQueries are opaque
                 }
 
-                if (a.Value is IQueryable
-                    && b.Value is IQueryable
+                if (a.IsEntityQueryable()
+                    && b.IsEntityQueryable()
                     && a.Value.GetType() == b.Value.GetType())
                 {
                     return true;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AsyncSimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AsyncSimpleQuerySqlServerTest.cs
@@ -20,14 +20,12 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public class AsyncSimpleQuerySqlServerTest : AsyncSimpleQueryTestBase<NorthwindQuerySqlServerFixture<NoopModelCustomizer>>
     {
-        private static readonly string EOL = Environment.NewLine;
-
         // ReSharper disable once UnusedParameter.Local
         public AsyncSimpleQuerySqlServerTest(NorthwindQuerySqlServerFixture<NoopModelCustomizer> fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
-            //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            Fixture.TestSqlLoggerFactory.Clear();
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         [ConditionalFact]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -4309,6 +4309,30 @@ ORDER BY [Id]
 OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY");
         }
 
+        public override void Streaming_chained_sync_query()
+        {
+            base.Streaming_chained_sync_query();
+
+            AssertContainsSql(
+                @"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]",
+                //
+                @"@_outer_CustomerID='ALFKI' (Size = 5)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = @_outer_CustomerID",
+                //
+                @"SELECT [y.Customer].[CustomerID], [y.Customer].[Address], [y.Customer].[City], [y.Customer].[CompanyName], [y.Customer].[ContactName], [y.Customer].[ContactTitle], [y.Customer].[Country], [y.Customer].[Fax], [y.Customer].[Phone], [y.Customer].[PostalCode], [y.Customer].[Region]
+FROM [Customers] AS [y.Customer]",
+                //
+                @"@_outer_CustomerID='ANATR' (Size = 5)
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = @_outer_CustomerID");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Issue:
When the query is projecting out a collection object in non-navigation case, we cause N+1 queries.
To support streaming behaviour, we inject QueryableAdapter (or async version) which would be evaluated on when enumerated.

When we are chaining on the navigation after such query, the QueryableAdapter is captured in ConstantExpression.
In our ExpressionEqualityComparer, during GetHashCode, we add such value if ConstantExpression is of type IQueryable. (so that we can fall back to Comparison)
During comparing such ConstantExpressions, we assumed if they are of type IQueryable then they are same. Which is true for IQueryable from DbSet.
But for QueryableAdapter which are also IQueryable, it could still evaluate to different results.
Another thing is, in `EntityQueryableExpressionVisitor` ConstantExpression of EntityQueryable are evaluated. But rest of them are kept intact.
Since we returned equality=true for all IQueryable, every subsequent query even though had different QueryableAdapter which gave different results we made cache hit and re-ran compiled query which has older value of QueryableAdapter (due to EntityQueryableExpressionVisitor) and would evaluate to incorrect values.

Resolves #9301
