### PR TITLE
Query: Process expression to lift properly in LiftOrderBy

### DIFF
--- a/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
@@ -441,11 +441,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
                         expression = nullableExpression.Operand;
                     }
 
-                    var expressionToAdd
-                        = expression.LiftExpressionFromSubquery(subquery)
-                          ?? subquery.Projection[subquery.AddToProjection(expression, resetProjectStar: false)].LiftExpressionFromSubquery(subquery);
+                    if (!(expression is ColumnExpression
+                        || expression is ColumnReferenceExpression
+                        || expression is AliasExpression))
+                    {
+                        expression = subquery.Projection[subquery.AddToProjection(expression, resetProjectStar: false)];
+                    }
 
-                    _orderBy.Add(new Ordering(expressionToAdd, ordering.OrderingDirection));
+                    _orderBy.Add(new Ordering(expression.LiftExpressionFromSubquery(subquery), ordering.OrderingDirection));
                 }
 
                 if (subquery.Limit == null

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -5,7 +5,7 @@
     <DeveloperBuildTestTfms>netcoreapp2.1</DeveloperBuildTestTfms>
     <StandardTestTfms>$(DeveloperBuildTestTfms)</StandardTestTfms>
     <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'True' ">netcoreapp2.1;netcoreapp2.0</StandardTestTfms>
-    <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'True' AND '$(CoreOnly)' != 'True' AND '$(OS)' == 'Windows_NT' ">$(StandardTestTfms);net461</StandardTestTfms>
+    <StandardTestTfms Condition=" '$(DeveloperBuild)' != 'True' AND '$(CoreOnly)' != 'True' AND '$(OS)' == 'Windows_NT' ">net461;$(StandardTestTfms)</StandardTestTfms>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/EFCore.SqlServer.FunctionalTests/EFCore.SqlServer.FunctionalTests.csproj
+++ b/test/EFCore.SqlServer.FunctionalTests/EFCore.SqlServer.FunctionalTests.csproj
@@ -31,7 +31,7 @@
     <ProjectReference Include="..\..\src\EFCore.Relational.Specification.Tests\EFCore.Relational.Specification.Tests.csproj" />
     <ProjectReference Include="..\..\src\EFCore.SqlServer\EFCore.SqlServer.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <Reference Include="System.Transactions" />
   </ItemGroup>


### PR DESCRIPTION
We used to rely on null check rather than properly checking for expression. This improves our logic when to add ordering expression to projection when lifting it from subquery
We started hitting this when we added Debug check in `LiftExpressionFromSubquery`

