### PR TITLE
[2.0.1] Query: Always evalaute Enum.ToString on client

### DIFF
--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -3966,6 +3966,23 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
+        [ConditionalFact]
+        public virtual void Enum_ToString_is_client_eval()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Gears
+                    .OrderBy(g => g.SquadId)
+                    .ThenBy(g => g.Nickname)
+                    .Select(g => g.Rank.ToString())
+                    .Take(1)
+                    .ToList();
+
+                var result = Assert.Single(query);
+                Assert.Equal("Corporal", result);
+            }
+        }
+
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext(TestStore);
 
         protected GearsOfWarQueryTestBase(TFixture fixture)

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerObjectToStringTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerObjectToStringTranslator.cs
@@ -45,16 +45,15 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
         /// </summary>
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            string storeType;
-
             if (methodCallExpression.Method.Name == nameof(ToString)
                 && methodCallExpression.Arguments.Count == 0
                 && methodCallExpression.Object != null
                 && _typeMapping.TryGetValue(
-                    methodCallExpression.Object.Type
-                        .UnwrapNullableType()
-                        .UnwrapEnumType(),
-                    out storeType))
+                    AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue9894", out var enabled)
+                    && enabled
+                        ? methodCallExpression.Object.Type.UnwrapNullableType().UnwrapEnumType()
+                        : methodCallExpression.Object.Type.UnwrapNullableType(),
+                    out var storeType))
             {
                 return new SqlFunctionExpression(
                     functionName: "CONVERT",

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -3857,6 +3857,19 @@ FROM [Gear] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ((@_outer_Nickname = [g].[LeaderNickname]) AND (@_outer_SquadId = [g].[LeaderSquadId]))");
         }
 
+        public override void Enum_ToString_is_client_eval()
+        {
+            base.Enum_ToString_is_client_eval();
+
+            AssertSql(
+                @"@__p_0='1'
+
+SELECT TOP(@__p_0) [g].[Rank]
+FROM [Gear] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [g].[SquadId], [g].[Nickname]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Since server would store underlying type of enum hence server eval causes incorrect result

Resolves #9894