### PR TITLE
Query: Use correct overload of DelimitIdentifier() in DefaultQuerySqlGenerator

### DIFF
--- a/samples/OracleProvider/src/OracleProvider/Query/Sql/Internal/OracleQuerySqlGenerator.cs
+++ b/samples/OracleProvider/src/OracleProvider/Query/Sql/Internal/OracleQuerySqlGenerator.cs
@@ -24,7 +24,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
 
         protected override string TypedTrueLiteral => "1";
         protected override string TypedFalseLiteral => "0";
-        protected override bool SupportsSchemas => false;
         protected override string AliasSeparator => " ";
 
         protected override string GenerateOperator(Expression expression)

--- a/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleSqlGenerationHelper.cs
+++ b/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleSqlGenerationHelper.cs
@@ -37,6 +37,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public override string DelimitIdentifier(string identifier)
             => $"\"{EscapeIdentifier(Check.NotEmpty(identifier, nameof(identifier)))}\""; // Interpolation okay; strings
 
+        public override string DelimitIdentifier(string name, string schema)
+            => DelimitIdentifier(name);
+
         public override void DelimitIdentifier(StringBuilder builder, string identifier)
         {
             Check.NotEmpty(identifier, nameof(identifier));
@@ -45,5 +48,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             EscapeIdentifier(builder, identifier);
             builder.Append('"');
         }
+
+        public override void DelimitIdentifier(StringBuilder builder, string name, string schema)
+            => DelimitIdentifier(builder, name);
     }
 }

--- a/samples/OracleProvider/test/OracleProvider.FunctionalTests/OracleMigrationSqlGeneratorTest.cs
+++ b/samples/OracleProvider/test/OracleProvider.FunctionalTests/OracleMigrationSqlGeneratorTest.cs
@@ -597,7 +597,7 @@ namespace Microsoft.EntityFrameworkCore
             base.CreateIndexOperation_unique();
 
             Assert.Equal(
-                "CREATE UNIQUE INDEX \"IX_People_Name\" ON \"dbo\".\"People\" (\"FirstName\", \"LastName\")",
+                "CREATE UNIQUE INDEX \"IX_People_Name\" ON \"People\" (\"FirstName\", \"LastName\")",
                 Sql);
         }
 
@@ -665,7 +665,7 @@ namespace Microsoft.EntityFrameworkCore
             base.DropIndexOperation();
 
             Assert.Equal(
-                "DROP INDEX \"IX_People_Name\" ON \"dbo\".\"People\"",
+                "DROP INDEX \"IX_People_Name\" ON \"People\"",
                 Sql);
         }
 

--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -165,11 +165,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         protected virtual string TypedFalseLiteral => "CAST(0 AS BIT)";
 
         /// <summary>
-        ///     Whether schemas should be generated when generating identifiers.
-        /// </summary>
-        protected virtual bool SupportsSchemas { get; } = true;
-
-        /// <summary>
         ///     The default alias separator.
         /// </summary>
         protected virtual string AliasSeparator { get; } = " AS ";
@@ -651,14 +646,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         {
             Check.NotNull(tableExpression, nameof(tableExpression));
 
-            if (SupportsSchemas
-                && tableExpression.Schema != null)
-            {
-                _relationalCommandBuilder.Append(SqlGenerator.DelimitIdentifier(tableExpression.Schema))
-                    .Append(".");
-            }
-
-            _relationalCommandBuilder.Append(SqlGenerator.DelimitIdentifier(tableExpression.Table))
+            _relationalCommandBuilder.Append(SqlGenerator.DelimitIdentifier(tableExpression.Table, tableExpression.Schema))
                 .Append(AliasSeparator)
                 .Append(SqlGenerator.DelimitIdentifier(tableExpression.Alias));
 
@@ -1360,8 +1348,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
             Check.NotEmpty(functionName, nameof(functionName));
             Check.NotNull(arguments, nameof(arguments));
 
-            if (SupportsSchemas
-                && !string.IsNullOrWhiteSpace(schema))
+            if (!string.IsNullOrWhiteSpace(schema))
             {
                 // ReSharper disable once AssignNullToNotNullAttribute
                 _relationalCommandBuilder.Append(SqlGenerator.DelimitIdentifier(schema))


### PR DESCRIPTION
Fixes #9560

I reviewed all places we generate SQL for schema and table name to ensure they were consistent.

You may want to review [ignoring whitespace changes](https://github.com/aspnet/EntityFrameworkCore/pull/9903/files?w=1) since the R# settings have diverged from Visual Studio's default formatting.