### PR TITLE
Query: Preserve Schema in SqlFunctionExpression while visiting children

### DIFF
--- a/src/EFCore.Specification.Tests/Query/DbFunctionsTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/DbFunctionsTestBase.cs
@@ -45,7 +45,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var count = context.Customers.Count(c => EF.Functions.Like(c.ContactName, "!%", "!"));
-                
+
                 Assert.Equal(0, count);
             }
         }


### PR DESCRIPTION
Issue was fixed in #10370
VisitChildren method was incorrect

This adds test for the scenario

Resolves #10421

