### PR TITLE
Small refactoring to RelationalTypeMapper to handle more metadata

### DIFF
--- a/samples/OracleProvider/src/OracleProvider/Metadata/Conventions/OracleConventionSetBuilder.cs
+++ b/samples/OracleProvider/src/OracleProvider/Metadata/Conventions/OracleConventionSetBuilder.cs
@@ -43,7 +43,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
         public static ConventionSet Build()
         {
-            var oracleTypeMapper = new OracleTypeMapper(new RelationalTypeMapperDependencies());
+            var oracleTypeMapper = new OracleTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies());
 
             return new OracleConventionSetBuilder(
                 new RelationalConventionSetBuilderDependencies(oracleTypeMapper, currentContext: null, setFinder: null))

--- a/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleTypeMapper.cs
+++ b/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleTypeMapper.cs
@@ -129,8 +129,10 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         private readonly Dictionary<Type, RelationalTypeMapping> _clrTypeMappings;
         private readonly HashSet<string> _disallowedMappings;
 
-        public OracleTypeMapper([NotNull] RelationalTypeMapperDependencies dependencies)
-            : base(dependencies)
+        public OracleTypeMapper(
+            [NotNull] CoreTypeMapperDependencies coreDependencies,
+            [NotNull] RelationalTypeMapperDependencies dependencies)
+            : base(coreDependencies, dependencies)
         {
             _storeTypeMappings
                 = new Dictionary<string, IList<RelationalTypeMapping>>(StringComparer.OrdinalIgnoreCase)

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
@@ -81,7 +81,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         /// </summary>
         public static ConventionSet Build()
         {
-            var sqlServerTypeMapper = new SqlServerTypeMapper(new RelationalTypeMapperDependencies());
+            var sqlServerTypeMapper = new SqlServerTypeMapper(
+                new CoreTypeMapperDependencies(), 
+                new RelationalTypeMapperDependencies());
 
             return new SqlServerConventionSetBuilder(
                     new RelationalConventionSetBuilderDependencies(sqlServerTypeMapper, null, null),

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMapper.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMapper.cs
@@ -178,8 +178,10 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public SqlServerTypeMapper([NotNull] RelationalTypeMapperDependencies dependencies)
-            : base(dependencies)
+        public SqlServerTypeMapper(
+            [NotNull] CoreTypeMapperDependencies coreDependencies,
+            [NotNull] RelationalTypeMapperDependencies dependencies)
+            : base(coreDependencies, dependencies)
         {
             _storeTypeMappings
                 = new Dictionary<string, IList<RelationalTypeMapping>>(StringComparer.OrdinalIgnoreCase)

--- a/src/EFCore.Sqlite.Core/Metadata/Conventions/SqliteConventionSetBuilder.cs
+++ b/src/EFCore.Sqlite.Core/Metadata/Conventions/SqliteConventionSetBuilder.cs
@@ -29,7 +29,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         /// </summary>
         public static ConventionSet Build()
         {
-            var relationalTypeMapper = new SqliteTypeMapper(new RelationalTypeMapperDependencies());
+            var relationalTypeMapper = new SqliteTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies());
 
             return new SqliteConventionSetBuilder(
                     new RelationalConventionSetBuilderDependencies(relationalTypeMapper, null, null))

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTypeMapper.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTypeMapper.cs
@@ -31,8 +31,10 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public SqliteTypeMapper([NotNull] RelationalTypeMapperDependencies dependencies)
-            : base(dependencies)
+        public SqliteTypeMapper(
+            [NotNull] CoreTypeMapperDependencies coreDependencies,
+            [NotNull] RelationalTypeMapperDependencies dependencies)
+            : base(coreDependencies, dependencies)
         {
             _storeTypeMappings
                 = new Dictionary<string, IList<RelationalTypeMapping>>(StringComparer.OrdinalIgnoreCase);

--- a/src/EFCore/Storage/CoreTypeMapper.cs
+++ b/src/EFCore/Storage/CoreTypeMapper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -34,6 +35,35 @@ namespace Microsoft.EntityFrameworkCore.Storage
             return type == typeof(string)
                    || type.GetTypeInfo().IsValueType
                    || type == typeof(byte[]);
+        }
+
+        /// <summary>
+        ///     Describes metadata needed to decide on a type mapping for a property or type.
+        /// </summary>
+        protected class TypeMappingInfo
+        {
+            /// <summary>
+            ///     Creates a new instance of <see cref="TypeMappingInfo" />.
+            /// </summary>
+            /// <param name="property"> The property for which mapping is needed. </param>
+            /// <param name="modelClrType"> The CLR type in the model for which mapping is needed. </param>
+            public TypeMappingInfo(
+                [CanBeNull] IProperty property = null,
+                [CanBeNull] Type modelClrType = null)
+            {
+                Property = property;
+                ModelClrType = modelClrType ?? property?.ClrType;
+            }
+
+            /// <summary>
+            ///     The property for which mapping is needed.
+            /// </summary>
+            public virtual IProperty Property { get; }
+
+            /// <summary>
+            ///     The CLR type in the model for which mapping is needed.
+            /// </summary>
+            public virtual Type ModelClrType { get; }
         }
     }
 }

--- a/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     new Model(),
                     migrationAssembly,
                     new MigrationsModelDiffer(
-                        new TestRelationalTypeMapper(new RelationalTypeMapperDependencies()),
+                        new TestRelationalTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()),
                         new MigrationsAnnotationProvider(new MigrationsAnnotationProviderDependencies()),
                         services.GetRequiredService<IChangeDetector>(),
                         services.GetRequiredService<StateManagerDependencies>(),

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -2189,6 +2189,8 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                         new LoggingOptions(),
                         new DiagnosticListener("Fake"))),
                 new RelationalModelValidatorDependencies(
-                    new SqlServerTypeMapper(new RelationalTypeMapperDependencies())));
+                    new SqlServerTypeMapper(
+                        new CoreTypeMapperDependencies(),
+                        new RelationalTypeMapperDependencies())));
     }
 }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ScaffoldingTypeMapperSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ScaffoldingTypeMapperSqlServerTest.cs
@@ -295,6 +295,8 @@ namespace Microsoft.EntityFrameworkCore
 
         private static ScaffoldingTypeMapper CreateMapper()
             => new ScaffoldingTypeMapper(
-                new SqlServerTypeMapper(new RelationalTypeMapperDependencies()));
+                new SqlServerTypeMapper(
+                    new CoreTypeMapperDependencies(),
+                    new RelationalTypeMapperDependencies()));
     }
 }

--- a/test/EFCore.Design.Tests/TestUtilities/FakeScaffoldingModelFactory.cs
+++ b/test/EFCore.Design.Tests/TestUtilities/FakeScaffoldingModelFactory.cs
@@ -67,7 +67,10 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 new CandidateNamingService(),
                 pluralizer,
                 new CSharpUtilities(),
-                new ScaffoldingTypeMapper(new SqlServerTypeMapper(new RelationalTypeMapperDependencies())))
+                new ScaffoldingTypeMapper(
+                    new SqlServerTypeMapper(
+                        new CoreTypeMapperDependencies(), 
+                        new RelationalTypeMapperDependencies())))
         {
         }
     }

--- a/test/EFCore.Relational.Tests/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConventionTest.cs
@@ -39,6 +39,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         }
 
         protected override PropertyMappingValidationConvention CreateConvention()
-            => new PropertyMappingValidationConvention(new TestRelationalTypeMapper(new RelationalTypeMapperDependencies()));
+            => new PropertyMappingValidationConvention(
+                new TestRelationalTypeMapper(
+                    new CoreTypeMapperDependencies(),
+                    new RelationalTypeMapperDependencies()));
     }
 }

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
@@ -87,16 +87,21 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
         protected virtual MigrationsModelDiffer CreateModelDiffer(DbContext ctx)
             => new MigrationsModelDiffer(
-                new ConcreteTypeMapper(new RelationalTypeMapperDependencies()),
-                new MigrationsAnnotationProvider(new MigrationsAnnotationProviderDependencies()),
+                new ConcreteTypeMapper(
+                    new CoreTypeMapperDependencies(),
+                    new RelationalTypeMapperDependencies()),
+                new MigrationsAnnotationProvider(
+                    new MigrationsAnnotationProviderDependencies()),
                 ctx.GetService<IChangeDetector>(),
                 ctx.GetService<StateManagerDependencies>(),
                 ctx.GetService<CommandBatchPreparerDependencies>());
 
         private class ConcreteTypeMapper : RelationalTypeMapper
         {
-            public ConcreteTypeMapper(RelationalTypeMapperDependencies dependencies)
-                : base(dependencies)
+            public ConcreteTypeMapper(
+                CoreTypeMapperDependencies coreDependencies,
+                RelationalTypeMapperDependencies dependencies)
+                : base(coreDependencies, dependencies)
             {
             }
 

--- a/test/EFCore.Relational.Tests/Migrations/MigrationCommandListBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/MigrationCommandListBuilderTest.cs
@@ -120,6 +120,8 @@ Statement3
             => new MigrationCommandListBuilder(
                 new RelationalCommandBuilderFactory(
                     new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
-                    new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies())));
+                    new FakeRelationalTypeMapper(
+                        new CoreTypeMapperDependencies(),
+                        new RelationalTypeMapperDependencies())));
     }
 }

--- a/test/EFCore.Relational.Tests/RelationalModelValidatorTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalModelValidatorTest.cs
@@ -797,7 +797,9 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         private static void GenerateMapping(IMutableProperty property)
-            => property[CoreAnnotationNames.TypeMapping] = new TestRelationalTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(property);
+            => property[CoreAnnotationNames.TypeMapping] = new TestRelationalTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies()).GetMapping(property);
 
         protected override void SetBaseType(EntityType entityType, EntityType baseEntityType)
         {
@@ -859,6 +861,7 @@ namespace Microsoft.EntityFrameworkCore
                         new DiagnosticListener("Fake"))),
                 new RelationalModelValidatorDependencies(
                     new TestRelationalTypeMapper(
+                        new CoreTypeMapperDependencies(),
                         new RelationalTypeMapperDependencies())));
 
         protected virtual ConventionSet CreateConventionSet() => TestRelationalConventionSetBuilder.Build();

--- a/test/EFCore.Relational.Tests/Storage/RawSqlCommandBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RawSqlCommandBuilderTest.cs
@@ -16,7 +16,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var builder = new RawSqlCommandBuilder(
                 new RelationalCommandBuilderFactory(
                     new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
-                    new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies())),
+                    new FakeRelationalTypeMapper(
+                        new CoreTypeMapperDependencies(),
+                        new RelationalTypeMapperDependencies())),
                 new RelationalSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
                 new ParameterNameGeneratorFactory(new ParameterNameGeneratorDependencies()));
 
@@ -32,7 +34,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var builder = new RawSqlCommandBuilder(
                 new RelationalCommandBuilderFactory(
                     new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
-                    new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies())),
+                    new FakeRelationalTypeMapper(
+                        new CoreTypeMapperDependencies(),
+                        new RelationalTypeMapperDependencies())),
                 new RelationalSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
                 new ParameterNameGeneratorFactory(new ParameterNameGeneratorDependencies()));
 
@@ -49,7 +53,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var builder = new RawSqlCommandBuilder(
                 new RelationalCommandBuilderFactory(
                     new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
-                    new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies())),
+                    new FakeRelationalTypeMapper(
+                        new CoreTypeMapperDependencies(),
+                        new RelationalTypeMapperDependencies())),
                 new RelationalSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
                 new ParameterNameGeneratorFactory(new ParameterNameGeneratorDependencies()));
 

--- a/test/EFCore.Relational.Tests/Storage/RelationalCommandBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalCommandBuilderTest.cs
@@ -15,7 +15,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             var commandBuilder = new RelationalCommandBuilder(
                 new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
-                new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies()));
+                new FakeRelationalTypeMapper(
+                    new CoreTypeMapperDependencies(),
+                    new RelationalTypeMapperDependencies()));
 
             var command = commandBuilder.Build();
 
@@ -28,7 +30,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             var commandBuilder = new RelationalCommandBuilder(
                 new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
-                new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies()));
+                new FakeRelationalTypeMapper(
+                    new CoreTypeMapperDependencies(),
+                    new RelationalTypeMapperDependencies()));
 
             commandBuilder.ParameterBuilder.AddParameter(
                 "InvariantName",

--- a/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
@@ -540,7 +540,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             var fakeConnection = CreateConnection();
 
-            var typeMapper = new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies());
+            var typeMapper = new FakeRelationalTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies());
 
             var dbParameter = new FakeDbParameter { ParameterName = "FirstParameter", Value = 17, DbType = DbType.Int32 };
 

--- a/test/EFCore.Relational.Tests/Storage/RelationalParameterBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalParameterBuilderTest.cs
@@ -14,7 +14,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [Fact]
         public void Can_add_dynamic_parameter()
         {
-            var typeMapper = new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies());
+            var typeMapper = new FakeRelationalTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies());
 
             var parameterBuilder = new RelationalParameterBuilder(typeMapper);
 
@@ -36,7 +38,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [InlineData(false)]
         public void Can_add_type_mapped_parameter_by_type(bool nullable)
         {
-            var typeMapper = new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies());
+            var typeMapper = new FakeRelationalTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies());
             var typeMapping = typeMapper.GetMapping(nullable ? typeof(int?) : typeof(int));
             var parameterBuilder = new RelationalParameterBuilder(typeMapper);
 
@@ -62,7 +66,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [InlineData(false)]
         public void Can_add_type_mapped_parameter_by_property(bool nullable)
         {
-            var typeMapper = new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies());
+            var typeMapper = new FakeRelationalTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies());
 
             var property = new Model().AddEntityType("MyType").AddProperty("MyProp", typeof(string));
             property.IsNullable = nullable;
@@ -89,7 +95,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [Fact]
         public void Can_add_composite_parameter()
         {
-            var typeMapper = new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies());
+            var typeMapper = new FakeRelationalTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies());
 
             var parameterBuilder = new RelationalParameterBuilder(typeMapper);
 
@@ -122,7 +130,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [Fact]
         public void Does_not_add_empty_composite_parameter()
         {
-            var typeMapper = new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies());
+            var typeMapper = new FakeRelationalTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies());
 
             var parameterBuilder = new RelationalParameterBuilder(typeMapper);
 

--- a/test/EFCore.Relational.Tests/Storage/RelationalTypeMapperTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalTypeMapperTest.cs
@@ -79,7 +79,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 property.SetMaxLength(maxLength);
             }
 
-            return new TestRelationalTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(property);
+            return new TestRelationalTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies()).GetMapping(property);
         }
 
         [Fact]
@@ -123,14 +125,18 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var property = CreateEntityType().AddProperty("MyProp", propertyType);
             property.Relational().ColumnType = typeName;
 
-            return new TestRelationalTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(property);
+            return new TestRelationalTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies()).GetMapping(property);
         }
 
         [Fact]
         public void Key_with_store_type_is_picked_up_by_FK()
         {
             var model = CreateModel();
-            var mapper = new TestRelationalTypeMapper(new RelationalTypeMapperDependencies());
+            var mapper = new TestRelationalTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies());
 
             Assert.Equal(
                 "money",
@@ -145,7 +151,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void String_key_with_max_length_is_picked_up_by_FK()
         {
             var model = CreateModel();
-            var mapper = new TestRelationalTypeMapper(new RelationalTypeMapperDependencies());
+            var mapper = new TestRelationalTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies());
 
             Assert.Equal(
                 "just_string(200)",
@@ -160,7 +168,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void Binary_key_with_max_length_is_picked_up_by_FK()
         {
             var model = CreateModel();
-            var mapper = new TestRelationalTypeMapper(new RelationalTypeMapperDependencies());
+            var mapper = new TestRelationalTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies());
 
             Assert.Equal(
                 "just_binary(100)",
@@ -175,7 +185,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void String_key_with_unicode_is_picked_up_by_FK()
         {
             var model = CreateModel();
-            var mapper = new TestRelationalTypeMapper(new RelationalTypeMapperDependencies());
+            var mapper = new TestRelationalTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies());
 
             Assert.Equal(
                 "ansi_string(900)",
@@ -190,7 +202,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void Key_store_type_if_preferred_if_specified()
         {
             var model = CreateModel();
-            var mapper = new TestRelationalTypeMapper(new RelationalTypeMapperDependencies());
+            var mapper = new TestRelationalTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies());
 
             Assert.Equal(
                 "money",
@@ -205,7 +219,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void String_FK_max_length_is_preferred_if_specified()
         {
             var model = CreateModel();
-            var mapper = new TestRelationalTypeMapper(new RelationalTypeMapperDependencies());
+            var mapper = new TestRelationalTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies());
 
             Assert.Equal(
                 "just_string(200)",
@@ -220,7 +236,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void Binary_FK_max_length_is_preferred_if_specified()
         {
             var model = CreateModel();
-            var mapper = new TestRelationalTypeMapper(new RelationalTypeMapperDependencies());
+            var mapper = new TestRelationalTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies());
 
             Assert.Equal(
                 "just_binary(100)",
@@ -235,7 +253,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void String_FK_unicode_is_preferred_if_specified()
         {
             var model = CreateModel();
-            var mapper = new TestRelationalTypeMapper(new RelationalTypeMapperDependencies());
+            var mapper = new TestRelationalTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies());
 
             Assert.Equal(
                 "ansi_string(900)",

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalTypeMapper.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalTypeMapper.cs
@@ -14,8 +14,10 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
         private static readonly RelationalTypeMapping _long = new LongTypeMapping("DefaultLong", DbType.Int64);
         private static readonly RelationalTypeMapping _string = new StringTypeMapping("DefaultString", DbType.String);
 
-        public FakeRelationalTypeMapper(RelationalTypeMapperDependencies dependencies)
-            : base(dependencies)
+        public FakeRelationalTypeMapper(
+            CoreTypeMapperDependencies coreDependencies,
+            RelationalTypeMapperDependencies dependencies)
+            : base(coreDependencies, dependencies)
         {
         }
 

--- a/test/EFCore.Relational.Tests/TestUtilities/TestRelationalConventionSetBuilder.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/TestRelationalConventionSetBuilder.cs
@@ -18,6 +18,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             => new TestRelationalConventionSetBuilder(
                     new RelationalConventionSetBuilderDependencies(
                         new TestRelationalTypeMapper(
+                            new CoreTypeMapperDependencies(),
                             new RelationalTypeMapperDependencies()), null, null))
                 .AddConventions(
                     new CoreConventionSetBuilder(

--- a/test/EFCore.Relational.Tests/TestUtilities/TestRelationalTypeMapper.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/TestRelationalTypeMapper.cs
@@ -58,8 +58,10 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         private static readonly RelationalTypeMapping _defaultTimeSpanMapping
             = new TimeSpanTypeMapping("default_timespan_mapping");
 
-        public TestRelationalTypeMapper(RelationalTypeMapperDependencies dependencies)
-            : base(dependencies)
+        public TestRelationalTypeMapper(
+            CoreTypeMapperDependencies coreDependencies,
+            RelationalTypeMapperDependencies dependencies)
+            : base(coreDependencies, dependencies)
         {
         }
 

--- a/test/EFCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/EFCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -514,7 +514,9 @@ namespace Microsoft.EntityFrameworkCore.Update
         }
 
         private static void GenerateMapping(IMutableProperty property)
-            => property[CoreAnnotationNames.TypeMapping] = new TestRelationalTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(property);
+            => property[CoreAnnotationNames.TypeMapping] = new TestRelationalTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies()).GetMapping(property);
 
         private static InternalEntityEntry CreateEntry(
             EntityState entityState,
@@ -541,13 +543,17 @@ namespace Microsoft.EntityFrameworkCore.Update
                 : base(
                     new RelationalCommandBuilderFactory(
                         new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
-                        new FakeRelationalTypeMapper(new RelationalTypeMapperDependencies())),
-                    new RelationalSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
+                        new FakeRelationalTypeMapper(
+                            new CoreTypeMapperDependencies(),
+                            new RelationalTypeMapperDependencies())),
+                    new RelationalSqlGenerationHelper(
+                        new RelationalSqlGenerationHelperDependencies()),
                     sqlGenerator ?? new FakeSqlGenerator(
                         RelationalTestHelpers.Instance.CreateContextServices().GetRequiredService<UpdateSqlGeneratorDependencies>()),
                     new TypedRelationalValueBufferFactoryFactory(
                         new RelationalValueBufferFactoryDependencies(
                             new FakeRelationalTypeMapper(
+                                new CoreTypeMapperDependencies(),
                                 new RelationalTypeMapperDependencies()))))
             {
                 ShouldAddCommand = true;

--- a/test/EFCore.Relational.Tests/Update/UpdateSqlGeneratorTest.cs
+++ b/test/EFCore.Relational.Tests/Update/UpdateSqlGeneratorTest.cs
@@ -15,6 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                     new RelationalSqlGenerationHelper(
                         new RelationalSqlGenerationHelperDependencies()),
                     new FakeRelationalTypeMapper(
+                        new CoreTypeMapperDependencies(),
                         new RelationalTypeMapperDependencies())));
 
         protected override TestHelpers TestHelpers => RelationalTestHelpers.Instance;

--- a/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
@@ -82,7 +82,7 @@ namespace Microsoft.EntityFrameworkCore
             var modelBuilder = base.Key_and_MaxLength_64_produce_nvarchar_64();
 
             var property = GetProperty<ColumnKeyAnnotationClass2>(modelBuilder, "PersonFirstName");
-            Assert.Equal("nvarchar(64)", new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).FindMapping(property).StoreType);
+            Assert.Equal("nvarchar(64)", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).FindMapping(property).StoreType);
 
             return modelBuilder;
         }
@@ -92,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore
             var modelBuilder = base.Timestamp_takes_precedence_over_MaxLength();
 
             var property = GetProperty<TimestampAndMaxlen>(modelBuilder, "MaxTimestamp");
-            Assert.Equal("rowversion", new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).FindMapping(property).StoreType);
+            Assert.Equal("rowversion", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).FindMapping(property).StoreType);
 
             return modelBuilder;
         }
@@ -102,7 +102,7 @@ namespace Microsoft.EntityFrameworkCore
             var modelBuilder = base.Timestamp_takes_precedence_over_MaxLength_with_value();
 
             var property = GetProperty<TimestampAndMaxlen>(modelBuilder, "NonMaxTimestamp");
-            Assert.Equal("rowversion", new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).FindMapping(property).StoreType);
+            Assert.Equal("rowversion", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).FindMapping(property).StoreType);
 
             return modelBuilder;
         }

--- a/test/EFCore.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
+++ b/test/EFCore.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
@@ -457,8 +457,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
         protected override MigrationsModelDiffer CreateModelDiffer(DbContext ctx)
             => new MigrationsModelDiffer(
-                new SqlServerTypeMapper(new RelationalTypeMapperDependencies()),
-                new SqlServerMigrationsAnnotationProvider(new MigrationsAnnotationProviderDependencies()),
+                new SqlServerTypeMapper(
+                    new CoreTypeMapperDependencies(),
+                    new RelationalTypeMapperDependencies()),
+                new SqlServerMigrationsAnnotationProvider(
+                    new MigrationsAnnotationProviderDependencies()),
                 ctx.GetService<IChangeDetector>(),
                 ctx.GetService<StateManagerDependencies>(),
                 ctx.GetService<CommandBatchPreparerDependencies>());

--- a/test/EFCore.SqlServer.Tests/SqlServerModelValidatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerModelValidatorTest.cs
@@ -252,7 +252,9 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         private static void GenerateMapping(IMutableProperty property)
-            => property[CoreAnnotationNames.TypeMapping] = new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(property);
+            => property[CoreAnnotationNames.TypeMapping] = new SqlServerTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies()).GetMapping(property);
 
         private class Cheese
         {
@@ -269,6 +271,8 @@ namespace Microsoft.EntityFrameworkCore
                         new LoggingOptions(),
                         new DiagnosticListener("Fake"))),
                 new RelationalModelValidatorDependencies(
-                    new SqlServerTypeMapper(new RelationalTypeMapperDependencies())));
+                    new SqlServerTypeMapper(
+                        new CoreTypeMapperDependencies(),
+                        new RelationalTypeMapperDependencies())));
     }
 }

--- a/test/EFCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
@@ -77,6 +77,7 @@ namespace Microsoft.EntityFrameworkCore
                         new SqlServerSqlGenerationHelper(
                             new RelationalSqlGenerationHelperDependencies()),
                         new SqlServerTypeMapper(
+                            new CoreTypeMapperDependencies(),
                             new RelationalTypeMapperDependencies()))),
                 state,
                 CreateConnection());
@@ -129,6 +130,7 @@ namespace Microsoft.EntityFrameworkCore
                     new SqlServerSqlGenerationHelper(
                         new RelationalSqlGenerationHelperDependencies()),
                     new SqlServerTypeMapper(
+                        new CoreTypeMapperDependencies(),
                         new RelationalTypeMapperDependencies())));
 
             var tests = new Func<Task>[threadCount];
@@ -177,6 +179,7 @@ namespace Microsoft.EntityFrameworkCore
                         new SqlServerSqlGenerationHelper(
                             new RelationalSqlGenerationHelperDependencies()),
                         new SqlServerTypeMapper(
+                            new CoreTypeMapperDependencies(),
                             new RelationalTypeMapperDependencies()))),
                 state,
                 CreateConnection());

--- a/test/EFCore.SqlServer.Tests/SqlServerTypeMapperTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerTypeMapperTest.cs
@@ -204,7 +204,9 @@ namespace Microsoft.EntityFrameworkCore
             property.IsUnicode(unicode);
             property.DeclaringEntityType.SetPrimaryKey(property);
 
-            var typeMapping = new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(property);
+            var typeMapping = new SqlServerTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies()).GetMapping(property);
 
             Assert.Null(typeMapping.DbType);
             Assert.Equal("nvarchar(450)", typeMapping.StoreType);
@@ -225,7 +227,9 @@ namespace Microsoft.EntityFrameworkCore
             var pk = property.DeclaringEntityType.SetPrimaryKey(property);
             property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
 
-            var typeMapping = new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(fkProperty);
+            var typeMapping = new SqlServerTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies()).GetMapping(fkProperty);
 
             Assert.Null(typeMapping.DbType);
             Assert.Equal("nvarchar(450)", typeMapping.StoreType);
@@ -247,7 +251,9 @@ namespace Microsoft.EntityFrameworkCore
             property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
             fkProperty.IsNullable = false;
 
-            var typeMapping = new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(fkProperty);
+            var typeMapping = new SqlServerTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies()).GetMapping(fkProperty);
 
             Assert.Null(typeMapping.DbType);
             Assert.Equal("nvarchar(450)", typeMapping.StoreType);
@@ -266,7 +272,9 @@ namespace Microsoft.EntityFrameworkCore
             property.IsUnicode(unicode);
             entityType.AddIndex(property);
 
-            var typeMapping = new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(property);
+            var typeMapping = new SqlServerTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies()).GetMapping(property);
 
             Assert.Null(typeMapping.DbType);
             Assert.Equal("nvarchar(450)", typeMapping.StoreType);
@@ -343,7 +351,9 @@ namespace Microsoft.EntityFrameworkCore
             property.IsUnicode(false);
             property.DeclaringEntityType.SetPrimaryKey(property);
 
-            var typeMapping = new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(property);
+            var typeMapping = new SqlServerTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies()).GetMapping(property);
 
             Assert.Equal(DbType.AnsiString, typeMapping.DbType);
             Assert.Equal("varchar(900)", typeMapping.StoreType);
@@ -362,7 +372,9 @@ namespace Microsoft.EntityFrameworkCore
             var pk = property.DeclaringEntityType.SetPrimaryKey(property);
             property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
 
-            var typeMapping = new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(fkProperty);
+            var typeMapping = new SqlServerTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies()).GetMapping(fkProperty);
 
             Assert.Equal(DbType.AnsiString, typeMapping.DbType);
             Assert.Equal("varchar(900)", typeMapping.StoreType);
@@ -382,7 +394,9 @@ namespace Microsoft.EntityFrameworkCore
             property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
             fkProperty.IsNullable = false;
 
-            var typeMapping = new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(fkProperty);
+            var typeMapping = new SqlServerTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies()).GetMapping(fkProperty);
 
             Assert.Equal(DbType.AnsiString, typeMapping.DbType);
             Assert.Equal("varchar(900)", typeMapping.StoreType);
@@ -399,7 +413,9 @@ namespace Microsoft.EntityFrameworkCore
             property.IsUnicode(false);
             entityType.AddIndex(property);
 
-            var typeMapping = new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(property);
+            var typeMapping = new SqlServerTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies()).GetMapping(property);
 
             Assert.Equal(DbType.AnsiString, typeMapping.DbType);
             Assert.Equal("varchar(900)", typeMapping.StoreType);
@@ -469,7 +485,9 @@ namespace Microsoft.EntityFrameworkCore
             var property = CreateEntityType().AddProperty("MyBinaryProp", typeof(byte[]));
             property.Relational().ColumnType = "binary(100)";
 
-            var typeMapping = new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(property);
+            var typeMapping = new SqlServerTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies()).GetMapping(property);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("binary(100)", typeMapping.StoreType);
@@ -482,7 +500,9 @@ namespace Microsoft.EntityFrameworkCore
             property.IsNullable = false;
             property.DeclaringEntityType.SetPrimaryKey(property);
 
-            var typeMapping = new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(property);
+            var typeMapping = new SqlServerTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies()).GetMapping(property);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("varbinary(900)", typeMapping.StoreType);
@@ -498,7 +518,9 @@ namespace Microsoft.EntityFrameworkCore
             var pk = property.DeclaringEntityType.SetPrimaryKey(property);
             property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
 
-            var typeMapping = new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(fkProperty);
+            var typeMapping = new SqlServerTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies()).GetMapping(fkProperty);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("varbinary(900)", typeMapping.StoreType);
@@ -515,7 +537,9 @@ namespace Microsoft.EntityFrameworkCore
             property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
             fkProperty.IsNullable = false;
 
-            var typeMapping = new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(fkProperty);
+            var typeMapping = new SqlServerTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies()).GetMapping(fkProperty);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("varbinary(900)", typeMapping.StoreType);
@@ -529,7 +553,9 @@ namespace Microsoft.EntityFrameworkCore
             var property = entityType.AddProperty("MyProp", typeof(byte[]));
             entityType.AddIndex(property);
 
-            var typeMapping = new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(property);
+            var typeMapping = new SqlServerTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies()).GetMapping(property);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("varbinary(900)", typeMapping.StoreType);
@@ -543,7 +569,9 @@ namespace Microsoft.EntityFrameworkCore
             property.IsConcurrencyToken = true;
             property.ValueGenerated = ValueGenerated.OnAddOrUpdate;
 
-            var typeMapping = new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(property);
+            var typeMapping = new SqlServerTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies()).GetMapping(property);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("rowversion", typeMapping.StoreType);
@@ -559,7 +587,9 @@ namespace Microsoft.EntityFrameworkCore
             property.ValueGenerated = ValueGenerated.OnAddOrUpdate;
             property.IsNullable = false;
 
-            var typeMapping = new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(property);
+            var typeMapping = new SqlServerTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies()).GetMapping(property);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("rowversion", typeMapping.StoreType);
@@ -573,7 +603,9 @@ namespace Microsoft.EntityFrameworkCore
             var property = CreateEntityType().AddProperty("MyProp", typeof(byte[]));
             property.IsConcurrencyToken = true;
 
-            var typeMapping = new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(property);
+            var typeMapping = new SqlServerTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies()).GetMapping(property);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("varbinary(max)", typeMapping.StoreType);
@@ -602,45 +634,51 @@ namespace Microsoft.EntityFrameworkCore
                 property.IsUnicode(unicode);
             }
 
-            return new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(property);
+            return new SqlServerTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies()).GetMapping(property);
         }
 
         [Fact]
         public void Does_default_mappings_for_sequence_types()
         {
-            Assert.Equal("int", new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(typeof(int)).StoreType);
-            Assert.Equal("smallint", new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(typeof(short)).StoreType);
-            Assert.Equal("bigint", new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(typeof(long)).StoreType);
-            Assert.Equal("tinyint", new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(typeof(byte)).StoreType);
+            Assert.Equal("int", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMapping(typeof(int)).StoreType);
+            Assert.Equal("smallint", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMapping(typeof(short)).StoreType);
+            Assert.Equal("bigint", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMapping(typeof(long)).StoreType);
+            Assert.Equal("tinyint", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMapping(typeof(byte)).StoreType);
         }
 
         [Fact]
         public void Does_default_mappings_for_strings_and_byte_arrays()
         {
-            Assert.Equal("nvarchar(max)", new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(typeof(string)).StoreType);
-            Assert.Equal("varbinary(max)", new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(typeof(byte[])).StoreType);
+            Assert.Equal("nvarchar(max)", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMapping(typeof(string)).StoreType);
+            Assert.Equal("varbinary(max)", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMapping(typeof(byte[])).StoreType);
         }
 
         [Fact]
         public void Does_default_mappings_for_values()
         {
-            Assert.Equal("nvarchar(max)", new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMappingForValue("Cheese").StoreType);
-            Assert.Equal("varbinary(max)", new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMappingForValue(new byte[1]).StoreType);
-            Assert.Equal("datetime2", new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMappingForValue(new DateTime()).StoreType);
+            Assert.Equal("nvarchar(max)", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMappingForValue("Cheese").StoreType);
+            Assert.Equal("varbinary(max)", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMappingForValue(new byte[1]).StoreType);
+            Assert.Equal("datetime2", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMappingForValue(new DateTime()).StoreType);
         }
 
         [Fact]
         public void Does_default_mappings_for_null_values()
         {
-            Assert.Equal("NULL", new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMappingForValue(null).StoreType);
-            Assert.Equal("NULL", new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMappingForValue(DBNull.Value).StoreType);
+            Assert.Equal("NULL", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMappingForValue(null).StoreType);
+            Assert.Equal("NULL", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMappingForValue(DBNull.Value).StoreType);
             Assert.Equal("NULL", RelationalTypeMapperExtensions.GetMappingForValue(null, "Itz").StoreType);
         }
 
         [Fact]
         public void Throws_for_unrecognized_types()
         {
-            var ex = Assert.Throws<InvalidOperationException>(() => new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping("magic"));
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => new SqlServerTypeMapper(
+                    new CoreTypeMapperDependencies(),
+                    new RelationalTypeMapperDependencies()).GetMapping("magic"));
+
             Assert.Equal(RelationalStrings.UnsupportedType("magic"), ex.Message);
         }
 
@@ -648,7 +686,11 @@ namespace Microsoft.EntityFrameworkCore
         public void Throws_for_unrecognized_property_types()
         {
             var property = new Model().AddEntityType("Entity1").AddProperty("Strange", typeof(object));
-            var ex = Assert.Throws<InvalidOperationException>(() => new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(property));
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => new SqlServerTypeMapper(
+                    new CoreTypeMapperDependencies(),
+                    new RelationalTypeMapperDependencies()).GetMapping(property));
+
             Assert.Equal(RelationalStrings.UnsupportedPropertyType("Entity1", "Strange", "object"), ex.Message);
         }
 
@@ -717,7 +759,7 @@ namespace Microsoft.EntityFrameworkCore
         [InlineData("VARCHAR", typeof(string), null, false)]
         public void Can_map_by_type_name(string typeName, Type clrType, int? size, bool unicode)
         {
-            var mapping = new SqlServerTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(typeName);
+            var mapping = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMapping(typeName);
 
             Assert.Equal(clrType, mapping.ClrType);
             Assert.Equal(size, mapping.Size);
@@ -729,7 +771,7 @@ namespace Microsoft.EntityFrameworkCore
         public void Key_with_store_type_is_picked_up_by_FK()
         {
             var model = CreateModel();
-            var mapper = new SqlServerTypeMapper(new RelationalTypeMapperDependencies());
+            var mapper = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies());
 
             Assert.Equal(
                 "money",
@@ -744,7 +786,7 @@ namespace Microsoft.EntityFrameworkCore
         public void String_key_with_max_length_is_picked_up_by_FK()
         {
             var model = CreateModel();
-            var mapper = new SqlServerTypeMapper(new RelationalTypeMapperDependencies());
+            var mapper = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies());
 
             Assert.Equal(
                 "nvarchar(200)",
@@ -759,7 +801,7 @@ namespace Microsoft.EntityFrameworkCore
         public void Binary_key_with_max_length_is_picked_up_by_FK()
         {
             var model = CreateModel();
-            var mapper = new SqlServerTypeMapper(new RelationalTypeMapperDependencies());
+            var mapper = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies());
 
             Assert.Equal(
                 "varbinary(100)",
@@ -774,7 +816,7 @@ namespace Microsoft.EntityFrameworkCore
         public void String_key_with_unicode_is_picked_up_by_FK()
         {
             var model = CreateModel();
-            var mapper = new SqlServerTypeMapper(new RelationalTypeMapperDependencies());
+            var mapper = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies());
 
             Assert.Equal(
                 "varchar(900)",
@@ -789,7 +831,7 @@ namespace Microsoft.EntityFrameworkCore
         public void Key_store_type_if_preferred_if_specified()
         {
             var model = CreateModel();
-            var mapper = new SqlServerTypeMapper(new RelationalTypeMapperDependencies());
+            var mapper = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies());
 
             Assert.Equal(
                 "money",
@@ -804,7 +846,7 @@ namespace Microsoft.EntityFrameworkCore
         public void String_FK_max_length_is_preferred_if_specified()
         {
             var model = CreateModel();
-            var mapper = new SqlServerTypeMapper(new RelationalTypeMapperDependencies());
+            var mapper = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies());
 
             Assert.Equal(
                 "nvarchar(200)",
@@ -819,7 +861,7 @@ namespace Microsoft.EntityFrameworkCore
         public void Binary_FK_max_length_is_preferred_if_specified()
         {
             var model = CreateModel();
-            var mapper = new SqlServerTypeMapper(new RelationalTypeMapperDependencies());
+            var mapper = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies());
 
             Assert.Equal(
                 "varbinary(100)",
@@ -834,7 +876,7 @@ namespace Microsoft.EntityFrameworkCore
         public void String_FK_unicode_is_preferred_if_specified()
         {
             var model = CreateModel();
-            var mapper = new SqlServerTypeMapper(new RelationalTypeMapperDependencies());
+            var mapper = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies());
 
             Assert.Equal(
                 "varchar(900)",

--- a/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingTest.cs
+++ b/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingTest.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Data.SqlClient;
-using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Xunit;
 
@@ -92,7 +91,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public override void GenerateSqlLiteral_returns_ByteArray_literal()
         {
             var value = new byte[] { 0xDA, 0x7A };
-            var literal = new SqlServerTypeMapper(new RelationalTypeMapperDependencies())
+            var literal = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies())
                 .GetMapping(typeof(byte[])).GenerateSqlLiteral(value);
             Assert.Equal("0xDA7A", literal);
         }
@@ -100,7 +99,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public override void GenerateSqlLiteral_returns_DateTime_literal()
         {
             var value = new DateTime(2015, 3, 12, 13, 36, 37, 371);
-            var literal = new SqlServerTypeMapper(new RelationalTypeMapperDependencies())
+            var literal = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies())
                 .GetMapping(typeof(DateTime)).GenerateSqlLiteral(value);
 
             Assert.Equal("'2015-03-12T13:36:37.371'", literal);
@@ -109,7 +108,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public override void GenerateSqlLiteral_returns_DateTimeOffset_literal()
         {
             var value = new DateTimeOffset(2015, 3, 12, 13, 36, 37, 371, new TimeSpan(-7, 0, 0));
-            var literal = new SqlServerTypeMapper(new RelationalTypeMapperDependencies())
+            var literal = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies())
                 .GetMapping(typeof(DateTimeOffset)).GenerateSqlLiteral(value);
 
             Assert.Equal("'2015-03-12T13:36:37.371-07:00'", literal);
@@ -118,7 +117,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [Fact]
         public virtual void GenerateSqlLiteralValue_returns_Unicode_String_literal()
         {
-            var literal = new SqlServerTypeMapper(new RelationalTypeMapperDependencies())
+            var literal = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies())
                 .GetMapping("nvarchar(max)").GenerateSqlLiteral("A Unicode String");
             Assert.Equal("N'A Unicode String'", literal);
         }
@@ -126,7 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [Fact]
         public virtual void GenerateSqlLiteralValue_returns_NonUnicode_String_literal()
         {
-            var literal = new SqlServerTypeMapper(new RelationalTypeMapperDependencies())
+            var literal = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies())
                 .GetMapping("varchar(max)").GenerateSqlLiteral("A Non-Unicode String");
             Assert.Equal("'A Non-Unicode String'", literal);
         }
@@ -137,7 +136,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [InlineData("Microsoft.SqlServer.Types.SqlGeometry", "geometry")]
         public virtual void Get_named_mappings_for_sql_type(string typeName, string udtName)
         {
-            var mappings = new TestSqlServerTypeMapper(new RelationalTypeMapperDependencies())
+            var mappings = new TestSqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies())
                 .GetClrTypeNameMappings();
 
             var mapping = mappings[typeName](typeof(Random));
@@ -149,8 +148,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
         private class TestSqlServerTypeMapper : SqlServerTypeMapper
         {
-            public TestSqlServerTypeMapper([NotNull] RelationalTypeMapperDependencies dependencies)
-                : base(dependencies)
+            public TestSqlServerTypeMapper(
+                CoreTypeMapperDependencies coreDependencies,
+                RelationalTypeMapperDependencies dependencies)
+                : base(coreDependencies, dependencies)
             {
             }
 

--- a/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
+++ b/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
@@ -19,6 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             optionsBuilder.UseSqlServer("Database=Crunchie", b => b.MaxBatchSize(1));
 
             var typeMapper = new SqlServerTypeMapper(
+                new CoreTypeMapperDependencies(),
                 new RelationalTypeMapperDependencies());
 
             var factory = new SqlServerModificationCommandBatchFactory(
@@ -50,6 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             optionsBuilder.UseSqlServer("Database=Crunchie");
 
             var typeMapper = new SqlServerTypeMapper(
+                new CoreTypeMapperDependencies(),
                 new RelationalTypeMapperDependencies());
 
             var factory = new SqlServerModificationCommandBatchFactory(

--- a/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
+++ b/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
@@ -16,6 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Update
         public void AddCommand_returns_false_when_max_batch_size_is_reached()
         {
             var typeMapper = new SqlServerTypeMapper(
+                new CoreTypeMapperDependencies(),
                 new RelationalTypeMapperDependencies());
 
             var batch = new SqlServerModificationCommandBatch(

--- a/test/EFCore.SqlServer.Tests/Update/SqlServerUpdateSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Update/SqlServerUpdateSqlGeneratorTest.cs
@@ -20,6 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                     new SqlServerSqlGenerationHelper(
                         new RelationalSqlGenerationHelperDependencies()),
                     new SqlServerTypeMapper(
+                        new CoreTypeMapperDependencies(),
                         new RelationalTypeMapperDependencies())));
 
         protected override TestHelpers TestHelpers => SqlServerTestHelpers.Instance;

--- a/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore
             var modelBuilder = base.Key_and_MaxLength_64_produce_nvarchar_64();
 
             var property = GetProperty<ColumnKeyAnnotationClass2>(modelBuilder, "PersonFirstName");
-            Assert.Equal("TEXT", new SqliteTypeMapper(new RelationalTypeMapperDependencies()).FindMapping(property).StoreType);
+            Assert.Equal("TEXT", new SqliteTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).FindMapping(property).StoreType);
 
             return modelBuilder;
         }
@@ -71,7 +71,7 @@ namespace Microsoft.EntityFrameworkCore
             var modelBuilder = base.Timestamp_takes_precedence_over_MaxLength();
 
             var property = GetProperty<TimestampAndMaxlen>(modelBuilder, "MaxTimestamp");
-            Assert.Equal("BLOB", new SqliteTypeMapper(new RelationalTypeMapperDependencies()).FindMapping(property).StoreType);
+            Assert.Equal("BLOB", new SqliteTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).FindMapping(property).StoreType);
 
             return modelBuilder;
         }
@@ -81,7 +81,7 @@ namespace Microsoft.EntityFrameworkCore
             var modelBuilder = base.Timestamp_takes_precedence_over_MaxLength_with_value();
 
             var property = GetProperty<TimestampAndMaxlen>(modelBuilder, "NonMaxTimestamp");
-            Assert.Equal("BLOB", new SqliteTypeMapper(new RelationalTypeMapperDependencies()).FindMapping(property).StoreType);
+            Assert.Equal("BLOB", new SqliteTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).FindMapping(property).StoreType);
 
             return modelBuilder;
         }

--- a/test/EFCore.Sqlite.Tests/SqliteModelValidatorTest.cs
+++ b/test/EFCore.Sqlite.Tests/SqliteModelValidatorTest.cs
@@ -84,7 +84,9 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         private static void GenerateMapping(IMutableProperty property)
-            => property[CoreAnnotationNames.TypeMapping] = new SqliteTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(property);
+            => property[CoreAnnotationNames.TypeMapping] = new SqliteTypeMapper(
+                new CoreTypeMapperDependencies(),
+                new RelationalTypeMapperDependencies()).GetMapping(property);
 
         protected override IModelValidator CreateModelValidator()
             => new SqliteModelValidator(
@@ -94,6 +96,8 @@ namespace Microsoft.EntityFrameworkCore
                         new LoggingOptions(),
                         new DiagnosticListener("Fake"))),
                 new RelationalModelValidatorDependencies(
-                    new SqliteTypeMapper(new RelationalTypeMapperDependencies())));
+                    new SqliteTypeMapper(
+                        new CoreTypeMapperDependencies(),
+                        new RelationalTypeMapperDependencies())));
     }
 }

--- a/test/EFCore.Sqlite.Tests/Storage/SqliteTypeMappingTest.cs
+++ b/test/EFCore.Sqlite.Tests/Storage/SqliteTypeMappingTest.cs
@@ -45,13 +45,13 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [InlineData("", typeof(string))]
         public void It_maps_strings_to_not_null_types(string typeName, Type clrType)
         {
-            Assert.Equal(clrType, new SqliteTypeMapper(new RelationalTypeMapperDependencies()).GetMapping(typeName).ClrType);
+            Assert.Equal(clrType, new SqliteTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMapping(typeName).ClrType);
         }
 
         public override void GenerateSqlLiteral_returns_DateTime_literal()
         {
             var value = new DateTime(2015, 3, 12, 13, 36, 37, 371);
-            var literal = new SqliteTypeMapper(new RelationalTypeMapperDependencies())
+            var literal = new SqliteTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies())
                 .GetMapping(typeof(DateTime)).GenerateSqlLiteral(value);
             Assert.Equal("'2015-03-12 13:36:37.371'", literal);
         }
@@ -59,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public override void GenerateSqlLiteral_returns_DateTimeOffset_literal()
         {
             var value = new DateTimeOffset(2015, 3, 12, 13, 36, 37, 371, new TimeSpan(-7, 0, 0));
-            var literal = new SqliteTypeMapper(new RelationalTypeMapperDependencies())
+            var literal = new SqliteTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies())
                 .GetMapping(typeof(DateTimeOffset)).GenerateSqlLiteral(value);
             Assert.Equal("'2015-03-12 13:36:37.371-07:00'", literal);
         }
@@ -67,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public override void GenerateSqlLiteral_returns_Guid_literal()
         {
             var value = new Guid("c6f43a9e-91e1-45ef-a320-832ea23b7292");
-            var literal = new SqliteTypeMapper(new RelationalTypeMapperDependencies())
+            var literal = new SqliteTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies())
                 .GetMapping(typeof(Guid)).GenerateSqlLiteral(value);
             Assert.Equal("X'9E3AF4C6E191EF45A320832EA23B7292'", literal);
         }

--- a/test/EFCore.Sqlite.Tests/Update/SqliteUpdateSqlGeneratorTest.cs
+++ b/test/EFCore.Sqlite.Tests/Update/SqliteUpdateSqlGeneratorTest.cs
@@ -19,6 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                     new SqliteSqlGenerationHelper(
                         new RelationalSqlGenerationHelperDependencies()),
                     new SqliteTypeMapper(
+                        new CoreTypeMapperDependencies(),
                         new RelationalTypeMapperDependencies())));
 
         protected override TestHelpers TestHelpers => SqliteTestHelpers.Instance;


### PR DESCRIPTION
As I have worked on value conversions I have run into the issue that the IProperty is no longer the only input to the type mapping process, since, for example, a value converter may also need to be applied. In the future, things like order preservation are likely to be the same. Therefore, this refactoring introduces parameter object and creates new overloads that using it, while preserving the behavior of existing code that is overriding the old methods.
