### PR TITLE
Query: Expand value list in InExpression before writing SQL

### DIFF
--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -993,8 +993,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             AssertQuery<Gear>(
                 gs => from g in gs
                       // ReSharper disable once ConstantNullCoalescingCondition
-                      // ReSharper disable once ConstantNullCoalescingCondition
-                      // ReSharper disable once ConstantNullCoalescingCondition
                       where (new { Name = g.LeaderNickname } ?? new { Name = g.FullName }) != null
                       select g.Nickname);
         }

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
@@ -1250,7 +1250,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void Where_compare_tuple_constructed_multi_value_equal()
         {
             AssertQuery<Customer>(
-                cs => cs.Where(c => new Tuple<string, string> (c.City, c.Country) == new Tuple<string, string>("London", "UK")));
+                cs => cs.Where(c => new Tuple<string, string>(c.City, c.Country) == new Tuple<string, string>("London", "UK")));
         }
 
         [ConditionalFact]

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -4083,5 +4083,21 @@ namespace Microsoft.EntityFrameworkCore.Query
                  .Take(5)
                  .Count());
         }
+
+        [ConditionalFact]
+        public virtual void OrderBy_empty_list_contains()
+        {
+            var list = new List<string>();
+            AssertQuery<Customer>(cs => cs.OrderBy(c => list.Contains(c.CustomerID)),
+                entryCount: 91);
+        }
+
+        [ConditionalFact]
+        public virtual void OrderBy_empty_list_does_not_contains()
+        {
+            var list = new List<string>();
+            AssertQuery<Customer>(cs => cs.OrderBy(c => !list.Contains(c.CustomerID)),
+                entryCount: 91);
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -668,7 +668,7 @@ INNER JOIN [Entities2] AS [e2] ON [e1].[NullableIntA] = [e2].[NullableIntB]");
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE ([e].[NullableStringA] IN (N'Foo') OR [e].[NullableStringA] IS NULL)");
+WHERE [e].[NullableStringA] IN (N'Foo') OR [e].[NullableStringA] IS NULL");
         }
 
         public override void Contains_with_local_array_closure_false_with_null()
@@ -688,7 +688,7 @@ WHERE [e].[NullableStringA] NOT IN (N'Foo') AND [e].[NullableStringA] IS NOT NUL
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE ([e].[NullableStringA] IN (N'Foo') OR [e].[NullableStringA] IS NULL)");
+WHERE [e].[NullableStringA] IN (N'Foo') OR [e].[NullableStringA] IS NULL");
         }
 
         public override void Where_multiple_ors_with_null()
@@ -718,7 +718,7 @@ WHERE [e].[NullableStringA] NOT IN (N'Foo', N'Blah') AND [e].[NullableStringA] I
             AssertSql(
                 @"SELECT [e].[Id]
 FROM [Entities1] AS [e]
-WHERE ([e].[NullableStringA] IN (N'Foo') OR [e].[NullableStringA] IS NULL)");
+WHERE [e].[NullableStringA] IN (N'Foo') OR [e].[NullableStringA] IS NULL");
         }
 
         public override void Where_multiple_ands_with_nullable_parameter_and_constant()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
@@ -866,8 +866,7 @@ WHERE 0 = 1");
 
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-WHERE 1 = 1");
+FROM [Customers] AS [c]");
         }
 
         public override void Contains_top_level()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -4354,6 +4354,26 @@ FROM (
 ) AS [t0]");
         }
 
+        public override void OrderBy_empty_list_contains()
+        {
+            base.OrderBy_empty_list_contains();
+
+            AssertSql(
+    @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY (SELECT 1)");
+        }
+
+        public override void OrderBy_empty_list_does_not_contains()
+        {
+            base.OrderBy_empty_list_does_not_contains();
+
+            AssertSql(
+    @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY (SELECT 1)");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Issue:
When the InExpression.Values is empty list, expression is always false. We used to expand values from parameters at time of generating SQL.
When OrderBy contains, the InExpression gets expanded to conditional for value type statement and later we find out that InExpression evaluates to false. But by then we have written incorrect SQL already.

Fix:
Pre-process and condense InExpression based on parameter values using a visitor. So that ORDER BY is away of final condensed form before writing SQL.

Also added small optimization
!(true) -> false & vice-versa.

Combined logic to generate InExpression into SQL in single method.
P.S. all Generate* method should be void.

First Part of #9951
