### PR TITLE
Fix #10222 - Using .Any() on table with owned entities causes IncludeIgnoredWarning

### DIFF
--- a/EFCore.sln.DotSettings
+++ b/EFCore.sln.DotSettings
@@ -62,8 +62,10 @@
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_CODE/@EntryValue">1</s:Int64>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_BLANK_LINES_IN_DECLARATIONS/@EntryValue">1</s:Int64>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/LINE_FEED_AT_FILE_END/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_CONSTRUCTOR_INITIALIZER_ON_SAME_LINE/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FIELD_ATTRIBUTE_ON_SAME_LINE/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FIELD_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_LINQ_ON_SINGLE_LINE/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_WHILE_ON_NEW_LINE/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SIMPLE_EMBEDDED_STATEMENT_STYLE/@EntryValue">LINE_BREAK</s:String>
@@ -121,6 +123,8 @@ Licensed under the Apache License, Version 2.0. See License.txt in the project r
 	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=13B3C0735924B9498D46F16CAB3349A2/RelativePath/@EntryValue"></s:String>
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File13B3C0735924B9498D46F16CAB3349A2/@KeyIndexDefined">True</s:Boolean>
 	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File13B3C0735924B9498D46F16CAB3349A2/RelativePriority/@EntryValue">1</s:Double>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>

--- a/src/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -30,6 +30,17 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [Fact]
+        public virtual void No_ignored_include_warning_when_implicit_load()
+        {
+            using (var context = CreateContext())
+            {
+                var count = context.Set<OwnedPerson>().Count();
+
+                Assert.Equal(4, count);
+            }
+        }
+
+        [Fact]
         public virtual void Query_for_branch_type_loads_all_owned_navs()
         {
             using (var context = CreateContext())
@@ -105,6 +116,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                 modelBuilder.Entity<Branch>().OwnsOne(p => p.BranchAddress).OwnsOne(a => a.Country);
                 modelBuilder.Entity<LeafA>().OwnsOne(p => p.LeafAAddress).OwnsOne(a => a.Country);
                 modelBuilder.Entity<LeafB>().OwnsOne(p => p.LeafBAddress).OwnsOne(a => a.Country);
+            }
+
+            public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+            {
+                return base.AddOptions(builder).ConfigureWarnings(wcb => wcb.Throw());
             }
 
             protected override void Seed(DbContext context)

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -373,7 +373,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                     _queryCompilationContext.AddAnnotations(
                         new[]
                         {
-                            new IncludeResultOperator(stack.Reverse().ToArray(), querySourceReferenceExpression)
+                            new IncludeResultOperator(
+                                stack.Reverse().ToArray(), 
+                                querySourceReferenceExpression,
+                                implicitLoad: true)
                         });
                 }
                 else

--- a/src/EFCore/Query/Internal/IncludeCompiler.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.cs
@@ -123,7 +123,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         /// </summary>
         public virtual void LogIgnoredIncludes()
         {
-            foreach (var includeResultOperator in _includeResultOperators)
+            foreach (var includeResultOperator in _includeResultOperators.Where(iro => !iro.IsImplicitLoad))
             {
                 _queryCompilationContext.Logger.IncludeIgnoredWarning(includeResultOperator);
             }

--- a/src/EFCore/Query/ResultOperators/Internal/IncludeResultOperator.cs
+++ b/src/EFCore/Query/ResultOperators/Internal/IncludeResultOperator.cs
@@ -22,20 +22,24 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
     /// </summary>
     public class IncludeResultOperator : SequenceTypePreservingResultOperatorBase, IQueryAnnotation
     {
-        private List<string> _navigationPropertyPaths;
         private readonly List<INavigation[]> _navigationPaths;
+
+        private List<string> _navigationPropertyPaths;
         private IQuerySource _querySource;
+        private Expression _pathFromQuerySource;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public IncludeResultOperator(
-            [NotNull] INavigation[] navigationPath, [NotNull] Expression pathFromQuerySource)
+            [NotNull] INavigation[] navigationPath, [NotNull] Expression pathFromQuerySource, bool implicitLoad = false)
         {
             _navigationPaths = new List<INavigation[]> { navigationPath };
             _navigationPropertyPaths = new List<string>();
-            PathFromQuerySource = pathFromQuerySource;
+            _pathFromQuerySource = pathFromQuerySource;
+
+            IsImplicitLoad = implicitLoad;
         }
 
         /// <summary>
@@ -47,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
             [NotNull] Expression pathFromQuerySource)
         {
             _navigationPropertyPaths = new List<string>(navigationPropertyPaths);
-            PathFromQuerySource = pathFromQuerySource;
+            _pathFromQuerySource = pathFromQuerySource;
         }
 
         /// <summary>
@@ -65,6 +69,12 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
                ?? (expression is MemberExpression memberExpression
                    ? GetQuerySource(memberExpression.Expression.RemoveConvert())
                    : null);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual bool IsImplicitLoad { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -88,7 +98,11 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Expression PathFromQuerySource { get; [param: NotNull] set; }
+        public virtual Expression PathFromQuerySource
+        {
+            get { return _pathFromQuerySource; }
+            [param: NotNull] set { _pathFromQuerySource = value; }
+        }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/test/EFCore.InMemory.FunctionalTests/Query/OwnedQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/OwnedQueryInMemoryTest.cs
@@ -14,6 +14,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             //TestLoggerFactory.TestOutputHelper = testOutputHelper;
         }
 
+        public override void No_ignored_include_warning_when_implicit_load()
+        {
+            base.No_ignored_include_warning_when_implicit_load();
+        }
+
         public class OwnedQueryInMemoryFixture : OwnedQueryFixtureBase
         {
             protected override ITestStoreFactory TestStoreFactory => InMemoryTestStoreFactory.Instance;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -16,6 +16,13 @@ namespace Microsoft.EntityFrameworkCore.Query
             fixture.TestSqlLoggerFactory.Clear();
         }
 
+
+        [Fact(Skip = "#8973")]
+        public override void No_ignored_include_warning_when_implicit_load()
+        {
+            base.No_ignored_include_warning_when_implicit_load();
+        }
+
         [Fact(Skip = "#8973")]
         public override void Query_for_base_type_loads_all_owned_navs()
         {

--- a/test/EFCore.Sqlite.FunctionalTests/Query/OwnedQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/OwnedQuerySqliteTest.cs
@@ -16,6 +16,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [Fact(Skip = "#8973")]
+        public override void No_ignored_include_warning_when_implicit_load()
+        {
+            base.No_ignored_include_warning_when_implicit_load();
+        }
+
+        [Fact(Skip = "#8973")]
         public override void Query_for_base_type_loads_all_owned_navs()
         {
             base.Query_for_base_type_loads_all_owned_navs();


### PR DESCRIPTION
- Added flag to IncludeResultOperator that tracks whether the Include was implicit. I.e. Added because of IsEagerLoad in model.