### PR TITLE
Fix #9923 - Perf Regression: AddDbContextPool in asp.net core System.InvalidOperationException

### DIFF
--- a/src/EFCore/EntityFrameworkServiceCollectionExtensions.cs
+++ b/src/EFCore/EntityFrameworkServiceCollectionExtensions.cs
@@ -165,7 +165,8 @@ namespace Microsoft.Extensions.DependencyInjection
                 ServiceLifetime.Singleton);
 
             serviceCollection.TryAddSingleton(sp => new DbContextPool<TContext>(sp.GetService<DbContextOptions<TContext>>()));
-            serviceCollection.AddScoped(sp => sp.GetService<DbContextPool<TContext>>().Rent());
+            serviceCollection.AddScoped<DbContextPool<TContext>.Lease>();
+            serviceCollection.AddScoped(sp => sp.GetService<DbContextPool<TContext>.Lease>().Context);
 
             return serviceCollection;
         }

--- a/src/EFCore/Internal/IDbContextPoolable.cs
+++ b/src/EFCore/Internal/IDbContextPoolable.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        void SetPool([NotNull] IDbContextPool contextPool);
+        void SetPool([CanBeNull] IDbContextPool contextPool);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used


### PR DESCRIPTION
Introduces a "lease" object, which is a scoped object that manages ownership of a pooled context instance. In particular, the lease object is responsible for returning instances to the pool at the end of the scope. This removes the complexity/race condition from DbContext.Dispose and greatly simplifies pooling in general.
