### PR TITLE
Query: Fix an issue in SubqueryProjection creation which caused inval…

### DIFF
--- a/EFCore.Runtime.sln
+++ b/EFCore.Runtime.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.12
+VisualStudioVersion = 15.0.27004.2009
 MinimumVisualStudioVersion = 15.0.26730.03
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EFCore", "src\EFCore\EFCore.csproj", "{715C38E9-B2F5-4DB2-8025-0C6492DEBDD4}"
 EndProject

--- a/src/EFCore.Relational/Extensions/RelationalExpressionExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalExpressionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
@@ -53,6 +54,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 case ColumnReferenceExpression columnReferenceExpression:
                     return new ColumnReferenceExpression(columnReferenceExpression, table);
             }
+
+            Debug.Fail("LiftExpressionFromSubquery was called on incorrect expression type.");
 
             return null;
         }

--- a/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
@@ -701,10 +701,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
                 uniqueAlias = uniqueAliasBase + counter++;
             }
 
-            var updatedExpression
-                = !string.Equals(currentAlias, uniqueAlias, StringComparison.OrdinalIgnoreCase)
-                    ? new AliasExpression(uniqueAlias, (expression as AliasExpression)?.Expression ?? expression)
-                    : expression;
+            var updatedExpression = expression;
+
+            if (!(expression is ColumnReferenceExpression
+                || expression is ColumnExpression
+                || expression is AliasExpression)
+                || !string.Equals(currentAlias, uniqueAlias, StringComparison.OrdinalIgnoreCase))
+            {
+                updatedExpression = new AliasExpression(uniqueAlias, (expression as AliasExpression)?.Expression ?? expression);
+            }
 
             var currentOrderingIndex = _orderBy.FindIndex(e => e.Expression.Equals(expression));
 

--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -1241,13 +1241,24 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
             Visit(aliasExpression.Expression);
 
-            if (aliasExpression.Alias != null)
+            if (aliasExpression.Alias != GetColumnName(aliasExpression.Expression))
             {
                 _relationalCommandBuilder.Append(AliasSeparator);
                 _relationalCommandBuilder.Append(SqlGenerator.DelimitIdentifier(aliasExpression.Alias));
             }
 
             return aliasExpression;
+        }
+
+        private static string GetColumnName(Expression expression)
+        {
+            expression = expression.RemoveConvert();
+            expression = (expression as NullableExpression)?.Operand.RemoveConvert()
+                         ?? expression;
+
+            return (expression as AliasExpression)?.Alias
+                   ?? (expression as ColumnExpression)?.Name
+                   ?? (expression as ColumnReferenceExpression)?.Name;
         }
 
         /// <summary>

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -593,5 +593,14 @@ namespace Microsoft.EntityFrameworkCore.Query
                       where o.CustomerID == "ALFKI"
                       select o.CustomerID == null ? true : o.OrderID < 100);
         }
+
+        [ConditionalFact]
+        public virtual void Projection_in_a_subquery_should_be_liftable()
+        {
+            AssertQuery<Employee>(
+                es => es.OrderBy(e => e.EmployeeID)
+                    .Select(e => string.Format("{0}", e.EmployeeID))
+                    .Skip(1));
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/RowNumberPagingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/RowNumberPagingTest.cs
@@ -872,6 +872,21 @@ FROM (
 WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_1))");
         }
 
+        public override void Projection_in_a_subquery_should_be_liftable()
+        {
+            base.Projection_in_a_subquery_should_be_liftable();
+
+            AssertSql(
+  @"@__p_0='1'
+
+SELECT [t].[EmployeeID]
+FROM (
+    SELECT [e].[EmployeeID], ROW_NUMBER() OVER(ORDER BY [e].[EmployeeID]) AS [__RowNumber__]
+    FROM [Employees] AS [e]
+) AS [t]
+WHERE [t].[__RowNumber__] > @__p_0");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
@@ -546,5 +546,18 @@ END
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] = N'ALFKI'");
         }
+
+        public override void Projection_in_a_subquery_should_be_liftable()
+        {
+            base.Projection_in_a_subquery_should_be_liftable();
+
+            AssertSql(
+    @"@__p_0='1'
+
+SELECT [e].[EmployeeID]
+FROM [Employees] AS [e]
+ORDER BY [e].[EmployeeID]
+OFFSET @__p_0 ROWS");
+        }
     }
 }


### PR DESCRIPTION
…id select expression

Issue: All projections in a subquery are required to be ColumnExpression/AliasExpression/ColumnReferenceExpression so that they can be lifted to outer select expression through LiftExpressionFromSubquery method.
In this particular case the expression had convert around it. Because its computed name was unique we did not change it causing invariant to break which later got converted to null projection.

Resolves #10273
