### PR TITLE
Add generic type conversion

### DIFF
--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMapper.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMapper.cs
@@ -46,33 +46,24 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
         private readonly ByteTypeMapping _byte = new ByteTypeMapping("tinyint", DbType.Byte);
 
-        // TODO.TM Less burden on handle nulls/nullables/non-exact matches
         private readonly UIntTypeMapping _uint = new UIntTypeMapping(
             "int",
-            new TypeConverter(
-                v => v == null ? null : (object)(int)Convert.ToUInt32(v), 
-                v => v == null ? null : (object)(uint)Convert.ToInt32(v)),
+            new TypeConverter<uint, int>(v => (int)v, v => (uint)v),
             DbType.Int32);
 
         private readonly ULongTypeMapping _ulong = new ULongTypeMapping(
             "bigint",
-            new TypeConverter(
-                v => v == null ? null : (object)(long)Convert.ToUInt64(v), 
-                v => v == null ? null : (object)(ulong)Convert.ToInt64(v)),
+            new TypeConverter<ulong, long>(v => (long)v, v => (ulong)v),
             DbType.Int64);
 
         private readonly UShortTypeMapping _ushort = new UShortTypeMapping(
             "smallint",
-            new TypeConverter(
-                v => v == null ? null : (object)(short)Convert.ToUInt16(v), 
-                v => v == null ? null : (object)(ushort)Convert.ToInt16(v)),
+            new TypeConverter<ushort, short>(v => (short)v, v => (ushort)v),
             DbType.Int16);
 
         private readonly SByteTypeMapping _sbyte = new SByteTypeMapping(
             "tinyint",
-            new TypeConverter(
-                v => v == null ? null : (object)(byte)Convert.ToSByte(v),
-                v => v == null ? null : (object)(sbyte)Convert.ToByte(v)),
+            new TypeConverter<sbyte, byte>(v => (byte)v, v => (sbyte)v),
             DbType.Byte);
 
         private readonly BoolTypeMapping _bool = new BoolTypeMapping("bit");

--- a/src/EFCore/Storage/TypeConverter.cs
+++ b/src/EFCore/Storage/TypeConverter.cs
@@ -11,33 +11,81 @@ namespace Microsoft.EntityFrameworkCore.Storage
     ///     Defines conversions from an object of one type in a model to an object of the same or
     ///     different type in the store.
     /// </summary>
-    public class TypeConverter
+    public abstract class TypeConverter
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="TypeConverter" /> class.
         /// </summary>
-        /// <param name="convertToStore"> The function to convert objects when writing data to the store. </param>
-        /// <param name="convertFromStore"> The function to convert objects when reading data from the store. </param>
-        // TODO.TM Generic, non-boxing delegates
-        public TypeConverter(
+        /// <param name="convertToStore">
+        ///     The function to convert objects when writing data to the store,
+        ///     setup to handle nulls, boxing, and non-exact matches of simple types.
+        /// </param>
+        /// <param name="convertFromStore">
+        ///     The function to convert objects when reading data from the store,
+        ///     setup to handle nulls, boxing, and non-exact matches of simple types.
+        /// </param>
+        /// <param name="rawConvertToStore">
+        ///     The function to convert objects when writing data to the store,
+        ///     exactly as supplied, which may be a generic delegate and may not handle
+        ///     nulls, boxing, and non-exact matches of simple types.
+        /// </param>
+        /// <param name="rawConvertFromStore">
+        ///     The function to convert objects when reading data from the store,
+        ///     exactly as supplied, which may be a generic delegate and may not handle
+        ///     nulls, boxing, and non-exact matches of simple types.
+        /// </param>
+        protected TypeConverter(
             [NotNull] Func<object, object> convertToStore,
-            [NotNull] Func<object, object> convertFromStore)
+            [NotNull] Func<object, object> convertFromStore,
+            [NotNull] Delegate rawConvertToStore,
+            [NotNull] Delegate rawConvertFromStore)
+
         {
             Check.NotNull(convertToStore, nameof(convertToStore));
             Check.NotNull(convertFromStore, nameof(convertFromStore));
+            Check.NotNull(rawConvertToStore, nameof(rawConvertToStore));
+            Check.NotNull(rawConvertFromStore, nameof(rawConvertFromStore));
 
             ConvertToStore = convertToStore;
             ConvertFromStore = convertFromStore;
+            RawConvertToStore = rawConvertToStore;
+            RawConvertFromStore = rawConvertFromStore;
         }
 
         /// <summary>
-        ///     Gets the function to convert objects when writing data to the store.
+        ///     Gets the function to convert objects when writing data to the store,
+        ///     setup to handle nulls, boxing, and non-exact matches of simple types.
         /// </summary>
         public virtual Func<object, object> ConvertToStore { get; }
 
         /// <summary>
-        ///     Gets the function to convert objects when reading data from the store.
+        ///     Gets the function to convert objects when reading data from the store,
+        ///     setup to handle nulls, boxing, and non-exact matches of simple types.
         /// </summary>
         public virtual Func<object, object> ConvertFromStore { get; }
+
+        /// <summary>
+        ///     Gets the function to convert objects when writing data to the store,
+        ///     exactly as supplied, which may be a generic delegate and may not handle
+        ///     nulls, boxing, and non-exact matches of simple types.
+        /// </summary>
+        public virtual Delegate RawConvertToStore { get; }
+
+        /// <summary>
+        ///     Gets the function to convert objects when reading data from the store,
+        ///     exactly as supplied, which may be a generic delegate and may not handle
+        ///     nulls, boxing, and non-exact matches of simple types.
+        /// </summary>
+        public virtual Delegate RawConvertFromStore { get; }
+
+        /// <summary>
+        ///     The CLR type used in the EF model.
+        /// </summary>
+        public abstract Type ModelType { get; }
+
+        /// <summary>
+        ///     The CLR type used when reading and writing from the store.
+        /// </summary>
+        public abstract Type StoreType { get; }
     }
 }

--- a/src/EFCore/Storage/TypeConverter`.cs
+++ b/src/EFCore/Storage/TypeConverter`.cs
@@ -1,0 +1,79 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    /// <summary>
+    ///     Defines conversions from an object of one type in a model to an object of the same or
+    ///     different type in the store.
+    /// </summary>
+    public class TypeConverter<TModel, TStore> : TypeConverter
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="TypeConverter{TModel,TStore}" /> class.
+        /// </summary>
+        /// <param name="convertToStore"> The function to convert objects when writing data to the store. </param>
+        /// <param name="convertFromStore"> The function to convert objects when reading data from the store. </param>
+        public TypeConverter(
+            [NotNull] Func<TModel, TStore> convertToStore,
+            [NotNull] Func<TStore, TModel> convertFromStore)
+            : base(
+                SanitizeConverter(Check.NotNull(convertToStore, nameof(convertToStore))),
+                SanitizeConverter(Check.NotNull(convertFromStore, nameof(convertFromStore))),
+                convertToStore,
+                convertFromStore)
+        {
+        }
+
+        private static Func<object, object> SanitizeConverter<TIn, TOut>(Func<TIn, TOut> convertToStore)
+            => typeof(TIn).IsNullableType()
+                ? (Func<object, object>)(v => convertToStore(SanitizeNullable<TIn>(v)))
+                : (v => v == null ? (object)null : convertToStore(SanitizeNonNullable<TIn>(v)));
+
+        private static T SanitizeNullable<T>(object value)
+        {
+            var unwrappedType = typeof(T).UnwrapNullableType();
+
+            return value == null
+                ? (T)value
+                : (T)(unwrappedType != value.GetType()
+                    ? Convert.ChangeType(value, unwrappedType)
+                    : value);
+        }
+
+        private static T SanitizeNonNullable<T>(object value)
+            => (T)(typeof(T) != value.GetType()
+                ? Convert.ChangeType(value, typeof(T))
+                : value);
+
+        /// <summary>
+        ///     Gets the function to convert objects when writing data to the store,
+        ///     exactly as supplied, which may be a generic delegate and may not handle
+        ///     nulls, boxing, and non-exact matches of simple types.
+        /// </summary>
+        public new virtual Func<TModel, TStore> RawConvertToStore
+            => (Func<TModel, TStore>)base.RawConvertToStore;
+
+        /// <summary>
+        ///     Gets the function to convert objects when reading data from the store,
+        ///     exactly as supplied, which may be a generic delegate and may not handle
+        ///     nulls, boxing, and non-exact matches of simple types.
+        /// </summary>
+        public new virtual Func<TStore, TModel> RawConvertFromStore
+            => (Func<TStore, TModel>)base.RawConvertFromStore;
+
+        /// <summary>
+        ///     The CLR type used in the EF model.
+        /// </summary>
+        public override Type ModelType => typeof(TModel);
+
+        /// <summary>
+        ///     The CLR type used when reading and writing from the store.
+        /// </summary>
+        public override Type StoreType => typeof(TStore);
+    }
+}

--- a/test/EFCore.Tests/Storage/TypeConverterTest.cs
+++ b/test/EFCore.Tests/Storage/TypeConverterTest.cs
@@ -1,0 +1,155 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    public class TypeConverterTest
+    {
+        private static readonly TypeConverter<uint, int> _uIntToInt
+            = new TypeConverter<uint, int>(v => (int)v, v => (uint)v);
+
+        [Fact]
+        public void Can_access_raw_converters()
+        {
+            Assert.Same(_uIntToInt.RawConvertFromStore, ((TypeConverter)_uIntToInt).RawConvertFromStore);
+            Assert.Same(_uIntToInt.RawConvertToStore, ((TypeConverter)_uIntToInt).RawConvertToStore);
+
+            Assert.Equal(1, _uIntToInt.RawConvertToStore(1));
+            Assert.Equal((uint)1, _uIntToInt.RawConvertFromStore(1));
+
+            Assert.Equal(-1, _uIntToInt.RawConvertToStore(uint.MaxValue));
+            Assert.Equal(uint.MaxValue, _uIntToInt.RawConvertFromStore(-1));
+        }
+
+        [Fact]
+        public void Can_convert_exact_types_with_non_nullable_converter()
+        {
+            Assert.Equal(1, _uIntToInt.ConvertToStore((uint)1));
+            Assert.Equal((uint)1, _uIntToInt.ConvertFromStore(1));
+
+            Assert.Equal(-1, _uIntToInt.ConvertToStore(uint.MaxValue));
+            Assert.Equal(uint.MaxValue, _uIntToInt.ConvertFromStore(-1));
+        }
+
+        [Fact]
+        public void Can_convert_nullable_types_with_non_nullable_converter()
+        {
+            Assert.Equal(1, _uIntToInt.ConvertToStore((uint?)1));
+            Assert.Equal((uint)1, _uIntToInt.ConvertFromStore((int?)1));
+
+            Assert.Equal(-1, _uIntToInt.ConvertToStore((uint?)uint.MaxValue));
+            Assert.Equal(uint.MaxValue, _uIntToInt.ConvertFromStore((int?)-1));
+        }
+
+        [Fact]
+        public void Can_convert_non_exact_types_with_non_nullable_converter()
+        {
+            Assert.Equal(1, _uIntToInt.ConvertToStore((ushort)1));
+            Assert.Equal((uint)1, _uIntToInt.ConvertFromStore((short)1));
+
+            Assert.Equal(1, _uIntToInt.ConvertToStore((ulong)1));
+            Assert.Equal((uint)1, _uIntToInt.ConvertFromStore((long)1));
+
+            Assert.Equal(1, _uIntToInt.ConvertToStore(1));
+            Assert.Equal((uint)1, _uIntToInt.ConvertFromStore(1));
+        }
+
+        [Fact]
+        public void Can_convert_non_exact_nullable_types_with_non_nullable_converter()
+        {
+            Assert.Equal(1, _uIntToInt.ConvertToStore((ushort?)1));
+            Assert.Equal((uint)1, _uIntToInt.ConvertFromStore((short?)1));
+
+            Assert.Equal(1, _uIntToInt.ConvertToStore((ulong?)1));
+            Assert.Equal((uint)1, _uIntToInt.ConvertFromStore((long?)1));
+
+            Assert.Equal(1, _uIntToInt.ConvertToStore((int?)1));
+            Assert.Equal((uint)1, _uIntToInt.ConvertFromStore((int?)1));
+        }
+
+        [Fact]
+        public void Can_handle_nulls_with_non_nullable_converter()
+        {
+            Assert.Null(_uIntToInt.ConvertToStore(null));
+            Assert.Null(_uIntToInt.ConvertFromStore(null));
+        }
+
+        private static readonly TypeConverter<uint?, int?> _nullableUIntToInt
+            = new TypeConverter<uint?, int?>(v => (int?)v, v => (uint?)v);
+
+        [Fact]
+        public void Can_convert_exact_types_with_nullable_converter()
+        {
+            Assert.Equal((int?)1, _nullableUIntToInt.ConvertToStore((uint?)1));
+            Assert.Equal((uint?)1, _nullableUIntToInt.ConvertFromStore((int?)1));
+
+            Assert.Equal((int?)-1, _nullableUIntToInt.ConvertToStore((uint?)uint.MaxValue));
+            Assert.Equal((uint?)uint.MaxValue, _nullableUIntToInt.ConvertFromStore((int?)-1));
+        }
+
+        [Fact]
+        public void Can_convert_non_nullable_types_with_nullable_converter()
+        {
+            Assert.Equal((int?)1, _nullableUIntToInt.ConvertToStore((uint?)1));
+            Assert.Equal((uint?)1, _nullableUIntToInt.ConvertFromStore((int?)1));
+
+            Assert.Equal((int?)-1, _nullableUIntToInt.ConvertToStore((uint?)uint.MaxValue));
+            Assert.Equal((uint?)uint.MaxValue, _nullableUIntToInt.ConvertFromStore((int?)-1));
+        }
+
+        [Fact]
+        public void Can_convert_non_exact_types_with_nullable_converter()
+        {
+            Assert.Equal((int?)1, _nullableUIntToInt.ConvertToStore((ushort?)1));
+            Assert.Equal((uint?)1, _nullableUIntToInt.ConvertFromStore((short?)1));
+
+            Assert.Equal((int?)1, _nullableUIntToInt.ConvertToStore((ulong?)1));
+            Assert.Equal((uint?)1, _nullableUIntToInt.ConvertFromStore((long?)1));
+
+            Assert.Equal((int?)1, _nullableUIntToInt.ConvertToStore((int?)1));
+            Assert.Equal((uint?)1, _nullableUIntToInt.ConvertFromStore((int?)1));
+        }
+
+        [Fact]
+        public void Can_convert_non_exact_nullable_types_with_nullable_converter()
+        {
+            Assert.Equal((int?)1, _nullableUIntToInt.ConvertToStore((ushort)1));
+            Assert.Equal((uint?)1, _nullableUIntToInt.ConvertFromStore((short)1));
+
+            Assert.Equal((int?)1, _nullableUIntToInt.ConvertToStore((ulong)1));
+            Assert.Equal((uint?)1, _nullableUIntToInt.ConvertFromStore((long)1));
+
+            Assert.Equal((int?)1, _nullableUIntToInt.ConvertToStore(1));
+            Assert.Equal((uint?)1, _nullableUIntToInt.ConvertFromStore(1));
+        }
+
+        [Fact]
+        public void Can_handle_nulls_with_nullable_converter()
+        {
+            Assert.Null(_nullableUIntToInt.ConvertToStore(null));
+            Assert.Null(_nullableUIntToInt.ConvertFromStore(null));
+        }
+
+        private static readonly TypeConverter<string, int?> _stringConverter
+            = new TypeConverter<string, int?>(
+                v => v.Equals("<null>", StringComparison.OrdinalIgnoreCase)
+                    ? null
+                    : (int?)int.Parse(v, CultureInfo.InvariantCulture),
+                v => v?.ToString(CultureInfo.InvariantCulture)
+                     ?? "<null>");
+
+        [Fact]
+        public void Can_convert_nulls_to_non_nulls()
+        {
+            Assert.Equal(1234, _stringConverter.ConvertToStore("1234"));
+            Assert.Equal("1234", _stringConverter.ConvertFromStore(1234));
+
+            Assert.Null(_stringConverter.ConvertToStore("<null>"));
+            Assert.Equal("<null>", _stringConverter.ConvertFromStore(null));
+        }
+    }
+}


### PR DESCRIPTION
Part of #242

This allows conversions to be defined using generics, which means they can be used without additional boxing. However, in our code we often have to deal with things like nullable FKs, null values, non-exact matches (e.g. using a short when the property is an int) and it would not be a great experience to have to define multiple conversion functions to handle all of this. Therefore, we add additional code around the simple generic function to handle these cases. In the materializer, for the common case where the type of the converter matches the type of the property, the non-boxing generic converter is used. In other cases, the compensated converter is used.
