### PR TITLE
Fix to #10441 - Query: Derived include types not inferred for collections

### DIFF
--- a/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarData.cs
+++ b/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarData.cs
@@ -217,12 +217,8 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
         public static IReadOnlyList<Faction> CreateFactions()
             => new List<Faction>
             {
-                new LocustHorde { Id = 1, Name = "Locust", Eradicated = true },
-                //    Commander = myrrah,
-                //Leaders = new List<LocustLeader> { karn, raam, skorge, myrrah }
-                new LocustHorde { Id = 2, Name = "Swarm", Eradicated = false }
-                //    Commander = swarmCommander,
-                //Leaders = new List<LocustLeader> { theSpeaker },
+                new LocustHorde { Id = 1, Name = "Locust", Eradicated = true, CommanderName = "Queen Myrrah" },
+                new LocustHorde { Id = 2, Name = "Swarm", Eradicated = false, CommanderName = "Unknown" }
             };
 
         public static void WireUp(

--- a/src/EFCore/EntityFrameworkQueryableExtensions.cs
+++ b/src/EFCore/EntityFrameworkQueryableExtensions.cs
@@ -2167,13 +2167,6 @@ namespace Microsoft.EntityFrameworkCore
                     && mi.GetParameters().Any(
                         pi => pi.Name == "navigationPropertyPath" && pi.ParameterType != typeof(string)));
 
-        internal static readonly MethodInfo IncludeOnDerivedMethodInfo
-            = typeof(EntityFrameworkQueryableExtensions)
-                .GetTypeInfo().GetDeclaredMethods(nameof(Include))
-                .Single(mi => mi.GetGenericArguments().Count() == 3
-                              && mi.GetParameters().Any(
-                                  pi => pi.Name == "navigationPropertyPath" && pi.ParameterType != typeof(string)));
-
         /// <summary>
         ///     Specifies related entities to include in the query results. The navigation property to be included is specified starting with the
         ///     type of entity being queried (<typeparamref name="TEntity" />). If you wish to include additional types based on the navigation
@@ -2204,6 +2197,18 @@ namespace Microsoft.EntityFrameworkCore
         ///                 .Include(blog => blog.Contributors);
         ///         </code>
         ///     </para>
+        ///     <para>
+        ///         The following query shows including a single level of related entities on a derived type using casting.
+        ///         <code>
+        ///             context.Blogs.Include(blog => ((SpecialBlog)blog).SpecialPosts);
+        ///         </code>
+        ///     </para>
+        ///     <para>
+        ///         The following query shows including a single level of related entities on a derived type using 'as' operator.
+        ///         <code>
+        ///             context.Blogs.Include(blog => (blog as SpecialBlog).SpecialPosts);
+        ///         </code>
+        ///     </para>
         /// </example>
         /// <typeparam name="TEntity"> The type of entity being queried. </typeparam>
         /// <typeparam name="TProperty"> The type of the related entity to be included. </typeparam>
@@ -2232,51 +2237,6 @@ namespace Microsoft.EntityFrameworkCore
                     : source);
         }
 
-        /// <summary>
-        ///     Specifies related entities to include in the query results. The navigation property to be included is specified starting with the
-        ///     type of entity on which it is declared (<typeparamref name="TDerived" />). If you wish to include additional types based on the navigation
-        ///     properties of the type being included, then chain a call to
-        ///     <see
-        ///         cref="ThenInclude{TEntity, TPreviousProperty, TDerived, TProperty}(IIncludableQueryable{TEntity, IEnumerable{TPreviousProperty}}, Expression{Func{TDerived, TProperty}})" />
-        ///     after this call.
-        /// </summary>
-        /// <example>
-        ///     <para>
-        ///         The following query shows including a single level of related entities on a derived type.
-        ///         <code>
-        ///             context.Blogs.Include((SpecialBlog specialBlog) => specialBlog.SpecialPosts);
-        ///         </code>
-        ///     </para>
-        /// </example>
-        /// <typeparam name="TEntity"> The type of entity being queried. </typeparam>
-        /// <typeparam name="TDerived"> The type of entity when including on a derived type. </typeparam>
-        /// <typeparam name="TProperty"> The type of the related entity to be included. </typeparam>
-        /// <param name="source"> The source query. </param>
-        /// <param name="navigationPropertyPath">
-        ///     A lambda expression representing the navigation property to be included (<c>(Derived t) => t.Property1</c>).
-        /// </param>
-        /// <returns>
-        ///     A new query with the related data included.
-        /// </returns>
-        public static IIncludableQueryable<TEntity, TProperty> Include<TEntity, TDerived, TProperty>(
-            [NotNull] this IQueryable<TEntity> source,
-            [NotNull] Expression<Func<TDerived, TProperty>> navigationPropertyPath)
-            where TEntity : class
-            where TDerived : TEntity
-        {
-            Check.NotNull(source, nameof(source));
-            Check.NotNull(navigationPropertyPath, nameof(navigationPropertyPath));
-
-            return new IncludableQueryable<TEntity, TProperty>(
-                source.Provider is EntityQueryProvider
-                    ? source.Provider.CreateQuery<TEntity>(
-                        Expression.Call(
-                            instance: null,
-                            method: IncludeOnDerivedMethodInfo.MakeGenericMethod(typeof(TEntity), typeof(TDerived), typeof(TProperty)),
-                            arguments: new[] { source.Expression, Expression.Quote(navigationPropertyPath) }))
-                    : source);
-        }
-
         internal static readonly MethodInfo ThenIncludeAfterEnumerableMethodInfo
             = GetThenIncludeMethodInfo(typeof(IEnumerable<>));
 
@@ -2292,30 +2252,10 @@ namespace Microsoft.EntityFrameworkCore
                                    && typeInfo.GetGenericTypeDefinition() == navType;
                         });
 
-        internal static readonly MethodInfo ThenIncludeOnDerivedAfterEnumerableMethodInfo
-            = GetThenIncludeOnDerivedMethodInfo(typeof(IEnumerable<>));
-
-        private static MethodInfo GetThenIncludeOnDerivedMethodInfo(Type navType)
-            => typeof(EntityFrameworkQueryableExtensions)
-                .GetTypeInfo().GetDeclaredMethods(nameof(EntityFrameworkQueryableExtensions.ThenInclude))
-                .Where(mi => mi.GetGenericArguments().Count() == 4)
-                .Single(mi =>
-                    {
-                        var typeInfo = mi.GetParameters()[0].ParameterType.GenericTypeArguments[1].GetTypeInfo();
-                        return typeInfo.IsGenericType
-                               && typeInfo.GetGenericTypeDefinition() == navType;
-                    });
-
         internal static readonly MethodInfo ThenIncludeAfterReferenceMethodInfo
             = typeof(EntityFrameworkQueryableExtensions)
                 .GetTypeInfo().GetDeclaredMethods(nameof(EntityFrameworkQueryableExtensions.ThenInclude))
                 .Single(mi => mi.GetGenericArguments().Count() == 3
-                              && mi.GetParameters()[0].ParameterType.GenericTypeArguments[1].IsGenericParameter);
-
-        internal static readonly MethodInfo ThenIncludeOnDerivedAfterReferenceMethodInfo
-            = typeof(EntityFrameworkQueryableExtensions)
-                .GetTypeInfo().GetDeclaredMethods(nameof(EntityFrameworkQueryableExtensions.ThenInclude))
-                .Single(mi => mi.GetGenericArguments().Count() == 4
                               && mi.GetParameters()[0].ParameterType.GenericTypeArguments[1].IsGenericParameter);
 
         /// <summary>
@@ -2341,6 +2281,20 @@ namespace Microsoft.EntityFrameworkCore
         ///             context.Blogs
         ///                 .Include(blog => blog.Posts).ThenInclude(post => post.Tags).ThenInclude(tag => tag.TagInfo)
         ///                 .Include(blog => blog.Contributors);
+        ///         </code>
+        ///     </para>
+        ///     <para>
+        ///         The following query shows including two levels of entities on the same branch, second one being on derived type using casting.
+        ///         <code>
+        ///             context.Blogs
+        ///                 .Include(blog => blog.Posts).ThenInclude(post => ((SpecialPost)post).SpecialTags);
+        ///         </code>
+        ///     </para>
+        ///     <para>
+        ///         The following query shows including two levels of entities on the same branch, second one being on derived type using 'as' operator.
+        ///         <code>
+        ///             context.Blogs
+        ///                 .Include(blog => blog.Posts).ThenInclude(post => (post as SpecialPost).SpecialTags);
         ///         </code>
         ///     </para>
         /// </example>
@@ -2372,43 +2326,6 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         /// <example>
         ///     <para>
-        ///         The following query shows including two levels of entities on the same branch, second one being on derived type.
-        ///         <code>
-        ///             context.Blogs
-        ///                 .Include(blog => blog.Posts).ThenInclude((SpecialPost specialPost) => specialPost.SpecialTags);
-        ///         </code>
-        ///     </para>
-        /// </example>
-        /// <typeparam name="TEntity"> The type of entity being queried. </typeparam>
-        /// <typeparam name="TPreviousProperty"> The type of the entity that was just included. </typeparam>
-        /// <typeparam name="TDerived"> The type of entity when including on a derived type. </typeparam>
-        /// <typeparam name="TProperty"> The type of the related entity to be included. </typeparam>
-        /// <param name="source"> The source query. </param>
-        /// <param name="navigationPropertyPath">
-        ///     A lambda expression representing the navigation property to be included (<c>(Derived t) => t.Property1</c>).
-        /// </param>
-        /// <returns>
-        ///     A new query with the related data included.
-        /// </returns>
-        public static IIncludableQueryable<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TDerived, TProperty>(
-            [NotNull] this IIncludableQueryable<TEntity, IEnumerable<TPreviousProperty>> source,
-            [NotNull] Expression<Func<TDerived, TProperty>> navigationPropertyPath)
-            where TEntity : class
-            where TDerived : TPreviousProperty
-            => new IncludableQueryable<TEntity, TProperty>(
-                source.Provider is EntityQueryProvider
-                    ? source.Provider.CreateQuery<TEntity>(
-                        Expression.Call(
-                            instance: null,
-                            method: ThenIncludeOnDerivedAfterEnumerableMethodInfo.MakeGenericMethod(typeof(TEntity), typeof(TPreviousProperty), typeof(TDerived), typeof(TProperty)),
-                            arguments: new[] { source.Expression, Expression.Quote(navigationPropertyPath) }))
-                    : source);
-
-        /// <summary>
-        ///     Specifies additional related data to be further included based on a related type that was just included.
-        /// </summary>
-        /// <example>
-        ///     <para>
         ///         The following query shows including a single level of related entities.
         ///         <code>
         ///             context.Blogs.Include(blog => blog.Posts);
@@ -2427,6 +2344,20 @@ namespace Microsoft.EntityFrameworkCore
         ///             context.Blogs
         ///                 .Include(blog => blog.Posts).ThenInclude(post => post.Tags).ThenInclude(tag => tag.TagInfo)
         ///                 .Include(blog => blog.Contributors);
+        ///         </code>
+        ///     </para>
+        ///     <para>
+        ///         The following query shows including two levels of entities on the same branch, second one being on derived type.
+        ///         <code>
+        ///             context.Blogs
+        ///                 .Include(blog => blog.Posts).ThenInclude(post => ((SpecialPost)post).SpecialTags);
+        ///         </code>
+        ///     </para>
+        ///     <para>
+        ///         The following query shows including two levels of entities on the same branch, second one being on derived type using alternative method.
+        ///         <code>
+        ///             context.Blogs
+        ///                 .Include(blog => blog.Posts).ThenInclude(post => (post as SpecialPost).SpecialTags);
         ///         </code>
         ///     </para>
         /// </example>
@@ -2450,43 +2381,6 @@ namespace Microsoft.EntityFrameworkCore
                         Expression.Call(
                             instance: null,
                             method: ThenIncludeAfterReferenceMethodInfo.MakeGenericMethod(typeof(TEntity), typeof(TPreviousProperty), typeof(TProperty)),
-                            arguments: new[] { source.Expression, Expression.Quote(navigationPropertyPath) }))
-                    : source);
-
-        /// <summary>
-        ///     Specifies additional related data to be further included based on a related type that was just included.
-        /// </summary>
-        /// <example>
-        ///     <para>
-        ///         The following query shows including two levels of entities on the same branch, second one being on derived type.
-        ///         <code>
-        ///             context.Blogs
-        ///                 .Include(blog => blog.Posts).ThenInclude((SpecialPost specialPost) => specialPost.SpecialTags);
-        ///         </code>
-        ///     </para>
-        /// </example>
-        /// <typeparam name="TEntity"> The type of entity being queried. </typeparam>
-        /// <typeparam name="TPreviousProperty"> The type of the entity that was just included. </typeparam>
-        /// <typeparam name="TDerived"> The type of entity when including on a derived type. </typeparam>
-        /// <typeparam name="TProperty"> The type of the related entity to be included. </typeparam>
-        /// <param name="source"> The source query. </param>
-        /// <param name="navigationPropertyPath">
-        ///     A lambda expression representing the navigation property to be included (<c>(Derived t) => t.Property1</c>).
-        /// </param>
-        /// <returns>
-        ///     A new query with the related data included.
-        /// </returns>
-        public static IIncludableQueryable<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TDerived, TProperty>(
-            [NotNull] this IIncludableQueryable<TEntity, TPreviousProperty> source,
-            [NotNull] Expression<Func<TDerived, TProperty>> navigationPropertyPath)
-            where TEntity : class
-            where TDerived : TPreviousProperty
-            => new IncludableQueryable<TEntity, TProperty>(
-                source.Provider is EntityQueryProvider
-                    ? source.Provider.CreateQuery<TEntity>(
-                        Expression.Call(
-                            instance: null,
-                            method: ThenIncludeOnDerivedAfterReferenceMethodInfo.MakeGenericMethod(typeof(TEntity), typeof(TPreviousProperty), typeof(TDerived), typeof(TProperty)),
                             arguments: new[] { source.Expression, Expression.Quote(navigationPropertyPath) }))
                     : source);
 

--- a/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
+++ b/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
@@ -170,7 +170,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
             do
             {
-                memberExpression = RemoveConvert(propertyAccessExpression) as MemberExpression;
+                memberExpression = RemoveTypeAs(RemoveConvert(propertyAccessExpression)) as MemberExpression;
 
                 var propertyInfo = memberExpression?.Member as PropertyInfo;
 
@@ -183,7 +183,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
                 propertyAccessExpression = memberExpression.Expression;
             }
-            while (memberExpression.Expression.RemoveConvert() != parameterExpression);
+            while (RemoveTypeAs(RemoveConvert(memberExpression.Expression)) != parameterExpression);
 
             return propertyInfos;
         }
@@ -203,6 +203,22 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
             return expression;
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static Expression RemoveTypeAs([CanBeNull] this Expression expression)
+        {
+            while (expression != null
+                   && (expression.NodeType == ExpressionType.TypeAs))
+            {
+                expression = RemoveConvert(((UnaryExpression)expression).Operand);
+            }
+
+            return expression;
+        }
+
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Query/ResultOperators/Internal/IncludeExpressionNode.cs
+++ b/src/EFCore/Query/ResultOperators/Internal/IncludeExpressionNode.cs
@@ -25,8 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
         /// </summary>
         public static readonly IReadOnlyCollection<MethodInfo> SupportedMethods = new[]
         {
-            EntityFrameworkQueryableExtensions.IncludeMethodInfo,
-            EntityFrameworkQueryableExtensions.IncludeOnDerivedMethodInfo
+            EntityFrameworkQueryableExtensions.IncludeMethodInfo
         };
 
         /// <summary>

--- a/src/EFCore/Query/ResultOperators/Internal/ThenIncludeExpressionNode.cs
+++ b/src/EFCore/Query/ResultOperators/Internal/ThenIncludeExpressionNode.cs
@@ -25,9 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
         public static readonly IReadOnlyCollection<MethodInfo> SupportedMethods = new[]
         {
             EntityFrameworkQueryableExtensions.ThenIncludeAfterEnumerableMethodInfo,
-            EntityFrameworkQueryableExtensions.ThenIncludeAfterReferenceMethodInfo,
-            EntityFrameworkQueryableExtensions.ThenIncludeOnDerivedAfterEnumerableMethodInfo,
-            EntityFrameworkQueryableExtensions.ThenIncludeOnDerivedAfterReferenceMethodInfo,
+            EntityFrameworkQueryableExtensions.ThenIncludeAfterReferenceMethodInfo
         };
 
         /// <summary>


### PR DESCRIPTION
There is a bug in the compiler that would cause it to not pick the correct overload for the ThenInclude method for collection navigations.
Fix is to remove the additional overloads and re-purpose the current ones, so that users can specify derived includes using them.

Previous declaration was:

customers.Include(SpecialCustomer sc => sc.SpecialOrders).ThenInclude(SpecialOrder so => so.SpecialOrderDetails)

New declaration is:

customers.Include(c => ((SpecialCustomer)c).SpecialOrders).ThenInclude(o => ((SpecialOrder)o).SpecialOrderDetails)

alternatively, using "as" operator:

customers.Include(c => (c as SpecialCustomer).SpecialOrders).ThenInclude(o => (o as SpecialOrder).SpecialOrderDetails)