### PR TITLE
RevEng: Remove incorrect warning about bool column with default being…

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -362,14 +362,16 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             }
 
             var clrType = typeScaffoldingInfo.ClrType;
-            var forceNullable = typeof(bool) == clrType && column.DefaultValueSql != null;
-            if (forceNullable)
+            if (column.IsNullable)
+            {
+                clrType = clrType.MakeNullable();
+            }
+
+            if (clrType == typeof(bool) && column.DefaultValueSql != null)
             {
                 _reporter.WriteWarning(
                     DesignStrings.NonNullableBoooleanColumnHasDefaultConstraint(column.DisplayName()));
-            }
-            if (column.IsNullable || forceNullable)
-            {
+
                 clrType = clrType.MakeNullable();
             }
 
@@ -420,7 +422,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             if (!(column.Table.PrimaryKey?.Columns.Contains(column) ?? false))
             {
-                property.IsRequired(!column.IsNullable && !forceNullable);
+                property.IsRequired(!column.IsNullable);
             }
 
             if ((bool?)column[ScaffoldingAnnotationNames.ConcurrencyToken] == true)

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpNamerTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpNamerTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore
         [InlineData("Name with no s at end", "Name_with_no_s_at_end")]
         public void Sanitizes_name_with_singularizer(string input, string output)
         {
-            var fakePluralizer = new FakePluralizer();
+            var fakePluralizer = new RelationalDatabaseModelFactoryTest.FakePluralizer();
             Assert.Equal(output, new CSharpNamer<string>(s => s, new CSharpUtilities(), fakePluralizer.Singularize).GetName(input));
         }
 
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore
         [InlineData("Name with no s at end", "Name_with_no_s_at_ends")]
         public void Sanitizes_name_with_pluralizer(string input, string output)
         {
-            var fakePluralizer = new FakePluralizer();
+            var fakePluralizer = new RelationalDatabaseModelFactoryTest.FakePluralizer();
             Assert.Equal(output, new CSharpNamer<string>(s => s, new CSharpUtilities(), fakePluralizer.Pluralize).GetName(input));
         }
     }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpUniqueNamerTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpUniqueNamerTest.cs
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore
         [InlineData("Name with no s at end", "Name_with_no_s_at_end")]
         public void Singularizes_names(string input, string output)
         {
-            var fakePluralizer = new FakePluralizer();
+            var fakePluralizer = new RelationalDatabaseModelFactoryTest.FakePluralizer();
             var namer = new CSharpUniqueNamer<DatabaseTable>(t => t.Name, new CSharpUtilities(), fakePluralizer.Singularize);
             var table = new DatabaseTable { Name = input };
             Assert.Equal(output, namer.GetName(table));
@@ -54,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore
         [InlineData("Name with no s at end", "Name_with_no_s_at_ends")]
         public void Pluralizes_names(string input, string output)
         {
-            var fakePluralizer = new FakePluralizer();
+            var fakePluralizer = new RelationalDatabaseModelFactoryTest.FakePluralizer();
             var namer = new CSharpUniqueNamer<DatabaseTable>(t => t.Name, new CSharpUtilities(), fakePluralizer.Pluralize);
             var table = new DatabaseTable { Name = input };
             Assert.Equal(output, namer.GetName(table));

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ReverseEngineeringConfigurationTests.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ReverseEngineeringConfigurationTests.cs
@@ -12,6 +12,7 @@ using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
+
 namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 {
     public class ReverseEngineeringConfigurationTests
@@ -28,8 +29,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         {
             var cSharpUtilities = new CSharpUtilities();
             var reverseEngineer = new ReverseEngineerScaffolder(
-                new FakeDatabaseModelFactory(),
-                new FakeScaffoldingModelFactory(new TestOperationReporter()),
+                new RelationalDatabaseModelFactoryTest.FakeDatabaseModelFactory(),
+                new RelationalDatabaseModelFactoryTest.FakeScaffoldingModelFactory(new TestOperationReporter()),
                 new CSharpScaffoldingGenerator(
                     new InMemoryFileService(),
                     new CSharpDbContextGenerator(new FakeScaffoldingCodeGenerator(), new FakeAnnotationCodeGenerator(), cSharpUtilities),


### PR DESCRIPTION
… made nullable if the column is already nullable

Also we marked required column as nullable when we derived nullable clr type

Resolves #10144
Resolves #10305

