### PR TITLE
Add .editorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,193 @@
+# Schema: http://EditorConfig.org
+# Docs: https://docs.microsoft.com/en-us/visualstudio/ide/editorconfig-code-style-settings-reference
+
+# top-most EditorConfig file
+root = true
+
+# Don't use tabs for indentation.
+[*]
+indent_style = space
+trim_trailing_whitespace = true
+
+# Code files
+[*.{cs,csx,vb,vbx}]
+indent_size = 4
+insert_final_newline = true
+#charset = utf-8-bom
+
+# Xml project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct,xml,stylecop}]
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_size = 2
+
+# Shell scripts
+[*.sh]
+end_of_line = lf
+
+[*.{cmd,bat}]
+end_of_line = crlf
+
+## Language conventions
+# Dotnet code style settings:
+[*.{cs,vb}]
+# Avoid "this." and "Me." if not necessary
+dotnet_style_qualification_for_event = false : warning
+dotnet_style_qualification_for_field = false : warning
+dotnet_style_qualification_for_method = false : warning
+dotnet_style_qualification_for_property = false : warning
+
+# Use language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members = true : warning
+dotnet_style_predefined_type_for_member_access = true : warning
+
+# Expression-level preferences
+dotnet_style_coalesce_expression = true : warning
+dotnet_style_collection_initializer = true : warning
+dotnet_style_explicit_tuple_names = true : warning
+dotnet_style_null_propagation = true : warning
+dotnet_style_object_initializer = true : warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true : warning
+dotnet_style_require_accessibility_modifiers = always : warning
+
+# CSharp code style settings:
+[*.cs]
+# Prefer "var" everywhere (Implicit and explicit types)
+csharp_style_var_elsewhere = true : warning
+csharp_style_var_for_built_in_types = true : warning
+csharp_style_var_when_type_is_apparent = true : warning
+
+# Expression-Bodied members
+csharp_style_expression_bodied_accessors = true : warning
+csharp_style_expression_bodied_constructors = true : warning
+csharp_style_expression_bodied_indexers = true : warning
+csharp_style_expression_bodied_methods = true : warning
+csharp_style_expression_bodied_operators = true : warning
+csharp_style_expression_bodied_properties = true : warning
+
+# Pattern matching
+csharp_style_pattern_matching_over_as_with_null_check = true : warning
+csharp_style_pattern_matching_over_is_with_cast_check = true : warning
+
+# Inlined variable declarations
+csharp_style_inlined_variable_declaration = true : warning
+
+# Expression-level preferences
+csharp_prefer_inferred_anonymous_type_member_names = true : warning
+csharp_prefer_inferred_tuple_names = true : warning
+csharp_prefer_simple_default_expression = true : warning
+csharp_preferred_modifier_order = public,private,protected,internal,const,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
+csharp_style_deconstructed_variable_declaration = true : warning
+csharp_style_pattern_local_over_anonymous_function = true : warning
+
+# Null-checking preference
+csharp_style_conditional_delegate_call = true : warning
+csharp_style_throw_expression = true : warning
+
+# Code block preferences
+csharp_prefer_braces = true : warning
+
+## Formatting conventions
+# Dotnet formatting settings:
+[*.{cs,vb}]
+# Organize usings
+dotnet_sort_system_directives_first = true
+
+# CSharp formatting settings:
+[*.cs]
+# Newline options
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+
+# Identation options
+csharp_indent_case_contents = true
+csharp_indent_labels = no_change
+csharp_indent_switch_labels = true
+
+# Spacing options
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+
+# Wrapping options
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = false
+
+## Naming conventions
+[*.{cs,vb}]
+
+## Naming styles
+
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+dotnet_naming_style.camel_case_style.capitalization = camel_case
+
+# PascalCase with I prefix
+dotnet_naming_style.interface_style.capitalization = pascal_case
+dotnet_naming_style.interface_style.required_prefix = I
+
+# camelCase with _ prefix
+dotnet_naming_style._camelCase.capitalization = camel_case
+dotnet_naming_style._camelCase.required_prefix = _
+
+## Rules
+# Interfaces
+dotnet_naming_rule.interface_naming.symbols = interface_symbol
+dotnet_naming_rule.interface_naming.style = interface_style
+dotnet_naming_rule.interface_naming.severity = warning
+dotnet_naming_symbols.interface_symbol.applicable_kinds = interface
+dotnet_naming_symbols.interface_symbol.applicable_accessibilities = *
+
+# Classes, Structs, Enums, Properties, Methods, Events
+dotnet_naming_rule.class_naming.symbols = class_symbol
+dotnet_naming_rule.class_naming.style = pascal_case_style
+dotnet_naming_rule.class_naming.severity = warning
+
+dotnet_naming_symbols.class_symbol.applicable_kinds = class, struct, enum, property, method, event
+dotnet_naming_symbols.class_symbol.applicable_accessibilities = *
+
+# Const fields
+dotnet_naming_rule.const_field_naming.symbols = const_field_symbol
+dotnet_naming_rule.const_field_naming.style = pascal_case_style
+dotnet_naming_rule.const_field_naming.severity = warning
+
+dotnet_naming_symbols.const_field_symbol.applicable_kinds = field
+dotnet_naming_symbols.const_field_symbol.applicable_accessibilities = *
+dotnet_naming_symbols.const_field_symbol.required_modifiers = const
+
+# Public fields
+dotnet_naming_rule.public_field_naming.symbols = public_field_symbol
+dotnet_naming_rule.public_field_naming.style = pascal_case_style
+dotnet_naming_rule.public_field_naming.severity = warning
+
+dotnet_naming_symbols.public_field_symbol.applicable_kinds = field
+dotnet_naming_symbols.public_field_symbol.applicable_accessibilities = public
+
+# Other fields
+dotnet_naming_rule.other_field_naming.symbols = other_field_symbol
+dotnet_naming_rule.other_field_naming.style = _camelCase
+dotnet_naming_rule.other_field_naming.severity = warning
+
+dotnet_naming_symbols.other_field_symbol.applicable_kinds = field
+dotnet_naming_symbols.other_field_symbol.applicable_accessibilities = *
+
+# Everything Else
+dotnet_naming_rule.everything_else_naming.symbols = everything_else
+dotnet_naming_rule.everything_else_naming.style = camel_case_style
+dotnet_naming_rule.everything_else_naming.severity = warning
+
+dotnet_naming_symbols.everything_else.applicable_kinds = *
+dotnet_naming_symbols.everything_else.applicable_accessibilities = *

--- a/EFCore.Runtime.sln
+++ b/EFCore.Runtime.sln
@@ -48,6 +48,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EFCore.Design", "src\EFCore
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EFCore.Design.Tests", "test\EFCore.Design.Tests\EFCore.Design.Tests.csproj", "{7583E3F0-8B29-4BEA-A55E-E8B66E6FD508}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{F6F469BA-DCFA-4A88-958D-A4A91FCDF8B1}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/EFCore.sln
+++ b/EFCore.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.10
+VisualStudioVersion = 15.0.27110.0
 MinimumVisualStudioVersion = 15.0.26730.03
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EFCore", "src\EFCore\EFCore.csproj", "{715C38E9-B2F5-4DB2-8025-0C6492DEBDD4}"
 EndProject
@@ -78,6 +78,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OracleProvider", "samples\O
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B9E4CC99-199C-4E3B-9EC5-D1FDFCD6C27B}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
 	EndProjectSection


### PR DESCRIPTION
This introduce .editorConfig file for common options & specifically our naming style.
.editorConfig is supported by R# & VS both. It overrides user-defined settings.

part of #9911