### PR TITLE
Use MSBuild to set NuGet feeds instead of NuGet.config

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 ﻿<Project>
   <Import Project="version.props" />
   <Import Project="build\dependencies.props" />
+  <Import Project="build\sources.props" />
 
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)build\Key.snk</AssemblyOriginatorKeyFile>

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,8 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="AspNetCore" value="https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json" />
-    <add key="AspNetCoreTools" value="https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json" />
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
+    <!-- Restore sources should be defined in build/sources.props. -->
   </packageSources>
 </configuration>

--- a/build/sources.props
+++ b/build/sources.props
@@ -1,0 +1,16 @@
+﻿<Project>
+  <Import Project="$(DotNetRestoreSourcePropsPath)" Condition="'$(DotNetRestoreSourcePropsPath)' != ''"/>
+
+  <PropertyGroup Label="RestoreSources">
+    <RestoreSources>$(DotNetRestoreSources)</RestoreSources>
+    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true' AND '$(AspNetUniverseBuildOffline)' != 'true' ">
+      $(RestoreSources);
+      https://dotnet.myget.org/F/aspnetcore-ci-dev/api/v3/index.json;
+      https://dotnet.myget.org/F/aspnetcore-tools/api/v3/index.json;
+    </RestoreSources>
+    <RestoreSources Condition="'$(DotNetBuildOffline)' != 'true'">
+      $(RestoreSources);
+      https://api.nuget.org/v3/index.json;
+    </RestoreSources>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Part of aspnet/Coherence-Signed#682

Required for orchestrated build. This pattern is already used in the release/2.0.0 build system.