### PR TITLE
Query: Make GetMappedProjectionTypes to return based on actual projections

### DIFF
--- a/src/EFCore.SqlServer/Query/Expressions/Internal/RowNumberExpression.cs
+++ b/src/EFCore.SqlServer/Query/Expressions/Internal/RowNumberExpression.cs
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override Type Type => typeof(int);
+        public override Type Type => typeof(long);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
+++ b/src/EFCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
@@ -177,11 +177,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
 
                 var innerRowNumberExpression = new AliasExpression(
                     RowNumberColumnName + (_counter != 0 ? $"{_counter}" : ""),
-                    new RowNumberExpression(subQuery.OrderBy
-                        .Select(o => new Ordering(
-                            o.Expression is AliasExpression ae ? ae.Expression : o.Expression,
-                            o.OrderingDirection))
-                        .ToList()));
+                    new RowNumberExpression(
+                        subQuery.OrderBy
+                            .Select(
+                                o => new Ordering(
+                                    o.Expression is AliasExpression ae ? ae.Expression : o.Expression,
+                                    o.OrderingDirection))
+                            .ToList()));
 
                 _counter++;
 
@@ -194,8 +196,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
 
                 if (subQuery.Offset != null)
                 {
-                    selectExpression.AddToPredicate
-                        (Expression.GreaterThan(rowNumberReferenceExpression, offset));
+                    selectExpression.AddToPredicate(
+                        Expression.GreaterThan(
+                            rowNumberReferenceExpression,
+                            ApplyConversion(offset, rowNumberReferenceExpression.Type)));
 
                     subQuery.Offset = null;
                 }
@@ -212,12 +216,19 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
                             : Expression.Add(offset, subQuery.Limit);
 
                     selectExpression.AddToPredicate(
-                        Expression.LessThanOrEqual(rowNumberReferenceExpression, limitExpression));
+                        Expression.LessThanOrEqual(
+                            rowNumberReferenceExpression,
+                            ApplyConversion(limitExpression, rowNumberReferenceExpression.Type)));
 
                     subQuery.Limit = null;
                 }
 
                 return selectExpression;
+            }
+
+            private static Expression ApplyConversion(Expression expression, Type type)
+            {
+                return expression.Type != type ? Expression.Convert(expression, type) : expression;
             }
 
             private Expression VisitExistExpression(ExistsExpression existsExpression)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/RowNumberPagingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/RowNumberPagingTest.cs
@@ -14,7 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public RowNumberPagingTest(NorthwindRowNumberPagingQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         public void Dispose()


### PR DESCRIPTION
…tions

Resolves #10035

Issue here was, our method to calculated projection types was not entirely accurate. It was not robust enough to handle a case where there is project star & projection both at the same time (Sql Generation handles that pretty well).
Due to the bug in the method, when we encouter project star with projection list, we returned based on projection only ignoring the star table. At present this kind of structure only arises with RowNumberPaging which ads RowNumber Expression on projection with star.
Hence we got incorrect type in first slot causing InvalidCastException.

Also changed type for RowNumberExpression since, RowNumber is of type bigint in SqlServer.

This PR brings projection & materialization on same page w.r.t. CLR types.

All tests passed when using `TypedRelationalValueBufferFactoryFactory` in SqlServer provider.
