### PR TITLE
Use initial type conversions to map unsigned types on SQL Server

### DIFF
--- a/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleTypeMapper.cs
+++ b/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleTypeMapper.cs
@@ -87,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
         private readonly OracleStringTypeMapping _xml = new OracleStringTypeMapping("XML", dbType: null, unicode: true);
 
-        private readonly Dictionary<string, RelationalTypeMapping> _storeTypeMappings;
+        private readonly Dictionary<string, IList<RelationalTypeMapping>> _storeTypeMappings;
         private readonly Dictionary<Type, RelationalTypeMapping> _clrTypeMappings;
         private readonly HashSet<string> _disallowedMappings;
 
@@ -95,28 +95,28 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             : base(dependencies)
         {
             _storeTypeMappings
-                = new Dictionary<string, RelationalTypeMapping>(StringComparer.OrdinalIgnoreCase)
+                = new Dictionary<string, IList<RelationalTypeMapping>>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { "number(19)", _long },
-                    { "blob", _variableLengthBinary },
-                    { "raw", _fixedLengthBinary },
-                    { "number(1)", _bool },
-                    { "char", _fixedLengthAnsiString },
-                    { "date", _date },
-                    { "timestamp", _datetime },
-                    { "timestamp(3) with time zone", _datetimeoffset3 },
-                    { "timestamp with time zone", _datetimeoffset },
-                    { "decimal(29,4)", _decimal },
-                    { "float(49)", _double },
-                    { "number(10)", _int },
-                    { "nchar", _fixedLengthUnicodeString },
-                    { "nvarchar2", _variableLengthUnicodeString },
-                    { "number(6)", _short },
-                    { "interval", _time },
-                    { "number(3)", _byte },
-                    { "raw(16)", _uniqueidentifier },
-                    { "varchar2", _variableLengthAnsiString },
-                    { "xml", _xml }
+                    { "number(19)", new List<RelationalTypeMapping> { _long } },
+                    { "blob", new List<RelationalTypeMapping> { _variableLengthBinary } },
+                    { "raw", new List<RelationalTypeMapping> { _fixedLengthBinary } },
+                    { "number(1)", new List<RelationalTypeMapping> { _bool } },
+                    { "char", new List<RelationalTypeMapping> { _fixedLengthAnsiString } },
+                    { "date", new List<RelationalTypeMapping> { _date } },
+                    { "timestamp", new List<RelationalTypeMapping> { _datetime } },
+                    { "timestamp(3) with time zone", new List<RelationalTypeMapping> { _datetimeoffset3 } },
+                    { "timestamp with time zone", new List<RelationalTypeMapping> { _datetimeoffset } },
+                    { "decimal(29,4)", new List<RelationalTypeMapping> { _decimal } },
+                    { "float(49)", new List<RelationalTypeMapping> { _double } },
+                    { "number(10)", new List<RelationalTypeMapping> { _int } },
+                    { "nchar", new List<RelationalTypeMapping> { _fixedLengthUnicodeString } },
+                    { "nvarchar2", new List<RelationalTypeMapping> { _variableLengthUnicodeString } },
+                    { "number(6)", new List<RelationalTypeMapping> { _short } },
+                    { "interval", new List<RelationalTypeMapping> { _time } },
+                    { "number(3)", new List<RelationalTypeMapping> { _byte } },
+                    { "raw(16)", new List<RelationalTypeMapping> { _uniqueidentifier } },
+                    { "varchar2", new List<RelationalTypeMapping> { _variableLengthAnsiString } },
+                    { "xml", new List<RelationalTypeMapping> { _xml } }
                 };
 
             _clrTypeMappings
@@ -206,7 +206,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         protected override IReadOnlyDictionary<Type, RelationalTypeMapping> GetClrTypeMappings()
             => _clrTypeMappings;
 
-        protected override IReadOnlyDictionary<string, RelationalTypeMapping> GetStoreTypeMappings()
+        protected override IReadOnlyDictionary<string, IList<RelationalTypeMapping>> GetMultipleStoreTypeMappings()
             => _storeTypeMappings;
 
         public override RelationalTypeMapping FindMapping(Type clrType)

--- a/src/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
@@ -516,7 +516,7 @@ FROM ""Customers""")
         [Fact]
         public virtual void From_sql_queryable_with_null_parameter()
         {
-            int? reportsTo = null;
+            uint? reportsTo = null;
 
             using (var context = CreateContext())
             {

--- a/src/EFCore.Relational.Specification.Tests/Query/QueryNoClientEvalTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/QueryNoClientEvalTestBase.cs
@@ -178,11 +178,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         RelationalEventId.QueryClientEvaluationWarning,
-                        RelationalStrings.LogClientEvalWarning.GenerateMessage("join Int32 i in __p_0 on [e1].EmployeeID equals [i]")),
+                        RelationalStrings.LogClientEvalWarning.GenerateMessage("join UInt32 i in __p_0 on [e1].EmployeeID equals [i]")),
                     Assert.Throws<InvalidOperationException>(
                         () =>
                             (from e1 in context.Employees
-                             join i in new[] { 1, 2, 3 } on e1.EmployeeID equals i
+                             join i in new uint[] { 1, 2, 3 } on e1.EmployeeID equals i
                              select e1)
                             .ToList()).Message);
             }
@@ -196,11 +196,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(
                     CoreStrings.WarningAsErrorTemplate(
                         RelationalEventId.QueryClientEvaluationWarning,
-                        RelationalStrings.LogClientEvalWarning.GenerateMessage("join Int32 i in __p_0 on [e1].EmployeeID equals [i]")),
+                        RelationalStrings.LogClientEvalWarning.GenerateMessage("join UInt32 i in __p_0 on [e1].EmployeeID equals [i]")),
                     Assert.Throws<InvalidOperationException>(
                         () =>
                             (from e1 in context.Employees
-                             join i in new[] { 1, 2, 3 } on e1.EmployeeID equals i into g
+                             join i in new uint[] { 1, 2, 3 } on e1.EmployeeID equals i into g
                              select e1)
                             .ToList()).Message);
             }

--- a/src/EFCore.Relational/Storage/IRelationalTypeMapper.cs
+++ b/src/EFCore.Relational/Storage/IRelationalTypeMapper.cs
@@ -35,8 +35,13 @@ namespace Microsoft.EntityFrameworkCore.Storage
         RelationalTypeMapping FindMapping([NotNull] Type clrType);
 
         /// <summary>
-        ///     Gets the mapping that represents the given database type.
-        ///     Returns null if no mapping is found.
+        ///     <para>
+        ///         Gets the mapping that represents the given database type.
+        ///         Returns null if no mapping is found.
+        ///     </para>
+        ///     <para>
+        ///         Note that sometimes the same store type can have different mappings; this method returns the default.
+        ///     </para>
         /// </summary>
         /// <param name="storeType"> The type to get the mapping for. </param>
         /// <returns> The type mapping to be used. </returns>

--- a/src/EFCore.Relational/Storage/RelationalTypeMapperExtensions.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapperExtensions.cs
@@ -81,7 +81,12 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         /// <summary>
-        ///     Gets the mapping that represents the given database type, throwing if no mapping is found.
+        ///     <para>
+        ///         Gets the mapping that represents the given database type, throwing if no mapping is found.
+        ///     </para>
+        ///     <para>
+        ///         Note that sometimes the same store type can have different mappings; this method returns the default.
+        ///     </para>
         /// </summary>
         /// <param name="typeMapper"> The type mapper. </param>
         /// <param name="typeName"> The type to get the mapping for. </param>

--- a/src/EFCore.Relational/Storage/SByteTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/SByteTypeMapping.cs
@@ -30,12 +30,26 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         /// <summary>
+        ///     Initializes a new instance of the <see cref="SByteTypeMapping" /> class.
+        /// </summary>
+        /// <param name="storeType"> The name of the database type. </param>
+        /// <param name="converter"> Converts types to and from the store whenever this mapping is used. </param>
+        /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
+        public SByteTypeMapping(
+            [NotNull] string storeType,
+            [NotNull] TypeConverter converter,
+            DbType? dbType = null)
+            : base(storeType, typeof(sbyte), converter, dbType)
+        {
+        }
+
+        /// <summary>
         ///     Creates a copy of this mapping.
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SByteTypeMapping(storeType, DbType);
+            => new SByteTypeMapping(storeType, Converter, DbType);
     }
 }

--- a/src/EFCore.Relational/Storage/UIntTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/UIntTypeMapping.cs
@@ -30,12 +30,26 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         /// <summary>
+        ///     Initializes a new instance of the <see cref="UIntTypeMapping" /> class.
+        /// </summary>
+        /// <param name="storeType"> The name of the database type. </param>
+        /// <param name="converter"> Converts types to and from the store whenever this mapping is used. </param>
+        /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
+        public UIntTypeMapping(
+            [NotNull] string storeType,
+            [NotNull] TypeConverter converter,
+            DbType? dbType = null)
+            : base(storeType, typeof(uint), converter, dbType)
+        {
+        }
+
+        /// <summary>
         ///     Creates a copy of this mapping.
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new UIntTypeMapping(storeType, DbType);
+            => new UIntTypeMapping(storeType, Converter, DbType);
     }
 }

--- a/src/EFCore.Relational/Storage/ULongTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/ULongTypeMapping.cs
@@ -25,7 +25,21 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public ULongTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : base(storeType, typeof(ulong), dbType, unicode: false, size: null)
+            : base(storeType, typeof(ulong), dbType)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="ULongTypeMapping" /> class.
+        /// </summary>
+        /// <param name="storeType"> The name of the database type. </param>
+        /// <param name="converter"> Converts types to and from the store whenever this mapping is used. </param>
+        /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
+        public ULongTypeMapping(
+            [NotNull] string storeType,
+            [NotNull] TypeConverter converter,
+            DbType? dbType = null)
+            : base(storeType, typeof(ulong), converter, dbType)
         {
         }
 
@@ -36,6 +50,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new ULongTypeMapping(storeType, DbType);
+            => new ULongTypeMapping(storeType, Converter, DbType);
     }
 }

--- a/src/EFCore.Relational/Storage/UShortTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/UShortTypeMapping.cs
@@ -30,12 +30,26 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         /// <summary>
+        ///     Initializes a new instance of the <see cref="UShortTypeMapping" /> class.
+        /// </summary>
+        /// <param name="storeType"> The name of the database type. </param>
+        /// <param name="converter"> Converts types to and from the store whenever this mapping is used. </param>
+        /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
+        public UShortTypeMapping(
+            [NotNull] string storeType,
+            [NotNull] TypeConverter converter,
+            DbType? dbType = null)
+            : base(storeType, typeof(ushort), converter, dbType)
+        {
+        }
+
+        /// <summary>
         ///     Creates a copy of this mapping.
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new UShortTypeMapping(storeType, DbType);
+            => new UShortTypeMapping(storeType, Converter, DbType);
     }
 }

--- a/src/EFCore.Specification.Tests/Query/AsyncQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncQueryTestBase.cs
@@ -327,6 +327,19 @@ namespace Microsoft.EntityFrameworkCore.Query
             => await AssertQueryScalar<TItem1, int>(actualQuery, expectedQuery, assertOrder);
 
         public virtual async Task AssertQueryScalar<TItem1>(
+            Func<IQueryable<TItem1>, IQueryable<uint>> query,
+            bool assertOrder = false)
+            where TItem1 : class
+            => await AssertQueryScalar(query, query, assertOrder);
+
+        public virtual async Task AssertQueryScalar<TItem1>(
+            Func<IQueryable<TItem1>, IQueryable<uint>> actualQuery,
+            Func<IQueryable<TItem1>, IQueryable<uint>> expectedQuery,
+            bool assertOrder = false)
+            where TItem1 : class
+            => await AssertQueryScalar<TItem1, uint>(actualQuery, expectedQuery, assertOrder);
+
+        public virtual async Task AssertQueryScalar<TItem1>(
             Func<IQueryable<TItem1>, IQueryable<long>> query,
             bool assertOrder = false)
             where TItem1 : class

--- a/src/EFCore.Specification.Tests/Query/AsyncSimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncSimpleQueryTestBase.cs
@@ -2104,7 +2104,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             await AssertQuery<Employee>(
                 es =>
-                    from e in es.Where(c => c.EmployeeID == -1).DefaultIfEmpty()
+                    from e in es.Where(c => c.EmployeeID == uint.MaxValue).DefaultIfEmpty()
                     select e);
         }
 
@@ -2113,7 +2113,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             await AssertQuery<Employee>(
                 es =>
-                    from e in es.Where(c => c.EmployeeID == -1).DefaultIfEmpty(new Employee())
+                    from e in es.Where(c => c.EmployeeID == uint.MaxValue).DefaultIfEmpty(new Employee())
                     select e,
                 entryCount: 1);
         }
@@ -2133,7 +2133,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             await AssertQueryScalar<Employee>(
                 es =>
-                    from e in es.Where(e => e.EmployeeID == -1).Select(e => e.EmployeeID).DefaultIfEmpty()
+                    from e in es.Where(e => e.EmployeeID == uint.MaxValue).Select(e => e.EmployeeID).DefaultIfEmpty()
                     select e);
         }
 
@@ -2888,7 +2888,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         private static int ClientEvalSelectorStateless() => 42;
 
-        protected internal int ClientEvalSelector(Order order) => order.EmployeeID % 10 ?? 0;
+        protected internal uint ClientEvalSelector(Order order) => order.EmployeeID % 10 ?? 0;
 
         [ConditionalFact]
         public virtual async Task Distinct()

--- a/src/EFCore.Specification.Tests/Query/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/QueryTestBase.cs
@@ -154,6 +154,19 @@ namespace Microsoft.EntityFrameworkCore.Query
             => AssertQueryScalar<TItem1, int>(actualQuery, expectedQuery, assertOrder);
 
         public virtual void AssertQueryScalar<TItem1>(
+            Func<IQueryable<TItem1>, IQueryable<uint>> query,
+            bool assertOrder = false)
+            where TItem1 : class
+            => AssertQueryScalar(query, query, assertOrder);
+
+        public virtual void AssertQueryScalar<TItem1>(
+            Func<IQueryable<TItem1>, IQueryable<uint>> actualQuery,
+            Func<IQueryable<TItem1>, IQueryable<uint>> expectedQuery,
+            bool assertOrder = false)
+            where TItem1 : class
+            => AssertQueryScalar<TItem1, uint>(actualQuery, expectedQuery, assertOrder);
+
+        public virtual void AssertQueryScalar<TItem1>(
             Func<IQueryable<TItem1>, IQueryable<long>> query,
             bool assertOrder = false)
             where TItem1 : class

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.JoinGroupJoin.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.JoinGroupJoin.cs
@@ -61,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 4);
         }
 
-        private int GetEmployeeID(Employee employee)
+        private uint GetEmployeeID(Employee employee)
         {
             return employee.EmployeeID;
         }
@@ -194,7 +194,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public virtual void Join_local_collection_int_closure_is_cached_correctly()
         {
-            var ids = new[] { 1, 2 };
+            var ids = new uint[] { 1, 2 };
 
             AssertQueryScalar<Employee>(
                 es =>
@@ -202,7 +202,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     join id in ids on e.EmployeeID equals id
                     select e.EmployeeID);
 
-            ids = new[] { 3 };
+            ids = new uint[] { 3 };
 
             AssertQueryScalar<Employee>(
                 es =>

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
@@ -421,7 +421,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         private static int ClientEvalSelectorStateless() => 42;
 
-        protected internal int ClientEvalSelector(Order order) => order.EmployeeID % 10 ?? 0;
+        protected internal uint ClientEvalSelector(Order order) => order.EmployeeID % 10 ?? 0;
 
         [ConditionalFact]
         public virtual void Distinct()
@@ -711,13 +711,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public virtual void Contains_with_local_int_array_closure()
         {
-            var ids = new[] { 0, 1 };
+            var ids = new uint[] { 0, 1 };
 
             AssertQuery<Employee>(
                 es =>
                     es.Where(e => ids.Contains(e.EmployeeID)), entryCount: 1);
 
-            ids = new[] { 0 };
+            ids = new uint[] { 0 };
 
             AssertQuery<Employee>(
                 es =>
@@ -727,13 +727,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public virtual void Contains_with_local_nullable_int_array_closure()
         {
-            var ids = new int?[] { 0, 1 };
+            var ids = new uint?[] { 0, 1 };
 
             AssertQuery<Employee>(
                 es =>
                     es.Where(e => ids.Contains(e.EmployeeID)), entryCount: 1);
 
-            ids = new int?[] { 0 };
+            ids = new uint?[] { 0 };
 
             AssertQuery<Employee>(
                 es =>

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -63,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             AssertQuery<Employee>(
                 es => es.Where(e => e.EmployeeID == 1)
                     .Select(e => new[] { e.EmployeeID, e.ReportsTo }),
-                elementAsserter: (e, a) => AssertArrays<int?>(e, a, 2));
+                elementAsserter: (e, a) => AssertArrays<uint?>(e, a, 2));
         }
 
         private static void AssertArrays<T>(object e, object a, int count)
@@ -493,7 +493,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 os => os
                     .Where(o => o.CustomerID == "ALFKI")
                     .OrderBy(o => o.OrderID)
-                    .Select(o => (int)o.EmployeeID),
+                    .Select(o => (uint)o.EmployeeID),
                 assertOrder: true);
         }
 

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
@@ -474,7 +474,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public virtual void Where_equals_using_object_overload_on_mismatched_types()
         {
-            long longPrm = 1;
+            ulong longPrm = 1;
 
             AssertQuery<Employee>(
                 es => es.Where(e => e.EmployeeID.Equals(longPrm)));
@@ -483,7 +483,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public virtual void Where_equals_using_int_overload_on_mismatched_types()
         {
-            short shortPrm = 1;
+            ushort shortPrm = 1;
 
             AssertQuery<Employee>(
                 es => es.Where(e => e.EmployeeID.Equals(shortPrm)),
@@ -493,7 +493,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public virtual void Where_equals_on_mismatched_types_nullable_int_long()
         {
-            long longPrm = 2;
+            ulong longPrm = 2;
 
             AssertQuery<Employee>(
                 es => es.Where(e => e.ReportsTo.Equals(longPrm)));
@@ -505,7 +505,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public virtual void Where_equals_on_mismatched_types_int_nullable_int()
         {
-            var intPrm = 2;
+            uint intPrm = 2;
 
             AssertQuery<Employee>(
                 es => es.Where(e => e.ReportsTo.Equals(intPrm)),
@@ -519,7 +519,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public virtual void Where_equals_on_mismatched_types_nullable_long_nullable_int()
         {
-            long? nullableLongPrm = 2;
+            ulong? nullableLongPrm = 2;
 
             AssertQuery<Employee>(
                 es => es.Where(e => nullableLongPrm.Equals(e.ReportsTo)));
@@ -531,7 +531,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public virtual void Where_equals_on_matched_nullable_int_types()
         {
-            int? nullableIntPrm = 2;
+            uint? nullableIntPrm = 2;
 
             AssertQuery<Employee>(
                 es => es.Where(e => nullableIntPrm.Equals(e.ReportsTo)),
@@ -545,7 +545,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public virtual void Where_equals_on_null_nullable_int_types()
         {
-            int? nullableIntPrm = null;
+            uint? nullableIntPrm = null;
 
             AssertQuery<Employee>(
                 es => es.Where(e => nullableIntPrm.Equals(e.ReportsTo)),

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -1792,7 +1792,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             AssertQuery<Employee>(
                 es =>
-                    from e in es.Where(c => c.EmployeeID == -1).DefaultIfEmpty()
+                    from e in es.Where(c => c.EmployeeID == uint.MaxValue).DefaultIfEmpty()
                     select e);
         }
 
@@ -1801,7 +1801,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             AssertQuery<Employee>(
                 es =>
-                    from e in es.Where(c => c.EmployeeID == -1).DefaultIfEmpty(new Employee())
+                    from e in es.Where(c => c.EmployeeID == uint.MaxValue).DefaultIfEmpty(new Employee())
                     select e,
                 entryCount: 1);
         }
@@ -1821,7 +1821,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             AssertQueryScalar<Employee>(
                 es =>
-                    from e in es.Where(e => e.EmployeeID == -1).Select(e => e.EmployeeID).DefaultIfEmpty()
+                    from e in es.Where(e => e.EmployeeID == uint.MaxValue).Select(e => e.EmployeeID).DefaultIfEmpty()
                     select e);
         }
 

--- a/src/EFCore.Specification.Tests/TestModels/Northwind/Employee.cs
+++ b/src/EFCore.Specification.Tests/TestModels/Northwind/Employee.cs
@@ -7,10 +7,10 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
 {
     public class Employee
     {
-        public int EmployeeID { get; set; }
+        public uint EmployeeID { get; set; }
         public string LastName { get; set; }
         public string FirstName { get; set; }
-        public string Title { get; set; } // shadow-prop in EF model
+        public string Title { get; set; }
         public string TitleOfCourtesy { get; set; }
         public DateTime? BirthDate { get; set; }
         public DateTime? HireDate { get; set; }
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
         public string Extension { get; set; }
         public byte[] Photo { get; set; }
         public string Notes { get; set; }
-        public int? ReportsTo { get; set; }
+        public uint? ReportsTo { get; set; }
         public string PhotoPath { get; set; }
 
         public Employee Manager { get; set; }

--- a/src/EFCore.Specification.Tests/TestModels/Northwind/Order.cs
+++ b/src/EFCore.Specification.Tests/TestModels/Northwind/Order.cs
@@ -10,7 +10,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
     {
         public int OrderID { get; set; }
         public string CustomerID { get; set; }
-        public int? EmployeeID { get; set; }
+        public uint? EmployeeID { get; set; }
         public DateTime? OrderDate { get; set; }
         public DateTime? RequiredDate { get; set; }
         public DateTime? ShippedDate { get; set; }

--- a/src/EFCore.Specification.Tests/TestModels/Northwind/Product.cs
+++ b/src/EFCore.Specification.Tests/TestModels/Northwind/Product.cs
@@ -18,9 +18,9 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
         public int? CategoryID { get; set; }
         public string QuantityPerUnit { get; set; }
         public decimal? UnitPrice { get; set; }
-        public short UnitsInStock { get; set; }
-        public short? UnitsOnOrder { get; set; }
-        public short? ReorderLevel { get; set; }
+        public ushort UnitsInStock { get; set; }
+        public ushort? UnitsOnOrder { get; set; }
+        public ushort? ReorderLevel { get; set; }
         public bool Discontinued { get; set; }
 
         public virtual List<OrderDetail> OrderDetails { get; set; }

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMapper.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMapper.cs
@@ -46,6 +46,35 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
         private readonly ByteTypeMapping _byte = new ByteTypeMapping("tinyint", DbType.Byte);
 
+        // TODO.TM Less burden on handle nulls/nullables/non-exact matches
+        private readonly UIntTypeMapping _uint = new UIntTypeMapping(
+            "int",
+            new TypeConverter(
+                v => v == null ? null : (object)(int)Convert.ToUInt32(v), 
+                v => v == null ? null : (object)(uint)Convert.ToInt32(v)),
+            DbType.Int32);
+
+        private readonly ULongTypeMapping _ulong = new ULongTypeMapping(
+            "bigint",
+            new TypeConverter(
+                v => v == null ? null : (object)(long)Convert.ToUInt64(v), 
+                v => v == null ? null : (object)(ulong)Convert.ToInt64(v)),
+            DbType.Int64);
+
+        private readonly UShortTypeMapping _ushort = new UShortTypeMapping(
+            "smallint",
+            new TypeConverter(
+                v => v == null ? null : (object)(short)Convert.ToUInt16(v), 
+                v => v == null ? null : (object)(ushort)Convert.ToInt16(v)),
+            DbType.Int16);
+
+        private readonly SByteTypeMapping _sbyte = new SByteTypeMapping(
+            "tinyint",
+            new TypeConverter(
+                v => v == null ? null : (object)(byte)Convert.ToSByte(v),
+                v => v == null ? null : (object)(sbyte)Convert.ToByte(v)),
+            DbType.Byte);
+
         private readonly BoolTypeMapping _bool = new BoolTypeMapping("bit");
 
         private readonly SqlServerStringTypeMapping _fixedLengthUnicodeString
@@ -84,7 +113,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
         private readonly SqlServerStringTypeMapping _xml = new SqlServerStringTypeMapping("xml", dbType: null, unicode: true);
 
-        private readonly Dictionary<string, RelationalTypeMapping> _storeTypeMappings;
+        private readonly Dictionary<string, IList<RelationalTypeMapping>> _storeTypeMappings;
         private readonly Dictionary<Type, RelationalTypeMapping> _clrTypeMappings;
         private readonly HashSet<string> _disallowedMappings;
 
@@ -96,46 +125,46 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             : base(dependencies)
         {
             _storeTypeMappings
-                = new Dictionary<string, RelationalTypeMapping>(StringComparer.OrdinalIgnoreCase)
+                = new Dictionary<string, IList<RelationalTypeMapping>>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { "bigint", _long },
-                    { "binary varying", _variableLengthBinary },
-                    { "binary", _fixedLengthBinary },
-                    { "bit", _bool },
-                    { "char varying", _variableLengthAnsiString },
-                    { "char", _fixedLengthAnsiString },
-                    { "character varying", _variableLengthAnsiString },
-                    { "character", _fixedLengthAnsiString },
-                    { "date", _date },
-                    { "datetime", _datetime },
-                    { "datetime2", _datetime2 },
-                    { "datetimeoffset", _datetimeoffset },
-                    { "dec", _decimal },
-                    { "decimal", _decimal },
-                    { "float", _double },
-                    { "image", _variableLengthBinary },
-                    { "int", _int },
-                    { "money", _decimal },
-                    { "national char varying", _variableLengthUnicodeString },
-                    { "national character varying", _variableLengthUnicodeString },
-                    { "national character", _fixedLengthUnicodeString },
-                    { "nchar", _fixedLengthUnicodeString },
-                    { "ntext", _variableLengthUnicodeString },
-                    { "numeric", _decimal },
-                    { "nvarchar", _variableLengthUnicodeString },
-                    { "real", _real },
-                    { "rowversion", _rowversion },
-                    { "smalldatetime", _datetime },
-                    { "smallint", _short },
-                    { "smallmoney", _decimal },
-                    { "text", _variableLengthAnsiString },
-                    { "time", _time },
-                    { "timestamp", _rowversion },
-                    { "tinyint", _byte },
-                    { "uniqueidentifier", _uniqueidentifier },
-                    { "varbinary", _variableLengthBinary },
-                    { "varchar", _variableLengthAnsiString },
-                    { "xml", _xml }
+                    { "bigint", new List<RelationalTypeMapping> { _long, _ulong } },
+                    { "binary varying", new List<RelationalTypeMapping> { _variableLengthBinary } },
+                    { "binary", new List<RelationalTypeMapping> { _fixedLengthBinary } },
+                    { "bit", new List<RelationalTypeMapping> { _bool } },
+                    { "char varying", new List<RelationalTypeMapping> { _variableLengthAnsiString } },
+                    { "char", new List<RelationalTypeMapping> { _fixedLengthAnsiString } },
+                    { "character varying", new List<RelationalTypeMapping> { _variableLengthAnsiString } },
+                    { "character", new List<RelationalTypeMapping> { _fixedLengthAnsiString } },
+                    { "date", new List<RelationalTypeMapping> { _date } },
+                    { "datetime", new List<RelationalTypeMapping> { _datetime } },
+                    { "datetime2", new List<RelationalTypeMapping> { _datetime2 } },
+                    { "datetimeoffset", new List<RelationalTypeMapping> { _datetimeoffset } },
+                    { "dec", new List<RelationalTypeMapping> { _decimal } },
+                    { "decimal", new List<RelationalTypeMapping> { _decimal } },
+                    { "float", new List<RelationalTypeMapping> { _double } },
+                    { "image", new List<RelationalTypeMapping> { _variableLengthBinary } },
+                    { "int", new List<RelationalTypeMapping> { _int, _uint } },
+                    { "money", new List<RelationalTypeMapping> { _decimal } },
+                    { "national char varying", new List<RelationalTypeMapping> { _variableLengthUnicodeString } },
+                    { "national character varying", new List<RelationalTypeMapping> { _variableLengthUnicodeString } },
+                    { "national character", new List<RelationalTypeMapping> { _fixedLengthUnicodeString } },
+                    { "nchar", new List<RelationalTypeMapping> { _fixedLengthUnicodeString } },
+                    { "ntext", new List<RelationalTypeMapping> { _variableLengthUnicodeString } },
+                    { "numeric", new List<RelationalTypeMapping> { _decimal } },
+                    { "nvarchar", new List<RelationalTypeMapping> { _variableLengthUnicodeString } },
+                    { "real", new List<RelationalTypeMapping> { _real } },
+                    { "rowversion", new List<RelationalTypeMapping> { _rowversion } },
+                    { "smalldatetime", new List<RelationalTypeMapping> { _datetime } },
+                    { "smallint", new List<RelationalTypeMapping> { _short, _ushort } },
+                    { "smallmoney", new List<RelationalTypeMapping> { _decimal } },
+                    { "text", new List<RelationalTypeMapping> { _variableLengthAnsiString } },
+                    { "time", new List<RelationalTypeMapping> { _time } },
+                    { "timestamp", new List<RelationalTypeMapping> { _rowversion } },
+                    { "tinyint", new List<RelationalTypeMapping> { _byte, _sbyte } },
+                    { "uniqueidentifier", new List<RelationalTypeMapping> { _uniqueidentifier } },
+                    { "varbinary", new List<RelationalTypeMapping> { _variableLengthBinary } },
+                    { "varchar", new List<RelationalTypeMapping> { _variableLengthAnsiString } },
+                    { "xml", new List<RelationalTypeMapping> { _xml } }
                 };
 
             // Note: sbyte, ushort, uint, char and ulong type mappings are not supported by SQL Server.
@@ -145,13 +174,17 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                 {
                     { typeof(int), _int },
                     { typeof(long), _long },
+                    { typeof(uint), _uint },
+                    { typeof(ulong), _ulong },
                     { typeof(DateTime), _datetime2 },
                     { typeof(Guid), _uniqueidentifier },
                     { typeof(bool), _bool },
                     { typeof(byte), _byte },
+                    { typeof(sbyte), _sbyte },
                     { typeof(double), _double },
                     { typeof(DateTimeOffset), _datetimeoffset },
                     { typeof(short), _short },
+                    { typeof(ushort), _ushort },
                     { typeof(float), _real },
                     { typeof(decimal), _decimal },
                     { typeof(TimeSpan), _time }
@@ -260,7 +293,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected override IReadOnlyDictionary<string, RelationalTypeMapping> GetStoreTypeMappings()
+        protected override IReadOnlyDictionary<string, IList<RelationalTypeMapping>> GetMultipleStoreTypeMappings()
             => _storeTypeMappings;
 
         /// <summary>

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTypeMapper.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTypeMapper.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         private static readonly ByteArrayTypeMapping _blob = new ByteArrayTypeMapping(_blobTypeName);
         private static readonly StringTypeMapping _text = new StringTypeMapping(_textTypeName);
 
-        private readonly Dictionary<string, RelationalTypeMapping> _storeTypeMappings;
+        private readonly Dictionary<string, IList<RelationalTypeMapping>> _storeTypeMappings;
         private readonly Dictionary<Type, RelationalTypeMapping> _clrTypeMappings;
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             : base(dependencies)
         {
             _storeTypeMappings
-                = new Dictionary<string, RelationalTypeMapping>(StringComparer.OrdinalIgnoreCase);
+                = new Dictionary<string, IList<RelationalTypeMapping>>(StringComparer.OrdinalIgnoreCase);
 
             _clrTypeMappings
                 = new Dictionary<Type, RelationalTypeMapping>
@@ -118,7 +118,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected override IReadOnlyDictionary<string, RelationalTypeMapping> GetStoreTypeMappings()
+        protected override IReadOnlyDictionary<string, IList<RelationalTypeMapping>> GetMultipleStoreTypeMappings()
             => _storeTypeMappings;
     }
 }

--- a/src/EFCore/Metadata/Internal/IEntityMaterializerSource.cs
+++ b/src/EFCore/Metadata/Internal/IEntityMaterializerSource.cs
@@ -28,6 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        [Obsolete("Use CreateReadValueExpression making sure to pass bound property if available.")]
         Expression CreateReadValueCallExpression([NotNull] Expression valueBuffer, int index);
 
         /// <summary>

--- a/src/EFCore/Metadata/Internal/PropertyAccessorsFactory.cs
+++ b/src/EFCore/Metadata/Internal/PropertyAccessorsFactory.cs
@@ -130,13 +130,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             var valueBufferParameter = Expression.Parameter(typeof(ValueBuffer), "valueBuffer");
 
-            return Expression.Lambda<Func<ValueBuffer, object>>(
+            var getter = Expression.Lambda<Func<ValueBuffer, object>>(
                     Expression.Call(
                         valueBufferParameter,
                         ValueBuffer.GetValueMethod,
                         Expression.Constant(property.GetIndex())),
                     valueBufferParameter)
                 .Compile();
+
+            var converter = property.FindMapping()?.Converter;
+
+            return converter != null 
+                ? (vb => converter.ConvertFromStore(getter(vb))) 
+                : getter;
         }
     }
 }

--- a/src/EFCore/Query/ExpressionVisitors/Internal/MemberAccessBindingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/MemberAccessBindingExpressionVisitor.cs
@@ -238,16 +238,30 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
         private static Expression TryCreateNullableAccessOperation(Expression accessOperation)
         {
-            if (accessOperation is MethodCallExpression methodCallExpression
-                && methodCallExpression.Method.MethodIsClosedFormOf(EntityMaterializerSource.TryReadValueMethod))
+            if (accessOperation is MethodCallExpression methodCallExpression)
             {
-                var tryReadValueMethodInfo = EntityMaterializerSource.TryReadValueMethod.MakeGenericMethod(accessOperation.Type.MakeNullable());
+                if (methodCallExpression.Method.MethodIsClosedFormOf(EntityMaterializerSource.TryReadValueMethod))
+                {
+                    var tryReadValueMethodInfo = EntityMaterializerSource.TryReadValueMethod.MakeGenericMethod(accessOperation.Type.MakeNullable());
 
-                return Expression.Call(
-                    tryReadValueMethodInfo,
-                    methodCallExpression.Arguments[0],
-                    methodCallExpression.Arguments[1],
-                    methodCallExpression.Arguments[2]);
+                    return Expression.Call(
+                        tryReadValueMethodInfo,
+                        methodCallExpression.Arguments[0],
+                        methodCallExpression.Arguments[1],
+                        methodCallExpression.Arguments[2]);
+                }
+
+                if (methodCallExpression.Method.MethodIsClosedFormOf(EntityMaterializerSource.TryReadValueWithConvertMethod))
+                {
+                    var tryReadValueMethodInfo = EntityMaterializerSource.TryReadValueWithConvertMethod.MakeGenericMethod(accessOperation.Type.MakeNullable());
+
+                    return Expression.Call(
+                        tryReadValueMethodInfo,
+                        methodCallExpression.Arguments[0],
+                        methodCallExpression.Arguments[1],
+                        methodCallExpression.Arguments[2],
+                        methodCallExpression.Arguments[3]);
+                }
             }
 
             return null;

--- a/src/EFCore/Storage/CoreTypeMapping.cs
+++ b/src/EFCore/Storage/CoreTypeMapping.cs
@@ -22,16 +22,26 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Initializes a new instance of the <see cref="CoreTypeMapping" /> class.
         /// </summary>
         /// <param name="clrType"> The .NET type used in the EF model. </param>
-        protected CoreTypeMapping([NotNull] Type clrType)
+        /// <param name="converter"> Converts types to and from the store whenever this mapping is used. </param>
+        protected CoreTypeMapping(
+            [NotNull] Type clrType,
+            [CanBeNull] TypeConverter converter = null)
         {
             Check.NotNull(clrType, nameof(clrType));
 
             ClrType = clrType;
+            Converter = converter;
         }
 
         /// <summary>
         ///     Gets the .NET type used in the EF model.
         /// </summary>
         public virtual Type ClrType { get; }
+
+        /// <summary>
+        ///     Converts types to and from the store whenever this mapping is used.
+        ///     May be null if no conversion is needed.
+        /// </summary>
+        public virtual TypeConverter Converter { get; }
     }
 }

--- a/src/EFCore/Storage/TypeConverter.cs
+++ b/src/EFCore/Storage/TypeConverter.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    /// <summary>
+    ///     Defines conversions from an object of one type in a model to an object of the same or
+    ///     different type in the store.
+    /// </summary>
+    public class TypeConverter
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="TypeConverter" /> class.
+        /// </summary>
+        /// <param name="convertToStore"> The function to convert objects when writing data to the store. </param>
+        /// <param name="convertFromStore"> The function to convert objects when reading data from the store. </param>
+        // TODO.TM Generic, non-boxing delegates
+        public TypeConverter(
+            [NotNull] Func<object, object> convertToStore,
+            [NotNull] Func<object, object> convertFromStore)
+        {
+            Check.NotNull(convertToStore, nameof(convertToStore));
+            Check.NotNull(convertFromStore, nameof(convertFromStore));
+
+            ConvertToStore = convertToStore;
+            ConvertFromStore = convertFromStore;
+        }
+
+        /// <summary>
+        ///     Gets the function to convert objects when writing data to the store.
+        /// </summary>
+        public virtual Func<object, object> ConvertToStore { get; }
+
+        /// <summary>
+        ///     Gets the function to convert objects when reading data from the store.
+        /// </summary>
+        public virtual Func<object, object> ConvertFromStore { get; }
+    }
+}

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
@@ -93,17 +93,17 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     { typeof(bool), new BoolTypeMapping("boolean") }
                 };
 
-            private readonly IReadOnlyDictionary<string, RelationalTypeMapping> _simpleNameMappings
-                = new Dictionary<string, RelationalTypeMapping>
+            private readonly IReadOnlyDictionary<string, IList<RelationalTypeMapping>> _simpleNameMappings
+                = new Dictionary<string, IList<RelationalTypeMapping>>
                 {
-                    { "varchar", new StringTypeMapping("varchar", dbType: null, unicode: false, size: null) },
-                    { "bigint", new LongTypeMapping("bigint") }
+                    { "varchar", new List<RelationalTypeMapping> { new StringTypeMapping("varchar") } },
+                    { "bigint", new List<RelationalTypeMapping> { new LongTypeMapping("bigint") } }
                 };
 
             protected override IReadOnlyDictionary<Type, RelationalTypeMapping> GetClrTypeMappings()
                 => _simpleMappings;
 
-            protected override IReadOnlyDictionary<string, RelationalTypeMapping> GetStoreTypeMappings()
+            protected override IReadOnlyDictionary<string, IList<RelationalTypeMapping>> GetMultipleStoreTypeMappings()
                 => _simpleNameMappings;
         }
     }

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalTypeMapper.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalTypeMapper.cs
@@ -27,18 +27,18 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
                 { typeof(string), _string }
             };
 
-        private readonly IReadOnlyDictionary<string, RelationalTypeMapping> _simpleNameMappings
-            = new Dictionary<string, RelationalTypeMapping>
+        private readonly IReadOnlyDictionary<string, IList<RelationalTypeMapping>> _simpleNameMappings
+            = new Dictionary<string, IList<RelationalTypeMapping>>
             {
-                { "DefaultInt", _int },
-                { "DefaultLong", _long },
-                { "DefaultString", _string }
+                { "DefaultInt", new List<RelationalTypeMapping> { _int  } },
+                { "DefaultLong", new List<RelationalTypeMapping> { _long } },
+                { "DefaultString", new List<RelationalTypeMapping> { _string } }
             };
 
         protected override IReadOnlyDictionary<Type, RelationalTypeMapping> GetClrTypeMappings()
             => _simpleMappings;
 
-        protected override IReadOnlyDictionary<string, RelationalTypeMapping> GetStoreTypeMappings()
+        protected override IReadOnlyDictionary<string, IList<RelationalTypeMapping>> GetMultipleStoreTypeMappings()
             => _simpleNameMappings;
     }
 }

--- a/test/EFCore.Relational.Tests/TestUtilities/TestRelationalTypeMapper.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/TestRelationalTypeMapper.cs
@@ -127,6 +127,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         protected override IReadOnlyDictionary<Type, RelationalTypeMapping> GetClrTypeMappings()
             => _simpleMappings;
 
+        [Obsolete("Override GetMultipleStoreTypeMappings instead.")] // Using the obsolete overload for testing
         protected override IReadOnlyDictionary<string, RelationalTypeMapping> GetStoreTypeMappings()
             => _simpleNameMappings;
 

--- a/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -101,6 +101,10 @@ WHERE [e].[Time] = @__timeSpan_0",
                         Bigint = 78L,
                         Smallint = 79,
                         Tinyint = 80,
+                        U_Int = uint.MaxValue,
+                        U_Bigint = ulong.MaxValue,
+                        U_Smallint = ushort.MaxValue,
+                        S_Tinyint = sbyte.MinValue,
                         Bit = true,
                         Money = 81.1m,
                         Smallmoney = 82.2m,
@@ -213,6 +217,18 @@ WHERE [e].[Time] = @__timeSpan_0",
 
                 decimal? param40 = 104m;
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.Numeric == param40));
+
+                uint? param41 = uint.MaxValue;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.U_Int == param41));
+
+                ulong? param42 = ulong.MaxValue;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.U_Bigint == param42));
+
+                ushort? param43 = ushort.MaxValue;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.U_Smallint == param43));
+
+                sbyte? param44 = sbyte.MinValue;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.S_Tinyint == param44));
             }
         }
 
@@ -321,6 +337,18 @@ WHERE [e].[Time] = @__timeSpan_0",
 
                 decimal? param40 = null;
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.Numeric == param40));
+
+                uint? param41 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.U_Int == param41));
+
+                ulong? param42 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.U_Bigint == param42));
+
+                ushort? param43 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.U_Smallint == param43));
+
+                sbyte? param44 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.S_Tinyint == param44));
             }
         }
 
@@ -365,14 +393,18 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p19='103.3'
 @p20='" + entity.NvarcharMax + @"' (Nullable = false) (Size = -1)
 @p21='84.4'
-@p22='2018-01-02T13:11:12' (DbType = DateTime)
-@p23='79'
-@p24='82.2'
-@p25='Gumball Rules!' (Nullable = false) (Size = 8000) (DbType = AnsiString)
-@p26='11:15:12'
-@p27='80' (Size = 1)
-@p28='0x595A5B5C' (Nullable = false) (Size = 8000)
-@p29='" + entity.VarcharMax + "' (Nullable = false) (Size = -1) (DbType = AnsiString)",
+@p22='128' (Size = 1)
+@p23='2018-01-02T13:11:12' (DbType = DateTime)
+@p24='79'
+@p25='82.2'
+@p26='Gumball Rules!' (Nullable = false) (Size = 8000) (DbType = AnsiString)
+@p27='11:15:12'
+@p28='80' (Size = 1)
+@p29='-1'
+@p30='-1'
+@p31='-1'
+@p32='0x595A5B5C' (Nullable = false) (Size = 8000)
+@p33='" + entity.VarcharMax + "' (Nullable = false) (Size = -1) (DbType = AnsiString)",
                 parameters,
                 ignoreLineEndingDifferences: true);
 
@@ -392,6 +424,10 @@ WHERE [e].[Time] = @__timeSpan_0",
             Assert.Equal(78, entity.Bigint);
             Assert.Equal(79, entity.Smallint);
             Assert.Equal(80, entity.Tinyint);
+            Assert.Equal(uint.MaxValue, entity.U_Int);
+            Assert.Equal(ulong.MaxValue, entity.U_Bigint);
+            Assert.Equal(ushort.MaxValue, entity.U_Smallint);
+            Assert.Equal(sbyte.MinValue, entity.S_Tinyint);
             Assert.True(entity.Bit);
             Assert.Equal(81.1m, entity.Money);
             Assert.Equal(82.2m, entity.Smallmoney);
@@ -427,6 +463,10 @@ WHERE [e].[Time] = @__timeSpan_0",
                 Bigint = 78L,
                 Smallint = 79,
                 Tinyint = 80,
+                U_Int = uint.MaxValue,
+                U_Bigint = ulong.MaxValue,
+                U_Smallint = ushort.MaxValue,
+                S_Tinyint = sbyte.MinValue,
                 Bit = true,
                 Money = 81.1m,
                 Smallmoney = 82.2m,
@@ -489,14 +529,18 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p19='103.3' (Nullable = true)
 @p20='don't' (Size = 4000)
 @p21='84.4' (Nullable = true)
-@p22='2018-01-02T13:11:12' (Nullable = true) (DbType = DateTime)
-@p23='79' (Nullable = true)
-@p24='82.2' (Nullable = true)
-@p25='Gumball Rules!' (Size = 8000) (DbType = AnsiString)
-@p26='11:15:12' (Nullable = true)
-@p27='80' (Nullable = true) (Size = 1)
-@p28='0x595A5B5C' (Size = 8000)
-@p29='C' (Size = 8000) (DbType = AnsiString)",
+@p22='128' (Nullable = true) (Size = 1)
+@p23='2018-01-02T13:11:12' (Nullable = true) (DbType = DateTime)
+@p24='79' (Nullable = true)
+@p25='82.2' (Nullable = true)
+@p26='Gumball Rules!' (Size = 8000) (DbType = AnsiString)
+@p27='11:15:12' (Nullable = true)
+@p28='80' (Nullable = true) (Size = 1)
+@p29='-1' (Nullable = true)
+@p30='-1' (Nullable = true)
+@p31='-1' (Nullable = true)
+@p32='0x595A5B5C' (Size = 8000)
+@p33='C' (Size = 8000) (DbType = AnsiString)",
                 parameters,
                 ignoreLineEndingDifferences: true);
 
@@ -512,6 +556,10 @@ WHERE [e].[Time] = @__timeSpan_0",
             Assert.Equal(78, entity.Bigint);
             Assert.Equal(79, entity.Smallint.Value);
             Assert.Equal(80, entity.Tinyint.Value);
+            Assert.Equal(uint.MaxValue, entity.U_Int);
+            Assert.Equal(ulong.MaxValue, entity.U_Bigint);
+            Assert.Equal(ushort.MaxValue, entity.U_Smallint);
+            Assert.Equal(sbyte.MinValue, entity.S_Tinyint);
             Assert.True(entity.Bit);
             Assert.Equal(81.1m, entity.Money);
             Assert.Equal(82.2m, entity.Smallmoney);
@@ -547,6 +595,10 @@ WHERE [e].[Time] = @__timeSpan_0",
                 Bigint = 78L,
                 Smallint = 79,
                 Tinyint = 80,
+                U_Int = uint.MaxValue,
+                U_Bigint = ulong.MaxValue,
+                U_Smallint = ushort.MaxValue,
+                S_Tinyint = sbyte.MinValue,
                 Bit = true,
                 Money = 81.1m,
                 Smallmoney = 82.2m,
@@ -609,14 +661,18 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p19='' (DbType = String)
 @p20='' (Size = 4000) (DbType = String)
 @p21='' (DbType = String)
-@p22='' (DbType = DateTime)
-@p23='' (DbType = Int16)
-@p24='' (DbType = String)
-@p25='' (Size = 8000)
-@p26='' (DbType = String)
-@p27='' (DbType = Byte)
-@p28='' (Size = 8000) (DbType = Binary)
-@p29='' (Size = 8000)",
+@p22='' (DbType = Byte)
+@p23='' (DbType = DateTime)
+@p24='' (DbType = Int16)
+@p25='' (DbType = String)
+@p26='' (Size = 8000)
+@p27='' (DbType = String)
+@p28='' (DbType = Byte)
+@p29='' (DbType = Int64)
+@p30='' (DbType = Int32)
+@p31='' (DbType = Int16)
+@p32='' (Size = 8000) (DbType = Binary)
+@p33='' (Size = 8000)",
                 parameters,
                 ignoreLineEndingDifferences: true);
 
@@ -632,6 +688,10 @@ WHERE [e].[Time] = @__timeSpan_0",
             Assert.Null(entity.Bigint);
             Assert.Null(entity.Smallint);
             Assert.Null(entity.Tinyint);
+            Assert.Null(entity.U_Int);
+            Assert.Null(entity.U_Bigint);
+            Assert.Null(entity.U_Smallint);
+            Assert.Null(entity.S_Tinyint);
             Assert.Null(entity.Bit);
             Assert.Null(entity.Money);
             Assert.Null(entity.Smallmoney);
@@ -915,14 +975,18 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p19='103.3'
 @p20='don't' (Size = 4000)
 @p21='84.4'
-@p22='2018-01-02T13:11:12' (DbType = DateTime)
-@p23='79'
-@p24='82.2'
-@p25='Gumball Rules!' (Size = 8000) (DbType = AnsiString)
-@p26='11:15:12'
-@p27='80' (Size = 1)
-@p28='0x595A5B5C' (Size = 8000)
-@p29='C' (Size = 8000) (DbType = AnsiString)",
+@p22='128' (Size = 1)
+@p23='2018-01-02T13:11:12' (DbType = DateTime)
+@p24='79'
+@p25='82.2'
+@p26='Gumball Rules!' (Size = 8000) (DbType = AnsiString)
+@p27='11:15:12'
+@p28='80' (Size = 1)
+@p29='-1'
+@p30='-1'
+@p31='-1'
+@p32='0x595A5B5C' (Size = 8000)
+@p33='C' (Size = 8000) (DbType = AnsiString)",
                 parameters,
                 ignoreLineEndingDifferences: true);
 
@@ -938,6 +1002,10 @@ WHERE [e].[Time] = @__timeSpan_0",
             Assert.Equal(78, entity.Bigint);
             Assert.Equal(79, entity.Smallint);
             Assert.Equal(80, entity.Tinyint);
+            Assert.Equal(uint.MaxValue, entity.U_Int);
+            Assert.Equal(ulong.MaxValue, entity.U_Bigint);
+            Assert.Equal(ushort.MaxValue, entity.U_Smallint);
+            Assert.Equal(sbyte.MinValue, entity.S_Tinyint);
             Assert.True(entity.Bit);
             Assert.Equal(81.1m, entity.Money);
             Assert.Equal(82.2m, entity.Smallmoney);
@@ -973,6 +1041,10 @@ WHERE [e].[Time] = @__timeSpan_0",
                 Bigint = 78L,
                 Smallint = 79,
                 Tinyint = 80,
+                U_Int = uint.MaxValue,
+                U_Bigint = ulong.MaxValue,
+                U_Smallint = ushort.MaxValue,
+                S_Tinyint = sbyte.MinValue,
                 Bit = true,
                 Money = 81.1m,
                 Smallmoney = 82.2m,
@@ -1035,14 +1107,18 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p19='103.3' (Nullable = true)
 @p20='don't' (Size = 4000)
 @p21='84.4' (Nullable = true)
-@p22='2018-01-02T13:11:12' (Nullable = true) (DbType = DateTime)
-@p23='79' (Nullable = true)
-@p24='82.2' (Nullable = true)
-@p25='Gumball Rules!' (Size = 8000) (DbType = AnsiString)
-@p26='11:15:12' (Nullable = true)
-@p27='80' (Nullable = true) (Size = 1)
-@p28='0x595A5B5C' (Size = 8000)
-@p29='C' (Size = 8000) (DbType = AnsiString)",
+@p22='128' (Nullable = true) (Size = 1)
+@p23='2018-01-02T13:11:12' (Nullable = true) (DbType = DateTime)
+@p24='79' (Nullable = true)
+@p25='82.2' (Nullable = true)
+@p26='Gumball Rules!' (Size = 8000) (DbType = AnsiString)
+@p27='11:15:12' (Nullable = true)
+@p28='80' (Nullable = true) (Size = 1)
+@p29='-1' (Nullable = true)
+@p30='-1' (Nullable = true)
+@p31='-1' (Nullable = true)
+@p32='0x595A5B5C' (Size = 8000)
+@p33='C' (Size = 8000) (DbType = AnsiString)",
                 parameters,
                 ignoreLineEndingDifferences: true);
 
@@ -1058,6 +1134,10 @@ WHERE [e].[Time] = @__timeSpan_0",
             Assert.Equal(78, entity.Bigint);
             Assert.Equal(79, entity.Smallint.Value);
             Assert.Equal(80, entity.Tinyint.Value);
+            Assert.Equal(uint.MaxValue, entity.U_Int);
+            Assert.Equal(ulong.MaxValue, entity.U_Bigint);
+            Assert.Equal(ushort.MaxValue, entity.U_Smallint);
+            Assert.Equal(sbyte.MinValue, entity.S_Tinyint);
             Assert.True(entity.Bit);
             Assert.Equal(81.1m, entity.Money);
             Assert.Equal(82.2m, entity.Smallmoney);
@@ -1093,6 +1173,10 @@ WHERE [e].[Time] = @__timeSpan_0",
                 Bigint = 78L,
                 Smallint = 79,
                 Tinyint = 80,
+                U_Int = uint.MaxValue,
+                U_Bigint = ulong.MaxValue,
+                U_Smallint = ushort.MaxValue,
+                S_Tinyint = sbyte.MinValue,
                 Bit = true,
                 Money = 81.1m,
                 Smallmoney = 82.2m,
@@ -1155,14 +1239,18 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p19='' (DbType = String)
 @p20='' (Size = 4000) (DbType = String)
 @p21='' (DbType = String)
-@p22='' (DbType = DateTime)
-@p23='' (DbType = Int16)
-@p24='' (DbType = String)
-@p25='' (Size = 8000)
-@p26='' (DbType = String)
-@p27='' (DbType = Byte)
-@p28='' (Size = 8000) (DbType = Binary)
-@p29='' (Size = 8000)",
+@p22='' (DbType = Byte)
+@p23='' (DbType = DateTime)
+@p24='' (DbType = Int16)
+@p25='' (DbType = String)
+@p26='' (Size = 8000)
+@p27='' (DbType = String)
+@p28='' (DbType = Byte)
+@p29='' (DbType = Int64)
+@p30='' (DbType = Int32)
+@p31='' (DbType = Int16)
+@p32='' (Size = 8000) (DbType = Binary)
+@p33='' (Size = 8000)",
                 parameters,
                 ignoreLineEndingDifferences: true);
 
@@ -1179,6 +1267,10 @@ WHERE [e].[Time] = @__timeSpan_0",
             Assert.Null(entity.Bigint);
             Assert.Null(entity.Smallint);
             Assert.Null(entity.Tinyint);
+            Assert.Null(entity.U_Int);
+            Assert.Null(entity.U_Bigint);
+            Assert.Null(entity.U_Smallint);
+            Assert.Null(entity.S_Tinyint);
             Assert.Null(entity.Bit);
             Assert.Null(entity.Money);
             Assert.Null(entity.Smallmoney);
@@ -1830,8 +1922,12 @@ BuiltInDataTypes.TestDouble ---> [float] [Precision = 53]
 BuiltInDataTypes.TestInt16 ---> [smallint] [Precision = 5 Scale = 0]
 BuiltInDataTypes.TestInt32 ---> [int] [Precision = 10 Scale = 0]
 BuiltInDataTypes.TestInt64 ---> [bigint] [Precision = 19 Scale = 0]
+BuiltInDataTypes.TestSignedByte ---> [tinyint] [Precision = 3 Scale = 0]
 BuiltInDataTypes.TestSingle ---> [real] [Precision = 24]
 BuiltInDataTypes.TestTimeSpan ---> [time] [Precision = 7]
+BuiltInDataTypes.TestUnsignedInt16 ---> [smallint] [Precision = 5 Scale = 0]
+BuiltInDataTypes.TestUnsignedInt32 ---> [int] [Precision = 10 Scale = 0]
+BuiltInDataTypes.TestUnsignedInt64 ---> [bigint] [Precision = 19 Scale = 0]
 BuiltInNullableDataTypes.Enum16 ---> [nullable smallint] [Precision = 5 Scale = 0]
 BuiltInNullableDataTypes.Enum32 ---> [nullable int] [Precision = 10 Scale = 0]
 BuiltInNullableDataTypes.Enum64 ---> [nullable bigint] [Precision = 19 Scale = 0]
@@ -1848,8 +1944,12 @@ BuiltInNullableDataTypes.TestNullableDouble ---> [nullable float] [Precision = 5
 BuiltInNullableDataTypes.TestNullableInt16 ---> [nullable smallint] [Precision = 5 Scale = 0]
 BuiltInNullableDataTypes.TestNullableInt32 ---> [nullable int] [Precision = 10 Scale = 0]
 BuiltInNullableDataTypes.TestNullableInt64 ---> [nullable bigint] [Precision = 19 Scale = 0]
+BuiltInNullableDataTypes.TestNullableSignedByte ---> [nullable tinyint] [Precision = 3 Scale = 0]
 BuiltInNullableDataTypes.TestNullableSingle ---> [nullable real] [Precision = 24]
 BuiltInNullableDataTypes.TestNullableTimeSpan ---> [nullable time] [Precision = 7]
+BuiltInNullableDataTypes.TestNullableUnsignedInt16 ---> [nullable smallint] [Precision = 5 Scale = 0]
+BuiltInNullableDataTypes.TestNullableUnsignedInt32 ---> [nullable int] [Precision = 10 Scale = 0]
+BuiltInNullableDataTypes.TestNullableUnsignedInt64 ---> [nullable bigint] [Precision = 19 Scale = 0]
 BuiltInNullableDataTypes.TestString ---> [nullable nvarchar] [MaxLength = -1]
 MappedDataTypes.Bigint ---> [bigint] [Precision = 19 Scale = 0]
 MappedDataTypes.Binary_varyingMax ---> [varbinary] [MaxLength = -1]
@@ -1873,12 +1973,16 @@ MappedDataTypes.Ntext ---> [ntext] [MaxLength = 1073741823]
 MappedDataTypes.Numeric ---> [numeric] [Precision = 18 Scale = 0]
 MappedDataTypes.NvarcharMax ---> [nvarchar] [MaxLength = -1]
 MappedDataTypes.Real ---> [real] [Precision = 24]
+MappedDataTypes.S_Tinyint ---> [tinyint] [Precision = 3 Scale = 0]
 MappedDataTypes.Smalldatetime ---> [smalldatetime] [Precision = 0]
 MappedDataTypes.Smallint ---> [smallint] [Precision = 5 Scale = 0]
 MappedDataTypes.Smallmoney ---> [smallmoney] [Precision = 10 Scale = 4]
 MappedDataTypes.Text ---> [text] [MaxLength = 2147483647]
 MappedDataTypes.Time ---> [time] [Precision = 7]
 MappedDataTypes.Tinyint ---> [tinyint] [Precision = 3 Scale = 0]
+MappedDataTypes.U_Bigint ---> [bigint] [Precision = 19 Scale = 0]
+MappedDataTypes.U_Int ---> [int] [Precision = 10 Scale = 0]
+MappedDataTypes.U_Smallint ---> [smallint] [Precision = 5 Scale = 0]
 MappedDataTypes.VarbinaryMax ---> [varbinary] [MaxLength = -1]
 MappedDataTypes.VarcharMax ---> [varchar] [MaxLength = -1]
 MappedDataTypesWithIdentity.Bigint ---> [bigint] [Precision = 19 Scale = 0]
@@ -1904,12 +2008,16 @@ MappedDataTypesWithIdentity.Ntext ---> [nullable ntext] [MaxLength = 1073741823]
 MappedDataTypesWithIdentity.Numeric ---> [numeric] [Precision = 18 Scale = 0]
 MappedDataTypesWithIdentity.NvarcharMax ---> [nullable nvarchar] [MaxLength = -1]
 MappedDataTypesWithIdentity.Real ---> [real] [Precision = 24]
+MappedDataTypesWithIdentity.S_Tinyint ---> [tinyint] [Precision = 3 Scale = 0]
 MappedDataTypesWithIdentity.Smalldatetime ---> [smalldatetime] [Precision = 0]
 MappedDataTypesWithIdentity.Smallint ---> [smallint] [Precision = 5 Scale = 0]
 MappedDataTypesWithIdentity.Smallmoney ---> [smallmoney] [Precision = 10 Scale = 4]
 MappedDataTypesWithIdentity.Text ---> [nullable text] [MaxLength = 2147483647]
 MappedDataTypesWithIdentity.Time ---> [time] [Precision = 7]
 MappedDataTypesWithIdentity.Tinyint ---> [tinyint] [Precision = 3 Scale = 0]
+MappedDataTypesWithIdentity.U_Bigint ---> [bigint] [Precision = 19 Scale = 0]
+MappedDataTypesWithIdentity.U_Int ---> [int] [Precision = 10 Scale = 0]
+MappedDataTypesWithIdentity.U_Smallint ---> [smallint] [Precision = 5 Scale = 0]
 MappedDataTypesWithIdentity.VarbinaryMax ---> [nullable varbinary] [MaxLength = -1]
 MappedDataTypesWithIdentity.VarcharMax ---> [nullable varchar] [MaxLength = -1]
 MappedNullableDataTypes.Bigint ---> [nullable bigint] [Precision = 19 Scale = 0]
@@ -1934,12 +2042,16 @@ MappedNullableDataTypes.Ntext ---> [nullable ntext] [MaxLength = 1073741823]
 MappedNullableDataTypes.Numeric ---> [nullable numeric] [Precision = 18 Scale = 0]
 MappedNullableDataTypes.NvarcharMax ---> [nullable nvarchar] [MaxLength = -1]
 MappedNullableDataTypes.Real ---> [nullable real] [Precision = 24]
+MappedNullableDataTypes.S_Tinyint ---> [nullable tinyint] [Precision = 3 Scale = 0]
 MappedNullableDataTypes.Smalldatetime ---> [nullable smalldatetime] [Precision = 0]
 MappedNullableDataTypes.Smallint ---> [nullable smallint] [Precision = 5 Scale = 0]
 MappedNullableDataTypes.Smallmoney ---> [nullable smallmoney] [Precision = 10 Scale = 4]
 MappedNullableDataTypes.Text ---> [nullable text] [MaxLength = 2147483647]
 MappedNullableDataTypes.Time ---> [nullable time] [Precision = 7]
 MappedNullableDataTypes.Tinyint ---> [nullable tinyint] [Precision = 3 Scale = 0]
+MappedNullableDataTypes.U_Bigint ---> [nullable bigint] [Precision = 19 Scale = 0]
+MappedNullableDataTypes.U_Int ---> [nullable int] [Precision = 10 Scale = 0]
+MappedNullableDataTypes.U_Smallint ---> [nullable smallint] [Precision = 5 Scale = 0]
 MappedNullableDataTypes.VarbinaryMax ---> [nullable varbinary] [MaxLength = -1]
 MappedNullableDataTypes.VarcharMax ---> [nullable varchar] [MaxLength = -1]
 MappedNullableDataTypesWithIdentity.Bigint ---> [nullable bigint] [Precision = 19 Scale = 0]
@@ -1965,12 +2077,16 @@ MappedNullableDataTypesWithIdentity.Ntext ---> [nullable ntext] [MaxLength = 107
 MappedNullableDataTypesWithIdentity.Numeric ---> [nullable numeric] [Precision = 18 Scale = 0]
 MappedNullableDataTypesWithIdentity.NvarcharMax ---> [nullable nvarchar] [MaxLength = -1]
 MappedNullableDataTypesWithIdentity.Real ---> [nullable real] [Precision = 24]
+MappedNullableDataTypesWithIdentity.S_Tinyint ---> [nullable tinyint] [Precision = 3 Scale = 0]
 MappedNullableDataTypesWithIdentity.Smalldatetime ---> [nullable smalldatetime] [Precision = 0]
 MappedNullableDataTypesWithIdentity.Smallint ---> [nullable smallint] [Precision = 5 Scale = 0]
 MappedNullableDataTypesWithIdentity.Smallmoney ---> [nullable smallmoney] [Precision = 10 Scale = 4]
 MappedNullableDataTypesWithIdentity.Text ---> [nullable text] [MaxLength = 2147483647]
 MappedNullableDataTypesWithIdentity.Time ---> [nullable time] [Precision = 7]
 MappedNullableDataTypesWithIdentity.Tinyint ---> [nullable tinyint] [Precision = 3 Scale = 0]
+MappedNullableDataTypesWithIdentity.U_Bigint ---> [nullable bigint] [Precision = 19 Scale = 0]
+MappedNullableDataTypesWithIdentity.U_Int ---> [nullable int] [Precision = 10 Scale = 0]
+MappedNullableDataTypesWithIdentity.U_Smallint ---> [nullable smallint] [Precision = 5 Scale = 0]
 MappedNullableDataTypesWithIdentity.VarbinaryMax ---> [nullable varbinary] [MaxLength = -1]
 MappedNullableDataTypesWithIdentity.VarcharMax ---> [nullable varchar] [MaxLength = -1]
 MappedPrecisionAndScaledDataTypes.Dec ---> [decimal] [Precision = 5 Scale = 2]
@@ -2087,22 +2203,14 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
                 modelBuilder.Entity<BuiltInDataTypes>(
                     b =>
                         {
-                            b.Ignore(dt => dt.TestUnsignedInt16);
-                            b.Ignore(dt => dt.TestUnsignedInt32);
-                            b.Ignore(dt => dt.TestUnsignedInt64);
                             b.Ignore(dt => dt.TestCharacter);
-                            b.Ignore(dt => dt.TestSignedByte);
                             b.Property(dt => dt.TestDecimal).HasColumnType("decimal(18,2)");
                         });
 
                 modelBuilder.Entity<BuiltInNullableDataTypes>(
                     b =>
                         {
-                            b.Ignore(dt => dt.TestNullableUnsignedInt16);
-                            b.Ignore(dt => dt.TestNullableUnsignedInt32);
-                            b.Ignore(dt => dt.TestNullableUnsignedInt64);
                             b.Ignore(dt => dt.TestNullableCharacter);
-                            b.Ignore(dt => dt.TestNullableSignedByte);
                         });
 
                 modelBuilder.Entity<MappedDataTypes>(
@@ -2174,6 +2282,12 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
                         typeName = typeName.Substring(0, typeName.IndexOf("Max")) + "(max)";
                     }
 
+                    if (typeName.StartsWith("U_")
+                        || typeName.StartsWith("S_"))
+                    {
+                        typeName = typeName.Substring(2);
+                    }
+
                     typeName = typeName.Replace('_', ' ');
 
                     entityType.GetOrAddProperty(propertyInfo).Relational().ColumnType = typeName;
@@ -2220,6 +2334,10 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
             public long Bigint { get; set; }
             public short Smallint { get; set; }
             public byte Tinyint { get; set; }
+            public uint U_Int { get; set; }
+            public ulong U_Bigint { get; set; }
+            public ushort U_Smallint { get; set; }
+            public sbyte S_Tinyint { get; set; }
             public bool Bit { get; set; }
             public decimal Money { get; set; }
             public decimal Smallmoney { get; set; }
@@ -2292,6 +2410,10 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
             public long? Bigint { get; set; }
             public short? Smallint { get; set; }
             public byte? Tinyint { get; set; }
+            public uint? U_Int { get; set; }
+            public ulong? U_Bigint { get; set; }
+            public ushort? U_Smallint { get; set; }
+            public sbyte? S_Tinyint { get; set; }
             public bool? Bit { get; set; }
             public decimal? Money { get; set; }
             public decimal? Smallmoney { get; set; }
@@ -2328,6 +2450,10 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
             public long Bigint { get; set; }
             public short Smallint { get; set; }
             public byte Tinyint { get; set; }
+            public uint U_Int { get; set; }
+            public ulong U_Bigint { get; set; }
+            public ushort U_Smallint { get; set; }
+            public sbyte S_Tinyint { get; set; }
             public bool Bit { get; set; }
             public decimal Money { get; set; }
             public decimal Smallmoney { get; set; }
@@ -2408,6 +2534,10 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
             public long? Bigint { get; set; }
             public short? Smallint { get; set; }
             public byte? Tinyint { get; set; }
+            public uint? U_Int { get; set; }
+            public ulong? U_Bigint { get; set; }
+            public ushort? U_Smallint { get; set; }
+            public sbyte? S_Tinyint { get; set; }
             public bool? Bit { get; set; }
             public decimal? Money { get; set; }
             public decimal? Smallmoney { get; set; }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
@@ -495,7 +495,7 @@ WHERE 0 = 1");
             base.Where_equals_using_int_overload_on_mismatched_types();
 
             AssertSql(
-                @"@__shortPrm_0='1' (DbType = Int32)
+                @"@__shortPrm_0='1'
 
 SELECT [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
 FROM [Employees] AS [e]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -203,7 +203,7 @@ FROM (
 LEFT JOIN (
     SELECT [c].[EmployeeID], [c].[City], [c].[Country], [c].[FirstName], [c].[ReportsTo], [c].[Title]
     FROM [Employees] AS [c]
-    WHERE [c].[EmployeeID] = -1
+    WHERE [c].[EmployeeID] = 4294967295
 ) AS [t] ON 1 = 1");
         }
 
@@ -230,7 +230,7 @@ LEFT JOIN (
             AssertSql(
                 @"SELECT [c].[EmployeeID], [c].[City], [c].[Country], [c].[FirstName], [c].[ReportsTo], [c].[Title]
 FROM [Employees] AS [c]
-WHERE [c].[EmployeeID] = -1");
+WHERE [c].[EmployeeID] = 4294967295");
         }
 
         public override void Default_if_empty_top_level_projection()
@@ -245,7 +245,7 @@ FROM (
 LEFT JOIN (
     SELECT [e].[EmployeeID]
     FROM [Employees] AS [e]
-    WHERE [e].[EmployeeID] = -1
+    WHERE [e].[EmployeeID] = 4294967295
 ) AS [t] ON 1 = 1");
         }
 
@@ -2969,7 +2969,7 @@ WHERE [c2].[CustomerID] = @_outer_CustomerID1");
             AssertSql(
                 @"SELECT [o].[CustomerID]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] IS NOT NULL AND (CHARINDEX(N'10', CONVERT(VARCHAR(11), [o].[EmployeeID])) > 0)");
+WHERE [o].[OrderDate] IS NOT NULL AND (CHARINDEX(N'10', CONVERT(VARCHAR(10), [o].[EmployeeID])) > 0)");
         }
 
         public override void Select_expression_long_to_string()

--- a/test/EFCore.SqlServer.Tests/SqlServerTypeMapperTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerTypeMapperTest.cs
@@ -49,20 +49,8 @@ namespace Microsoft.EntityFrameworkCore
         [Fact]
         public void Throws_for_SQL_Server_mappings_to_unsupported_types()
         {
-            var ex = Assert.Throws<InvalidOperationException>(() => GetTypeMapping(typeof(sbyte)).StoreType);
-            Assert.Equal(RelationalStrings.UnsupportedPropertyType("MyType", "MyProp", "sbyte"), ex.Message);
-
-            ex = Assert.Throws<InvalidOperationException>(() => GetTypeMapping(typeof(ushort)).StoreType);
-            Assert.Equal(RelationalStrings.UnsupportedPropertyType("MyType", "MyProp", "ushort"), ex.Message);
-
-            ex = Assert.Throws<InvalidOperationException>(() => GetTypeMapping(typeof(uint)).StoreType);
-            Assert.Equal(RelationalStrings.UnsupportedPropertyType("MyType", "MyProp", "uint"), ex.Message);
-
-            ex = Assert.Throws<InvalidOperationException>(() => GetTypeMapping(typeof(char)).StoreType);
+            var ex = Assert.Throws<InvalidOperationException>(() => GetTypeMapping(typeof(char)).StoreType);
             Assert.Equal(RelationalStrings.UnsupportedPropertyType("MyType", "MyProp", "char"), ex.Message);
-
-            ex = Assert.Throws<InvalidOperationException>(() => GetTypeMapping(typeof(ulong)).StoreType);
-            Assert.Equal(RelationalStrings.UnsupportedPropertyType("MyType", "MyProp", "ulong"), ex.Message);
         }
 
         [Fact]


### PR DESCRIPTION
Part of #242

This is not a complete implementation of type conversions. It is enough to get conversions for ulong, uint, ushort, and sbyte mapped on SQL Server. The default mappings for these types are to their signed counterparts. We can discuss if we want to change that to something else--there are pros and cons of every conversion.
