### PR TITLE
Only use the store type name for finding a type mapping if it has been explicitly set

### DIFF
--- a/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleTypeMapper.cs
+++ b/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleTypeMapper.cs
@@ -203,8 +203,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             }
         }
 
-        protected override string GetColumnType(IProperty property) => property.Oracle().ColumnType;
-
         protected override IReadOnlyDictionary<Type, RelationalTypeMapping> GetClrTypeMappings()
             => _clrTypeMappings;
 

--- a/src/EFCore.Relational/Storage/RelationalTypeMapper.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapper.cs
@@ -46,13 +46,13 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <returns> The type mappings. </returns>
         protected abstract IReadOnlyDictionary<string, RelationalTypeMapping> GetStoreTypeMappings();
 
-        // Not using IRelationalAnnotationProvider here because type mappers are Singletons
         /// <summary>
         ///     Gets column type for the given property.
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <returns> The name of the database type. </returns>
-        protected abstract string GetColumnType([NotNull] IProperty property);
+        protected virtual string GetColumnType([NotNull] IProperty property) 
+            => (string)Check.NotNull(property, nameof(property))[RelationalAnnotationNames.ColumnType];
 
         /// <summary>
         ///     Ensures that the given type name is a valid type for the relational database.

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMapper.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMapper.cs
@@ -253,12 +253,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected override string GetColumnType(IProperty property) => property.SqlServer().ColumnType;
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
         protected override IReadOnlyDictionary<Type, RelationalTypeMapping> GetClrTypeMappings()
             => _clrTypeMappings;
 

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTypeMapper.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTypeMapper.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
@@ -62,12 +61,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                     { typeof(Guid), new SqliteGuidTypeMapping(_blobTypeName) }
                 };
         }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        protected override string GetColumnType(IProperty property) => property.Relational().ColumnType;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
@@ -9,7 +9,6 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
-using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.EntityFrameworkCore.Update.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Migrations.Internal
@@ -76,8 +75,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 : base(dependencies)
             {
             }
-
-            protected override string GetColumnType(IProperty property) => property.TestProvider().ColumnType;
 
             public override RelationalTypeMapping FindMapping(Type clrType)
                 => clrType == typeof(string)

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalTypeMapper.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalTypeMapper.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
@@ -14,8 +13,6 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
         private static readonly RelationalTypeMapping _int = new IntTypeMapping("int", DbType.Int32);
         private static readonly RelationalTypeMapping _long = new LongTypeMapping("DefaultLong", DbType.Int64);
         private static readonly RelationalTypeMapping _string = new StringTypeMapping("DefaultString", DbType.String);
-
-        protected override string GetColumnType(IProperty property) => property.TestProvider().ColumnType;
 
         public FakeRelationalTypeMapper(RelationalTypeMapperDependencies dependencies)
             : base(dependencies)

--- a/test/EFCore.Relational.Tests/TestUtilities/TestRelationalTypeMapper.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/TestRelationalTypeMapper.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Data;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities
@@ -63,8 +62,6 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             : base(dependencies)
         {
         }
-
-        protected override string GetColumnType(IProperty property) => property.TestProvider().ColumnType;
 
         private readonly IReadOnlyDictionary<Type, RelationalTypeMapping> _simpleMappings
             = new Dictionary<Type, RelationalTypeMapping>

--- a/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingTest.cs
+++ b/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingTest.cs
@@ -59,5 +59,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 .GetMapping("varchar(max)").GenerateSqlLiteral("A Non-Unicode String");
             Assert.Equal("'A Non-Unicode String'", literal);
         }
+
+        protected override DbContextOptions ContextOptions { get; }
+            = new DbContextOptionsBuilder().UseSqlServer("Server=Dummy").Options;
     }
 }

--- a/test/EFCore.Sqlite.Tests/Storage/SqliteTypeMappingTest.cs
+++ b/test/EFCore.Sqlite.Tests/Storage/SqliteTypeMappingTest.cs
@@ -63,5 +63,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 .GetMapping(typeof(Guid)).GenerateSqlLiteral(value);
             Assert.Equal("X'9E3AF4C6E191EF45A320832EA23B7292'", literal);
         }
+
+        protected override DbContextOptions ContextOptions { get; } 
+            = new DbContextOptionsBuilder().UseSqlite("Filename=dummmy.db").Options;
     }
 }


### PR DESCRIPTION
Issue #9916
