### PR TITLE
Query: Contains should translate to IN only when operand & from expre…

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -615,8 +615,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
             Check.NotNull(methodCallExpression, nameof(methodCallExpression));
 
             var operand = _queryModelVisitor.QueryCompilationContext.Model.Relational().FindDbFunction(methodCallExpression.Method) != null
-                            ? methodCallExpression.Object
-                            : Visit(methodCallExpression.Object);
+                ? methodCallExpression.Object
+                : Visit(methodCallExpression.Object);
 
             if (operand != null
                 || methodCallExpression.Object == null)
@@ -909,8 +909,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                     || fromExpression.NodeType == ExpressionType.ListInit
                     || fromExpression.NodeType == ExpressionType.NewArrayInit)
                 {
-                    var containsItem = Visit(contains.Item)?.RemoveConvert();
-                    if (containsItem != null && !containsItem.Type.Equals(typeof(Expression[])))
+                    var containsItem = Visit(contains.Item);
+                    if (containsItem != null
+                        && containsItem.Type == contains.Item.Type)
                     {
                         return new InExpression(containsItem, new[] { fromExpression });
                     }

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
@@ -1313,5 +1313,17 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Where(o => o.CustomerID == "QUICK")
                     .Where(o => o.OrderDate > new DateTime(1998, 1, 1)), entryCount: 8);
         }
+
+        [ConditionalFact]
+        public virtual void Where_navigation_contains()
+        {
+            using (var context = CreateContext())
+            {
+                var cusotmer = context.Customers.Include(c => c.Orders).Single(c => c.CustomerID == "ALFKI");
+                var orderDetails = context.OrderDetails.Where(od => cusotmer.Orders.Contains(od.Order)).ToList();
+
+                Assert.Equal(12, orderDetails.Count);
+            }
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
@@ -1417,5 +1417,30 @@ FROM [Customers] AS [c]");
 FROM [Orders] AS [o]
 WHERE ([o].[CustomerID] = N'QUICK') AND ([o].[OrderDate] > '1998-01-01T00:00:00.000')");
         }
+
+        public override void Where_navigation_contains()
+        {
+            base.Where_navigation_contains();
+
+            AssertSql(
+                @"SELECT TOP(2) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY [c].[CustomerID]",
+                //
+                @"SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
+FROM [Orders] AS [c.Orders]
+INNER JOIN (
+    SELECT TOP(1) [c0].[CustomerID]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] = N'ALFKI'
+    ORDER BY [c0].[CustomerID]
+) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
+ORDER BY [t].[CustomerID]",
+                //
+                @"SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice], [od.Order].[OrderID], [od.Order].[CustomerID], [od.Order].[EmployeeID], [od.Order].[OrderDate]
+FROM [Order Details] AS [od]
+INNER JOIN [Orders] AS [od.Order] ON [od].[OrderID] = [od.Order].[OrderID]");
+        }
     }
 }


### PR DESCRIPTION
…ssion both are Sql-Compatible

Resolves #10081
Issue: When trying to translate Contains.Item, we convert `x.Blog` to `x.BlogId` since entity comparison is same as identity comparison on entities.
But in case of Contains subquery, we don't visit FromExpression. Instead of validating that FromExpression can be represented in SQL typemapping, we rely on the fact that if translation of Contains.Item can be represented then FromExpression should be.
But that assumption is only valid when the type of Contains.Item does not change during translation. (like scenario above). If type changes (because earlier was not compatible in typemapping), then Contains cannot be translated to InExpression.

This also fixes #9424 in different way since in that case also, Tuple translate to Expression[] changing types.
