### PR TITLE
Query: Apply conditional collapse to comparisons only for truly comparison Expressions

### DIFF
--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -3066,19 +3066,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public virtual void Enum_ToString_is_client_eval()
         {
-            using (var context = CreateContext())
-            {
-                var query = context.Gears
-                    .OrderBy(g => g.SquadId)
-                    .ThenBy(g => g.Nickname)
-                    .Select(g => g.Rank.ToString())
-                    .Take(1)
-                    .ToList();
-
-                var result = Assert.Single(query);
-
-                Assert.Equal("Corporal", result);
-            }
+            AssertQuery<Gear>(
+                gs =>
+                    gs.OrderBy(g => g.SquadId)
+                        .ThenBy(g => g.Nickname)
+                        .Select(g => g.Rank.ToString()));
         }
 
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();

--- a/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
+++ b/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
@@ -136,7 +136,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         {
             var propertyInfos = MatchPropertyAccess(parameterExpression, propertyAccessExpression);
 
-            return (propertyInfos != null) && (propertyInfos.Count == 1) ? propertyInfos[0] : null;
+            return propertyInfos != null && propertyInfos.Count == 1 ? propertyInfos[0] : null;
         }
 
         /// <summary>
@@ -197,9 +197,9 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// </summary>
         public static Expression RemoveConvert([CanBeNull] this Expression expression)
         {
-            while ((expression != null)
-                   && ((expression.NodeType == ExpressionType.Convert)
-                       || (expression.NodeType == ExpressionType.ConvertChecked)))
+            while (expression != null
+                   && (expression.NodeType == ExpressionType.Convert
+                       || expression.NodeType == ExpressionType.ConvertChecked))
             {
                 expression = RemoveConvert(((UnaryExpression)expression).Operand);
             }
@@ -231,8 +231,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
         {
             Check.NotNull(expression, nameof(expression));
 
-            return (expression.NodeType == ExpressionType.AndAlso)
-                   || (expression.NodeType == ExpressionType.OrElse);
+            return expression.NodeType == ExpressionType.AndAlso
+                   || expression.NodeType == ExpressionType.OrElse;
         }
 
         /// <summary>
@@ -243,13 +243,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
         {
             Check.NotNull(expression, nameof(expression));
 
-            return (expression.NodeType == ExpressionType.Equal)
-                   || (expression.NodeType == ExpressionType.NotEqual)
-                   || (expression.NodeType == ExpressionType.LessThan)
-                   || (expression.NodeType == ExpressionType.LessThanOrEqual)
-                   || (expression.NodeType == ExpressionType.GreaterThan)
-                   || (expression.NodeType == ExpressionType.GreaterThanOrEqual)
-                   || (expression.NodeType == ExpressionType.Not);
+            return expression.Type == typeof(bool)
+                   && (expression.NodeType == ExpressionType.Equal
+                       || expression.NodeType == ExpressionType.NotEqual
+                       || expression.NodeType == ExpressionType.LessThan
+                       || expression.NodeType == ExpressionType.LessThanOrEqual
+                       || expression.NodeType == ExpressionType.GreaterThan
+                       || expression.NodeType == ExpressionType.GreaterThanOrEqual
+                       || expression.NodeType == ExpressionType.Not);
         }
 
         /// <summary>
@@ -321,9 +322,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
             testExpression = null;
             resultExpression = null;
-            var binaryTest = conditionalExpression.Test as BinaryExpression;
 
-            if (binaryTest == null
+            if (!(conditionalExpression.Test is BinaryExpression binaryTest)
                 || !(binaryTest.NodeType == ExpressionType.Equal
                      || binaryTest.NodeType == ExpressionType.NotEqual))
             {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -4214,9 +4213,7 @@ LEFT JOIN (
             base.Enum_ToString_is_client_eval();
 
             AssertSql(
-                @"@__p_0='1'
-
-SELECT TOP(@__p_0) [g].[Rank]
+                @"SELECT [g].[Rank]
 FROM [Gears] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
 ORDER BY [g].[SquadId], [g].[Nickname]");

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -1177,7 +1177,7 @@ WHERE ([c].[FirstName] = @__firstName_0) AND ([c].[LastName] = @__8__locals1_det
                                     on eVersion.RootEntityId equals (int?)eRoot.Id
                                     into RootEntities
                                 from eRootJoined in RootEntities.DefaultIfEmpty()
-                                    // ReSharper disable once ConstantNullCoalescingCondition
+                                // ReSharper disable once ConstantNullCoalescingCondition
                                 select new { One = 1, Coalesce = eRootJoined ?? (eVersion ?? eRootJoined) };
 
                     var result = query.ToList();
@@ -1198,7 +1198,7 @@ WHERE ([c].[FirstName] = @__firstName_0) AND ([c].[LastName] = @__8__locals1_det
                                     on eVersion.RootEntityId equals (int?)eRoot.Id
                                     into RootEntities
                                 from eRootJoined in RootEntities.DefaultIfEmpty()
-                                    // ReSharper disable once ConstantNullCoalescingCondition
+                                // ReSharper disable once ConstantNullCoalescingCondition
                                 select new { One = eRootJoined, Two = 2, Coalesce = eRootJoined ?? (eVersion ?? eRootJoined) };
 
                     var result = query.ToList();
@@ -1219,7 +1219,7 @@ WHERE ([c].[FirstName] = @__firstName_0) AND ([c].[LastName] = @__8__locals1_det
                                     on eVersion.RootEntityId equals (int?)eRoot.Id
                                     into RootEntities
                                 from eRootJoined in RootEntities.DefaultIfEmpty()
-                                    // ReSharper disable once MergeConditionalExpression
+                                // ReSharper disable once MergeConditionalExpression
                                 select eRootJoined != null ? eRootJoined : eVersion;
 
                     var result = query.ToList();
@@ -2042,7 +2042,7 @@ WHERE [c].[Id] IN (
 
                     return (MemoryCache)typeof(CompiledQueryCache).GetTypeInfo()
                         .GetField("_memoryCache", BindingFlags.Instance | BindingFlags.NonPublic)
-                        .GetValue(compiledQueryCache);
+                        ?.GetValue(compiledQueryCache);
                 }
             }
         }
@@ -2194,14 +2194,16 @@ WHERE [w].[Val] = 1");
                         context.Widgets.AddRange(w1, w2, w3);
                         context.SaveChanges();
 
-                        context.Database.ExecuteSqlCommand(@"CREATE FUNCTION foo.AddOne (@num int)  
+                        context.Database.ExecuteSqlCommand(
+                            @"CREATE FUNCTION foo.AddOne (@num int)
                                                             RETURNS int
                                                                 AS
                                                             BEGIN  
                                                                 return @num + 1 ;
                                                             END");
 
-                        context.Database.ExecuteSqlCommand(@"CREATE FUNCTION dbo.AddTwo (@num int)  
+                        context.Database.ExecuteSqlCommand(
+                            @"CREATE FUNCTION dbo.AddTwo (@num int)
                                                             RETURNS int
                                                                 AS
                                                             BEGIN  
@@ -2251,7 +2253,6 @@ WHERE [w].[Val] = 1");
             public int Id { get; set; }
             public int Val { get; set; }
         }
-
 
         #endregion
 
@@ -2582,15 +2583,15 @@ ORDER BY [t0].[c], [t0].[c0], [t0].[Id]");
             return CreateTestStore(
                 () => new MyContext9735(_options),
                 context =>
-                {
-                    context.AddRange(
-                        new Address9735 {Name = "An A"},
-                        new Customer9735 {Name = "A B", AddressId = 1}
-                    );
-                    context.SaveChanges();
+                    {
+                        context.AddRange(
+                            new Address9735 { Name = "An A" },
+                            new Customer9735 { Name = "A B", AddressId = 1 }
+                        );
+                        context.SaveChanges();
 
-                    ClearLog();
-                });
+                        ClearLog();
+                    });
         }
 
         #endregion
@@ -2771,12 +2772,11 @@ WHERE ([e].[IsDeleted] = 0) AND (@__ef_filter__IsModerated_0 IS NULL OR [e].[IsM
 
                 using (var context = new MyContext9825(_options))
                 {
-                        context.IndirectionFlag = null;
+                    context.IndirectionFlag = null;
                     var exception = Assert.Throws<NullReferenceException>(() => context.Chains.ToList());
                     Assert.Equal("Object reference not set to an instance of an object.", exception.Message);
                     Assert.StartsWith(
                         @"   at lambda_method(Closure , QueryContext )", exception.StackTrace);
-
                 }
 
                 AssertSql(
@@ -2866,17 +2866,14 @@ WHERE ([e].[IsEnabled] = 1) AND ((@__ef_filter__BasePrice_0 + @__ef_filter__Cust
                             new EntityWithContextBoundComplexExpression9825 { IsDeleted = true, IsModerated = false },
                             new EntityWithContextBoundComplexExpression9825 { IsDeleted = false, IsModerated = true },
                             new EntityWithContextBoundComplexExpression9825 { IsDeleted = true, IsModerated = true },
-
                             new EntityWithContextBoundMemberChain9825 { IsDeleted = false, IsModerated = false },
                             new EntityWithContextBoundMemberChain9825 { IsDeleted = true, IsModerated = false },
                             new EntityWithContextBoundMemberChain9825 { IsDeleted = false, IsModerated = true },
                             new EntityWithContextBoundMemberChain9825 { IsDeleted = true, IsModerated = true },
-
                             new EntityWithLocalVariableAccessInFilter9825 { IsDeleted = false, IsModerated = false },
                             new EntityWithLocalVariableAccessInFilter9825 { IsDeleted = true, IsModerated = false },
                             new EntityWithLocalVariableAccessInFilter9825 { IsDeleted = false, IsModerated = true },
                             new EntityWithLocalVariableAccessInFilter9825 { IsDeleted = true, IsModerated = true },
-
                             new EntityWithComplexContextBoundExpression9825 { IsEnabled = true },
                             new EntityWithComplexContextBoundExpression9825 { IsEnabled = false }
                         );
@@ -2972,7 +2969,7 @@ WHERE ([e].[IsEnabled] = 1) AND ((@__ef_filter__BasePrice_0 + @__ef_filter__Cust
                                 from x in context.Children
                                 select new
                                 {
-                                    ParentId = x.ParentId,
+                                    x.ParentId,
                                     OtherParent = x.OtherParent.Name
                                 })
                             on p.Id equals c.ParentId into child
@@ -2993,25 +2990,25 @@ WHERE ([e].[IsEnabled] = 1) AND ((@__ef_filter__BasePrice_0 + @__ef_filter__Cust
             => CreateTestStore(
                 () => new MyContext9892(_options),
                 context =>
-                {
-                    context.Parents.Add(new Parent9892 { Name = "Parent1" });
-                    context.Parents.Add(new Parent9892 { Name = "Parent2" });
-                    context.Parents.Add(new Parent9892 { Name = "Parent3" });
+                    {
+                        context.Parents.Add(new Parent9892 { Name = "Parent1" });
+                        context.Parents.Add(new Parent9892 { Name = "Parent2" });
+                        context.Parents.Add(new Parent9892 { Name = "Parent3" });
 
-                    context.OtherParents.Add(new OtherParent9892 { Name = "OtherParent1" });
-                    context.OtherParents.Add(new OtherParent9892 { Name = "OtherParent2" });
+                        context.OtherParents.Add(new OtherParent9892 { Name = "OtherParent1" });
+                        context.OtherParents.Add(new OtherParent9892 { Name = "OtherParent2" });
 
-                    context.SaveChanges();
+                        context.SaveChanges();
 
-                    context.Children.Add(new Child9892 { ParentId = 1, OtherParentId = 1 });
-                    context.Children.Add(new Child9892 { ParentId = 1, OtherParentId = 2 });
-                    context.Children.Add(new Child9892 { ParentId = 2, OtherParentId = 1 });
-                    context.Children.Add(new Child9892 { ParentId = 2, OtherParentId = 2 });
+                        context.Children.Add(new Child9892 { ParentId = 1, OtherParentId = 1 });
+                        context.Children.Add(new Child9892 { ParentId = 1, OtherParentId = 2 });
+                        context.Children.Add(new Child9892 { ParentId = 2, OtherParentId = 1 });
+                        context.Children.Add(new Child9892 { ParentId = 2, OtherParentId = 2 });
 
-                    context.SaveChanges();
+                        context.SaveChanges();
 
-                    ClearLog();
-                });
+                        ClearLog();
+                    });
 
         public class MyContext9892 : DbContext
         {
@@ -3045,6 +3042,86 @@ WHERE ([e].[IsEnabled] = 1) AND ((@__ef_filter__BasePrice_0 + @__ef_filter__Cust
             public Parent9892 Parent { get; set; }
             public int OtherParentId { get; set; }
             public OtherParent9892 OtherParent { get; set; }
+        }
+
+        #endregion
+
+        #region Bug9468
+
+        [Fact]
+        public virtual void Conditional_expression_with_conditions_does_not_collapse_if_nullable_bool()
+        {
+            using (CreateDatabase9468())
+            {
+                using (var context = new MyContext9468(_options))
+                {
+                    var query = context.Carts.Select(
+                        t => new
+                        {
+                            Processing = t.Configuration != null ? !t.Configuration.Processed : (bool?)null
+                        }).ToList();
+
+                    Assert.Single(query.Where(t => t.Processing == null));
+                    Assert.Single(query.Where(t => t.Processing == true));
+                    Assert.Single(query.Where(t => t.Processing == false));
+
+                    AssertSql(
+                        @"SELECT CASE
+    WHEN [t].[ConfigurationId] IS NOT NULL
+    THEN CASE
+        WHEN [t.Configuration].[Processed] = 0
+        THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+    END ELSE NULL
+END AS [Processing]
+FROM [Carts] AS [t]
+LEFT JOIN [Configuration9468] AS [t.Configuration] ON [t].[ConfigurationId] = [t.Configuration].[Id]");
+                }
+            }
+        }
+
+        private SqlServerTestStore CreateDatabase9468()
+            => CreateTestStore(
+                () => new MyContext9468(_options),
+                context =>
+                    {
+                        context.AddRange(
+                            new Cart9468(),
+                            new Cart9468
+                            {
+                                Configuration = new Configuration9468 { Processed = true }
+                            },
+                            new Cart9468
+                            {
+                                Configuration = new Configuration9468()
+                            }
+                        );
+
+                        context.SaveChanges();
+
+                        ClearLog();
+                    });
+
+        public class MyContext9468 : DbContext
+        {
+            public MyContext9468(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            public DbSet<Cart9468> Carts { get; set; }
+        }
+
+        public class Cart9468
+        {
+            public int Id { get; set; }
+            public int? ConfigurationId { get; set; }
+            public Configuration9468 Configuration { get; set; }
+        }
+
+        public class Configuration9468
+        {
+            public int Id { get; set; }
+            public bool Processed { get; set; }
         }
 
         #endregion


### PR DESCRIPTION
Issue:
We have optimization to convert `a ? b : c` where a, b, c are all comparison expression to `a && b || c && d`.
For this case, while b seemed like comparison expression but it was in such pattern due to being nullable bool. (b == true)
A true comparison expression is of type bool since it gives true/false answer. If it is not then its value type expression.
In user case, since we tried incorrect optimization, we ended up with mismatched types in AndAlso expression.

Fix is to improve logic of IsComparisonExpression to only identify boolean expression

Resolves #9468
