### PR TITLE
RevEng: Rewrite SqlServerDatabaseModelFactory for improved scripts

### DIFF
--- a/src/EFCore.SqlServer/Diagnostics/SqlServerEventId.cs
+++ b/src/EFCore.SqlServer/Diagnostics/SqlServerEventId.cs
@@ -52,7 +52,12 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             TableFound,
             TableSkipped,
             TypeAliasFound,
-            ForeignKeyTableMissingWarning
+            ForeignKeyTableMissingWarning,
+            PrimaryKeyFound,
+            UniqueConstraintFound,
+            IndexFound,
+            ForeignKeyFound,
+            ForeignKeyPrincipalColumnMissingWarning
         }
 
         private static readonly string _validationPrefix = DbLoggerCategory.Model.Validation.Name + ".";
@@ -97,6 +102,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     A column of a foreign key was found.
         ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
+        [Obsolete]
         public static readonly EventId ForeignKeyColumnFound = MakeScaffoldingId(Id.ForeignKeyColumnFound);
 
         /// <summary>
@@ -189,6 +195,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     The table referened by an index was not found.
         ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
+        [Obsolete]
         public static readonly EventId IndexTableMissingWarning = MakeScaffoldingId(Id.IndexTableMissingWarning);
 
         /// <summary>
@@ -208,18 +215,21 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     A table was skipped.
         ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
+        [Obsolete]
         public static readonly EventId TableSkipped = MakeScaffoldingId(Id.TableSkipped);
 
         /// <summary>
         ///     A column was skipped.
         ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
+        [Obsolete]
         public static readonly EventId ColumnSkipped = MakeScaffoldingId(Id.ColumnSkipped);
 
         /// <summary>
         ///     An index was skipped.
         ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
+        [Obsolete]
         public static readonly EventId IndexColumnFound = MakeScaffoldingId(Id.IndexColumnFound);
 
         /// <summary>
@@ -239,6 +249,37 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     A foreign key table was not found.
         ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
+        [Obsolete]
         public static readonly EventId ForeignKeyTableMissingWarning = MakeScaffoldingId(Id.ForeignKeyTableMissingWarning);
+
+        /// <summary>
+        ///     Primary key was found.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        /// </summary>
+        public static readonly EventId PrimaryKeyFound = MakeScaffoldingId(Id.PrimaryKeyFound);
+
+        /// <summary>
+        ///     An unique constraint was found.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        /// </summary>
+        public static readonly EventId UniqueConstraintFound = MakeScaffoldingId(Id.UniqueConstraintFound);
+
+        /// <summary>
+        ///     An index was found.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        /// </summary>
+        public static readonly EventId IndexFound = MakeScaffoldingId(Id.IndexFound);
+
+        /// <summary>
+        ///     A foreign key was found.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        /// </summary>
+        public static readonly EventId ForeignKeyFound = MakeScaffoldingId(Id.ForeignKeyFound);
+
+        /// <summary>
+        ///     A principal column referenced by a foreign key was not found.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        /// </summary>
+        public static readonly EventId ForeignKeyPrincipalColumnMissingWarning = MakeScaffoldingId(Id.ForeignKeyPrincipalColumnMissingWarning);
     }
 }

--- a/src/EFCore.SqlServer/Internal/SqlServerLoggerExtensions.cs
+++ b/src/EFCore.SqlServer/Internal/SqlServerLoggerExtensions.cs
@@ -1,9 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -96,18 +94,17 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// </summary>
         public static void ColumnFound(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
-            [CanBeNull] string tableName,
-            [CanBeNull] string columnName,
-            [CanBeNull] string dataTypeName,
-            int? ordinal,
-            bool? nullable,
-            int? primaryKeyOrdinal,
+            [NotNull] string tableName,
+            [NotNull] string columnName,
+            int ordinal,
+            [NotNull] string dataTypeName,
+            int maxLength,
+            int precision,
+            int scale,
+            bool nullable,
+            bool identity,
             [CanBeNull] string defaultValue,
-            [CanBeNull] string computedValue,
-            int? precision,
-            int? scale,
-            int? maxLength,
-            bool? identity)
+            [CanBeNull] string computedValue)
         {
             // No DiagnosticsSource events because these are purely design-time messages
 
@@ -125,16 +122,15 @@ namespace Microsoft.EntityFrameworkCore.Internal
                         definition.MessageFormat,
                         tableName,
                         columnName,
-                        dataTypeName,
                         ordinal,
-                        nullable,
-                        primaryKeyOrdinal,
-                        defaultValue,
-                        computedValue,
+                        dataTypeName,
+                        maxLength,
                         precision,
                         scale,
-                        maxLength,
-                        identity));
+                        nullable,
+                        identity,
+                        defaultValue,
+                        computedValue));
             }
         }
 
@@ -142,41 +138,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public static void ForeignKeyColumnFound(
-            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
-            [CanBeNull] string tableName,
-            [CanBeNull] string foreignKeyName,
-            [CanBeNull] string principalTableName,
-            [CanBeNull] string columnName,
-            [CanBeNull] string principalColumnName,
-            [CanBeNull] string updateAction,
-            [CanBeNull] string deleteAction,
-            int? ordinal)
-        {
+        public static void ForeignKeyFound(
+                [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+                [NotNull] string foreignKeyName,
+                [NotNull] string tableName,
+                [NotNull] string principalTableName,
+                [NotNull] string onDeleteAction)
             // No DiagnosticsSource events because these are purely design-time messages
-
-            var definition = SqlServerStrings.LogFoundForeignKeyColumn;
-
-            Debug.Assert(LogLevel.Debug == definition.Level);
-
-            if (diagnostics.GetLogBehavior(definition.EventId, definition.Level) != WarningBehavior.Ignore)
-            {
-                definition.Log(
-                    diagnostics,
-                    l => l.LogDebug(
-                        definition.EventId,
-                        null,
-                        definition.MessageFormat,
-                        tableName,
-                        foreignKeyName,
-                        principalTableName,
-                        columnName,
-                        principalColumnName,
-                        updateAction,
-                        deleteAction,
-                        ordinal));
-            }
-        }
+            => SqlServerStrings.LogFoundForeignKey.Log(diagnostics, foreignKeyName, tableName, principalTableName, onDeleteAction);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -184,7 +153,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// </summary>
         public static void DefaultSchemaFound(
                 [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
-                [CanBeNull] string schemaName)
+                [NotNull] string schemaName)
             // No DiagnosticsSource events because these are purely design-time messages
             => SqlServerStrings.LogFoundDefaultSchema.Log(diagnostics, schemaName);
 
@@ -194,8 +163,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// </summary>
         public static void TypeAliasFound(
                 [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
-                [CanBeNull] string typeAliasName,
-                [CanBeNull] string systemTypeName)
+                [NotNull] string typeAliasName,
+                [NotNull] string systemTypeName)
             // No DiagnosticsSource events because these are purely design-time messages
             => SqlServerStrings.LogFoundTypeAlias.Log(diagnostics, typeAliasName, systemTypeName);
 
@@ -203,23 +172,35 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public static void ColumnSkipped(
+        public static void PrimaryKeyFound(
                 [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
-                [CanBeNull] string tableName,
-                [CanBeNull] string columnName)
+                [NotNull] string primaryKeyName,
+                [NotNull] string tableName)
             // No DiagnosticsSource events because these are purely design-time messages
-            => SqlServerStrings.LogColumnNotInSelectionSet.Log(diagnostics, columnName, tableName);
+            => SqlServerStrings.LogFoundPrimaryKey.Log(diagnostics, primaryKeyName, tableName);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public static void ForeignKeyTableMissingWarning(
+        public static void UniqueConstraintFound(
                 [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
-                [CanBeNull] string foreignKeyName,
-                [CanBeNull] string tableName)
+                [NotNull] string uniqueConstraintName,
+                [NotNull] string tableName)
             // No DiagnosticsSource events because these are purely design-time messages
-            => SqlServerStrings.LogForeignKeyTableNotInSelectionSet.Log(diagnostics, foreignKeyName, tableName);
+            => SqlServerStrings.LogFoundUniqueConstraint.Log(diagnostics, uniqueConstraintName, tableName);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static void IndexFound(
+                [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+                [NotNull] string indexName,
+                [NotNull] string tableName,
+                bool unique)
+            // No DiagnosticsSource events because these are purely design-time messages
+            => SqlServerStrings.LogFoundIndex.Log(diagnostics, indexName, tableName, unique);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -237,26 +218,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public static void IndexColumnFound(
+        public static void ForeignKeyPrincipalColumnMissingWarning(
                 [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
-                [CanBeNull] string tableName,
-                [CanBeNull] string indexName,
-                bool? unique,
-                [CanBeNull] string columnName,
-                int? ordinal)
+                [NotNull] string foreignKeyName,
+                [NotNull] string tableName,
+                [NotNull] string principalColumnName,
+                [NotNull] string principalTableName)
             // No DiagnosticsSource events because these are purely design-time messages
-            => SqlServerStrings.LogFoundIndexColumn.Log(diagnostics, indexName, tableName, columnName, ordinal);
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public static void IndexTableMissingWarning(
-                [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
-                [CanBeNull] string indexName,
-                [CanBeNull] string tableName)
-            // No DiagnosticsSource events because these are purely design-time messages
-            => SqlServerStrings.LogUnableToFindTableForIndex.Log(diagnostics, indexName, tableName);
+            => SqlServerStrings.LogPrincipalColumnNotFound.Log(diagnostics, foreignKeyName, tableName, principalColumnName, principalTableName);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -284,13 +253,13 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// </summary>
         public static void SequenceFound(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
-            [CanBeNull] string sequenceName,
-            [CanBeNull] string sequenceTypeName,
-            bool? cyclic,
-            int? increment,
-            long? start,
-            long? min,
-            long? max)
+            [NotNull] string sequenceName,
+            [NotNull] string sequenceTypeName,
+            bool cyclic,
+            int increment,
+            long start,
+            long min,
+            long max)
         {
             // No DiagnosticsSource events because these are purely design-time messages
             var definition = SqlServerStrings.LogFoundSequence;
@@ -321,18 +290,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// </summary>
         public static void TableFound(
                 [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
-                [CanBeNull] string tableName)
+                [NotNull] string tableName)
             // No DiagnosticsSource events because these are purely design-time messages
             => SqlServerStrings.LogFoundTable.Log(diagnostics, tableName);
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public static void TableSkipped(
-                [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
-                [CanBeNull] string tableName)
-            // No DiagnosticsSource events because these are purely design-time messages
-            => SqlServerStrings.LogTableNotInSelectionSet.Log(diagnostics, tableName);
     }
 }

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -67,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             => GetString("TransientExceptionDetected");
 
         /// <summary>
-        ///     No type was specified for the decimal column '{property}' on entity type '{entityType}'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accomadate all the values using 'ForSqlServerHasColumnType()'.
+        ///     No type was specified for the decimal column '{property}' on entity type '{entityType}'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accomadate all the values using 'ForHasColumnType()'.
         /// </summary>
         public static readonly EventDefinition<string, string> LogDefaultDecimalTypeColumn
             = new EventDefinition<string, string>(
@@ -139,7 +139,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                     _resourceManager.GetString("LogFoundTypeAlias")));
 
         /// <summary>
-        ///     Found column with table: {tableName}, column name: {columnName}, data type: {dataType}, ordinal: {ordinal}, nullable: {isNullable}, primary key ordinal: {primaryKeyOrdinal}, default value: {defaultValue}, computed value: {computedValue}, precision: {precision}, scale: {scale}, maximum length: {maxLength}, identity: {isIdentity}
+        ///     Found column with table: {tableName}, column name: {columnName}, ordinal: {ordinal}, data type: {dataType}, maximum length: {maxLength}, precision: {precision}, scale: {scale}, nullable: {isNullable}, identity: {isIdentity}, default value: {defaultValue}, computed value: {computedValue}
         /// </summary>
         public static readonly FallbackEventDefinition LogFoundColumn
             = new FallbackEventDefinition(
@@ -148,25 +148,16 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 _resourceManager.GetString("LogFoundColumn"));
 
         /// <summary>
-        ///     Found foreign key column with table: {tableName}, foreign key name: {fkName}, principal table: {principalTableName}, column name: {columnName}, principal column name: {principalColumnName}, update action: {updateAction}, delete action: {deleteAction}, ordinal: {ordinal}.
+        ///     Found foreign key on table: {tableName}, name: {foreignKeyName}, principal table: {principalTableName}, delete action: {deleteAction}.
         /// </summary>
-        public static readonly FallbackEventDefinition LogFoundForeignKeyColumn
-            = new FallbackEventDefinition(
-                SqlServerEventId.ForeignKeyColumnFound,
+        public static readonly EventDefinition<string, string, string, string> LogFoundForeignKey
+            = new EventDefinition<string, string, string, string>(
+                SqlServerEventId.ForeignKeyFound,
                 LogLevel.Debug,
-                _resourceManager.GetString("LogFoundForeignKeyColumn"));
-
-        /// <summary>
-        ///     Column {columnName} belongs to table {tableName} which is not included in the selection set. Skipping.
-        /// </summary>
-        public static readonly EventDefinition<string, string> LogColumnNotInSelectionSet
-            = new EventDefinition<string, string>(
-                SqlServerEventId.ColumnSkipped,
-                LogLevel.Debug,
-                LoggerMessage.Define<string, string>(
+                LoggerMessage.Define<string, string, string, string>(
                     LogLevel.Debug,
-                    SqlServerEventId.ColumnSkipped,
-                    _resourceManager.GetString("LogColumnNotInSelectionSet")));
+                    SqlServerEventId.ForeignKeyFound,
+                    _resourceManager.GetString("LogFoundForeignKey")));
 
         /// <summary>
         ///     For foreign key {fkName} on table {tableName}, unable to model the end of the foreign key on principal table {principaltableName}. This is usually because the principal table was not included in the selection set.
@@ -179,30 +170,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
                     LogLevel.Warning,
                     SqlServerEventId.ForeignKeyReferencesMissingPrincipalTableWarning,
                     _resourceManager.GetString("LogPrincipalTableNotInSelectionSet")));
-
-        /// <summary>
-        ///     Found index column on index {indexName} on table {tableName}, column name: {columnName}, ordinal: {ordinal}.
-        /// </summary>
-        public static readonly EventDefinition<string, string, string, int?> LogFoundIndexColumn
-            = new EventDefinition<string, string, string, int?>(
-                SqlServerEventId.IndexColumnFound,
-                LogLevel.Debug,
-                LoggerMessage.Define<string, string, string, int?>(
-                    LogLevel.Debug,
-                    SqlServerEventId.IndexColumnFound,
-                    _resourceManager.GetString("LogFoundIndexColumn")));
-
-        /// <summary>
-        ///     For index {indexName}. Unable to find parent table {tableName}. Skipping index.
-        /// </summary>
-        public static readonly EventDefinition<string, string> LogUnableToFindTableForIndex
-            = new EventDefinition<string, string>(
-                SqlServerEventId.IndexTableMissingWarning,
-                LogLevel.Debug,
-                LoggerMessage.Define<string, string>(
-                    LogLevel.Debug,
-                    SqlServerEventId.IndexTableMissingWarning,
-                    _resourceManager.GetString("LogUnableToFindTableForIndex")));
 
         /// <summary>
         ///     Unable to find a schema in the database matching the selected schema {schema}.
@@ -250,34 +217,10 @@ namespace Microsoft.EntityFrameworkCore.Internal
                     _resourceManager.GetString("LogFoundTable")));
 
         /// <summary>
-        ///     Table {tableName} is not included in the selection set. Skipping.
-        /// </summary>
-        public static readonly EventDefinition<string> LogTableNotInSelectionSet
-            = new EventDefinition<string>(
-                SqlServerEventId.TableSkipped,
-                LogLevel.Debug,
-                LoggerMessage.Define<string>(
-                    LogLevel.Debug,
-                    SqlServerEventId.TableSkipped,
-                    _resourceManager.GetString("LogTableNotInSelectionSet")));
-
-        /// <summary>
         ///     The database name could not be determined. To use EnsureDeleted, the connection string must specify Initial Catalog.
         /// </summary>
         public static string NoInitialCatalog
             => GetString("NoInitialCatalog");
-
-        /// <summary>
-        ///     Foreign key {fkName} is defined on table {tableName} which is not included in the selection set. Skipping.
-        /// </summary>
-        public static readonly EventDefinition<string, string> LogForeignKeyTableNotInSelectionSet
-            = new EventDefinition<string, string>(
-                SqlServerEventId.ForeignKeyTableMissingWarning,
-                LogLevel.Debug,
-                LoggerMessage.Define<string, string>(
-                    LogLevel.Debug,
-                    SqlServerEventId.ForeignKeyTableMissingWarning,
-                    _resourceManager.GetString("LogForeignKeyTableNotInSelectionSet")));
 
         /// <summary>
         ///     '{entityType1}.{property1}' and '{entityType2}.{property2}' are both mapped to column '{columnName}' in '{table}' but are configured with different value generation strategies.
@@ -286,6 +229,62 @@ namespace Microsoft.EntityFrameworkCore.Internal
             => string.Format(
                 GetString("DuplicateColumnNameValueGenerationStrategyMismatch", nameof(entityType1), nameof(property1), nameof(entityType2), nameof(property2), nameof(columnName), nameof(table)),
                 entityType1, property1, entityType2, property2, columnName, table);
+
+        /// <summary>
+        ///     Found index with name: {indexName}, table: {tableName}, is unique: {isUnique}.
+        /// </summary>
+        public static readonly EventDefinition<string, string, bool> LogFoundIndex
+            = new EventDefinition<string, string, bool>(
+                SqlServerEventId.IndexFound,
+                LogLevel.Debug,
+                LoggerMessage.Define<string, string, bool>(
+                    LogLevel.Debug,
+                    SqlServerEventId.IndexFound,
+                    _resourceManager.GetString("LogFoundIndex")));
+
+        /// <summary>
+        ///     Found primary key with name: {primaryKeyName}, table: {tableName}.
+        /// </summary>
+        public static readonly EventDefinition<string, string> LogFoundPrimaryKey
+            = new EventDefinition<string, string>(
+                SqlServerEventId.PrimaryKeyFound,
+                LogLevel.Debug,
+                LoggerMessage.Define<string, string>(
+                    LogLevel.Debug,
+                    SqlServerEventId.PrimaryKeyFound,
+                    _resourceManager.GetString("LogFoundPrimaryKey")));
+
+        /// <summary>
+        ///     Found unique constraint with name: {uniqueConstraintName}, table: {tableName}.
+        /// </summary>
+        public static readonly EventDefinition<string, string> LogFoundUniqueConstraint
+            = new EventDefinition<string, string>(
+                SqlServerEventId.UniqueConstraintFound,
+                LogLevel.Debug,
+                LoggerMessage.Define<string, string>(
+                    LogLevel.Debug,
+                    SqlServerEventId.UniqueConstraintFound,
+                    _resourceManager.GetString("LogFoundUniqueConstraint")));
+
+        /// <summary>
+        ///     For foreign key {foreignKeyName} on table {tableName}, unable to find the column called {principalColumnName} on the foreign key's principal table, {principaltableName}. Skipping foreign key.
+        /// </summary>
+        public static readonly EventDefinition<string, string, string, string> LogPrincipalColumnNotFound
+            = new EventDefinition<string, string, string, string>(
+                SqlServerEventId.ForeignKeyPrincipalColumnMissingWarning,
+                LogLevel.Warning,
+                LoggerMessage.Define<string, string, string, string>(
+                    LogLevel.Warning,
+                    SqlServerEventId.ForeignKeyPrincipalColumnMissingWarning,
+                    _resourceManager.GetString("LogPrincipalColumnNotFound")));
+
+        /// <summary>
+        ///     The specified table '{table}' is not valid. Specify tables using the format '[schema].[table]'.
+        /// </summary>
+        public static string InvalidTableToIncludeInScaffolding([CanBeNull] object table)
+            => string.Format(
+                GetString("InvalidTableToIncludeInScaffolding", nameof(table)),
+                table);
 
         private static string GetString(string name, params string[] formatterNames)
         {

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -139,7 +139,7 @@
     <value>An exception has been raised that is likely due to a transient failure. If you are connecting to a SQL Azure database consider using SqlAzureExecutionStrategy.</value>
   </data>
   <data name="LogDefaultDecimalTypeColumn" xml:space="preserve">
-    <value>No type was specified for the decimal column '{property}' on entity type '{entityType}'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accomadate all the values using 'ForSqlServerHasColumnType()'.</value>
+    <value>No type was specified for the decimal column '{property}' on entity type '{entityType}'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accomadate all the values using 'ForHasColumnType()'.</value>
     <comment>Warning SqlServerEventId.DecimalTypeDefaultWarning string string</comment>
   </data>
   <data name="LogByteIdentityColumn" xml:space="preserve">
@@ -164,28 +164,16 @@
     <comment>Debug SqlServerEventId.TypeAliasFound string string</comment>
   </data>
   <data name="LogFoundColumn" xml:space="preserve">
-    <value>Found column with table: {tableName}, column name: {columnName}, data type: {dataType}, ordinal: {ordinal}, nullable: {isNullable}, primary key ordinal: {primaryKeyOrdinal}, default value: {defaultValue}, computed value: {computedValue}, precision: {precision}, scale: {scale}, maximum length: {maxLength}, identity: {isIdentity}</value>
-    <comment>Debug SqlServerEventId.ColumnFound string string string int? bool? int? string string int? int? int? bool?</comment>
+    <value>Found column with table: {tableName}, column name: {columnName}, ordinal: {ordinal}, data type: {dataType}, maximum length: {maxLength}, precision: {precision}, scale: {scale}, nullable: {isNullable}, identity: {isIdentity}, default value: {defaultValue}, computed value: {computedValue}</value>
+    <comment>Debug SqlServerEventId.ColumnFound string string int string int int int bool bool string string</comment>
   </data>
-  <data name="LogFoundForeignKeyColumn" xml:space="preserve">
-    <value>Found foreign key column with table: {tableName}, foreign key name: {fkName}, principal table: {principalTableName}, column name: {columnName}, principal column name: {principalColumnName}, update action: {updateAction}, delete action: {deleteAction}, ordinal: {ordinal}.</value>
-    <comment>Debug SqlServerEventId.ForeignKeyColumnFound string string string string string string string int?</comment>
-  </data>
-  <data name="LogColumnNotInSelectionSet" xml:space="preserve">
-    <value>Column {columnName} belongs to table {tableName} which is not included in the selection set. Skipping.</value>
-    <comment>Debug SqlServerEventId.ColumnSkipped string string</comment>
+  <data name="LogFoundForeignKey" xml:space="preserve">
+    <value>Found foreign key on table: {tableName}, name: {foreignKeyName}, principal table: {principalTableName}, delete action: {deleteAction}.</value>
+    <comment>Debug SqlServerEventId.ForeignKeyFound string string string string</comment>
   </data>
   <data name="LogPrincipalTableNotInSelectionSet" xml:space="preserve">
     <value>For foreign key {fkName} on table {tableName}, unable to model the end of the foreign key on principal table {principaltableName}. This is usually because the principal table was not included in the selection set.</value>
     <comment>Warning SqlServerEventId.ForeignKeyReferencesMissingPrincipalTableWarning string string string</comment>
-  </data>
-  <data name="LogFoundIndexColumn" xml:space="preserve">
-    <value>Found index column on index {indexName} on table {tableName}, column name: {columnName}, ordinal: {ordinal}.</value>
-    <comment>Debug SqlServerEventId.IndexColumnFound string string string int?</comment>
-  </data>
-  <data name="LogUnableToFindTableForIndex" xml:space="preserve">
-    <value>For index {indexName}. Unable to find parent table {tableName}. Skipping index.</value>
-    <comment>Debug SqlServerEventId.IndexTableMissingWarning string string</comment>
   </data>
   <data name="LogMissingSchema" xml:space="preserve">
     <value>Unable to find a schema in the database matching the selected schema {schema}.</value>
@@ -197,24 +185,35 @@
   </data>
   <data name="LogFoundSequence" xml:space="preserve">
     <value>Found sequence name: {name}, data type: {dataType}, cyclic: {isCyclic}, increment: {increment}, start: {start}, minimum: {min}, maximum: {max}.</value>
-    <comment>Debug SqlServerEventId.SequenceFound string string bool? int? long? long? long?</comment>
+    <comment>Debug SqlServerEventId.SequenceFound string string bool int long long long</comment>
   </data>
   <data name="LogFoundTable" xml:space="preserve">
     <value>Found table with name: {name}.</value>
     <comment>Debug SqlServerEventId.TableFound string</comment>
   </data>
-  <data name="LogTableNotInSelectionSet" xml:space="preserve">
-    <value>Table {tableName} is not included in the selection set. Skipping.</value>
-    <comment>Debug SqlServerEventId.TableSkipped string</comment>
-  </data>
   <data name="NoInitialCatalog" xml:space="preserve">
     <value>The database name could not be determined. To use EnsureDeleted, the connection string must specify Initial Catalog.</value>
   </data>
-  <data name="LogForeignKeyTableNotInSelectionSet" xml:space="preserve">
-    <value>Foreign key {fkName} is defined on table {tableName} which is not included in the selection set. Skipping.</value>
-    <comment>Debug SqlServerEventId.ForeignKeyTableMissingWarning string string</comment>
-  </data>
   <data name="DuplicateColumnNameValueGenerationStrategyMismatch" xml:space="preserve">
     <value>'{entityType1}.{property1}' and '{entityType2}.{property2}' are both mapped to column '{columnName}' in '{table}' but are configured with different value generation strategies.</value>
+  </data>
+  <data name="LogFoundIndex" xml:space="preserve">
+    <value>Found index with name: {indexName}, table: {tableName}, is unique: {isUnique}.</value>
+    <comment>Debug SqlServerEventId.IndexFound string string bool</comment>
+  </data>
+  <data name="LogFoundPrimaryKey" xml:space="preserve">
+    <value>Found primary key with name: {primaryKeyName}, table: {tableName}.</value>
+    <comment>Debug SqlServerEventId.PrimaryKeyFound string string</comment>
+  </data>
+  <data name="LogFoundUniqueConstraint" xml:space="preserve">
+    <value>Found unique constraint with name: {uniqueConstraintName}, table: {tableName}.</value>
+    <comment>Debug SqlServerEventId.UniqueConstraintFound string string</comment>
+  </data>
+  <data name="LogPrincipalColumnNotFound" xml:space="preserve">
+    <value>For foreign key {foreignKeyName} on table {tableName}, unable to find the column called {principalColumnName} on the foreign key's principal table, {principaltableName}. Skipping foreign key.</value>
+    <comment>Warning SqlServerEventId.ForeignKeyPrincipalColumnMissingWarning string string string string</comment>
+  </data>
+  <data name="InvalidTableToIncludeInScaffolding" xml:space="preserve">
+    <value>The specified table '{table}' is not valid. Specify tables using the format '[schema].[table]'.</value>
   </data>
 </root>

--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlDataReaderExtension.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlDataReaderExtension.cs
@@ -23,5 +23,17 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 ? default
                 : reader.GetFieldValue<T>(idx);
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static T GetValueOrDefault<T>([NotNull] this DbDataRecord record, [NotNull] string name)
+        {
+            var idx = record.GetOrdinal(name);
+            return record.IsDBNull(idx)
+                ? default
+                : (T)record.GetValue(idx);
+        }
     }
 }


### PR DESCRIPTION
Resolves #6196, #9473, #9526, #9568, #10034

Issue#6196 Sequences are only scaffolded if the schema is in selection list
Issue#9473 Type aliases are storing fully-specified underlying type
Issue#9526 Decimal/Numeric always scaffold precision, scale
Issue#9568 Execute separate query to fetch metadata which are parametrized on table & schema
Issue#10034 At present we don't have a way to scaffold custom type for Sequence, we always get typemapping based on CLR type. So when alias is used for Sequence, we will send underlying system type for scaffolding
