### PR TITLE
Use ReferenceEquals for navigation value comparison in SetProperty

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -749,7 +749,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 var asProperty = propertyBase as IProperty;
                 var propertyIndex = asProperty?.GetIndex();
 
-                if (!Equals(currentValue, value)
+                var valuesEqual = asProperty != null
+                    ? Equals(currentValue, value)
+                    : ReferenceEquals(currentValue, value);
+
+                if (!valuesEqual
                     || (propertyIndex.HasValue
                         && (_stateData.IsPropertyFlagged(propertyIndex.Value, PropertyFlag.Unknown)
                             || _stateData.IsPropertyFlagged(propertyIndex.Value, PropertyFlag.Null)

--- a/test/EFCore.Tests/ChangeTracking/Internal/OwnedFixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/OwnedFixupTest.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Xunit;
 
+// ReSharper disable UnusedParameter.Local
 // ReSharper disable UnusedAutoPropertyAccessor.Local
 // ReSharper disable AccessToDisposedClosure
 // ReSharper disable InconsistentNaming
@@ -847,6 +848,30 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             public Child Child1 { get; set; }
             public Child Child2 { get; set; }
+
+            public override bool Equals(object obj)
+            {
+                Assert.False(true);
+                return false;
+            }
+
+            public override int GetHashCode()
+            {
+                Assert.False(true);
+                return base.GetHashCode();
+            }
+
+            public static bool operator ==(Parent value, Parent other)
+            {
+                Assert.False(true);
+                return false;
+            }
+
+            public static bool operator !=(Parent value, Parent other)
+            {
+                Assert.False(true);
+                return true;
+            }
         }
 
         private class Child
@@ -855,6 +880,30 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             public Parent Parent { get; set; }
             public SubChild SubChild { get; set; }
+
+            public override bool Equals(object obj)
+            {
+                Assert.False(true);
+                return false;
+            }
+
+            public override int GetHashCode()
+            {
+                Assert.False(true);
+                return base.GetHashCode();
+            }
+
+            public static bool operator ==(Child value, Child other)
+            {
+                Assert.False(true);
+                return false;
+            }
+
+            public static bool operator !=(Child value, Child other)
+            {
+                Assert.False(true);
+                return true;
+            }
         }
 
         // ReSharper disable once ClassNeverInstantiated.Local
@@ -864,6 +913,30 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             public string Name { get; set; }
 
             public Child Child { get; set; }
+
+            public override bool Equals(object obj)
+            {
+                Assert.False(true);
+                return false;
+            }
+
+            public override int GetHashCode()
+            {
+                Assert.False(true);
+                return base.GetHashCode();
+            }
+
+            public static bool operator ==(SubChild value, SubChild other)
+            {
+                Assert.False(true);
+                return false;
+            }
+
+            public static bool operator !=(SubChild value, SubChild other)
+            {
+                Assert.False(true);
+                return true;
+            }
         }
 
         private class ParentPN


### PR DESCRIPTION
Fixes #10030
