### PR TITLE
Adding a null check to prevent SqlCommand exception for UDT

### DIFF
--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerUdtTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerUdtTypeMapping.cs
@@ -69,7 +69,10 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                 parameter.GetType(),
                 CreateUdtTypeNameAccessor);
 
-            _udtTypeNameSetter(parameter, UdtTypeName);
+            if (parameter.Value != null && parameter.Value != DBNull.Value)
+            {
+                _udtTypeNameSetter(parameter, UdtTypeName);
+            }
         }
 
         private static Action<DbParameter, string> CreateUdtTypeNameAccessor(Type paramType)


### PR DESCRIPTION
Implemented a null/dbnull value check before assigning an UDT typename (string) to a DbParameter. 


Fixes: #10214

**Please check if the PR fulfills these requirements**

- [X] The code builds and tests pass (verified by our automated build checks)
- [X] Commit messages follow this format
```
    Summary of the changes
    - Detail 1
    - Detail 2

    Fixes #bugnumber
```
- [ ] Tests for the changes have been added (for bug fixes / features) **No tests were added as it requires reference to Microsoft.SqlServer.Types and I couldn't find any started tests for UDT in context of saving to a DB.**
- [X] Code meets the expectations our engineering guidelines. https://github.com/aspnet/Home/wiki/Engineering-guidelines.

Please review the guidelines for CONTRIBUTING.md for more details.