### PR TITLE
Workaround xunit/xunit#1487

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/EFCore.Relational.Specification.Tests.csproj
+++ b/src/EFCore.Relational.Specification.Tests/EFCore.Relational.Specification.Tests.csproj
@@ -9,13 +9,14 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EnableApiCheck>false</EnableApiCheck>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\EFCore.Relational\EFCore.Relational.csproj" />
     <ProjectReference Include="..\EFCore.Specification.Tests\EFCore.Specification.Tests.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <Reference Include="System.Transactions" />
   </ItemGroup>

--- a/src/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
+++ b/src/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
@@ -9,6 +9,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EnableApiCheck>false</EnableApiCheck>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Slight changes in xunit.core 2.3.0-rc3 would cause these packages not to produce a nupkg. See https://github.com/xunit/xunit/issues/1487

cref https://github.com/aspnet/Universe/pull/578