### PR TITLE
Fix log time output

### DIFF
--- a/src/EFCore.Relational/Internal/RelationalLoggerExtensions.cs
+++ b/src/EFCore.Relational/Internal/RelationalLoggerExtensions.cs
@@ -108,7 +108,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             {
                 definition.Log(
                     diagnostics,
-                    string.Format(CultureInfo.InvariantCulture, "{0:N0}", duration.Milliseconds),
+                    string.Format(CultureInfo.InvariantCulture, "{0:N0}", duration.TotalMilliseconds),
                     command.Parameters.FormatParameters(ShouldLogParameterValues(diagnostics, command)),
                     command.CommandType,
                     command.CommandTimeout,
@@ -140,7 +140,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             var d = (EventDefinition<string, string, CommandType, int, string, string>)definition;
             var p = (CommandExecutedEventData)payload;
             return d.GenerateMessage(
-                string.Format(CultureInfo.InvariantCulture, "{0:N0}", p.Duration.Milliseconds),
+                string.Format(CultureInfo.InvariantCulture, "{0:N0}", p.Duration.TotalMilliseconds),
                 p.Command.Parameters.FormatParameters(p.LogParameterValues),
                 p.Command.CommandType,
                 p.Command.CommandTimeout,
@@ -170,7 +170,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             {
                 definition.Log(
                     diagnostics,
-                    string.Format(CultureInfo.InvariantCulture, "{0:N0}", duration.Milliseconds),
+                    string.Format(CultureInfo.InvariantCulture, "{0:N0}", duration.TotalMilliseconds),
                     command.Parameters.FormatParameters(ShouldLogParameterValues(diagnostics, command)),
                     command.CommandType,
                     command.CommandTimeout,
@@ -203,7 +203,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             var d = (EventDefinition<string, string, CommandType, int, string, string>)definition;
             var p = (CommandErrorEventData)payload;
             return d.GenerateMessage(
-                string.Format(CultureInfo.InvariantCulture, "{0:N0}", p.Duration.Milliseconds),
+                string.Format(CultureInfo.InvariantCulture, "{0:N0}", p.Duration.TotalMilliseconds),
                 p.Command.Parameters.FormatParameters(p.LogParameterValues),
                 p.Command.CommandType,
                 p.Command.CommandTimeout,

--- a/test/EFCore.Relational.Tests/Utilities/DbParameterCollectionExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Utilities/DbParameterCollectionExtensionsTest.cs
@@ -10,7 +10,7 @@ using Xunit;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Utilities
 {
-    public class RelationalLoggerExtensionsTest
+    public class DbParameterCollectionExtensionsTest
     {
         [Fact]
         public void Short_byte_arrays_are_not_truncated()


### PR DESCRIPTION
Summary of the changes
 - Fixes log outputs so times are sent as total milliseconds, instead of just the millisesond part
 - Renamed wrongly named RelationLoggerExtensionsTests

    Fixes #10223