### PR TITLE
Add support for using response files from EF commands

### DIFF
--- a/src/ef/Commands/CommandBase.cs
+++ b/src/ef/Commands/CommandBase.cs
@@ -14,6 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
             var noColor = command.Option("--no-color", Resources.NoColorDescription);
             var prefixOutput = command.Option("--prefix-output", Resources.PrefixDescription);
 
+            command.HandleResponseFiles = true;
+
             command.OnExecute(
                 () =>
                     {


### PR DESCRIPTION
Summary of the changes
- Enable response files at command line

Manual tests include:

`dotnet ./dotnet-ef.dll migrations add initial @BloggingContext.ef.config`

(BloggingContext.ef.config contents)

```
-p
C:\playground\AppToBuilder\AppToBuilder.csproj
-s
C:\playground\AppToBuilder\AppToBuilder.csproj
```

`dotnet ./dotnet-ef.dll @BloggingContext.ef.config`

(BloggingContext.ef.config contents)

```
migrations
add
initial
-p
C:\playground\AppToBuilder\AppToBuilder.csproj
-s
C:\playground\AppToBuilder\AppToBuilder.csproj
```

Relative path:
`dotnet ./dotnet-ef.dll migrations add initial @D:/BloggingContext.ef.config` 

Error condition (no migration name):
`dotnet ./dotnet-ef.dll migrations add @D:/BloggingContext.ef.config`

Fixes #10409