### PR TITLE
Query: inline deterministic fields

### DIFF
--- a/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
@@ -219,7 +219,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         /// </summary>
         protected override Expression VisitMember(MemberExpression memberExpression)
         {
-            if (!_partialEvaluationInfo.IsEvaluatableExpression(memberExpression))
+            if (memberExpression.Member is FieldInfo fieldInfo
+                && fieldInfo.IsStatic && fieldInfo.IsInitOnly
+                || !_partialEvaluationInfo.IsEvaluatableExpression(memberExpression))
             {
                 return base.VisitMember(memberExpression);
             }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -2559,10 +2559,9 @@ BEGIN
                     Assert.Equal(1, result.Count);
 
                     AssertSql(
-                        @"@__p_1='2'
-@__Empty_0='' (Size = 4000)
+                        @"@__p_0='2'
 
-SELECT TOP(@__p_1) [b].[Id], [b].[AddressId], [b].[CustomerDetailsId], [b].[Name]
+SELECT TOP(@__p_0) [b].[Id], [b].[AddressId], [b].[CustomerDetailsId], [b].[Name]
 FROM [Customers] AS [b]
 LEFT JOIN [CustomerDetails9735] AS [b.CustomerDetails] ON [b].[CustomerDetailsId] = [b.CustomerDetails].[Id]
 ORDER BY CASE
@@ -2570,23 +2569,22 @@ ORDER BY CASE
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END, CASE
     WHEN [b].[CustomerDetailsId] IS NOT NULL
-    THEN [b.CustomerDetails].[Name] ELSE @__Empty_0
+    THEN [b.CustomerDetails].[Name] ELSE N''
 END, [b].[Id]",
                         //
-                        @"@__p_1='2'
-@__Empty_0='' (Size = 4000)
+                        @"@__p_0='2'
 
 SELECT [b.Orders].[Id], [b.Orders].[CustomerId], [b.Orders].[Name]
 FROM [Order9735] AS [b.Orders]
 INNER JOIN (
     SELECT DISTINCT [t].*
     FROM (
-        SELECT TOP(@__p_1) [b0].[Id], CASE
+        SELECT TOP(@__p_0) [b0].[Id], CASE
             WHEN [b0].[AddressId] > 0
             THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
         END AS [c], CASE
             WHEN [b0].[CustomerDetailsId] IS NOT NULL
-            THEN [b.CustomerDetails0].[Name] ELSE @__Empty_0
+            THEN [b.CustomerDetails0].[Name] ELSE N''
         END AS [c0], [b0].[AddressId], [b0].[CustomerDetailsId], [b.CustomerDetails0].[Name]
         FROM [Customers] AS [b0]
         LEFT JOIN [CustomerDetails9735] AS [b.CustomerDetails0] ON [b0].[CustomerDetailsId] = [b.CustomerDetails0].[Id]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Functions.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Functions.cs
@@ -1063,11 +1063,9 @@ WHERE ([o].[CustomerID] = N'ALFKI') AND (CONVERT(nvarchar(max), CONVERT(nvarchar
             base.Indexof_with_emptystring();
 
             AssertSql(
-                @"@__Empty_0='' (Size = 4000)
-
-SELECT CASE
-    WHEN @__Empty_0 = N''
-    THEN 0 ELSE CHARINDEX(@__Empty_0, [c].[ContactName]) - 1
+                @"SELECT CASE
+    WHEN N'' = N''
+    THEN 0 ELSE CHARINDEX(N'', [c].[ContactName]) - 1
 END
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = N'ALFKI'");
@@ -1078,9 +1076,7 @@ WHERE [c].[CustomerID] = N'ALFKI'");
             base.Replace_with_emptystring();
 
             AssertSql(
-                @"@__Empty_0='' (Size = 4000)
-
-SELECT REPLACE([c].[ContactName], N'ari', @__Empty_0)
+                @"SELECT REPLACE([c].[ContactName], N'ari', N'')
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] = N'ALFKI'");
         }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
@@ -321,9 +321,7 @@ WHERE (instr(""c"".""City"", 'Sea') - 1) <> -1");
             base.Indexof_with_emptystring();
 
             AssertSql(
-                @"@__Empty_0=''
-
-SELECT instr(""c"".""ContactName"", @__Empty_0) - 1
+                @"SELECT instr(""c"".""ContactName"", '') - 1
 FROM ""Customers"" AS ""c""
 WHERE ""c"".""CustomerID"" = 'ALFKI'");
         }
@@ -343,9 +341,7 @@ WHERE replace(""c"".""City"", 'Sea', 'Rea') = 'Reattle'");
             base.Replace_with_emptystring();
 
             AssertSql(
-                @"@__Empty_0=''
-
-SELECT replace(""c"".""ContactName"", 'ari', @__Empty_0)
+                @"SELECT replace(""c"".""ContactName"", 'ari', '')
 FROM ""Customers"" AS ""c""
 WHERE ""c"".""CustomerID"" = 'ALFKI'");
         }


### PR DESCRIPTION
Fixes #10547 