### PR TITLE
[2.0.1] Query: Unique-fy ordering & projection created by IncludeComp…

### DIFF
--- a/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
@@ -818,14 +818,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
                                 return true;
                             }
 
-                            if (o.Expression is NullableExpression nullableExpression1
+                            if (o.Expression.RemoveConvert() is NullableExpression nullableExpression1
                                 && _expressionEqualityComparer
                                     .Equals(nullableExpression1.Operand.RemoveConvert(), ordering.Expression))
                             {
                                 return true;
                             }
 
-                            return ordering.Expression is NullableExpression nullableExpression2
+                            return ordering.Expression.RemoveConvert() is NullableExpression nullableExpression2
                                    && _expressionEqualityComparer
                                        .Equals(nullableExpression2.Operand.RemoveConvert(), o.Expression);
                         }

--- a/src/EFCore.Specification.Tests/Query/ComplexNavigationsOwnedQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/ComplexNavigationsOwnedQueryTestBase.cs
@@ -390,6 +390,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
         }
 
+        public override void Include_reference_collection_order_by_reference_navigation()
+        {
+        }
+
         protected override IQueryable<Level1> GetExpectedLevelOne()
             => ComplexNavigationsData.SplitLevelOnes.AsQueryable();
 

--- a/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -3674,6 +3674,23 @@ namespace Microsoft.EntityFrameworkCore.Query
                 expectedIncludes: new List<IExpectedInclude> { new ExpectedInclude<Level1>(e => e.OneToMany_Optional, "OneToMany_Optional") });
         }
 
+        [ConditionalFact]
+        public virtual void Include_reference_collection_order_by_reference_navigation()
+        {
+            AssertIncludeQuery<Level1>(
+                l1s => l1s
+                    .Include(l1 => l1.OneToOne_Optional_FK.OneToMany_Optional)
+                    .OrderBy(l1 => l1.OneToOne_Optional_FK.Id),
+                l1s => l1s
+                    .Include(l1 => l1.OneToOne_Optional_FK.OneToMany_Optional)
+                    .OrderBy(l1 => MaybeScalar<int>(l1.OneToOne_Optional_FK, () => l1.OneToOne_Optional_FK.Id)),
+                expectedIncludes: new List<IExpectedInclude>
+                {
+                    new ExpectedInclude<Level1>(e => e.OneToOne_Optional_FK, "OneToOne_Optional_FK"),
+                    new ExpectedInclude<Level2>(e => e.OneToMany_Optional, "OneToMany_Optional", "OneToOne_Optional_FK")
+                });
+        }
+
         private static TResult Maybe<TResult>(object caller, Func<TResult> expression) where TResult : class
         {
             if (caller == null)

--- a/test/EFCore.InMemory.FunctionalTests/Query/ComplexNavigationsQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/ComplexNavigationsQueryInMemoryTest.cs
@@ -20,10 +20,16 @@ namespace Microsoft.EntityFrameworkCore.Query
             base.Nested_group_join_with_take();
         }
 
-        [ConditionalFact(Skip = " issue #9591")]
+        [ConditionalFact(Skip = "issue #9591")]
         public override void Multi_include_with_groupby_in_subquery()
         {
             base.Multi_include_with_groupby_in_subquery();
+        }
+
+        [ConditionalFact(Skip = "Issue #10060")]
+        public override void Include_reference_collection_order_by_reference_navigation()
+        {
+            base.Include_reference_collection_order_by_reference_navigation();
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -15,7 +15,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             ComplexNavigationsQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         private bool SupportsOffset => TestEnvironment.GetFlag(nameof(SqlServerCondition.SupportsOffset)) ?? true;
@@ -3234,6 +3235,26 @@ INNER JOIN (
     FROM [Level2] AS [l20]
 ) AS [t] ON [l2.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
 ORDER BY [t].[c], [t].[Name], [t].[Id]");
+        }
+
+        public override void Include_reference_collection_order_by_reference_navigation()
+        {
+            base.Include_reference_collection_order_by_reference_navigation();
+
+            AssertSql(
+    @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToOne_Optional_FK].[Id], [l1.OneToOne_Optional_FK].[Date], [l1.OneToOne_Optional_FK].[Level1_Optional_Id], [l1.OneToOne_Optional_FK].[Level1_Required_Id], [l1.OneToOne_Optional_FK].[Name], [l1.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+FROM [Level1] AS [l1]
+LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
+ORDER BY [l1.OneToOne_Optional_FK].[Id]",
+    //
+    @"SELECT [l1.OneToOne_Optional_FK.OneToMany_Optional].[Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Optional_Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Required_Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Name], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [Level3] AS [l1.OneToOne_Optional_FK.OneToMany_Optional]
+INNER JOIN (
+    SELECT DISTINCT [l1.OneToOne_Optional_FK0].[Id]
+    FROM [Level1] AS [l10]
+    LEFT JOIN [Level2] AS [l1.OneToOne_Optional_FK0] ON [l10].[Id] = [l1.OneToOne_Optional_FK0].[Level1_Optional_Id]
+) AS [t] ON [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
+ORDER BY [t].[Id]");
         }
 
         private void AssertSql(params string[] expected)


### PR DESCRIPTION
…iler with existing ordering

Resolves #10045

The issue: When you have reference.collection include and orderby reference.property, the ordering is expanded by navigation rewrite and it is null-compensated. Whereas the ordering collection include adds missed null-compensation hence they were not matching property causing multiple orderings/projection in QueryModel, which would map to same SqlFragment causing projection count mismatch.
The fix is to unique-fy ordering by including null-compensation. Due to new pattern generated by Include, downstream code needs to understand & match more patterns.

I will add quirks once approved. 
