### PR TITLE
Add a way to run functional test against shipped providers

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -3,6 +3,7 @@
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
+    <FunctionalTests_PackageVersion>0.0.0</FunctionalTests_PackageVersion>
     <InternalAspNetCoreSdkPackageVersion>2.1.0-preview1-15626</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftAspNetCoreHostingWebHostBuilderFactorySourcesPackageVersion>2.1.0-preview1-27807</MicrosoftAspNetCoreHostingWebHostBuilderFactorySourcesPackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>2.3.1</MicrosoftCodeAnalysisCSharpPackageVersion>

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -1,6 +1,10 @@
 ﻿<Project>
 
   <Target Name="_FilterTestProjects" BeforeTargets="TestProjects">
+    <PropertyGroup Condition="'$(TestFilter)' == '' And '$(FunctionalTests_PackageVersion)' != '0.0.0'">
+      <TestFilter>FunctionalTests</TestFilter>
+    </PropertyGroup>
+  
     <ItemGroup Condition="'$(TestFilter)' != ''">
       <ProjectsToTest Remove="@(ProjectsToTest)"/>
       <ProjectsToTest Include="$(RepositoryRoot)test\*$(TestFilter)*\*.csproj" Exclude="@(ExcludeFromTest)" />

--- a/src/EFCore.Relational.Specification.Tests/EFCore.Relational.Specification.Tests.csproj
+++ b/src/EFCore.Relational.Specification.Tests/EFCore.Relational.Specification.Tests.csproj
@@ -10,6 +10,10 @@
     <EnableApiCheck>false</EnableApiCheck>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(FunctionalTests_PackageVersion)' == '2.0.0'">
+   <DefineConstants>$(DefineConstants);Test20</DefineConstants>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\EFCore.Relational\EFCore.Relational.csproj" />

--- a/src/EFCore.Relational.Specification.Tests/Query/QueryNoClientEvalTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/QueryNoClientEvalTestBase.cs
@@ -182,7 +182,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                     Assert.Throws<InvalidOperationException>(
                         () =>
                             (from e1 in context.Employees
+#if Test20
+                             join i in new int[] { 1, 2, 3 } on e1.EmployeeID equals i
+#else
                              join i in new uint[] { 1, 2, 3 } on e1.EmployeeID equals i
+#endif
                              select e1)
                             .ToList()).Message);
             }
@@ -200,7 +204,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                     Assert.Throws<InvalidOperationException>(
                         () =>
                             (from e1 in context.Employees
+#if Test20
+                             join i in new int[] { 1, 2, 3 } on e1.EmployeeID equals i into g
+#else
                              join i in new uint[] { 1, 2, 3 } on e1.EmployeeID equals i into g
+#endif
                              select e1)
                             .ToList()).Message);
             }

--- a/src/EFCore.Relational.Specification.Tests/TransactionTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/TransactionTestBase.cs
@@ -119,6 +119,7 @@ namespace Microsoft.EntityFrameworkCore
             AssertStoreInitialState();
         }
 
+#if !Test20
         [Theory]
         [InlineData(true, true)]
         [InlineData(true, false)]
@@ -408,6 +409,7 @@ namespace Microsoft.EntityFrameworkCore
 
             AssertStoreInitialState();
         }
+#endif
 
         [Fact]
         public virtual void SaveChanges_does_not_close_connection_opened_by_user()
@@ -862,6 +864,23 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [Fact]
+        public virtual void UseTransaction_will_not_dispose_external_transaction()
+        {
+            using (var transaction = TestStore.BeginTransaction())
+            {
+                using (var context = CreateContext())
+                {
+                    context.Database.UseTransaction(transaction);
+
+                    context.Database.GetService<IRelationalConnection>().Dispose();
+
+                    Assert.NotNull(transaction.Connection);
+                }
+            }
+        }
+
+#if !Test20
+        [Fact]
         public virtual void UseTransaction_throws_if_ambient_transaction_started()
         {
             if (!AmbientTransactionsSupported)
@@ -879,22 +898,6 @@ namespace Microsoft.EntityFrameworkCore
                             () => context.Database.UseTransaction(transaction));
                         Assert.Equal(RelationalStrings.ConflictingAmbientTransaction, ex.Message);
                     }
-                }
-            }
-        }
-
-        [Fact]
-        public virtual void UseTransaction_will_not_dispose_external_transaction()
-        {
-            using (var transaction = TestStore.BeginTransaction())
-            {
-                using (var context = CreateContext())
-                {
-                    context.Database.UseTransaction(transaction);
-
-                    context.Database.GetService<IRelationalConnection>().Dispose();
-
-                    Assert.NotNull(transaction.Connection);
                 }
             }
         }
@@ -1113,6 +1116,7 @@ namespace Microsoft.EntityFrameworkCore
                 }
             }
         }
+#endif
 
         [Theory]
         [InlineData(true)]

--- a/src/EFCore.Relational.Specification.Tests/UpdatesRelationalTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/UpdatesRelationalTestBase.cs
@@ -26,7 +26,9 @@ namespace Microsoft.EntityFrameworkCore
         protected override string UpdateConcurrencyMessage
             => RelationalStrings.UpdateConcurrencyException(1, 0);
 
+#if !Test20
         protected override string UpdateConcurrencyTokenMessage
             => RelationalStrings.UpdateConcurrencyException(1, 0);
+#endif
     }
 }

--- a/src/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
+++ b/src/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
@@ -10,7 +10,11 @@
     <EnableApiCheck>false</EnableApiCheck>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
-
+  
+  <PropertyGroup Condition="'$(FunctionalTests_PackageVersion)' == '2.0.0'">
+   <DefineConstants>$(DefineConstants);Test20</DefineConstants>
+  </PropertyGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\EFCore\EFCore.csproj" />
   </ItemGroup>

--- a/src/EFCore.Specification.Tests/Query/AsyncSimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncSimpleQueryTestBase.cs
@@ -2104,12 +2104,18 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 91);
         }
 
+#if Test20
+        private const int NonExistentID = -1;
+#else
+        private const uint NonExistentID = uint.MaxValue;
+#endif
+
         [ConditionalFact]
         public virtual async Task Default_if_empty_top_level()
         {
             await AssertQuery<Employee>(
                 es =>
-                    from e in es.Where(c => c.EmployeeID == uint.MaxValue).DefaultIfEmpty()
+                    from e in es.Where(c => c.EmployeeID == NonExistentID).DefaultIfEmpty()
                     select e);
         }
 
@@ -2118,7 +2124,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             await AssertQuery<Employee>(
                 es =>
-                    from e in es.Where(c => c.EmployeeID == uint.MaxValue).DefaultIfEmpty(new Employee())
+                    from e in es.Where(c => c.EmployeeID == NonExistentID).DefaultIfEmpty(new Employee())
                     select e,
                 entryCount: 1);
         }
@@ -2138,7 +2144,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             await AssertQueryScalar<Employee>(
                 es =>
-                    from e in es.Where(e => e.EmployeeID == uint.MaxValue).Select(e => e.EmployeeID).DefaultIfEmpty()
+                    from e in es.Where(e => e.EmployeeID == NonExistentID).Select(e => e.EmployeeID).DefaultIfEmpty()
                     select e);
         }
 
@@ -2623,7 +2629,11 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         private static int ClientEvalSelectorStateless() => 42;
 
+#if Test20
+        protected internal int ClientEvalSelector(Order order) => order.EmployeeID % 10 ?? 0;
+#else
         protected internal uint ClientEvalSelector(Order order) => order.EmployeeID % 10 ?? 0;
+#endif
 
         [ConditionalFact]
         public virtual async Task Distinct()

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.JoinGroupJoin.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.JoinGroupJoin.cs
@@ -61,7 +61,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 4);
         }
 
+#if Test20
+        private int GetEmployeeID(Employee employee)
+#else
         private uint GetEmployeeID(Employee employee)
+#endif
         {
             return employee.EmployeeID;
         }
@@ -194,7 +198,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public virtual void Join_local_collection_int_closure_is_cached_correctly()
         {
+#if Test20
+            var ids = new int[] { 1, 2 };
+#else
             var ids = new uint[] { 1, 2 };
+#endif
 
             AssertQueryScalar<Employee>(
                 es =>
@@ -202,7 +210,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                     join id in ids on e.EmployeeID equals id
                     select e.EmployeeID);
 
+#if Test20
+            ids = new int[] { 3 };
+#else
             ids = new uint[] { 3 };
+#endif
 
             AssertQueryScalar<Employee>(
                 es =>

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
@@ -427,7 +427,11 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         private static int ClientEvalSelectorStateless() => 42;
 
+#if Test20
+        protected internal int ClientEvalSelector(Order order) => order.EmployeeID % 10 ?? 0;
+#else
         protected internal uint ClientEvalSelector(Order order) => order.EmployeeID % 10 ?? 0;
+#endif
 
         [ConditionalFact]
         public virtual void Distinct()
@@ -717,13 +721,21 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public virtual void Contains_with_local_int_array_closure()
         {
+#if Test20
+            var ids = new int[] { 0, 1 };
+#else
             var ids = new uint[] { 0, 1 };
+#endif
 
             AssertQuery<Employee>(
                 es =>
                     es.Where(e => ids.Contains(e.EmployeeID)), entryCount: 1);
 
+#if Test20
+            ids = new int[] { 0 };
+#else
             ids = new uint[] { 0 };
+#endif
 
             AssertQuery<Employee>(
                 es =>
@@ -733,13 +745,21 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public virtual void Contains_with_local_nullable_int_array_closure()
         {
+#if Test20
+            var ids = new int?[] { 0, 1 };
+#else
             var ids = new uint?[] { 0, 1 };
+#endif
 
             AssertQuery<Employee>(
                 es =>
                     es.Where(e => ids.Contains(e.EmployeeID)), entryCount: 1);
 
+#if Test20
+            ids = new int?[] { 0 };
+#else
             ids = new uint?[] { 0 };
+#endif
 
             AssertQuery<Employee>(
                 es =>

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             AssertQuery<Customer>(
                 cs => cs.Select(c => string.Join(", ", c.Orders.Select(o => o.CustomerID))));
         }
-        
+
         [ConditionalFact]
         public virtual void Project_to_object_array()
         {
@@ -63,7 +63,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             AssertQuery<Employee>(
                 es => es.Where(e => e.EmployeeID == 1)
                     .Select(e => new[] { e.EmployeeID, e.ReportsTo }),
+#if Test20
+                elementAsserter: (e, a) => AssertArrays<int?>(e, a, 2));
+#else
                 elementAsserter: (e, a) => AssertArrays<uint?>(e, a, 2));
+#endif
         }
 
         private static void AssertArrays<T>(object e, object a, int count)
@@ -493,7 +497,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                 os => os
                     .Where(o => o.CustomerID == "ALFKI")
                     .OrderBy(o => o.OrderID)
+#if Test20
+                    .Select(o => (int)o.EmployeeID),
+#else
                     .Select(o => (uint)o.EmployeeID),
+#endif
                 assertOrder: true);
         }
 

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
@@ -504,7 +504,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public virtual void Where_equals_using_object_overload_on_mismatched_types()
         {
+#if Test20
+            long longPrm = 1;
+#else
             ulong longPrm = 1;
+#endif
 
             AssertQuery<Employee>(
                 es => es.Where(e => e.EmployeeID.Equals(longPrm)));
@@ -513,7 +517,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public virtual void Where_equals_using_int_overload_on_mismatched_types()
         {
+#if Test20
+            short shortPrm = 1;
+#else
             ushort shortPrm = 1;
+#endif
 
             AssertQuery<Employee>(
                 es => es.Where(e => e.EmployeeID.Equals(shortPrm)),
@@ -523,7 +531,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public virtual void Where_equals_on_mismatched_types_nullable_int_long()
         {
+#if Test20
+            long longPrm = 2;
+#else
             ulong longPrm = 2;
+#endif
 
             AssertQuery<Employee>(
                 es => es.Where(e => e.ReportsTo.Equals(longPrm)));
@@ -535,7 +547,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public virtual void Where_equals_on_mismatched_types_int_nullable_int()
         {
+#if Test20
+            var intPrm = 2;
+#else
             uint intPrm = 2;
+#endif
 
             AssertQuery<Employee>(
                 es => es.Where(e => e.ReportsTo.Equals(intPrm)),
@@ -549,7 +565,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public virtual void Where_equals_on_mismatched_types_nullable_long_nullable_int()
         {
+#if Test20
             ulong? nullableLongPrm = 2;
+#else
+            ulong? nullableLongPrm = 2;
+#endif
 
             AssertQuery<Employee>(
                 es => es.Where(e => nullableLongPrm.Equals(e.ReportsTo)));
@@ -561,7 +581,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public virtual void Where_equals_on_matched_nullable_int_types()
         {
+#if Test20
+            int? nullableIntPrm = 2;
+#else
             uint? nullableIntPrm = 2;
+#endif
 
             AssertQuery<Employee>(
                 es => es.Where(e => nullableIntPrm.Equals(e.ReportsTo)),
@@ -575,7 +599,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         [ConditionalFact]
         public virtual void Where_equals_on_null_nullable_int_types()
         {
+#if Test20
+            int? nullableIntPrm = null;
+#else
             uint? nullableIntPrm = null;
+#endif
 
             AssertQuery<Employee>(
                 es => es.Where(e => nullableIntPrm.Equals(e.ReportsTo)),

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -1794,12 +1794,18 @@ namespace Microsoft.EntityFrameworkCore.Query
             public string Bar { get; set; }
         }
 
+#if Test20
+        protected const int NonExistentID = -1;
+#else
+        protected const uint NonExistentID = uint.MaxValue;
+#endif
+
         [ConditionalFact]
         public virtual void Default_if_empty_top_level()
         {
             AssertQuery<Employee>(
                 es =>
-                    from e in es.Where(c => c.EmployeeID == uint.MaxValue).DefaultIfEmpty()
+                    from e in es.Where(c => c.EmployeeID == NonExistentID).DefaultIfEmpty()
                     select e);
         }
 
@@ -1808,7 +1814,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             AssertQuery<Employee>(
                 es =>
-                    from e in es.Where(c => c.EmployeeID == uint.MaxValue).DefaultIfEmpty(new Employee())
+                    from e in es.Where(c => c.EmployeeID == NonExistentID).DefaultIfEmpty(new Employee())
                     select e,
                 entryCount: 1);
         }
@@ -1828,7 +1834,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             AssertQueryScalar<Employee>(
                 es =>
-                    from e in es.Where(e => e.EmployeeID == uint.MaxValue).Select(e => e.EmployeeID).DefaultIfEmpty()
+                    from e in es.Where(e => e.EmployeeID == NonExistentID).Select(e => e.EmployeeID).DefaultIfEmpty()
                     select e);
         }
 

--- a/src/EFCore.Specification.Tests/TestModels/Northwind/Employee.cs
+++ b/src/EFCore.Specification.Tests/TestModels/Northwind/Employee.cs
@@ -7,7 +7,11 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
 {
     public class Employee
     {
+#if Test20
+        public int EmployeeID { get; set; }
+#else
         public uint EmployeeID { get; set; }
+#endif
         public string LastName { get; set; }
         public string FirstName { get; set; }
         public string Title { get; set; }
@@ -23,7 +27,11 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
         public string Extension { get; set; }
         public byte[] Photo { get; set; }
         public string Notes { get; set; }
+#if Test20
+        public int? ReportsTo { get; set; }
+#else
         public uint? ReportsTo { get; set; }
+#endif
         public string PhotoPath { get; set; }
 
         public Employee Manager { get; set; }

--- a/src/EFCore.Specification.Tests/TestModels/Northwind/Order.cs
+++ b/src/EFCore.Specification.Tests/TestModels/Northwind/Order.cs
@@ -10,7 +10,11 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
     {
         public int OrderID { get; set; }
         public string CustomerID { get; set; }
+#if Test20
+        public int? EmployeeID { get; set; }
+#else
         public uint? EmployeeID { get; set; }
+#endif
         public DateTime? OrderDate { get; set; }
         public DateTime? RequiredDate { get; set; }
         public DateTime? ShippedDate { get; set; }

--- a/src/EFCore.Specification.Tests/TestModels/Northwind/Product.cs
+++ b/src/EFCore.Specification.Tests/TestModels/Northwind/Product.cs
@@ -18,9 +18,15 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
         public int? CategoryID { get; set; }
         public string QuantityPerUnit { get; set; }
         public decimal? UnitPrice { get; set; }
+#if Test20
+        public short UnitsInStock { get; set; }
+        public short? UnitsOnOrder { get; set; }
+        public short? ReorderLevel { get; set; }
+#else
         public ushort UnitsInStock { get; set; }
         public ushort? UnitsOnOrder { get; set; }
         public ushort? ReorderLevel { get; set; }
+#endif
         public bool Discontinued { get; set; }
 
         public virtual List<OrderDetail> OrderDetails { get; set; }

--- a/src/EFCore.Specification.Tests/UpdatesTestBase.cs
+++ b/src/EFCore.Specification.Tests/UpdatesTestBase.cs
@@ -74,6 +74,7 @@ namespace Microsoft.EntityFrameworkCore
                     });
         }
 
+#if !Test20
         [Fact]
         public virtual void Save_partial_update_on_concurrency_token_original_value_mismatch_throws()
         {
@@ -98,6 +99,7 @@ namespace Microsoft.EntityFrameworkCore
                                 () => context.SaveChanges()).Message);
                     });
         }
+#endif
 
         [Fact]
         public virtual void Can_remove_partial()
@@ -143,6 +145,7 @@ namespace Microsoft.EntityFrameworkCore
                     });
         }
 
+#if !Test20
         [Fact]
         public virtual void Remove_partial_on_concurrency_token_original_value_mismatch_throws()
         {
@@ -164,6 +167,7 @@ namespace Microsoft.EntityFrameworkCore
                                 () => context.SaveChanges()).Message);
                     });
         }
+#endif
 
         [Fact]
         public virtual void Save_replaced_principal()
@@ -337,7 +341,10 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         protected abstract string UpdateConcurrencyMessage { get; }
+
+#if !Test20
         protected abstract string UpdateConcurrencyTokenMessage { get; }
+#endif
 
         protected virtual void ExecuteWithStrategyInTransaction(
             Action<UpdatesContext> testOperation,

--- a/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Extensions.DependencyInjection
         ///           public void ConfigureServices(IServiceCollection services)
         ///           {
         ///               var connectionString = "connection string to database";
-        /// 
+        ///
         ///               services
         ///                   .AddEntityFrameworkSqlServer()
         ///                   .AddDbContext&lt;MyContext&gt;((serviceProvider, options) =>

--- a/test/EFCore.InMemory.FunctionalTests/EFCore.InMemory.FunctionalTests.csproj
+++ b/test/EFCore.InMemory.FunctionalTests/EFCore.InMemory.FunctionalTests.csproj
@@ -11,9 +11,20 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  
+  <PropertyGroup Condition="'$(FunctionalTests_PackageVersion)' == '2.0.0'">
+   <DefineConstants>$(DefineConstants);Test20</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(FunctionalTests_PackageVersion)' == '0.0.0'">
+    <ProjectReference Include="..\..\src\EFCore.InMemory\EFCore.InMemory.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(FunctionalTests_PackageVersion)' != '0.0.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="$(FunctionalTests_PackageVersion)" />
+  </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\src\EFCore.InMemory\EFCore.InMemory.csproj" />
     <ProjectReference Include="..\..\src\EFCore.Specification.Tests\EFCore.Specification.Tests.csproj" />
   </ItemGroup>
 

--- a/test/EFCore.InMemory.FunctionalTests/GlobalDatabaseTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/GlobalDatabaseTest.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
+#if !Test20
     public class GlobalDatabaseTest
     {
         private static readonly InMemoryDatabaseRoot _databaseRoot = new InMemoryDatabaseRoot();
@@ -165,4 +166,5 @@ namespace Microsoft.EntityFrameworkCore
             public int Id { get; set; }
         }
     }
+#endif
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/QueryBugsInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/QueryBugsInMemoryTest.cs
@@ -10,9 +10,7 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
 // ReSharper disable MergeConditionalExpression
-
 // ReSharper disable ConstantNullCoalescingCondition
-
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Query
 {

--- a/test/EFCore.InMemory.FunctionalTests/UpdatesInMemoryWithSensitiveDataLoggingTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/UpdatesInMemoryWithSensitiveDataLoggingTest.cs
@@ -12,7 +12,9 @@ namespace Microsoft.EntityFrameworkCore
         {
         }
 
+#if !Test20
         protected override string UpdateConcurrencyTokenMessage
             => InMemoryStrings.UpdateConcurrencyTokenExceptionSensitive("Product", "Id:984ade3c-2f7b-4651-a351-642e92ab7146", "Price:3.49", "Price:1.49");
+#endif
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/UpdatesInMemoryWithoutSensitiveDataLoggingTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/UpdatesInMemoryWithoutSensitiveDataLoggingTest.cs
@@ -12,7 +12,9 @@ namespace Microsoft.EntityFrameworkCore
         {
         }
 
+#if !Test20
         protected override string UpdateConcurrencyTokenMessage
             => InMemoryStrings.UpdateConcurrencyTokenException("Product", "{'Price'}");
+#endif
     }
 }

--- a/test/EFCore.InMemory.Tests/EFCore.InMemory.Tests.csproj
+++ b/test/EFCore.InMemory.Tests/EFCore.InMemory.Tests.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\EFCore.InMemory\EFCore.InMemory.csproj" />
     <ProjectReference Include="..\EFCore.InMemory.FunctionalTests\EFCore.InMemory.FunctionalTests.csproj" />
     <ProjectReference Include="..\EFCore.Tests\EFCore.Tests.csproj" />
   </ItemGroup>

--- a/test/EFCore.SqlServer.FunctionalTests/BatchingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BatchingTest.cs
@@ -141,6 +141,8 @@ namespace Microsoft.EntityFrameworkCore
                 context => Assert.Equal(2, context.Owners.Count()));
         }
 
+
+#if !Test20
         [Theory]
         [InlineData(3)]
         [InlineData(4)]
@@ -184,6 +186,7 @@ namespace Microsoft.EntityFrameworkCore
                         Assert.Equal(minBatchSize <= 3 ? 2 : 4, Fixture.TestSqlLoggerFactory.SqlStatements.Count);
                     }, context => AssertDatabaseState(context, false, expectedBlogs));
         }
+#endif
 
         private void AssertDatabaseState(DbContext context, bool clientOrder, List<Blog> expectedBlogs)
         {

--- a/test/EFCore.SqlServer.FunctionalTests/EFCore.SqlServer.FunctionalTests.csproj
+++ b/test/EFCore.SqlServer.FunctionalTests/EFCore.SqlServer.FunctionalTests.csproj
@@ -26,10 +26,21 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  
+  <PropertyGroup Condition="'$(FunctionalTests_PackageVersion)' == '2.0.0'">
+   <DefineConstants>$(DefineConstants);Test20</DefineConstants>
+  </PropertyGroup>
 
+  <ItemGroup Condition="'$(FunctionalTests_PackageVersion)' == '0.0.0'">
+    <ProjectReference Include="..\..\src\EFCore.SqlServer\EFCore.SqlServer.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(FunctionalTests_PackageVersion)' != '0.0.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(FunctionalTests_PackageVersion)" />
+  </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\..\src\EFCore.Relational.Specification.Tests\EFCore.Relational.Specification.Tests.csproj" />
-    <ProjectReference Include="..\..\src\EFCore.SqlServer\EFCore.SqlServer.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/test/EFCore.SqlServer.FunctionalTests/Query/DbFunctionsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/DbFunctionsSqlServerTest.cs
@@ -49,6 +49,7 @@ FROM [Customers] AS [c]
 WHERE [c].[ContactName] LIKE N'!%' ESCAPE N'!'");
         }
 
+#if !Test20
         [ConditionalFact]
         [SqlServerCondition(SqlServerCondition.SupportsFullTextSearch)]
         public async void FreeText_Search_Literal()
@@ -224,6 +225,7 @@ WHERE ((FREETEXT([c.Manager].[Title], N'President', LANGUAGE 1033)) AND (FREETEX
                         e => EF.Functions.FreeText(e.City, e.FirstName.ToUpper())));
             }
         }
+#endif
 
         public override void DateDiff_Year()
         {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -203,7 +203,7 @@ FROM (
 LEFT JOIN (
     SELECT [c].[EmployeeID], [c].[City], [c].[Country], [c].[FirstName], [c].[ReportsTo], [c].[Title]
     FROM [Employees] AS [c]
-    WHERE [c].[EmployeeID] = 4294967295
+    WHERE [c].[EmployeeID] = " + NonExistentID + @"
 ) AS [t] ON 1 = 1");
         }
 
@@ -230,7 +230,7 @@ LEFT JOIN (
             AssertSql(
                 @"SELECT [c].[EmployeeID], [c].[City], [c].[Country], [c].[FirstName], [c].[ReportsTo], [c].[Title]
 FROM [Employees] AS [c]
-WHERE [c].[EmployeeID] = 4294967295");
+WHERE [c].[EmployeeID] = " + NonExistentID);
         }
 
         public override void Default_if_empty_top_level_projection()
@@ -245,7 +245,7 @@ FROM (
 LEFT JOIN (
     SELECT [e].[EmployeeID]
     FROM [Employees] AS [e]
-    WHERE [e].[EmployeeID] = 4294967295
+    WHERE [e].[EmployeeID] = " + NonExistentID + @"
 ) AS [t] ON 1 = 1");
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerDatabaseCreatorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerDatabaseCreatorTest.cs
@@ -569,6 +569,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
+#if !Test20
         [Fact]
         public void GenerateCreateScript_works()
         {
@@ -588,8 +589,8 @@ namespace Microsoft.EntityFrameworkCore
                     "    [OrNothing] float NOT NULL," + EOL +
                     "    [Fuse] smallint NOT NULL," + EOL +
                     "    [WayRound] bigint NOT NULL," + EOL +
-                    "    [On] real NOT NULL," + EOL +                    
-                    "    [AndChew] varbinary(max) NULL," + EOL +                    
+                    "    [On] real NOT NULL," + EOL +
+                    "    [AndChew] varbinary(max) NULL," + EOL +
                     "    [AndRow] rowversion NULL," + EOL +
                     "    CONSTRAINT [PK_Blogs] PRIMARY KEY ([Key1], [Key2])" + EOL +
                     ");" + EOL +
@@ -597,6 +598,7 @@ namespace Microsoft.EntityFrameworkCore
                     script);
             }
         }
+#endif
 
         private static readonly string EOL = Environment.NewLine;
     }

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerDbFunctionMetadataTests.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerDbFunctionMetadataTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
+#if !Test20
     public class SqlServerDbFunctionMetadataTests
     {
         public class TestMethods
@@ -71,4 +72,5 @@ namespace Microsoft.EntityFrameworkCore
             return new ModelBuilder(conventionset);
         }
     }
+#endif
 }

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestRelationalTransaction.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestRelationalTransaction.cs
@@ -22,9 +22,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         private readonly TestSqlServerConnection _testConnection;
 
         public TestRelationalTransaction(
-            IRelationalConnection connection, 
-            DbTransaction transaction, 
-            IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> logger, 
+            IRelationalConnection connection,
+            DbTransaction transaction,
+            IDiagnosticsLogger<DbLoggerCategory.Database.Transaction> logger,
             bool transactionOwned)
             : base(connection, transaction, logger, transactionOwned)
         {

--- a/test/EFCore.SqlServer.Tests/EFCore.SqlServer.Tests.csproj
+++ b/test/EFCore.SqlServer.Tests/EFCore.SqlServer.Tests.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\EFCore.SqlServer\EFCore.SqlServer.csproj" />
     <ProjectReference Include="..\EFCore.Relational.Tests\EFCore.Relational.Tests.csproj" />
     <ProjectReference Include="..\EFCore.SqlServer.FunctionalTests\EFCore.SqlServer.FunctionalTests.csproj" />
   </ItemGroup>

--- a/test/EFCore.Sqlite.FunctionalTests/EFCore.Sqlite.FunctionalTests.csproj
+++ b/test/EFCore.Sqlite.FunctionalTests/EFCore.Sqlite.FunctionalTests.csproj
@@ -16,10 +16,21 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  
+  <PropertyGroup Condition="'$(FunctionalTests_PackageVersion)' == '2.0.0'">
+   <DefineConstants>$(DefineConstants);Test20</DefineConstants>
+  </PropertyGroup>
 
+  <ItemGroup Condition="'$(FunctionalTests_PackageVersion)' == '0.0.0'">
+    <ProjectReference Include="..\..\src\EFCore.Sqlite.Core\EFCore.Sqlite.Core.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(FunctionalTests_PackageVersion)' != '0.0.0'">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(FunctionalTests_PackageVersion)" />
+  </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\..\src\EFCore.Relational.Specification.Tests\EFCore.Relational.Specification.Tests.csproj" />
-    <ProjectReference Include="..\..\src\EFCore.Sqlite.Core\EFCore.Sqlite.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/test/EFCore.Sqlite.Tests/EFCore.Sqlite.Tests.csproj
+++ b/test/EFCore.Sqlite.Tests/EFCore.Sqlite.Tests.csproj
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\EFCore.Sqlite.Core\EFCore.Sqlite.Core.csproj" />
     <ProjectReference Include="..\EFCore.Relational.Tests\EFCore.Relational.Tests.csproj" />
     <ProjectReference Include="..\EFCore.Sqlite.FunctionalTests\EFCore.Sqlite.FunctionalTests.csproj" />
   </ItemGroup>

--- a/test/EFCore.Tests/EFCore.Tests.csproj
+++ b/test/EFCore.Tests/EFCore.Tests.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\EFCore.InMemory\EFCore.InMemory.csproj" />
     <ProjectReference Include="..\EFCore.InMemory.FunctionalTests\EFCore.InMemory.FunctionalTests.csproj" />
     <ProjectReference Include="..\..\src\EFCore.Specification.Tests\EFCore.Specification.Tests.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #9961

To run them use
```
 .\build.cmd /p:FunctionalTests_PackageVersion=2.0.0
```

Or change the line in `build\dependencies.props` to:
```
<FunctionalTests_PackageVersion>2.0.0</FunctionalTests_PackageVersion>
```
    
   