### PR TITLE
Query: Funcletize accessing array element

### DIFF
--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
@@ -36,11 +37,40 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public virtual void Where_indexer_closure()
         {
-            // ReSharper disable once ConvertToConstant.Local
-            var city = new[] { "London" };
+            var cities = new[] { "London" };
 
             AssertQuery<Customer>(
-                cs => cs.Where(c => c.City == city[0]),
+                cs => cs.Where(c => c.City == cities[0]),
+                entryCount: 6);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_dictionary_key_access_closure()
+        {
+            var predicateMap = new Dictionary<string, string> { ["City"] = "London" };
+
+            AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == predicateMap["City"]),
+                entryCount: 6);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_tuple_item_closure()
+        {
+            var predicateTuple = new Tuple<string, string>("ALFKI", "London");
+
+            AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == predicateTuple.Item2),
+                entryCount: 6);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_named_tuple_item_closure()
+        {
+            (string CustomerID, string City) predicateTuple = ("ALFKI", "London");
+
+            AssertQuery<Customer>(
+                cs => cs.Where(c => c.City == predicateTuple.City),
                 entryCount: 6);
         }
 

--- a/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
@@ -306,6 +306,12 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         /// </summary>
         protected override Expression VisitBinary(BinaryExpression binaryExpression)
         {
+            if (binaryExpression.NodeType == ExpressionType.ArrayIndex
+                && _partialEvaluationInfo.IsEvaluatableExpression(binaryExpression))
+            {
+                return TryExtractParameter(binaryExpression);
+            }
+
             if (!binaryExpression.IsLogicalOperation())
             {
                 return base.VisitBinary(binaryExpression);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
@@ -36,8 +36,47 @@ WHERE [c].[City] = @__city_0");
             base.Where_indexer_closure();
 
             AssertSql(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]");
+                @"@__p_0='London' (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[City] = @__p_0");
+        }
+
+        public override void Where_dictionary_key_access_closure()
+        {
+            base.Where_dictionary_key_access_closure();
+
+            AssertSql(
+                @"@__get_Item_0='London' (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[City] = @__get_Item_0");
+        }
+
+        public override void Where_tuple_item_closure()
+        {
+            base.Where_tuple_item_closure();
+
+            AssertSql(
+                @"@__predicateTuple_Item2_0='London' (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[City] = @__predicateTuple_Item2_0");
+        }
+
+        public override void Where_named_tuple_item_closure()
+        {
+            base.Where_named_tuple_item_closure();
+
+            AssertSql(
+                @"@__predicateTuple_Item2_0='London' (Size = 4000)
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[City] = @__predicateTuple_Item2_0");
         }
 
         public override void Where_simple_closure_constant()


### PR DESCRIPTION
Resolves #6859

Array access is BinaryExpression with node type of ArrayIndex. Since we always used base method for BinaryExpression except logical expression, we would end up evaluating array separately from access hence always caused client evaluation.
Fix is to process array access as whole instead of visiting left & right subtree.

