### PR TITLE
Fix #800 - Query: Sum should return zero for empty collections regardless of the type.

### DIFF
--- a/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -755,10 +755,16 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     }
 
                     handlerContext.SelectExpression.SetProjectionExpression(sumExpression);
-
-                    return (Expression)_transformClientExpressionMethodInfo
-                        .MakeGenericMethod(sumExpression.Type)
-                        .Invoke(null, new object[] { handlerContext, /*throwOnNullResult:*/ false });
+                    
+                    var clientExpression 
+                        = (Expression)_transformClientExpressionMethodInfo
+                            .MakeGenericMethod(sumExpression.Type.UnwrapNullableType())
+                            .Invoke(null, new object[] { handlerContext, /*throwOnNullResult:*/ false });
+                    
+                    return
+                        sumExpression.Type.IsNullableType()
+                            ? Expression.Convert(clientExpression, sumExpression.Type)
+                            : clientExpression;
                 }
             }
 

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
@@ -69,6 +69,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void Sum_with_no_data_nullable()
+        {
+            AssertSingleResult<Order>(os => os.Where(o => o.OrderID < 0).Select(o => (int?)o.OrderID).Sum());
+        }
+
+        [ConditionalFact]
         public virtual void Sum_with_binary_expression()
         {
             AssertSingleResult<Order>(os => os.Select(o => o.OrderID * 2).Sum());


### PR DESCRIPTION
- Special case Sum for nullable types: result should be (T?)default(T)
