### PR TITLE
Add a test helper for creating default service instances

### DIFF
--- a/src/EFCore.Specification.Tests/TestUtilities/TestServiceFactory.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/TestServiceFactory.cs
@@ -1,0 +1,51 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities
+{
+    public class TestServiceFactory
+    {
+        public static readonly TestServiceFactory Instance = new TestServiceFactory();
+
+        private TestServiceFactory()
+        {
+        }
+
+        private readonly ConcurrentDictionary<Type, IServiceProvider> _factories
+            = new ConcurrentDictionary<Type, IServiceProvider>();
+
+        public TService Create<TService>()
+            where TService : class
+        {
+            return _factories.GetOrAdd(
+                typeof(TService),
+                t => AddType(new ServiceCollection(), typeof(TService)).BuildServiceProvider()).GetService<TService>();
+        }
+
+        private static ServiceCollection AddType(ServiceCollection serviceCollection, Type serviceType)
+        {
+            serviceCollection.AddSingleton(serviceType);
+
+            var constructors = serviceType.GetConstructors();
+            var constructor = constructors
+                .FirstOrDefault(c => c.GetParameters().Length == constructors.Max(c2 => c2.GetParameters().Length));
+
+            if (constructor == null)
+            {
+                throw new InvalidOperationException("Cannot use with no public constructors.");
+            }
+
+            foreach (var parameter in constructor.GetParameters())
+            {
+                AddType(serviceCollection, parameter.ParameterType);
+            }
+
+            return serviceCollection;
+        }
+    }
+}

--- a/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     new Model(),
                     migrationAssembly,
                     new MigrationsModelDiffer(
-                        new TestRelationalTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()),
+                        TestServiceFactory.Instance.Create<TestRelationalTypeMapper>(),
                         new MigrationsAnnotationProvider(new MigrationsAnnotationProviderDependencies()),
                         services.GetRequiredService<IChangeDetector>(),
                         services.GetRequiredService<StateManagerDependencies>(),

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -2189,8 +2189,6 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                         new LoggingOptions(),
                         new DiagnosticListener("Fake"))),
                 new RelationalModelValidatorDependencies(
-                    new SqlServerTypeMapper(
-                        new CoreTypeMapperDependencies(),
-                        new RelationalTypeMapperDependencies())));
+                    TestServiceFactory.Instance.Create<SqlServerTypeMapper>()));
     }
 }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ScaffoldingTypeMapperSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ScaffoldingTypeMapperSqlServerTest.cs
@@ -5,6 +5,7 @@ using System;
 using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
@@ -294,9 +295,6 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         private static ScaffoldingTypeMapper CreateMapper()
-            => new ScaffoldingTypeMapper(
-                new SqlServerTypeMapper(
-                    new CoreTypeMapperDependencies(),
-                    new RelationalTypeMapperDependencies()));
+            => new ScaffoldingTypeMapper(TestServiceFactory.Instance.Create<SqlServerTypeMapper>());
     }
 }

--- a/test/EFCore.Design.Tests/TestUtilities/FakeScaffoldingModelFactory.cs
+++ b/test/EFCore.Design.Tests/TestUtilities/FakeScaffoldingModelFactory.cs
@@ -67,10 +67,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 new CandidateNamingService(),
                 pluralizer,
                 new CSharpUtilities(),
-                new ScaffoldingTypeMapper(
-                    new SqlServerTypeMapper(
-                        new CoreTypeMapperDependencies(), 
-                        new RelationalTypeMapperDependencies())))
+                new ScaffoldingTypeMapper(TestServiceFactory.Instance.Create<SqlServerTypeMapper>()))
         {
         }
     }

--- a/test/EFCore.Relational.Tests/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConventionTest.cs
@@ -40,8 +40,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
         protected override PropertyMappingValidationConvention CreateConvention()
             => new PropertyMappingValidationConvention(
-                new TestRelationalTypeMapper(
-                    new CoreTypeMapperDependencies(),
-                    new RelationalTypeMapperDependencies()));
+                TestServiceFactory.Instance.Create<TestRelationalTypeMapper>());
     }
 }

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
@@ -87,9 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
         protected virtual MigrationsModelDiffer CreateModelDiffer(DbContext ctx)
             => new MigrationsModelDiffer(
-                new ConcreteTypeMapper(
-                    new CoreTypeMapperDependencies(),
-                    new RelationalTypeMapperDependencies()),
+                TestServiceFactory.Instance.Create<ConcreteTypeMapper>(),
                 new MigrationsAnnotationProvider(
                     new MigrationsAnnotationProviderDependencies()),
                 ctx.GetService<IChangeDetector>(),

--- a/test/EFCore.Relational.Tests/Migrations/MigrationCommandListBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/MigrationCommandListBuilderTest.cs
@@ -120,8 +120,6 @@ Statement3
             => new MigrationCommandListBuilder(
                 new RelationalCommandBuilderFactory(
                     new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
-                    new FakeRelationalTypeMapper(
-                        new CoreTypeMapperDependencies(),
-                        new RelationalTypeMapperDependencies())));
+                    TestServiceFactory.Instance.Create<FakeRelationalTypeMapper>()));
     }
 }

--- a/test/EFCore.Relational.Tests/RelationalModelValidatorTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalModelValidatorTest.cs
@@ -797,9 +797,8 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         private static void GenerateMapping(IMutableProperty property)
-            => property[CoreAnnotationNames.TypeMapping] = new TestRelationalTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies()).GetMapping(property);
+            => property[CoreAnnotationNames.TypeMapping]
+                = TestServiceFactory.Instance.Create<TestRelationalTypeMapper>().GetMapping(property);
 
         protected override void SetBaseType(EntityType entityType, EntityType baseEntityType)
         {
@@ -860,9 +859,7 @@ namespace Microsoft.EntityFrameworkCore
                         new LoggingOptions(),
                         new DiagnosticListener("Fake"))),
                 new RelationalModelValidatorDependencies(
-                    new TestRelationalTypeMapper(
-                        new CoreTypeMapperDependencies(),
-                        new RelationalTypeMapperDependencies())));
+                    TestServiceFactory.Instance.Create<TestRelationalTypeMapper>()));
 
         protected virtual ConventionSet CreateConventionSet() => TestRelationalConventionSetBuilder.Build();
     }

--- a/test/EFCore.Relational.Tests/Storage/RawSqlCommandBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RawSqlCommandBuilderTest.cs
@@ -16,9 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var builder = new RawSqlCommandBuilder(
                 new RelationalCommandBuilderFactory(
                     new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
-                    new FakeRelationalTypeMapper(
-                        new CoreTypeMapperDependencies(),
-                        new RelationalTypeMapperDependencies())),
+                    TestServiceFactory.Instance.Create<FakeRelationalTypeMapper>()),
                 new RelationalSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
                 new ParameterNameGeneratorFactory(new ParameterNameGeneratorDependencies()));
 
@@ -34,9 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var builder = new RawSqlCommandBuilder(
                 new RelationalCommandBuilderFactory(
                     new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
-                    new FakeRelationalTypeMapper(
-                        new CoreTypeMapperDependencies(),
-                        new RelationalTypeMapperDependencies())),
+                    TestServiceFactory.Instance.Create<FakeRelationalTypeMapper>()),
                 new RelationalSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
                 new ParameterNameGeneratorFactory(new ParameterNameGeneratorDependencies()));
 
@@ -53,9 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var builder = new RawSqlCommandBuilder(
                 new RelationalCommandBuilderFactory(
                     new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
-                    new FakeRelationalTypeMapper(
-                        new CoreTypeMapperDependencies(),
-                        new RelationalTypeMapperDependencies())),
+                    TestServiceFactory.Instance.Create<FakeRelationalTypeMapper>()),
                 new RelationalSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()),
                 new ParameterNameGeneratorFactory(new ParameterNameGeneratorDependencies()));
 

--- a/test/EFCore.Relational.Tests/Storage/RelationalCommandBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalCommandBuilderTest.cs
@@ -15,9 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             var commandBuilder = new RelationalCommandBuilder(
                 new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
-                new FakeRelationalTypeMapper(
-                    new CoreTypeMapperDependencies(),
-                    new RelationalTypeMapperDependencies()));
+                TestServiceFactory.Instance.Create<FakeRelationalTypeMapper>());
 
             var command = commandBuilder.Build();
 
@@ -30,9 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             var commandBuilder = new RelationalCommandBuilder(
                 new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
-                new FakeRelationalTypeMapper(
-                    new CoreTypeMapperDependencies(),
-                    new RelationalTypeMapperDependencies()));
+                TestServiceFactory.Instance.Create<FakeRelationalTypeMapper>());
 
             commandBuilder.ParameterBuilder.AddParameter(
                 "InvariantName",

--- a/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
@@ -540,9 +540,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             var fakeConnection = CreateConnection();
 
-            var typeMapper = new FakeRelationalTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies());
+            var typeMapper = TestServiceFactory.Instance.Create<FakeRelationalTypeMapper>();
 
             var dbParameter = new FakeDbParameter { ParameterName = "FirstParameter", Value = 17, DbType = DbType.Int32 };
 

--- a/test/EFCore.Relational.Tests/Storage/RelationalParameterBuilderTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalParameterBuilderTest.cs
@@ -4,6 +4,7 @@
 using System.Data;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider;
 using Xunit;
 
@@ -14,9 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [Fact]
         public void Can_add_dynamic_parameter()
         {
-            var typeMapper = new FakeRelationalTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies());
+            var typeMapper = TestServiceFactory.Instance.Create<FakeRelationalTypeMapper>();
 
             var parameterBuilder = new RelationalParameterBuilder(typeMapper);
 
@@ -38,9 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [InlineData(false)]
         public void Can_add_type_mapped_parameter_by_type(bool nullable)
         {
-            var typeMapper = new FakeRelationalTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies());
+            var typeMapper = TestServiceFactory.Instance.Create<FakeRelationalTypeMapper>();
             var typeMapping = typeMapper.GetMapping(nullable ? typeof(int?) : typeof(int));
             var parameterBuilder = new RelationalParameterBuilder(typeMapper);
 
@@ -66,9 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [InlineData(false)]
         public void Can_add_type_mapped_parameter_by_property(bool nullable)
         {
-            var typeMapper = new FakeRelationalTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies());
+            var typeMapper = TestServiceFactory.Instance.Create<FakeRelationalTypeMapper>();
 
             var property = new Model().AddEntityType("MyType").AddProperty("MyProp", typeof(string));
             property.IsNullable = nullable;
@@ -95,9 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [Fact]
         public void Can_add_composite_parameter()
         {
-            var typeMapper = new FakeRelationalTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies());
+            var typeMapper = TestServiceFactory.Instance.Create<FakeRelationalTypeMapper>();
 
             var parameterBuilder = new RelationalParameterBuilder(typeMapper);
 
@@ -130,9 +123,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [Fact]
         public void Does_not_add_empty_composite_parameter()
         {
-            var typeMapper = new FakeRelationalTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies());
+            var typeMapper = TestServiceFactory.Instance.Create<FakeRelationalTypeMapper>();
 
             var parameterBuilder = new RelationalParameterBuilder(typeMapper);
 

--- a/test/EFCore.Relational.Tests/Storage/RelationalTypeMapperTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalTypeMapperTest.cs
@@ -79,9 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 property.SetMaxLength(maxLength);
             }
 
-            return new TestRelationalTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies()).GetMapping(property);
+            return TestServiceFactory.Instance.Create<TestRelationalTypeMapper>().GetMapping(property);
         }
 
         [Fact]
@@ -125,18 +123,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var property = CreateEntityType().AddProperty("MyProp", propertyType);
             property.Relational().ColumnType = typeName;
 
-            return new TestRelationalTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies()).GetMapping(property);
+            return TestServiceFactory.Instance.Create<TestRelationalTypeMapper>().GetMapping(property);
         }
 
         [Fact]
         public void Key_with_store_type_is_picked_up_by_FK()
         {
             var model = CreateModel();
-            var mapper = new TestRelationalTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies());
+            var mapper = TestServiceFactory.Instance.Create<TestRelationalTypeMapper>();
 
             Assert.Equal(
                 "money",
@@ -151,9 +145,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void String_key_with_max_length_is_picked_up_by_FK()
         {
             var model = CreateModel();
-            var mapper = new TestRelationalTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies());
+            var mapper = TestServiceFactory.Instance.Create<TestRelationalTypeMapper>();
 
             Assert.Equal(
                 "just_string(200)",
@@ -168,9 +160,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void Binary_key_with_max_length_is_picked_up_by_FK()
         {
             var model = CreateModel();
-            var mapper = new TestRelationalTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies());
+            var mapper = TestServiceFactory.Instance.Create<TestRelationalTypeMapper>();
 
             Assert.Equal(
                 "just_binary(100)",
@@ -185,9 +175,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void String_key_with_unicode_is_picked_up_by_FK()
         {
             var model = CreateModel();
-            var mapper = new TestRelationalTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies());
+            var mapper = TestServiceFactory.Instance.Create<TestRelationalTypeMapper>();
 
             Assert.Equal(
                 "ansi_string(900)",
@@ -202,9 +190,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void Key_store_type_if_preferred_if_specified()
         {
             var model = CreateModel();
-            var mapper = new TestRelationalTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies());
+            var mapper = TestServiceFactory.Instance.Create<TestRelationalTypeMapper>();
 
             Assert.Equal(
                 "money",
@@ -219,9 +205,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void String_FK_max_length_is_preferred_if_specified()
         {
             var model = CreateModel();
-            var mapper = new TestRelationalTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies());
+            var mapper = TestServiceFactory.Instance.Create<TestRelationalTypeMapper>();
 
             Assert.Equal(
                 "just_string(200)",
@@ -236,9 +220,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void Binary_FK_max_length_is_preferred_if_specified()
         {
             var model = CreateModel();
-            var mapper = new TestRelationalTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies());
+            var mapper = TestServiceFactory.Instance.Create<TestRelationalTypeMapper>();
 
             Assert.Equal(
                 "just_binary(100)",
@@ -253,9 +235,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public void String_FK_unicode_is_preferred_if_specified()
         {
             var model = CreateModel();
-            var mapper = new TestRelationalTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies());
+            var mapper = TestServiceFactory.Instance.Create<TestRelationalTypeMapper>();
 
             Assert.Equal(
                 "ansi_string(900)",

--- a/test/EFCore.Relational.Tests/TestUtilities/TestRelationalConventionSetBuilder.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/TestRelationalConventionSetBuilder.cs
@@ -17,9 +17,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public static ConventionSet Build()
             => new TestRelationalConventionSetBuilder(
                     new RelationalConventionSetBuilderDependencies(
-                        new TestRelationalTypeMapper(
-                            new CoreTypeMapperDependencies(),
-                            new RelationalTypeMapperDependencies()), null, null))
+                        TestServiceFactory.Instance.Create<TestRelationalTypeMapper>(), null, null))
                 .AddConventions(
                     new CoreConventionSetBuilder(
                             new CoreConventionSetBuilderDependencies(

--- a/test/EFCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
+++ b/test/EFCore.Relational.Tests/Update/ReaderModificationCommandBatchTest.cs
@@ -514,9 +514,7 @@ namespace Microsoft.EntityFrameworkCore.Update
         }
 
         private static void GenerateMapping(IMutableProperty property)
-            => property[CoreAnnotationNames.TypeMapping] = new TestRelationalTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies()).GetMapping(property);
+            => property[CoreAnnotationNames.TypeMapping] = TestServiceFactory.Instance.Create<TestRelationalTypeMapper>().GetMapping(property);
 
         private static InternalEntityEntry CreateEntry(
             EntityState entityState,
@@ -543,18 +541,14 @@ namespace Microsoft.EntityFrameworkCore.Update
                 : base(
                     new RelationalCommandBuilderFactory(
                         new FakeDiagnosticsLogger<DbLoggerCategory.Database.Command>(),
-                        new FakeRelationalTypeMapper(
-                            new CoreTypeMapperDependencies(),
-                            new RelationalTypeMapperDependencies())),
+                        TestServiceFactory.Instance.Create<FakeRelationalTypeMapper>()),
                     new RelationalSqlGenerationHelper(
                         new RelationalSqlGenerationHelperDependencies()),
                     sqlGenerator ?? new FakeSqlGenerator(
                         RelationalTestHelpers.Instance.CreateContextServices().GetRequiredService<UpdateSqlGeneratorDependencies>()),
                     new TypedRelationalValueBufferFactoryFactory(
                         new RelationalValueBufferFactoryDependencies(
-                            new FakeRelationalTypeMapper(
-                                new CoreTypeMapperDependencies(),
-                                new RelationalTypeMapperDependencies()))))
+                            TestServiceFactory.Instance.Create<FakeRelationalTypeMapper>())))
             {
                 ShouldAddCommand = true;
                 ShouldValidateSql = true;

--- a/test/EFCore.Relational.Tests/Update/UpdateSqlGeneratorTest.cs
+++ b/test/EFCore.Relational.Tests/Update/UpdateSqlGeneratorTest.cs
@@ -14,9 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 new UpdateSqlGeneratorDependencies(
                     new RelationalSqlGenerationHelper(
                         new RelationalSqlGenerationHelperDependencies()),
-                    new FakeRelationalTypeMapper(
-                        new CoreTypeMapperDependencies(),
-                        new RelationalTypeMapperDependencies())));
+                    TestServiceFactory.Instance.Create<FakeRelationalTypeMapper>()));
 
         protected override TestHelpers TestHelpers => RelationalTestHelpers.Instance;
 

--- a/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
@@ -82,7 +82,7 @@ namespace Microsoft.EntityFrameworkCore
             var modelBuilder = base.Key_and_MaxLength_64_produce_nvarchar_64();
 
             var property = GetProperty<ColumnKeyAnnotationClass2>(modelBuilder, "PersonFirstName");
-            Assert.Equal("nvarchar(64)", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).FindMapping(property).StoreType);
+            Assert.Equal("nvarchar(64)", TestServiceFactory.Instance.Create<SqlServerTypeMapper>().FindMapping(property).StoreType);
 
             return modelBuilder;
         }
@@ -92,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore
             var modelBuilder = base.Timestamp_takes_precedence_over_MaxLength();
 
             var property = GetProperty<TimestampAndMaxlen>(modelBuilder, "MaxTimestamp");
-            Assert.Equal("rowversion", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).FindMapping(property).StoreType);
+            Assert.Equal("rowversion", TestServiceFactory.Instance.Create<SqlServerTypeMapper>().FindMapping(property).StoreType);
 
             return modelBuilder;
         }
@@ -102,7 +102,7 @@ namespace Microsoft.EntityFrameworkCore
             var modelBuilder = base.Timestamp_takes_precedence_over_MaxLength_with_value();
 
             var property = GetProperty<TimestampAndMaxlen>(modelBuilder, "NonMaxTimestamp");
-            Assert.Equal("rowversion", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).FindMapping(property).StoreType);
+            Assert.Equal("rowversion", TestServiceFactory.Instance.Create<SqlServerTypeMapper>().FindMapping(property).StoreType);
 
             return modelBuilder;
         }

--- a/test/EFCore.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
+++ b/test/EFCore.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
@@ -457,9 +457,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 
         protected override MigrationsModelDiffer CreateModelDiffer(DbContext ctx)
             => new MigrationsModelDiffer(
-                new SqlServerTypeMapper(
-                    new CoreTypeMapperDependencies(),
-                    new RelationalTypeMapperDependencies()),
+                TestServiceFactory.Instance.Create<SqlServerTypeMapper>(),
                 new SqlServerMigrationsAnnotationProvider(
                     new MigrationsAnnotationProviderDependencies()),
                 ctx.GetService<IChangeDetector>(),

--- a/test/EFCore.SqlServer.Tests/SqlServerModelValidatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerModelValidatorTest.cs
@@ -252,9 +252,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         private static void GenerateMapping(IMutableProperty property)
-            => property[CoreAnnotationNames.TypeMapping] = new SqlServerTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies()).GetMapping(property);
+            => property[CoreAnnotationNames.TypeMapping] = TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(property);
 
         private class Cheese
         {
@@ -271,8 +269,6 @@ namespace Microsoft.EntityFrameworkCore
                         new LoggingOptions(),
                         new DiagnosticListener("Fake"))),
                 new RelationalModelValidatorDependencies(
-                    new SqlServerTypeMapper(
-                        new CoreTypeMapperDependencies(),
-                        new RelationalTypeMapperDependencies())));
+                    TestServiceFactory.Instance.Create<SqlServerTypeMapper>()));
     }
 }

--- a/test/EFCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerSequenceValueGeneratorTest.cs
@@ -76,9 +76,7 @@ namespace Microsoft.EntityFrameworkCore
                     new UpdateSqlGeneratorDependencies(
                         new SqlServerSqlGenerationHelper(
                             new RelationalSqlGenerationHelperDependencies()),
-                        new SqlServerTypeMapper(
-                            new CoreTypeMapperDependencies(),
-                            new RelationalTypeMapperDependencies()))),
+                        TestServiceFactory.Instance.Create<SqlServerTypeMapper>())),
                 state,
                 CreateConnection());
 
@@ -129,9 +127,7 @@ namespace Microsoft.EntityFrameworkCore
                 new UpdateSqlGeneratorDependencies(
                     new SqlServerSqlGenerationHelper(
                         new RelationalSqlGenerationHelperDependencies()),
-                    new SqlServerTypeMapper(
-                        new CoreTypeMapperDependencies(),
-                        new RelationalTypeMapperDependencies())));
+                    TestServiceFactory.Instance.Create<SqlServerTypeMapper>()));
 
             var tests = new Func<Task>[threadCount];
             var generatedValues = new List<long>[threadCount];
@@ -178,9 +174,7 @@ namespace Microsoft.EntityFrameworkCore
                     new UpdateSqlGeneratorDependencies(
                         new SqlServerSqlGenerationHelper(
                             new RelationalSqlGenerationHelperDependencies()),
-                        new SqlServerTypeMapper(
-                            new CoreTypeMapperDependencies(),
-                            new RelationalTypeMapperDependencies()))),
+                        TestServiceFactory.Instance.Create<SqlServerTypeMapper>())),
                 state,
                 CreateConnection());
 

--- a/test/EFCore.SqlServer.Tests/SqlServerTypeMapperTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerTypeMapperTest.cs
@@ -204,9 +204,7 @@ namespace Microsoft.EntityFrameworkCore
             property.IsUnicode(unicode);
             property.DeclaringEntityType.SetPrimaryKey(property);
 
-            var typeMapping = new SqlServerTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies()).GetMapping(property);
+            var typeMapping = TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(property);
 
             Assert.Null(typeMapping.DbType);
             Assert.Equal("nvarchar(450)", typeMapping.StoreType);
@@ -227,9 +225,7 @@ namespace Microsoft.EntityFrameworkCore
             var pk = property.DeclaringEntityType.SetPrimaryKey(property);
             property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
 
-            var typeMapping = new SqlServerTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies()).GetMapping(fkProperty);
+            var typeMapping = TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(fkProperty);
 
             Assert.Null(typeMapping.DbType);
             Assert.Equal("nvarchar(450)", typeMapping.StoreType);
@@ -251,9 +247,7 @@ namespace Microsoft.EntityFrameworkCore
             property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
             fkProperty.IsNullable = false;
 
-            var typeMapping = new SqlServerTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies()).GetMapping(fkProperty);
+            var typeMapping = TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(fkProperty);
 
             Assert.Null(typeMapping.DbType);
             Assert.Equal("nvarchar(450)", typeMapping.StoreType);
@@ -272,9 +266,7 @@ namespace Microsoft.EntityFrameworkCore
             property.IsUnicode(unicode);
             entityType.AddIndex(property);
 
-            var typeMapping = new SqlServerTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies()).GetMapping(property);
+            var typeMapping = TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(property);
 
             Assert.Null(typeMapping.DbType);
             Assert.Equal("nvarchar(450)", typeMapping.StoreType);
@@ -351,9 +343,7 @@ namespace Microsoft.EntityFrameworkCore
             property.IsUnicode(false);
             property.DeclaringEntityType.SetPrimaryKey(property);
 
-            var typeMapping = new SqlServerTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies()).GetMapping(property);
+            var typeMapping = TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(property);
 
             Assert.Equal(DbType.AnsiString, typeMapping.DbType);
             Assert.Equal("varchar(900)", typeMapping.StoreType);
@@ -372,9 +362,7 @@ namespace Microsoft.EntityFrameworkCore
             var pk = property.DeclaringEntityType.SetPrimaryKey(property);
             property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
 
-            var typeMapping = new SqlServerTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies()).GetMapping(fkProperty);
+            var typeMapping = TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(fkProperty);
 
             Assert.Equal(DbType.AnsiString, typeMapping.DbType);
             Assert.Equal("varchar(900)", typeMapping.StoreType);
@@ -394,9 +382,7 @@ namespace Microsoft.EntityFrameworkCore
             property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
             fkProperty.IsNullable = false;
 
-            var typeMapping = new SqlServerTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies()).GetMapping(fkProperty);
+            var typeMapping = TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(fkProperty);
 
             Assert.Equal(DbType.AnsiString, typeMapping.DbType);
             Assert.Equal("varchar(900)", typeMapping.StoreType);
@@ -413,9 +399,7 @@ namespace Microsoft.EntityFrameworkCore
             property.IsUnicode(false);
             entityType.AddIndex(property);
 
-            var typeMapping = new SqlServerTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies()).GetMapping(property);
+            var typeMapping = TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(property);
 
             Assert.Equal(DbType.AnsiString, typeMapping.DbType);
             Assert.Equal("varchar(900)", typeMapping.StoreType);
@@ -485,9 +469,7 @@ namespace Microsoft.EntityFrameworkCore
             var property = CreateEntityType().AddProperty("MyBinaryProp", typeof(byte[]));
             property.Relational().ColumnType = "binary(100)";
 
-            var typeMapping = new SqlServerTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies()).GetMapping(property);
+            var typeMapping = TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(property);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("binary(100)", typeMapping.StoreType);
@@ -500,9 +482,7 @@ namespace Microsoft.EntityFrameworkCore
             property.IsNullable = false;
             property.DeclaringEntityType.SetPrimaryKey(property);
 
-            var typeMapping = new SqlServerTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies()).GetMapping(property);
+            var typeMapping = TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(property);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("varbinary(900)", typeMapping.StoreType);
@@ -518,9 +498,7 @@ namespace Microsoft.EntityFrameworkCore
             var pk = property.DeclaringEntityType.SetPrimaryKey(property);
             property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
 
-            var typeMapping = new SqlServerTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies()).GetMapping(fkProperty);
+            var typeMapping = TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(fkProperty);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("varbinary(900)", typeMapping.StoreType);
@@ -537,9 +515,7 @@ namespace Microsoft.EntityFrameworkCore
             property.DeclaringEntityType.AddForeignKey(fkProperty, pk, property.DeclaringEntityType);
             fkProperty.IsNullable = false;
 
-            var typeMapping = new SqlServerTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies()).GetMapping(fkProperty);
+            var typeMapping = TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(fkProperty);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("varbinary(900)", typeMapping.StoreType);
@@ -553,9 +529,7 @@ namespace Microsoft.EntityFrameworkCore
             var property = entityType.AddProperty("MyProp", typeof(byte[]));
             entityType.AddIndex(property);
 
-            var typeMapping = new SqlServerTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies()).GetMapping(property);
+            var typeMapping = TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(property);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("varbinary(900)", typeMapping.StoreType);
@@ -569,9 +543,7 @@ namespace Microsoft.EntityFrameworkCore
             property.IsConcurrencyToken = true;
             property.ValueGenerated = ValueGenerated.OnAddOrUpdate;
 
-            var typeMapping = new SqlServerTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies()).GetMapping(property);
+            var typeMapping = TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(property);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("rowversion", typeMapping.StoreType);
@@ -587,9 +559,7 @@ namespace Microsoft.EntityFrameworkCore
             property.ValueGenerated = ValueGenerated.OnAddOrUpdate;
             property.IsNullable = false;
 
-            var typeMapping = new SqlServerTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies()).GetMapping(property);
+            var typeMapping = TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(property);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("rowversion", typeMapping.StoreType);
@@ -603,9 +573,7 @@ namespace Microsoft.EntityFrameworkCore
             var property = CreateEntityType().AddProperty("MyProp", typeof(byte[]));
             property.IsConcurrencyToken = true;
 
-            var typeMapping = new SqlServerTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies()).GetMapping(property);
+            var typeMapping = TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(property);
 
             Assert.Equal(DbType.Binary, typeMapping.DbType);
             Assert.Equal("varbinary(max)", typeMapping.StoreType);
@@ -634,40 +602,38 @@ namespace Microsoft.EntityFrameworkCore
                 property.IsUnicode(unicode);
             }
 
-            return new SqlServerTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies()).GetMapping(property);
+            return TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(property);
         }
 
         [Fact]
         public void Does_default_mappings_for_sequence_types()
         {
-            Assert.Equal("int", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMapping(typeof(int)).StoreType);
-            Assert.Equal("smallint", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMapping(typeof(short)).StoreType);
-            Assert.Equal("bigint", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMapping(typeof(long)).StoreType);
-            Assert.Equal("tinyint", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMapping(typeof(byte)).StoreType);
+            Assert.Equal("int", TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(typeof(int)).StoreType);
+            Assert.Equal("smallint", TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(typeof(short)).StoreType);
+            Assert.Equal("bigint", TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(typeof(long)).StoreType);
+            Assert.Equal("tinyint", TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(typeof(byte)).StoreType);
         }
 
         [Fact]
         public void Does_default_mappings_for_strings_and_byte_arrays()
         {
-            Assert.Equal("nvarchar(max)", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMapping(typeof(string)).StoreType);
-            Assert.Equal("varbinary(max)", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMapping(typeof(byte[])).StoreType);
+            Assert.Equal("nvarchar(max)", TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(typeof(string)).StoreType);
+            Assert.Equal("varbinary(max)", TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(typeof(byte[])).StoreType);
         }
 
         [Fact]
         public void Does_default_mappings_for_values()
         {
-            Assert.Equal("nvarchar(max)", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMappingForValue("Cheese").StoreType);
-            Assert.Equal("varbinary(max)", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMappingForValue(new byte[1]).StoreType);
-            Assert.Equal("datetime2", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMappingForValue(new DateTime()).StoreType);
+            Assert.Equal("nvarchar(max)", TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMappingForValue("Cheese").StoreType);
+            Assert.Equal("varbinary(max)", TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMappingForValue(new byte[1]).StoreType);
+            Assert.Equal("datetime2", TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMappingForValue(new DateTime()).StoreType);
         }
 
         [Fact]
         public void Does_default_mappings_for_null_values()
         {
-            Assert.Equal("NULL", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMappingForValue(null).StoreType);
-            Assert.Equal("NULL", new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMappingForValue(DBNull.Value).StoreType);
+            Assert.Equal("NULL", TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMappingForValue(null).StoreType);
+            Assert.Equal("NULL", TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMappingForValue(DBNull.Value).StoreType);
             Assert.Equal("NULL", RelationalTypeMapperExtensions.GetMappingForValue(null, "Itz").StoreType);
         }
 
@@ -675,9 +641,7 @@ namespace Microsoft.EntityFrameworkCore
         public void Throws_for_unrecognized_types()
         {
             var ex = Assert.Throws<InvalidOperationException>(
-                () => new SqlServerTypeMapper(
-                    new CoreTypeMapperDependencies(),
-                    new RelationalTypeMapperDependencies()).GetMapping("magic"));
+                () => TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping("magic"));
 
             Assert.Equal(RelationalStrings.UnsupportedType("magic"), ex.Message);
         }
@@ -687,9 +651,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             var property = new Model().AddEntityType("Entity1").AddProperty("Strange", typeof(object));
             var ex = Assert.Throws<InvalidOperationException>(
-                () => new SqlServerTypeMapper(
-                    new CoreTypeMapperDependencies(),
-                    new RelationalTypeMapperDependencies()).GetMapping(property));
+                () => TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(property));
 
             Assert.Equal(RelationalStrings.UnsupportedPropertyType("Entity1", "Strange", "object"), ex.Message);
         }
@@ -759,7 +721,7 @@ namespace Microsoft.EntityFrameworkCore
         [InlineData("VARCHAR", typeof(string), null, false)]
         public void Can_map_by_type_name(string typeName, Type clrType, int? size, bool unicode)
         {
-            var mapping = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMapping(typeName);
+            var mapping = TestServiceFactory.Instance.Create<SqlServerTypeMapper>().GetMapping(typeName);
 
             Assert.Equal(clrType, mapping.ClrType);
             Assert.Equal(size, mapping.Size);
@@ -771,7 +733,7 @@ namespace Microsoft.EntityFrameworkCore
         public void Key_with_store_type_is_picked_up_by_FK()
         {
             var model = CreateModel();
-            var mapper = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies());
+            var mapper = TestServiceFactory.Instance.Create<SqlServerTypeMapper>();
 
             Assert.Equal(
                 "money",
@@ -786,7 +748,7 @@ namespace Microsoft.EntityFrameworkCore
         public void String_key_with_max_length_is_picked_up_by_FK()
         {
             var model = CreateModel();
-            var mapper = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies());
+            var mapper = TestServiceFactory.Instance.Create<SqlServerTypeMapper>();
 
             Assert.Equal(
                 "nvarchar(200)",
@@ -801,7 +763,7 @@ namespace Microsoft.EntityFrameworkCore
         public void Binary_key_with_max_length_is_picked_up_by_FK()
         {
             var model = CreateModel();
-            var mapper = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies());
+            var mapper = TestServiceFactory.Instance.Create<SqlServerTypeMapper>();
 
             Assert.Equal(
                 "varbinary(100)",
@@ -816,7 +778,7 @@ namespace Microsoft.EntityFrameworkCore
         public void String_key_with_unicode_is_picked_up_by_FK()
         {
             var model = CreateModel();
-            var mapper = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies());
+            var mapper = TestServiceFactory.Instance.Create<SqlServerTypeMapper>();
 
             Assert.Equal(
                 "varchar(900)",
@@ -831,7 +793,7 @@ namespace Microsoft.EntityFrameworkCore
         public void Key_store_type_if_preferred_if_specified()
         {
             var model = CreateModel();
-            var mapper = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies());
+            var mapper = TestServiceFactory.Instance.Create<SqlServerTypeMapper>();
 
             Assert.Equal(
                 "money",
@@ -846,7 +808,7 @@ namespace Microsoft.EntityFrameworkCore
         public void String_FK_max_length_is_preferred_if_specified()
         {
             var model = CreateModel();
-            var mapper = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies());
+            var mapper = TestServiceFactory.Instance.Create<SqlServerTypeMapper>();
 
             Assert.Equal(
                 "nvarchar(200)",
@@ -861,7 +823,7 @@ namespace Microsoft.EntityFrameworkCore
         public void Binary_FK_max_length_is_preferred_if_specified()
         {
             var model = CreateModel();
-            var mapper = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies());
+            var mapper = TestServiceFactory.Instance.Create<SqlServerTypeMapper>();
 
             Assert.Equal(
                 "varbinary(100)",
@@ -876,7 +838,7 @@ namespace Microsoft.EntityFrameworkCore
         public void String_FK_unicode_is_preferred_if_specified()
         {
             var model = CreateModel();
-            var mapper = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies());
+            var mapper = TestServiceFactory.Instance.Create<SqlServerTypeMapper>();
 
             Assert.Equal(
                 "varchar(900)",

--- a/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingTest.cs
+++ b/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingTest.cs
@@ -7,6 +7,7 @@ using System.Data;
 using System.Data.Common;
 using System.Data.SqlClient;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -91,7 +92,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public override void GenerateSqlLiteral_returns_ByteArray_literal()
         {
             var value = new byte[] { 0xDA, 0x7A };
-            var literal = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies())
+            var literal = TestServiceFactory.Instance.Create<SqlServerTypeMapper>()
                 .GetMapping(typeof(byte[])).GenerateSqlLiteral(value);
             Assert.Equal("0xDA7A", literal);
         }
@@ -99,7 +100,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public override void GenerateSqlLiteral_returns_DateTime_literal()
         {
             var value = new DateTime(2015, 3, 12, 13, 36, 37, 371);
-            var literal = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies())
+            var literal = TestServiceFactory.Instance.Create<SqlServerTypeMapper>()
                 .GetMapping(typeof(DateTime)).GenerateSqlLiteral(value);
 
             Assert.Equal("'2015-03-12T13:36:37.371'", literal);
@@ -108,7 +109,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public override void GenerateSqlLiteral_returns_DateTimeOffset_literal()
         {
             var value = new DateTimeOffset(2015, 3, 12, 13, 36, 37, 371, new TimeSpan(-7, 0, 0));
-            var literal = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies())
+            var literal = TestServiceFactory.Instance.Create<SqlServerTypeMapper>()
                 .GetMapping(typeof(DateTimeOffset)).GenerateSqlLiteral(value);
 
             Assert.Equal("'2015-03-12T13:36:37.371-07:00'", literal);
@@ -117,7 +118,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [Fact]
         public virtual void GenerateSqlLiteralValue_returns_Unicode_String_literal()
         {
-            var literal = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies())
+            var literal = TestServiceFactory.Instance.Create<SqlServerTypeMapper>()
                 .GetMapping("nvarchar(max)").GenerateSqlLiteral("A Unicode String");
             Assert.Equal("N'A Unicode String'", literal);
         }
@@ -125,7 +126,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [Fact]
         public virtual void GenerateSqlLiteralValue_returns_NonUnicode_String_literal()
         {
-            var literal = new SqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies())
+            var literal = TestServiceFactory.Instance.Create<SqlServerTypeMapper>()
                 .GetMapping("varchar(max)").GenerateSqlLiteral("A Non-Unicode String");
             Assert.Equal("'A Non-Unicode String'", literal);
         }
@@ -136,8 +137,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [InlineData("Microsoft.SqlServer.Types.SqlGeometry", "geometry")]
         public virtual void Get_named_mappings_for_sql_type(string typeName, string udtName)
         {
-            var mappings = new TestSqlServerTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies())
-                .GetClrTypeNameMappings();
+            var mappings = TestServiceFactory.Instance.Create<TestSqlServerTypeMapper>().GetClrTypeNameMappings();
 
             var mapping = mappings[typeName](typeof(Random));
 

--- a/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
+++ b/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchFactoryTest.cs
@@ -18,9 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             var optionsBuilder = new DbContextOptionsBuilder();
             optionsBuilder.UseSqlServer("Database=Crunchie", b => b.MaxBatchSize(1));
 
-            var typeMapper = new SqlServerTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies());
+            var typeMapper = TestServiceFactory.Instance.Create<SqlServerTypeMapper>();
 
             var factory = new SqlServerModificationCommandBatchFactory(
                 new RelationalCommandBuilderFactory(
@@ -50,9 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             var optionsBuilder = new DbContextOptionsBuilder();
             optionsBuilder.UseSqlServer("Database=Crunchie");
 
-            var typeMapper = new SqlServerTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies());
+            var typeMapper = TestServiceFactory.Instance.Create<SqlServerTypeMapper>();
 
             var factory = new SqlServerModificationCommandBatchFactory(
                 new RelationalCommandBuilderFactory(

--- a/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
+++ b/test/EFCore.SqlServer.Tests/Update/SqlServerModificationCommandBatchTest.cs
@@ -15,9 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Update
         [Fact]
         public void AddCommand_returns_false_when_max_batch_size_is_reached()
         {
-            var typeMapper = new SqlServerTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies());
+            var typeMapper = TestServiceFactory.Instance.Create<SqlServerTypeMapper>();
 
             var batch = new SqlServerModificationCommandBatch(
                 new RelationalCommandBuilderFactory(

--- a/test/EFCore.SqlServer.Tests/Update/SqlServerUpdateSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Update/SqlServerUpdateSqlGeneratorTest.cs
@@ -19,9 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 new UpdateSqlGeneratorDependencies(
                     new SqlServerSqlGenerationHelper(
                         new RelationalSqlGenerationHelperDependencies()),
-                    new SqlServerTypeMapper(
-                        new CoreTypeMapperDependencies(),
-                        new RelationalTypeMapperDependencies())));
+                    TestServiceFactory.Instance.Create<SqlServerTypeMapper>()));
 
         protected override TestHelpers TestHelpers => SqlServerTestHelpers.Instance;
 

--- a/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore
             var modelBuilder = base.Key_and_MaxLength_64_produce_nvarchar_64();
 
             var property = GetProperty<ColumnKeyAnnotationClass2>(modelBuilder, "PersonFirstName");
-            Assert.Equal("TEXT", new SqliteTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).FindMapping(property).StoreType);
+            Assert.Equal("TEXT", TestServiceFactory.Instance.Create<SqliteTypeMapper>().FindMapping(property).StoreType);
 
             return modelBuilder;
         }
@@ -71,7 +71,7 @@ namespace Microsoft.EntityFrameworkCore
             var modelBuilder = base.Timestamp_takes_precedence_over_MaxLength();
 
             var property = GetProperty<TimestampAndMaxlen>(modelBuilder, "MaxTimestamp");
-            Assert.Equal("BLOB", new SqliteTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).FindMapping(property).StoreType);
+            Assert.Equal("BLOB", TestServiceFactory.Instance.Create<SqliteTypeMapper>().FindMapping(property).StoreType);
 
             return modelBuilder;
         }
@@ -81,7 +81,7 @@ namespace Microsoft.EntityFrameworkCore
             var modelBuilder = base.Timestamp_takes_precedence_over_MaxLength_with_value();
 
             var property = GetProperty<TimestampAndMaxlen>(modelBuilder, "NonMaxTimestamp");
-            Assert.Equal("BLOB", new SqliteTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).FindMapping(property).StoreType);
+            Assert.Equal("BLOB", TestServiceFactory.Instance.Create<SqliteTypeMapper>().FindMapping(property).StoreType);
 
             return modelBuilder;
         }

--- a/test/EFCore.Sqlite.Tests/SqliteModelValidatorTest.cs
+++ b/test/EFCore.Sqlite.Tests/SqliteModelValidatorTest.cs
@@ -84,9 +84,8 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         private static void GenerateMapping(IMutableProperty property)
-            => property[CoreAnnotationNames.TypeMapping] = new SqliteTypeMapper(
-                new CoreTypeMapperDependencies(),
-                new RelationalTypeMapperDependencies()).GetMapping(property);
+            => property[CoreAnnotationNames.TypeMapping]
+                = TestServiceFactory.Instance.Create<SqliteTypeMapper>().GetMapping(property);
 
         protected override IModelValidator CreateModelValidator()
             => new SqliteModelValidator(
@@ -96,8 +95,6 @@ namespace Microsoft.EntityFrameworkCore
                         new LoggingOptions(),
                         new DiagnosticListener("Fake"))),
                 new RelationalModelValidatorDependencies(
-                    new SqliteTypeMapper(
-                        new CoreTypeMapperDependencies(),
-                        new RelationalTypeMapperDependencies())));
+                    TestServiceFactory.Instance.Create<SqliteTypeMapper>()));
     }
 }

--- a/test/EFCore.Sqlite.Tests/Storage/SqliteTypeMappingTest.cs
+++ b/test/EFCore.Sqlite.Tests/Storage/SqliteTypeMappingTest.cs
@@ -6,6 +6,7 @@ using System.Data;
 using System.Data.Common;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -45,30 +46,27 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [InlineData("", typeof(string))]
         public void It_maps_strings_to_not_null_types(string typeName, Type clrType)
         {
-            Assert.Equal(clrType, new SqliteTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies()).GetMapping(typeName).ClrType);
+            Assert.Equal(clrType, TestServiceFactory.Instance.Create<SqliteTypeMapper>().GetMapping(typeName).ClrType);
         }
 
         public override void GenerateSqlLiteral_returns_DateTime_literal()
         {
             var value = new DateTime(2015, 3, 12, 13, 36, 37, 371);
-            var literal = new SqliteTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies())
-                .GetMapping(typeof(DateTime)).GenerateSqlLiteral(value);
+            var literal = TestServiceFactory.Instance.Create<SqliteTypeMapper>().GetMapping(typeof(DateTime)).GenerateSqlLiteral(value);
             Assert.Equal("'2015-03-12 13:36:37.371'", literal);
         }
 
         public override void GenerateSqlLiteral_returns_DateTimeOffset_literal()
         {
             var value = new DateTimeOffset(2015, 3, 12, 13, 36, 37, 371, new TimeSpan(-7, 0, 0));
-            var literal = new SqliteTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies())
-                .GetMapping(typeof(DateTimeOffset)).GenerateSqlLiteral(value);
+            var literal = TestServiceFactory.Instance.Create<SqliteTypeMapper>().GetMapping(typeof(DateTimeOffset)).GenerateSqlLiteral(value);
             Assert.Equal("'2015-03-12 13:36:37.371-07:00'", literal);
         }
 
         public override void GenerateSqlLiteral_returns_Guid_literal()
         {
             var value = new Guid("c6f43a9e-91e1-45ef-a320-832ea23b7292");
-            var literal = new SqliteTypeMapper(new CoreTypeMapperDependencies(), new RelationalTypeMapperDependencies())
-                .GetMapping(typeof(Guid)).GenerateSqlLiteral(value);
+            var literal = TestServiceFactory.Instance.Create<SqliteTypeMapper>().GetMapping(typeof(Guid)).GenerateSqlLiteral(value);
             Assert.Equal("X'9E3AF4C6E191EF45A320832EA23B7292'", literal);
         }
 

--- a/test/EFCore.Sqlite.Tests/Update/SqliteUpdateSqlGeneratorTest.cs
+++ b/test/EFCore.Sqlite.Tests/Update/SqliteUpdateSqlGeneratorTest.cs
@@ -18,9 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 new UpdateSqlGeneratorDependencies(
                     new SqliteSqlGenerationHelper(
                         new RelationalSqlGenerationHelperDependencies()),
-                    new SqliteTypeMapper(
-                        new CoreTypeMapperDependencies(),
-                        new RelationalTypeMapperDependencies())));
+                    TestServiceFactory.Instance.Create<SqliteTypeMapper>()));
 
         protected override TestHelpers TestHelpers => SqliteTestHelpers.Instance;
 


### PR DESCRIPTION
For some types that have a lot of unit tests there is a lot of code just to call the default constructors for a service, its dependency objects, and its dependencies. This change adds a simple helper that uses the D.I. system to create factories for this code. This greatly reduces the amount of test code that needs to change when a new dependency is added. This change uses the factory for type mappers. Use for other types can be added as needed.