### PR TITLE
Style: Remove enforcement of expression body on methods/constructor d…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -65,11 +65,12 @@ csharp_style_var_when_type_is_apparent = true : warning
 
 # Expression-Bodied members
 csharp_style_expression_bodied_accessors = true : warning
-csharp_style_expression_bodied_constructors = true : warning
 csharp_style_expression_bodied_indexers = true : warning
-csharp_style_expression_bodied_methods = true : warning
 csharp_style_expression_bodied_operators = true : warning
 csharp_style_expression_bodied_properties = true : warning
+# Explicitly disabled due to difference in coding style between source and tests
+#csharp_style_expression_bodied_constructors = true : warning
+#csharp_style_expression_bodied_methods = true : warning
 
 # Pattern matching
 csharp_style_pattern_matching_over_as_with_null_check = true : warning

--- a/benchmarks/.editorconfig
+++ b/benchmarks/.editorconfig
@@ -1,6 +1,0 @@
-# Benchmark specific rules
-# CSharp code style settings:
-[*.cs]
-# Expression-Bodied members
-csharp_style_expression_bodied_constructors = false : warning
-csharp_style_expression_bodied_methods = false : warning

--- a/src/EFCore.Relational.Specification.Tests/.editorconfig
+++ b/src/EFCore.Relational.Specification.Tests/.editorconfig
@@ -1,6 +1,0 @@
-# Benchmark specific rules
-# CSharp code style settings:
-[*.cs]
-# Expression-Bodied members
-csharp_style_expression_bodied_constructors = false : warning
-csharp_style_expression_bodied_methods = false : warning

--- a/src/EFCore.Specification.Tests/.editorconfig
+++ b/src/EFCore.Specification.Tests/.editorconfig
@@ -1,6 +1,0 @@
-# Benchmark specific rules
-# CSharp code style settings:
-[*.cs]
-# Expression-Bodied members
-csharp_style_expression_bodied_constructors = false : warning
-csharp_style_expression_bodied_methods = false : warning

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -1,6 +1,0 @@
-# Benchmark specific rules
-# CSharp code style settings:
-[*.cs]
-# Expression-Bodied members
-csharp_style_expression_bodied_constructors = false : warning
-csharp_style_expression_bodied_methods = false : warning


### PR DESCRIPTION
…ue to differences between source/test

Due to differences and a lot of code to be changed to enforce correctly, removed the enforcement allowing us to refactor whichever way it seems useful in the context.
