### PR TITLE
Query: Translate Distinct after Include to server

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
@@ -221,17 +221,22 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
 
                 if (sqlExpression == null)
                 {
-                    if (expression is QuerySourceReferenceExpression qsre)
+                    switch (expression)
                     {
-                        if (QueryModelVisitor.ParentQueryModelVisitor != null
-                            && selectExpression.HandlesQuerySource(qsre.ReferencedQuerySource))
-                        {
-                            selectExpression.ProjectStarTable = selectExpression.GetTableForQuerySource(qsre.ReferencedQuerySource);
-                        }
-                    }
-                    else
-                    {
-                        QueryModelVisitor.RequiresClientProjection = true;
+                        case MethodCallExpression methodCallExpression when IncludeCompiler.IsIncludeMethod(methodCallExpression):
+                            return base.Visit(expression);
+
+                        case QuerySourceReferenceExpression qsre:
+                            if (QueryModelVisitor.ParentQueryModelVisitor != null
+                                && selectExpression.HandlesQuerySource(qsre.ReferencedQuerySource))
+                            {
+                                selectExpression.ProjectStarTable = selectExpression.GetTableForQuerySource(qsre.ReferencedQuerySource);
+                            }
+                            break;
+
+                        default:
+                            QueryModelVisitor.RequiresClientProjection = true;
+                            break;
                     }
                 }
                 else
@@ -558,4 +563,3 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         }
     }
 }
-

--- a/src/EFCore.Specification.Tests/Query/IncludeTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/IncludeTestBase.cs
@@ -3713,6 +3713,71 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual void Include_reference_distinct_is_server_evaluated(bool useString)
+        {
+            using (var context = CreateContext())
+            {
+                var orders
+                    = useString
+                        ? context.Orders
+                            .Where(o => o.OrderID < 10250)
+                            .Include("Customer")
+                            .Distinct()
+                            .ToList()
+                        : context.Orders
+                            .Where(o => o.OrderID < 10250)
+                            .Include(o => o.Customer)
+                            .Distinct()
+                            .ToList();
+
+                foreach (var order in orders)
+                {
+                    CheckIsLoaded(
+                        context,
+                        order,
+                        orderDetailsLoaded: false,
+                        productLoaded: false,
+                        customerLoaded: true,
+                        ordersLoaded: false);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual void Include_collection_distinct_is_server_evaluated(bool useString)
+        {
+            using (var context = CreateContext())
+            {
+                var customers
+                    = useString
+                        ? context.Customers
+                            .Where(c => c.CustomerID.StartsWith("A"))
+                            .Include("Orders")
+                            .Distinct()
+                            .ToList()
+                        : context.Customers
+                            .Where(c => c.CustomerID.StartsWith("A"))
+                            .Include(o => o.Orders)
+                            .Distinct()
+                            .ToList();
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
+            }
+        }
+
         private static void CheckIsLoaded(
             NorthwindContext context,
             Customer customer,


### PR DESCRIPTION
Issue: When visiting Selector with _Include method we could not translate it and ended up setting RequiresClientProjection=true which caused Distinct to not get lifted
Fix: _Include should not cause client eval since it would get removed. This allows us to translate Distinct to server.
As a side effect of this in Collection Include case, our distinct order removal logic needs to pattern match more.

Resolves #9912
