### PR TITLE
Tools: Hook AssemblyResolve on .NET Core

### DIFF
--- a/src/ef/ReflectionOperationExecutor.cs
+++ b/src/ef/ReflectionOperationExecutor.cs
@@ -5,10 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
-
-#if NET461
 using System.IO;
-#endif
 
 namespace Microsoft.EntityFrameworkCore.Tools
 {
@@ -28,12 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Tools
             string rootNamespace)
             : base(assembly, startupAssembly, projectDir, dataDirectory, rootNamespace)
         {
-#if NET461
             AppDomain.CurrentDomain.AssemblyResolve += ResolveAssembly;
-#elif NETCOREAPP2_0
-#else
-#error target frameworks need to be updated.
-#endif
 
             _commandsAssembly = Assembly.Load(new AssemblyName { Name = DesignAssemblyName });
             var reportHandlerType = _commandsAssembly.GetType(ReportHandlerTypeName, throwOnError: true, ignoreCase: false);
@@ -69,7 +61,6 @@ namespace Microsoft.EntityFrameworkCore.Tools
                 resultHandler,
                 arguments);
 
-#if NET461
         private Assembly ResolveAssembly(object sender, ResolveEventArgs args)
         {
             var assemblyName = new AssemblyName(args.Name);
@@ -94,9 +85,5 @@ namespace Microsoft.EntityFrameworkCore.Tools
 
         public override void Dispose()
             => AppDomain.CurrentDomain.AssemblyResolve -= ResolveAssembly;
-#elif NETCOREAPP2_0
-#else
-#error target frameworks need to be updated.
-#endif
     }
 }


### PR DESCRIPTION
This enables using a separate migrations assembly when the startup project contains the DbContext.

(Found while writing [docs about it](https://github.com/bricelam/EntityFramework.Docs/blob/migrate/entity-framework/core/managing-schemas/migrations/projects.md).)

Verification: Manually tested