### PR TITLE
Compile value converter expressions directly into ValueBuffer factory

### DIFF
--- a/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
@@ -620,7 +620,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         /// </returns>
         [Obsolete("Use GetMappedProjectionTypes().")]
         public virtual IEnumerable<Type> GetProjectionTypes() 
-            => GetMappedProjectionTypes().Select(t => t.ClrType);
+            => GetMappedProjectionTypes().Select(t => t.StoreType);
 
         /// <summary>
         ///     Gets the types of the expressions in <see cref="Projection" />.

--- a/src/EFCore.Relational/Storage/TypeMaterializationInfo.cs
+++ b/src/EFCore.Relational/Storage/TypeMaterializationInfo.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     Creates a new <see cref="TypeMaterializationInfo" /> instance.
         /// </summary>
-        /// <param name="clrType"> The type for the value to be read. </param>
+        /// <param name="modelType"> The type that is needed in the model after conversion. </param>
         /// <param name="property"> The property associated with the type, or <c>null</c> if none. </param>
         /// <param name="typeMapper"> The type mapper to use to find a mapping if the property does not have one already bound. </param>
         /// <param name="index">
@@ -26,28 +26,34 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     or -1 if no index mapping is needed.
         /// </param>
         public TypeMaterializationInfo(
-            [NotNull] Type clrType,
+            [NotNull] Type modelType,
             [CanBeNull] IProperty property,
             [CanBeNull] IRelationalTypeMapper typeMapper, 
             int index = -1)
         {
-            Check.NotNull(clrType, nameof(clrType));
+            Check.NotNull(modelType, nameof(modelType));
 
             var mapping = property?.FindRelationalMapping()
-                      ?? typeMapper?.GetMapping(clrType);
+                      ?? typeMapper?.GetMapping(modelType);
 
-            ClrType = mapping?.Converter?.StoreType ?? clrType;
+            StoreType = mapping?.Converter?.StoreType
+                        ?? modelType.UnwrapNullableType().UnwrapEnumType();
 
+            ModelType = modelType;
             Mapping = mapping;
-
             Property = property;
             Index = index;
         }
 
         /// <summary>
-        ///     The type mapping for the value to be read.
+        ///     The type that will be read from the store.
         /// </summary>
-        public virtual Type ClrType { get; }
+        public virtual Type StoreType { get; }
+
+        /// <summary>
+        ///     The type that is needed in the model after conversion.
+        /// </summary>
+        public virtual Type ModelType { get; }
 
         /// <summary>
         ///     The type mapping for the value to be read.
@@ -71,7 +77,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="other"> The object to compare with the current object. </param>
         /// <returns> <c>True</c> if the specified object is equal to the current object; otherwise, <c>false</c>. </returns>
         protected virtual bool Equals([NotNull] TypeMaterializationInfo other)
-            => ClrType == other.ClrType
+            => StoreType == other.StoreType
+               && ModelType == other.ModelType
                && Equals(Mapping, other.Mapping)
                && Equals(Property, other.Property)
                && Index == other.Index;
@@ -93,9 +100,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <returns> A hash code for the current object. </returns>
         public override int GetHashCode()
         {
-            var hashCode = (Mapping?.GetHashCode() ?? 0 * 397) ^ (Property?.GetHashCode() ?? 0);
-            hashCode = (hashCode * 397) ^ ClrType.GetHashCode();
-            return (hashCode * 397) ^ Index;
+            unchecked
+            {
+                var hashCode = StoreType.GetHashCode();
+                hashCode = (hashCode * 397) ^ ModelType.GetHashCode();
+                hashCode = (hashCode * 397) ^ (Mapping?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ (Property?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ Index;
+                return hashCode;
+            }
         }
     }
 }

--- a/src/EFCore/Metadata/Internal/PropertyAccessorsFactory.cs
+++ b/src/EFCore/Metadata/Internal/PropertyAccessorsFactory.cs
@@ -132,19 +132,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             var valueBufferParameter = Expression.Parameter(typeof(ValueBuffer), "valueBuffer");
 
-            var getter = Expression.Lambda<Func<ValueBuffer, object>>(
+            return Expression.Lambda<Func<ValueBuffer, object>>(
                     Expression.Call(
                         valueBufferParameter,
                         ValueBuffer.GetValueMethod,
                         Expression.Constant(property.GetIndex())),
                     valueBufferParameter)
                 .Compile();
-
-            var converter = property.FindMapping()?.Converter;
-
-            return converter != null 
-                ? (vb => converter.ConvertFromStore(getter(vb))) 
-                : getter;
         }
     }
 }

--- a/src/EFCore/Query/ExpressionVisitors/Internal/MemberAccessBindingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/MemberAccessBindingExpressionVisitor.cs
@@ -237,28 +237,19 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         }
 
         private static bool TryMakeNullable(
-            MethodInfo method, 
+            MethodInfo method,
             Type type,
             out MethodInfo convertedMethod)
         {
-            foreach (var candidate in _readValueMethods)
+            if (method.MethodIsClosedFormOf(EntityMaterializerSource.TryReadValueMethod))
             {
-                if (method.MethodIsClosedFormOf(candidate))
-                {
-                    convertedMethod = candidate.MakeGenericMethod(type.MakeNullable());
-                    return true;
-                }
+                convertedMethod = EntityMaterializerSource.TryReadValueMethod.MakeGenericMethod(type.MakeNullable());
+                return true;
             }
+
             convertedMethod = null;
             return false;
         }
-
-        private static readonly MethodInfo[] _readValueMethods =
-        {
-            EntityMaterializerSource.TryReadValueMethod,
-            EntityMaterializerSource.TryReadValueWithConvertMethod,
-            EntityMaterializerSource.TryReadValueWithObjectConvertMethod
-        };
 
         private static Expression TryCreateNullableAccessOperation(Expression accessOperation)
             => accessOperation is MethodCallExpression methodCallExpression

--- a/src/EFCore/Storage/ValueConverter.cs
+++ b/src/EFCore/Storage/ValueConverter.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -24,32 +25,32 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     The function to convert objects when reading data from the store,
         ///     setup to handle nulls, boxing, and non-exact matches of simple types.
         /// </param>
-        /// <param name="rawConvertToStore">
-        ///     The function to convert objects when writing data to the store,
-        ///     exactly as supplied, which may be a generic delegate and may not handle
+        /// <param name="convertToStoreExpression">
+        ///     The expression to convert objects when writing data to the store,
+        ///     exactly as supplied and may not handle
         ///     nulls, boxing, and non-exact matches of simple types.
         /// </param>
-        /// <param name="rawConvertFromStore">
-        ///     The function to convert objects when reading data from the store,
-        ///     exactly as supplied, which may be a generic delegate and may not handle
+        /// <param name="convertFromStoreExpression">
+        ///     The expression to convert objects when reading data from the store,
+        ///     exactly as supplied and may not handle
         ///     nulls, boxing, and non-exact matches of simple types.
         /// </param>
         protected ValueConverter(
             [NotNull] Func<object, object> convertToStore,
             [NotNull] Func<object, object> convertFromStore,
-            [NotNull] Delegate rawConvertToStore,
-            [NotNull] Delegate rawConvertFromStore)
+            [NotNull] LambdaExpression convertToStoreExpression,
+            [NotNull] LambdaExpression convertFromStoreExpression)
 
         {
             Check.NotNull(convertToStore, nameof(convertToStore));
             Check.NotNull(convertFromStore, nameof(convertFromStore));
-            Check.NotNull(rawConvertToStore, nameof(rawConvertToStore));
-            Check.NotNull(rawConvertFromStore, nameof(rawConvertFromStore));
+            Check.NotNull(convertToStoreExpression, nameof(convertToStoreExpression));
+            Check.NotNull(convertFromStoreExpression, nameof(convertFromStoreExpression));
 
             ConvertToStore = convertToStore;
             ConvertFromStore = convertFromStore;
-            RawConvertToStore = rawConvertToStore;
-            RawConvertFromStore = rawConvertFromStore;
+            ConvertToStoreExpression = convertToStoreExpression;
+            ConvertFromStoreExpression = convertFromStoreExpression;
         }
 
         /// <summary>
@@ -65,18 +66,18 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public virtual Func<object, object> ConvertFromStore { get; }
 
         /// <summary>
-        ///     Gets the function to convert objects when writing data to the store,
-        ///     exactly as supplied, which may be a generic delegate and may not handle
+        ///     Gets the expression to convert objects when writing data to the store,
+        ///     exactly as supplied and may not handle
         ///     nulls, boxing, and non-exact matches of simple types.
         /// </summary>
-        public virtual Delegate RawConvertToStore { get; }
+        public virtual LambdaExpression ConvertToStoreExpression { get; }
 
         /// <summary>
-        ///     Gets the function to convert objects when reading data from the store,
-        ///     exactly as supplied, which may be a generic delegate and may not handle
+        ///     Gets the expression to convert objects when reading data from the store,
+        ///     exactly as supplied and may not handle
         ///     nulls, boxing, and non-exact matches of simple types.
         /// </summary>
-        public virtual Delegate RawConvertFromStore { get; }
+        public virtual LambdaExpression ConvertFromStoreExpression { get; }
 
         /// <summary>
         ///     The CLR type used in the EF model.

--- a/test/EFCore.Relational.Tests/Storage/RelationalTypeMappingTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalTypeMappingTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Xunit;
 
@@ -15,7 +16,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         private class FakeValueConverter : ValueConverter
         {
             public FakeValueConverter()
-                : base(_ => _ , _ => _, (Func<object, object>)(_ => _), (Func<object, object>)(_ => _))
+                : base(
+                      _ => _ , 
+                      _ => _, 
+                      (Expression<Func<object, object>>)(_ => _), 
+                      (Expression<Func<object, object>>)(_ => _))
             {
             }
 

--- a/test/EFCore.Tests/Storage/TypeConverterTest.cs
+++ b/test/EFCore.Tests/Storage/TypeConverterTest.cs
@@ -15,14 +15,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [Fact]
         public void Can_access_raw_converters()
         {
-            Assert.Same(_uIntToInt.RawConvertFromStore, ((ValueConverter)_uIntToInt).RawConvertFromStore);
-            Assert.Same(_uIntToInt.RawConvertToStore, ((ValueConverter)_uIntToInt).RawConvertToStore);
+            Assert.Same(_uIntToInt.ConvertFromStoreExpression, ((ValueConverter)_uIntToInt).ConvertFromStoreExpression);
+            Assert.Same(_uIntToInt.ConvertToStoreExpression, ((ValueConverter)_uIntToInt).ConvertToStoreExpression);
 
-            Assert.Equal(1, _uIntToInt.RawConvertToStore(1));
-            Assert.Equal((uint)1, _uIntToInt.RawConvertFromStore(1));
+            Assert.Equal(1, _uIntToInt.ConvertToStoreExpression.Compile()(1));
+            Assert.Equal((uint)1, _uIntToInt.ConvertFromStoreExpression.Compile()(1));
 
-            Assert.Equal(-1, _uIntToInt.RawConvertToStore(uint.MaxValue));
-            Assert.Equal(uint.MaxValue, _uIntToInt.RawConvertFromStore(-1));
+            Assert.Equal(-1, _uIntToInt.ConvertToStoreExpression.Compile()(uint.MaxValue));
+            Assert.Equal(uint.MaxValue, _uIntToInt.ConvertFromStoreExpression.Compile()(-1));
         }
 
         [Fact]
@@ -139,8 +139,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 v => v.Equals("<null>", StringComparison.OrdinalIgnoreCase)
                     ? null
                     : (int?)int.Parse(v, CultureInfo.InvariantCulture),
-                v => v?.ToString(CultureInfo.InvariantCulture)
-                     ?? "<null>");
+                v => v != null
+                    ? v.Value.ToString(CultureInfo.InvariantCulture)
+                    : "<null>");
 
         [Fact]
         public void Can_convert_nulls_to_non_nulls()


### PR DESCRIPTION
This moves converting a store value to happen immediately after the value is read from the data reader. This means that it only needs to happen in one place, which will make it cleaner when implementing more complex conversions; such as those needed for Oracle.

Value converters are now registered as expressions, and the expression is compiled directly into the materializer code with no lambda or method invocation, which should be optimal for perf.