### PR TITLE
Update default SQL Server type mappings for ulong, uint, ushort, sbyte

### DIFF
--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMapper.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMapper.cs
@@ -47,24 +47,44 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         private readonly ByteTypeMapping _byte = new ByteTypeMapping("tinyint", DbType.Byte);
 
         private readonly UIntTypeMapping _uint = new UIntTypeMapping(
-            "int",
-            new ValueConverter<uint, int>(v => (int)v, v => (uint)v),
-            DbType.Int32);
+            "bigint",
+            new ValueConverter<uint, long>(v => (long)v, v => (uint)v),
+            DbType.Int64);
 
         private readonly ULongTypeMapping _ulong = new ULongTypeMapping(
             "bigint",
             new ValueConverter<ulong, long>(v => (long)v, v => (ulong)v),
             DbType.Int64);
 
-        private readonly UShortTypeMapping _ushort = new UShortTypeMapping(
+        private readonly UShortTypeMapping _ushort32 = new UShortTypeMapping(
+            "int",
+            new ValueConverter<ushort, int>(v => v, v => (ushort)v),
+            DbType.Int32);
+
+        private readonly SByteTypeMapping _sbyte16 = new SByteTypeMapping(
+            "smallint",
+            new ValueConverter<sbyte, short>(v => v, v => (sbyte)v),
+            DbType.Int16);
+
+        private readonly UIntTypeMapping _uint32 = new UIntTypeMapping(
+            "int",
+            new ValueConverter<uint, int>(v => (int)v, v => (uint)v),
+            DbType.Int32);
+
+        private readonly UShortTypeMapping _ushort16 = new UShortTypeMapping(
             "smallint",
             new ValueConverter<ushort, short>(v => (short)v, v => (ushort)v),
             DbType.Int16);
 
-        private readonly SByteTypeMapping _sbyte = new SByteTypeMapping(
+        private readonly SByteTypeMapping _sbyte8 = new SByteTypeMapping(
             "tinyint",
             new ValueConverter<sbyte, byte>(v => (byte)v, v => (sbyte)v),
             DbType.Byte);
+
+        private readonly ULongTypeMapping _ulongDecimal = new ULongTypeMapping(
+            "decimal(20, 0)",
+            new ValueConverter<ulong, decimal>(v => v, v => (ulong)v),
+            DbType.Decimal);
 
         private readonly BoolTypeMapping _bool = new BoolTypeMapping("bit");
 
@@ -118,7 +138,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             _storeTypeMappings
                 = new Dictionary<string, IList<RelationalTypeMapping>>(StringComparer.OrdinalIgnoreCase)
                 {
-                    { "bigint", new List<RelationalTypeMapping> { _long, _ulong } },
+                    { "bigint", new List<RelationalTypeMapping> { _long, _uint, _ulong } },
                     { "binary varying", new List<RelationalTypeMapping> { _variableLengthBinary } },
                     { "binary", new List<RelationalTypeMapping> { _fixedLengthBinary } },
                     { "bit", new List<RelationalTypeMapping> { _bool } },
@@ -131,10 +151,10 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                     { "datetime2", new List<RelationalTypeMapping> { _datetime2 } },
                     { "datetimeoffset", new List<RelationalTypeMapping> { _datetimeoffset } },
                     { "dec", new List<RelationalTypeMapping> { _decimal } },
-                    { "decimal", new List<RelationalTypeMapping> { _decimal } },
+                    { "decimal", new List<RelationalTypeMapping> { _decimal, _ulongDecimal } },
                     { "float", new List<RelationalTypeMapping> { _double } },
                     { "image", new List<RelationalTypeMapping> { _variableLengthBinary } },
-                    { "int", new List<RelationalTypeMapping> { _int, _uint } },
+                    { "int", new List<RelationalTypeMapping> { _int, _ushort32, _uint32 } },
                     { "money", new List<RelationalTypeMapping> { _decimal } },
                     { "national char varying", new List<RelationalTypeMapping> { _variableLengthUnicodeString } },
                     { "national character varying", new List<RelationalTypeMapping> { _variableLengthUnicodeString } },
@@ -146,12 +166,12 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                     { "real", new List<RelationalTypeMapping> { _real } },
                     { "rowversion", new List<RelationalTypeMapping> { _rowversion } },
                     { "smalldatetime", new List<RelationalTypeMapping> { _datetime } },
-                    { "smallint", new List<RelationalTypeMapping> { _short, _ushort } },
+                    { "smallint", new List<RelationalTypeMapping> { _short, _sbyte16, _ushort16 } },
                     { "smallmoney", new List<RelationalTypeMapping> { _decimal } },
                     { "text", new List<RelationalTypeMapping> { _variableLengthAnsiString } },
                     { "time", new List<RelationalTypeMapping> { _time } },
                     { "timestamp", new List<RelationalTypeMapping> { _rowversion } },
-                    { "tinyint", new List<RelationalTypeMapping> { _byte, _sbyte } },
+                    { "tinyint", new List<RelationalTypeMapping> { _byte, _sbyte8 } },
                     { "uniqueidentifier", new List<RelationalTypeMapping> { _uniqueidentifier } },
                     { "varbinary", new List<RelationalTypeMapping> { _variableLengthBinary } },
                     { "varchar", new List<RelationalTypeMapping> { _variableLengthAnsiString } },
@@ -166,16 +186,16 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                     { typeof(int), _int },
                     { typeof(long), _long },
                     { typeof(uint), _uint },
-                    { typeof(ulong), _ulong },
+                    { typeof(ulong), _ulongDecimal },
                     { typeof(DateTime), _datetime2 },
                     { typeof(Guid), _uniqueidentifier },
                     { typeof(bool), _bool },
                     { typeof(byte), _byte },
-                    { typeof(sbyte), _sbyte },
+                    { typeof(sbyte), _sbyte16 },
                     { typeof(double), _double },
                     { typeof(DateTimeOffset), _datetimeoffset },
                     { typeof(short), _short },
-                    { typeof(ushort), _ushort },
+                    { typeof(ushort), _ushort32 },
                     { typeof(float), _real },
                     { typeof(decimal), _decimal },
                     { typeof(TimeSpan), _time }

--- a/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -101,10 +101,14 @@ WHERE [e].[Time] = @__timeSpan_0",
                         Bigint = 78L,
                         Smallint = 79,
                         Tinyint = 80,
-                        U_Int = uint.MaxValue,
-                        U_Bigint = ulong.MaxValue,
-                        U_Smallint = ushort.MaxValue,
-                        S_Tinyint = sbyte.MinValue,
+                        _Bigint = uint.MaxValue,
+                        __Bigint = ulong.MaxValue,
+                        _Int = ushort.MaxValue,
+                        _Smallint = sbyte.MinValue,
+                        __Decimal_20_0 = ulong.MaxValue,
+                        __Int = uint.MaxValue,
+                        __Smallint = ushort.MaxValue,
+                        __Tinyint = sbyte.MinValue,
                         Bit = true,
                         Money = 81.1m,
                         Smallmoney = 82.2m,
@@ -219,16 +223,28 @@ WHERE [e].[Time] = @__timeSpan_0",
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.Numeric == param40));
 
                 uint? param41 = uint.MaxValue;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.U_Int == param41));
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e._Bigint == param41));
 
                 ulong? param42 = ulong.MaxValue;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.U_Bigint == param42));
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.__Bigint == param42));
 
                 ushort? param43 = ushort.MaxValue;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.U_Smallint == param43));
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e._Int == param43));
 
                 sbyte? param44 = sbyte.MinValue;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.S_Tinyint == param44));
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e._Smallint == param44));
+
+                uint? param45 = uint.MaxValue;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.__Int == param45));
+
+                ushort? param46 = ushort.MaxValue;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.__Smallint == param46));
+
+                sbyte? param47 = sbyte.MinValue;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.__Tinyint == param47));
+
+                ulong? param48 = ulong.MaxValue;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 999 && e.__Decimal_20_0 == param48));
             }
         }
 
@@ -339,16 +355,28 @@ WHERE [e].[Time] = @__timeSpan_0",
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.Numeric == param40));
 
                 uint? param41 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.U_Int == param41));
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e._Bigint == param41));
 
                 ulong? param42 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.U_Bigint == param42));
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.__Bigint == param42));
 
                 ushort? param43 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.U_Smallint == param43));
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e._Int == param43));
 
                 sbyte? param44 = null;
-                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.S_Tinyint == param44));
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e._Smallint == param44));
+
+                uint? param45 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.__Int == param45));
+
+                ushort? param46 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.__Smallint == param46));
+
+                sbyte? param47 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.__Tinyint == param47));
+
+                ulong? param48 = null;
+                Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.__Decimal_20_0 == param48));
             }
         }
 
@@ -393,18 +421,22 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p19='103.3'
 @p20='" + entity.NvarcharMax + @"' (Nullable = false) (Size = -1)
 @p21='84.4'
-@p22='128' (Size = 1)
-@p23='2018-01-02T13:11:12' (DbType = DateTime)
-@p24='79'
-@p25='82.2'
-@p26='Gumball Rules!' (Nullable = false) (Size = 8000) (DbType = AnsiString)
-@p27='11:15:12'
-@p28='80' (Size = 1)
-@p29='-1'
-@p30='-1'
-@p31='-1'
-@p32='0x595A5B5C' (Nullable = false) (Size = 8000)
-@p33='" + entity.VarcharMax + "' (Nullable = false) (Size = -1) (DbType = AnsiString)",
+@p22='2018-01-02T13:11:12' (DbType = DateTime)
+@p23='79'
+@p24='82.2'
+@p25='Gumball Rules!' (Nullable = false) (Size = 8000) (DbType = AnsiString)
+@p26='11:15:12'
+@p27='80' (Size = 1)
+@p28='0x595A5B5C' (Nullable = false) (Size = 8000)
+@p29='" + entity.VarcharMax + @"' (Nullable = false) (Size = -1) (DbType = AnsiString)
+@p30='4294967295'
+@p31='65535'
+@p32='-128'
+@p33='-1'
+@p34='18446744073709551615' (Precision = 20)
+@p35='-1'
+@p36='-1'
+@p37='128' (Size = 1)",
                 parameters,
                 ignoreLineEndingDifferences: true);
 
@@ -424,10 +456,14 @@ WHERE [e].[Time] = @__timeSpan_0",
             Assert.Equal(78, entity.Bigint);
             Assert.Equal(79, entity.Smallint);
             Assert.Equal(80, entity.Tinyint);
-            Assert.Equal(uint.MaxValue, entity.U_Int);
-            Assert.Equal(ulong.MaxValue, entity.U_Bigint);
-            Assert.Equal(ushort.MaxValue, entity.U_Smallint);
-            Assert.Equal(sbyte.MinValue, entity.S_Tinyint);
+            Assert.Equal(uint.MaxValue, entity._Bigint);
+            Assert.Equal(ulong.MaxValue, entity.__Bigint);
+            Assert.Equal(ushort.MaxValue, entity._Int);
+            Assert.Equal(sbyte.MinValue, entity._Smallint);
+            Assert.Equal(ulong.MaxValue, entity.__Decimal_20_0);
+            Assert.Equal(uint.MaxValue, entity.__Int);
+            Assert.Equal(ushort.MaxValue, entity.__Smallint);
+            Assert.Equal(sbyte.MinValue, entity.__Tinyint);
             Assert.True(entity.Bit);
             Assert.Equal(81.1m, entity.Money);
             Assert.Equal(82.2m, entity.Smallmoney);
@@ -463,10 +499,14 @@ WHERE [e].[Time] = @__timeSpan_0",
                 Bigint = 78L,
                 Smallint = 79,
                 Tinyint = 80,
-                U_Int = uint.MaxValue,
-                U_Bigint = ulong.MaxValue,
-                U_Smallint = ushort.MaxValue,
-                S_Tinyint = sbyte.MinValue,
+                _Bigint = uint.MaxValue,
+                __Bigint = ulong.MaxValue,
+                _Int = ushort.MaxValue,
+                _Smallint = sbyte.MinValue,
+                __Decimal_20_0 = ulong.MaxValue,
+                __Int = uint.MaxValue,
+                __Smallint = ushort.MaxValue,
+                __Tinyint = sbyte.MinValue,
                 Bit = true,
                 Money = 81.1m,
                 Smallmoney = 82.2m,
@@ -529,18 +569,22 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p19='103.3' (Nullable = true)
 @p20='don't' (Size = 4000)
 @p21='84.4' (Nullable = true)
-@p22='128' (Nullable = true) (Size = 1)
-@p23='2018-01-02T13:11:12' (Nullable = true) (DbType = DateTime)
-@p24='79' (Nullable = true)
-@p25='82.2' (Nullable = true)
-@p26='Gumball Rules!' (Size = 8000) (DbType = AnsiString)
-@p27='11:15:12' (Nullable = true)
-@p28='80' (Nullable = true) (Size = 1)
-@p29='-1' (Nullable = true)
-@p30='-1' (Nullable = true)
-@p31='-1' (Nullable = true)
-@p32='0x595A5B5C' (Size = 8000)
-@p33='C' (Size = 8000) (DbType = AnsiString)",
+@p22='2018-01-02T13:11:12' (Nullable = true) (DbType = DateTime)
+@p23='79' (Nullable = true)
+@p24='82.2' (Nullable = true)
+@p25='Gumball Rules!' (Size = 8000) (DbType = AnsiString)
+@p26='11:15:12' (Nullable = true)
+@p27='80' (Nullable = true) (Size = 1)
+@p28='0x595A5B5C' (Size = 8000)
+@p29='C' (Size = 8000) (DbType = AnsiString)
+@p30='4294967295' (Nullable = true)
+@p31='65535' (Nullable = true)
+@p32='-128' (Nullable = true)
+@p33='-1' (Nullable = true)
+@p34='18446744073709551615' (Nullable = true) (Precision = 20)
+@p35='-1' (Nullable = true)
+@p36='-1' (Nullable = true)
+@p37='128' (Nullable = true) (Size = 1)",
                 parameters,
                 ignoreLineEndingDifferences: true);
 
@@ -556,10 +600,14 @@ WHERE [e].[Time] = @__timeSpan_0",
             Assert.Equal(78, entity.Bigint);
             Assert.Equal(79, entity.Smallint.Value);
             Assert.Equal(80, entity.Tinyint.Value);
-            Assert.Equal(uint.MaxValue, entity.U_Int);
-            Assert.Equal(ulong.MaxValue, entity.U_Bigint);
-            Assert.Equal(ushort.MaxValue, entity.U_Smallint);
-            Assert.Equal(sbyte.MinValue, entity.S_Tinyint);
+            Assert.Equal(uint.MaxValue, entity._Bigint);
+            Assert.Equal(ulong.MaxValue, entity.__Bigint);
+            Assert.Equal(ushort.MaxValue, entity._Int);
+            Assert.Equal(sbyte.MinValue, entity._Smallint);
+            Assert.Equal(ulong.MaxValue, entity.__Decimal_20_0);
+            Assert.Equal(uint.MaxValue, entity.__Int);
+            Assert.Equal(ushort.MaxValue, entity.__Smallint);
+            Assert.Equal(sbyte.MinValue, entity.__Tinyint);
             Assert.True(entity.Bit);
             Assert.Equal(81.1m, entity.Money);
             Assert.Equal(82.2m, entity.Smallmoney);
@@ -595,10 +643,14 @@ WHERE [e].[Time] = @__timeSpan_0",
                 Bigint = 78L,
                 Smallint = 79,
                 Tinyint = 80,
-                U_Int = uint.MaxValue,
-                U_Bigint = ulong.MaxValue,
-                U_Smallint = ushort.MaxValue,
-                S_Tinyint = sbyte.MinValue,
+                _Bigint = uint.MaxValue,
+                __Bigint = ulong.MaxValue,
+                _Int = ushort.MaxValue,
+                _Smallint = sbyte.MinValue,
+                __Decimal_20_0 = ulong.MaxValue,
+                __Int = uint.MaxValue,
+                __Smallint = ushort.MaxValue,
+                __Tinyint = sbyte.MinValue,
                 Bit = true,
                 Money = 81.1m,
                 Smallmoney = 82.2m,
@@ -661,18 +713,22 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p19='' (DbType = String)
 @p20='' (Size = 4000) (DbType = String)
 @p21='' (DbType = String)
-@p22='' (DbType = Byte)
-@p23='' (DbType = DateTime)
-@p24='' (DbType = Int16)
-@p25='' (DbType = String)
-@p26='' (Size = 8000)
-@p27='' (DbType = String)
-@p28='' (DbType = Byte)
-@p29='' (DbType = Int64)
-@p30='' (DbType = Int32)
-@p31='' (DbType = Int16)
-@p32='' (Size = 8000) (DbType = Binary)
-@p33='' (Size = 8000)",
+@p22='' (DbType = DateTime)
+@p23='' (DbType = Int16)
+@p24='' (DbType = String)
+@p25='' (Size = 8000)
+@p26='' (DbType = String)
+@p27='' (DbType = Byte)
+@p28='' (Size = 8000) (DbType = Binary)
+@p29='' (Size = 8000)
+@p30='' (DbType = Int64)
+@p31='' (DbType = Int32)
+@p32='' (DbType = Int16)
+@p33='' (DbType = Int64)
+@p34='' (DbType = Decimal)
+@p35='' (DbType = Int32)
+@p36='' (DbType = Int16)
+@p37='' (DbType = Byte)",
                 parameters,
                 ignoreLineEndingDifferences: true);
 
@@ -688,10 +744,14 @@ WHERE [e].[Time] = @__timeSpan_0",
             Assert.Null(entity.Bigint);
             Assert.Null(entity.Smallint);
             Assert.Null(entity.Tinyint);
-            Assert.Null(entity.U_Int);
-            Assert.Null(entity.U_Bigint);
-            Assert.Null(entity.U_Smallint);
-            Assert.Null(entity.S_Tinyint);
+            Assert.Null(entity._Bigint);
+            Assert.Null(entity.__Bigint);
+            Assert.Null(entity._Int);
+            Assert.Null(entity._Smallint);
+            Assert.Null(entity.__Decimal_20_0);
+            Assert.Null(entity.__Int);
+            Assert.Null(entity.__Smallint);
+            Assert.Null(entity.__Tinyint);
             Assert.Null(entity.Bit);
             Assert.Null(entity.Money);
             Assert.Null(entity.Smallmoney);
@@ -975,18 +1035,22 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p19='103.3'
 @p20='don't' (Size = 4000)
 @p21='84.4'
-@p22='128' (Size = 1)
-@p23='2018-01-02T13:11:12' (DbType = DateTime)
-@p24='79'
-@p25='82.2'
-@p26='Gumball Rules!' (Size = 8000) (DbType = AnsiString)
-@p27='11:15:12'
-@p28='80' (Size = 1)
-@p29='-1'
-@p30='-1'
-@p31='-1'
-@p32='0x595A5B5C' (Size = 8000)
-@p33='C' (Size = 8000) (DbType = AnsiString)",
+@p22='2018-01-02T13:11:12' (DbType = DateTime)
+@p23='79'
+@p24='82.2'
+@p25='Gumball Rules!' (Size = 8000) (DbType = AnsiString)
+@p26='11:15:12'
+@p27='80' (Size = 1)
+@p28='0x595A5B5C' (Size = 8000)
+@p29='C' (Size = 8000) (DbType = AnsiString)
+@p30='4294967295'
+@p31='65535'
+@p32='-128'
+@p33='-1'
+@p34='18446744073709551615' (Nullable = true) (Precision = 20)
+@p35='-1'
+@p36='-1'
+@p37='128' (Size = 1)",
                 parameters,
                 ignoreLineEndingDifferences: true);
 
@@ -1002,10 +1066,14 @@ WHERE [e].[Time] = @__timeSpan_0",
             Assert.Equal(78, entity.Bigint);
             Assert.Equal(79, entity.Smallint);
             Assert.Equal(80, entity.Tinyint);
-            Assert.Equal(uint.MaxValue, entity.U_Int);
-            Assert.Equal(ulong.MaxValue, entity.U_Bigint);
-            Assert.Equal(ushort.MaxValue, entity.U_Smallint);
-            Assert.Equal(sbyte.MinValue, entity.S_Tinyint);
+            Assert.Equal(uint.MaxValue, entity._Bigint);
+            Assert.Equal(ulong.MaxValue, entity.__Bigint);
+            Assert.Equal(ushort.MaxValue, entity._Int);
+            Assert.Equal(sbyte.MinValue, entity._Smallint);
+            Assert.Equal(ulong.MaxValue, entity.__Decimal_20_0);
+            Assert.Equal(uint.MaxValue, entity.__Int);
+            Assert.Equal(ushort.MaxValue, entity.__Smallint);
+            Assert.Equal(sbyte.MinValue, entity.__Tinyint);
             Assert.True(entity.Bit);
             Assert.Equal(81.1m, entity.Money);
             Assert.Equal(82.2m, entity.Smallmoney);
@@ -1041,10 +1109,14 @@ WHERE [e].[Time] = @__timeSpan_0",
                 Bigint = 78L,
                 Smallint = 79,
                 Tinyint = 80,
-                U_Int = uint.MaxValue,
-                U_Bigint = ulong.MaxValue,
-                U_Smallint = ushort.MaxValue,
-                S_Tinyint = sbyte.MinValue,
+                _Bigint = uint.MaxValue,
+                __Bigint = ulong.MaxValue,
+                _Int = ushort.MaxValue,
+                _Smallint = sbyte.MinValue,
+                __Decimal_20_0 = ulong.MaxValue,
+                __Int = uint.MaxValue,
+                __Smallint = ushort.MaxValue,
+                __Tinyint = sbyte.MinValue,
                 Bit = true,
                 Money = 81.1m,
                 Smallmoney = 82.2m,
@@ -1107,18 +1179,22 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p19='103.3' (Nullable = true)
 @p20='don't' (Size = 4000)
 @p21='84.4' (Nullable = true)
-@p22='128' (Nullable = true) (Size = 1)
-@p23='2018-01-02T13:11:12' (Nullable = true) (DbType = DateTime)
-@p24='79' (Nullable = true)
-@p25='82.2' (Nullable = true)
-@p26='Gumball Rules!' (Size = 8000) (DbType = AnsiString)
-@p27='11:15:12' (Nullable = true)
-@p28='80' (Nullable = true) (Size = 1)
-@p29='-1' (Nullable = true)
-@p30='-1' (Nullable = true)
-@p31='-1' (Nullable = true)
-@p32='0x595A5B5C' (Size = 8000)
-@p33='C' (Size = 8000) (DbType = AnsiString)",
+@p22='2018-01-02T13:11:12' (Nullable = true) (DbType = DateTime)
+@p23='79' (Nullable = true)
+@p24='82.2' (Nullable = true)
+@p25='Gumball Rules!' (Size = 8000) (DbType = AnsiString)
+@p26='11:15:12' (Nullable = true)
+@p27='80' (Nullable = true) (Size = 1)
+@p28='0x595A5B5C' (Size = 8000)
+@p29='C' (Size = 8000) (DbType = AnsiString)
+@p30='4294967295' (Nullable = true)
+@p31='65535' (Nullable = true)
+@p32='-128' (Nullable = true)
+@p33='-1' (Nullable = true)
+@p34='18446744073709551615' (Nullable = true) (Precision = 20)
+@p35='-1' (Nullable = true)
+@p36='-1' (Nullable = true)
+@p37='128' (Nullable = true) (Size = 1)",
                 parameters,
                 ignoreLineEndingDifferences: true);
 
@@ -1134,10 +1210,14 @@ WHERE [e].[Time] = @__timeSpan_0",
             Assert.Equal(78, entity.Bigint);
             Assert.Equal(79, entity.Smallint.Value);
             Assert.Equal(80, entity.Tinyint.Value);
-            Assert.Equal(uint.MaxValue, entity.U_Int);
-            Assert.Equal(ulong.MaxValue, entity.U_Bigint);
-            Assert.Equal(ushort.MaxValue, entity.U_Smallint);
-            Assert.Equal(sbyte.MinValue, entity.S_Tinyint);
+            Assert.Equal(uint.MaxValue, entity._Bigint);
+            Assert.Equal(ulong.MaxValue, entity.__Bigint);
+            Assert.Equal(ushort.MaxValue, entity._Int);
+            Assert.Equal(sbyte.MinValue, entity._Smallint);
+            Assert.Equal(ulong.MaxValue, entity.__Decimal_20_0);
+            Assert.Equal(uint.MaxValue, entity.__Int);
+            Assert.Equal(ushort.MaxValue, entity.__Smallint);
+            Assert.Equal(sbyte.MinValue, entity.__Tinyint);
             Assert.True(entity.Bit);
             Assert.Equal(81.1m, entity.Money);
             Assert.Equal(82.2m, entity.Smallmoney);
@@ -1173,10 +1253,14 @@ WHERE [e].[Time] = @__timeSpan_0",
                 Bigint = 78L,
                 Smallint = 79,
                 Tinyint = 80,
-                U_Int = uint.MaxValue,
-                U_Bigint = ulong.MaxValue,
-                U_Smallint = ushort.MaxValue,
-                S_Tinyint = sbyte.MinValue,
+                _Bigint = uint.MaxValue,
+                __Bigint = ulong.MaxValue,
+                _Int = ushort.MaxValue,
+                _Smallint = sbyte.MinValue,
+                __Decimal_20_0 = ulong.MaxValue,
+                __Int = uint.MaxValue,
+                __Smallint = ushort.MaxValue,
+                __Tinyint = sbyte.MinValue,
                 Bit = true,
                 Money = 81.1m,
                 Smallmoney = 82.2m,
@@ -1239,18 +1323,22 @@ WHERE [e].[Time] = @__timeSpan_0",
 @p19='' (DbType = String)
 @p20='' (Size = 4000) (DbType = String)
 @p21='' (DbType = String)
-@p22='' (DbType = Byte)
-@p23='' (DbType = DateTime)
-@p24='' (DbType = Int16)
-@p25='' (DbType = String)
-@p26='' (Size = 8000)
-@p27='' (DbType = String)
-@p28='' (DbType = Byte)
-@p29='' (DbType = Int64)
-@p30='' (DbType = Int32)
-@p31='' (DbType = Int16)
-@p32='' (Size = 8000) (DbType = Binary)
-@p33='' (Size = 8000)",
+@p22='' (DbType = DateTime)
+@p23='' (DbType = Int16)
+@p24='' (DbType = String)
+@p25='' (Size = 8000)
+@p26='' (DbType = String)
+@p27='' (DbType = Byte)
+@p28='' (Size = 8000) (DbType = Binary)
+@p29='' (Size = 8000)
+@p30='' (DbType = Int64)
+@p31='' (DbType = Int32)
+@p32='' (DbType = Int16)
+@p33='' (DbType = Int64)
+@p34='' (DbType = Decimal)
+@p35='' (DbType = Int32)
+@p36='' (DbType = Int16)
+@p37='' (DbType = Byte)",
                 parameters,
                 ignoreLineEndingDifferences: true);
 
@@ -1267,10 +1355,14 @@ WHERE [e].[Time] = @__timeSpan_0",
             Assert.Null(entity.Bigint);
             Assert.Null(entity.Smallint);
             Assert.Null(entity.Tinyint);
-            Assert.Null(entity.U_Int);
-            Assert.Null(entity.U_Bigint);
-            Assert.Null(entity.U_Smallint);
-            Assert.Null(entity.S_Tinyint);
+            Assert.Null(entity._Bigint);
+            Assert.Null(entity.__Bigint);
+            Assert.Null(entity._Int);
+            Assert.Null(entity._Smallint);
+            Assert.Null(entity.__Decimal_20_0);
+            Assert.Null(entity.__Int);
+            Assert.Null(entity.__Smallint);
+            Assert.Null(entity.__Tinyint);
             Assert.Null(entity.Bit);
             Assert.Null(entity.Money);
             Assert.Null(entity.Smallmoney);
@@ -1922,12 +2014,12 @@ BuiltInDataTypes.TestDouble ---> [float] [Precision = 53]
 BuiltInDataTypes.TestInt16 ---> [smallint] [Precision = 5 Scale = 0]
 BuiltInDataTypes.TestInt32 ---> [int] [Precision = 10 Scale = 0]
 BuiltInDataTypes.TestInt64 ---> [bigint] [Precision = 19 Scale = 0]
-BuiltInDataTypes.TestSignedByte ---> [tinyint] [Precision = 3 Scale = 0]
+BuiltInDataTypes.TestSignedByte ---> [smallint] [Precision = 5 Scale = 0]
 BuiltInDataTypes.TestSingle ---> [real] [Precision = 24]
 BuiltInDataTypes.TestTimeSpan ---> [time] [Precision = 7]
-BuiltInDataTypes.TestUnsignedInt16 ---> [smallint] [Precision = 5 Scale = 0]
-BuiltInDataTypes.TestUnsignedInt32 ---> [int] [Precision = 10 Scale = 0]
-BuiltInDataTypes.TestUnsignedInt64 ---> [bigint] [Precision = 19 Scale = 0]
+BuiltInDataTypes.TestUnsignedInt16 ---> [int] [Precision = 10 Scale = 0]
+BuiltInDataTypes.TestUnsignedInt32 ---> [bigint] [Precision = 19 Scale = 0]
+BuiltInDataTypes.TestUnsignedInt64 ---> [decimal] [Precision = 20 Scale = 0]
 BuiltInNullableDataTypes.Enum16 ---> [nullable smallint] [Precision = 5 Scale = 0]
 BuiltInNullableDataTypes.Enum32 ---> [nullable int] [Precision = 10 Scale = 0]
 BuiltInNullableDataTypes.Enum64 ---> [nullable bigint] [Precision = 19 Scale = 0]
@@ -1944,13 +2036,21 @@ BuiltInNullableDataTypes.TestNullableDouble ---> [nullable float] [Precision = 5
 BuiltInNullableDataTypes.TestNullableInt16 ---> [nullable smallint] [Precision = 5 Scale = 0]
 BuiltInNullableDataTypes.TestNullableInt32 ---> [nullable int] [Precision = 10 Scale = 0]
 BuiltInNullableDataTypes.TestNullableInt64 ---> [nullable bigint] [Precision = 19 Scale = 0]
-BuiltInNullableDataTypes.TestNullableSignedByte ---> [nullable tinyint] [Precision = 3 Scale = 0]
+BuiltInNullableDataTypes.TestNullableSignedByte ---> [nullable smallint] [Precision = 5 Scale = 0]
 BuiltInNullableDataTypes.TestNullableSingle ---> [nullable real] [Precision = 24]
 BuiltInNullableDataTypes.TestNullableTimeSpan ---> [nullable time] [Precision = 7]
-BuiltInNullableDataTypes.TestNullableUnsignedInt16 ---> [nullable smallint] [Precision = 5 Scale = 0]
-BuiltInNullableDataTypes.TestNullableUnsignedInt32 ---> [nullable int] [Precision = 10 Scale = 0]
-BuiltInNullableDataTypes.TestNullableUnsignedInt64 ---> [nullable bigint] [Precision = 19 Scale = 0]
+BuiltInNullableDataTypes.TestNullableUnsignedInt16 ---> [nullable int] [Precision = 10 Scale = 0]
+BuiltInNullableDataTypes.TestNullableUnsignedInt32 ---> [nullable bigint] [Precision = 19 Scale = 0]
+BuiltInNullableDataTypes.TestNullableUnsignedInt64 ---> [nullable decimal] [Precision = 20 Scale = 0]
 BuiltInNullableDataTypes.TestString ---> [nullable nvarchar] [MaxLength = -1]
+MappedDataTypes.__Bigint ---> [bigint] [Precision = 19 Scale = 0]
+MappedDataTypes.__Decimal_20_0 ---> [decimal] [Precision = 20 Scale = 0]
+MappedDataTypes.__Int ---> [int] [Precision = 10 Scale = 0]
+MappedDataTypes.__Smallint ---> [smallint] [Precision = 5 Scale = 0]
+MappedDataTypes.__Tinyint ---> [tinyint] [Precision = 3 Scale = 0]
+MappedDataTypes._Bigint ---> [bigint] [Precision = 19 Scale = 0]
+MappedDataTypes._Int ---> [int] [Precision = 10 Scale = 0]
+MappedDataTypes._Smallint ---> [smallint] [Precision = 5 Scale = 0]
 MappedDataTypes.Bigint ---> [bigint] [Precision = 19 Scale = 0]
 MappedDataTypes.Binary_varyingMax ---> [varbinary] [MaxLength = -1]
 MappedDataTypes.Bit ---> [bit]
@@ -1973,18 +2073,22 @@ MappedDataTypes.Ntext ---> [ntext] [MaxLength = 1073741823]
 MappedDataTypes.Numeric ---> [numeric] [Precision = 18 Scale = 0]
 MappedDataTypes.NvarcharMax ---> [nvarchar] [MaxLength = -1]
 MappedDataTypes.Real ---> [real] [Precision = 24]
-MappedDataTypes.S_Tinyint ---> [tinyint] [Precision = 3 Scale = 0]
 MappedDataTypes.Smalldatetime ---> [smalldatetime] [Precision = 0]
 MappedDataTypes.Smallint ---> [smallint] [Precision = 5 Scale = 0]
 MappedDataTypes.Smallmoney ---> [smallmoney] [Precision = 10 Scale = 4]
 MappedDataTypes.Text ---> [text] [MaxLength = 2147483647]
 MappedDataTypes.Time ---> [time] [Precision = 7]
 MappedDataTypes.Tinyint ---> [tinyint] [Precision = 3 Scale = 0]
-MappedDataTypes.U_Bigint ---> [bigint] [Precision = 19 Scale = 0]
-MappedDataTypes.U_Int ---> [int] [Precision = 10 Scale = 0]
-MappedDataTypes.U_Smallint ---> [smallint] [Precision = 5 Scale = 0]
 MappedDataTypes.VarbinaryMax ---> [varbinary] [MaxLength = -1]
 MappedDataTypes.VarcharMax ---> [varchar] [MaxLength = -1]
+MappedDataTypesWithIdentity.__Bigint ---> [bigint] [Precision = 19 Scale = 0]
+MappedDataTypesWithIdentity.__Decimal_20_0 ---> [nullable decimal] [Precision = 20 Scale = 0]
+MappedDataTypesWithIdentity.__Int ---> [int] [Precision = 10 Scale = 0]
+MappedDataTypesWithIdentity.__Smallint ---> [smallint] [Precision = 5 Scale = 0]
+MappedDataTypesWithIdentity.__Tinyint ---> [tinyint] [Precision = 3 Scale = 0]
+MappedDataTypesWithIdentity._Bigint ---> [bigint] [Precision = 19 Scale = 0]
+MappedDataTypesWithIdentity._Int ---> [int] [Precision = 10 Scale = 0]
+MappedDataTypesWithIdentity._Smallint ---> [smallint] [Precision = 5 Scale = 0]
 MappedDataTypesWithIdentity.Bigint ---> [bigint] [Precision = 19 Scale = 0]
 MappedDataTypesWithIdentity.Binary_varyingMax ---> [nullable varbinary] [MaxLength = -1]
 MappedDataTypesWithIdentity.Bit ---> [bit]
@@ -2008,18 +2112,22 @@ MappedDataTypesWithIdentity.Ntext ---> [nullable ntext] [MaxLength = 1073741823]
 MappedDataTypesWithIdentity.Numeric ---> [numeric] [Precision = 18 Scale = 0]
 MappedDataTypesWithIdentity.NvarcharMax ---> [nullable nvarchar] [MaxLength = -1]
 MappedDataTypesWithIdentity.Real ---> [real] [Precision = 24]
-MappedDataTypesWithIdentity.S_Tinyint ---> [tinyint] [Precision = 3 Scale = 0]
 MappedDataTypesWithIdentity.Smalldatetime ---> [smalldatetime] [Precision = 0]
 MappedDataTypesWithIdentity.Smallint ---> [smallint] [Precision = 5 Scale = 0]
 MappedDataTypesWithIdentity.Smallmoney ---> [smallmoney] [Precision = 10 Scale = 4]
 MappedDataTypesWithIdentity.Text ---> [nullable text] [MaxLength = 2147483647]
 MappedDataTypesWithIdentity.Time ---> [time] [Precision = 7]
 MappedDataTypesWithIdentity.Tinyint ---> [tinyint] [Precision = 3 Scale = 0]
-MappedDataTypesWithIdentity.U_Bigint ---> [bigint] [Precision = 19 Scale = 0]
-MappedDataTypesWithIdentity.U_Int ---> [int] [Precision = 10 Scale = 0]
-MappedDataTypesWithIdentity.U_Smallint ---> [smallint] [Precision = 5 Scale = 0]
 MappedDataTypesWithIdentity.VarbinaryMax ---> [nullable varbinary] [MaxLength = -1]
 MappedDataTypesWithIdentity.VarcharMax ---> [nullable varchar] [MaxLength = -1]
+MappedNullableDataTypes.__Bigint ---> [nullable bigint] [Precision = 19 Scale = 0]
+MappedNullableDataTypes.__Decimal_20_0 ---> [nullable decimal] [Precision = 20 Scale = 0]
+MappedNullableDataTypes.__Int ---> [nullable int] [Precision = 10 Scale = 0]
+MappedNullableDataTypes.__Smallint ---> [nullable smallint] [Precision = 5 Scale = 0]
+MappedNullableDataTypes.__Tinyint ---> [nullable tinyint] [Precision = 3 Scale = 0]
+MappedNullableDataTypes._Bigint ---> [nullable bigint] [Precision = 19 Scale = 0]
+MappedNullableDataTypes._Int ---> [nullable int] [Precision = 10 Scale = 0]
+MappedNullableDataTypes._Smallint ---> [nullable smallint] [Precision = 5 Scale = 0]
 MappedNullableDataTypes.Bigint ---> [nullable bigint] [Precision = 19 Scale = 0]
 MappedNullableDataTypes.Binary_varyingMax ---> [nullable varbinary] [MaxLength = -1]
 MappedNullableDataTypes.Bit ---> [nullable bit]
@@ -2042,18 +2150,22 @@ MappedNullableDataTypes.Ntext ---> [nullable ntext] [MaxLength = 1073741823]
 MappedNullableDataTypes.Numeric ---> [nullable numeric] [Precision = 18 Scale = 0]
 MappedNullableDataTypes.NvarcharMax ---> [nullable nvarchar] [MaxLength = -1]
 MappedNullableDataTypes.Real ---> [nullable real] [Precision = 24]
-MappedNullableDataTypes.S_Tinyint ---> [nullable tinyint] [Precision = 3 Scale = 0]
 MappedNullableDataTypes.Smalldatetime ---> [nullable smalldatetime] [Precision = 0]
 MappedNullableDataTypes.Smallint ---> [nullable smallint] [Precision = 5 Scale = 0]
 MappedNullableDataTypes.Smallmoney ---> [nullable smallmoney] [Precision = 10 Scale = 4]
 MappedNullableDataTypes.Text ---> [nullable text] [MaxLength = 2147483647]
 MappedNullableDataTypes.Time ---> [nullable time] [Precision = 7]
 MappedNullableDataTypes.Tinyint ---> [nullable tinyint] [Precision = 3 Scale = 0]
-MappedNullableDataTypes.U_Bigint ---> [nullable bigint] [Precision = 19 Scale = 0]
-MappedNullableDataTypes.U_Int ---> [nullable int] [Precision = 10 Scale = 0]
-MappedNullableDataTypes.U_Smallint ---> [nullable smallint] [Precision = 5 Scale = 0]
 MappedNullableDataTypes.VarbinaryMax ---> [nullable varbinary] [MaxLength = -1]
 MappedNullableDataTypes.VarcharMax ---> [nullable varchar] [MaxLength = -1]
+MappedNullableDataTypesWithIdentity.__Bigint ---> [nullable bigint] [Precision = 19 Scale = 0]
+MappedNullableDataTypesWithIdentity.__Decimal_20_0 ---> [nullable decimal] [Precision = 20 Scale = 0]
+MappedNullableDataTypesWithIdentity.__Int ---> [nullable int] [Precision = 10 Scale = 0]
+MappedNullableDataTypesWithIdentity.__Smallint ---> [nullable smallint] [Precision = 5 Scale = 0]
+MappedNullableDataTypesWithIdentity.__Tinyint ---> [nullable tinyint] [Precision = 3 Scale = 0]
+MappedNullableDataTypesWithIdentity._Bigint ---> [nullable bigint] [Precision = 19 Scale = 0]
+MappedNullableDataTypesWithIdentity._Int ---> [nullable int] [Precision = 10 Scale = 0]
+MappedNullableDataTypesWithIdentity._Smallint ---> [nullable smallint] [Precision = 5 Scale = 0]
 MappedNullableDataTypesWithIdentity.Bigint ---> [nullable bigint] [Precision = 19 Scale = 0]
 MappedNullableDataTypesWithIdentity.Binary_varyingMax ---> [nullable varbinary] [MaxLength = -1]
 MappedNullableDataTypesWithIdentity.Bit ---> [nullable bit]
@@ -2077,16 +2189,12 @@ MappedNullableDataTypesWithIdentity.Ntext ---> [nullable ntext] [MaxLength = 107
 MappedNullableDataTypesWithIdentity.Numeric ---> [nullable numeric] [Precision = 18 Scale = 0]
 MappedNullableDataTypesWithIdentity.NvarcharMax ---> [nullable nvarchar] [MaxLength = -1]
 MappedNullableDataTypesWithIdentity.Real ---> [nullable real] [Precision = 24]
-MappedNullableDataTypesWithIdentity.S_Tinyint ---> [nullable tinyint] [Precision = 3 Scale = 0]
 MappedNullableDataTypesWithIdentity.Smalldatetime ---> [nullable smalldatetime] [Precision = 0]
 MappedNullableDataTypesWithIdentity.Smallint ---> [nullable smallint] [Precision = 5 Scale = 0]
 MappedNullableDataTypesWithIdentity.Smallmoney ---> [nullable smallmoney] [Precision = 10 Scale = 4]
 MappedNullableDataTypesWithIdentity.Text ---> [nullable text] [MaxLength = 2147483647]
 MappedNullableDataTypesWithIdentity.Time ---> [nullable time] [Precision = 7]
 MappedNullableDataTypesWithIdentity.Tinyint ---> [nullable tinyint] [Precision = 3 Scale = 0]
-MappedNullableDataTypesWithIdentity.U_Bigint ---> [nullable bigint] [Precision = 19 Scale = 0]
-MappedNullableDataTypesWithIdentity.U_Int ---> [nullable int] [Precision = 10 Scale = 0]
-MappedNullableDataTypesWithIdentity.U_Smallint ---> [nullable smallint] [Precision = 5 Scale = 0]
 MappedNullableDataTypesWithIdentity.VarbinaryMax ---> [nullable varbinary] [MaxLength = -1]
 MappedNullableDataTypesWithIdentity.VarcharMax ---> [nullable varchar] [MaxLength = -1]
 MappedPrecisionAndScaledDataTypes.Dec ---> [decimal] [Precision = 5 Scale = 2]
@@ -2282,16 +2390,41 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
                         typeName = typeName.Substring(0, typeName.IndexOf("Max")) + "(max)";
                     }
 
-                    if (typeName.StartsWith("U_")
-                        || typeName.StartsWith("S_"))
+                    while (typeName.StartsWith("_"))
                     {
-                        typeName = typeName.Substring(2);
+                        typeName = typeName.Substring(1);
+                    }
+
+                    if (TryExtractSize(typeName, out typeName, out var size1))
+                    {
+                        if (TryExtractSize(typeName, out typeName, out var size2))
+                        {
+                            typeName += "(" + size2 + "," + size1 + ")";
+                        }
+                        else
+                        {
+                            typeName += "(" + size1 + ")";
+                        }
                     }
 
                     typeName = typeName.Replace('_', ' ');
 
                     entityType.GetOrAddProperty(propertyInfo).Relational().ColumnType = typeName;
                 }
+            }
+
+            private static bool TryExtractSize(string typeName, out string trimmedName, out int size)
+            {
+                var lastScore = typeName.LastIndexOf("_", StringComparison.Ordinal);
+                if (lastScore > 0 && char.IsNumber(typeName.Last()))
+                {
+                    size = int.Parse(typeName.Substring(lastScore + 1));
+                    trimmedName = typeName.Substring(0, lastScore);
+                    return true;
+                }
+                size = -1;
+                trimmedName = typeName;
+                return false;
             }
 
             private static void MapSizedColumnTypes<TEntity>(ModelBuilder modelBuilder)
@@ -2334,10 +2467,14 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
             public long Bigint { get; set; }
             public short Smallint { get; set; }
             public byte Tinyint { get; set; }
-            public uint U_Int { get; set; }
-            public ulong U_Bigint { get; set; }
-            public ushort U_Smallint { get; set; }
-            public sbyte S_Tinyint { get; set; }
+            public uint _Bigint { get; set; }
+            public ulong __Bigint { get; set; }
+            public ulong __Decimal_20_0 { get; set; }
+            public ushort _Int { get; set; }
+            public sbyte _Smallint { get; set; }
+            public uint __Int { get; set; }
+            public ushort __Smallint { get; set; }
+            public sbyte __Tinyint { get; set; }
             public bool Bit { get; set; }
             public decimal Money { get; set; }
             public decimal Smallmoney { get; set; }
@@ -2410,10 +2547,14 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
             public long? Bigint { get; set; }
             public short? Smallint { get; set; }
             public byte? Tinyint { get; set; }
-            public uint? U_Int { get; set; }
-            public ulong? U_Bigint { get; set; }
-            public ushort? U_Smallint { get; set; }
-            public sbyte? S_Tinyint { get; set; }
+            public uint? _Bigint { get; set; }
+            public ulong? __Bigint { get; set; }
+            public ulong? __Decimal_20_0 { get; set; }
+            public ushort? _Int { get; set; }
+            public sbyte? _Smallint { get; set; }
+            public uint? __Int { get; set; }
+            public ushort? __Smallint { get; set; }
+            public sbyte? __Tinyint { get; set; }
             public bool? Bit { get; set; }
             public decimal? Money { get; set; }
             public decimal? Smallmoney { get; set; }
@@ -2450,10 +2591,14 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
             public long Bigint { get; set; }
             public short Smallint { get; set; }
             public byte Tinyint { get; set; }
-            public uint U_Int { get; set; }
-            public ulong U_Bigint { get; set; }
-            public ushort U_Smallint { get; set; }
-            public sbyte S_Tinyint { get; set; }
+            public uint _Bigint { get; set; }
+            public ulong __Bigint { get; set; }
+            public ulong? __Decimal_20_0 { get; set; }
+            public ushort _Int { get; set; }
+            public sbyte _Smallint { get; set; }
+            public uint __Int { get; set; }
+            public ushort __Smallint { get; set; }
+            public sbyte __Tinyint { get; set; }
             public bool Bit { get; set; }
             public decimal Money { get; set; }
             public decimal Smallmoney { get; set; }
@@ -2534,10 +2679,14 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
             public long? Bigint { get; set; }
             public short? Smallint { get; set; }
             public byte? Tinyint { get; set; }
-            public uint? U_Int { get; set; }
-            public ulong? U_Bigint { get; set; }
-            public ushort? U_Smallint { get; set; }
-            public sbyte? S_Tinyint { get; set; }
+            public uint? _Bigint { get; set; }
+            public ulong? __Bigint { get; set; }
+            public ushort? _Int { get; set; }
+            public ulong? __Decimal_20_0 { get; set; }
+            public sbyte? _Smallint { get; set; }
+            public uint? __Int { get; set; }
+            public ushort? __Smallint { get; set; }
+            public sbyte? __Tinyint { get; set; }
             public bool? Bit { get; set; }
             public decimal? Money { get; set; }
             public decimal? Smallmoney { get; set; }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/MappingQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/MappingQuerySqlServerTest.cs
@@ -77,6 +77,10 @@ FROM [dbo].[Orders] AS [o]",
                             e.Metadata.SqlServer().TableName = "Customers";
                             e.Metadata.SqlServer().Schema = "dbo";
                         });
+
+                modelBuilder.Entity<MappedEmployee>()
+                    .Property(c => c.EmployeeID)
+                    .HasColumnType("int");
             }
         }
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQuerySqlServerFixture.cs
@@ -20,13 +20,27 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .Property(c => c.CustomerID)
                 .HasColumnType("nchar(5)");
 
+            modelBuilder.Entity<Employee>(
+                b =>
+                    {
+                        b.Property(c => c.EmployeeID).HasColumnType("int");
+                        b.Property(c => c.ReportsTo).HasColumnType("int");
+                    });
+
+            modelBuilder.Entity<Order>()
+                .Property(o => o.EmployeeID)
+                .HasColumnType("int");
+
             modelBuilder.Entity<OrderDetail>()
                 .Property(od => od.UnitPrice)
                 .HasColumnType("money");
 
-            modelBuilder.Entity<Product>()
-                .Property(p => p.UnitPrice)
-                .HasColumnType("money");
+            modelBuilder.Entity<Product>(
+                b =>
+                    {
+                        b.Property(p => p.UnitPrice).HasColumnType("money");
+                        b.Property(p => p.UnitsInStock).HasColumnType("smallint");
+                    });
         }
     }
 }

--- a/test/EFCore.Tests/Storage/TypeConverterTest.cs
+++ b/test/EFCore.Tests/Storage/TypeConverterTest.cs
@@ -78,6 +78,62 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.Null(_uIntToInt.ConvertFromStore(null));
         }
 
+        private static readonly ValueConverter<uint, long> _uIntToLong
+            = new ValueConverter<uint, long>(v => v, v => (uint)v);
+
+        [Fact]
+        public void Can_convert_exact_types_with_non_nullable_uint_long_converter()
+        {
+            Assert.Equal((long)1, _uIntToLong.ConvertToStore((uint)1));
+            Assert.Equal((uint)1, _uIntToLong.ConvertFromStore((long)1));
+
+            Assert.Equal((long)uint.MaxValue, _uIntToLong.ConvertToStore(uint.MaxValue));
+            Assert.Equal(uint.MaxValue, _uIntToLong.ConvertFromStore((long)uint.MaxValue));
+        }
+
+        [Fact]
+        public void Can_convert_nullable_types_with_non_nullable_uint_long_converter()
+        {
+            Assert.Equal((long)1, _uIntToLong.ConvertToStore((uint?)1));
+            Assert.Equal((uint)1, _uIntToLong.ConvertFromStore((long?)1));
+
+            Assert.Equal((long)uint.MaxValue, _uIntToLong.ConvertToStore((uint?)uint.MaxValue));
+            Assert.Equal(uint.MaxValue, _uIntToLong.ConvertFromStore((long?)-1));
+        }
+
+        [Fact]
+        public void Can_convert_non_exact_types_with_non_nullable_uint_long_converter()
+        {
+            Assert.Equal((long)1, _uIntToLong.ConvertToStore((ushort)1));
+            Assert.Equal((uint)1, _uIntToLong.ConvertFromStore((short)1));
+
+            Assert.Equal((long)1, _uIntToLong.ConvertToStore((ulong)1));
+            Assert.Equal((uint)1, _uIntToLong.ConvertFromStore((long)1));
+
+            Assert.Equal((long)1, _uIntToLong.ConvertToStore(1));
+            Assert.Equal((uint)1, _uIntToLong.ConvertFromStore(1));
+        }
+
+        [Fact]
+        public void Can_convert_non_exact_nullable_types_with_non_nullable_uint_long_converter()
+        {
+            Assert.Equal((long)1, _uIntToLong.ConvertToStore((ushort?)1));
+            Assert.Equal((uint)1, _uIntToLong.ConvertFromStore((short?)1));
+
+            Assert.Equal((long)1, _uIntToLong.ConvertToStore((ulong?)1));
+            Assert.Equal((uint)1, _uIntToLong.ConvertFromStore((long?)1));
+
+            Assert.Equal((long)1, _uIntToLong.ConvertToStore((int?)1));
+            Assert.Equal((uint)1, _uIntToLong.ConvertFromStore((int?)1));
+        }
+
+        [Fact]
+        public void Can_handle_nulls_with_non_nullable_uint_long_converter()
+        {
+            Assert.Null(_uIntToLong.ConvertToStore(null));
+            Assert.Null(_uIntToLong.ConvertFromStore(null));
+        }
+
         private static readonly ValueConverter<uint?, int?> _nullableUIntToInt
             = new ValueConverter<uint?, int?>(v => (int?)v, v => (uint?)v);
 
@@ -150,6 +206,19 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             Assert.Null(_stringConverter.ConvertToStore("<null>"));
             Assert.Equal("<null>", _stringConverter.ConvertFromStore(null));
+        }
+
+        private static readonly ValueConverter<ulong, decimal> _ulongToDecimnalConverter
+            = new ValueConverter<ulong, decimal>(v => v, v => (ulong)v);
+
+        [Fact]
+        public void Can_convert_exact_types_with_ulong_decimal_converter()
+        {
+            Assert.Equal((decimal)1, _ulongToDecimnalConverter.ConvertToStore((ulong)1));
+            Assert.Equal((ulong)1, _ulongToDecimnalConverter.ConvertFromStore((decimal)1));
+
+            Assert.Equal((decimal)ulong.MaxValue, _ulongToDecimnalConverter.ConvertToStore(ulong.MaxValue));
+            Assert.Equal(ulong.MaxValue, _ulongToDecimnalConverter.ConvertFromStore((decimal)ulong.MaxValue));
         }
     }
 }


### PR DESCRIPTION
Issues #6480, #242

Now using these as the default conversions:
* sbyte -> smallint
* ushort -> int
* uint -> bigint
* ulong -> decimal(20, 0)

These use wider columns on the server put preserve semantics. The previous mappings can be used simply by specifying the store type of the column--this is how the Northwind tests are still able to use unsigned types without changing the database.
