### PR TITLE
FromSql allows sql statement with trailing semicolon

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/Query/AsyncFromSqlQueryTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/AsyncFromSqlQueryTestBase.cs
@@ -81,6 +81,20 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [Fact]
+        public virtual async Task From_sql_queryable_with_semicolon_composed()
+        {
+            using (var context = CreateContext())
+            {
+                var actual = await context.Set<Customer>()
+                    .FromSql(@"SELECT * FROM ""Customers"";")
+                    .Where(c => c.ContactName.Contains("z"))
+                    .ToArrayAsync();
+
+                Assert.Equal(14, actual.Length);
+            }
+        }
+
+        [Fact]
         public virtual async Task From_sql_queryable_multiple_composed()
         {
             using (var context = CreateContext())

--- a/src/EFCore.Relational/RawSqlString.cs
+++ b/src/EFCore.Relational/RawSqlString.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     Constructs a <see cref="RawSqlString" /> from a see <see cref="string" />
         /// </summary>
         /// <param name="s"> The string. </param>
-        public RawSqlString([NotNull] string s) => Format = s?.Replace(";", string.Empty);
+        public RawSqlString([NotNull] string s) => Format = s.TrimEnd(';', ' ');
 
         /// <summary>
         ///     The string format.

--- a/src/EFCore.Relational/RawSqlString.cs
+++ b/src/EFCore.Relational/RawSqlString.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     Constructs a <see cref="RawSqlString" /> from a see <see cref="string" />
         /// </summary>
         /// <param name="s"> The string. </param>
-        public RawSqlString([NotNull] string s) => Format = s;
+        public RawSqlString([NotNull] string s) => Format = s?.Replace(";", string.Empty);
 
         /// <summary>
         ///     The string format.

--- a/test/EFCore.Relational.Tests/RawSqlStringTest.cs
+++ b/test/EFCore.Relational.Tests/RawSqlStringTest.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class RawSqlStringTest
+    {
+        [Fact]
+        public void Trailing_semicolon_gets_removed()
+        {
+            var sql = "SELECT * FROM Customers;";
+
+            var sut = new RawSqlString(sql);
+
+            Assert.Equal("SELECT * FROM Customers", sut.Format);
+        }
+
+        [Fact]
+        public void Trailing_semicolon_followed_by_space_gets_removed()
+        {
+            var sql = "SELECT * FROM Customers; ";
+
+            var sut = new RawSqlString(sql);
+
+            Assert.Equal("SELECT * FROM Customers", sut.Format);
+        }
+
+        [Fact]
+        public void Trailing_semicolon_separated_by_space_gets_removed()
+        {
+            var sql = "SELECT * FROM Customers ;";
+
+            var sut = new RawSqlString(sql);
+
+            Assert.Equal("SELECT * FROM Customers", sut.Format);
+        }
+
+        [Fact]
+        public void Multiple_trailing_semicolons_are_removed()
+        {
+            var sql = "SELECT * FROM Customers;;";
+
+            var sut = new RawSqlString(sql);
+
+            Assert.Equal("SELECT * FROM Customers", sut.Format);
+        }
+
+        [Fact]
+        public void Multiple_trailing_semicolons_separated_by_space_are_removed()
+        {
+            var sql = "SELECT * FROM Customers; ;";
+
+            var sut = new RawSqlString(sql);
+
+            Assert.Equal("SELECT * FROM Customers", sut.Format);
+        }
+
+        [Fact]
+        public void Semicolons_not_at_the_end_are_kept()
+        {
+            var text = "abc;def;xyz;";
+
+            var sut = new RawSqlString(text);
+
+            Assert.Equal("abc;def;xyz", sut.Format);
+        }
+    }
+}


### PR DESCRIPTION
The sql statement in `FromSql` can be terminated by a semicolon `;`.  
The ; gets replaced by an empty string.

Fixes #10474 