### PR TITLE
Allow relational providers to limit the length of the generated identifiers.

### DIFF
--- a/samples/OracleProvider/src/OracleProvider/Metadata/Conventions/OracleConventionSetBuilder.cs
+++ b/samples/OracleProvider/src/OracleProvider/Metadata/Conventions/OracleConventionSetBuilder.cs
@@ -25,6 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             var valueGenerationStrategyConvention = new OracleValueGenerationStrategyConvention();
             conventionSet.ModelInitializedConventions.Add(valueGenerationStrategyConvention);
+            conventionSet.ModelInitializedConventions.Add(new RelationalMaxIdentifierLengthConvention(128));
 
             ValueGeneratorConvention valueGeneratorConvention = new OracleValueGeneratorConvention();
             ReplaceConvention(conventionSet.BaseEntityTypeChangedConventions, valueGeneratorConvention);

--- a/samples/OracleProvider/test/OracleProvider.FunctionalTests/MonsterFixupChangedChangingOracleTest.cs
+++ b/samples/OracleProvider/test/OracleProvider.FunctionalTests/MonsterFixupChangedChangingOracleTest.cs
@@ -21,9 +21,10 @@ namespace Microsoft.EntityFrameworkCore
             public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
                 => base.AddOptions(builder).ConfigureWarnings(w => w.Log(RelationalEventId.QueryClientEvaluationWarning));
 
-            protected override void OnModelCreating<TMessage, TProductPhoto, TProductReview>(ModelBuilder builder)
+            protected override void OnModelCreating<TMessage, TProduct, TProductPhoto, TProductReview, TComputerDetail, TDimensions>(
+                ModelBuilder builder)
             {
-                base.OnModelCreating<TMessage, TProductPhoto, TProductReview>(builder);
+                base.OnModelCreating<TMessage, TProduct, TProductPhoto, TProductReview, TComputerDetail, TDimensions>(builder);
 
                 builder.Entity<TMessage>().Property(e => e.MessageId).UseOracleIdentityColumn();
                 builder.Entity<TProductPhoto>().Property(e => e.PhotoId).UseOracleIdentityColumn();

--- a/samples/OracleProvider/test/OracleProvider.FunctionalTests/UpdatesOracleTest.cs
+++ b/samples/OracleProvider/test/OracleProvider.FunctionalTests/UpdatesOracleTest.cs
@@ -1,5 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.EntityFrameworkCore.TestModels.UpdatesModel;
+using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -8,6 +12,19 @@ namespace Microsoft.EntityFrameworkCore
         public UpdatesOracleTest(UpdatesOracleFixture fixture)
             : base(fixture)
         {
+        }
+
+        public override void Identifiers_are_generated_correctly()
+        {
+            using (var context = CreateContext())
+            {
+                var entityType = context.Model.FindEntityType(typeof(
+                    LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCorrectly));
+                Assert.Equal("LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorking~", entityType.Relational().TableName);
+                Assert.Equal("PK_LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWork~", entityType.GetKeys().Single().Relational().Name);
+                Assert.Equal("FK_LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWork~", entityType.GetForeignKeys().Single().Relational().Name);
+                Assert.Equal("IX_LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWork~", entityType.GetIndexes().Single().Relational().Name);
+            }
         }
     }
 }

--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -62,6 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     GenerateFluentApiForAnnotation(ref annotations, RelationalAnnotationNames.DefaultSchema, nameof(RelationalModelBuilderExtensions.HasDefaultSchema), stringBuilder);
 
                     IgnoreAnnotationTypes(annotations, RelationalAnnotationNames.DbFunction);
+                    IgnoreAnnotationTypes(annotations, RelationalAnnotationNames.MaxIdentifierLength);
 
                     GenerateAnnotations(annotations, stringBuilder);
                 }

--- a/src/EFCore.Relational.Specification.Tests/StoreGeneratedFixupRelationalTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/StoreGeneratedFixupRelationalTestBase.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public abstract class StoreGeneratedFixupRelationalTestBase<TFixture> : StoreGeneratedFixupTestBase<TFixture>
+        where TFixture : StoreGeneratedFixupRelationalTestBase<TFixture>.StoreGeneratedFixupRelationalFixtureBase, new()
+    {
+        protected StoreGeneratedFixupRelationalTestBase(TFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        public abstract class StoreGeneratedFixupRelationalFixtureBase : StoreGeneratedFixupFixtureBase
+        {
+            protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+            {
+                base.OnModelCreating(modelBuilder, context);
+
+                modelBuilder.Entity<Item>().HasOne(i => i.Game).WithMany(g => g.Items).HasConstraintName("FK_GameEntity_Game_GameId");
+                modelBuilder.Entity<Actor>().HasOne(i => i.Game).WithMany(g => g.Actors).HasConstraintName("FK_GameEntity_Game_GameId");
+            }
+        }
+    }
+}

--- a/src/EFCore.Relational.Specification.Tests/UpdatesRelationalTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/UpdatesRelationalTestBase.cs
@@ -4,7 +4,9 @@
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
+using Xunit;
 
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore
 {
     public abstract class UpdatesRelationalTestBase<TFixture> : UpdatesTestBase<TFixture>
@@ -14,6 +16,9 @@ namespace Microsoft.EntityFrameworkCore
             : base(fixture)
         {
         }
+
+        [Fact]
+        public abstract void Identifiers_are_generated_correctly();
 
         protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
             => facade.UseTransaction(transaction.GetDbTransaction());

--- a/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalMaxConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalMaxConvention.cs
@@ -1,38 +1,39 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
-namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class RelationalKeyBuilderAnnotations : RelationalKeyAnnotations
+    public class RelationalMaxIdentifierLengthConvention : IModelInitializedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public RelationalKeyBuilderAnnotations(
-            [NotNull] InternalKeyBuilder internalBuilder,
-            ConfigurationSource configurationSource)
-            : base(new RelationalAnnotationsBuilder(internalBuilder, configurationSource))
+        public RelationalMaxIdentifierLengthConvention(int maxIdentifierLength)
         {
+            MaxIdentifierLength = maxIdentifierLength;
         }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual bool HasName([CanBeNull] string value) => SetName(value);
+        public virtual int MaxIdentifierLength { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual bool CanSetName([CanBeNull] string value)
-            => Annotations.CanSetAnnotation(RelationalAnnotationNames.Name, value);
+        public virtual InternalModelBuilder Apply(InternalModelBuilder modelBuilder)
+        {
+            modelBuilder.Relational(ConfigurationSource.Convention).HasMaxIdentifierLength(MaxIdentifierLength);
+            return modelBuilder;
+        }
     }
 }

--- a/src/EFCore.Relational/Metadata/Internal/ConstraintNamer.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ConstraintNamer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -21,18 +21,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public static string GetDefaultName([NotNull] IForeignKey foreignKey)
         {
-            var otherForeignKeyNames = new HashSet<string>(
-                foreignKey.DeclaringEntityType.RootType().GetDerivedTypesInclusive()
-                    .SelectMany(et => et.GetDeclaredForeignKeys())
-                    .Where(fk => fk != foreignKey)
-                    .Where(
-                        fk => !ConfigurationSource.Convention.Overrides(
-                            (fk as ForeignKey)
-                            ?.FindAnnotation(RelationalAnnotationNames.Name)
-                            ?.GetConfigurationSource()))
-                    .Select(fk => fk.Relational().Name),
-                StringComparer.OrdinalIgnoreCase);
-
             var baseName = new StringBuilder()
                 .Append("FK_")
                 .Append(foreignKey.DeclaringEntityType.Relational().TableName)
@@ -42,14 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 .AppendJoin(foreignKey.Properties.Select(p => p.Relational().ColumnName), "_")
                 .ToString();
 
-            var name = baseName;
-            var uniquifier = 0;
-            while (otherForeignKeyNames.Contains(name))
-            {
-                name = baseName + uniquifier++;
-            }
-
-            return name;
+            return Truncate(baseName, null, foreignKey.DeclaringEntityType.Model.GetMaxIdentifierLength());
         }
 
         /// <summary>
@@ -58,18 +39,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public static string GetDefaultName([NotNull] IIndex index)
         {
-            var otherIndexNames = new HashSet<string>(
-                index.DeclaringEntityType.RootType().GetDerivedTypesInclusive()
-                    .SelectMany(et => et.GetDeclaredIndexes())
-                    .Where(i => i != index)
-                    .Where(
-                        i => !ConfigurationSource.Convention.Overrides(
-                            (i as Index)
-                            ?.FindAnnotation(RelationalAnnotationNames.Name)
-                            ?.GetConfigurationSource()))
-                    .Select(i => i.Relational().Name),
-                StringComparer.OrdinalIgnoreCase);
-
             var baseName = new StringBuilder()
                 .Append("IX_")
                 .Append(index.DeclaringEntityType.Relational().TableName)
@@ -77,26 +46,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 .AppendJoin(index.Properties.Select(p => p.Relational().ColumnName), "_")
                 .ToString();
 
-            var name = baseName;
-            var uniquifier = 0;
-            while (otherIndexNames.Contains(name))
-            {
-                name = baseName + uniquifier++;
-            }
-
-            return name;
+            return Truncate(baseName, null, index.DeclaringEntityType.Model.GetMaxIdentifierLength());
         }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public static string GetDefaultName([NotNull] IKey Key)
+        public static string GetDefaultName([NotNull] IKey key)
         {
             var builder = new StringBuilder();
-            var tableName = Key.DeclaringEntityType.Relational().TableName;
+            var tableName = key.DeclaringEntityType.Relational().TableName;
 
-            if (Key.IsPrimaryKey())
+            if (key.IsPrimaryKey())
             {
                 builder
                     .Append("PK_")
@@ -108,10 +70,110 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     .Append("AK_")
                     .Append(tableName)
                     .Append("_")
-                    .AppendJoin(Key.Properties.Select(p => p.Relational().ColumnName), "_");
+                    .AppendJoin(key.Properties.Select(p => p.Relational().ColumnName), "_");
+            }
+
+            return Truncate(builder.ToString(), null, key.DeclaringEntityType.Model.GetMaxIdentifierLength());
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string GetDefaultName([NotNull] IProperty property)
+        {
+            var sharedTablePrincipalPrimaryKeyProperty = property.FindSharedTablePrincipalPrimaryKeyProperty();
+            if (sharedTablePrincipalPrimaryKeyProperty != null)
+            {
+                return sharedTablePrincipalPrimaryKeyProperty.Relational().ColumnName;
+            }
+
+            var entityType = property.DeclaringEntityType;
+            StringBuilder builder = null;
+            do
+            {
+                var ownership = entityType.GetForeignKeys().SingleOrDefault(fk => fk.IsOwnership);
+                if (ownership == null)
+                {
+                    entityType = null;
+                }
+                else
+                {
+                    var ownerType = ownership.PrincipalEntityType;
+                    var entityTypeAnnotations = entityType.Relational();
+                    var ownerTypeAnnotations = ownerType.Relational();
+                    if (entityTypeAnnotations.TableName == ownerTypeAnnotations.TableName
+                        && entityTypeAnnotations.Schema == ownerTypeAnnotations.Schema)
+                    {
+                        if (builder == null)
+                        {
+                            builder = new StringBuilder();
+                        }
+                        builder.Insert(0, "_");
+                        builder.Insert(0, ownership.PrincipalToDependent.Name);
+                        entityType = ownerType;
+                    }
+                    else
+                    {
+                        entityType = null;
+                    }
+                }
+            }
+            while (entityType != null);
+
+            var baseName = property.Name;
+            if (builder != null)
+            {
+                builder.Append(property.Name);
+                baseName = builder.ToString();
+            }
+
+            return Truncate(baseName, null, property.DeclaringEntityType.Model.GetMaxIdentifierLength());
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string Truncate([NotNull] string name, int? uniquifier, int maxLength)
+        {
+            var uniquifierLength = GetLength(uniquifier);
+            var maxNameLength = maxLength - uniquifierLength;
+
+            var builder = new StringBuilder();
+            if (name.Length <= maxLength)
+            {
+                builder.Append(name);
+            }
+            else
+            {
+                builder.Append(name.Substring(0, maxNameLength - 1));
+                builder.Append("~");
+            }
+            if (uniquifier != null)
+            {
+                builder.Append(uniquifier.Value);
             }
 
             return builder.ToString();
+        }
+
+        private static int GetLength(int? number)
+        {
+            if (number == null)
+            {
+                return 0;
+            }
+
+            var length = 0;
+            do
+            {
+                number /= 10;
+                length++;
+            }
+            while (number.Value >= 1);
+
+            return length;
         }
     }
 }

--- a/src/EFCore.Relational/Metadata/Internal/RelationalForeignKeyBuilderAnnotations.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalForeignKeyBuilderAnnotations.cs
@@ -26,6 +26,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual bool HasConstraintName([CanBeNull] string value) => SetName(value);
+        public virtual bool HasName([CanBeNull] string value) => SetName(value);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual bool CanSetName([CanBeNull] string value)
+            => Annotations.CanSetAnnotation(RelationalAnnotationNames.Name, value);
     }
 }

--- a/src/EFCore.Relational/Metadata/Internal/RelationalIndexBuilderAnnotations.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalIndexBuilderAnnotations.cs
@@ -32,6 +32,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public virtual bool CanSetName([CanBeNull] string value)
+            => Annotations.CanSetAnnotation(RelationalAnnotationNames.Name, value);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual bool HasFilter([CanBeNull] string value) => SetFilter(value);
     }
 }

--- a/src/EFCore.Relational/Metadata/Internal/RelationalModelBuilderAnnotations.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalModelBuilderAnnotations.cs
@@ -27,5 +27,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual bool HasDefaultSchema([CanBeNull] string value) => SetDefaultSchema(value);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual bool HasMaxIdentifierLength(int? value) => SetMaxIdentifierLength(value);
     }
 }

--- a/src/EFCore.Relational/Metadata/Internal/RelationalModelExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/RelationalModelExtensions.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public static class RelationalModelExtensions
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static int GetMaxIdentifierLength([NotNull] this IModel model)
+            => (model as Model)?.Relational().MaxIdentifierLength ?? short.MaxValue;
+    }
+}

--- a/src/EFCore.Relational/Metadata/RelationalAnnotationNames.cs
+++ b/src/EFCore.Relational/Metadata/RelationalAnnotationNames.cs
@@ -93,5 +93,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     The name for DbFunction annotations.
         /// </summary>
         public const string DbFunction = Prefix + "DbFunction";
+
+        /// <summary>
+        ///     The maximum length for database identifiers.
+        /// </summary>
+        public const string MaxIdentifierLength = Prefix + "MaxIdentifierLength";
     }
 }

--- a/src/EFCore.Relational/Metadata/RelationalEntityTypeAnnotations.cs
+++ b/src/EFCore.Relational/Metadata/RelationalEntityTypeAnnotations.cs
@@ -80,9 +80,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         }
 
         private string GetDefaultTableName()
-            => EntityType.HasDefiningNavigation()
+            => ConstraintNamer.Truncate(
+                EntityType.HasDefiningNavigation()
                 ? $"{GetAnnotations(EntityType.DefiningEntityType).TableName}_{EntityType.DefiningNavigationName}"
-                : EntityType.ShortName();
+                : EntityType.ShortName(),
+                null,
+                EntityType.Model.GetMaxIdentifierLength());
 
         /// <summary>
         ///     Attempts to set the <see cref="TableName" /> using the semantics of the <see cref="RelationalAnnotations" /> in use.

--- a/src/EFCore.Relational/Metadata/RelationalModelAnnotations.cs
+++ b/src/EFCore.Relational/Metadata/RelationalModelAnnotations.cs
@@ -32,8 +32,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="annotations">
         ///     The <see cref="RelationalAnnotations" /> helper representing the <see cref="IModel" /> to annotate.
         /// </param>
-        protected RelationalModelAnnotations(
-            [NotNull] RelationalAnnotations annotations) => Annotations = annotations;
+        protected RelationalModelAnnotations([NotNull] RelationalAnnotations annotations)
+            => Annotations = annotations;
 
         /// <summary>
         ///     The <see cref="RelationalAnnotations" /> helper representing the <see cref="IModel" /> to annotate.
@@ -133,6 +133,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             => Annotations.SetAnnotation(
                 RelationalAnnotationNames.DefaultSchema,
                 Check.NullButNotEmpty(value, nameof(value)));
+
+        /// <summary>
+        ///     The maximum length allowed for store identifiers.
+        /// </summary>
+        public virtual int MaxIdentifierLength
+        {
+            get => (int?)Annotations.Metadata[RelationalAnnotationNames.MaxIdentifierLength] ?? short.MaxValue;
+            set => SetMaxIdentifierLength(value);
+        }
+
+        /// <summary>
+        ///     Attempts to set the <see cref="MaxIdentifierLength" /> using the semantics of the <see cref="RelationalAnnotations" /> in use.
+        /// </summary>
+        /// <param name="value"> The value to set. </param>
+        /// <returns> <c>True</c> if the annotation was set; <c>false</c> otherwise. </returns>
+        protected virtual bool SetMaxIdentifierLength(int? value)
+            => Annotations.SetAnnotation(RelationalAnnotationNames.MaxIdentifierLength, value);
 
         /// <summary>
         ///     Finds an <see cref="ISequence" /> with the given name.

--- a/src/EFCore.Relational/RelationalReferenceCollectionBuilderExtensions.cs
+++ b/src/EFCore.Relational/RelationalReferenceCollectionBuilderExtensions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore
 
             referenceCollectionBuilder.GetInfrastructure<InternalRelationshipBuilder>()
                 .Relational(ConfigurationSource.Explicit)
-                .HasConstraintName(name);
+                .HasName(name);
 
             return referenceCollectionBuilder;
         }

--- a/src/EFCore.Relational/RelationalReferenceOwnershipBuilderExtensions.cs
+++ b/src/EFCore.Relational/RelationalReferenceOwnershipBuilderExtensions.cs
@@ -105,7 +105,7 @@ namespace Microsoft.EntityFrameworkCore
 
             referenceReferenceBuilder.GetInfrastructure<InternalRelationshipBuilder>()
                 .Relational(ConfigurationSource.Explicit)
-                .HasConstraintName(name);
+                .HasName(name);
 
             return referenceReferenceBuilder;
         }

--- a/src/EFCore.Relational/RelationalReferenceReferenceBuilderExtensions.cs
+++ b/src/EFCore.Relational/RelationalReferenceReferenceBuilderExtensions.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore
 
             referenceReferenceBuilder.GetInfrastructure<InternalRelationshipBuilder>()
                 .Relational(ConfigurationSource.Explicit)
-                .HasConstraintName(name);
+                .HasName(name);
 
             return referenceReferenceBuilder;
         }

--- a/src/EFCore.Specification.Tests/MonsterFixupTestBase.cs
+++ b/src/EFCore.Specification.Tests/MonsterFixupTestBase.cs
@@ -1389,10 +1389,14 @@ namespace Microsoft.EntityFrameworkCore
 
             public abstract MonsterContext CreateContext(DbContextOptions options);
 
-            protected virtual void OnModelCreating<TMessage, TProductPhoto, TProductReview>(ModelBuilder builder)
+            protected virtual void OnModelCreating<TMessage, TProduct, TProductPhoto, TProductReview, TComputerDetail, TDimensions>(
+                ModelBuilder builder)
                 where TMessage : class, IMessage
+                where TProduct : class, IProduct
                 where TProductPhoto : class, IProductPhoto
                 where TProductReview : class, IProductReview
+                where TComputerDetail : class, IComputerDetail
+                where TDimensions : class, IDimensions
             {
             }
         }
@@ -1410,8 +1414,11 @@ namespace Microsoft.EntityFrameworkCore
                 base.OnModelCreating(modelBuilder, context);
                 modelBuilder.HasChangeTrackingStrategy(ChangeTrackingStrategy.Snapshot);
                 OnModelCreating<SnapshotMonsterContext.Message,
+                    SnapshotMonsterContext.Product,
                     SnapshotMonsterContext.ProductPhoto,
-                    SnapshotMonsterContext.ProductReview>(modelBuilder);
+                    SnapshotMonsterContext.ProductReview,
+                    SnapshotMonsterContext.ComputerDetail,
+                    SnapshotMonsterContext.Dimensions>(modelBuilder);
             }
         }
 
@@ -1428,8 +1435,11 @@ namespace Microsoft.EntityFrameworkCore
                 base.OnModelCreating(modelBuilder, context);
                 modelBuilder.HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangedNotifications);
                 OnModelCreating<ChangedOnlyMonsterContext.Message,
+                    ChangedOnlyMonsterContext.Product,
                     ChangedOnlyMonsterContext.ProductPhoto,
-                    ChangedOnlyMonsterContext.ProductReview>(modelBuilder);
+                    ChangedOnlyMonsterContext.ProductReview,
+                    ChangedOnlyMonsterContext.ComputerDetail,
+                    ChangedOnlyMonsterContext.Dimensions>(modelBuilder);
             }
         }
 
@@ -1446,8 +1456,11 @@ namespace Microsoft.EntityFrameworkCore
                 base.OnModelCreating(modelBuilder, context);
                 modelBuilder.HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications);
                 OnModelCreating<ChangedChangingMonsterContext.Message,
+                    ChangedChangingMonsterContext.Product,
                     ChangedChangingMonsterContext.ProductPhoto,
-                    ChangedChangingMonsterContext.ProductReview>(modelBuilder);
+                    ChangedChangingMonsterContext.ProductReview,
+                    ChangedChangingMonsterContext.ComputerDetail,
+                    ChangedChangingMonsterContext.Dimensions>(modelBuilder);
             }
         }
 

--- a/src/EFCore.Specification.Tests/Query/ChangeTrackingTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/ChangeTrackingTestBase.cs
@@ -427,7 +427,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected NorthwindContext CreateContext() => Fixture.CreateContext();
 
-        protected NorthwindContext CreateNoTrackingContext()
+        protected virtual NorthwindContext CreateNoTrackingContext()
             => new NorthwindContext(
                 new DbContextOptionsBuilder(Fixture.CreateOptions())
                     .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking).Options);

--- a/src/EFCore.Specification.Tests/TestModels/UpdatesModel/Login.cs
+++ b/src/EFCore.Specification.Tests/TestModels/UpdatesModel/Login.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.EntityFrameworkCore.TestModels.UpdatesModel
+{
+    public class LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCorrectly
+    {
+        public int LoginId { get; set; }
+        public string LoginId1 { get; set; }
+        public Guid LoginId2 { get; set; }
+        public decimal LoginId3 { get; set; }
+        public bool LoginId4 { get; set; }
+        public byte LoginId5 { get; set; }
+        public short LoginId6 { get; set; }
+        public long LoginId7 { get; set; }
+        public DateTime LoginId8 { get; set; }
+        public DateTimeOffset LoginId9 { get; set; }
+        public TimeSpan LoginId10 { get; set; }
+        public byte? LoginId11 { get; set; }
+        public short? LoginId12 { get; set; }
+        public int? LoginId13 { get; set; }
+        public long? LoginId14 { get; set; }
+
+        public virtual Profile Profile { get; set; }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestModels/UpdatesModel/Profile.cs
+++ b/src/EFCore.Specification.Tests/TestModels/UpdatesModel/Profile.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace Microsoft.EntityFrameworkCore.TestModels.UpdatesModel
+{
+    public class Profile
+    {
+        public int ProfileId { get; set; }
+        public string ProfileId1 { get; set; }
+        public Guid ProfileId2 { get; set; }
+        public decimal ProfileId3 { get; set; }
+        public bool ProfileId4 { get; set; }
+        public byte ProfileId5 { get; set; }
+        public short ProfileId6 { get; set; }
+        public long ProfileId7 { get; set; }
+        public DateTime ProfileId8 { get; set; }
+        public DateTimeOffset ProfileId9 { get; set; }
+        public TimeSpan ProfileId10 { get; set; }
+        public byte? ProfileId11 { get; set; }
+        public short? ProfileId12 { get; set; }
+        public int? ProfileId13 { get; set; }
+        public long? ProfileId14 { get; set; }
+
+        public virtual LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCorrectly User { get; set; }
+    }
+}

--- a/src/EFCore.Specification.Tests/UpdatesFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/UpdatesFixtureBase.cs
@@ -22,6 +22,42 @@ namespace Microsoft.EntityFrameworkCore
             modelBuilder.Entity<Category>()
                 .Property(e => e.Id)
                 .ValueGeneratedNever();
+
+            modelBuilder.Entity<LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCorrectly>().HasKey(l => new
+            {
+                l.LoginId,
+                l.LoginId1,
+                l.LoginId3,
+                l.LoginId4,
+                l.LoginId5,
+                l.LoginId6,
+                l.LoginId7,
+                l.LoginId8,
+                l.LoginId9,
+                l.LoginId10,
+                l.LoginId11,
+                l.LoginId12,
+                l.LoginId13,
+                l.LoginId14
+            });
+
+            modelBuilder.Entity<Profile>().HasKey(l => new
+            {
+                l.ProfileId,
+                l.ProfileId1,
+                l.ProfileId3,
+                l.ProfileId4,
+                l.ProfileId5,
+                l.ProfileId6,
+                l.ProfileId7,
+                l.ProfileId8,
+                l.ProfileId9,
+                l.ProfileId10,
+                l.ProfileId11,
+                l.ProfileId12,
+                l.ProfileId13,
+                l.ProfileId14
+            });
         }
 
         protected override void Seed(UpdatesContext context)

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
@@ -41,6 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             var valueGenerationStrategyConvention = new SqlServerValueGenerationStrategyConvention();
             conventionSet.ModelInitializedConventions.Add(valueGenerationStrategyConvention);
+            conventionSet.ModelInitializedConventions.Add(new RelationalMaxIdentifierLengthConvention(128));
 
             ValueGeneratorConvention valueGeneratorConvention = new SqlServerValueGeneratorConvention();
             ReplaceConvention(conventionSet.BaseEntityTypeChangedConventions, valueGeneratorConvention);

--- a/src/EFCore/Metadata/Internal/PropertyExtensions.cs
+++ b/src/EFCore/Metadata/Internal/PropertyExtensions.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static CoreTypeMapping FindMapping(
-            [NotNull] this IProperty property) 
+            [NotNull] this IProperty property)
             => (CoreTypeMapping)property[CoreAnnotationNames.TypeMapping];
 
         /// <summary>

--- a/test/EFCore.InMemory.FunctionalTests/MonsterFixupSnapshotInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/MonsterFixupSnapshotInMemoryTest.cs
@@ -16,9 +16,10 @@ namespace Microsoft.EntityFrameworkCore
         {
             protected override ITestStoreFactory TestStoreFactory => InMemoryTestStoreFactory.Instance;
 
-            protected override void OnModelCreating<TMessage, TProductPhoto, TProductReview>(ModelBuilder builder)
+            protected override void OnModelCreating<TMessage, TProduct, TProductPhoto, TProductReview, TComputerDetail, TDimensions>(
+                ModelBuilder builder)
             {
-                base.OnModelCreating<TMessage, TProductPhoto, TProductReview>(builder);
+                base.OnModelCreating<TMessage, TProduct, TProductPhoto, TProductReview, TComputerDetail, TDimensions>(builder);
 
                 builder.Entity<TMessage>().Property(e => e.MessageId).ValueGeneratedOnAdd();
                 builder.Entity<TProductPhoto>().Property(e => e.PhotoId).ValueGeneratedOnAdd();

--- a/test/EFCore.Relational.Tests/Metadata/InternalRelationalMetadataBuilderExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/InternalRelationalMetadataBuilderExtensionsTest.cs
@@ -160,13 +160,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             entityTypeBuilder.Property("Id", typeof(int), ConfigurationSource.Convention);
             var relationshipBuilder = entityTypeBuilder.HasForeignKey("Splot", new[] { "Id" }, ConfigurationSource.Convention);
 
-            Assert.True(relationshipBuilder.Relational(ConfigurationSource.Convention).HasConstraintName("Splew"));
+            Assert.True(relationshipBuilder.Relational(ConfigurationSource.Convention).HasName("Splew"));
             Assert.Equal("Splew", relationshipBuilder.Metadata.Relational().Name);
 
-            Assert.True(relationshipBuilder.Relational(ConfigurationSource.DataAnnotation).HasConstraintName("Splow"));
+            Assert.True(relationshipBuilder.Relational(ConfigurationSource.DataAnnotation).HasName("Splow"));
             Assert.Equal("Splow", relationshipBuilder.Metadata.Relational().Name);
 
-            Assert.False(relationshipBuilder.Relational(ConfigurationSource.Convention).HasConstraintName("Splod"));
+            Assert.False(relationshipBuilder.Relational(ConfigurationSource.Convention).HasName("Splod"));
             Assert.Equal("Splow", relationshipBuilder.Metadata.Relational().Name);
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
 
+// ReSharper disable InconsistentNaming
 // ReSharper disable ParameterOnlyUsedForPreconditionCheck.Local
 // ReSharper disable CompareOfFloatsByEqualityOperator
 // ReSharper disable UnusedParameter.Local
@@ -2707,6 +2708,10 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
 
                 modelBuilder.Entity<BuiltInDataTypes>()
                     .Property(dt => dt.TestDecimal)
+                    .HasColumnType("decimal(18,2)");
+
+                modelBuilder.Entity<BuiltInNullableDataTypes>()
+                    .Property(dt => dt.TestNullableDecimal)
                     .HasColumnType("decimal(18,2)");
 
                 modelBuilder.Entity<MappedDataTypes>(

--- a/test/EFCore.SqlServer.FunctionalTests/MonsterFixupChangedChangingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/MonsterFixupChangedChangingSqlServerTest.cs
@@ -21,13 +21,31 @@ namespace Microsoft.EntityFrameworkCore
             public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
                 => base.AddOptions(builder).ConfigureWarnings(w => w.Log(RelationalEventId.QueryClientEvaluationWarning));
 
-            protected override void OnModelCreating<TMessage, TProductPhoto, TProductReview>(ModelBuilder builder)
+            protected override void OnModelCreating<TMessage, TProduct, TProductPhoto, TProductReview, TComputerDetail, TDimensions>(
+                ModelBuilder builder)
             {
-                base.OnModelCreating<TMessage, TProductPhoto, TProductReview>(builder);
+                base.OnModelCreating<TMessage, TProduct, TProductPhoto, TProductReview, TComputerDetail, TDimensions>(builder);
 
                 builder.Entity<TMessage>().Property(e => e.MessageId).UseSqlServerIdentityColumn();
+
+                builder.Entity<TProduct>()
+                    .OwnsOne(c => (TDimensions)c.Dimensions, db =>
+                        {
+                            db.Property(d => d.Depth).HasColumnType("decimal(18,2)");
+                            db.Property(d => d.Width).HasColumnType("decimal(18,2)");
+                            db.Property(d => d.Height).HasColumnType("decimal(18,2)");
+                        });
+
                 builder.Entity<TProductPhoto>().Property(e => e.PhotoId).UseSqlServerIdentityColumn();
                 builder.Entity<TProductReview>().Property(e => e.ReviewId).UseSqlServerIdentityColumn();
+
+                builder.Entity<TComputerDetail>()
+                    .OwnsOne(c => (TDimensions)c.Dimensions, db =>
+                        {
+                            db.Property(d => d.Depth).HasColumnType("decimal(18,2)");
+                            db.Property(d => d.Width).HasColumnType("decimal(18,2)");
+                            db.Property(d => d.Height).HasColumnType("decimal(18,2)");
+                        });
             }
         }
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ChangeTrackingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ChangeTrackingSqlServerTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -11,5 +12,10 @@ namespace Microsoft.EntityFrameworkCore.Query
             : base(fixture)
         {
         }
+
+        protected override NorthwindContext CreateNoTrackingContext()
+            => new NorthwindRelationalContext(
+                new DbContextOptionsBuilder(Fixture.CreateOptions())
+                    .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking).Options);
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQuerySqlServerFixture.cs
@@ -41,6 +41,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                         b.Property(p => p.UnitPrice).HasColumnType("money");
                         b.Property(p => p.UnitsInStock).HasColumnType("smallint");
                     });
+
+            modelBuilder.Entity<MostExpensiveProduct>()
+                .Property(p => p.UnitPrice)
+                .HasColumnType("money");
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -170,6 +170,11 @@ namespace Microsoft.EntityFrameworkCore
                     .Entity<ByteAdNum>()
                     .Property(e => e.Id)
                     .ValueGeneratedOnAdd();
+
+                modelBuilder
+                    .Entity<NownNum>()
+                    .Property(e => e.Id)
+                    .HasColumnType("numeric(18, 0)");
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/StoreGeneratedFixupSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/StoreGeneratedFixupSqlServerTest.cs
@@ -9,7 +9,7 @@ using Xunit;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore
 {
-    public class StoreGeneratedFixupSqlServerTest : StoreGeneratedFixupTestBase<StoreGeneratedFixupSqlServerTest.StoreGeneratedFixupSqlServerFixture>
+    public class StoreGeneratedFixupSqlServerTest : StoreGeneratedFixupRelationalTestBase<StoreGeneratedFixupSqlServerTest.StoreGeneratedFixupSqlServerFixture>
     {
         public StoreGeneratedFixupSqlServerTest(StoreGeneratedFixupSqlServerFixture fixture)
             : base(fixture)
@@ -61,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore
         protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
             => facade.UseTransaction(transaction.GetDbTransaction());
 
-        public class StoreGeneratedFixupSqlServerFixture : StoreGeneratedFixupFixtureBase
+        public class StoreGeneratedFixupSqlServerFixture : StoreGeneratedFixupRelationalFixtureBase
         {
             protected override ITestStoreFactory TestStoreFactory => SqlServerTestStoreFactory.Instance;
 

--- a/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerFixture.cs
@@ -16,6 +16,12 @@ namespace Microsoft.EntityFrameworkCore
 
             modelBuilder.Entity<Product>()
                 .Property(p => p.Price).HasColumnType("decimal(18,2)");
+
+            modelBuilder.Entity<LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCorrectly>()
+                .Property(l => l.LoginId3).HasColumnType("decimal(18,2)");
+
+            modelBuilder.Entity<Profile>()
+                    .Property(l => l.ProfileId3).HasColumnType("decimal(18,2)");
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerTest.cs
@@ -1,6 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
+using Microsoft.EntityFrameworkCore.TestModels.UpdatesModel;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore
@@ -28,6 +31,19 @@ UPDATE [Categories] SET [Name] = @p0
 WHERE [Id] = @p1;
 SELECT @@ROWCOUNT;"
             }, assertOrder: false);
+        }
+
+        public override void Identifiers_are_generated_correctly()
+        {
+            using (var context = CreateContext())
+            {
+                var entityType = context.Model.FindEntityType(typeof(
+                    LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCorrectly));
+                Assert.Equal("LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorking~", entityType.Relational().TableName);
+                Assert.Equal("PK_LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWork~", entityType.GetKeys().Single().Relational().Name);
+                Assert.Equal("FK_LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWork~", entityType.GetForeignKeys().Single().Relational().Name);
+                Assert.Equal("IX_LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWork~", entityType.GetIndexes().Single().Relational().Name);
+            }
         }
     }
 }

--- a/test/EFCore.SqlServer.Tests/Metadata/Conventions/SqlServerValueGenerationStrategyConventionTest.cs
+++ b/test/EFCore.SqlServer.Tests/Metadata/Conventions/SqlServerValueGenerationStrategyConventionTest.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
+// ReSharper disable InconsistentNaming
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 {
@@ -15,10 +16,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         {
             var model = SqlServerTestHelpers.Instance.CreateConventionBuilder().Model;
 
-            Assert.Equal(1, model.GetAnnotations().Count());
+            var annotations = model.GetAnnotations().OrderBy(a => a.Name).ToList();
+            Assert.Equal(2, annotations.Count);
 
-            Assert.Equal(SqlServerAnnotationNames.ValueGenerationStrategy, model.GetAnnotations().Single().Name);
-            Assert.Equal(SqlServerValueGenerationStrategy.IdentityColumn, model.GetAnnotations().Single().Value);
+            Assert.Equal(SqlServerAnnotationNames.ValueGenerationStrategy, annotations.Last().Name);
+            Assert.Equal(SqlServerValueGenerationStrategy.IdentityColumn, annotations.Last().Value);
         }
 
         [Fact]
@@ -28,21 +30,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 .ForSqlServerUseSequenceHiLo()
                 .Model;
 
-            var annotations = model.GetAnnotations().OrderBy(a => a.Name);
-            Assert.Equal(3, annotations.Count());
+            var annotations = model.GetAnnotations().OrderBy(a => a.Name).ToList();
+            Assert.Equal(4, annotations.Count);
+
+            Assert.Equal(RelationalAnnotationNames.MaxIdentifierLength, annotations[0].Name);
 
             Assert.Equal(
                 RelationalAnnotationNames.SequencePrefix +
                 "." +
                 SqlServerModelAnnotations.DefaultHiLoSequenceName,
-                annotations.ElementAt(0).Name);
-            Assert.NotNull(annotations.ElementAt(0).Value);
+                annotations[1].Name);
+            Assert.NotNull(annotations[1].Value);
 
-            Assert.Equal(SqlServerAnnotationNames.HiLoSequenceName, annotations.ElementAt(1).Name);
-            Assert.Equal(SqlServerModelAnnotations.DefaultHiLoSequenceName, annotations.ElementAt(1).Value);
+            Assert.Equal(SqlServerAnnotationNames.HiLoSequenceName, annotations[2].Name);
+            Assert.Equal(SqlServerModelAnnotations.DefaultHiLoSequenceName, annotations[2].Value);
 
-            Assert.Equal(SqlServerAnnotationNames.ValueGenerationStrategy, annotations.ElementAt(2).Name);
-            Assert.Equal(SqlServerValueGenerationStrategy.SequenceHiLo, annotations.ElementAt(2).Value);
+            Assert.Equal(SqlServerAnnotationNames.ValueGenerationStrategy, annotations[3].Name);
+            Assert.Equal(SqlServerValueGenerationStrategy.SequenceHiLo, annotations[3].Value);
         }
     }
 }

--- a/test/EFCore.SqlServer.Tests/Metadata/SqlServerInternalMetadataBuilderExtensionsTest.cs
+++ b/test/EFCore.SqlServer.Tests/Metadata/SqlServerInternalMetadataBuilderExtensionsTest.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Xunit;
 
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     public class SqlServerInternalMetadataBuilderExtensionsTest
@@ -159,13 +160,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             entityTypeBuilder.Property("Id", typeof(int), ConfigurationSource.Convention);
             var relationshipBuilder = entityTypeBuilder.HasForeignKey("Splot", new[] { "Id" }, ConfigurationSource.Convention);
 
-            Assert.True(relationshipBuilder.SqlServer(ConfigurationSource.Convention).HasConstraintName("Splew"));
+            Assert.True(relationshipBuilder.SqlServer(ConfigurationSource.Convention).HasName("Splew"));
             Assert.Equal("Splew", relationshipBuilder.Metadata.Relational().Name);
 
-            Assert.True(relationshipBuilder.SqlServer(ConfigurationSource.DataAnnotation).HasConstraintName("Splow"));
+            Assert.True(relationshipBuilder.SqlServer(ConfigurationSource.DataAnnotation).HasName("Splow"));
             Assert.Equal("Splow", relationshipBuilder.Metadata.Relational().Name);
 
-            Assert.False(relationshipBuilder.SqlServer(ConfigurationSource.Convention).HasConstraintName("Splod"));
+            Assert.False(relationshipBuilder.SqlServer(ConfigurationSource.Convention).HasName("Splod"));
             Assert.Equal("Splow", relationshipBuilder.Metadata.Relational().Name);
 
             Assert.Equal(

--- a/test/EFCore.Sqlite.FunctionalTests/MonsterFixupChangedOnlySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/MonsterFixupChangedOnlySqliteTest.cs
@@ -20,9 +20,11 @@ namespace Microsoft.EntityFrameworkCore
             public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
                 => base.AddOptions(builder).ConfigureWarnings(w => w.Log(RelationalEventId.QueryClientEvaluationWarning));
 
-            protected override void OnModelCreating<TMessage, TProductPhoto, TProductReview>(ModelBuilder builder)
+            protected override void OnModelCreating<TMessage, TProduct, TProductPhoto, TProductReview, TComputerDetail, TDimensions>(
+                ModelBuilder builder)
             {
-                base.OnModelCreating<TMessage, TProductPhoto, TProductReview>(builder);
+                base.OnModelCreating<TMessage, TProduct, TProductPhoto, TProductReview, TComputerDetail, TDimensions>(builder);
+
                 builder.Entity<TMessage>().HasKey(e => e.MessageId);
                 builder.Entity<TProductPhoto>().HasKey(e => e.PhotoId);
                 builder.Entity<TProductReview>().HasKey(e => e.ReviewId);

--- a/test/EFCore.Sqlite.FunctionalTests/Query/ChangeTrackingSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/ChangeTrackingSqliteTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -11,5 +12,10 @@ namespace Microsoft.EntityFrameworkCore.Query
             : base(fixture)
         {
         }
+
+        protected override NorthwindContext CreateNoTrackingContext()
+            => new NorthwindRelationalContext(
+                new DbContextOptionsBuilder(Fixture.CreateOptions())
+                    .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking).Options);
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/StoreGeneratedFixupSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/StoreGeneratedFixupSqliteTest.cs
@@ -9,7 +9,7 @@ using Xunit;
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore
 {
-    public class StoreGeneratedFixupSqliteTest : StoreGeneratedFixupTestBase<StoreGeneratedFixupSqliteTest.StoreGeneratedFixupSqliteFixture>
+    public class StoreGeneratedFixupSqliteTest : StoreGeneratedFixupRelationalTestBase<StoreGeneratedFixupSqliteTest.StoreGeneratedFixupSqliteFixture>
     {
         public StoreGeneratedFixupSqliteTest(StoreGeneratedFixupSqliteFixture fixture)
             : base(fixture)
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore
         protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
             => facade.UseTransaction(transaction.GetDbTransaction());
 
-        public class StoreGeneratedFixupSqliteFixture : StoreGeneratedFixupFixtureBase
+        public class StoreGeneratedFixupSqliteFixture : StoreGeneratedFixupRelationalFixtureBase
         {
             protected override ITestStoreFactory TestStoreFactory => SqliteTestStoreFactory.Instance;
         }

--- a/test/EFCore.Sqlite.FunctionalTests/UpdatesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/UpdatesSqliteTest.cs
@@ -1,5 +1,9 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.EntityFrameworkCore.TestModels.UpdatesModel;
+using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -8,6 +12,19 @@ namespace Microsoft.EntityFrameworkCore
         public UpdatesSqliteTest(UpdatesSqliteFixture fixture)
             : base(fixture)
         {
+        }
+
+        public override void Identifiers_are_generated_correctly()
+        {
+            using (var context = CreateContext())
+            {
+                var entityType = context.Model.FindEntityType(typeof(
+                    LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCorrectly));
+                Assert.Equal("LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCorrectly", entityType.Relational().TableName);
+                Assert.Equal("PK_LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCorrectly", entityType.GetKeys().Single().Relational().Name);
+                Assert.Equal("FK_LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCorrectly_Profile_ProfileId_ProfileId1_ProfileId3_ProfileId4_ProfileId5_ProfileId6_ProfileId7_ProfileId8_ProfileId9_ProfileId10_ProfileId11_ProfileId12_ProfileId13_ProfileId14", entityType.GetForeignKeys().Single().Relational().Name);
+                Assert.Equal("IX_LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCorrectly_ProfileId_ProfileId1_ProfileId3_ProfileId4_ProfileId5_ProfileId6_ProfileId7_ProfileId8_ProfileId9_ProfileId10_ProfileId11_ProfileId12_ProfileId13_ProfileId14", entityType.GetIndexes().Single().Relational().Name);
+            }
         }
     }
 }

--- a/test/EFCore.Sqlite.Tests/Metadata/Internal/SqliteInternalMetadataBuilderExtensionsTest.cs
+++ b/test/EFCore.Sqlite.Tests/Metadata/Internal/SqliteInternalMetadataBuilderExtensionsTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using Xunit;
 
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     public class SqliteInternalMetadataBuilderExtensionsTest
@@ -118,13 +119,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             entityTypeBuilder.Property("Id", typeof(int), ConfigurationSource.Convention);
             var relationshipBuilder = entityTypeBuilder.HasForeignKey("Splot", new[] { "Id" }, ConfigurationSource.Convention);
 
-            Assert.True(relationshipBuilder.Sqlite(ConfigurationSource.Convention).HasConstraintName("Splew"));
+            Assert.True(relationshipBuilder.Sqlite(ConfigurationSource.Convention).HasName("Splew"));
             Assert.Equal("Splew", relationshipBuilder.Metadata.Relational().Name);
 
-            Assert.True(relationshipBuilder.Sqlite(ConfigurationSource.DataAnnotation).HasConstraintName("Splow"));
+            Assert.True(relationshipBuilder.Sqlite(ConfigurationSource.DataAnnotation).HasName("Splow"));
             Assert.Equal("Splow", relationshipBuilder.Metadata.Relational().Name);
 
-            Assert.False(relationshipBuilder.Sqlite(ConfigurationSource.Convention).HasConstraintName("Splod"));
+            Assert.False(relationshipBuilder.Sqlite(ConfigurationSource.Convention).HasName("Splod"));
             Assert.Equal("Splow", relationshipBuilder.Metadata.Relational().Name);
 
             Assert.Equal(

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -132,9 +132,16 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         }
 
         protected virtual void VerifyError(string expectedMessage, IModel model)
-            => Assert.Equal(expectedMessage, Assert.Throws<InvalidOperationException>(() => Validate(model)).Message);
+        {
+            ((Model)model).Validate();
+            Assert.Equal(expectedMessage, Assert.Throws<InvalidOperationException>(() => Validate(model)).Message);
+        }
 
-        protected virtual void Validate(IModel model) => CreateModelValidator().Validate(model);
+        protected virtual void Validate(IModel model)
+        {
+            ((Model)model).Validate();
+            CreateModelValidator().Validate(model);
+        }
 
         protected virtual DiagnosticsLogger<DbLoggerCategory.Model.Validation> CreateLogger(bool sensitiveDataLoggingEnabled = false)
         {


### PR DESCRIPTION
Move identifier uniquification to conventions to make it deterministic.
Fix default decimal type mapping validation in SqlServer.

Fixes #9209
Fixes #10213
Fixes #10329