### PR TITLE
Change Private Methods to Protected Virtual in DbContext and EntityType Generators

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -82,8 +82,20 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             return _sb.ToString();
         }
 
-        private void GenerateClass(IModel model, string contextName, string connectionString, bool useDataAnnotations)
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual void GenerateClass(
+            [NotNull] IModel model,
+            [NotNull] string contextName,
+            [NotNull] string connectionString,
+            bool useDataAnnotations)
         {
+            Check.NotNull(model, nameof(model));
+            Check.NotNull(contextName, nameof(contextName));
+            Check.NotNull(connectionString, nameof(connectionString));
+
             _sb.AppendLine($"public partial class {contextName} : DbContext");
             _sb.AppendLine("{");
 
@@ -124,8 +136,15 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             }
         }
 
-        private void GenerateOnConfiguring(string connectionString)
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual void GenerateOnConfiguring(
+            [NotNull] string connectionString)
         {
+            Check.NotNull(connectionString, nameof(connectionString));
+
             _sb.AppendLine("protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)");
             _sb.AppendLine("{");
 
@@ -156,8 +175,16 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             _sb.AppendLine();
         }
 
-        private void GenerateOnModelCreating(IModel model, bool useDataAnnotations)
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual void GenerateOnModelCreating(
+            [NotNull] IModel model,
+            bool useDataAnnotations)
         {
+            Check.NotNull(model, nameof(model));
+
             _sb.AppendLine("protected override void OnModelCreating(ModelBuilder modelBuilder)");
             _sb.Append("{");
 

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
@@ -81,8 +81,15 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             return _sb.ToString();
         }
 
-        private void GenerateClass(IEntityType entityType)
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual void GenerateClass(
+            [NotNull] IEntityType entityType)
         {
+            Check.NotNull(entityType, nameof(entityType));
+
             if (_useDataAnnotations)
             {
                 GenerateEntityTypeDataAnnotations(entityType);
@@ -102,8 +109,15 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             _sb.AppendLine("}");
         }
 
-        private void GenerateEntityTypeDataAnnotations(IEntityType entityType)
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual void GenerateEntityTypeDataAnnotations(
+            [NotNull] IEntityType entityType)
         {
+            Check.NotNull(entityType, nameof(entityType));
+
             GenerateTableAttribute(entityType);
         }
 
@@ -131,8 +145,15 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             }
         }
 
-        private void GenerateConstructor(IEntityType entityType)
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual void GenerateConstructor(
+            [NotNull] IEntityType entityType)
         {
+            Check.NotNull(entityType, nameof(entityType));
+
             var collectionNavigations = entityType.GetNavigations().Where(n => n.IsCollection()).ToList();
 
             if (collectionNavigations.Count > 0)
@@ -153,8 +174,15 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             }
         }
 
-        private void GenerateProperties(IEntityType entityType)
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual void GenerateProperties(
+            [NotNull] IEntityType entityType)
         {
+            Check.NotNull(entityType, nameof(entityType));
+
             foreach (var property in entityType.GetProperties().OrderBy(p => p.Scaffolding().ColumnOrdinal))
             {
                 if (_useDataAnnotations)
@@ -166,8 +194,15 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             }
         }
 
-        private void GeneratePropertyDataAnnotations(IProperty property)
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual void GeneratePropertyDataAnnotations(
+            [NotNull] IProperty property)
         {
+            Check.NotNull(property, nameof(property));
+
             GenerateKeyAttribute(property);
             GenerateRequiredAttribute(property);
             GenerateColumnAttribute(property);
@@ -248,8 +283,15 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             }
         }
 
-        private void GenerateNavigationProperties(IEntityType entityType)
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual void GenerateNavigationProperties(
+            [NotNull] IEntityType entityType)
         {
+            Check.NotNull(entityType, nameof(entityType));
+
             var sortedNavigations = entityType.GetNavigations()
                 .OrderBy(n => n.IsDependentToPrincipal() ? 0 : 1)
                 .ThenBy(n => n.IsCollection() ? 1 : 0);


### PR DESCRIPTION
Open up extensibility points in the DbContext and EntityType generators to allow for scaffolding customization. 

**Please check if the PR fulfills these requirements**

- [x] The code builds and tests pass (verified by our automated build checks)
- [x] Commit messages follow this format
```
    Summary of the changes
    - Detail 1
    - Detail 2

    Fixes #bugnumber
```
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Code meets the expectations our engineering guidelines. https://github.com/aspnet/Home/wiki/Engineering-guidelines.

Please review the guidelines for CONTRIBUTING.md for more details.