### PR TITLE
Added scaffold line argument to not put connection string in dbcontext

### DIFF
--- a/src/EFCore.Design/Design/Internal/DatabaseOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DatabaseOperations.cs
@@ -60,7 +60,8 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             [NotNull] IEnumerable<string> tables,
             bool useDataAnnotations,
             bool overwriteFiles,
-            bool useDatabaseNames)
+            bool useDatabaseNames,
+            bool dontAddConnectionString)
         {
             Check.NotEmpty(provider, nameof(provider));
             Check.NotEmpty(connectionString, nameof(connectionString));
@@ -82,7 +83,8 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                 dbContextClassName,
                 useDataAnnotations,
                 overwriteFiles,
-                useDatabaseNames);
+                useDatabaseNames,
+                dontAddConnectionString);
         }
     }
 }

--- a/src/EFCore.Design/Design/OperationExecutor.cs
+++ b/src/EFCore.Design/Design/OperationExecutor.cs
@@ -432,12 +432,13 @@ namespace Microsoft.EntityFrameworkCore.Design
                 var useDataAnnotations = (bool)args["useDataAnnotations"];
                 var overwriteFiles = (bool)args["overwriteFiles"];
                 var useDatabaseNames = (bool)args["useDatabaseNames"];
+                var dontAddConnectionString = (bool)args["dontAddConnectionString"];
 
                 Execute(
                     () => executor.ScaffoldContextImpl(
                         provider,
                         connectionString, outputDir, dbContextClassName,
-                        schemaFilters, tableFilters, useDataAnnotations, overwriteFiles, useDatabaseNames));
+                        schemaFilters, tableFilters, useDataAnnotations, overwriteFiles, useDatabaseNames, dontAddConnectionString));
             }
         }
 
@@ -450,7 +451,8 @@ namespace Microsoft.EntityFrameworkCore.Design
             [NotNull] IEnumerable<string> tableFilters,
             bool useDataAnnotations,
             bool overwriteFiles,
-            bool useDatabaseNames)
+            bool useDatabaseNames,
+            bool dontAddConnectionString)
         {
             Check.NotNull(provider, nameof(provider));
             Check.NotNull(connectionString, nameof(connectionString));
@@ -466,7 +468,7 @@ namespace Microsoft.EntityFrameworkCore.Design
 
             var files = _databaseOperations.Value.ScaffoldContext(
                 provider, connectionString, outputDir, dbContextClassName,
-                schemaFilters, tableFilters, useDataAnnotations, overwriteFiles, useDatabaseNames);
+                schemaFilters, tableFilters, useDataAnnotations, overwriteFiles, useDatabaseNames, dontAddConnectionString);
 
             return new Hashtable
             {

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -58,7 +58,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             string @namespace,
             string contextName,
             string connectionString,
-            bool useDataAnnotations)
+            bool useDataAnnotations,
+            bool dontAddConnectionString)
         {
             Check.NotNull(model, nameof(model));
 
@@ -74,7 +75,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             using (_sb.Indent())
             {
-                GenerateClass(model, contextName, connectionString, useDataAnnotations);
+                GenerateClass(model, contextName, connectionString, useDataAnnotations, dontAddConnectionString);
             }
 
             _sb.AppendLine("}");
@@ -90,7 +91,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             [NotNull] IModel model,
             [NotNull] string contextName,
             [NotNull] string connectionString,
-            bool useDataAnnotations)
+            bool useDataAnnotations,
+            bool dontAddConnectionString)
         {
             Check.NotNull(model, nameof(model));
             Check.NotNull(contextName, nameof(contextName));
@@ -103,7 +105,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             {
                 GenerateDbSets(model);
                 GenerateEntityTypeErrors(model);
-                GenerateOnConfiguring(connectionString);
+                GenerateOnConfiguring(connectionString, dontAddConnectionString);
                 GenerateOnModelCreating(model, useDataAnnotations);
             }
 
@@ -142,7 +144,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected virtual void GenerateOnConfiguring(
-            [NotNull] string connectionString)
+            [NotNull] string connectionString,
+            bool dontAddConnectionString)
         {
             Check.NotNull(connectionString, nameof(connectionString));
 
@@ -154,20 +157,23 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 _sb.AppendLine("if (!optionsBuilder.IsConfigured)");
                 _sb.AppendLine("{");
 
-                using (_sb.Indent())
+                if (!dontAddConnectionString)
                 {
-                    _sb.DecrementIndent()
-                        .DecrementIndent()
-                        .DecrementIndent()
-                        .DecrementIndent()
-                        .AppendLine("#warning " + DesignStrings.SensitiveInformationWarning)
-                        .IncrementIndent()
-                        .IncrementIndent()
-                        .IncrementIndent()
-                        .IncrementIndent();
+                    using (_sb.Indent())
+                    {
+                        _sb.DecrementIndent()
+                            .DecrementIndent()
+                            .DecrementIndent()
+                            .DecrementIndent()
+                            .AppendLine("#warning " + DesignStrings.SensitiveInformationWarning)
+                            .IncrementIndent()
+                            .IncrementIndent()
+                            .IncrementIndent()
+                            .IncrementIndent();
 
-                    _sb.AppendLine(
-                        $"optionsBuilder{_providerCodeGenerator.GenerateUseProvider(connectionString, Language)};");
+                        _sb.AppendLine(
+                            $"optionsBuilder{_providerCodeGenerator.GenerateUseProvider(connectionString, Language)};");
+                    }
                 }
 
                 _sb.AppendLine("}");

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpScaffoldingGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpScaffoldingGenerator.cs
@@ -65,7 +65,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             string @namespace,
             string contextName,
             string connectionString,
-            bool useDataAnnotations)
+            bool useDataAnnotations,
+            bool dontAddConnectionString)
         {
             Check.NotNull(model, nameof(model));
             Check.NotEmpty(outputPath, nameof(outputPath));
@@ -75,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             var resultingFiles = new ReverseEngineerFiles();
 
-            var generatedCode = CSharpDbContextGenerator.WriteCode(model, @namespace, contextName, connectionString, useDataAnnotations);
+            var generatedCode = CSharpDbContextGenerator.WriteCode(model, @namespace, contextName, connectionString, useDataAnnotations, dontAddConnectionString);
 
             // output DbContext .cs file
             var dbContextFileName = contextName + FileExtension;

--- a/src/EFCore.Design/Scaffolding/Internal/ICSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/ICSharpDbContextGenerator.cs
@@ -21,6 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             [NotNull] string @namespace,
             [NotNull] string contextName,
             [NotNull] string connectionString,
-            bool useDataAnnotations);
+            bool useDataAnnotations,
+            bool dontAddConnectionString);
     }
 }

--- a/src/EFCore.Design/Scaffolding/Internal/IReverseEngineerScaffolder.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/IReverseEngineerScaffolder.cs
@@ -27,6 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             [CanBeNull] string contextName,
             bool useDataAnnotations,
             bool overwriteFiles,
-            bool useDatabaseNames);
+            bool useDatabaseNames,
+            bool dontAddConnectionString);
     }
 }

--- a/src/EFCore.Design/Scaffolding/Internal/IScaffoldingCodeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/IScaffoldingCodeGenerator.cs
@@ -48,6 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             [NotNull] string @namespace,
             [NotNull] string contextName,
             [NotNull] string connectionString,
-            bool dataAnnotations);
+            bool dataAnnotations,
+            bool dontAddConnectionString);
     }
 }

--- a/src/EFCore.Design/Scaffolding/Internal/ReverseEngineerScaffolder.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/ReverseEngineerScaffolder.cs
@@ -66,7 +66,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             string contextName,
             bool useDataAnnotations,
             bool overwriteFiles,
-            bool useDatabaseNames)
+            bool useDatabaseNames,
+            bool dontAddConnectionString)
         {
             Check.NotEmpty(connectionString, nameof(connectionString));
             Check.NotNull(tables, nameof(tables));
@@ -121,7 +122,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             CheckOutputFiles(codeGenerator, outputPath ?? projectPath, contextName, model, overwriteFiles);
 
-            return codeGenerator.WriteCode(model, outputPath ?? projectPath, @namespace, contextName, connectionString, useDataAnnotations);
+            return codeGenerator.WriteCode(model, outputPath ?? projectPath, @namespace, contextName, connectionString, useDataAnnotations, dontAddConnectionString);
         }
 
         // if outputDir is a subfolder of projectDir, then use each subfolder as a subnamespace

--- a/src/EFCore.Design/Scaffolding/Internal/ScaffoldingCodeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/ScaffoldingCodeGenerator.cs
@@ -121,6 +121,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             string @namespace,
             string contextName,
             string connectionString,
-            bool dataAnnotations);
+            bool dataAnnotations,
+            bool dontAddConnectionString);
     }
 }

--- a/src/dotnet-ef/Properties/Resources.Designer.cs
+++ b/src/dotnet-ef/Properties/Resources.Designer.cs
@@ -377,6 +377,12 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
         public static string NoBuildDescription
             => GetString("NoBuildDescription");
 
+        /// <summary>
+        ///     Don't add connection string to database context
+        /// </summary>
+        public static string DontAddConnectionStringDescription
+            => GetString("DontAddConnectionStringDescription");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/dotnet-ef/Properties/Resources.resx
+++ b/src/dotnet-ef/Properties/Resources.resx
@@ -291,4 +291,7 @@
   <data name="NoBuildDescription" xml:space="preserve">
     <value>Don't build the project. Only use this when the build is up-to-date.</value>
   </data>
+  <data name="DontAddConnectionStringDescription" xml:space="preserve">
+    <value>Don't add connection string to database context</value>
+  </data>
 </root>

--- a/src/ef/Commands/DbContextScaffoldCommand.Configure.cs
+++ b/src/ef/Commands/DbContextScaffoldCommand.Configure.cs
@@ -18,6 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
         private CommandOption _tables;
         private CommandOption _useDatabaseNames;
         private CommandOption _json;
+        private CommandOption _dontIncludeConnectionString;
 
         public override void Configure(CommandLineApplication command)
         {
@@ -33,7 +34,8 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
             _schemas = command.Option("--schema <SCHEMA_NAME>...", Resources.SchemasDescription);
             _tables = command.Option("-t|--table <TABLE_NAME>...", Resources.TablesDescription);
             _useDatabaseNames = command.Option("--use-database-names", Resources.UseDatabaseNamesDescription);
-            _json = Json.ConfigureOption(command);
+            _dontIncludeConnectionString = command.Option("--dont-add-connection-string", Resources.DontAddConnectionStringDescription);
+            _json = Json.ConfigureOption(command);            
 
             base.Configure(command);
         }

--- a/src/ef/Commands/DbContextScaffoldCommand.cs
+++ b/src/ef/Commands/DbContextScaffoldCommand.cs
@@ -35,7 +35,8 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
                 _tables.Values,
                 _dataAnnotations.HasValue(),
                 _force.HasValue(),
-                _useDatabaseNames.HasValue());
+                _useDatabaseNames.HasValue(),
+                _dontIncludeConnectionString.HasValue());
             if (_json.HasValue())
             {
                 ReportJsonResults(result);

--- a/src/ef/IOperationExecutor.cs
+++ b/src/ef/IOperationExecutor.cs
@@ -26,7 +26,8 @@ namespace Microsoft.EntityFrameworkCore.Tools
             IEnumerable<string> tableFilters,
             bool useDataAnnotations,
             bool overwriteFiles,
-            bool useDatabaseNames);
+            bool useDatabaseNames,
+            bool dontAddConnectionString);
 
         string ScriptMigration(string fromMigration, string toMigration, bool idempotent, string contextType);
     }

--- a/src/ef/OperationExecutorBase.cs
+++ b/src/ef/OperationExecutorBase.cs
@@ -150,7 +150,8 @@ namespace Microsoft.EntityFrameworkCore.Tools
             IEnumerable<string> tableFilters,
             bool useDataAnnotations,
             bool overwriteFiles,
-            bool useDatabaseNames)
+            bool useDatabaseNames,
+            bool dontAddConnectionString)
             => InvokeOperation<IDictionary>(
                 "ScaffoldContext",
                 new Dictionary<string, object>
@@ -163,7 +164,8 @@ namespace Microsoft.EntityFrameworkCore.Tools
                     ["tableFilters"] = tableFilters,
                     ["useDataAnnotations"] = useDataAnnotations,
                     ["overwriteFiles"] = overwriteFiles,
-                    ["useDatabaseNames"] = useDatabaseNames
+                    ["useDatabaseNames"] = useDatabaseNames,
+                    ["dontAddConnectionString"] = dontAddConnectionString
                 });
 
         public string ScriptMigration(

--- a/src/ef/Properties/Resources.Designer.cs
+++ b/src/ef/Properties/Resources.Designer.cs
@@ -435,6 +435,12 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
         public static string LanguageDescription
             => GetString("LanguageDescription");
 
+        /// <summary>
+        ///     Don't add connection string to database context
+        /// </summary>
+        public static string DontAddConnectionStringDescription
+            => GetString("DontAddConnectionStringDescription");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/ef/Properties/Resources.resx
+++ b/src/ef/Properties/Resources.resx
@@ -309,4 +309,7 @@
   <data name="LanguageDescription" xml:space="preserve">
     <value>The language.  Defaults to 'C#'.</value>
   </data>
+  <data name="DontAddConnectionStringDescription" xml:space="preserve">
+    <value>Don't add connection string to database context</value>
+  </data>
 </root>

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ReverseEngineeringConfigurationTests.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ReverseEngineeringConfigurationTests.cs
@@ -54,7 +54,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                             contextName: contextName,
                             useDataAnnotations: false,
                             overwriteFiles: false,
-                            useDatabaseNames: false))
+                            useDatabaseNames: false,
+                            dontAddConnectionString: false))
                     .Message);
         }
 


### PR DESCRIPTION
Current database-first workflows require running the `dotnet ef scaffold` command any time database updates have been done so the `DbContext` (and all associated POCOs) reflect the current schema.  

However, the current scaffold command creates a `DbContext` that contains an `OnConfiguring()` method that contains the connection string that was used for context generation.  When running scaffold command after every update it is easy to forget to strip the connection string out prior to committing to source control.  It can also lead to accidental scenarios where the `DbContext` is using this connection string instead of the proper one for its environment (e.g. development database when it should be connecting to production).

To remedy this I added a command line option for the scaffold command of `--dont-add-connection-string`.  When this is provided it scaffolds the `OnConfiguring()` method (so users can see that the override exists) but it does not add the connection string to the generated code.

This will allow users to execute scaffolding without having to worry about sensitive information being checked into source control.

References issue #10432


**Please check if the PR fulfills these requirements**

- [x] The code builds and tests pass (verified by our automated build checks)
- [x] Commit messages follow this format
```
    Summary of the changes
    - Detail 1
    - Detail 2

    Fixes #bugnumber
```
- [ ] Tests for the changes have been added (for bug fixes / features) **Not done since no scaffolding tests could be found**
- [x] Code meets the expectations our engineering guidelines. https://github.com/aspnet/Home/wiki/Engineering-guidelines.

Please review the guidelines for CONTRIBUTING.md for more details.