### PR TITLE
 Query: Filters: Fix 10463 - Error when referencing DbSet in filter

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
@@ -302,7 +302,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void Where_multiple_ors_with_nullable_parameter()
         {
             string prm = null;
-            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => e.NullableStringA == "Foo" || e.NullableStringA == prm));
+            AssertQuery<NullSemanticsEntity1>(
+                es => es.Where(e => e.NullableStringA == "Foo" || e.NullableStringA == prm));
         }
 
         [Fact]

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -890,6 +890,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
         public static string InvalidMinBatchSize
             => GetString("InvalidMinBatchSize");
 
+        /// <summary>
+        ///     Expected a non-null value for query parameter '{parameter}'.
+        /// </summary>
+        public static string ExpectedNonNullParameter([CanBeNull] object parameter)
+            => string.Format(
+                GetString("ExpectedNonNullParameter", nameof(parameter)),
+                parameter);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -443,4 +443,7 @@
   <data name="InvalidMinBatchSize" xml:space="preserve">
     <value>The specified MinBatchSize value is not valid. It must be a positive number.</value>
   </data>
+  <data name="ExpectedNonNullParameter" xml:space="preserve">
+    <value>Expected a non-null value for query parameter '{parameter}'.</value>
+  </data>
 </root>

--- a/src/EFCore.Specification.Tests/Query/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/QueryTestBase.cs
@@ -80,7 +80,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             bool assertOrder = false,
             int entryCount = 0)
             where TItem1 : class
-            => Fixture.QueryAsserter.AssertQuery(query, query, elementSorter, elementAsserter, assertOrder, entryCount, isAsync: false).Wait();
+            => Fixture.QueryAsserter.AssertQuery(query, query, elementSorter, elementAsserter, assertOrder, entryCount).GetAwaiter().GetResult();
 
         public virtual void AssertQuery<TItem1>(
             Func<IQueryable<TItem1>, IQueryable<object>> actualQuery,
@@ -90,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             bool assertOrder = false,
             int entryCount = 0)
             where TItem1 : class
-            => Fixture.QueryAsserter.AssertQuery(actualQuery, expectedQuery, elementSorter, elementAsserter, assertOrder, entryCount, isAsync: false).Wait();
+            => Fixture.QueryAsserter.AssertQuery(actualQuery, expectedQuery, elementSorter, elementAsserter, assertOrder, entryCount).GetAwaiter().GetResult();
 
         public virtual void AssertQuery<TItem1, TItem2>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> query,
@@ -100,7 +100,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             int entryCount = 0)
             where TItem1 : class
             where TItem2 : class
-            => Fixture.QueryAsserter.AssertQuery(query, query, elementSorter, elementAsserter, assertOrder, entryCount, isAsync: false).Wait();
+            => Fixture.QueryAsserter.AssertQuery(query, query, elementSorter, elementAsserter, assertOrder, entryCount).GetAwaiter().GetResult();
 
         public virtual void AssertQuery<TItem1, TItem2>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> actualQuery,
@@ -111,7 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             int entryCount = 0)
             where TItem1 : class
             where TItem2 : class
-            => Fixture.QueryAsserter.AssertQuery(actualQuery, expectedQuery, elementSorter, elementAsserter, assertOrder, entryCount, isAsync: false).Wait();
+            => Fixture.QueryAsserter.AssertQuery(actualQuery, expectedQuery, elementSorter, elementAsserter, assertOrder, entryCount).GetAwaiter().GetResult();
 
         public virtual void AssertQuery<TItem1, TItem2, TItem3>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<object>> query,
@@ -134,7 +134,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             where TItem2 : class
             where TItem3 : class
-            => Fixture.QueryAsserter.AssertQuery(actualQuery, expectedQuery, elementSorter, elementAsserter, assertOrder, entryCount, isAsync: false).Wait();
+            => Fixture.QueryAsserter.AssertQuery(actualQuery, expectedQuery, elementSorter, elementAsserter, assertOrder, entryCount).GetAwaiter().GetResult();
 
         #endregion
 
@@ -216,7 +216,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             bool assertOrder = false)
             where TItem1 : class
             where TResult : struct
-            => Fixture.QueryAsserter.AssertQueryScalar(actualQuery, expectedQuery, assertOrder).Wait();
+            => Fixture.QueryAsserter.AssertQueryScalar(actualQuery, expectedQuery, assertOrder).GetAwaiter().GetResult();
 
         public virtual void AssertQueryScalar<TItem1, TItem2>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<int>> query,
@@ -255,7 +255,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             where TItem2 : class
             where TResult : struct
-            => Fixture.QueryAsserter.AssertQueryScalar(actualQuery, expectedQuery, assertOrder).Wait();
+            => Fixture.QueryAsserter.AssertQueryScalar(actualQuery, expectedQuery, assertOrder).GetAwaiter().GetResult();
 
         public virtual void AssertQueryScalar<TItem1, TItem2, TItem3>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<int>> query,
@@ -273,7 +273,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem2 : class
             where TItem3 : class
             where TResult : struct
-            => Fixture.QueryAsserter.AssertQueryScalar(actualQuery, expectedQuery, assertOrder).Wait();
+            => Fixture.QueryAsserter.AssertQueryScalar(actualQuery, expectedQuery, assertOrder).GetAwaiter().GetResult();
 
         #endregion
 

--- a/src/EFCore/EntityFrameworkQueryableExtensions.cs
+++ b/src/EFCore/EntityFrameworkQueryableExtensions.cs
@@ -201,7 +201,7 @@ namespace Microsoft.EntityFrameworkCore
         private static readonly MethodInfo _longCount = GetMethod(nameof(Queryable.LongCount));
 
         /// <summary>
-        ///     Asynchronously returns an <see cref="Int64" /> that represents the total number of elements in a sequence.
+        ///     Asynchronously returns an <see cref="long" /> that represents the total number of elements in a sequence.
         /// </summary>
         /// <remarks>
         ///     Multiple active operations on the same context instance are not supported.  Use 'await' to ensure
@@ -232,7 +232,7 @@ namespace Microsoft.EntityFrameworkCore
         private static readonly MethodInfo _longCountPredicate = GetMethod(nameof(Queryable.LongCount), parameterCount: 1);
 
         /// <summary>
-        ///     Asynchronously returns an <see cref="Int64" /> that represents the number of elements in a sequence
+        ///     Asynchronously returns an <see cref="long" /> that represents the number of elements in a sequence
         ///     that satisfy a condition.
         /// </summary>
         /// <remarks>

--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -105,7 +105,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(IExecutionStrategyFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IAsyncQueryProvider), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IQueryCompiler), new ServiceCharacteristics(ServiceLifetime.Scoped) },
-                { typeof(IQueryProcessor), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+                { typeof(IQueryModelGenerator), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IQueryOptimizer), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IEntityResultFindingExpressionVisitorFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IRequiresMaterializationExpressionVisitorFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
@@ -224,7 +224,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<ICompiledQueryCache, CompiledQueryCache>();
             TryAdd<IAsyncQueryProvider, EntityQueryProvider>();
             TryAdd<IQueryCompiler, QueryCompiler>();
-            TryAdd<IQueryProcessor, QueryProcessor>();
+            TryAdd<IQueryModelGenerator, QueryModelGenerator>();
             TryAdd<IQueryAnnotationExtractor, QueryAnnotationExtractor>();
             TryAdd<IQueryOptimizer, QueryOptimizer>();
             TryAdd<IEntityTrackingInfoFactory, EntityTrackingInfoFactory>();

--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -105,6 +105,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(IExecutionStrategyFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IAsyncQueryProvider), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IQueryCompiler), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+                { typeof(IQueryProcessor), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IQueryOptimizer), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IEntityResultFindingExpressionVisitorFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IRequiresMaterializationExpressionVisitorFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
@@ -223,6 +224,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<ICompiledQueryCache, CompiledQueryCache>();
             TryAdd<IAsyncQueryProvider, EntityQueryProvider>();
             TryAdd<IQueryCompiler, QueryCompiler>();
+            TryAdd<IQueryProcessor, QueryProcessor>();
             TryAdd<IQueryAnnotationExtractor, QueryAnnotationExtractor>();
             TryAdd<IQueryOptimizer, QueryOptimizer>();
             TryAdd<IEntityTrackingInfoFactory, EntityTrackingInfoFactory>();

--- a/src/EFCore/Internal/InternalDbSet.cs
+++ b/src/EFCore/Internal/InternalDbSet.cs
@@ -55,6 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 }
 
                 _entityType = _context.Model.FindEntityType(typeof(TEntity));
+
                 if (_entityType == null)
                 {
                     throw new InvalidOperationException(CoreStrings.InvalidSetType(typeof(TEntity).ShortDisplayName()));

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -102,7 +102,10 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             LinqOperatorProvider = queryCompilationContext.LinqOperatorProvider;
 
-            _filterApplyingExpressionVisitor = new FilterApplyingExpressionVisitor(_queryCompilationContext);
+            _filterApplyingExpressionVisitor
+                = new FilterApplyingExpressionVisitor(
+                    _queryCompilationContext,
+                    dependencies.QueryProcessor);
         }
 
         /// <summary>

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -104,8 +104,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             _filterApplyingExpressionVisitor
                 = new FilterApplyingExpressionVisitor(
-                    _queryCompilationContext,
-                    dependencies.QueryProcessor);
+                    _queryCompilationContext, dependencies.QueryModelGenerator);
         }
 
         /// <summary>

--- a/src/EFCore/Query/EntityQueryModelVisitorDependencies.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitorDependencies.cs
@@ -76,6 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <param name="resultOperatorHandler"> The <see cref="IResultOperatorHandler" /> to be used when processing the query. </param>
         /// <param name="entityMaterializerSource"> The <see cref="IEntityMaterializerSource" /> to be used when processing the query. </param>
         /// <param name="expressionPrinter"> The <see cref="IExpressionPrinter" /> to be used when processing the query. </param>
+        /// <param name="queryProcessor"> The <see cref="IQueryProcessor" /> to be used when processing the query. </param>
         public EntityQueryModelVisitorDependencies(
             [NotNull] IQueryOptimizer queryOptimizer,
             [NotNull] INavigationRewritingExpressionVisitorFactory navigationRewritingExpressionVisitorFactory,
@@ -88,7 +89,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             [NotNull] IQueryAnnotationExtractor queryAnnotationExtractor,
             [NotNull] IResultOperatorHandler resultOperatorHandler,
             [NotNull] IEntityMaterializerSource entityMaterializerSource,
-            [NotNull] IExpressionPrinter expressionPrinter)
+            [NotNull] IExpressionPrinter expressionPrinter,
+            [NotNull] IQueryProcessor queryProcessor)
         {
             Check.NotNull(queryOptimizer, nameof(queryOptimizer));
             Check.NotNull(navigationRewritingExpressionVisitorFactory, nameof(navigationRewritingExpressionVisitorFactory));
@@ -102,6 +104,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Check.NotNull(resultOperatorHandler, nameof(resultOperatorHandler));
             Check.NotNull(entityMaterializerSource, nameof(entityMaterializerSource));
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
+            Check.NotNull(queryProcessor, nameof(queryProcessor));
 
             QueryOptimizer = queryOptimizer;
             NavigationRewritingExpressionVisitorFactory = navigationRewritingExpressionVisitorFactory;
@@ -115,6 +118,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             ResultOperatorHandler = resultOperatorHandler;
             EntityMaterializerSource = entityMaterializerSource;
             ExpressionPrinter = expressionPrinter;
+            QueryProcessor = queryProcessor;
         }
 
         /// <summary>
@@ -178,6 +182,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         public IQueryAnnotationExtractor QueryAnnotationExtractor { get; }
 
         /// <summary>
+        ///     Gets the <see cref="IQueryProcessor" /> to be used when processing a query.
+        /// </summary>
+        public IQueryProcessor QueryProcessor { get; }
+
+        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="resultOperatorHandler"> A replacement for the current dependency of this type. </param>
@@ -195,7 +204,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 QueryAnnotationExtractor,
                 resultOperatorHandler,
                 EntityMaterializerSource,
-                ExpressionPrinter);
+                ExpressionPrinter,
+                QueryProcessor);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -215,7 +225,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 QueryAnnotationExtractor,
                 ResultOperatorHandler,
                 EntityMaterializerSource,
-                ExpressionPrinter);
+                ExpressionPrinter,
+                QueryProcessor);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -235,7 +246,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 QueryAnnotationExtractor,
                 ResultOperatorHandler,
                 EntityMaterializerSource,
-                ExpressionPrinter);
+                ExpressionPrinter,
+                QueryProcessor);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -255,7 +267,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 QueryAnnotationExtractor,
                 ResultOperatorHandler,
                 EntityMaterializerSource,
-                ExpressionPrinter);
+                ExpressionPrinter,
+                QueryProcessor);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -275,7 +288,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 QueryAnnotationExtractor,
                 ResultOperatorHandler,
                 EntityMaterializerSource,
-                ExpressionPrinter);
+                ExpressionPrinter,
+                QueryProcessor);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -295,7 +309,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 QueryAnnotationExtractor,
                 ResultOperatorHandler,
                 EntityMaterializerSource,
-                ExpressionPrinter);
+                ExpressionPrinter,
+                QueryProcessor);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -315,7 +330,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 QueryAnnotationExtractor,
                 ResultOperatorHandler,
                 EntityMaterializerSource,
-                ExpressionPrinter);
+                ExpressionPrinter,
+                QueryProcessor);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -335,7 +351,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 QueryAnnotationExtractor,
                 ResultOperatorHandler,
                 EntityMaterializerSource,
-                ExpressionPrinter);
+                ExpressionPrinter,
+                QueryProcessor);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -355,7 +372,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 QueryAnnotationExtractor,
                 ResultOperatorHandler,
                 EntityMaterializerSource,
-                ExpressionPrinter);
+                ExpressionPrinter,
+                QueryProcessor);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -375,7 +393,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 queryAnnotationExtractor,
                 ResultOperatorHandler,
                 EntityMaterializerSource,
-                ExpressionPrinter);
+                ExpressionPrinter,
+                QueryProcessor);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -395,7 +414,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 QueryAnnotationExtractor,
                 ResultOperatorHandler,
                 entityMaterializerSource,
-                ExpressionPrinter);
+                ExpressionPrinter,
+                QueryProcessor);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -415,6 +435,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 QueryAnnotationExtractor,
                 ResultOperatorHandler,
                 EntityMaterializerSource,
-                expressionPrinter);
+                expressionPrinter,
+                QueryProcessor);
     }
 }

--- a/src/EFCore/Query/EntityQueryModelVisitorDependencies.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitorDependencies.cs
@@ -76,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <param name="resultOperatorHandler"> The <see cref="IResultOperatorHandler" /> to be used when processing the query. </param>
         /// <param name="entityMaterializerSource"> The <see cref="IEntityMaterializerSource" /> to be used when processing the query. </param>
         /// <param name="expressionPrinter"> The <see cref="IExpressionPrinter" /> to be used when processing the query. </param>
-        /// <param name="queryProcessor"> The <see cref="IQueryProcessor" /> to be used when processing the query. </param>
+        /// <param name="queryModelGenerator"> The <see cref="IQueryModelGenerator" /> to be used when processing the query. </param>
         public EntityQueryModelVisitorDependencies(
             [NotNull] IQueryOptimizer queryOptimizer,
             [NotNull] INavigationRewritingExpressionVisitorFactory navigationRewritingExpressionVisitorFactory,
@@ -90,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             [NotNull] IResultOperatorHandler resultOperatorHandler,
             [NotNull] IEntityMaterializerSource entityMaterializerSource,
             [NotNull] IExpressionPrinter expressionPrinter,
-            [NotNull] IQueryProcessor queryProcessor)
+            [NotNull] IQueryModelGenerator queryModelGenerator)
         {
             Check.NotNull(queryOptimizer, nameof(queryOptimizer));
             Check.NotNull(navigationRewritingExpressionVisitorFactory, nameof(navigationRewritingExpressionVisitorFactory));
@@ -104,7 +104,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Check.NotNull(resultOperatorHandler, nameof(resultOperatorHandler));
             Check.NotNull(entityMaterializerSource, nameof(entityMaterializerSource));
             Check.NotNull(expressionPrinter, nameof(expressionPrinter));
-            Check.NotNull(queryProcessor, nameof(queryProcessor));
+            Check.NotNull(queryModelGenerator, nameof(queryModelGenerator));
 
             QueryOptimizer = queryOptimizer;
             NavigationRewritingExpressionVisitorFactory = navigationRewritingExpressionVisitorFactory;
@@ -118,7 +118,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             ResultOperatorHandler = resultOperatorHandler;
             EntityMaterializerSource = entityMaterializerSource;
             ExpressionPrinter = expressionPrinter;
-            QueryProcessor = queryProcessor;
+            QueryModelGenerator = queryModelGenerator;
         }
 
         /// <summary>
@@ -182,9 +182,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         public IQueryAnnotationExtractor QueryAnnotationExtractor { get; }
 
         /// <summary>
-        ///     Gets the <see cref="IQueryProcessor" /> to be used when processing a query.
+        ///     Gets the <see cref="IQueryModelGenerator" /> to be used when processing a query.
         /// </summary>
-        public IQueryProcessor QueryProcessor { get; }
+        public IQueryModelGenerator QueryModelGenerator { get; }
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -205,7 +205,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 resultOperatorHandler,
                 EntityMaterializerSource,
                 ExpressionPrinter,
-                QueryProcessor);
+                QueryModelGenerator);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -226,7 +226,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ResultOperatorHandler,
                 EntityMaterializerSource,
                 ExpressionPrinter,
-                QueryProcessor);
+                QueryModelGenerator);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -247,7 +247,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ResultOperatorHandler,
                 EntityMaterializerSource,
                 ExpressionPrinter,
-                QueryProcessor);
+                QueryModelGenerator);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -268,7 +268,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ResultOperatorHandler,
                 EntityMaterializerSource,
                 ExpressionPrinter,
-                QueryProcessor);
+                QueryModelGenerator);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -289,7 +289,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ResultOperatorHandler,
                 EntityMaterializerSource,
                 ExpressionPrinter,
-                QueryProcessor);
+                QueryModelGenerator);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -310,7 +310,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ResultOperatorHandler,
                 EntityMaterializerSource,
                 ExpressionPrinter,
-                QueryProcessor);
+                QueryModelGenerator);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -331,7 +331,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ResultOperatorHandler,
                 EntityMaterializerSource,
                 ExpressionPrinter,
-                QueryProcessor);
+                QueryModelGenerator);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -352,7 +352,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ResultOperatorHandler,
                 EntityMaterializerSource,
                 ExpressionPrinter,
-                QueryProcessor);
+                QueryModelGenerator);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -373,7 +373,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ResultOperatorHandler,
                 EntityMaterializerSource,
                 ExpressionPrinter,
-                QueryProcessor);
+                QueryModelGenerator);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -394,7 +394,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ResultOperatorHandler,
                 EntityMaterializerSource,
                 ExpressionPrinter,
-                QueryProcessor);
+                QueryModelGenerator);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -415,7 +415,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ResultOperatorHandler,
                 entityMaterializerSource,
                 ExpressionPrinter,
-                QueryProcessor);
+                QueryModelGenerator);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -436,6 +436,27 @@ namespace Microsoft.EntityFrameworkCore.Query
                 ResultOperatorHandler,
                 EntityMaterializerSource,
                 expressionPrinter,
-                QueryProcessor);
+                QueryModelGenerator);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="queryModelGenerator"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public EntityQueryModelVisitorDependencies With([NotNull] IQueryModelGenerator queryModelGenerator)
+            => new EntityQueryModelVisitorDependencies(
+                QueryOptimizer,
+                NavigationRewritingExpressionVisitorFactory,
+                QuerySourceTracingExpressionVisitorFactory,
+                EntityResultFindingExpressionVisitorFactory,
+                TaskBlockingExpressionVisitor,
+                MemberAccessBindingExpressionVisitorFactory,
+                ProjectionExpressionVisitorFactory,
+                EntityQueryableExpressionVisitorFactory,
+                QueryAnnotationExtractor,
+                ResultOperatorHandler,
+                EntityMaterializerSource,
+                ExpressionPrinter,
+                queryModelGenerator);
     }
 }

--- a/src/EFCore/Query/Internal/IQueryModelGenerator.cs
+++ b/src/EFCore/Query/Internal/IQueryModelGenerator.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IQueryProcessor
+    public interface IQueryModelGenerator
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Query/Internal/IQueryProcessor.cs
+++ b/src/EFCore/Query/Internal/IQueryProcessor.cs
@@ -1,0 +1,34 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Remotion.Linq;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public interface IQueryProcessor
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        QueryModel ParseQuery([NotNull] Expression query);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        Expression ExtractParameters(
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger,
+            [NotNull] Expression query,
+            [NotNull] IParameterValues parameterValues,
+            bool parameterize = true,
+            bool generateContextAccessors = false);
+    }
+}

--- a/src/EFCore/Query/Internal/QueryModelGenerator.cs
+++ b/src/EFCore/Query/Internal/QueryModelGenerator.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class QueryProcessor : IQueryProcessor
+    public class QueryModelGenerator : IQueryModelGenerator
     {
         private readonly INodeTypeProvider _nodeTypeProvider;
         private readonly IEvaluatableExpressionFilter _evaluatableExpressionFilter;
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public QueryProcessor(
+        public QueryModelGenerator(
             [NotNull] INodeTypeProviderFactory nodeTypeProviderFactory,
             [NotNull] IEvaluatableExpressionFilter evaluatableExpressionFilter)
         {

--- a/src/EFCore/Query/Internal/QueryOptimizer.cs
+++ b/src/EFCore/Query/Internal/QueryOptimizer.cs
@@ -241,6 +241,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 var newExpressionTypeInfo = newExpression.Type.GetTypeInfo();
                 var castResultOperatorTypes = subQueryModel.ResultOperators.OfType<CastResultOperator>().Select(cre => cre.CastItemType).ToList();
                 var type = castResultOperatorTypes.LastOrDefault(t => newExpressionTypeInfo.IsAssignableFrom(t.GetTypeInfo()));
+
                 if (type != null
                     && type != newExpression.Type)
                 {

--- a/src/EFCore/Query/Internal/QueryProcessor.cs
+++ b/src/EFCore/Query/Internal/QueryProcessor.cs
@@ -1,0 +1,84 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Remotion.Linq;
+using Remotion.Linq.Parsing.ExpressionVisitors.Transformation;
+using Remotion.Linq.Parsing.ExpressionVisitors.TreeEvaluation;
+using Remotion.Linq.Parsing.Structure;
+using Remotion.Linq.Parsing.Structure.ExpressionTreeProcessors;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class QueryProcessor : IQueryProcessor
+    {
+        private readonly INodeTypeProvider _nodeTypeProvider;
+        private readonly IEvaluatableExpressionFilter _evaluatableExpressionFilter;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public QueryProcessor(
+            [NotNull] INodeTypeProviderFactory nodeTypeProviderFactory,
+            [NotNull] IEvaluatableExpressionFilter evaluatableExpressionFilter)
+        {
+            Check.NotNull(nodeTypeProviderFactory, nameof(nodeTypeProviderFactory));
+            Check.NotNull(evaluatableExpressionFilter, nameof(evaluatableExpressionFilter));
+
+            _nodeTypeProvider = nodeTypeProviderFactory.Create();
+            _evaluatableExpressionFilter = evaluatableExpressionFilter;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Expression ExtractParameters(
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger,
+            Expression query,
+            IParameterValues parameterValues,
+            bool parameterize = true,
+            bool generateContextAccessors = false)
+        {
+            Check.NotNull(query, nameof(query));
+            Check.NotNull(parameterValues, nameof(parameterValues));
+
+            var visitor
+                = new ParameterExtractingExpressionVisitor(
+                    _evaluatableExpressionFilter,
+                    parameterValues,
+                    logger,
+                    parameterize,
+                    generateContextAccessors);
+
+            return visitor.ExtractParameters(query);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual QueryModel ParseQuery(Expression query)
+            => CreateQueryParser(_nodeTypeProvider).GetParsedQuery(query);
+
+        private QueryParser CreateQueryParser(INodeTypeProvider nodeTypeProvider)
+            => new QueryParser(
+                new ExpressionTreeParser(
+                    nodeTypeProvider,
+                    new CompoundExpressionTreeProcessor(
+                        new IExpressionTreeProcessor[]
+                        {
+                            new PartialEvaluatingExpressionTreeProcessor(_evaluatableExpressionFilter),
+                            new TransformingExpressionTreeProcessor(ExpressionTransformerRegistry.CreateDefault())
+                        })));
+    }
+}

--- a/src/EFCore/breakingchanges.netcore.json
+++ b/src/EFCore/breakingchanges.netcore.json
@@ -1,42 +1,47 @@
-  [
-    {
-      "TypeId": "public static class Microsoft.EntityFrameworkCore.Diagnostics.CoreEventId",
-      "MemberId": "public const System.Int32 CoreBaseId = 100000",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public static class Microsoft.EntityFrameworkCore.Diagnostics.CoreEventId",
-      "MemberId": "public const System.Int32 ProviderBaseId = 300000",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public static class Microsoft.EntityFrameworkCore.Diagnostics.CoreEventId",
-      "MemberId": "public const System.Int32 ProviderDesignBaseId = 350000",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public static class Microsoft.EntityFrameworkCore.Diagnostics.CoreEventId",
-      "MemberId": "public const System.Int32 RelationalBaseId = 200000",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IDbContextTransactionManager : Microsoft.EntityFrameworkCore.Infrastructure.IResettableService",
-      "MemberId": "System.Transactions.Transaction get_EnlistedTransaction()",
-      "Kind": "Addition"
-    },
-    {
-      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IDbContextTransactionManager : Microsoft.EntityFrameworkCore.Infrastructure.IResettableService",
-      "MemberId": "System.Void EnlistTransaction(System.Transactions.Transaction transaction)",
-      "Kind": "Addition"
-    },
-    {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.ChangeTracking.ChangeTracker : Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager>",
-      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.DbContext context)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public interface Microsoft.EntityFrameworkCore.Update.IUpdateEntry",
-      "MemberId": "Microsoft.EntityFrameworkCore.Update.IUpdateEntry get_SharedIdentityEntry()",
-      "Kind": "Addition"
-    }
-  ]
+[
+  {
+    "TypeId": "public static class Microsoft.EntityFrameworkCore.Diagnostics.CoreEventId",
+    "MemberId": "public const System.Int32 CoreBaseId = 100000",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public static class Microsoft.EntityFrameworkCore.Diagnostics.CoreEventId",
+    "MemberId": "public const System.Int32 ProviderBaseId = 300000",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public static class Microsoft.EntityFrameworkCore.Diagnostics.CoreEventId",
+    "MemberId": "public const System.Int32 ProviderDesignBaseId = 350000",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public static class Microsoft.EntityFrameworkCore.Diagnostics.CoreEventId",
+    "MemberId": "public const System.Int32 RelationalBaseId = 200000",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IDbContextTransactionManager : Microsoft.EntityFrameworkCore.Infrastructure.IResettableService",
+    "MemberId": "System.Transactions.Transaction get_EnlistedTransaction()",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IDbContextTransactionManager : Microsoft.EntityFrameworkCore.Infrastructure.IResettableService",
+    "MemberId": "System.Void EnlistTransaction(System.Transactions.Transaction transaction)",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.ChangeTracking.ChangeTracker : Microsoft.EntityFrameworkCore.Infrastructure.IInfrastructure<Microsoft.EntityFrameworkCore.ChangeTracking.Internal.IStateManager>",
+    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.DbContext context)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Update.IUpdateEntry",
+    "MemberId": "Microsoft.EntityFrameworkCore.Update.IUpdateEntry get_SharedIdentityEntry()",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Query.EntityQueryModelVisitorDependencies",
+    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.Internal.IQueryOptimizer queryOptimizer, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.INavigationRewritingExpressionVisitorFactory navigationRewritingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IQuerySourceTracingExpressionVisitorFactory querySourceTracingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IEntityResultFindingExpressionVisitorFactory entityResultFindingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.ITaskBlockingExpressionVisitor taskBlockingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IMemberAccessBindingExpressionVisitorFactory memberAccessBindingExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IProjectionExpressionVisitorFactory projectionExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.IEntityQueryableExpressionVisitorFactory entityQueryableExpressionVisitorFactory, Microsoft.EntityFrameworkCore.Query.Internal.IQueryAnnotationExtractor queryAnnotationExtractor, Microsoft.EntityFrameworkCore.Query.IResultOperatorHandler resultOperatorHandler, Microsoft.EntityFrameworkCore.Metadata.Internal.IEntityMaterializerSource entityMaterializerSource, Microsoft.EntityFrameworkCore.Query.Internal.IExpressionPrinter expressionPrinter)",
+    "Kind": "Removal"
+  }
+]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FiltersInheritanceSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FiltersInheritanceSqlServerTest.cs
@@ -63,10 +63,10 @@ WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)");
             base.Can_use_of_type_bird();
 
             AssertSql(
-                @"SELECT [b].[Species], [b].[CountryId], [b].[Discriminator], [b].[Name], [b].[EagleId], [b].[IsFlightless], [b].[Group], [b].[FoundOn]
-FROM [Animal] AS [b]
-WHERE [b].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([b].[CountryId] = 1)
-ORDER BY [b].[Species]");
+                @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+FROM [Animal] AS [a]
+WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)
+ORDER BY [a].[Species]");
         }
 
         public override void Can_use_of_type_bird_predicate()
@@ -74,10 +74,10 @@ ORDER BY [b].[Species]");
             base.Can_use_of_type_bird_predicate();
 
             AssertSql(
-                @"SELECT [b].[Species], [b].[CountryId], [b].[Discriminator], [b].[Name], [b].[EagleId], [b].[IsFlightless], [b].[Group], [b].[FoundOn]
-FROM [Animal] AS [b]
-WHERE ([b].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([b].[CountryId] = 1)) AND ([b].[CountryId] = 1)
-ORDER BY [b].[Species]");
+                @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+FROM [Animal] AS [a]
+WHERE ([a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)) AND ([a].[CountryId] = 1)
+ORDER BY [a].[Species]");
         }
 
         public override void Can_use_of_type_bird_with_projection()
@@ -85,9 +85,9 @@ ORDER BY [b].[Species]");
             base.Can_use_of_type_bird_with_projection();
 
             AssertSql(
-                @"SELECT [b].[EagleId]
-FROM [Animal] AS [b]
-WHERE [b].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([b].[CountryId] = 1)");
+                @"SELECT [a].[EagleId]
+FROM [Animal] AS [a]
+WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)");
         }
 
         public override void Can_use_of_type_bird_first()
@@ -95,10 +95,10 @@ WHERE [b].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([b].[CountryId] = 1)");
             base.Can_use_of_type_bird_first();
 
             AssertSql(
-                @"SELECT TOP(1) [b].[Species], [b].[CountryId], [b].[Discriminator], [b].[Name], [b].[EagleId], [b].[IsFlightless], [b].[Group], [b].[FoundOn]
-FROM [Animal] AS [b]
-WHERE [b].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([b].[CountryId] = 1)
-ORDER BY [b].[Species]");
+                @"SELECT TOP(1) [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+FROM [Animal] AS [a]
+WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle') AND ([a].[CountryId] = 1)
+ORDER BY [a].[Species]");
         }
 
         public override void Can_use_of_type_kiwi()
@@ -106,9 +106,9 @@ ORDER BY [b].[Species]");
             base.Can_use_of_type_kiwi();
 
             AssertSql(
-                @"SELECT [k].[Species], [k].[CountryId], [k].[Discriminator], [k].[Name], [k].[EagleId], [k].[IsFlightless], [k].[FoundOn]
-FROM [Animal] AS [k]
-WHERE ([k].[Discriminator] = N'Kiwi') AND ([k].[CountryId] = 1)");
+                @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[FoundOn]
+FROM [Animal] AS [a]
+WHERE ([a].[Discriminator] = N'Kiwi') AND ([a].[CountryId] = 1)");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FiltersSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FiltersSqlServerTest.cs
@@ -190,9 +190,9 @@ FROM [Products] AS [p1]",
                 //
                 @"@__ef_filter___quantity_0='50'
 
-SELECT [o].[OrderID], [o].[ProductID], [o].[Discount], [o].[Quantity], [o].[UnitPrice]
-FROM [Order Details] AS [o]
-WHERE [o].[Quantity] > @__ef_filter___quantity_0");
+SELECT [od].[OrderID], [od].[ProductID], [od].[Discount], [od].[Quantity], [od].[UnitPrice]
+FROM [Order Details] AS [od]
+WHERE [od].[Quantity] > @__ef_filter___quantity_0");
         }
 
         public override void Navs_query()
@@ -207,9 +207,9 @@ SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[Cont
 FROM [Customers] AS [c]
 INNER JOIN [Orders] AS [c.Orders] ON [c].[CustomerID] = [c.Orders].[CustomerID]
 INNER JOIN (
-    SELECT [o].*
-    FROM [Order Details] AS [o]
-    WHERE [o].[Quantity] > @__ef_filter___quantity_1
+    SELECT [od].*
+    FROM [Order Details] AS [od]
+    WHERE [od].[Quantity] > @__ef_filter___quantity_1
 ) AS [t] ON [c.Orders].[OrderID] = [t].[OrderID]
 WHERE (([c].[CompanyName] LIKE @__ef_filter__TenantPrefix_0 + N'%' AND (LEFT([c].[CompanyName], LEN(@__ef_filter__TenantPrefix_0)) = @__ef_filter__TenantPrefix_0)) OR (@__ef_filter__TenantPrefix_0 = N'')) AND ([t].[Discount] < CAST(10 AS real))");
         }


### PR DESCRIPTION
- Adjust parameterizer to correctly handle DbSet eval when parameterizing filters.
- Introduce IQueryProcessor so we can parse queries inside the query compiler itself.