### PR TITLE
Query: Make InExpression.Equals null safe

### DIFF
--- a/src/EFCore.Relational/Query/Expressions/AliasExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/AliasExpression.cs
@@ -135,9 +135,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         }
 
         /// <summary>
-        ///     Creates a <see cref="String" /> representation of the Expression.
+        ///     Creates a <see cref="string" /> representation of the Expression.
         /// </summary>
-        /// <returns>A <see cref="String" /> representation of the Expression.</returns>
+        /// <returns>A <see cref="string" /> representation of the Expression.</returns>
         public override string ToString()
             => Alias != null ? "(" + _expression + ") AS " + Alias : _expression.ToString();
     }

--- a/src/EFCore.Relational/Query/Expressions/ColumnExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/ColumnExpression.cs
@@ -150,9 +150,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         }
 
         /// <summary>
-        ///     Creates a <see cref="String" /> representation of the Expression.
+        ///     Creates a <see cref="string" /> representation of the Expression.
         /// </summary>
-        /// <returns>A <see cref="String" /> representation of the Expression.</returns>
+        /// <returns>A <see cref="string" /> representation of the Expression.</returns>
         public override string ToString() => _tableExpression.Alias + "." + Name;
     }
 }

--- a/src/EFCore.Relational/Query/Expressions/ColumnReferenceExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/ColumnReferenceExpression.cs
@@ -172,9 +172,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         }
 
         /// <summary>
-        ///     Creates a <see cref="String" /> representation of the Expression.
+        ///     Creates a <see cref="string" /> representation of the Expression.
         /// </summary>
-        /// <returns>A <see cref="String" /> representation of the Expression.</returns>
+        /// <returns>A <see cref="string" /> representation of the Expression.</returns>
         public override string ToString() => _tableExpression.Alias + "." + Name;
     }
 }

--- a/src/EFCore.Relational/Query/Expressions/DiscriminatorPredicateExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/DiscriminatorPredicateExpression.cs
@@ -129,9 +129,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         }
 
         /// <summary>
-        ///     Creates a <see cref="String" /> representation of the Expression.
+        ///     Creates a <see cref="string" /> representation of the Expression.
         /// </summary>
-        /// <returns>A <see cref="String" /> representation of the Expression.</returns>
+        /// <returns>A <see cref="string" /> representation of the Expression.</returns>
         public override string ToString() => _predicate.ToString();
     }
 }

--- a/src/EFCore.Relational/Query/Expressions/ExplicitCastExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/ExplicitCastExpression.cs
@@ -125,9 +125,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         }
 
         /// <summary>
-        ///     Creates a <see cref="String" /> representation of the Expression.
+        ///     Creates a <see cref="string" /> representation of the Expression.
         /// </summary>
-        /// <returns>A <see cref="String" /> representation of the Expression.</returns>
+        /// <returns>A <see cref="string" /> representation of the Expression.</returns>
         public override string ToString() => "CAST(" + Operand + " AS " + _type.Name + ")";
     }
 }

--- a/src/EFCore.Relational/Query/Expressions/InExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/InExpression.cs
@@ -175,8 +175,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
 
         private bool Equals(InExpression other)
             => Operand.Equals(other.Operand)
-               && Values.SequenceEqual(other.Values)
-               && SubQuery.Equals(other.SubQuery);
+                && (Values == null
+                    ? other.Values == null
+                    : Values.SequenceEqual(other.Values))
+                && (SubQuery == null
+                    ? other.SubQuery == null
+                    : SubQuery.Equals(other.SubQuery));
 
         /// <summary>
         ///     Returns a hash code for this object.
@@ -198,9 +202,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         }
 
         /// <summary>
-        ///     Creates a <see cref="String" /> representation of the Expression.
+        ///     Creates a <see cref="string" /> representation of the Expression.
         /// </summary>
-        /// <returns>A <see cref="String" /> representation of the Expression.</returns>
+        /// <returns>A <see cref="string" /> representation of the Expression.</returns>
         public override string ToString()
             => Operand + " IN (" + (Values != null ? string.Join(", ", Values) : SubQuery.ToString()) + ")";
     }

--- a/src/EFCore.Relational/Query/Expressions/IsNullExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/IsNullExpression.cs
@@ -111,9 +111,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         public override int GetHashCode() => _operand.GetHashCode();
 
         /// <summary>
-        ///     Creates a <see cref="String" /> representation of the Expression.
+        ///     Creates a <see cref="string" /> representation of the Expression.
         /// </summary>
-        /// <returns>A <see cref="String" /> representation of the Expression.</returns>
+        /// <returns>A <see cref="string" /> representation of the Expression.</returns>
         public override string ToString() => $"{Operand} IS NULL"; // Interpolation okay; value is string.
     }
 }

--- a/src/EFCore.Specification.Tests/Query/IncludeTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/IncludeTestBase.cs
@@ -3811,6 +3811,146 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual void Include_collection_OrderBy_empty_list_contains(bool useString)
+        {
+            using (var context = CreateContext())
+            {
+                var list = new List<string>();
+                var customers
+                    = useString
+                        ? context.Customers
+                            .Include("Orders")
+                            .Where(c => c.CustomerID.StartsWith("A"))
+                            .OrderBy(c => list.Contains(c.CustomerID))
+                            .Skip(1)
+                            .ToList()
+                        : context.Customers
+                            .Include(c => c.Orders)
+                            .Where(c => c.CustomerID.StartsWith("A"))
+                            .OrderBy(c => list.Contains(c.CustomerID))
+                            .Skip(1)
+                            .ToList();
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual void Include_collection_OrderBy_empty_list_does_not_contains(bool useString)
+        {
+            using (var context = CreateContext())
+            {
+                var list = new List<string>();
+                var customers
+                    = useString
+                        ? context.Customers
+                            .Include("Orders")
+                            .Where(c => c.CustomerID.StartsWith("A"))
+                            .OrderBy(c => !list.Contains(c.CustomerID))
+                            .Skip(1)
+                            .ToList()
+                        : context.Customers
+                            .Include(c => c.Orders)
+                            .Where(c => c.CustomerID.StartsWith("A"))
+                            .OrderBy(c => !list.Contains(c.CustomerID))
+                            .Skip(1)
+                            .ToList();
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual void Include_collection_OrderBy_list_contains(bool useString)
+        {
+            using (var context = CreateContext())
+            {
+                var list = new List<string> { "ALFKI" };
+                var customers
+                    = useString
+                        ? context.Customers
+                            .Include("Orders")
+                            .Where(c => c.CustomerID.StartsWith("A"))
+                            .OrderBy(c => list.Contains(c.CustomerID))
+                            .Skip(1)
+                            .ToList()
+                        : context.Customers
+                            .Include(c => c.Orders)
+                            .Where(c => c.CustomerID.StartsWith("A"))
+                            .OrderBy(c => list.Contains(c.CustomerID))
+                            .Skip(1)
+                            .ToList();
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public virtual void Include_collection_OrderBy_list_does_not_contains(bool useString)
+        {
+            using (var context = CreateContext())
+            {
+                var list = new List<string> { "ALFKI" };
+                var customers
+                    = useString
+                        ? context.Customers
+                            .Include("Orders")
+                            .Where(c => c.CustomerID.StartsWith("A"))
+                            .OrderBy(c => !list.Contains(c.CustomerID))
+                            .Skip(1)
+                            .ToList()
+                        : context.Customers
+                            .Include(c => c.Orders)
+                            .Where(c => c.CustomerID.StartsWith("A"))
+                            .OrderBy(c => !list.Contains(c.CustomerID))
+                            .Skip(1)
+                            .ToList();
+
+                foreach (var customer in customers)
+                {
+                    CheckIsLoaded(
+                        context,
+                        customer,
+                        ordersLoaded: true,
+                        orderDetailsLoaded: false,
+                        productLoaded: false);
+                }
+            }
+        }
+
         private static void CheckIsLoaded(
             NorthwindContext context,
             Customer customer,

--- a/test/EFCore.SqlServer.FunctionalTests/Query/IncludeSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/IncludeSqlServerTest.cs
@@ -1475,6 +1475,126 @@ INNER JOIN (
 ORDER BY [t].[OrderID]");
         }
 
+        public override void Include_collection_OrderBy_empty_list_contains(bool useString)
+        {
+            base.Include_collection_OrderBy_empty_list_contains(useString);
+
+            AssertSql(
+    @"@__p_1='1'
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+ORDER BY (SELECT 1), [c].[CustomerID]
+OFFSET @__p_1 ROWS",
+    //
+    @"@__p_1='1'
+
+SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
+FROM [Orders] AS [c.Orders]
+INNER JOIN (
+    SELECT [c0].[CustomerID], 0 AS [c]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c0].[CustomerID], LEN(N'A')) = N'A')
+    ORDER BY [c], [c0].[CustomerID]
+    OFFSET @__p_1 ROWS
+) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
+ORDER BY [t].[c], [t].[CustomerID]");
+        }
+
+        public override void Include_collection_OrderBy_empty_list_does_not_contains(bool useString)
+        {
+            base.Include_collection_OrderBy_empty_list_does_not_contains(useString);
+
+            AssertSql(
+    @"@__p_1='1'
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+ORDER BY (SELECT 1), [c].[CustomerID]
+OFFSET @__p_1 ROWS",
+    //
+    @"@__p_1='1'
+
+SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
+FROM [Orders] AS [c.Orders]
+INNER JOIN (
+    SELECT [c0].[CustomerID], 1 AS [c]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c0].[CustomerID], LEN(N'A')) = N'A')
+    ORDER BY [c], [c0].[CustomerID]
+    OFFSET @__p_1 ROWS
+) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
+ORDER BY [t].[c], [t].[CustomerID]");
+        }
+
+        public override void Include_collection_OrderBy_list_contains(bool useString)
+        {
+            base.Include_collection_OrderBy_list_contains(useString);
+
+            AssertSql(
+    @"@__p_1='1'
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+ORDER BY CASE
+    WHEN [c].[CustomerID] IN (N'ALFKI')
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END, [c].[CustomerID]
+OFFSET @__p_1 ROWS",
+    //
+    @"@__p_1='1'
+
+SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
+FROM [Orders] AS [c.Orders]
+INNER JOIN (
+    SELECT [c0].[CustomerID], CASE
+        WHEN [c0].[CustomerID] IN (N'ALFKI')
+        THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+    END AS [c]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c0].[CustomerID], LEN(N'A')) = N'A')
+    ORDER BY [c], [c0].[CustomerID]
+    OFFSET @__p_1 ROWS
+) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
+ORDER BY [t].[c], [t].[CustomerID]");
+        }
+
+        public override void Include_collection_OrderBy_list_does_not_contains(bool useString)
+        {
+            base.Include_collection_OrderBy_list_does_not_contains(useString);
+
+            AssertSql(
+    @"@__p_1='1'
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')
+ORDER BY CASE
+    WHEN [c].[CustomerID] NOT IN (N'ALFKI')
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END, [c].[CustomerID]
+OFFSET @__p_1 ROWS",
+    //
+    @"@__p_1='1'
+
+SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
+FROM [Orders] AS [c.Orders]
+INNER JOIN (
+    SELECT [c0].[CustomerID], CASE
+        WHEN [c0].[CustomerID] NOT IN (N'ALFKI')
+        THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+    END AS [c]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c0].[CustomerID], LEN(N'A')) = N'A')
+    ORDER BY [c], [c0].[CustomerID]
+    OFFSET @__p_1 ROWS
+) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
+ORDER BY [t].[c], [t].[CustomerID]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
When there is InExpression in order by and used with collection include query, we threw NRE when trying to lift the order by in SelectExpression

Resolves #9951
