### PR TITLE
Revert DependencyModel version

### DIFF
--- a/src/Microsoft.EntityFrameworkCore.Design/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Design/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Shared design-time components for Entity Framework Core tools.",
   "packOptions": {
     "tags": [
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "Microsoft.AspNetCore.Hosting.Abstractions": "1.1.3",
-    "Microsoft.EntityFrameworkCore.Relational.Design": "1.1.4",
+    "Microsoft.EntityFrameworkCore.Relational.Design": "1.1.5",
     "NETStandard.Library": "1.6.1-*"
   },
   "frameworks": {

--- a/src/Microsoft.EntityFrameworkCore.InMemory/project.json
+++ b/src/Microsoft.EntityFrameworkCore.InMemory/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "In-memory database provider for Entity Framework Core (to be used for testing purposes).",
   "packOptions": {
     "tags": [
@@ -23,7 +23,7 @@
     }
   },
   "dependencies": {
-    "Microsoft.EntityFrameworkCore": "1.1.4",
+    "Microsoft.EntityFrameworkCore": "1.1.5",
     "NETStandard.Library": "1.6.1-*"
   },
   "frameworks": {

--- a/src/Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Shared design-time test suite for Entity Framework Core relational database providers.",
   "packOptions": {
     "tags": [
@@ -22,10 +22,10 @@
   "dependencies": {
     "Microsoft.CodeAnalysis.CSharp": "1.3.0",
     "Microsoft.DotNet.InternalAbstractions": "1.0.0",
-    "Microsoft.EntityFrameworkCore.Design": "1.1.4",
-    "Microsoft.EntityFrameworkCore.Relational.Design": "1.1.4",
-    "Microsoft.EntityFrameworkCore.Relational.Specification.Tests": "1.1.4",
-    "Microsoft.Extensions.DependencyModel": "1.1.4-servicing-001653",
+    "Microsoft.EntityFrameworkCore.Design": "1.1.5",
+    "Microsoft.EntityFrameworkCore.Relational.Design": "1.1.5",
+    "Microsoft.EntityFrameworkCore.Relational.Specification.Tests": "1.1.5",
+    "Microsoft.Extensions.DependencyModel": "1.1.2",
     "NETStandard.Library": "1.6.1"
   },
   "frameworks": {

--- a/src/Microsoft.EntityFrameworkCore.Relational.Design/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Design/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Shared design-time Entity Framework Core components for relational database providers.",
   "packOptions": {
     "tags": [
@@ -22,7 +22,7 @@
     }
   },
   "dependencies": {
-    "Microsoft.EntityFrameworkCore.Relational": "1.1.4",
+    "Microsoft.EntityFrameworkCore.Relational": "1.1.5",
     "NETStandard.Library": "1.6.1-*"
   },
   "frameworks": {

--- a/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Relational.Specification.Tests/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Shared test suite for Entity Framework Core relational database providers.",
   "packOptions": {
     "tags": [
@@ -19,9 +19,9 @@
     "xmlDoc": true
   },
   "dependencies": {
-    "Microsoft.EntityFrameworkCore.Relational": "1.1.4",
-    "Microsoft.EntityFrameworkCore.Relational.Design": "1.1.4",
-    "Microsoft.EntityFrameworkCore.Specification.Tests": "1.1.4",
+    "Microsoft.EntityFrameworkCore.Relational": "1.1.5",
+    "Microsoft.EntityFrameworkCore.Relational.Design": "1.1.5",
+    "Microsoft.EntityFrameworkCore.Specification.Tests": "1.1.5",
     "NETStandard.Library": "1.6.1-*"
   },
   "frameworks": {

--- a/src/Microsoft.EntityFrameworkCore.Relational/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Relational/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Shared Entity Framework Core components for relational database providers.",
   "packOptions": {
     "tags": [
@@ -25,7 +25,7 @@
     }
   },
   "dependencies": {
-    "Microsoft.EntityFrameworkCore": "1.1.4",
+    "Microsoft.EntityFrameworkCore": "1.1.5",
     "NETStandard.Library": "1.6.1-*"
   },
   "frameworks": {

--- a/src/Microsoft.EntityFrameworkCore.Specification.Tests/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Specification.Tests/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Shared test suite for Entity Framework Core database providers.",
   "packOptions": {
     "tags": [
@@ -19,7 +19,7 @@
     "xmlDoc": true
   },
   "dependencies": {
-    "Microsoft.EntityFrameworkCore.InMemory": "1.1.4",
+    "Microsoft.EntityFrameworkCore.InMemory": "1.1.5",
     "Microsoft.Extensions.RuntimeEnvironment.Sources": {
       "version": "1.1.0-*",
       "type": "build"

--- a/src/Microsoft.EntityFrameworkCore.SqlServer.Design/project.json
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer.Design/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Design-time Entity Framework Core Functionality for Microsoft SQL Server.",
   "packOptions": {
     "tags": [
@@ -20,8 +20,8 @@
     }
   },
   "dependencies": {
-    "Microsoft.EntityFrameworkCore.Relational.Design": "1.1.4",
-    "Microsoft.EntityFrameworkCore.SqlServer": "1.1.4",
+    "Microsoft.EntityFrameworkCore.Relational.Design": "1.1.5",
+    "Microsoft.EntityFrameworkCore.SqlServer": "1.1.5",
     "NETStandard.Library": "1.6.1-*"
   },
   "frameworks": {

--- a/src/Microsoft.EntityFrameworkCore.SqlServer/project.json
+++ b/src/Microsoft.EntityFrameworkCore.SqlServer/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Microsoft SQL Server database provider for Entity Framework Core.",
   "packOptions": {
     "tags": [
@@ -26,7 +26,7 @@
     }
   },
   "dependencies": {
-    "Microsoft.EntityFrameworkCore.Relational": "1.1.4",
+    "Microsoft.EntityFrameworkCore.Relational": "1.1.5",
     "NETStandard.Library": "1.6.1-*"
   },
   "frameworks": {

--- a/src/Microsoft.EntityFrameworkCore.Sqlite.Design/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite.Design/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Design-time Entity Framework Core functionality for SQLite",
   "packOptions": {
     "tags": [
@@ -20,8 +20,8 @@
     }
   },
   "dependencies": {
-    "Microsoft.EntityFrameworkCore.Relational.Design": "1.1.4",
-    "Microsoft.EntityFrameworkCore.Sqlite": "1.1.4",
+    "Microsoft.EntityFrameworkCore.Relational.Design": "1.1.5",
+    "Microsoft.EntityFrameworkCore.Sqlite": "1.1.5",
     "NETStandard.Library": "1.6.1-*"
   },
   "frameworks": {

--- a/src/Microsoft.EntityFrameworkCore.Sqlite/project.json
+++ b/src/Microsoft.EntityFrameworkCore.Sqlite/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "SQLite database provider for Entity Framework Core.",
   "packOptions": {
     "tags": [
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "Microsoft.Data.Sqlite": "1.1.0-*",
-    "Microsoft.EntityFrameworkCore.Relational": "1.1.4",
+    "Microsoft.EntityFrameworkCore.Relational": "1.1.5",
     "NETStandard.Library": "1.6.1-*"
   },
   "frameworks": {

--- a/src/Microsoft.EntityFrameworkCore/project.json
+++ b/src/Microsoft.EntityFrameworkCore/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Entity Framework Core is a lightweight and extensible version of the popular Entity Framework data access technology.\r\n\r\nCommonly Used Types:\r\nMicrosoft.EntityFrameworkCore.DbContext\r\nMicrosoft.EntityFrameworkCore.DbSet",
   "packOptions": {
     "tags": [

--- a/test/Microsoft.EntityFrameworkCore.Design.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Design.FunctionalTests/project.json
@@ -6,9 +6,9 @@
   },
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-*",
-    "Microsoft.EntityFrameworkCore.Design": "1.1.4",
-    "Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests": "1.1.4",
-    "Microsoft.EntityFrameworkCore.SqlServer": "1.1.4"
+    "Microsoft.EntityFrameworkCore.Design": "1.1.5",
+    "Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests": "1.1.5",
+    "Microsoft.EntityFrameworkCore.SqlServer": "1.1.5"
   },
   "testRunner": "xunit",
   "frameworks": {

--- a/test/Microsoft.EntityFrameworkCore.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.FunctionalTests/project.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-*",
-    "Microsoft.EntityFrameworkCore.Specification.Tests": "1.1.4"
+    "Microsoft.EntityFrameworkCore.Specification.Tests": "1.1.5"
   },
   "testRunner": "xunit",
   "frameworks": {

--- a/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.InMemory.FunctionalTests/project.json
@@ -5,7 +5,7 @@
   },
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-*",
-    "Microsoft.EntityFrameworkCore.Specification.Tests": "1.1.4"
+    "Microsoft.EntityFrameworkCore.Specification.Tests": "1.1.5"
   },
   "testRunner": "xunit",
   "frameworks": {

--- a/test/Microsoft.EntityFrameworkCore.Relational.Design.Tests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Design.Tests/project.json
@@ -4,7 +4,7 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests": "1.1.4",
+    "Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests": "1.1.5",
     "Microsoft.EntityFrameworkCore.Relational.Tests": {
       "target": "project"
     }

--- a/test/Microsoft.EntityFrameworkCore.Relational.Tests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Relational.Tests/project.json
@@ -4,7 +4,7 @@
     "keyFile": "../../tools/Key.snk"
   },
   "dependencies": {
-    "Microsoft.EntityFrameworkCore.Relational.Specification.Tests": "1.1.4",
+    "Microsoft.EntityFrameworkCore.Relational.Specification.Tests": "1.1.5",
     "Microsoft.EntityFrameworkCore.Tests": {
       "target": "project"
     }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.Design.FunctionalTests/project.json
@@ -12,8 +12,8 @@
   },
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-*",
-    "Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests": "1.1.4",
-    "Microsoft.EntityFrameworkCore.SqlServer.Design": "1.1.4",
+    "Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests": "1.1.5",
+    "Microsoft.EntityFrameworkCore.SqlServer.Design": "1.1.5",
     "Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests": {
       "target": "project"
     }

--- a/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.SqlServer.FunctionalTests/project.json
@@ -15,9 +15,9 @@
   },
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-*",
-    "Microsoft.EntityFrameworkCore.Relational.Specification.Tests": "1.1.4",
-    "Microsoft.EntityFrameworkCore.SqlServer": "1.1.4",
-    "Microsoft.EntityFrameworkCore.SqlServer.Design": "1.1.4",
+    "Microsoft.EntityFrameworkCore.Relational.Specification.Tests": "1.1.5",
+    "Microsoft.EntityFrameworkCore.SqlServer": "1.1.5",
+    "Microsoft.EntityFrameworkCore.SqlServer.Design": "1.1.5",
     "Microsoft.Extensions.Configuration.EnvironmentVariables": "1.1.1",
     "Microsoft.Extensions.Configuration.Json": "1.1.1"
   },

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.Design.FunctionalTests/project.json
@@ -8,8 +8,8 @@
     }
   },
   "dependencies": {
-    "Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests": "1.1.4",
-    "Microsoft.EntityFrameworkCore.Sqlite.Design": "1.1.4",
+    "Microsoft.EntityFrameworkCore.Relational.Design.Specification.Tests": "1.1.5",
+    "Microsoft.EntityFrameworkCore.Sqlite.Design": "1.1.5",
     "Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests": {
       "target": "project"
     }

--- a/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Sqlite.FunctionalTests/project.json
@@ -9,9 +9,9 @@
   },
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-*",
-    "Microsoft.EntityFrameworkCore.Relational.Specification.Tests": "1.1.4",
-    "Microsoft.EntityFrameworkCore.Sqlite": "1.1.4",
-    "Microsoft.EntityFrameworkCore.Sqlite.Design": "1.1.4"
+    "Microsoft.EntityFrameworkCore.Relational.Specification.Tests": "1.1.5",
+    "Microsoft.EntityFrameworkCore.Sqlite": "1.1.5",
+    "Microsoft.EntityFrameworkCore.Sqlite.Design": "1.1.5"
   },
   "publishOptions": {
     "includeFiles": "northwind.db"

--- a/test/Microsoft.EntityFrameworkCore.Tests/project.json
+++ b/test/Microsoft.EntityFrameworkCore.Tests/project.json
@@ -5,7 +5,7 @@
   },
   "dependencies": {
     "dotnet-test-xunit": "2.2.0-*",
-    "Microsoft.EntityFrameworkCore.Specification.Tests": "1.1.4",
+    "Microsoft.EntityFrameworkCore.Specification.Tests": "1.1.5",
     "Moq": "4.6.36-*"
   },
   "testRunner": "xunit",


### PR DESCRIPTION
FYI. Diff with 1.1.4 for comparison but it's checked in as rel/1.1.5 which is what Coherence-Patch builds