### PR TITLE
Design: Allow referencing additional design-time services

### DIFF
--- a/src/EFCore.Design/Properties/DesignStrings.Designer.cs
+++ b/src/EFCore.Design/Properties/DesignStrings.Designer.cs
@@ -588,6 +588,28 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 GetString("RevertingMigration", nameof(name)),
                 name);
 
+        /// <summary>
+        ///     Finding design-time services referenced by assembly '{startupAssembly}'.
+        /// </summary>
+        public static string FindingReferencedServices([CanBeNull] object startupAssembly)
+            => string.Format(
+                GetString("FindingReferencedServices", nameof(startupAssembly)),
+                startupAssembly);
+
+        /// <summary>
+        ///     No referenced design-time services were found.
+        /// </summary>
+        public static string NoReferencedServices
+            => GetString("NoReferencedServices");
+
+        /// <summary>
+        ///     Using design-time services from assembly '{referencedAssembly}'.
+        /// </summary>
+        public static string UsingReferencedServices([CanBeNull] object referencedAssembly)
+            => string.Format(
+                GetString("UsingReferencedServices", nameof(referencedAssembly)),
+                referencedAssembly);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore.Design/Properties/DesignStrings.resx
+++ b/src/EFCore.Design/Properties/DesignStrings.resx
@@ -345,4 +345,13 @@ Change your target project to the migrations project by using the Package Manage
   <data name="RevertingMigration" xml:space="preserve">
     <value>Reverting migration '{name}'.</value>
   </data>
+  <data name="FindingReferencedServices" xml:space="preserve">
+    <value>Finding design-time services referenced by assembly '{startupAssembly}'.</value>
+  </data>
+  <data name="NoReferencedServices" xml:space="preserve">
+    <value>No referenced design-time services were found.</value>
+  </data>
+  <data name="UsingReferencedServices" xml:space="preserve">
+    <value>Using design-time services from assembly '{referencedAssembly}'.</value>
+  </data>
 </root>

--- a/src/EFCore/Design/DesignTimeServicesReferenceAttribute.cs
+++ b/src/EFCore/Design/DesignTimeServicesReferenceAttribute.cs
@@ -1,0 +1,42 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.Design
+{
+    /// <summary>
+    ///     <para>
+    ///         Identifies where to find additional design time services.
+    ///     </para>
+    ///     <para>
+    ///         This attribute is typically used by design-time extensions. It is generally not used in application code.
+    ///     </para>
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Assembly)]
+    public sealed class DesignTimeServicesReferenceAttribute : Attribute
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DesignTimeServicesReferenceAttribute" /> class.
+        /// </summary>
+        /// <param name="typeName">
+        ///     The assembly-qualified name of the type that can be used to add additional design time services to a <see cref="ServiceCollection" />.
+        ///     This type should implement <see cref="IDesignTimeServices" />.
+        /// </param>
+        public DesignTimeServicesReferenceAttribute([NotNull] string typeName)
+        {
+            Check.NotEmpty(typeName, nameof(typeName));
+
+            TypeName = typeName;
+        }
+
+        /// <summary>
+        ///     Gets the assembly-qualified name of the type that can be used to add additional design time services to a <see cref="ServiceCollection" />.
+        ///     This type should implement <see cref="IDesignTimeServices" />.
+        /// </summary>
+        public string TypeName { get; }
+    }
+}


### PR DESCRIPTION
Note, referenced services can override default and provider services, but the user can override referenced services.

Resolves #10154

@tonysneed This was the easy part. 😄 The harder part is going to be authoring NuGet packages to automatically add this attribute to the user's project. See [my comment](https://github.com/aspnet/EntityFrameworkCore/issues/10154#issuecomment-340047623) on the issue for my thoughts on doing this. I'm going to start working on a few design-time extensions. I'll CC you when I work out the specifics to how to do this.