### PR TITLE
Query: Perf: Reduce per-iteration allocations during query execution.

### DIFF
--- a/src/EFCore/Query/Internal/IQueryBuffer.cs
+++ b/src/EFCore/Query/Internal/IQueryBuffer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        void IncludeCollection<TEntity, TRelated>(
+        void IncludeCollection<TEntity, TRelated, TElement>(
             int includeId,
             [NotNull] INavigation navigation,
             [CanBeNull] INavigation inverseNavigation,
@@ -65,13 +65,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             bool tracking,
             [NotNull] TEntity instance,
             [NotNull] Func<IEnumerable<TRelated>> valuesFactory,
-            [CanBeNull] Func<TEntity, TRelated, bool> joinPredicate);
+            [CanBeNull] Func<TEntity, TRelated, bool> joinPredicate)
+            where TRelated : TElement;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        Task IncludeCollectionAsync<TEntity, TRelated>(
+        Task IncludeCollectionAsync<TEntity, TRelated, TElement>(
             int includeId,
             [NotNull] INavigation navigation,
             [CanBeNull] INavigation inverseNavigation,
@@ -82,6 +83,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             [NotNull] TEntity instance,
             [NotNull] Func<IAsyncEnumerable<TRelated>> valuesFactory,
             [CanBeNull] Func<TEntity, TRelated, bool> joinPredicate,
-            CancellationToken cancellationToken);
+            CancellationToken cancellationToken)
+            where TRelated : TElement;
     }
 }


### PR DESCRIPTION
- Prevent delegate creation in QueryingEnumerator.
- Create a single instance of ExecutionStrategy per query (instead of per iteration!)
- Remove allocation of temp list and enumerator during IncludeCollection.

Allocations reduced by ~17% during execution of single Include query return ~500K results.

