### PR TITLE
Set ProjectStarTable whenever QSRE is being projected out

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
@@ -227,8 +227,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                             return base.Visit(expression);
 
                         case QuerySourceReferenceExpression qsre:
-                            if (QueryModelVisitor.ParentQueryModelVisitor != null
-                                && selectExpression.HandlesQuerySource(qsre.ReferencedQuerySource))
+                            if (selectExpression.HandlesQuerySource(qsre.ReferencedQuerySource))
                             {
                                 selectExpression.ProjectStarTable = selectExpression.GetTableForQuerySource(qsre.ReferencedQuerySource);
                             }

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -233,7 +233,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs =>
                     from c in cs
 #pragma warning disable CS1718 // Comparison made to same variable
-                    // ReSharper disable once EqualExpressionComparison
+                        // ReSharper disable once EqualExpressionComparison
                     where c == c
 #pragma warning restore CS1718 // Comparison made to same variable
                     select c.CustomerID);
@@ -2539,7 +2539,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 var orders
                     = (from o in context.Orders.Take(1)
-                       // ReSharper disable once UseMethodAny.0
+                           // ReSharper disable once UseMethodAny.0
                        where (from od in context.OrderDetails.OrderBy(od => od.OrderID).Take(2)
                               where (from c in context.Set<Customer>()
                                      where c.CustomerID == o.CustomerID
@@ -4037,6 +4037,19 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 Assert.Equal(830, results.SelectMany(r => r.Orders).ToList().Count);
             }
+        }
+
+        [ConditionalFact]
+        public virtual void Join_take_count_works()
+        {
+            AssertSingleResult<Order, Customer>(
+                (os, cs) =>
+                (from o in os.Where(o => o.OrderID > 690 && o.OrderID < 710)
+                 join c in cs.Where(c => c.CustomerID == "ALFKI")
+                  on o.CustomerID equals c.CustomerID
+                 select o)
+                 .Take(5)
+                 .Count());
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -4333,6 +4333,26 @@ FROM [Orders] AS [o]
 WHERE [o].[CustomerID] = @_outer_CustomerID");
         }
 
+        public override void Join_take_count_works()
+        {
+            base.Join_take_count_works();
+
+            AssertSql(
+    @"@__p_0='5'
+
+SELECT COUNT(*)
+FROM (
+    SELECT TOP(@__p_0) [o].*
+    FROM [Orders] AS [o]
+    INNER JOIN (
+        SELECT [c].*
+        FROM [Customers] AS [c]
+        WHERE [c].[CustomerID] = N'ALFKI'
+    ) AS [t] ON [o].[CustomerID] = [t].[CustomerID]
+    WHERE ([o].[OrderID] > 690) AND ([o].[OrderID] < 710)
+) AS [t0]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Resolves #10112

Issue here was, we set ProjectStarTable for QSRE only in subquery. But in this case even though it is top level, it later gets pushed down due to Take-Count sequence causing it to be subquery without projection & projectStarTable set.

Whenever we are projecting QSRE, we can set ProjectStarTable regardless of level. It is just a mapping for us between QSRE returned by queryModel & ProjectStarTable returned by SelectExpression.

