### PR TITLE
Allow mapping to SqlGeography, SqlGeometry, and HierarchyId columns on .NET Framework

### DIFF
--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMapper.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMapper.cs
@@ -48,9 +48,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
         private readonly StringTypeMapping _unicodeFixedChar
             = new StringTypeMapping(
-                "nchar(1)", 
+                "nchar(1)",
                 new ValueConverter<char, string>(
-                    v => v.ToString(), 
+                    v => v.ToString(),
                     v => v != null && v.Length >= 1 ? v[0] : (char)0),
                 unicode: true);
 
@@ -162,6 +162,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             new ValueConverter<ulong, decimal>(v => v, v => (ulong)v),
             DbType.Decimal);
 
+        private readonly IReadOnlyDictionary<string, Func<Type, RelationalTypeMapping>> _namedClrMappings
+            = new Dictionary<string, Func<Type, RelationalTypeMapping>>(StringComparer.Ordinal)
+            {
+                { "Microsoft.SqlServer.Types.SqlHierarchyId", t => new SqlServerUdtTypeMapping("hierarchyid", t) },
+                { "Microsoft.SqlServer.Types.SqlGeography", t => new SqlServerUdtTypeMapping("geography", t) },
+                { "Microsoft.SqlServer.Types.SqlGeometry", t => new SqlServerUdtTypeMapping("geometry", t) }
+            };
+
         private readonly Dictionary<string, IList<RelationalTypeMapping>> _storeTypeMappings;
         private readonly Dictionary<Type, RelationalTypeMapping> _clrTypeMappings;
         private readonly HashSet<string> _disallowedMappings;
@@ -237,7 +245,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                     { typeof(float), _real },
                     { typeof(decimal), _decimal },
                     { typeof(TimeSpan), _time },
-                    { typeof(char), _unicodeFixedChar },
+                    { typeof(char), _unicodeFixedChar }
                 };
 
             // These are disallowed only if specified without any kind of length specified in parenthesis.
@@ -331,6 +339,13 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                 throw new ArgumentException(SqlServerStrings.UnqualifiedDataType(storeType));
             }
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override IReadOnlyDictionary<string, Func<Type, RelationalTypeMapping>> GetClrTypeNameMappings()
+            => _namedClrMappings;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerUdtTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerUdtTypeMapping.cs
@@ -1,0 +1,89 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Storage.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class SqlServerUdtTypeMapping : RelationalTypeMapping
+    {
+        private static Action<DbParameter, string> _udtTypeNameSetter;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public SqlServerUdtTypeMapping(
+            [NotNull] string storeType,
+            [NotNull] Type clrType,
+            [CanBeNull] string udtTypeName = null,
+            [CanBeNull] ValueConverter converter = null,
+            DbType? dbType = null,
+            bool unicode = false,
+            int? size = null)
+            : base(storeType, clrType, converter, dbType, unicode, size)
+        {
+            UdtTypeName = udtTypeName ?? storeType;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual string UdtTypeName { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override RelationalTypeMapping Clone(string storeType, int? size)
+            => new SqlServerUdtTypeMapping(storeType, ClrType, UdtTypeName, Converter, DbType, IsUnicode, size);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override CoreTypeMapping Clone(ValueConverter converter)
+            => new SqlServerUdtTypeMapping(StoreType, ClrType, UdtTypeName, ComposeConverter(converter), DbType, IsUnicode, Size);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override void ConfigureParameter(DbParameter parameter)
+            => SetUdtTypeName(parameter);
+
+        private void SetUdtTypeName(DbParameter parameter)
+        {
+            NonCapturingLazyInitializer.EnsureInitialized(
+                ref _udtTypeNameSetter,
+                parameter.GetType(),
+                CreateUdtTypeNameAccessor);
+
+            _udtTypeNameSetter(parameter, UdtTypeName);
+        }
+
+        private static Action<DbParameter, string> CreateUdtTypeNameAccessor(Type paramType)
+        {
+            var paramParam = Expression.Parameter(typeof(DbParameter), "parameter");
+            var valueParam = Expression.Parameter(typeof(string), "value");
+
+            return Expression.Lambda<Action<DbParameter, string>>(
+                Expression.Call(
+                    Expression.Convert(paramParam, paramType),
+                    paramType.GetProperty("UdtTypeName").SetMethod,
+                    valueParam),
+                paramParam,
+                valueParam).Compile();
+        }
+    }
+}

--- a/test/EFCore.Relational.Tests/Storage/RelationalTypeMappingTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalTypeMappingTest.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 {
     public abstract class RelationalTypeMappingTest
     {
-        private class FakeValueConverter : ValueConverter<object, object>
+        protected class FakeValueConverter : ValueConverter<object, object>
         {
             public FakeValueConverter()
                 : base(_ => _, _ => _)


### PR DESCRIPTION
Part of issue #1100

This change allows properties of type SqlGeography, SqlGeometry, and HierarchyId to be included in entity classes and mapped by convention to corresponding database columns.

WARNING: This is by no-means full spatial support for EF Core. These are the important limitations:
* It only works when running on .NET Framework. It will not work on .NET Core, since SqlClient for .NET Core does not support these types.
* Query support is limited:
  * LINQ queries that don't use the semantics of the SQL types should work.
  * Queries that need to use the type semantics (e.g. using STDistance) can be done with FromSql queries, but not LINQ
  * See issue #10108 for some test code and issue #10109 for some ideas to make LINQ work better
* The SQL Server spatial types do not provide a good client-side programming experience. A proper .NET spatial library is needed for a good, cross-platform experience.

Note that this change also allows more general mapping of types not directly referenced from the provider, and more specifically UDTs on SQL Server.