### PR TITLE
Update AppServiceProviderFactory to use WebHostFactoryResolver

### DIFF
--- a/src/EFCore.Design/EFCore.Design.csproj
+++ b/src/EFCore.Design/EFCore.Design.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.WebHostBuilderFactory.Sources" />
     <PackageReference Include="StyleCop.Analyzers" Version="$(StyleCopAnalyzersVersion)" PrivateAssets="All">
       <!-- Build-only assets are exempt from using a version from lineups. -->
       <NoWarn>KRB4002</NoWarn>

--- a/test/EFCore.Design.Tests/TestUtilities/TestAppServiceProviderFactory.cs
+++ b/test/EFCore.Design.Tests/TestUtilities/TestAppServiceProviderFactory.cs
@@ -9,13 +9,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 {
     public class TestAppServiceProviderFactory : AppServiceProviderFactory
     {
-        private readonly Type _programType;
-
         public TestAppServiceProviderFactory(Assembly startupAssembly, Type programType, IOperationReporter reporter = null)
-            : base(startupAssembly, reporter ?? new TestOperationReporter())
-            => _programType = programType;
-
-        protected override Type FindProgramClass()
-            => _programType;
+            : base(startupAssembly, reporter ?? new TestOperationReporter()) { }
     }
 }

--- a/test/EFCore.Tests/TestUtilities/MockAssembly.cs
+++ b/test/EFCore.Tests/TestUtilities/MockAssembly.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Reflection;
 
@@ -11,20 +12,49 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
     public class MockAssembly : Assembly
     {
         public static Assembly Create(params Type[] definedTypes)
+            => Create(definedTypes, new MockMethodInfo(definedTypes.First()));
+
+        public static Assembly Create(Type[] definedTypes, MethodInfo entryPoint)
         {
             var definedTypeInfos = definedTypes.Select(t => t.GetTypeInfo()).ToArray();
 
-            return new MockAssembly(definedTypeInfos);
+            return new MockAssembly(definedTypeInfos, entryPoint);
         }
 
-        public MockAssembly(IEnumerable<TypeInfo> definedTypes)
+        public MockAssembly(IEnumerable<TypeInfo> definedTypes, MethodInfo entryPoint)
         {
             DefinedTypes = definedTypes;
+            EntryPoint = entryPoint;
         }
+
+        public override MethodInfo EntryPoint { get; }
 
         public override IEnumerable<TypeInfo> DefinedTypes { get; }
 
         public override AssemblyName GetName()
             => new AssemblyName(nameof(MockAssembly));
+
+        private class MockMethodInfo : MethodInfo
+        {
+            public MockMethodInfo(Type declaringType)
+            {
+                DeclaringType = declaringType;
+            }
+
+            public override Type DeclaringType { get; }
+
+            public override ICustomAttributeProvider ReturnTypeCustomAttributes => throw new NotImplementedException();
+            public override RuntimeMethodHandle MethodHandle => throw new NotImplementedException();
+            public override MethodAttributes Attributes => throw new NotImplementedException();
+            public override string Name => throw new NotImplementedException();
+            public override Type ReflectedType => throw new NotImplementedException();
+            public override MethodInfo GetBaseDefinition() => throw new NotImplementedException();
+            public override object[] GetCustomAttributes(bool inherit) => throw new NotImplementedException();
+            public override object[] GetCustomAttributes(Type attributeType, bool inherit) => throw new NotImplementedException();
+            public override MethodImplAttributes GetMethodImplementationFlags() => throw new NotImplementedException();
+            public override ParameterInfo[] GetParameters() => throw new NotImplementedException();
+            public override object Invoke(object obj, BindingFlags invokeAttr, Binder binder, object[] parameters, CultureInfo culture) => throw new NotImplementedException();
+            public override bool IsDefined(Type attributeType, bool inherit) => throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
Uses the new shared sources package we created to abstract the aspnet templates host initialization logic. It finds either
IWebHostBuilder CreateWebHostBuilder(string[] args) or
IWebHost BuildWebHost(string[] args)
and provides a factory method that can be used to produce an IWebHost instance