### PR TITLE
[2.0.1] Use MSBuild to set NuGet feeds instead of NuGet.config

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,4 +1,5 @@
 <Project>
+  <Import Project="build\sources.props" />
   <Import Project="build\dependencies.props" />
   <Import Project="build\dependencies.targets" />
   <Import Project="build\dependencies.g.targets" Condition="Exists('build\dependencies.g.targets') AND '$(DesignTimeBuild)' != 'true'" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,9 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="AspNetCorePatch" value="https://dotnet.myget.org/F/aspnet-2-0-2-october2017-patch/api/v3/index.json" />
-    <add key="AspNetCore" value="https://dotnet.myget.org/F/aspnetcore-master/api/v3/index.json" />
-    <add key="AspNetCoreTools" value="https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json" />
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    <!-- Restore sources should be defined in build/sources.props. -->
   </packageSources>
 </configuration>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,10 +3,10 @@
     <AspNetCoreVersion>2.0.0</AspNetCoreVersion>
     <CoreFxVersion>4.4.0</CoreFxVersion>
     <DiagnosticSourceVersion>4.4.1</DiagnosticSourceVersion>
-    <DependencyModelVersion>2.0.0</DependencyModelVersion>
     <EF6Version>6.1.3</EF6Version>
     <InternalAspNetCoreSdkVersion>2.0.1-rtm-15400</InternalAspNetCoreSdkVersion>
     <JsonNetVersion>10.0.1</JsonNetVersion>
+    <MicrosoftExtensionsDependencyModelPackageVersion>2.0.2-servicing-25728-02</MicrosoftExtensionsDependencyModelPackageVersion>
     <MoqVersion>4.7.49</MoqVersion>
     <NETFrameworkPackageVersion>2.0.0</NETFrameworkPackageVersion>
     <NETStandardImplicitPackageVersion>2.0.0</NETStandardImplicitPackageVersion>

--- a/build/sources.props
+++ b/build/sources.props
@@ -1,0 +1,14 @@
+﻿<Project>
+  <Import Project="$(DotNetRestoreSourcePropsPath)" Condition="'$(DotNetRestoreSourcePropsPath)' != ''"/>
+
+  <PropertyGroup>
+    <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
+    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
+      $(RestoreSources);
+      https://dotnet.myget.org/F/aspnet-2-0-2-october2017-patch/api/v3/index.json;
+      https://dotnet.myget.org/F/aspnetcore-master/api/v3/index.json;
+      https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json;
+      https://api.nuget.org/v3/index.json;
+    </RestoreSources>
+  </PropertyGroup>
+</Project>

--- a/src/EFCore.Relational.Design.Specification.Tests/EFCore.Relational.Design.Specification.Tests.csproj
+++ b/src/EFCore.Relational.Design.Specification.Tests/EFCore.Relational.Design.Specification.Tests.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynVersion)" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(DependencyModelVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelPackageVersion)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Changes
 - Use MSBuild to set NuGet feeds instead of NuGet.config. This allows us to configure feeds conditionally using MSBuild properties which is not possible with NuGet.config
 - Upgrade Microsoft.Extensions.DependencyModel to the latest 2.0.x build

FYI - CI is expected to fail until we mirror Microsoft.Extensions.DependencyModel 2.0.2-servicing-25728-02 to our feed