### PR TITLE
[2.0.1] RevEng: Fix scaffolding for nvarchar(4000)

### DIFF
--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
@@ -43,6 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         private static string ColumnKey(DatabaseTable table, string columnName) => TableKey(table) + ".[" + columnName + "]";
 
         private static readonly ISet<string> _dateTimePrecisionTypes = new HashSet<string> { "datetimeoffset", "datetime2", "time" };
+        private static readonly ISet<string> _maxLengthRequiredTypes = new HashSet<string> { "binary", "varbinary", "char", "varchar", "nchar", "nvarchar" };
 
         // see https://msdn.microsoft.com/en-us/library/ff878091.aspx
         private static readonly Dictionary<string, long[]> _defaultSequenceMinMax = new Dictionary<string, long[]>(StringComparer.OrdinalIgnoreCase)
@@ -485,6 +486,14 @@ ORDER BY schema_name(t.schema_id), t.name, c.column_id";
 
         private string GetStoreType(string dataTypeName, int? precision, int? scale, int? maxLength)
         {
+            if (!(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue9963", out var enabled) && enabled)) {
+                if (_maxLengthRequiredTypes.Contains(dataTypeName)
+                    && maxLength == null)
+                {
+                    maxLength = 8000;
+                }
+            }
+
             if ((dataTypeName == "nvarchar"
                  || dataTypeName == "nchar")
                 && maxLength != -1)

--- a/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/SqlServerReverseEngineerTestE2EContext.cs
+++ b/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/AllFluentApi/SqlServerReverseEngineerTestE2EContext.cs
@@ -239,7 +239,8 @@ namespace E2ETest.Namespace
 
                 entity.Property(e => e.TypeAliasColumn)
                     .HasColumnName("typeAliasColumn")
-                    .HasColumnType("TestTypeAlias");
+                    .HasColumnType("TestTypeAlias")
+                    .HasMaxLength(4000);
 
                 entity.Property(e => e.UniqueidentifierColumn).HasColumnName("uniqueidentifierColumn");
 

--- a/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/AllDataTypes.cs
+++ b/test/EFCore.SqlServer.Design.FunctionalTests/ReverseEngineering/Expected/Attributes/AllDataTypes.cs
@@ -106,6 +106,7 @@ namespace E2ETest.Namespace.SubDir
         [Column("xmlColumn", TypeName = "xml")]
         public string XmlColumn { get; set; }
         [Column("typeAliasColumn", TypeName = "TestTypeAlias")]
+        [StringLength(4000)]
         public string TypeAliasColumn { get; set; }
         [Column("binaryVaryingColumn")]
         [MaxLength(1)]

--- a/test/EFCore.SqlServer.Design.FunctionalTests/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/EFCore.SqlServer.Design.FunctionalTests/SqlServerDatabaseModelFactoryTest.cs
@@ -3,14 +3,19 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
 using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
+using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.Extensions.Logging;
 using Xunit;
 // ReSharper disable InconsistentNaming
 
@@ -362,6 +367,205 @@ CREATE SEQUENCE [NumericSequence_defaults]
                         Assert.Null(s.MinValue);
                         Assert.Null(s.MaxValue);
                     });
+        }
+
+        [Fact]
+        public void Default_max_length_are_added_to_binary_varbinary()
+        {
+            Test(
+                @"
+CREATE TABLE DefaultRequiredLengthBinaryColumns (
+    Id int,
+    binaryColumn binary(8000),
+    binaryVaryingColumn binary varying(8000),
+    varbinaryColumn varbinary(8000)
+);",
+                Enumerable.Empty<string>(),
+                Enumerable.Empty<string>(),
+                dbModel =>
+                {
+                    var columns = dbModel.Tables.Single(e => e.Name == "DefaultRequiredLengthBinaryColumns").Columns;
+
+                    Assert.Equal("binary(8000)", columns.Single(c => c.Name == "binaryColumn").StoreType);
+                    Assert.Equal("varbinary(8000)", columns.Single(c => c.Name == "binaryVaryingColumn").StoreType);
+                    Assert.Equal("varbinary(8000)", columns.Single(c => c.Name == "varbinaryColumn").StoreType);
+                },
+                @"DROP TABLE DefaultRequiredLengthBinaryColumns;");
+        }
+
+        [Fact]
+        public void Default_max_length_are_added_to_char_1()
+        {
+            Test(
+                @"
+CREATE TABLE DefaultRequiredLengthCharColumns (
+    Id int,
+    charColumn char(8000)
+);",
+                Enumerable.Empty<string>(),
+                Enumerable.Empty<string>(),
+                dbModel =>
+                {
+                    var columns = dbModel.Tables.Single(e => e.Name == "DefaultRequiredLengthCharColumns").Columns;
+
+                    Assert.Equal("char(8000)", columns.Single(c => c.Name == "charColumn").StoreType);
+                },
+                @"DROP TABLE DefaultRequiredLengthCharColumns;");
+        }
+
+        [Fact]
+        public void Default_max_length_are_added_to_char_2()
+        {
+            Test(
+                @"
+CREATE TABLE DefaultRequiredLengthCharColumns (
+    Id int,
+    characterColumn character(8000)
+);",
+                Enumerable.Empty<string>(),
+                Enumerable.Empty<string>(),
+                dbModel =>
+                {
+                    var columns = dbModel.Tables.Single(e => e.Name == "DefaultRequiredLengthCharColumns").Columns;
+
+                    Assert.Equal("char(8000)", columns.Single(c => c.Name == "characterColumn").StoreType);
+                },
+                @"DROP TABLE DefaultRequiredLengthCharColumns;");
+        }
+
+        [Fact]
+        public void Default_max_length_are_added_to_varchar()
+        {
+            Test(
+                @"
+CREATE TABLE DefaultRequiredLengthVarcharColumns (
+    Id int,
+    charVaryingColumn char varying(8000),
+    characterVaryingColumn character varying(8000),
+    varcharColumn varchar(8000)
+);",
+                Enumerable.Empty<string>(),
+                Enumerable.Empty<string>(),
+                dbModel =>
+                {
+                    var columns = dbModel.Tables.Single(e => e.Name == "DefaultRequiredLengthVarcharColumns").Columns;
+
+                    Assert.Equal("varchar(8000)", columns.Single(c => c.Name == "charVaryingColumn").StoreType);
+                    Assert.Equal("varchar(8000)", columns.Single(c => c.Name == "characterVaryingColumn").StoreType);
+                    Assert.Equal("varchar(8000)", columns.Single(c => c.Name == "varcharColumn").StoreType);
+                },
+                @"DROP TABLE DefaultRequiredLengthVarcharColumns;");
+        }
+
+        [Fact]
+        public void Default_max_length_are_added_to_nchar_1()
+        {
+            Test(
+                @"
+CREATE TABLE DefaultRequiredLengthNcharColumns (
+    Id int,
+    natioanlCharColumn national char(4000),
+);",
+                Enumerable.Empty<string>(),
+                Enumerable.Empty<string>(),
+                dbModel =>
+                {
+                    var columns = dbModel.Tables.Single(e => e.Name == "DefaultRequiredLengthNcharColumns").Columns;
+
+                    Assert.Equal("nchar(4000)", columns.Single(c => c.Name == "natioanlCharColumn").StoreType);
+                },
+                @"DROP TABLE DefaultRequiredLengthNcharColumns;");
+        }
+
+        [Fact]
+        public void Default_max_length_are_added_to_nchar_2()
+        {
+            Test(
+                @"
+CREATE TABLE DefaultRequiredLengthNcharColumns (
+    Id int,
+    nationalCharacterColumn national character(4000),
+);",
+                Enumerable.Empty<string>(),
+                Enumerable.Empty<string>(),
+                dbModel =>
+                {
+                    var columns = dbModel.Tables.Single(e => e.Name == "DefaultRequiredLengthNcharColumns").Columns;
+
+                    Assert.Equal("nchar(4000)", columns.Single(c => c.Name == "nationalCharacterColumn").StoreType);
+                },
+                @"DROP TABLE DefaultRequiredLengthNcharColumns;");
+        }
+
+        [Fact]
+        public void Default_max_length_are_added_to_nchar_3()
+        {
+            Test(
+                @"
+CREATE TABLE DefaultRequiredLengthNcharColumns (
+    Id int,
+    ncharColumn nchar(4000),
+);",
+                Enumerable.Empty<string>(),
+                Enumerable.Empty<string>(),
+                dbModel =>
+                {
+                    var columns = dbModel.Tables.Single(e => e.Name == "DefaultRequiredLengthNcharColumns").Columns;
+
+                    Assert.Equal("nchar(4000)", columns.Single(c => c.Name == "ncharColumn").StoreType);
+                },
+                @"DROP TABLE DefaultRequiredLengthNcharColumns;");
+        }
+
+        [Fact]
+        public void Default_max_length_are_added_to_nvarchar()
+        {
+            Test(
+                @"
+CREATE TABLE DefaultRequiredLengthNvarcharColumns (
+    Id int,
+    nationalCharVaryingColumn national char varying(4000),
+    nationalCharacterVaryingColumn national character varying(4000),
+    nvarcharColumn nvarchar(4000)
+);",
+                Enumerable.Empty<string>(),
+                Enumerable.Empty<string>(),
+                dbModel =>
+                {
+                    var columns = dbModel.Tables.Single(e => e.Name == "DefaultRequiredLengthNvarcharColumns").Columns;
+
+                    Assert.Equal("nvarchar(4000)", columns.Single(c => c.Name == "nationalCharVaryingColumn").StoreType);
+                    Assert.Equal("nvarchar(4000)", columns.Single(c => c.Name == "nationalCharacterVaryingColumn").StoreType);
+                    Assert.Equal("nvarchar(4000)", columns.Single(c => c.Name == "nvarcharColumn").StoreType);
+                },
+                @"DROP TABLE DefaultRequiredLengthNvarcharColumns;");
+        }
+
+        private readonly List<Tuple<LogLevel, EventId, string>> Log = new List<Tuple<LogLevel, EventId, string>>();
+
+        private void Test(string createSql, IEnumerable<string> tables, IEnumerable<string> schemas, Action<DatabaseModel> asserter, string cleanupSql)
+        {
+            _fixture.TestStore.ExecuteNonQuery(createSql);
+
+            try
+            {
+                var databaseModelFactory = new SqlServerDatabaseModelFactory(
+                    new DiagnosticsLogger<DbLoggerCategory.Scaffolding>(
+                        new ListLoggerFactory(Log),
+                        new LoggingOptions(),
+                        new DiagnosticListener("Fake")));
+
+                var databaseModel = databaseModelFactory.Create(_fixture.TestStore.ConnectionString, tables, schemas);
+                Assert.NotNull(databaseModel);
+                asserter(databaseModel);
+            }
+            finally
+            {
+                if (!string.IsNullOrEmpty(cleanupSql))
+                {
+                    _fixture.TestStore.ExecuteNonQuery(cleanupSql);
+                }
+            }
         }
 
         private readonly SqlServerDatabaseModelFixture _fixture;


### PR DESCRIPTION
Types which requires length specified returns needs default length of 8000 specified

Resolves #9963 
