### PR TITLE
Initial implementation of lazy-loading and entities with constructors

### DIFF
--- a/samples/OracleProvider/src/OracleProvider/Metadata/Conventions/OracleConventionSetBuilder.cs
+++ b/samples/OracleProvider/src/OracleProvider/Metadata/Conventions/OracleConventionSetBuilder.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
@@ -54,7 +55,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 new RelationalConventionSetBuilderDependencies(oracleTypeMapper, currentContext: null, setFinder: null))
                 .AddConventions(
                     new CoreConventionSetBuilder(
-                        new CoreConventionSetBuilderDependencies(oracleTypeMapper))
+                        new CoreConventionSetBuilderDependencies(
+                            oracleTypeMapper,
+                            new ConstructorBindingFactory()))
                         .CreateConventionSet());
         }
     }

--- a/samples/OracleProvider/test/OracleProvider.FunctionalTests/WithConstructorsOracleTest.cs
+++ b/samples/OracleProvider/test/OracleProvider.FunctionalTests/WithConstructorsOracleTest.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class WithConstructorsOracleTest : WithConstructorsTestBase<WithConstructorsOracleTest.WithConstructorsOracleFixture>
+    {
+        public WithConstructorsOracleTest(WithConstructorsOracleFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
+            => facade.UseTransaction(transaction.GetDbTransaction());
+
+        public class WithConstructorsOracleFixture : WithConstructorsFixtureBase
+        {
+            protected override ITestStoreFactory TestStoreFactory => OracleTestStoreFactory.Instance;
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+            {
+                base.OnModelCreating(modelBuilder, context);
+
+                modelBuilder.Entity<HasContext<DbContext>>().ToTable("HasContext_DbContext");
+                modelBuilder.Entity<HasContext<WithConstructorsContext>>().ToTable("HasContext_WithConstructorsContext");
+                modelBuilder.Entity<HasContext<OtherContext>>().ToTable("HasContext_OtherContext");
+
+                modelBuilder.Entity<Blog>(
+                    b => { b.Property("_blogId").HasColumnName("BlogId"); });
+
+                modelBuilder.Entity<Post>(
+                    b => { b.Property("_id").HasColumnName("Id"); });
+            }
+        }
+    }
+}

--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -668,7 +668,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 annotations,
                 RelationshipDiscoveryConvention.NavigationCandidatesAnnotationName,
                 RelationshipDiscoveryConvention.AmbiguousNavigationsAnnotationName,
-                InversePropertyAttributeConvention.InverseNavigationsAnnotationName);
+                InversePropertyAttributeConvention.InverseNavigationsAnnotationName,
+                CoreAnnotationNames.ConstructorBinding);
 
             if (annotations.Any())
             {

--- a/src/EFCore.InMemory/Query/Internal/IMaterializerFactory.cs
+++ b/src/EFCore.InMemory/Query/Internal/IMaterializerFactory.cs
@@ -19,6 +19,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        Expression<Func<IEntityType, ValueBuffer, object>> CreateMaterializer([NotNull] IEntityType entityType);
+        Expression<Func<IEntityType, ValueBuffer, DbContext, object>> CreateMaterializer([NotNull] IEntityType entityType);
     }
 }

--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryModelVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryModelVisitor.cs
@@ -49,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             QueryContext queryContext,
             IEntityType entityType,
             IKey key,
-            Func<IEntityType, ValueBuffer, object> materializer,
+            Func<IEntityType, ValueBuffer, DbContext, object> materializer,
             bool queryStateManager)
             where TEntity : class
             => ((InMemoryQueryContext)queryContext).Store
@@ -67,7 +67,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                                             key,
                                             new EntityLoadInfo(
                                                 valueBuffer,
-                                                vr => materializer(t.EntityType, vr)),
+                                                queryContext.Context,
+                                                (vr, c) => materializer(t.EntityType, vr, c)),
                                             queryStateManager,
                                             throwOnNullKey: false);
                                 }));

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/BufferedEntityShaper`.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/BufferedEntityShaper`.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             [NotNull] IQuerySource querySource,
             bool trackingQuery,
             [NotNull] IKey key,
-            [NotNull] Func<ValueBuffer, object> materializer,
+            [NotNull] Func<ValueBuffer, DbContext, object> materializer,
             [CanBeNull] Dictionary<Type, int[]> typeIndexMap)
             : base(querySource, trackingQuery, key, materializer)
         {
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 = (TEntity)queryContext.QueryBuffer
                     .GetEntity(
                         Key,
-                        new EntityLoadInfo(valueBuffer, Materializer, _typeIndexMap),
+                        new EntityLoadInfo(valueBuffer, queryContext.Context, Materializer, _typeIndexMap),
                         queryStateManager: IsTrackingQuery,
                         throwOnNullKey: !AllowNullResult);
 

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/BufferedOffsetEntityShaper.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/BufferedOffsetEntityShaper.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             [NotNull] IQuerySource querySource,
             bool trackingQuery,
             [NotNull] IKey key,
-            [NotNull] Func<ValueBuffer, object> materializer,
+            [NotNull] Func<ValueBuffer, DbContext, object> materializer,
             [CanBeNull] Dictionary<Type, int[]> typeIndexMap)
             : base(querySource, trackingQuery, key, materializer, typeIndexMap)
         {

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/EntityShaper.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/EntityShaper.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             [NotNull] IQuerySource querySource,
             bool trackingQuery,
             [NotNull] IKey key,
-            [NotNull] Func<ValueBuffer, object> materializer)
+            [NotNull] Func<ValueBuffer, DbContext, object> materializer)
             : base(querySource)
         {
             IsTrackingQuery = trackingQuery;
@@ -47,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual Func<ValueBuffer, object> Materializer { get; }
+        protected virtual Func<ValueBuffer, DbContext, object> Materializer { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/IMaterializerFactory.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/IMaterializerFactory.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        Expression<Func<ValueBuffer, object>> CreateMaterializer(
+        Expression<Func<ValueBuffer, DbContext, object>> CreateMaterializer(
             [NotNull] IEntityType entityType,
             [NotNull] SelectExpression selectExpression,
             [NotNull] Func<IProperty, SelectExpression, int> projectionAdder,

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/UnbufferedEntityShaper.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/UnbufferedEntityShaper.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             [NotNull] IQuerySource querySource,
             bool trackingQuery,
             [NotNull] IKey key,
-            [NotNull] Func<ValueBuffer, object> materializer)
+            [NotNull] Func<ValueBuffer, DbContext, object> materializer)
             : base(querySource, trackingQuery, key, materializer)
         {
         }
@@ -51,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 }
             }
 
-            return (TEntity)Materializer(valueBuffer);
+            return (TEntity)Materializer(valueBuffer, queryContext.Context);
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/UnbufferedOffsetEntityShaper.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/UnbufferedOffsetEntityShaper.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             [NotNull] IQuerySource querySource,
             bool trackingQuery,
             [NotNull] IKey key,
-            [NotNull] Func<ValueBuffer, object> materializer)
+            [NotNull] Func<ValueBuffer, DbContext, object> materializer)
             : base(querySource, trackingQuery, key, materializer)
         {
         }

--- a/src/EFCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
@@ -340,7 +340,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
             IQuerySource querySource,
             bool trackingQuery,
             IKey key,
-            Func<ValueBuffer, object> materializer,
+            Func<ValueBuffer, DbContext, object> materializer,
             Dictionary<Type, int[]> typeIndexMap,
             bool useQueryBuffer)
             where TEntity : class

--- a/src/EFCore.Specification.Tests/DatabindingTestBase.cs
+++ b/src/EFCore.Specification.Tests/DatabindingTestBase.cs
@@ -862,7 +862,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             using (var context = CreateF1Context())
             {
-                var ferrari = context.Teams.Include(t => t.Drivers).Single(t => t.Id == Team.Ferrari);
+                var ferrari = context.Teams.Single(t => t.Id == Team.Ferrari);
                 var navBindingList = ((IListSource)ferrari.Drivers).GetList();
 
                 var larry = new Driver
@@ -882,7 +882,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             using (var context = CreateF1Context())
             {
-                var ferrari = context.Teams.Include(t => t.Drivers).Single(t => t.Id == Team.Ferrari);
+                var ferrari = context.Teams.Single(t => t.Id == Team.Ferrari);
                 var navBindingList = ((IListSource)ferrari.Drivers).GetList();
                 var localDrivers = context.Drivers.Local;
 
@@ -909,7 +909,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             using (var context = CreateF1Context())
             {
-                var ferrari = context.Teams.Include(t => t.Drivers).Single(t => t.Id == Team.Ferrari);
+                var ferrari = context.Teams.Single(t => t.Id == Team.Ferrari);
                 var navBindingList = ((IListSource)ferrari.Drivers).GetList();
                 var localDrivers = context.Drivers.Local;
 

--- a/src/EFCore.Specification.Tests/FieldMappingTestBase.cs
+++ b/src/EFCore.Specification.Tests/FieldMappingTestBase.cs
@@ -555,20 +555,20 @@ namespace Microsoft.EntityFrameworkCore
 
             int IBlogAccesor.AccessId
             {
-                get { return Id; }
-                set { Id = value; }
+                get => Id;
+                set => Id = value;
             }
 
             string IBlogAccesor.AccessTitle
             {
-                get { return Title; }
-                set { Title = value; }
+                get => Title;
+                set => Title = value;
             }
 
             IEnumerable<IPostAccesor> IBlogAccesor.AccessPosts
             {
-                get { return Posts; }
-                set { Posts = (IEnumerable<PostAuto>)value; }
+                get => Posts;
+                set => Posts = (IEnumerable<PostAuto>)value;
             }
         }
 
@@ -584,26 +584,26 @@ namespace Microsoft.EntityFrameworkCore
 
             int IPostAccesor.AccessId
             {
-                get { return Id; }
-                set { Id = value; }
+                get => Id;
+                set => Id = value;
             }
 
             string IPostAccesor.AccessTitle
             {
-                get { return Title; }
-                set { Title = value; }
+                get => Title;
+                set => Title = value;
             }
 
             int IPostAccesor.AccessBlogId
             {
-                get { return BlogId; }
-                set { BlogId = value; }
+                get => BlogId;
+                set => BlogId = value;
             }
 
             IBlogAccesor IPostAccesor.AccessBlog
             {
-                get { return Blog; }
-                set { Blog = (BlogAuto)value; }
+                get => Blog;
+                set => Blog = (BlogAuto)value;
             }
         }
 
@@ -617,40 +617,40 @@ namespace Microsoft.EntityFrameworkCore
             [DatabaseGenerated(DatabaseGeneratedOption.None)]
             public int Id
             {
-                get { return _id; }
-                set { _id = value; }
+                get => _id;
+                set => _id = value;
             }
 
             // ReSharper disable once ConvertToAutoProperty
             public string Title
             {
-                get { return _title; }
-                set { _title = value; }
+                get => _title;
+                set => _title = value;
             }
 
             // ReSharper disable once ConvertToAutoProperty
             public IEnumerable<PostFull> Posts
             {
-                get { return _posts; }
-                set { _posts = (ICollection<PostFull>)value; }
+                get => _posts;
+                set => _posts = (ICollection<PostFull>)value;
             }
 
             int IBlogAccesor.AccessId
             {
-                get { return Id; }
-                set { Id = value; }
+                get => Id;
+                set => Id = value;
             }
 
             string IBlogAccesor.AccessTitle
             {
-                get { return Title; }
-                set { Title = value; }
+                get => Title;
+                set => Title = value;
             }
 
             IEnumerable<IPostAccesor> IBlogAccesor.AccessPosts
             {
-                get { return Posts; }
-                set { Posts = (IEnumerable<PostFull>)value; }
+                get => Posts;
+                set => Posts = (IEnumerable<PostFull>)value;
             }
         }
 
@@ -665,53 +665,53 @@ namespace Microsoft.EntityFrameworkCore
             [DatabaseGenerated(DatabaseGeneratedOption.None)]
             public int Id
             {
-                get { return _id; }
-                set { _id = value; }
+                get => _id;
+                set => _id = value;
             }
 
             // ReSharper disable once ConvertToAutoProperty
             public string Title
             {
-                get { return _title; }
-                set { _title = value; }
+                get => _title;
+                set => _title = value;
             }
 
             // ReSharper disable once ConvertToAutoProperty
             public int BlogId
             {
-                get { return _blogId; }
-                set { _blogId = value; }
+                get => _blogId;
+                set => _blogId = value;
             }
 
             // ReSharper disable once ConvertToAutoProperty
             public BlogFull Blog
             {
-                get { return _blog; }
-                set { _blog = value; }
+                get => _blog;
+                set => _blog = value;
             }
 
             int IPostAccesor.AccessId
             {
-                get { return Id; }
-                set { Id = value; }
+                get => Id;
+                set => Id = value;
             }
 
             string IPostAccesor.AccessTitle
             {
-                get { return Title; }
-                set { Title = value; }
+                get => Title;
+                set => Title = value;
             }
 
             int IPostAccesor.AccessBlogId
             {
-                get { return BlogId; }
-                set { BlogId = value; }
+                get => BlogId;
+                set => BlogId = value;
             }
 
             IBlogAccesor IPostAccesor.AccessBlog
             {
-                get { return Blog; }
-                set { Blog = (BlogFull)value; }
+                get => Blog;
+                set => Blog = (BlogFull)value;
             }
         }
 
@@ -725,40 +725,40 @@ namespace Microsoft.EntityFrameworkCore
             [DatabaseGenerated(DatabaseGeneratedOption.None)]
             public int Id
             {
-                get { return _myid; }
-                set { _myid = value; }
+                get => _myid;
+                set => _myid = value;
             }
 
             // ReSharper disable once ConvertToAutoProperty
             public string Title
             {
-                get { return _mytitle; }
-                set { _mytitle = value; }
+                get => _mytitle;
+                set => _mytitle = value;
             }
 
             // ReSharper disable once ConvertToAutoProperty
             public IEnumerable<PostFullExplicit> Posts
             {
-                get { return _myposts; }
-                set { _myposts = (ICollection<PostFullExplicit>)value; }
+                get => _myposts;
+                set => _myposts = (ICollection<PostFullExplicit>)value;
             }
 
             int IBlogAccesor.AccessId
             {
-                get { return Id; }
-                set { Id = value; }
+                get => Id;
+                set => Id = value;
             }
 
             string IBlogAccesor.AccessTitle
             {
-                get { return Title; }
-                set { Title = value; }
+                get => Title;
+                set => Title = value;
             }
 
             IEnumerable<IPostAccesor> IBlogAccesor.AccessPosts
             {
-                get { return Posts; }
-                set { Posts = (IEnumerable<PostFullExplicit>)value; }
+                get => Posts;
+                set => Posts = (IEnumerable<PostFullExplicit>)value;
             }
         }
 
@@ -773,53 +773,53 @@ namespace Microsoft.EntityFrameworkCore
             [DatabaseGenerated(DatabaseGeneratedOption.None)]
             public int Id
             {
-                get { return _myid; }
-                set { _myid = value; }
+                get => _myid;
+                set => _myid = value;
             }
 
             // ReSharper disable once ConvertToAutoProperty
             public string Title
             {
-                get { return _mytitle; }
-                set { _mytitle = value; }
+                get => _mytitle;
+                set => _mytitle = value;
             }
 
             // ReSharper disable once ConvertToAutoProperty
             public int BlogId
             {
-                get { return _myblogId; }
-                set { _myblogId = value; }
+                get => _myblogId;
+                set => _myblogId = value;
             }
 
             // ReSharper disable once ConvertToAutoProperty
             public BlogFullExplicit Blog
             {
-                get { return _myblog; }
-                set { _myblog = value; }
+                get => _myblog;
+                set => _myblog = value;
             }
 
             int IPostAccesor.AccessId
             {
-                get { return Id; }
-                set { Id = value; }
+                get => Id;
+                set => Id = value;
             }
 
             string IPostAccesor.AccessTitle
             {
-                get { return Title; }
-                set { Title = value; }
+                get => Title;
+                set => Title = value;
             }
 
             int IPostAccesor.AccessBlogId
             {
-                get { return BlogId; }
-                set { BlogId = value; }
+                get => BlogId;
+                set => BlogId = value;
             }
 
             IBlogAccesor IPostAccesor.AccessBlog
             {
-                get { return Blog; }
-                set { Blog = (BlogFullExplicit)value; }
+                get => Blog;
+                set => Blog = (BlogFullExplicit)value;
             }
         }
 
@@ -841,20 +841,20 @@ namespace Microsoft.EntityFrameworkCore
 
             int IBlogAccesor.AccessId
             {
-                get { return Id; }
-                set { _id = value; }
+                get => Id;
+                set => _id = value;
             }
 
             string IBlogAccesor.AccessTitle
             {
-                get { return Title; }
-                set { _title = value; }
+                get => Title;
+                set => _title = value;
             }
 
             IEnumerable<IPostAccesor> IBlogAccesor.AccessPosts
             {
-                get { return Posts; }
-                set { _posts = (ICollection<PostReadOnly>)value; }
+                get => Posts;
+                set => _posts = (ICollection<PostReadOnly>)value;
             }
         }
 
@@ -880,26 +880,26 @@ namespace Microsoft.EntityFrameworkCore
 
             int IPostAccesor.AccessId
             {
-                get { return Id; }
-                set { _id = value; }
+                get => Id;
+                set => _id = value;
             }
 
             string IPostAccesor.AccessTitle
             {
-                get { return Title; }
-                set { _title = value; }
+                get => Title;
+                set => _title = value;
             }
 
             int IPostAccesor.AccessBlogId
             {
-                get { return BlogId; }
-                set { _blogId = value; }
+                get => BlogId;
+                set => _blogId = value;
             }
 
             IBlogAccesor IPostAccesor.AccessBlog
             {
-                get { return Blog; }
-                set { _blog = (BlogReadOnly)value; }
+                get => Blog;
+                set => _blog = (BlogReadOnly)value;
             }
         }
 
@@ -921,20 +921,20 @@ namespace Microsoft.EntityFrameworkCore
 
             int IBlogAccesor.AccessId
             {
-                get { return Id; }
-                set { _myid = value; }
+                get => Id;
+                set => _myid = value;
             }
 
             string IBlogAccesor.AccessTitle
             {
-                get { return Title; }
-                set { _mytitle = value; }
+                get => Title;
+                set => _mytitle = value;
             }
 
             IEnumerable<IPostAccesor> IBlogAccesor.AccessPosts
             {
-                get { return Posts; }
-                set { _myposts = (ICollection<PostReadOnlyExplicit>)value; }
+                get => Posts;
+                set => _myposts = (ICollection<PostReadOnlyExplicit>)value;
             }
         }
 
@@ -960,26 +960,26 @@ namespace Microsoft.EntityFrameworkCore
 
             int IPostAccesor.AccessId
             {
-                get { return Id; }
-                set { _myid = value; }
+                get => Id;
+                set => _myid = value;
             }
 
             string IPostAccesor.AccessTitle
             {
-                get { return Title; }
-                set { _mytitle = value; }
+                get => Title;
+                set => _mytitle = value;
             }
 
             int IPostAccesor.AccessBlogId
             {
-                get { return BlogId; }
-                set { _myblogId = value; }
+                get => BlogId;
+                set => _myblogId = value;
             }
 
             IBlogAccesor IPostAccesor.AccessBlog
             {
-                get { return Blog; }
-                set { _myblog = (BlogReadOnlyExplicit)value; }
+                get => Blog;
+                set => _myblog = (BlogReadOnlyExplicit)value;
             }
         }
 
@@ -992,35 +992,35 @@ namespace Microsoft.EntityFrameworkCore
             [DatabaseGenerated(DatabaseGeneratedOption.None)]
             public int Id
             {
-                set { _id = value; }
+                set => _id = value;
             }
 
             public string Title
             {
-                set { _title = value; }
+                set => _title = value;
             }
 
             public IEnumerable<PostWriteOnly> Posts
             {
-                set { _posts = (ICollection<PostWriteOnly>)value; }
+                set => _posts = (ICollection<PostWriteOnly>)value;
             }
 
             int IBlogAccesor.AccessId
             {
-                get { return _id; }
-                set { Id = value; }
+                get => _id;
+                set => Id = value;
             }
 
             string IBlogAccesor.AccessTitle
             {
-                get { return _title; }
-                set { Title = value; }
+                get => _title;
+                set => Title = value;
             }
 
             IEnumerable<IPostAccesor> IBlogAccesor.AccessPosts
             {
-                get { return _posts; }
-                set { Posts = (IEnumerable<PostWriteOnly>)value; }
+                get => _posts;
+                set => Posts = (IEnumerable<PostWriteOnly>)value;
             }
         }
 
@@ -1034,46 +1034,46 @@ namespace Microsoft.EntityFrameworkCore
             [DatabaseGenerated(DatabaseGeneratedOption.None)]
             public int Id
             {
-                set { _id = value; }
+                set => _id = value;
             }
 
             public string Title
             {
-                set { _title = value; }
+                set => _title = value;
             }
 
             public int BlogId
             {
-                set { _blogId = value; }
+                set => _blogId = value;
             }
 
             public BlogWriteOnly Blog
             {
-                set { _blog = value; }
+                set => _blog = value;
             }
 
             int IPostAccesor.AccessId
             {
-                get { return _id; }
-                set { Id = value; }
+                get => _id;
+                set => Id = value;
             }
 
             string IPostAccesor.AccessTitle
             {
-                get { return _title; }
-                set { Title = value; }
+                get => _title;
+                set => Title = value;
             }
 
             int IPostAccesor.AccessBlogId
             {
-                get { return _blogId; }
-                set { BlogId = value; }
+                get => _blogId;
+                set => BlogId = value;
             }
 
             IBlogAccesor IPostAccesor.AccessBlog
             {
-                get { return _blog; }
-                set { Blog = (BlogWriteOnly)value; }
+                get => _blog;
+                set => Blog = (BlogWriteOnly)value;
             }
         }
 
@@ -1086,35 +1086,35 @@ namespace Microsoft.EntityFrameworkCore
             [DatabaseGenerated(DatabaseGeneratedOption.None)]
             public int Id
             {
-                set { _myid = value; }
+                set => _myid = value;
             }
 
             public string Title
             {
-                set { _mytitle = value; }
+                set => _mytitle = value;
             }
 
             public IEnumerable<PostWriteOnlyExplicit> Posts
             {
-                set { _myposts = (ICollection<PostWriteOnlyExplicit>)value; }
+                set => _myposts = (ICollection<PostWriteOnlyExplicit>)value;
             }
 
             int IBlogAccesor.AccessId
             {
-                get { return _myid; }
-                set { Id = value; }
+                get => _myid;
+                set => Id = value;
             }
 
             string IBlogAccesor.AccessTitle
             {
-                get { return _mytitle; }
-                set { Title = value; }
+                get => _mytitle;
+                set => Title = value;
             }
 
             IEnumerable<IPostAccesor> IBlogAccesor.AccessPosts
             {
-                get { return _myposts; }
-                set { Posts = (IEnumerable<PostWriteOnlyExplicit>)value; }
+                get => _myposts;
+                set => Posts = (IEnumerable<PostWriteOnlyExplicit>)value;
             }
         }
 
@@ -1128,46 +1128,46 @@ namespace Microsoft.EntityFrameworkCore
             [DatabaseGenerated(DatabaseGeneratedOption.None)]
             public int Id
             {
-                set { _myid = value; }
+                set => _myid = value;
             }
 
             public string Title
             {
-                set { _mytitle = value; }
+                set => _mytitle = value;
             }
 
             public int BlogId
             {
-                set { _myblogId = value; }
+                set => _myblogId = value;
             }
 
             public BlogWriteOnlyExplicit Blog
             {
-                set { _myblog = value; }
+                set => _myblog = value;
             }
 
             int IPostAccesor.AccessId
             {
-                get { return _myid; }
-                set { Id = value; }
+                get => _myid;
+                set => Id = value;
             }
 
             string IPostAccesor.AccessTitle
             {
-                get { return _mytitle; }
-                set { Title = value; }
+                get => _mytitle;
+                set => Title = value;
             }
 
             int IPostAccesor.AccessBlogId
             {
-                get { return _myblogId; }
-                set { BlogId = value; }
+                get => _myblogId;
+                set => BlogId = value;
             }
 
             IBlogAccesor IPostAccesor.AccessBlog
             {
-                get { return _myblog; }
-                set { Blog = (BlogWriteOnlyExplicit)value; }
+                get => _myblog;
+                set => Blog = (BlogWriteOnlyExplicit)value;
             }
         }
 
@@ -1182,21 +1182,21 @@ namespace Microsoft.EntityFrameworkCore
 
             int IBlogAccesor.AccessId
             {
-                get { return _id; }
-                set { _id = value; }
+                get => _id;
+                set => _id = value;
             }
 
             // ReSharper disable once ConvertToAutoProperty
             string IBlogAccesor.AccessTitle
             {
-                get { return _title; }
-                set { _title = value; }
+                get => _title;
+                set => _title = value;
             }
 
             IEnumerable<IPostAccesor> IBlogAccesor.AccessPosts
             {
-                get { return Posts; }
-                set { Posts = (IEnumerable<PostFields>)value; }
+                get => Posts;
+                set => Posts = (IEnumerable<PostFields>)value;
             }
         }
 

--- a/src/EFCore.Specification.Tests/GraphUpdatesFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/GraphUpdatesFixtureBase.cs
@@ -939,128 +939,128 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public Guid AlternateId
             {
-                get { return _alternateId; }
-                set { SetWithNotify(value, ref _alternateId); }
+                get => _alternateId;
+                set => SetWithNotify(value, ref _alternateId);
             }
 
             public IEnumerable<Required1> RequiredChildren
             {
-                get { return _requiredChildren; }
-                set { SetWithNotify(value, ref _requiredChildren); }
+                get => _requiredChildren;
+                set => SetWithNotify(value, ref _requiredChildren);
             }
 
             public IEnumerable<Optional1> OptionalChildren
             {
-                get { return _optionalChildren; }
-                set { SetWithNotify(value, ref _optionalChildren); }
+                get => _optionalChildren;
+                set => SetWithNotify(value, ref _optionalChildren);
             }
 
             public RequiredSingle1 RequiredSingle
             {
-                get { return _requiredSingle; }
-                set { SetWithNotify(value, ref _requiredSingle); }
+                get => _requiredSingle;
+                set => SetWithNotify(value, ref _requiredSingle);
             }
 
             public RequiredNonPkSingle1 RequiredNonPkSingle
             {
-                get { return _requiredNonPkSingle; }
-                set { SetWithNotify(value, ref _requiredNonPkSingle); }
+                get => _requiredNonPkSingle;
+                set => SetWithNotify(value, ref _requiredNonPkSingle);
             }
 
             public RequiredNonPkSingle1Derived RequiredNonPkSingleDerived
             {
-                get { return _requiredNonPkSingleDerived; }
-                set { SetWithNotify(value, ref _requiredNonPkSingleDerived); }
+                get => _requiredNonPkSingleDerived;
+                set => SetWithNotify(value, ref _requiredNonPkSingleDerived);
             }
 
             public RequiredNonPkSingle1MoreDerived RequiredNonPkSingleMoreDerived
             {
-                get { return _requiredNonPkSingleMoreDerived; }
-                set { SetWithNotify(value, ref _requiredNonPkSingleMoreDerived); }
+                get => _requiredNonPkSingleMoreDerived;
+                set => SetWithNotify(value, ref _requiredNonPkSingleMoreDerived);
             }
 
             public OptionalSingle1 OptionalSingle
             {
-                get { return _optionalSingle; }
-                set { SetWithNotify(value, ref _optionalSingle); }
+                get => _optionalSingle;
+                set => SetWithNotify(value, ref _optionalSingle);
             }
 
             public OptionalSingle1Derived OptionalSingleDerived
             {
-                get { return _optionalSingleDerived; }
-                set { SetWithNotify(value, ref _optionalSingleDerived); }
+                get => _optionalSingleDerived;
+                set => SetWithNotify(value, ref _optionalSingleDerived);
             }
 
             public OptionalSingle1MoreDerived OptionalSingleMoreDerived
             {
-                get { return _optionalSingleMoreDerived; }
-                set { SetWithNotify(value, ref _optionalSingleMoreDerived); }
+                get => _optionalSingleMoreDerived;
+                set => SetWithNotify(value, ref _optionalSingleMoreDerived);
             }
 
             public IEnumerable<RequiredAk1> RequiredChildrenAk
             {
-                get { return _requiredChildrenAk; }
-                set { SetWithNotify(value, ref _requiredChildrenAk); }
+                get => _requiredChildrenAk;
+                set => SetWithNotify(value, ref _requiredChildrenAk);
             }
 
             public IEnumerable<OptionalAk1> OptionalChildrenAk
             {
-                get { return _optionalChildrenAk; }
-                set { SetWithNotify(value, ref _optionalChildrenAk); }
+                get => _optionalChildrenAk;
+                set => SetWithNotify(value, ref _optionalChildrenAk);
             }
 
             public RequiredSingleAk1 RequiredSingleAk
             {
-                get { return _requiredSingleAk; }
-                set { SetWithNotify(value, ref _requiredSingleAk); }
+                get => _requiredSingleAk;
+                set => SetWithNotify(value, ref _requiredSingleAk);
             }
 
             public RequiredNonPkSingleAk1 RequiredNonPkSingleAk
             {
-                get { return _requiredNonPkSingleAk; }
-                set { SetWithNotify(value, ref _requiredNonPkSingleAk); }
+                get => _requiredNonPkSingleAk;
+                set => SetWithNotify(value, ref _requiredNonPkSingleAk);
             }
 
             public RequiredNonPkSingleAk1Derived RequiredNonPkSingleAkDerived
             {
-                get { return _requiredNonPkSingleAkDerived; }
-                set { SetWithNotify(value, ref _requiredNonPkSingleAkDerived); }
+                get => _requiredNonPkSingleAkDerived;
+                set => SetWithNotify(value, ref _requiredNonPkSingleAkDerived);
             }
 
             public RequiredNonPkSingleAk1MoreDerived RequiredNonPkSingleAkMoreDerived
             {
-                get { return _requiredNonPkSingleAkMoreDerived; }
-                set { SetWithNotify(value, ref _requiredNonPkSingleAkMoreDerived); }
+                get => _requiredNonPkSingleAkMoreDerived;
+                set => SetWithNotify(value, ref _requiredNonPkSingleAkMoreDerived);
             }
 
             public OptionalSingleAk1 OptionalSingleAk
             {
-                get { return _optionalSingleAk; }
-                set { SetWithNotify(value, ref _optionalSingleAk); }
+                get => _optionalSingleAk;
+                set => SetWithNotify(value, ref _optionalSingleAk);
             }
 
             public OptionalSingleAk1Derived OptionalSingleAkDerived
             {
-                get { return _optionalSingleAkDerived; }
-                set { SetWithNotify(value, ref _optionalSingleAkDerived); }
+                get => _optionalSingleAkDerived;
+                set => SetWithNotify(value, ref _optionalSingleAkDerived);
             }
 
             public OptionalSingleAk1MoreDerived OptionalSingleAkMoreDerived
             {
-                get { return _optionalSingleAkMoreDerived; }
-                set { SetWithNotify(value, ref _optionalSingleAkMoreDerived); }
+                get => _optionalSingleAkMoreDerived;
+                set => SetWithNotify(value, ref _optionalSingleAkMoreDerived);
             }
 
             public IEnumerable<RequiredComposite1> RequiredCompositeChildren
             {
-                get { return _requiredCompositeChildren; }
-                set { SetWithNotify(value, ref _requiredCompositeChildren); }
+                get => _requiredCompositeChildren;
+                set => SetWithNotify(value, ref _requiredCompositeChildren);
             }
 
             public override bool Equals(object obj)
@@ -1081,26 +1081,26 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public int ParentId
             {
-                get { return _parentId; }
-                set { SetWithNotify(value, ref _parentId); }
+                get => _parentId;
+                set => SetWithNotify(value, ref _parentId);
             }
 
             public Root Parent
             {
-                get { return _parent; }
-                set { SetWithNotify(value, ref _parent); }
+                get => _parent;
+                set => SetWithNotify(value, ref _parent);
             }
 
             public IEnumerable<Required2> Children
             {
-                get { return _children; }
-                set { SetWithNotify(value, ref _children); }
+                get => _children;
+                set => SetWithNotify(value, ref _children);
             }
 
             public override bool Equals(object obj)
@@ -1134,20 +1134,20 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public int ParentId
             {
-                get { return _parentId; }
-                set { SetWithNotify(value, ref _parentId); }
+                get => _parentId;
+                set => SetWithNotify(value, ref _parentId);
             }
 
             public Required1 Parent
             {
-                get { return _parent; }
-                set { SetWithNotify(value, ref _parent); }
+                get => _parent;
+                set => SetWithNotify(value, ref _parent);
             }
 
             public override bool Equals(object obj)
@@ -1183,32 +1183,32 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public int? ParentId
             {
-                get { return _parentId; }
-                set { SetWithNotify(value, ref _parentId); }
+                get => _parentId;
+                set => SetWithNotify(value, ref _parentId);
             }
 
             public Root Parent
             {
-                get { return _parent; }
-                set { SetWithNotify(value, ref _parent); }
+                get => _parent;
+                set => SetWithNotify(value, ref _parent);
             }
 
             public IEnumerable<Optional2> Children
             {
-                get { return _children; }
-                set { SetWithNotify(value, ref _children); }
+                get => _children;
+                set => SetWithNotify(value, ref _children);
             }
 
             public ICollection<OptionalComposite2> CompositeChildren
             {
-                get { return _compositeChildren; }
-                set { SetWithNotify(value, ref _compositeChildren); }
+                get => _compositeChildren;
+                set => SetWithNotify(value, ref _compositeChildren);
             }
 
             public override bool Equals(object obj)
@@ -1242,20 +1242,20 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public int? ParentId
             {
-                get { return _parentId; }
-                set { SetWithNotify(value, ref _parentId); }
+                get => _parentId;
+                set => SetWithNotify(value, ref _parentId);
             }
 
             public Optional1 Parent
             {
-                get { return _parent; }
-                set { SetWithNotify(value, ref _parent); }
+                get => _parent;
+                set => SetWithNotify(value, ref _parent);
             }
 
             public override bool Equals(object obj)
@@ -1289,20 +1289,20 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public Root Root
             {
-                get { return _root; }
-                set { SetWithNotify(value, ref _root); }
+                get => _root;
+                set => SetWithNotify(value, ref _root);
             }
 
             public RequiredSingle2 Single
             {
-                get { return _single; }
-                set { SetWithNotify(value, ref _single); }
+                get => _single;
+                set => SetWithNotify(value, ref _single);
             }
 
             public override bool Equals(object obj)
@@ -1321,14 +1321,14 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public RequiredSingle1 Back
             {
-                get { return _back; }
-                set { SetWithNotify(value, ref _back); }
+                get => _back;
+                set => SetWithNotify(value, ref _back);
             }
 
             public override bool Equals(object obj)
@@ -1349,26 +1349,26 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public int RootId
             {
-                get { return _rootId; }
-                set { SetWithNotify(value, ref _rootId); }
+                get => _rootId;
+                set => SetWithNotify(value, ref _rootId);
             }
 
             public Root Root
             {
-                get { return _root; }
-                set { SetWithNotify(value, ref _root); }
+                get => _root;
+                set => SetWithNotify(value, ref _root);
             }
 
             public RequiredNonPkSingle2 Single
             {
-                get { return _single; }
-                set { SetWithNotify(value, ref _single); }
+                get => _single;
+                set => SetWithNotify(value, ref _single);
             }
 
             public override bool Equals(object obj)
@@ -1387,14 +1387,14 @@ namespace Microsoft.EntityFrameworkCore
 
             public int DerivedRootId
             {
-                get { return _derivedRootId; }
-                set { SetWithNotify(value, ref _derivedRootId); }
+                get => _derivedRootId;
+                set => SetWithNotify(value, ref _derivedRootId);
             }
 
             public Root DerivedRoot
             {
-                get { return _derivedRoot; }
-                set { SetWithNotify(value, ref _derivedRoot); }
+                get => _derivedRoot;
+                set => SetWithNotify(value, ref _derivedRoot);
             }
 
             public override bool Equals(object obj) => base.Equals(obj as RequiredNonPkSingle1Derived);
@@ -1409,14 +1409,14 @@ namespace Microsoft.EntityFrameworkCore
 
             public int MoreDerivedRootId
             {
-                get { return _moreDerivedRootId; }
-                set { SetWithNotify(value, ref _moreDerivedRootId); }
+                get => _moreDerivedRootId;
+                set => SetWithNotify(value, ref _moreDerivedRootId);
             }
 
             public Root MoreDerivedRoot
             {
-                get { return _moreDerivedRoot; }
-                set { SetWithNotify(value, ref _moreDerivedRoot); }
+                get => _moreDerivedRoot;
+                set => SetWithNotify(value, ref _moreDerivedRoot);
             }
 
             public override bool Equals(object obj) => base.Equals(obj as RequiredNonPkSingle1MoreDerived);
@@ -1432,20 +1432,20 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public int BackId
             {
-                get { return _backId; }
-                set { SetWithNotify(value, ref _backId); }
+                get => _backId;
+                set => SetWithNotify(value, ref _backId);
             }
 
             public RequiredNonPkSingle1 Back
             {
-                get { return _back; }
-                set { SetWithNotify(value, ref _back); }
+                get => _back;
+                set => SetWithNotify(value, ref _back);
             }
 
             public override bool Equals(object obj)
@@ -1480,26 +1480,26 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public int? RootId
             {
-                get { return _rootId; }
-                set { SetWithNotify(value, ref _rootId); }
+                get => _rootId;
+                set => SetWithNotify(value, ref _rootId);
             }
 
             public Root Root
             {
-                get { return _root; }
-                set { SetWithNotify(value, ref _root); }
+                get => _root;
+                set => SetWithNotify(value, ref _root);
             }
 
             public OptionalSingle2 Single
             {
-                get { return _single; }
-                set { SetWithNotify(value, ref _single); }
+                get => _single;
+                set => SetWithNotify(value, ref _single);
             }
 
             public override bool Equals(object obj)
@@ -1518,14 +1518,14 @@ namespace Microsoft.EntityFrameworkCore
 
             public int? DerivedRootId
             {
-                get { return _derivedRootId; }
-                set { SetWithNotify(value, ref _derivedRootId); }
+                get => _derivedRootId;
+                set => SetWithNotify(value, ref _derivedRootId);
             }
 
             public Root DerivedRoot
             {
-                get { return _derivedRoot; }
-                set { SetWithNotify(value, ref _derivedRoot); }
+                get => _derivedRoot;
+                set => SetWithNotify(value, ref _derivedRoot);
             }
 
             public override bool Equals(object obj) => base.Equals(obj as OptionalSingle1Derived);
@@ -1540,14 +1540,14 @@ namespace Microsoft.EntityFrameworkCore
 
             public int? MoreDerivedRootId
             {
-                get { return _moreDerivedRootId; }
-                set { SetWithNotify(value, ref _moreDerivedRootId); }
+                get => _moreDerivedRootId;
+                set => SetWithNotify(value, ref _moreDerivedRootId);
             }
 
             public Root MoreDerivedRoot
             {
-                get { return _moreDerivedRoot; }
-                set { SetWithNotify(value, ref _moreDerivedRoot); }
+                get => _moreDerivedRoot;
+                set => SetWithNotify(value, ref _moreDerivedRoot);
             }
 
             public override bool Equals(object obj) => base.Equals(obj as OptionalSingle1MoreDerived);
@@ -1563,20 +1563,20 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public int? BackId
             {
-                get { return _backId; }
-                set { SetWithNotify(value, ref _backId); }
+                get => _backId;
+                set => SetWithNotify(value, ref _backId);
             }
 
             public OptionalSingle1 Back
             {
-                get { return _back; }
-                set { SetWithNotify(value, ref _back); }
+                get => _back;
+                set => SetWithNotify(value, ref _back);
             }
 
             public override bool Equals(object obj)
@@ -1613,38 +1613,38 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public Guid AlternateId
             {
-                get { return _alternateId; }
-                set { SetWithNotify(value, ref _alternateId); }
+                get => _alternateId;
+                set => SetWithNotify(value, ref _alternateId);
             }
 
             public Guid ParentId
             {
-                get { return _parentId; }
-                set { SetWithNotify(value, ref _parentId); }
+                get => _parentId;
+                set => SetWithNotify(value, ref _parentId);
             }
 
             public Root Parent
             {
-                get { return _parent; }
-                set { SetWithNotify(value, ref _parent); }
+                get => _parent;
+                set => SetWithNotify(value, ref _parent);
             }
 
             public IEnumerable<RequiredAk2> Children
             {
-                get { return _children; }
-                set { SetWithNotify(value, ref _children); }
+                get => _children;
+                set => SetWithNotify(value, ref _children);
             }
 
             public IEnumerable<RequiredComposite2> CompositeChildren
             {
-                get { return _compositeChildren; }
-                set { SetWithNotify(value, ref _compositeChildren); }
+                get => _compositeChildren;
+                set => SetWithNotify(value, ref _compositeChildren);
             }
 
             public override bool Equals(object obj)
@@ -1679,26 +1679,26 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public Guid AlternateId
             {
-                get { return _alternateId; }
-                set { SetWithNotify(value, ref _alternateId); }
+                get => _alternateId;
+                set => SetWithNotify(value, ref _alternateId);
             }
 
             public Guid ParentId
             {
-                get { return _parentId; }
-                set { SetWithNotify(value, ref _parentId); }
+                get => _parentId;
+                set => SetWithNotify(value, ref _parentId);
             }
 
             public RequiredAk1 Parent
             {
-                get { return _parent; }
-                set { SetWithNotify(value, ref _parent); }
+                get => _parent;
+                set => SetWithNotify(value, ref _parent);
             }
 
             public override bool Equals(object obj)
@@ -1719,20 +1719,20 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public Guid ParentAlternateId
             {
-                get { return _parentAlternateId; }
-                set { SetWithNotify(value, ref _parentAlternateId); }
+                get => _parentAlternateId;
+                set => SetWithNotify(value, ref _parentAlternateId);
             }
 
             public Root Parent
             {
-                get { return _parent; }
-                set { SetWithNotify(value, ref _parent); }
+                get => _parent;
+                set => SetWithNotify(value, ref _parent);
             }
 
             public override bool Equals(object obj)
@@ -1743,8 +1743,8 @@ namespace Microsoft.EntityFrameworkCore
 
             public ICollection<OptionalOverlaping2> CompositeChildren
             {
-                get { return _compositeChildren; }
-                set { SetWithNotify(value, ref _compositeChildren); }
+                get => _compositeChildren;
+                set => SetWithNotify(value, ref _compositeChildren);
             }
 
             public override int GetHashCode() => _id;
@@ -1760,32 +1760,32 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public Guid ParentAlternateId
             {
-                get { return _parentAlternateId; }
-                set { SetWithNotify(value, ref _parentAlternateId); }
+                get => _parentAlternateId;
+                set => SetWithNotify(value, ref _parentAlternateId);
             }
 
             public int? ParentId
             {
-                get { return _parentId; }
-                set { SetWithNotify(value, ref _parentId); }
+                get => _parentId;
+                set => SetWithNotify(value, ref _parentId);
             }
 
             public RequiredComposite1 Parent
             {
-                get { return _parent; }
-                set { SetWithNotify(value, ref _parent); }
+                get => _parent;
+                set => SetWithNotify(value, ref _parent);
             }
 
             public Root Root
             {
-                get { return _root; }
-                set { SetWithNotify(value, ref _root); }
+                get => _root;
+                set => SetWithNotify(value, ref _root);
             }
 
             public override bool Equals(object obj)
@@ -1806,26 +1806,26 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public Guid ParentAlternateId
             {
-                get { return _alternateId; }
-                set { SetWithNotify(value, ref _alternateId); }
+                get => _alternateId;
+                set => SetWithNotify(value, ref _alternateId);
             }
 
             public int ParentId
             {
-                get { return _parentId; }
-                set { SetWithNotify(value, ref _parentId); }
+                get => _parentId;
+                set => SetWithNotify(value, ref _parentId);
             }
 
             public RequiredAk1 Parent
             {
-                get { return _parent; }
-                set { SetWithNotify(value, ref _parent); }
+                get => _parent;
+                set => SetWithNotify(value, ref _parent);
             }
 
             public override bool Equals(object obj)
@@ -1862,38 +1862,38 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public Guid AlternateId
             {
-                get { return _alternateId; }
-                set { SetWithNotify(value, ref _alternateId); }
+                get => _alternateId;
+                set => SetWithNotify(value, ref _alternateId);
             }
 
             public Guid? ParentId
             {
-                get { return _parentId; }
-                set { SetWithNotify(value, ref _parentId); }
+                get => _parentId;
+                set => SetWithNotify(value, ref _parentId);
             }
 
             public Root Parent
             {
-                get { return _parent; }
-                set { SetWithNotify(value, ref _parent); }
+                get => _parent;
+                set => SetWithNotify(value, ref _parent);
             }
 
             public IEnumerable<OptionalAk2> Children
             {
-                get { return _children; }
-                set { SetWithNotify(value, ref _children); }
+                get => _children;
+                set => SetWithNotify(value, ref _children);
             }
 
             public ICollection<OptionalComposite2> CompositeChildren
             {
-                get { return _compositeChildren; }
-                set { SetWithNotify(value, ref _compositeChildren); }
+                get => _compositeChildren;
+                set => SetWithNotify(value, ref _compositeChildren);
             }
 
             public override bool Equals(object obj)
@@ -1928,26 +1928,26 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public Guid AlternateId
             {
-                get { return _alternateId; }
-                set { SetWithNotify(value, ref _alternateId); }
+                get => _alternateId;
+                set => SetWithNotify(value, ref _alternateId);
             }
 
             public Guid? ParentId
             {
-                get { return _parentId; }
-                set { SetWithNotify(value, ref _parentId); }
+                get => _parentId;
+                set => SetWithNotify(value, ref _parentId);
             }
 
             public OptionalAk1 Parent
             {
-                get { return _parent; }
-                set { SetWithNotify(value, ref _parent); }
+                get => _parent;
+                set => SetWithNotify(value, ref _parent);
             }
 
             public override bool Equals(object obj)
@@ -1970,38 +1970,38 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public Guid ParentAlternateId
             {
-                get { return _alternateId; }
-                set { SetWithNotify(value, ref _alternateId); }
+                get => _alternateId;
+                set => SetWithNotify(value, ref _alternateId);
             }
 
             public int? ParentId
             {
-                get { return _parentId; }
-                set { SetWithNotify(value, ref _parentId); }
+                get => _parentId;
+                set => SetWithNotify(value, ref _parentId);
             }
 
             public OptionalAk1 Parent
             {
-                get { return _parent; }
-                set { SetWithNotify(value, ref _parent); }
+                get => _parent;
+                set => SetWithNotify(value, ref _parent);
             }
 
             public int? Parent2Id
             {
-                get { return _parent2Id; }
-                set { SetWithNotify(value, ref _parent2Id); }
+                get => _parent2Id;
+                set => SetWithNotify(value, ref _parent2Id);
             }
 
             public Optional1 Parent2
             {
-                get { return _parent2; }
-                set { SetWithNotify(value, ref _parent2); }
+                get => _parent2;
+                set => SetWithNotify(value, ref _parent2);
             }
 
             public override bool Equals(object obj)
@@ -2038,38 +2038,38 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public Guid AlternateId
             {
-                get { return _alternateId; }
-                set { SetWithNotify(value, ref _alternateId); }
+                get => _alternateId;
+                set => SetWithNotify(value, ref _alternateId);
             }
 
             public Guid RootId
             {
-                get { return _rootId; }
-                set { SetWithNotify(value, ref _rootId); }
+                get => _rootId;
+                set => SetWithNotify(value, ref _rootId);
             }
 
             public Root Root
             {
-                get { return _root; }
-                set { SetWithNotify(value, ref _root); }
+                get => _root;
+                set => SetWithNotify(value, ref _root);
             }
 
             public RequiredSingleAk2 Single
             {
-                get { return _single; }
-                set { SetWithNotify(value, ref _single); }
+                get => _single;
+                set => SetWithNotify(value, ref _single);
             }
 
             public RequiredSingleComposite2 SingleComposite
             {
-                get { return _singleComposite; }
-                set { SetWithNotify(value, ref _singleComposite); }
+                get => _singleComposite;
+                set => SetWithNotify(value, ref _singleComposite);
             }
 
             public override bool Equals(object obj)
@@ -2090,26 +2090,26 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public Guid AlternateId
             {
-                get { return _alternateId; }
-                set { SetWithNotify(value, ref _alternateId); }
+                get => _alternateId;
+                set => SetWithNotify(value, ref _alternateId);
             }
 
             public Guid BackId
             {
-                get { return _backId; }
-                set { SetWithNotify(value, ref _backId); }
+                get => _backId;
+                set => SetWithNotify(value, ref _backId);
             }
 
             public RequiredSingleAk1 Back
             {
-                get { return _back; }
-                set { SetWithNotify(value, ref _back); }
+                get => _back;
+                set => SetWithNotify(value, ref _back);
             }
 
             public override bool Equals(object obj)
@@ -2130,26 +2130,26 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public Guid BackAlternateId
             {
-                get { return _alternateId; }
-                set { SetWithNotify(value, ref _alternateId); }
+                get => _alternateId;
+                set => SetWithNotify(value, ref _alternateId);
             }
 
             public int BackId
             {
-                get { return _backId; }
-                set { SetWithNotify(value, ref _backId); }
+                get => _backId;
+                set => SetWithNotify(value, ref _backId);
             }
 
             public RequiredSingleAk1 Back
             {
-                get { return _back; }
-                set { SetWithNotify(value, ref _back); }
+                get => _back;
+                set => SetWithNotify(value, ref _back);
             }
 
             public override bool Equals(object obj)
@@ -2171,32 +2171,32 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public Guid AlternateId
             {
-                get { return _alternateId; }
-                set { SetWithNotify(value, ref _alternateId); }
+                get => _alternateId;
+                set => SetWithNotify(value, ref _alternateId);
             }
 
             public Guid RootId
             {
-                get { return _rootId; }
-                set { SetWithNotify(value, ref _rootId); }
+                get => _rootId;
+                set => SetWithNotify(value, ref _rootId);
             }
 
             public Root Root
             {
-                get { return _root; }
-                set { SetWithNotify(value, ref _root); }
+                get => _root;
+                set => SetWithNotify(value, ref _root);
             }
 
             public RequiredNonPkSingleAk2 Single
             {
-                get { return _single; }
-                set { SetWithNotify(value, ref _single); }
+                get => _single;
+                set => SetWithNotify(value, ref _single);
             }
 
             public override bool Equals(object obj)
@@ -2215,14 +2215,14 @@ namespace Microsoft.EntityFrameworkCore
 
             public Guid DerivedRootId
             {
-                get { return _derivedRootId; }
-                set { SetWithNotify(value, ref _derivedRootId); }
+                get => _derivedRootId;
+                set => SetWithNotify(value, ref _derivedRootId);
             }
 
             public Root DerivedRoot
             {
-                get { return _derivedRoot; }
-                set { SetWithNotify(value, ref _derivedRoot); }
+                get => _derivedRoot;
+                set => SetWithNotify(value, ref _derivedRoot);
             }
 
             public override bool Equals(object obj) => base.Equals(obj as RequiredNonPkSingleAk1Derived);
@@ -2237,14 +2237,14 @@ namespace Microsoft.EntityFrameworkCore
 
             public Guid MoreDerivedRootId
             {
-                get { return _moreDerivedRootId; }
-                set { SetWithNotify(value, ref _moreDerivedRootId); }
+                get => _moreDerivedRootId;
+                set => SetWithNotify(value, ref _moreDerivedRootId);
             }
 
             public Root MoreDerivedRoot
             {
-                get { return _moreDerivedRoot; }
-                set { SetWithNotify(value, ref _moreDerivedRoot); }
+                get => _moreDerivedRoot;
+                set => SetWithNotify(value, ref _moreDerivedRoot);
             }
 
             public override bool Equals(object obj) => base.Equals(obj as RequiredNonPkSingleAk1MoreDerived);
@@ -2261,26 +2261,26 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public Guid AlternateId
             {
-                get { return _alternateId; }
-                set { SetWithNotify(value, ref _alternateId); }
+                get => _alternateId;
+                set => SetWithNotify(value, ref _alternateId);
             }
 
             public Guid BackId
             {
-                get { return _backId; }
-                set { SetWithNotify(value, ref _backId); }
+                get => _backId;
+                set => SetWithNotify(value, ref _backId);
             }
 
             public RequiredNonPkSingleAk1 Back
             {
-                get { return _back; }
-                set { SetWithNotify(value, ref _back); }
+                get => _back;
+                set => SetWithNotify(value, ref _back);
             }
 
             public override bool Equals(object obj)
@@ -2317,38 +2317,38 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public Guid AlternateId
             {
-                get { return _alternateId; }
-                set { SetWithNotify(value, ref _alternateId); }
+                get => _alternateId;
+                set => SetWithNotify(value, ref _alternateId);
             }
 
             public Guid? RootId
             {
-                get { return _rootId; }
-                set { SetWithNotify(value, ref _rootId); }
+                get => _rootId;
+                set => SetWithNotify(value, ref _rootId);
             }
 
             public Root Root
             {
-                get { return _root; }
-                set { SetWithNotify(value, ref _root); }
+                get => _root;
+                set => SetWithNotify(value, ref _root);
             }
 
             public OptionalSingleComposite2 SingleComposite
             {
-                get { return _singleComposite; }
-                set { SetWithNotify(value, ref _singleComposite); }
+                get => _singleComposite;
+                set => SetWithNotify(value, ref _singleComposite);
             }
 
             public OptionalSingleAk2 Single
             {
-                get { return _single; }
-                set { SetWithNotify(value, ref _single); }
+                get => _single;
+                set => SetWithNotify(value, ref _single);
             }
 
             public override bool Equals(object obj)
@@ -2367,14 +2367,14 @@ namespace Microsoft.EntityFrameworkCore
 
             public Guid? DerivedRootId
             {
-                get { return _derivedRootId; }
-                set { SetWithNotify(value, ref _derivedRootId); }
+                get => _derivedRootId;
+                set => SetWithNotify(value, ref _derivedRootId);
             }
 
             public Root DerivedRoot
             {
-                get { return _derivedRoot; }
-                set { SetWithNotify(value, ref _derivedRoot); }
+                get => _derivedRoot;
+                set => SetWithNotify(value, ref _derivedRoot);
             }
 
             public override bool Equals(object obj) => base.Equals(obj as OptionalSingleAk1Derived);
@@ -2389,14 +2389,14 @@ namespace Microsoft.EntityFrameworkCore
 
             public Guid? MoreDerivedRootId
             {
-                get { return _moreDerivedRootId; }
-                set { SetWithNotify(value, ref _moreDerivedRootId); }
+                get => _moreDerivedRootId;
+                set => SetWithNotify(value, ref _moreDerivedRootId);
             }
 
             public Root MoreDerivedRoot
             {
-                get { return _moreDerivedRoot; }
-                set { SetWithNotify(value, ref _moreDerivedRoot); }
+                get => _moreDerivedRoot;
+                set => SetWithNotify(value, ref _moreDerivedRoot);
             }
 
             public override bool Equals(object obj) => base.Equals(obj as OptionalSingleAk1MoreDerived);
@@ -2413,26 +2413,26 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public Guid AlternateId
             {
-                get { return _alternateId; }
-                set { SetWithNotify(value, ref _alternateId); }
+                get => _alternateId;
+                set => SetWithNotify(value, ref _alternateId);
             }
 
             public Guid? BackId
             {
-                get { return _backId; }
-                set { SetWithNotify(value, ref _backId); }
+                get => _backId;
+                set => SetWithNotify(value, ref _backId);
             }
 
             public OptionalSingleAk1 Back
             {
-                get { return _back; }
-                set { SetWithNotify(value, ref _back); }
+                get => _back;
+                set => SetWithNotify(value, ref _back);
             }
 
             public override bool Equals(object obj)
@@ -2453,26 +2453,26 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public Guid ParentAlternateId
             {
-                get { return _alternateId; }
-                set { SetWithNotify(value, ref _alternateId); }
+                get => _alternateId;
+                set => SetWithNotify(value, ref _alternateId);
             }
 
             public int? BackId
             {
-                get { return _backId; }
-                set { SetWithNotify(value, ref _backId); }
+                get => _backId;
+                set => SetWithNotify(value, ref _backId);
             }
 
             public OptionalSingleAk1 Back
             {
-                get { return _back; }
-                set { SetWithNotify(value, ref _back); }
+                get => _back;
+                set => SetWithNotify(value, ref _back);
             }
 
             public override bool Equals(object obj)
@@ -2506,20 +2506,20 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public int Status
             {
-                get { return _status; }
-                set { SetWithNotify(value, ref _status); }
+                get => _status;
+                set => SetWithNotify(value, ref _status);
             }
 
             public ICollection<BadOrder> BadOrders
             {
-                get { return _badOrders; }
-                set { SetWithNotify(value, ref _badOrders); }
+                get => _badOrders;
+                set => SetWithNotify(value, ref _badOrders);
             }
         }
 
@@ -2531,20 +2531,20 @@ namespace Microsoft.EntityFrameworkCore
 
             public int Id
             {
-                get { return _id; }
-                set { SetWithNotify(value, ref _id); }
+                get => _id;
+                set => SetWithNotify(value, ref _id);
             }
 
             public int? BadCustomerId
             {
-                get { return _badCustomerId; }
-                set { SetWithNotify(value, ref _badCustomerId); }
+                get => _badCustomerId;
+                set => SetWithNotify(value, ref _badCustomerId);
             }
 
             public BadCustomer BadCustomer
             {
-                get { return _badCustomer; }
-                set { SetWithNotify(value, ref _badCustomer); }
+                get => _badCustomer;
+                set => SetWithNotify(value, ref _badCustomer);
             }
         }
 

--- a/src/EFCore.Specification.Tests/OptimisticConcurrencyTestBase.cs
+++ b/src/EFCore.Specification.Tests/OptimisticConcurrencyTestBase.cs
@@ -123,13 +123,13 @@ namespace Microsoft.EntityFrameworkCore
             return ConcurrencyTestAsync(
                 c =>
                     {
-                        var team = c.Teams.Include(t => t.Chassis).Single(t => t.Id == Team.McLaren);
+                        var team = c.Teams.Single(t => t.Id == Team.McLaren);
                         team.Chassis.Name = "MP4-25b";
                         team.Principal = "Larry David";
                     },
                 c =>
                     {
-                        var team = c.Teams.Include(t => t.Chassis).Single(t => t.Id == Team.McLaren);
+                        var team = c.Teams.Single(t => t.Id == Team.McLaren);
                         team.Chassis.Name = "MP4-25c";
                         team.Principal = "Jerry Seinfeld";
                     },
@@ -155,7 +155,7 @@ namespace Microsoft.EntityFrameworkCore
                     },
                 c =>
                     {
-                        var team = c.Teams.Include(t => t.Chassis).Single(t => t.Id == Team.McLaren);
+                        var team = c.Teams.Single(t => t.Id == Team.McLaren);
                         Assert.Equal("MP4-25b", team.Chassis.Name);
                         Assert.Equal("Larry David", team.Principal);
                     });
@@ -167,13 +167,13 @@ namespace Microsoft.EntityFrameworkCore
             return ConcurrencyTestAsync(
                 c =>
                     {
-                        var team = c.Teams.Include(t => t.Drivers).Single(t => t.Id == Team.McLaren);
+                        var team = c.Teams.Single(t => t.Id == Team.McLaren);
                         team.Drivers.Single(d => d.Name == "Jenson Button").Poles = 1;
                         team.Principal = "Larry David";
                     },
                 c =>
                     {
-                        var team = c.Teams.Include(t => t.Drivers).Single(t => t.Id == Team.McLaren);
+                        var team = c.Teams.Single(t => t.Id == Team.McLaren);
                         team.Drivers.Single(d => d.Name == "Jenson Button").Poles = 2;
                         team.Principal = "Jerry Seinfeld";
                     },
@@ -199,7 +199,7 @@ namespace Microsoft.EntityFrameworkCore
                     },
                 c =>
                     {
-                        var team = c.Teams.Include(t => t.Drivers).Single(t => t.Id == Team.McLaren);
+                        var team = c.Teams.Single(t => t.Id == Team.McLaren);
                         Assert.Equal(1, team.Drivers.Single(d => d.Name == "Jenson Button").Poles);
                         Assert.Equal("Larry David", team.Principal);
                     });
@@ -224,7 +224,7 @@ namespace Microsoft.EntityFrameworkCore
                 c =>
                     Assert.Equal(
                         "Cosworth",
-                        c.Engines.Include(e => e.EngineSupplier).Single(e => e.Name == "056").EngineSupplier.Name));
+                        c.Engines.Single(e => e.Name == "056").EngineSupplier.Name));
         }
 
         #endregion

--- a/src/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Chassis.cs
+++ b/src/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Chassis.cs
@@ -5,10 +5,30 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel
 {
     public class Chassis
     {
+        private readonly ILazyLoader _loader;
+        private Team _team;
+
+        public Chassis()
+        {
+        }
+
+        private Chassis(
+            ILazyLoader loader,
+            int teamId,
+            string name)
+        {
+            _loader = loader;
+            TeamId = teamId;
+            Name = name;
+        }
+
         public int TeamId { get; set; }
-
         public string Name { get; set; }
-
-        public virtual Team Team { get; set; }
+        
+        public virtual Team Team
+        {
+            get => _loader.Load(this, ref _team);
+            set => _team = value;
+        }
     }
 }

--- a/src/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Driver.cs
+++ b/src/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Driver.cs
@@ -5,8 +5,41 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel
 {
     public class Driver
     {
-        public int Id { get; set; }
+        private readonly ILazyLoader _loader;
+        private Team _team;
 
+        public Driver()
+        {
+        }
+
+        protected Driver(
+            ILazyLoader loader,
+            int id,
+            string name,
+            int? carNumber,
+            int championships,
+            int races,
+            int wins,
+            int podiums,
+            int poles,
+            int fastestLaps,
+            int teamId)
+        {
+            _loader = loader;
+
+            Id = id;
+            Name = name;
+            CarNumber = carNumber;
+            Championships = championships;
+            Races = races;
+            Wins = wins;
+            Podiums = podiums;
+            Poles = poles;
+            FastestLaps = fastestLaps;
+            TeamId = teamId;
+        }
+
+        public int Id { get; set; }
         public string Name { get; set; }
         public int? CarNumber { get; set; }
         public int Championships { get; set; }
@@ -16,7 +49,12 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel
         public int Poles { get; set; }
         public int FastestLaps { get; set; }
 
-        public virtual Team Team { get; set; }
+        public virtual Team Team
+        {
+            get => _loader.Load(this, ref _team);
+            set => _team = value;
+        }
+
         public int TeamId { get; set; }
     }
 }

--- a/src/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Engine.cs
+++ b/src/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Engine.cs
@@ -7,18 +7,44 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel
 {
     public class Engine
     {
-        public int Id { get; set; }
+        private readonly ILazyLoader _loader;
+        private EngineSupplier _engineSupplier;
+        private ICollection<Team> _teams;
+        private ICollection<Gearbox> _gearboxes;
 
+        public Engine()
+        {
+        }
+
+        public Engine(ILazyLoader loader, int id, string name)
+        {
+            _loader = loader;
+            Id = id;
+            Name = name;
+        }
+
+        public int Id { get; set; }
         public string Name { get; set; }
 
         public Location StorageLocation { get; set; }
 
         public int EngineSupplierId { get; set; }
+        public virtual EngineSupplier EngineSupplier
+        {
+            get => _loader.Load(this, ref _engineSupplier);
+            set => _engineSupplier = value;
+        }
 
-        public virtual EngineSupplier EngineSupplier { get; set; }
+        public virtual ICollection<Team> Teams
+        {
+            get => _loader.Load(this, ref _teams);
+            set => _teams = value;
+        }
 
-        public virtual ICollection<Team> Teams { get; set; }
-
-        public virtual ICollection<Gearbox> Gearboxes { get; set; } // Uni-directional
+        public virtual ICollection<Gearbox> Gearboxes
+        {
+            get => _loader.Load(this, ref _gearboxes);
+            set => _gearboxes = value;
+        }
     }
 }

--- a/src/EFCore.Specification.Tests/TestModels/ConcurrencyModel/EngineSupplier.cs
+++ b/src/EFCore.Specification.Tests/TestModels/ConcurrencyModel/EngineSupplier.cs
@@ -7,10 +7,27 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel
 {
     public class EngineSupplier
     {
-        public int Id { get; set; }
+        private readonly ILazyLoader _loader;
+        private ICollection<Engine> _engines;
 
+        public EngineSupplier()
+        {
+        }
+
+        private EngineSupplier(ILazyLoader loader, int id, string name)
+        {
+            _loader = loader;
+            Id = id;
+            Name = name;
+        }
+
+        public int Id { get; set; }
         public string Name { get; set; }
 
-        public virtual ICollection<Engine> Engines { get; set; }
+        public virtual ICollection<Engine> Engines
+        {
+            get => _loader.Load(this, ref _engines);
+            set => _engines = value;
+        }
     }
 }

--- a/src/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Gearbox.cs
+++ b/src/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Gearbox.cs
@@ -5,6 +5,16 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel
 {
     public class Gearbox
     {
+        public Gearbox()
+        {
+        }
+
+        private Gearbox(int id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+
         public int Id { get; set; }
         public string Name { get; set; }
     }

--- a/src/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Location.cs
+++ b/src/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Location.cs
@@ -5,8 +5,17 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel
 {
     public class Location
     {
-        public double Latitude { get; set; }
+        public Location()
+        {
+        }
 
+        private Location(double latitude, double longitude)
+        {
+            Latitude = latitude;
+            Longitude = longitude;
+        }
+
+        public double Latitude { get; set; }
         public double Longitude { get; set; }
     }
 }

--- a/src/EFCore.Specification.Tests/TestModels/ConcurrencyModel/SponsorDetails.cs
+++ b/src/EFCore.Specification.Tests/TestModels/ConcurrencyModel/SponsorDetails.cs
@@ -5,6 +5,16 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel
 {
     public class SponsorDetails
     {
+        public SponsorDetails()
+        {
+        }
+
+        private SponsorDetails(int days, decimal space)
+        {
+            Days = days;
+            Space = space;
+        }
+
         public int Days { get; set; }
         public decimal Space { get; set; }
     }

--- a/src/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Team.cs
+++ b/src/EFCore.Specification.Tests/TestModels/ConcurrencyModel/Team.cs
@@ -10,11 +10,48 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel
 {
     public class Team
     {
+        private readonly ILazyLoader _loader;
         private readonly ObservableCollection<Driver> _drivers = new ObservableCollectionListSource<Driver>();
         private readonly ObservableCollection<Sponsor> _sponsors = new ObservableCollection<Sponsor>();
+        private Engine _engine;
+        private Chassis _chassis;
+        private Gearbox _gearbox;
+
+        public Team()
+        {
+        }
+
+        private Team(
+            ILazyLoader loader,
+            int id,
+            string name,
+            string constructor,
+            string tire,
+            string principal,
+            int constructorsChampionships,
+            int driversChampionships,
+            int races,
+            int victories,
+            int poles,
+            int fastestLaps,
+            int? gearboxId)
+        {
+            _loader = loader;
+            Id = id;
+            Name = name;
+            Constructor = constructor;
+            Tire = tire;
+            Principal = principal;
+            ConstructorsChampionships = constructorsChampionships;
+            DriversChampionships = driversChampionships;
+            Races = races;
+            Victories = victories;
+            Poles = poles;
+            FastestLaps = fastestLaps;
+            GearboxId = gearboxId;
+        }
 
         public int Id { get; set; }
-
         public string Name { get; set; }
         public string Constructor { get; set; }
         public string Tire { get; set; }
@@ -26,17 +63,37 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel
         public int Poles { get; set; }
         public int FastestLaps { get; set; }
 
-        public virtual Engine Engine { get; set; } // Independent Association
+        public virtual Engine Engine
+        {
+            get => _loader.Load(this, ref _engine);
+            set => _engine = value;
+        }
 
-        public virtual Chassis Chassis { get; set; }
+        public virtual Chassis Chassis
+        {
+            get => _loader.Load(this, ref _chassis);
+            set => _chassis = value;
+        }
 
-        public virtual ICollection<Driver> Drivers => _drivers;
+        public virtual ICollection<Driver> Drivers
+        {
+            get
+            {
+                _loader?.Load(this);
+                return _drivers;
+            }
+        }
 
         [NotMapped]
         public virtual ICollection<Sponsor> Sponsors => _sponsors;
 
         public int? GearboxId { get; set; }
-        public virtual Gearbox Gearbox { get; set; } // Uni-directional
+
+        public virtual Gearbox Gearbox
+        {
+            get => _loader.Load(this, ref _gearbox);
+            set => _gearbox = value;
+        }
 
         public const int McLaren = 1;
         public const int Mercedes = 2;

--- a/src/EFCore.Specification.Tests/TestModels/ConcurrencyModel/TestDriver.cs
+++ b/src/EFCore.Specification.Tests/TestModels/ConcurrencyModel/TestDriver.cs
@@ -5,5 +5,24 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel
 {
     public class TestDriver : Driver
     {
+        public TestDriver()
+        {
+        }
+
+        private TestDriver(
+            ILazyLoader loader,
+            int id,
+            string name,
+            int? carNumber,
+            int championships,
+            int races,
+            int wins,
+            int podiums,
+            int poles,
+            int fastestLaps,
+            int teamId)
+            : base(loader, id, name, carNumber, championships, races, wins, podiums, poles, fastestLaps, teamId)
+        {
+        }
     }
 }

--- a/src/EFCore.Specification.Tests/TestModels/ConcurrencyModel/TitleSponsor.cs
+++ b/src/EFCore.Specification.Tests/TestModels/ConcurrencyModel/TitleSponsor.cs
@@ -5,6 +5,22 @@ namespace Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel
 {
     public class TitleSponsor : Sponsor
     {
-        public SponsorDetails Details { get; set; }
+        private readonly ILazyLoader _loader;
+        private SponsorDetails _details;
+
+        public TitleSponsor()
+        {
+        }
+
+        private TitleSponsor(ILazyLoader loader)
+        {
+            _loader = loader;
+        }
+
+        public SponsorDetails Details
+        {
+            get => _loader.Load(this, ref _details);
+            set => _details = value;
+        }
     }
 }

--- a/src/EFCore.Specification.Tests/TestUtilities/TestPocoLoadingExtensions.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/TestPocoLoadingExtensions.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities
+{
+    public static class TestPocoLoadingExtensions
+    {
+        public static TRelated Load<TRelated>(
+            this Action<object, string> loader,
+            object entity,
+            ref TRelated navigationField,
+            [CallerMemberName] string navigationName = null)
+            where TRelated : class
+        {
+            loader?.Invoke(entity, navigationName);
+
+            return navigationField;
+        }
+    }
+}

--- a/src/EFCore.Specification.Tests/WithConstructorsTestBase.cs
+++ b/src/EFCore.Specification.Tests/WithConstructorsTestBase.cs
@@ -1,0 +1,400 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public abstract class WithConstructorsTestBase<TFixture> : IClassFixture<TFixture>
+        where TFixture : WithConstructorsTestBase<TFixture>.WithConstructorsFixtureBase, new()
+    {
+        protected WithConstructorsTestBase(TFixture fixture) => Fixture = fixture;
+
+        protected TFixture Fixture { get; }
+
+        protected DbContext CreateContext() => Fixture.CreateContext();
+
+        protected virtual void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
+        {
+        }
+
+        [Fact]
+        public virtual void Query_and_update_using_constructors_with_property_parameters()
+        {
+            TestHelpers.ExecuteWithStrategyInTransaction(
+                CreateContext, UseTransaction,
+                context =>
+                {
+                    var blog = context.Set<Blog>().Include(e => e.Posts).Single();
+
+                    Assert.Equal("Puppies", blog.Title);
+
+                    var posts = blog.Posts.OrderBy(e => e.Title).ToList();
+
+                    Assert.Equal(2, posts.Count);
+
+                    Assert.StartsWith("Baxter", posts[0].Title);
+                    Assert.StartsWith("He", posts[0].Content);
+
+                    Assert.StartsWith("Golden", posts[1].Title);
+                    Assert.StartsWith("Smaller", posts[1].Content);
+
+                    posts[0].Content += " He is just trying to make a living.";
+
+                    blog.AddPost(new Post("Olive has a TPLO", "Yes she does."));
+
+                    var newBlog = context.Add(new Blog("Cats", 100)).Entity;
+                    newBlog.AddPost(new Post("Baxter is a cat.", "With dog friends."));
+
+                    context.SaveChanges();
+                },
+                context =>
+                {
+                    var blogs = context.Set<Blog>().Include(e => e.Posts).OrderBy(e => e.Title).ToList();
+
+                    Assert.Equal(2, blogs.Count);
+
+                    Assert.Equal("Cats", blogs[0].Title);
+                    Assert.Equal("Puppies", blogs[1].Title);
+
+                    var posts = blogs[0].Posts.OrderBy(e => e.Title).ToList();
+
+                    Assert.Equal(1, posts.Count);
+
+                    Assert.StartsWith("Baxter", posts[0].Title);
+                    Assert.StartsWith("With dog", posts[0].Content);
+
+                    posts = blogs[1].Posts.OrderBy(e => e.Title).ToList();
+
+                    Assert.Equal(3, posts.Count);
+
+                    Assert.StartsWith("Baxter", posts[0].Title);
+                    Assert.EndsWith("living.", posts[0].Content);
+
+                    Assert.StartsWith("Golden", posts[1].Title);
+                    Assert.StartsWith("Smaller", posts[1].Content);
+
+                    Assert.StartsWith("Olive", posts[2].Title);
+                    Assert.StartsWith("Yes", posts[2].Content);
+                });
+        }
+
+        [Fact]
+        public virtual void Query_with_context_injected()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Same(context, context.Set<HasContext<DbContext>>().Single().Context);
+                Assert.Same(context, context.Set<HasContext<WithConstructorsContext>>().Single().Context);
+                Assert.Null(context.Set<HasContext<OtherContext>>().Single().Context);
+            }
+
+            // Ensure new context instance is injected on repeated uses
+            using (var context = CreateContext())
+            {
+                Assert.Same(context, context.Set<HasContext<DbContext>>().Single().Context);
+                Assert.Same(context, context.Set<HasContext<WithConstructorsContext>>().Single().Context);
+                Assert.Null(context.Set<HasContext<OtherContext>>().Single().Context);
+            }
+        }
+
+        [Fact]
+        public virtual void Query_with_loader_injected_for_reference()
+        {
+            using (var context = CreateContext())
+            {
+                var post = context.Set<LazyPost>().OrderBy(e => e.Id).First();
+
+                Assert.NotNull(post.LazyBlog);
+                Assert.Contains(post, post.LazyBlog.LazyPosts);
+            }
+        }
+
+        [Fact]
+        public virtual void Query_with_loader_injected_for_collections()
+        {
+            using (var context = CreateContext())
+            {
+                var blog = context.Set<LazyBlog>().Single();
+
+                Assert.Equal(2, blog.LazyPosts.Count());
+                Assert.Same(blog, blog.LazyPosts.First().LazyBlog);
+                Assert.Same(blog, blog.LazyPosts.Skip(1).First().LazyBlog);
+            }
+        }
+
+        [Fact]
+        public virtual void Query_with_POCO_loader_injected_for_reference()
+        {
+            using (var context = CreateContext())
+            {
+                var post = context.Set<LazyPocoPost>().OrderBy(e => e.Id).First();
+
+                Assert.NotNull(post.LazyPocoBlog);
+                Assert.Contains(post, post.LazyPocoBlog.LazyPocoPosts);
+            }
+        }
+
+        [Fact]
+        public virtual void Query_with_POCO_loader_injected_for_collections()
+        {
+            using (var context = CreateContext())
+            {
+                var blog = context.Set<LazyPocoBlog>().Single();
+
+                Assert.Equal(2, blog.LazyPocoPosts.Count());
+                Assert.Same(blog, blog.LazyPocoPosts.First().LazyPocoBlog);
+                Assert.Same(blog, blog.LazyPocoPosts.Skip(1).First().LazyPocoBlog);
+            }
+        }
+
+        protected class Blog
+        {
+            private int _blogId;
+
+            private Blog(
+                int blogId,
+                string title,
+                int? monthlyRevenue)
+            {
+                _blogId = blogId;
+                Title = title;
+                MonthlyRevenue = monthlyRevenue;
+            }
+
+            public Blog(
+                string title,
+                int? monthlyRevenue = null)
+                : this(0, title, monthlyRevenue)
+            {
+            }
+
+            public string Title { get; }
+            public int? MonthlyRevenue { get; set; }
+
+            public IEnumerable<Post> Posts { get; } = new List<Post>();
+
+            public void AddPost(Post post)
+                => ((List<Post>)Posts).Add(post);
+        }
+
+        protected class Post
+        {
+            private int _id;
+
+            private Post(
+                int id,
+                string title,
+                string content)
+            {
+                _id = id;
+                Title = title;
+                Content = content;
+            }
+
+            public Post(
+                string title,
+                string content,
+                Blog blog = null)
+                : this(0, title, content)
+            {
+                Blog = blog;
+            }
+
+            public string Title { get; }
+            public string Content { get; set; }
+
+            // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Local
+            public Blog Blog { get; private set; }
+        }
+
+        protected class HasContext<TContext>
+            where TContext : DbContext
+        {
+            public HasContext()
+            {
+            }
+
+            private HasContext(TContext context, int id)
+            {
+                Context = context;
+                Id = id;
+            }
+
+            // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Local
+            public int Id { get; private set; }
+            public TContext Context { get; }
+        }
+
+        protected class LazyBlog
+        {
+            private readonly ILazyLoader _loader;
+            private ICollection<LazyPost> _lazyPosts = new List<LazyPost>();
+
+            public LazyBlog()
+            {
+            }
+
+            private LazyBlog(ILazyLoader loader)
+            {
+                _loader = loader;
+            }
+
+            public int Id { get; set; }
+
+            public void AddPost(LazyPost post) => _lazyPosts.Add(post);
+
+            public IEnumerable<LazyPost> LazyPosts => _loader.Load(this, ref _lazyPosts);
+        }
+
+        protected class LazyPost
+        {
+            private readonly ILazyLoader _loader;
+            private LazyBlog _lazyBlog;
+
+            public LazyPost()
+            {
+            }
+
+            private LazyPost(ILazyLoader loader)
+            {
+                _loader = loader;
+            }
+
+            public int Id { get; set; }
+
+            public LazyBlog LazyBlog
+            {
+                get => _loader.Load(this, ref _lazyBlog);
+                set => _lazyBlog = value;
+            }
+        }
+
+        protected class LazyPocoBlog
+        {
+            private readonly Action<object, string> _loader;
+            private ICollection<LazyPocoPost> _lazyPocoPosts = new List<LazyPocoPost>();
+
+            public LazyPocoBlog()
+            {
+            }
+
+            private LazyPocoBlog(Action<object, string> lazyLoader)
+            {
+                _loader = lazyLoader;
+            }
+
+            public int Id { get; set; }
+
+            public void AddPost(LazyPocoPost post) => _lazyPocoPosts.Add(post);
+
+            public IEnumerable<LazyPocoPost> LazyPocoPosts => _loader.Load(this, ref _lazyPocoPosts);
+        }
+
+        protected class LazyPocoPost
+        {
+            private readonly Action<object, string> _loader;
+            private LazyPocoBlog _lazyPocoBlog;
+
+            public LazyPocoPost()
+            {
+            }
+
+            private LazyPocoPost(Action<object, string> lazyLoader)
+            {
+                _loader = lazyLoader;
+            }
+
+            public int Id { get; set; }
+
+            public LazyPocoBlog LazyPocoBlog
+            {
+                get => _loader.Load(this, ref _lazyPocoBlog);
+                set => _lazyPocoBlog = value;
+            }
+        }
+
+        public class OtherContext : DbContext
+        {
+        }
+
+        public class WithConstructorsContext : DbContext
+        {
+            public WithConstructorsContext(DbContextOptions options)
+                : base(options)
+            {
+            }
+        }
+
+        public abstract class WithConstructorsFixtureBase : SharedStoreFixtureBase<WithConstructorsContext>
+        {
+            protected override string StoreName { get; } = "WithConstructors";
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+            {
+                modelBuilder.Entity<Blog>(
+                    b =>
+                    {
+                        b.HasKey("_blogId");
+                        b.Property(e => e.Title);
+                    });
+
+                modelBuilder.Entity<Post>(
+                    b =>
+                    {
+                        b.HasKey("_id");
+                        b.Property(e => e.Title);
+                    });
+
+                modelBuilder.Entity<HasContext<DbContext>>();
+                modelBuilder.Entity<HasContext<WithConstructorsContext>>();
+                modelBuilder.Entity<HasContext<OtherContext>>();
+
+                modelBuilder.Entity<LazyBlog>();
+                modelBuilder.Entity<LazyPocoBlog>();
+            }
+
+            protected override void Seed(WithConstructorsContext context)
+            {
+                var blog = new Blog("Puppies");
+
+                var post1 = new Post(
+                    "Golden Toasters Rock",
+                    "Smaller than the Black Library Dog, and more chewy.",
+                    blog);
+
+                var post2 = new Post(
+                    "Baxter is not a dog",
+                    "He is a cat. Who eats dog food. And wags his tail.",
+                    blog);
+
+                context.AddRange(blog, post1, post2);
+
+                context.AddRange(
+                    new HasContext<DbContext>(),
+                    new HasContext<WithConstructorsContext>(),
+                    new HasContext<OtherContext>());
+
+                var lazyBlog = new LazyBlog();
+                lazyBlog.AddPost(new LazyPost());
+                lazyBlog.AddPost(new LazyPost());
+
+                context.Add(lazyBlog);
+
+                var lazyPocoBlog = new LazyPocoBlog();
+                lazyPocoBlog.AddPost(new LazyPocoPost());
+                lazyPocoBlog.AddPost(new LazyPocoPost());
+
+                context.Add(lazyPocoBlog);
+
+                context.SaveChanges();
+            }
+        }
+    }
+}

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
@@ -93,7 +94,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                     new SqlServerSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()))
                 .AddConventions(
                     new CoreConventionSetBuilder(
-                            new CoreConventionSetBuilderDependencies(sqlServerTypeMapper))
+                            new CoreConventionSetBuilderDependencies(
+                                sqlServerTypeMapper,
+                                new ConstructorBindingFactory()))
                         .CreateConventionSet());
         }
     }

--- a/src/EFCore.Sqlite.Core/Metadata/Conventions/SqliteConventionSetBuilder.cs
+++ b/src/EFCore.Sqlite.Core/Metadata/Conventions/SqliteConventionSetBuilder.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
@@ -40,7 +41,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                     new RelationalConventionSetBuilderDependencies(relationalTypeMapper, null, null))
                 .AddConventions(
                     new CoreConventionSetBuilder(
-                        new CoreConventionSetBuilderDependencies(relationalTypeMapper)).CreateConventionSet());
+                            new CoreConventionSetBuilderDependencies(
+                                relationalTypeMapper,
+                                new ConstructorBindingFactory()))
+                        .CreateConventionSet());
         }
     }
 }

--- a/src/EFCore/ChangeTracking/ChangeTracker.cs
+++ b/src/EFCore/ChangeTracking/ChangeTracker.cs
@@ -73,6 +73,18 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         /// <summary>
         ///     <para>
+        ///         Gets or sets a value indicating whether navigation properties for tracked entities
+        ///         will be loaded on first access.
+        ///     </para>
+        ///     <para>
+        ///         The default value is true. However, lazy loading will only occur for navigation properties
+        ///         of entities that have also been configured in the model for lazy loading.
+        ///     </para>
+        /// </summary>
+        public virtual bool LazyLoadingEnabled { get; set; } = true;
+
+        /// <summary>
+        ///     <para>
         ///         Gets or sets the tracking behavior for LINQ queries run against the context. Disabling change tracking
         ///         is useful for read-only scenarios because it avoids the overhead of setting up change tracking for each
         ///         entity instance. You should not disable change tracking if you want to manipulate entity instances and

--- a/src/EFCore/ChangeTracking/Internal/ArrayPropertyValues.cs
+++ b/src/EFCore/ChangeTracking/Internal/ArrayPropertyValues.cs
@@ -35,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override object ToObject()
-            => MaterializerSource.GetMaterializer(EntityType)(new ValueBuffer(_values));
+            => MaterializerSource.GetMaterializer(EntityType)(new ValueBuffer(_values), InternalEntry.StateManager.Context);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -143,7 +143,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             {
                 _trackingQueryMode = TrackingQueryMode.Multiple;
 
-                var entityType = _model.FindEntityType(entity.GetType());
+                var entityType = _model.FindRuntimeEntityType(entity.GetType());
                 if (entityType == null)
                 {
                     if (_model.HasEntityTypeWithDefiningNavigation(entity.GetType()))
@@ -199,7 +199,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
             var valueBuffer = new ValueBuffer(valuesArray);
 
-            var entity = entityType.HasClrType() ? EntityMaterializerSource.GetMaterializer(entityType)(valueBuffer) : null;
+            var entity = entityType.HasClrType() ? EntityMaterializerSource.GetMaterializer(entityType)(valueBuffer, Context) : null;
             var entry = _internalEntityEntryFactory.Create(this, entityType, entity, valueBuffer);
 
             AddToReferenceMap(entry);
@@ -271,7 +271,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 this,
                 baseEntityType.ClrType == clrType
                     ? baseEntityType
-                    : _model.FindEntityType(clrType),
+                    : _model.FindRuntimeEntityType(clrType),
                 entity, valueBuffer);
 
             foreach (var key in baseEntityType.GetKeys())
@@ -509,7 +509,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
                 foreach (var keyValuePair in _referencedUntrackedEntities.Value.ToList())
                 {
-                    var untrackedEntityType = _model.FindEntityType(keyValuePair.Key.GetType());
+                    var untrackedEntityType = _model.FindRuntimeEntityType(keyValuePair.Key.GetType());
                     if (navigations.Any(n => n.GetTargetType().IsAssignableFrom(untrackedEntityType))
                         || untrackedEntityType.GetNavigations().Any(n => n.GetTargetType().IsAssignableFrom(entityType)))
                     {

--- a/src/EFCore/ChangeTracking/LocalView.cs
+++ b/src/EFCore/ChangeTracking/LocalView.cs
@@ -66,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         public LocalView([NotNull] DbSet<TEntity> set)
         {
             _context = set.GetService<ICurrentDbContext>().Context;
-            _context.CheckDisposed();
+            CheckDisposed();
 
             _stateManager = _context.GetDependencies().StateManager;
 
@@ -74,6 +74,14 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
             _count = _stateManager.Entries
                 .Count(e => e.Entity is TEntity && e.EntityState != EntityState.Deleted);
+        }
+
+        private void CheckDisposed()
+        {
+            if (_context.IsDisposed)
+            {
+                throw new ObjectDisposedException(_context.GetType().ShortDisplayName(), CoreStrings.ContextDisposed);
+            }
         }
 
         /// <summary>
@@ -172,7 +180,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// <returns> An enumerator for the collection. </returns>
         public virtual IEnumerator<TEntity> GetEnumerator()
         {
-            _context.CheckDisposed();
+            CheckDisposed();
 
             return _stateManager.Entries.Where(e => e.EntityState != EntityState.Deleted)
                 .Select(e => e.Entity)
@@ -204,7 +212,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             // to Add it again since doing so would change its state to Added, which is probably not what
             // was wanted in this case.
 
-            _context.CheckDisposed();
+            CheckDisposed();
 
             var entry = _stateManager.GetOrCreateEntry(item);
             if (entry.EntityState == EntityState.Deleted
@@ -245,7 +253,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// </summary>
         public virtual void Clear()
         {
-            _context.CheckDisposed();
+            CheckDisposed();
 
             foreach (var entry in _stateManager.Entries
                 .Where(e => e.Entity is TEntity && e.EntityState != EntityState.Deleted)
@@ -263,7 +271,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// <returns> True if the entity is being tracked by the context and has not been marked as Deleted. </returns>
         public virtual bool Contains(TEntity item)
         {
-            _context.CheckDisposed();
+            CheckDisposed();
 
             var entry = _stateManager.TryGetEntry(item);
 
@@ -278,7 +286,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// <param name="arrayIndex"> The index into the array to start copying. </param>
         public virtual void CopyTo(TEntity[] array, int arrayIndex)
         {
-            _context.CheckDisposed();
+            CheckDisposed();
 
             foreach (var entry in _stateManager.Entries)
             {
@@ -307,7 +315,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// <returns>True if the entity was being tracked and was not already Deleted. </returns>
         public virtual bool Remove(TEntity item)
         {
-            _context.CheckDisposed();
+            CheckDisposed();
 
             var entry = _stateManager.TryGetEntry(item);
             if (entry != null

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -278,13 +278,18 @@ namespace Microsoft.EntityFrameworkCore
             => _dbContextDependencies ?? (_dbContextDependencies = InternalServiceProvider.GetRequiredService<IDbContextDependencies>());
 
         [DebuggerStepThrough]
-        internal void CheckDisposed()
+        private void CheckDisposed()
         {
             if (_disposed)
             {
                 throw new ObjectDisposedException(GetType().ShortDisplayName(), CoreStrings.ContextDisposed);
             }
         }
+
+        /// <summary>
+        ///     Returns whether or not the context has been disposed.
+        /// </summary>
+        public virtual bool IsDisposed => _disposed;
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/Diagnostics/CoreEventId.cs
+++ b/src/EFCore/Diagnostics/CoreEventId.cs
@@ -64,7 +64,9 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             ServiceProviderCreated,
             ManyServiceProvidersCreatedWarning,
             ContextInitialized,
-            ExecutionStrategyRetrying
+            ExecutionStrategyRetrying,
+            LazyLoadOnDisposedContextWarning,
+            NavigationLazyLoading
         }
 
         private static readonly string _updatePrefix = DbLoggerCategory.Update.Name + ".";
@@ -291,5 +293,31 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     </para>
         /// </summary>
         public static readonly EventId ExecutionStrategyRetrying = MakeInfraId(Id.ExecutionStrategyRetrying);
+
+        /// <summary>
+        ///     <para>
+        ///         A navigation property is being lazy-loaded.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Infrastructure" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="LazyLoadingEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
+        /// </summary>
+        public static readonly EventId NavigationLazyLoading = MakeInfraId(Id.NavigationLazyLoading);
+
+        /// <summary>
+        ///     <para>
+        ///         An attempt was made to lazy-load a property after the DbContext had been disposed.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Infrastructure" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="LazyLoadingEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
+        /// </summary>
+        public static readonly EventId LazyLoadOnDisposedContextWarning = MakeInfraId(Id.LazyLoadOnDisposedContextWarning);
     }
 }

--- a/src/EFCore/Diagnostics/LazyLoadingEventData.cs
+++ b/src/EFCore/Diagnostics/LazyLoadingEventData.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     A <see cref="DiagnosticSource" /> event payload class for events from <see cref="ILazyLoader" />
+    /// </summary>
+    public class LazyLoadingEventData : DbContextEventData
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="context"> The current <see cref="DbContext" />. </param>
+        /// <param name="entity"> The entity instance on which lazy-loading was initiated. </param>
+        /// <param name="navigationPropertyName"> The navigation property name of the relationship to be loaded. </param>
+        public LazyLoadingEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventData, string> messageGenerator,
+            [NotNull] DbContext context,
+            [NotNull] object entity,
+            [NotNull] string navigationPropertyName)
+            : base(eventDefinition, messageGenerator, context)
+        {
+            Entity = entity;
+            NavigationPropertyName = navigationPropertyName;
+        }
+
+        /// <summary>
+        ///     The entity instance on which lazy-loading was initiated.
+        /// </summary>
+        public virtual object Entity { get; }
+
+        /// <summary>
+        ///     The navigation property name of the relationship to be loaded.
+        /// </summary>
+        public virtual string NavigationPropertyName { get; }
+    }
+}

--- a/src/EFCore/Extensions/Internal/CoreLoggerExtensions.cs
+++ b/src/EFCore/Extensions/Internal/CoreLoggerExtensions.cs
@@ -587,5 +587,81 @@ namespace Microsoft.EntityFrameworkCore.Internal
             return d.GenerateMessage(
                 (int)p.Delay.TotalMilliseconds, Environment.NewLine, p.ExceptionsEncountered[p.ExceptionsEncountered.Count - 1]);
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static void LazyLoadOnDisposedContextWarning(
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Infrastructure> diagnostics,
+            [NotNull] DbContext context,
+            [NotNull] object entityType,
+            [NotNull] string navigationName)
+        {
+            var definition = CoreStrings.LazyLoadOnDisposedContextWarning;
+
+            // Checking for enabled here to avoid string formatting if not needed.
+            if (diagnostics.GetLogBehavior(definition.EventId, definition.Level) != WarningBehavior.Ignore)
+            {
+                definition.Log(diagnostics, navigationName, entityType.GetType().ShortDisplayName());
+            }
+
+            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            {
+                diagnostics.DiagnosticSource.Write(
+                    definition.EventId.Name,
+                    new LazyLoadingEventData(
+                        definition,
+                        LazyLoadOnDisposedContextWarning,
+                        context,
+                        entityType,
+                        navigationName));
+            }
+        }
+
+        private static string LazyLoadOnDisposedContextWarning(EventDefinitionBase definition, EventData payload)
+        {
+            var d = (EventDefinition<string, string>)definition;
+            var p = (LazyLoadingEventData)payload;
+            return d.GenerateMessage(p.NavigationPropertyName, p.Entity.GetType().ShortDisplayName());
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static void NavigationLazyLoading(
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Infrastructure> diagnostics,
+            [NotNull] DbContext context,
+            [NotNull] object entityType,
+            [NotNull] string navigationName)
+        {
+            var definition = CoreStrings.NavigationLazyLoading;
+
+            // Checking for enabled here to avoid string formatting if not needed.
+            if (diagnostics.GetLogBehavior(definition.EventId, definition.Level) != WarningBehavior.Ignore)
+            {
+                definition.Log(diagnostics, navigationName, entityType.GetType().ShortDisplayName());
+            }
+
+            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            {
+                diagnostics.DiagnosticSource.Write(
+                    definition.EventId.Name,
+                    new LazyLoadingEventData(
+                        definition,
+                        NavigationLazyLoading,
+                        context,
+                        entityType,
+                        navigationName));
+            }
+        }
+
+        private static string NavigationLazyLoading(EventDefinitionBase definition, EventData payload)
+        {
+            var d = (EventDefinition<string, string>)definition;
+            var p = (LazyLoadingEventData)payload;
+            return d.GenerateMessage(p.NavigationPropertyName, p.Entity.GetType().ShortDisplayName());
+        }
     }
 }

--- a/src/EFCore/Extensions/ModelExtensions.cs
+++ b/src/EFCore/Extensions/ModelExtensions.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore
     public static class ModelExtensions
     {
         /// <summary>
-        ///     Gets the entity that maps the given entity class. Returns null if no entity type with the given name is found
+        ///     Gets the entity that maps the given entity class. Returns null if no entity type with the given CLR type is found
         ///     or the entity type has a defining navigation.
         /// </summary>
         /// <param name="model"> The model to find the entity type in. </param>
@@ -25,6 +25,25 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> The entity type, or null if none if found. </returns>
         public static IEntityType FindEntityType([NotNull] this IModel model, [NotNull] Type type)
             => Check.NotNull(model, nameof(model)).AsModel().FindEntityType(Check.NotNull(type, nameof(type)));
+
+        /// <summary>
+        ///     Gets the entity that maps the given entity class, where the class may be a proxy derived from the
+        ///     actual entity type. Returns null if no entity type with the given CLR type is found
+        ///     or the entity type has a defining navigation.
+        /// </summary>
+        /// <param name="model"> The model to find the entity type in. </param>
+        /// <param name="type"> The type to find the corresponding entity type for. </param>
+        /// <returns> The entity type, or null if none if found. </returns>
+        public static IEntityType FindRuntimeEntityType([NotNull] this IModel model, [NotNull] Type type)
+        {
+            Check.NotNull(type, nameof(type));
+            var realModel = Check.NotNull(model, nameof(model)).AsModel();
+
+            return realModel.FindEntityType(type)
+                   ?? (type.BaseType == null
+                       ? null
+                       : realModel.FindEntityType(type.BaseType));
+        }
 
         /// <summary>
         ///     Gets the entity type for the given type, defining navigation name

--- a/src/EFCore/ILazyLoader.cs
+++ b/src/EFCore/ILazyLoader.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    ///     A service that can be injected into entities to give them the capability
+    ///     of loading navigation properties automatically the first time they are accessed.
+    /// </summary>
+    public interface ILazyLoader
+    {
+        /// <summary>
+        ///     Loads a navigation property if it has not already been loaded.
+        /// </summary>
+        /// <param name="entity"> The entity on which the navigation property is located. </param>
+        /// <param name="navigationName"> The navigation property name. </param>
+        // ReSharper disable once AssignNullToNotNullAttribute
+        void Load([NotNull] object entity, [NotNull] [CallerMemberName] string navigationName = null);
+    }
+}

--- a/src/EFCore/Infrastructure/CoreOptionsExtension.cs
+++ b/src/EFCore/Infrastructure/CoreOptionsExtension.cs
@@ -38,8 +38,9 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         private int? _maxPoolSize;
         private long? _serviceProviderHash;
         private string _logFragment;
-        private WarningsConfiguration _warningsConfiguration = new WarningsConfiguration();
 
+        private WarningsConfiguration _warningsConfiguration 
+                    = new WarningsConfiguration().TryWithExplicit(CoreEventId.LazyLoadOnDisposedContextWarning, WarningBehavior.Throw);
         /// <summary>
         ///     Creates a new set of options with everything set to default values.
         /// </summary>

--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -89,6 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(IProjectionExpressionVisitorFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IDiagnosticsLogger<>), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IValueConverterSelector), new ServiceCharacteristics(ServiceLifetime.Singleton) },
+                { typeof(IConstructorBindingFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IEntityGraphAttacher), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IKeyPropagator), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(INavigationFixer), new ServiceCharacteristics(ServiceLifetime.Scoped) },
@@ -124,6 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(IQueryContextFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IEntityQueryableExpressionVisitorFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IEntityQueryModelVisitorFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+                { typeof(ILazyLoader), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IEntityStateListener), new ServiceCharacteristics(ServiceLifetime.Scoped, multipleRegistrations: true) },
                 { typeof(INavigationListener), new ServiceCharacteristics(ServiceLifetime.Scoped, multipleRegistrations: true) },
                 { typeof(IKeyListener), new ServiceCharacteristics(ServiceLifetime.Scoped, multipleRegistrations: true) },
@@ -259,6 +261,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<Func<IStateManager>>(p => p.GetService<IStateManager>);
             TryAdd<IEvaluatableExpressionFilter, EvaluatableExpressionFilter>();
             TryAdd<IValueConverterSelector, ValueConverterSelector>();
+            TryAdd<IConstructorBindingFactory, ConstructorBindingFactory>();
+            TryAdd<ILazyLoader, LazyLoader>();
 
             ServiceCollectionMap
                 .TryAddSingleton<DiagnosticSource>(new DiagnosticListener(DbLoggerCategory.Name));

--- a/src/EFCore/Infrastructure/ModelCustomizerDependencies.cs
+++ b/src/EFCore/Infrastructure/ModelCustomizerDependencies.cs
@@ -39,7 +39,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///         the constructor at any point in this process.
         ///     </para>
         /// </summary>
-        // ReSharper disable once EmptyConstructor
         public ModelCustomizerDependencies([NotNull] IDbSetFinder setFinder)
         {
             Check.NotNull(setFinder, nameof(setFinder));

--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -343,11 +343,16 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
             foreach (var entityType in model.GetEntityTypes())
             {
+                var constructorBinding = (ConstructorBinding)entityType[CoreAnnotationNames.ConstructorBinding];
+
                 foreach (var propertyBase in entityType
                     .GetDeclaredProperties()
                     .Cast<IPropertyBase>()
                     .Concat(entityType.GetDeclaredNavigations())
-                    .Where(e => !e.IsShadowProperty))
+                    .Where(
+                        e => !e.IsShadowProperty
+                             && (constructorBinding == null
+                                 || constructorBinding.ParameterBindings.All(p => p.ConsumedProperty != e))))
                 {
                     if (!propertyBase.TryGetMemberInfo(
                         forConstruction: true,

--- a/src/EFCore/Internal/InternalDbSet.cs
+++ b/src/EFCore/Internal/InternalDbSet.cs
@@ -47,7 +47,10 @@ namespace Microsoft.EntityFrameworkCore.Internal
         {
             get
             {
-                _context.CheckDisposed();
+                if (_context.IsDisposed)
+                {
+                    throw new ObjectDisposedException(_context.GetType().ShortDisplayName(), CoreStrings.ContextDisposed);
+                }
 
                 if (_entityType != null)
                 {

--- a/src/EFCore/Internal/LazyLoader.cs
+++ b/src/EFCore/Internal/LazyLoader.cs
@@ -1,0 +1,70 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class LazyLoader : ILazyLoader
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public LazyLoader(
+            [NotNull] ICurrentDbContext currentContext,
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Infrastructure> logger)
+        {
+            Check.NotNull(currentContext, nameof(currentContext));
+            Check.NotNull(logger, nameof(logger));
+
+            Context = currentContext.Context;
+            Logger = logger;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual IDiagnosticsLogger<DbLoggerCategory.Infrastructure> Logger { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual DbContext Context { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        // ReSharper disable once AssignNullToNotNullAttribute
+        public virtual void Load(object entity, [CallerMemberName] string navigationName = null)
+        {
+            Check.NotNull(entity, nameof(entity));
+            Check.NotEmpty(navigationName, nameof(navigationName));
+
+            if (Context.IsDisposed)
+            {
+                Logger.LazyLoadOnDisposedContextWarning(Context, entity, navigationName);
+            }
+            else if (Context.ChangeTracker.LazyLoadingEnabled)
+            {
+                var entry = Context.Entry(entity).Navigation(navigationName);
+                if (!entry.IsLoaded)
+                {
+                    Logger.NavigationLazyLoading(Context, entity, navigationName);
+
+                    entry.Load();
+                }
+            }
+        }
+    }
+}

--- a/src/EFCore/LazyLoaderExtensions.cs
+++ b/src/EFCore/LazyLoaderExtensions.cs
@@ -1,0 +1,40 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    ///     Extension methods for the <see cref="ILazyLoader" /> service that make it more
+    ///     convenient to use from entity classes.
+    /// </summary>
+    public static class LazyLoaderExtensions
+    {
+        /// <summary>
+        ///     Loads a navigation property if it has not already been loaded.
+        /// </summary>
+        /// <typeparam name="TRelated"> The type of the navigation property. </typeparam>
+        /// <param name="loader">The loader instance, which may be <c>null</c>.</param>
+        /// <param name="entity"> The entity on which the navigation property is located. </param>
+        /// <param name="navigationField"> A reference to the backing field for the navigation. </param>
+        /// <param name="navigationName"> The navigation property name. </param>
+        /// <returns>
+        ///     The loaded navigation property value, or the navigation property value unchanged if the loader is <c>null</c>.
+        /// </returns>
+        public static TRelated Load<TRelated>(
+            [CanBeNull] this ILazyLoader loader,
+            [NotNull] object entity,
+            [CanBeNull] ref TRelated navigationField,
+            // ReSharper disable once AssignNullToNotNullAttribute
+            [NotNull] [CallerMemberName] string navigationName = null)
+            where TRelated : class
+        {
+            // ReSharper disable once AssignNullToNotNullAttribute
+            loader?.Load(entity, navigationName);
+
+            return navigationField;
+        }
+    }
+}

--- a/src/EFCore/Metadata/Conventions/Internal/ConstructorBindingConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConstructorBindingConvention.cs
@@ -1,0 +1,93 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class ConstructorBindingConvention : IModelBuiltConvention
+    {
+        private readonly IConstructorBindingFactory _bindingFactory;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public ConstructorBindingConvention([NotNull] IConstructorBindingFactory bindingFactory)
+            => _bindingFactory = bindingFactory;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual InternalModelBuilder Apply(InternalModelBuilder modelBuilder)
+        {
+            foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
+            {
+                if (entityType.ClrType != null
+                    && !entityType.ClrType.IsAbstract)
+                {
+                    var foundBinding = (ConstructorBinding)null;
+                    var bindingFailures = new List<IEnumerable<ParameterInfo>>();
+
+                    foreach (var constructor in entityType.ClrType.GetTypeInfo()
+                        .DeclaredConstructors
+                        .Where(c => !c.IsStatic)
+                        .OrderByDescending(c => c.GetParameters().Length))
+                    {
+                        var parameterCount = constructor.GetParameters().Length;
+
+                        if (foundBinding != null
+                            && foundBinding.ParameterBindings.Count != parameterCount)
+                        {
+                            break;
+                        }
+
+                        if (_bindingFactory.TryBindConstructor(entityType, constructor, out var binding, out var failures))
+                        {
+                            if (foundBinding?.ParameterBindings.Count == parameterCount)
+                            {
+                                throw new InvalidOperationException(
+                                    CoreStrings.ConstructorConflict(
+                                        FormatConstructorString(entityType, foundBinding),
+                                        FormatConstructorString(entityType, binding)));
+                            }
+
+                            foundBinding = binding;
+                        }
+
+                        bindingFailures.Add(failures);
+                    }
+
+                    if (foundBinding == null)
+                    {
+                        throw new InvalidOperationException(
+                            CoreStrings.ConstructorNotFound(
+                                entityType.DisplayName(),
+                                string.Join("', '", bindingFailures.SelectMany(f => f).Select(f => f.Name))));
+                    }
+
+                    entityType.Builder.HasAnnotation(
+                        CoreAnnotationNames.ConstructorBinding,
+                        foundBinding,
+                        ConfigurationSource.Convention);
+                }
+            }
+
+            return modelBuilder;
+        }
+
+        private static string FormatConstructorString(EntityType entityType, ConstructorBinding binding)
+            => entityType.DisplayName() + "(" + string.Join(", ", binding.ParameterBindings.Select(b => b.ParameterType.ShortDisplayName())) + ")";
+    }
+}

--- a/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
@@ -121,6 +121,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             conventionSet.ModelBuiltConventions.Add(new RelationshipValidationConvention());
             conventionSet.ModelBuiltConventions.Add(foreignKeyPropertyDiscoveryConvention);
             conventionSet.ModelBuiltConventions.Add(new ChangeTrackingStrategyConvention());
+            conventionSet.ModelBuiltConventions.Add(new ConstructorBindingConvention(Dependencies.ConstructorBindingFactory));
 
             conventionSet.NavigationAddedConventions.Add(backingFieldConvention);
             conventionSet.NavigationAddedConventions.Add(new RequiredNavigationAttributeConvention());

--- a/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilderDependencies.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilderDependencies.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -47,11 +48,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///         directly from your code. This API may change or be removed in future releases.
         ///     </para>
         /// </summary>
-        public CoreConventionSetBuilderDependencies([NotNull] ITypeMapper typeMapper)
+        public CoreConventionSetBuilderDependencies(
+            [NotNull] ITypeMapper typeMapper,
+            [NotNull] IConstructorBindingFactory constructorBindingFactory)
         {
             Check.NotNull(typeMapper, nameof(typeMapper));
+            Check.NotNull(constructorBindingFactory, nameof(constructorBindingFactory));
 
             TypeMapper = typeMapper;
+            ConstructorBindingFactory = constructorBindingFactory;
         }
 
         /// <summary>
@@ -61,11 +66,25 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         public ITypeMapper TypeMapper { get; }
 
         /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public IConstructorBindingFactory ConstructorBindingFactory { get; }
+
+        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="typeMapper"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public CoreConventionSetBuilderDependencies With([NotNull] ITypeMapper typeMapper)
-            => new CoreConventionSetBuilderDependencies(typeMapper);
+            => new CoreConventionSetBuilderDependencies(typeMapper, ConstructorBindingFactory);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="constructorBindingFactory"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public CoreConventionSetBuilderDependencies With([NotNull] IConstructorBindingFactory constructorBindingFactory)
+            => new CoreConventionSetBuilderDependencies(TypeMapper, constructorBindingFactory);
     }
 }

--- a/src/EFCore/Metadata/Internal/ConstructorBinding.cs
+++ b/src/EFCore/Metadata/Internal/ConstructorBinding.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public abstract class ConstructorBinding
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected ConstructorBinding(
+            [NotNull] IReadOnlyList<ParameterBinding> parameterBindings)
+        {
+            ParameterBindings = parameterBindings;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public abstract Expression CreateConstructorExpression(ParameterBindingInfo bindingInfo);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual IReadOnlyList<ParameterBinding> ParameterBindings { get; }
+    }
+}

--- a/src/EFCore/Metadata/Internal/ConstructorBindingFactory.cs
+++ b/src/EFCore/Metadata/Internal/ConstructorBindingFactory.cs
@@ -1,0 +1,55 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class ConstructorBindingFactory : IConstructorBindingFactory
+    {
+        private readonly IList<ParameterBindingFactory> _factories
+            = new List<ParameterBindingFactory>
+            {
+                new PropertyParameterBindingFactory(),
+                new ContextParameterBindingFactory(),
+                new LazyLoaderParameterBindingFactory(),
+                new EntityTypeParameterBindingFactory()
+            };
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual bool TryBindConstructor(
+            IMutableEntityType entityType,
+            ConstructorInfo constructor,
+            out ConstructorBinding binding,
+            out IEnumerable<ParameterInfo> failedBindings)
+        {
+            IEnumerable<(ParameterInfo Parameter, ParameterBinding Binding)> bindings
+                = constructor.GetParameters().Select(
+                        p => (p, _factories.Select(f => f.TryBindParameter(entityType, p))
+                            .FirstOrDefault(b => b != null)))
+                    .ToList();
+
+            if (bindings.Any(b => b.Binding == null))
+            {
+                failedBindings = bindings.Where(b => b.Binding == null).Select(b => b.Parameter);
+                binding = null;
+
+                return false;
+            }
+
+            failedBindings = null;
+            binding = new DirectConstructorBinding(constructor, bindings.Select(b => b.Binding).ToList());
+
+            return true;
+        }
+    }
+}

--- a/src/EFCore/Metadata/Internal/ContextParameterBinding.cs
+++ b/src/EFCore/Metadata/Internal/ContextParameterBinding.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class ContextParameterBinding : ParameterBinding
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public ContextParameterBinding([NotNull] Type contextType)
+            : base(contextType, null)
+        {
+            ContextType = contextType;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Type ContextType { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override Expression BindToParameter(ParameterBindingInfo bindingInfo)
+            => Expression.TypeAs(bindingInfo.ContextExpression, ContextType);
+    }
+}

--- a/src/EFCore/Metadata/Internal/ContextParameterBindingFactory.cs
+++ b/src/EFCore/Metadata/Internal/ContextParameterBindingFactory.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.EntityFrameworkCore.Storage;
+using System.Reflection;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
@@ -9,12 +9,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IEntityMaterializer
+    public class ContextParameterBindingFactory : ParameterBindingFactory
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        object CreateEntity(ValueBuffer valueBuffer);
+        public override ParameterBinding TryBindParameter(IMutableEntityType enityType, ParameterInfo parameter)
+            => typeof(DbContext).IsAssignableFrom(parameter.ParameterType)
+                ? new ContextParameterBinding(parameter.ParameterType)
+                : null;
     }
 }

--- a/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
+++ b/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
@@ -49,6 +49,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public const string ConstructorBinding = "ConstructorBinding";
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public const string TypeMapping = "Relational:TypeMapping"; // "Relational:" prefix to prevent breaking changes from 2.0
 
         /// <summary>

--- a/src/EFCore/Metadata/Internal/DirectConstructorBinding.cs
+++ b/src/EFCore/Metadata/Internal/DirectConstructorBinding.cs
@@ -1,0 +1,45 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class DirectConstructorBinding : ConstructorBinding
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public DirectConstructorBinding(
+            [NotNull] ConstructorInfo constructor,
+            [NotNull] IReadOnlyList<ParameterBinding> parameterBindings)
+            : base(parameterBindings)
+        {
+            Constructor = constructor;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual ConstructorInfo Constructor { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override Expression CreateConstructorExpression(ParameterBindingInfo bindingInfo)
+            => Expression.New(
+                Constructor,
+                ParameterBindings.Select(b => b.BindToParameter(bindingInfo)));
+    }
+}

--- a/src/EFCore/Metadata/Internal/EntityTypeParameterBinding.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeParameterBinding.cs
@@ -1,0 +1,30 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class EntityTypeParameterBinding : ParameterBinding
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public EntityTypeParameterBinding()
+            : base(typeof(IEntityType), null)
+        {
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override Expression BindToParameter(ParameterBindingInfo bindingInfo)
+            => Expression.Constant(bindingInfo.EnityType, typeof(IEntityType));
+    }
+}

--- a/src/EFCore/Metadata/Internal/EntityTypeParameterBindingFactory.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeParameterBindingFactory.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class EntityTypeParameterBindingFactory : ParameterBindingFactory
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override ParameterBinding TryBindParameter(IMutableEntityType enityType, ParameterInfo parameter)
+            => parameter.ParameterType == typeof(IEntityType)
+                ? new EntityTypeParameterBinding()
+                : null;
+    }
+}

--- a/src/EFCore/Metadata/Internal/FactoryMethodConstructorBinding.cs
+++ b/src/EFCore/Metadata/Internal/FactoryMethodConstructorBinding.cs
@@ -1,0 +1,73 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class FactoryMethodConstructorBinding : ConstructorBinding
+    {
+        private readonly object _factoryInstance;
+        private readonly MethodInfo _factoryMethod;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public FactoryMethodConstructorBinding(
+            [NotNull] MethodInfo factoryMethod,
+            [NotNull] IReadOnlyList<ParameterBinding> parameterBindings)
+            : base(parameterBindings)
+        {
+            _factoryMethod = factoryMethod;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public FactoryMethodConstructorBinding(
+            [NotNull] object factoryInstance,
+            [NotNull] MethodInfo factoryMethod,
+            [NotNull] IReadOnlyList<ParameterBinding> parameterBindings)
+            : this(factoryMethod, parameterBindings)
+        {
+            _factoryInstance = factoryInstance;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override Expression CreateConstructorExpression(ParameterBindingInfo bindingInfo)
+        {
+            var arguments = ParameterBindings.Select(b => b.BindToParameter(bindingInfo));
+
+            Expression expression
+                = _factoryInstance == null
+                    ? Expression.Call(
+                        _factoryMethod,
+                        arguments)
+                    : Expression.Call(
+                        Expression.Constant(_factoryInstance),
+                        _factoryMethod,
+                        arguments);
+
+            if (_factoryMethod.ReturnType != bindingInfo.EnityType.ClrType)
+            {
+                expression = Expression.Convert(expression, bindingInfo.EnityType.ClrType);
+            }
+
+            return expression;
+        }
+    }
+}

--- a/src/EFCore/Metadata/Internal/IConstructorBindingFactory.cs
+++ b/src/EFCore/Metadata/Internal/IConstructorBindingFactory.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Reflection;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public interface IConstructorBindingFactory
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        bool TryBindConstructor(
+            [NotNull] IMutableEntityType entityType,
+            [NotNull] ConstructorInfo constructor,
+            [CanBeNull] out ConstructorBinding binding,
+            [CanBeNull] out IEnumerable<ParameterInfo> failedBindings);
+    }
+}

--- a/src/EFCore/Metadata/Internal/IEntityMaterializerSource.cs
+++ b/src/EFCore/Metadata/Internal/IEntityMaterializerSource.cs
@@ -38,12 +38,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         Expression CreateMaterializeExpression(
             [NotNull] IEntityType entityType,
             [NotNull] Expression valueBufferExpression,
+            [NotNull] Expression contextExpression,
             [CanBeNull] int[] indexMap = null);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        Func<ValueBuffer, object> GetMaterializer([NotNull] IEntityType entityType);
+        Func<ValueBuffer, DbContext, object> GetMaterializer([NotNull] IEntityType entityType);
     }
 }

--- a/src/EFCore/Metadata/Internal/LazyLoaderParameterBindingFactory.cs
+++ b/src/EFCore/Metadata/Internal/LazyLoaderParameterBindingFactory.cs
@@ -1,0 +1,49 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Reflection;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class LazyLoaderParameterBindingFactory : ParameterBindingFactory
+    {
+        private static readonly MethodInfo _loadMethod = typeof(ILazyLoader).GetMethod(nameof(ILazyLoader.Load));
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override ParameterBinding TryBindParameter(IMutableEntityType enityType, ParameterInfo parameter)
+        {
+            if (parameter.ParameterType == typeof(ILazyLoader))
+            {
+                EnsureFieldAccess(enityType);
+
+                return new ServiceParameterBinding(typeof(ILazyLoader), typeof(ILazyLoader));
+            }
+
+            if (parameter.ParameterType == typeof(Action<object, string>)
+                && parameter.Name.Equals("lazyLoader", StringComparison.OrdinalIgnoreCase))
+            {
+                EnsureFieldAccess(enityType);
+
+                return new ServiceMethodParameterBinding(typeof(Action<object, string>), typeof(ILazyLoader), _loadMethod);
+            }
+
+            return null;
+        }
+
+        private static void EnsureFieldAccess(IMutableEntityType enityType)
+        {
+            foreach (var navigation in enityType.GetNavigations())
+            {
+                navigation.SetPropertyAccessMode(PropertyAccessMode.Field);
+            }
+        }
+    }
+}

--- a/src/EFCore/Metadata/Internal/ParameterBinding.cs
+++ b/src/EFCore/Metadata/Internal/ParameterBinding.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public abstract class ParameterBinding
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected ParameterBinding(
+            [NotNull] Type parameterType,
+            [CanBeNull] IPropertyBase consumedProperty)
+        {
+            ParameterType = parameterType;
+            ConsumedProperty = consumedProperty;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Type ParameterType { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual IPropertyBase ConsumedProperty { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public abstract Expression BindToParameter(ParameterBindingInfo bindingInfo);
+    }
+}

--- a/src/EFCore/Metadata/Internal/ParameterBindingFactory.cs
+++ b/src/EFCore/Metadata/Internal/ParameterBindingFactory.cs
@@ -1,0 +1,23 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Reflection;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public abstract class ParameterBindingFactory
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public abstract ParameterBinding TryBindParameter(
+            [NotNull] IMutableEntityType enityType,
+            [NotNull] ParameterInfo parameter);
+    }
+}

--- a/src/EFCore/Metadata/Internal/ParameterBindingInfo.cs
+++ b/src/EFCore/Metadata/Internal/ParameterBindingInfo.cs
@@ -1,0 +1,58 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public struct ParameterBindingInfo
+    {
+        private readonly int[] _indexMap;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public ParameterBindingInfo(
+            [NotNull] IEntityType enityType,
+            [NotNull] Expression valueBufferExpression,
+            [NotNull] Expression contextExpression,
+            [CanBeNull] int[] indexMap)
+        {
+            _indexMap = indexMap;
+            EnityType = enityType;
+            ValueBufferExpression = valueBufferExpression;
+            ContextExpression = contextExpression;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public IEntityType EnityType { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public Expression ValueBufferExpression { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public Expression ContextExpression { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public int GetValueBufferIndex([NotNull] IPropertyBase property)
+            => _indexMap?[property.GetIndex()] ?? property.GetIndex();
+    }
+}

--- a/src/EFCore/Metadata/Internal/PropertyParameterBinding.cs
+++ b/src/EFCore/Metadata/Internal/PropertyParameterBinding.cs
@@ -1,0 +1,35 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class PropertyParameterBinding : ParameterBinding
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public PropertyParameterBinding([NotNull] IProperty consumedProperty)
+            : base(consumedProperty.ClrType, consumedProperty)
+        {
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override Expression BindToParameter(ParameterBindingInfo bindingInfo)
+            => Expression.Call(
+                EntityMaterializerSource.TryReadValueMethod.MakeGenericMethod(ConsumedProperty.ClrType),
+                bindingInfo.ValueBufferExpression,
+                Expression.Constant(bindingInfo.GetValueBufferIndex(ConsumedProperty)),
+                Expression.Constant(ConsumedProperty, typeof(IPropertyBase)));
+    }
+}

--- a/src/EFCore/Metadata/Internal/PropertyParameterBindingFactory.cs
+++ b/src/EFCore/Metadata/Internal/PropertyParameterBindingFactory.cs
@@ -1,0 +1,48 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class PropertyParameterBindingFactory : ParameterBindingFactory
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override ParameterBinding TryBindParameter(IMutableEntityType enityType, ParameterInfo parameter)
+        {
+            var candidateNames = GetCandidatePropertyNames(parameter);
+
+            return enityType.GetProperties().Where(
+                p => p.ClrType == parameter.ParameterType
+                     && candidateNames.Any(c => c.Equals(p.Name, StringComparison.Ordinal)))
+                .Select(p => new PropertyParameterBinding(p)).FirstOrDefault();
+        }
+
+        private static IList<string> GetCandidatePropertyNames([NotNull] ParameterInfo parameter)
+        {
+            var name = parameter.Name;
+            var pascalized = char.ToUpperInvariant(name[0]) + name.Substring(1);
+
+            return new List<string>
+            {
+                name,
+                pascalized,
+                "_" + name,
+                "_" + pascalized,
+                "m_" + name,
+                "m_" + pascalized
+            };
+        }
+    }
+}

--- a/src/EFCore/Metadata/Internal/ServiceMethodParameterBinding.cs
+++ b/src/EFCore/Metadata/Internal/ServiceMethodParameterBinding.cs
@@ -1,0 +1,65 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class ServiceMethodParameterBinding : ServiceParameterBinding
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public ServiceMethodParameterBinding(
+            [NotNull] Type parameterType,
+            [NotNull] Type serviceType,
+            [NotNull] MethodInfo method)
+            : base(parameterType, serviceType)
+        {
+            Method = method;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual MethodInfo Method { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override Expression BindToParameter(ParameterBindingInfo bindingInfo)
+        {
+            var parameters = Method.GetParameters().Select(
+                (p, i) => Expression.Parameter(p.ParameterType, "param" + i)).ToArray();
+
+            var serviceVariable = Expression.Variable(ServiceType, "service");
+
+            return Expression.Block(
+                new[] { serviceVariable },
+                new List<Expression>
+                {
+                    Expression.Assign(
+                        serviceVariable,
+                        base.BindToParameter(bindingInfo)),
+                    Expression.Lambda(
+                        Expression.Call(
+                            serviceVariable,
+                            Method,
+                            parameters),
+                        parameters)
+                });
+        }
+    }
+}

--- a/src/EFCore/Metadata/Internal/ServiceParameterBinding.cs
+++ b/src/EFCore/Metadata/Internal/ServiceParameterBinding.cs
@@ -1,0 +1,48 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class ServiceParameterBinding : ParameterBinding
+    {
+        private static readonly MethodInfo _getServiceMethod
+            = typeof(AccessorExtensions).GetMethod(nameof(AccessorExtensions.GetService));
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public ServiceParameterBinding(
+            [NotNull] Type parameterType,
+            [NotNull] Type serviceType)
+            : base(parameterType, null)
+        {
+            ServiceType = serviceType;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Type ServiceType { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override Expression BindToParameter(ParameterBindingInfo bindingInfo)
+            => Expression.Call(
+                _getServiceMethod.MakeGenericMethod(ServiceType),
+                Expression.Convert(bindingInfo.ContextExpression, typeof(IInfrastructure<IServiceProvider>)));
+    }
+}

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -271,12 +271,20 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 field, fieldType, entityType, property, propertyType);
 
         /// <summary>
-        ///     No field was found backing property '{property}' of entity type '{entity}'. Either configure a backing field or use a different '{pam}'.
+        ///     No field was found backing property '{property}' of entity type '{entity}'. Either name the backing field so that it is picked up by convention, configure the backing field to use, or use a different '{pam}'.
         /// </summary>
         public static string NoBackingField([CanBeNull] object property, [CanBeNull] object entity, [CanBeNull] object pam)
             => string.Format(
                 GetString("NoBackingField", nameof(property), nameof(entity), nameof(pam)),
                 property, entity, pam);
+
+        /// <summary>
+        ///     No field was found backing property '{property}' of entity type '{entity}'. Lazy-loaded navigation properties must have backing fields. Either name the backing field so that it is picked up by convention or configure the backing field to use.
+        /// </summary>
+        public static string NoBackingFieldLazyLoading([CanBeNull] object property, [CanBeNull] object entity)
+            => string.Format(
+                GetString("NoBackingFieldLazyLoading", nameof(property), nameof(entity)),
+                property, entity);
 
         /// <summary>
         ///     No backing field could be found for property '{property}' of entity type '{entity}' and the property does not have a setter.
@@ -1911,6 +1919,22 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 entityType, derivedType);
 
         /// <summary>
+        ///     No suitable constructor found for entity type '{entityType}'. The following parameters could not be bound to properties of the entity: '{parameters}'.
+        /// </summary>
+        public static string ConstructorNotFound([CanBeNull] object entityType, [CanBeNull] object parameters)
+            => string.Format(
+                GetString("ConstructorNotFound", nameof(entityType), nameof(parameters)),
+                entityType, parameters);
+
+        /// <summary>
+        ///     Two constructors were found with the same number of parameters that could both be used by Entity Framework. The constructor to use must be configured explicitly. The two constructors are '{firstConstructor}' and '{secondConstructor}'.
+        /// </summary>
+        public static string ConstructorConflict([CanBeNull] object firstConstructor, [CanBeNull] object secondConstructor)
+            => string.Format(
+                GetString("ConstructorConflict", nameof(firstConstructor), nameof(secondConstructor)),
+                firstConstructor, secondConstructor);
+
+        /// <summary>
         ///     The type '{entityType}' cannot be marked as owned because a non-owned entity type with the same name already exists.
         /// </summary>
         public static string ClashingNonOwnedEntityType([CanBeNull] object entityType)
@@ -1935,6 +1959,30 @@ namespace Microsoft.EntityFrameworkCore.Internal
                     LogLevel.Information,
                     CoreEventId.ExecutionStrategyRetrying,
                     _resourceManager.GetString("LogExecutionStrategyRetrying")));
+
+        /// <summary>
+        ///     Navigation property '{navigation}' of entity type '{entityType}' is being lazy-loaded.
+        /// </summary>
+        public static readonly EventDefinition<string, string> NavigationLazyLoading
+            = new EventDefinition<string, string>(
+                CoreEventId.NavigationLazyLoading,
+                LogLevel.Information,
+                LoggerMessage.Define<string, string>(
+                    LogLevel.Information,
+                    CoreEventId.NavigationLazyLoading,
+                    _resourceManager.GetString("NavigationLazyLoading")));
+
+        /// <summary>
+        ///     An attempt was made to lazy-load navigation property '{navigation}' on entity type '{entityType}' after the associated DbContext was disposed.
+        /// </summary>
+        public static readonly EventDefinition<string, string> LazyLoadOnDisposedContextWarning
+            = new EventDefinition<string, string>(
+                CoreEventId.LazyLoadOnDisposedContextWarning,
+                LogLevel.Warning,
+                LoggerMessage.Define<string, string>(
+                    LogLevel.Warning,
+                    CoreEventId.LazyLoadOnDisposedContextWarning,
+                    _resourceManager.GetString("LazyLoadOnDisposedContextWarning")));
 
         private static string GetString(string name, params string[] formatterNames)
         {

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -214,7 +214,10 @@
     <value>The specified field '{field}' of type '{fieldType}' cannot be used for the property '{entityType}.{property}' of type '{propertyType}'. Only backing fields of types that are assignable from the property type can be used.</value>
   </data>
   <data name="NoBackingField" xml:space="preserve">
-    <value>No field was found backing property '{property}' of entity type '{entity}'. Either configure a backing field or use a different '{pam}'.</value>
+    <value>No field was found backing property '{property}' of entity type '{entity}'. Either name the backing field so that it is picked up by convention, configure the backing field to use, or use a different '{pam}'.</value>
+  </data>
+  <data name="NoBackingFieldLazyLoading" xml:space="preserve">
+    <value>No field was found backing property '{property}' of entity type '{entity}'. Lazy-loaded navigation properties must have backing fields. Either name the backing field so that it is picked up by convention or configure the backing field to use.</value>
   </data>
   <data name="NoFieldOrSetter" xml:space="preserve">
     <value>No backing field could be found for property '{property}' of entity type '{entity}' and the property does not have a setter.</value>
@@ -832,6 +835,12 @@
   <data name="SeedDatumDerivedType" xml:space="preserve">
     <value>The seed entity for entity type '{entityType}' cannot be added because the value provided is of a derived type '{derivedType}'. Add the derived seed entities to the corresponding entity type.</value>
   </data>
+  <data name="ConstructorNotFound" xml:space="preserve">
+    <value>No suitable constructor found for entity type '{entityType}'. The following parameters could not be bound to properties of the entity: '{parameters}'.</value>
+  </data>
+  <data name="ConstructorConflict" xml:space="preserve">
+    <value>Two constructors were found with the same number of parameters that could both be used by Entity Framework. The constructor to use must be configured explicitly. The two constructors are '{firstConstructor}' and '{secondConstructor}'.</value>
+  </data>
   <data name="ClashingNonOwnedEntityType" xml:space="preserve">
     <value>The type '{entityType}' cannot be marked as owned because a non-owned entity type with the same name already exists.</value>
   </data>
@@ -841,5 +850,13 @@
   <data name="LogExecutionStrategyRetrying" xml:space="preserve">
     <value>A transient exception has been encountered during execution and the operation will be retried after {delay}ms.{newline}{error}</value>
     <comment>Information CoreEventId.ExecutionStrategyRetrying int string Exception</comment>
+  </data>
+  <data name="NavigationLazyLoading" xml:space="preserve">
+    <value>Navigation property '{navigation}' of entity type '{entityType}' is being lazy-loaded.</value>
+    <comment>Information CoreEventId.NavigationLazyLoading DbContext object string</comment>
+  </data>
+  <data name="LazyLoadOnDisposedContextWarning" xml:space="preserve">
+    <value>An attempt was made to lazy-load navigation property '{navigation}' on entity type '{entityType}' after the associated DbContext was disposed.</value>
+    <comment>Warning CoreEventId.LazyLoadOnDisposedContextWarning DbContext object string</comment>
   </data>
 </root>

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -235,12 +235,7 @@ namespace MyNamespace
                         new CSharpMigrationOperationGeneratorDependencies(codeHelper)),
                     new CSharpSnapshotGenerator(new CSharpSnapshotGeneratorDependencies(codeHelper))));
 
-            var modelBuilder = new ModelBuilder(
-                new CoreConventionSetBuilder(
-                        new CoreConventionSetBuilderDependencies(
-                            TestServiceFactory.Instance.Create<CoreTypeMapper>()))
-                    .CreateConventionSet());
-
+            var modelBuilder = new ModelBuilder(TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
             modelBuilder.Entity<EntityWithEveryPrimitive>(
                 eb =>
                     {

--- a/test/EFCore.InMemory.FunctionalTests/WithConstructorsInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/WithConstructorsInMemoryTest.cs
@@ -1,0 +1,31 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class WithConstructorsInMemoryTest : WithConstructorsTestBase<WithConstructorsInMemoryTest.WithConstructorsInMemoryFixture>
+    {
+        public WithConstructorsInMemoryTest(WithConstructorsInMemoryFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        public override void Query_and_update_using_constructors_with_property_parameters()
+        {
+            base.Query_and_update_using_constructors_with_property_parameters();
+
+            Fixture.Reseed();
+        }
+
+        public class WithConstructorsInMemoryFixture : WithConstructorsFixtureBase
+        {
+            protected override ITestStoreFactory TestStoreFactory => InMemoryTestStoreFactory.Instance;
+
+            public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+                => base.AddOptions(builder).ConfigureWarnings(w => w.Log(InMemoryEventId.TransactionIgnoredWarning));
+        }
+    }
+}

--- a/test/EFCore.Relational.Tests/Metadata/Conventions/Internal/DiscriminatorConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/Conventions/Internal/DiscriminatorConventionTest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
-using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
@@ -165,9 +164,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var modelBuilder
                 = new InternalModelBuilder(
                     new Model(
-                        new CoreConventionSetBuilder(
-                                new CoreConventionSetBuilderDependencies(
-                                    TestServiceFactory.Instance.Create<CoreTypeMapper>()))
+                        TestServiceFactory.Instance.Create<CoreConventionSetBuilder>()
                             .CreateConventionSet()));
 
             return modelBuilder.Entity(typeof(T), ConfigurationSource.Explicit);

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -6106,17 +6106,51 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
         private class Blog
         {
+            private readonly Action<object, string> _loader;
+            private ICollection<Post> _posts;
+
+            public Blog()
+            {
+            }
+
+            private Blog(Action<object, string> lazyLoader)
+            {
+                _loader = lazyLoader;
+            }
+
             public int BlogId { get; set; }
             public string Url { get; set; }
-            public ICollection<Post> Posts { get; set; }
+
+            public ICollection<Post> Posts
+            {
+                get => _loader.Load(this, ref _posts);
+                set => _posts = value;
+            }
         }
 
         private class Post
         {
+            private readonly ILazyLoader _loader;
+            private Blog _blog;
+
+            public Post()
+            {
+            }
+
+            private Post(ILazyLoader loader)
+            {
+                _loader = loader;
+            }
+
             public int PostId { get; set; }
             public string Title { get; set; }
             public int? BlogId { get; set; }
-            public Blog Blog { get; set; }
+
+            public Blog Blog
+            {
+                get => _loader.Load(this, ref _blog);
+                set => _blog = value;
+            }
         }
 
         protected override ModelBuilder CreateModelBuilder() => RelationalTestHelpers.Instance.CreateConventionBuilder();

--- a/test/EFCore.Relational.Tests/TestUtilities/TestRelationalConventionSetBuilder.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/TestRelationalConventionSetBuilder.cs
@@ -18,9 +18,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                     new RelationalConventionSetBuilderDependencies(
                         TestServiceFactory.Instance.Create<TestRelationalTypeMapper>(), null, null))
                 .AddConventions(
-                    new CoreConventionSetBuilder(
-                            new CoreConventionSetBuilderDependencies(
-                                TestServiceFactory.Instance.Create<TestRelationalTypeMapper>()))
+                    TestServiceFactory.Instance.Create<CoreConventionSetBuilder>()
                         .CreateConventionSet());
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/LoadSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/LoadSqlServerTest.cs
@@ -18,6 +18,402 @@ namespace Microsoft.EntityFrameworkCore
             fixture.TestSqlLoggerFactory.Clear();
         }
 
+        public override void Lazy_load_collection(EntityState state)
+        {
+            base.Lazy_load_collection(state);
+
+            Assert.Equal(
+                @"@__get_Item_0='707' (Nullable = true)
+
+SELECT [e].[Id], [e].[ParentId]
+FROM [Child] AS [e]
+WHERE [e].[ParentId] = @__get_Item_0",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override void Lazy_load_many_to_one_reference_to_principal(EntityState state)
+        {
+            base.Lazy_load_many_to_one_reference_to_principal(state);
+
+            Assert.Equal(
+                @"@__get_Item_0='707'
+
+SELECT [e].[Id], [e].[AlternateId]
+FROM [Parent] AS [e]
+WHERE [e].[Id] = @__get_Item_0",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override void Lazy_load_one_to_one_reference_to_principal(EntityState state)
+        {
+            base.Lazy_load_one_to_one_reference_to_principal(state);
+
+            Assert.Equal(
+                @"@__get_Item_0='707'
+
+SELECT [e].[Id], [e].[AlternateId]
+FROM [Parent] AS [e]
+WHERE [e].[Id] = @__get_Item_0",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override void Lazy_load_one_to_one_reference_to_dependent(EntityState state)
+        {
+            base.Lazy_load_one_to_one_reference_to_dependent(state);
+
+            Assert.Equal(
+                @"@__get_Item_0='707' (Nullable = true)
+
+SELECT [e].[Id], [e].[ParentId]
+FROM [Single] AS [e]
+WHERE [e].[ParentId] = @__get_Item_0",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override void Lazy_load_one_to_one_PK_to_PK_reference_to_principal(EntityState state)
+        {
+            base.Lazy_load_one_to_one_PK_to_PK_reference_to_principal(state);
+
+            Assert.Equal(
+                @"@__get_Item_0='707'
+
+SELECT [e].[Id], [e].[AlternateId]
+FROM [Parent] AS [e]
+WHERE [e].[Id] = @__get_Item_0",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override void Lazy_load_one_to_one_PK_to_PK_reference_to_dependent(EntityState state)
+        {
+            base.Lazy_load_one_to_one_PK_to_PK_reference_to_dependent(state);
+
+            Assert.Equal(
+                @"@__get_Item_0='707'
+
+SELECT [e].[Id]
+FROM [SinglePkToPk] AS [e]
+WHERE [e].[Id] = @__get_Item_0",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override void Lazy_load_many_to_one_reference_to_principal_null_FK(EntityState state)
+        {
+            base.Lazy_load_many_to_one_reference_to_principal_null_FK(state);
+
+            Assert.Equal("", Sql);
+        }
+
+        public override void Lazy_load_one_to_one_reference_to_principal_null_FK(EntityState state)
+        {
+            base.Lazy_load_one_to_one_reference_to_principal_null_FK(state);
+
+            Assert.Equal("", Sql);
+        }
+
+        public override void Lazy_load_collection_not_found(EntityState state)
+        {
+            base.Lazy_load_collection_not_found(state);
+
+            Assert.Equal(
+                @"@__get_Item_0='767' (Nullable = true)
+
+SELECT [e].[Id], [e].[ParentId]
+FROM [Child] AS [e]
+WHERE [e].[ParentId] = @__get_Item_0",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override void Lazy_load_many_to_one_reference_to_principal_not_found(EntityState state)
+        {
+            base.Lazy_load_many_to_one_reference_to_principal_not_found(state);
+
+            Assert.Equal(
+                @"@__get_Item_0='787'
+
+SELECT [e].[Id], [e].[AlternateId]
+FROM [Parent] AS [e]
+WHERE [e].[Id] = @__get_Item_0",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override void Lazy_load_one_to_one_reference_to_principal_not_found(EntityState state)
+        {
+            base.Lazy_load_one_to_one_reference_to_principal_not_found(state);
+
+            Assert.Equal(
+                @"@__get_Item_0='787'
+
+SELECT [e].[Id], [e].[AlternateId]
+FROM [Parent] AS [e]
+WHERE [e].[Id] = @__get_Item_0",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override void Lazy_load_one_to_one_reference_to_dependent_not_found(EntityState state)
+        {
+            base.Lazy_load_one_to_one_reference_to_dependent_not_found(state);
+
+            Assert.Equal(
+                @"@__get_Item_0='767' (Nullable = true)
+
+SELECT [e].[Id], [e].[ParentId]
+FROM [Single] AS [e]
+WHERE [e].[ParentId] = @__get_Item_0",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override void Lazy_load_collection_already_loaded(EntityState state)
+        {
+            base.Lazy_load_collection_already_loaded(state);
+
+            Assert.Equal("", Sql);
+        }
+
+        public override void Lazy_load_many_to_one_reference_to_principal_already_loaded(EntityState state)
+        {
+            base.Lazy_load_many_to_one_reference_to_principal_already_loaded(state);
+
+            Assert.Equal("", Sql);
+        }
+
+        public override void Lazy_load_one_to_one_reference_to_principal_already_loaded(EntityState state)
+        {
+            base.Lazy_load_one_to_one_reference_to_principal_already_loaded(state);
+
+            Assert.Equal("", Sql);
+        }
+
+        public override void Lazy_load_one_to_one_reference_to_dependent_already_loaded(EntityState state)
+        {
+            base.Lazy_load_one_to_one_reference_to_dependent_already_loaded(state);
+
+            Assert.Equal("", Sql);
+        }
+
+        public override void Lazy_load_one_to_one_PK_to_PK_reference_to_principal_already_loaded(EntityState state)
+        {
+            base.Lazy_load_one_to_one_PK_to_PK_reference_to_principal_already_loaded(state);
+
+            Assert.Equal("", Sql);
+        }
+
+        public override void Lazy_load_one_to_one_PK_to_PK_reference_to_dependent_already_loaded(EntityState state)
+        {
+            base.Lazy_load_one_to_one_PK_to_PK_reference_to_dependent_already_loaded(state);
+
+            Assert.Equal("", Sql);
+        }
+
+        public override void Lazy_load_many_to_one_reference_to_principal_alternate_key(EntityState state)
+        {
+            base.Lazy_load_many_to_one_reference_to_principal_alternate_key(state);
+
+            Assert.Equal(
+                @"@__get_Item_0='Root' (Size = 450)
+
+SELECT [e].[Id], [e].[AlternateId]
+FROM [Parent] AS [e]
+WHERE [e].[AlternateId] = @__get_Item_0",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override void Lazy_load_one_to_one_reference_to_principal_alternate_key(EntityState state)
+        {
+            base.Lazy_load_one_to_one_reference_to_principal_alternate_key(state);
+
+            Assert.Equal(
+                @"@__get_Item_0='Root' (Size = 450)
+
+SELECT [e].[Id], [e].[AlternateId]
+FROM [Parent] AS [e]
+WHERE [e].[AlternateId] = @__get_Item_0",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override void Lazy_load_one_to_one_reference_to_dependent_alternate_key(EntityState state)
+        {
+            base.Lazy_load_one_to_one_reference_to_dependent_alternate_key(state);
+
+            Assert.Equal(
+                @"@__get_Item_0='Root' (Size = 450)
+
+SELECT [e].[Id], [e].[ParentId]
+FROM [SingleAk] AS [e]
+WHERE [e].[ParentId] = @__get_Item_0",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override void Lazy_load_many_to_one_reference_to_principal_null_FK_alternate_key(EntityState state)
+        {
+            base.Lazy_load_many_to_one_reference_to_principal_null_FK_alternate_key(state);
+
+            Assert.Equal("", Sql);
+        }
+
+        public override void Lazy_load_one_to_one_reference_to_principal_null_FK_alternate_key(EntityState state)
+        {
+            base.Lazy_load_one_to_one_reference_to_principal_null_FK_alternate_key(state);
+
+            Assert.Equal("", Sql);
+        }
+
+        public override void Lazy_load_collection_shadow_fk(EntityState state)
+        {
+            base.Lazy_load_collection_shadow_fk(state);
+
+            Assert.Equal(
+                @"@__get_Item_0='707' (Nullable = true)
+
+SELECT [e].[Id], [e].[ParentId]
+FROM [ChildShadowFk] AS [e]
+WHERE [e].[ParentId] = @__get_Item_0",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override void Lazy_load_many_to_one_reference_to_principal_shadow_fk(EntityState state)
+        {
+            base.Lazy_load_many_to_one_reference_to_principal_shadow_fk(state);
+
+            Assert.Equal(
+                @"@__get_Item_0='707'
+
+SELECT [e].[Id], [e].[AlternateId]
+FROM [Parent] AS [e]
+WHERE [e].[Id] = @__get_Item_0",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override void Lazy_load_one_to_one_reference_to_principal_shadow_fk(EntityState state)
+        {
+            base.Lazy_load_one_to_one_reference_to_principal_shadow_fk(state);
+
+            Assert.Equal(
+                @"@__get_Item_0='707'
+
+SELECT [e].[Id], [e].[AlternateId]
+FROM [Parent] AS [e]
+WHERE [e].[Id] = @__get_Item_0",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override void Lazy_load_one_to_one_reference_to_dependent_shadow_fk(EntityState state)
+        {
+            base.Lazy_load_one_to_one_reference_to_dependent_shadow_fk(state);
+
+            Assert.Equal(
+                @"@__get_Item_0='707' (Nullable = true)
+
+SELECT [e].[Id], [e].[ParentId]
+FROM [SingleShadowFk] AS [e]
+WHERE [e].[ParentId] = @__get_Item_0",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override void Lazy_load_many_to_one_reference_to_principal_null_FK_shadow_fk(EntityState state)
+        {
+            base.Lazy_load_many_to_one_reference_to_principal_null_FK_shadow_fk(state);
+
+            Assert.Equal("", Sql);
+        }
+
+        public override void Lazy_load_one_to_one_reference_to_principal_null_FK_shadow_fk(EntityState state)
+        {
+            base.Lazy_load_one_to_one_reference_to_principal_null_FK_shadow_fk(state);
+
+            Assert.Equal("", Sql);
+        }
+
+        public override void Lazy_load_collection_composite_key(EntityState state)
+        {
+            base.Lazy_load_collection_composite_key(state);
+
+            Assert.Equal(
+                @"@__get_Item_0='Root' (Size = 450)
+@__get_Item_1='707' (Nullable = true)
+
+SELECT [e].[Id], [e].[ParentAlternateId], [e].[ParentId]
+FROM [ChildCompositeKey] AS [e]
+WHERE ([e].[ParentAlternateId] = @__get_Item_0) AND ([e].[ParentId] = @__get_Item_1)",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override void Lazy_load_many_to_one_reference_to_principal_composite_key(EntityState state)
+        {
+            base.Lazy_load_many_to_one_reference_to_principal_composite_key(state);
+
+            Assert.Equal(
+                @"@__get_Item_0='Root' (Size = 450)
+@__get_Item_1='707'
+
+SELECT [e].[Id], [e].[AlternateId]
+FROM [Parent] AS [e]
+WHERE ([e].[AlternateId] = @__get_Item_0) AND ([e].[Id] = @__get_Item_1)",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override void Lazy_load_one_to_one_reference_to_principal_composite_key(EntityState state)
+        {
+            base.Lazy_load_one_to_one_reference_to_principal_composite_key(state);
+
+            Assert.Equal(
+                @"@__get_Item_0='Root' (Size = 450)
+@__get_Item_1='707'
+
+SELECT [e].[Id], [e].[AlternateId]
+FROM [Parent] AS [e]
+WHERE ([e].[AlternateId] = @__get_Item_0) AND ([e].[Id] = @__get_Item_1)",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override void Lazy_load_one_to_one_reference_to_dependent_composite_key(EntityState state)
+        {
+            base.Lazy_load_one_to_one_reference_to_dependent_composite_key(state);
+
+            Assert.Equal(
+                @"@__get_Item_0='Root' (Size = 450)
+@__get_Item_1='707' (Nullable = true)
+
+SELECT [e].[Id], [e].[ParentAlternateId], [e].[ParentId]
+FROM [SingleCompositeKey] AS [e]
+WHERE ([e].[ParentAlternateId] = @__get_Item_0) AND ([e].[ParentId] = @__get_Item_1)",
+                Sql,
+                ignoreLineEndingDifferences: true);
+        }
+
+        public override void Lazy_load_many_to_one_reference_to_principal_null_FK_composite_key(EntityState state)
+        {
+            base.Lazy_load_many_to_one_reference_to_principal_null_FK_composite_key(state);
+
+            Assert.Equal("", Sql);
+        }
+
+        public override void Lazy_load_one_to_one_reference_to_principal_null_FK_composite_key(EntityState state)
+        {
+            base.Lazy_load_one_to_one_reference_to_principal_null_FK_composite_key(state);
+
+            Assert.Equal("", Sql);
+        }
+
         public override async Task Load_collection(EntityState state, bool async)
         {
             await base.Load_collection(state, async);

--- a/test/EFCore.SqlServer.FunctionalTests/WithConstructorsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/WithConstructorsSqlServerTest.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class WithConstructorsSqlServerTest : WithConstructorsTestBase<WithConstructorsSqlServerTest.WithConstructorsSqlServerFixture>
+    {
+        public WithConstructorsSqlServerTest(WithConstructorsSqlServerFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
+            => facade.UseTransaction(transaction.GetDbTransaction());
+
+        public class WithConstructorsSqlServerFixture : WithConstructorsFixtureBase
+        {
+            protected override ITestStoreFactory TestStoreFactory => SqlServerTestStoreFactory.Instance;
+        }
+    }
+}

--- a/test/EFCore.SqlServer.Tests/SqlServerModelValidatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerModelValidatorTest.cs
@@ -47,10 +47,7 @@ namespace Microsoft.EntityFrameworkCore
 
         public override void Detects_incompatible_shared_columns_with_shared_table()
         {
-            var modelBuilder = new ModelBuilder(
-                new CoreConventionSetBuilder(
-                    new CoreConventionSetBuilderDependencies(
-                        TestServiceFactory.Instance.Create<CoreTypeMapper>())).CreateConventionSet());
+            var modelBuilder = new ModelBuilder(TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
 
             modelBuilder.Entity<A>().HasOne<B>().WithOne().IsRequired().HasForeignKey<A>(a => a.Id).HasPrincipalKey<B>(b => b.Id);
             modelBuilder.Entity<A>().Property(a => a.P0).HasColumnType("someInt");
@@ -147,10 +144,7 @@ namespace Microsoft.EntityFrameworkCore
         [Fact]
         public virtual void Detects_incompatible_momory_optimized_shared_table()
         {
-            var modelBuilder = new ModelBuilder(
-                new CoreConventionSetBuilder(
-                    new CoreConventionSetBuilderDependencies(
-                        TestServiceFactory.Instance.Create<CoreTypeMapper>())).CreateConventionSet());
+            var modelBuilder = new ModelBuilder(TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
 
             modelBuilder.Entity<A>().HasOne<B>().WithOne().IsRequired().HasForeignKey<A>(a => a.Id).HasPrincipalKey<B>(b => b.Id);
             modelBuilder.Entity<A>().ToTable("Table").ForSqlServerIsMemoryOptimized();
@@ -164,11 +158,7 @@ namespace Microsoft.EntityFrameworkCore
         [Fact]
         public virtual void Throws_for_unsupported_data_types()
         {
-            var modelBuilder = new ModelBuilder(
-                new CoreConventionSetBuilder(
-                    new CoreConventionSetBuilderDependencies(
-                        TestServiceFactory.Instance.Create<CoreTypeMapper>())).CreateConventionSet());
-
+            var modelBuilder = new ModelBuilder(TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
             modelBuilder.Entity<Cheese>().Property(e => e.Name).HasColumnType("nvarchar");
 
             Assert.Equal(

--- a/test/EFCore.Sqlite.FunctionalTests/WithConstructorsSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/WithConstructorsSqliteTest.cs
@@ -1,0 +1,25 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    public class WithConstructorsSqliteTest : WithConstructorsTestBase<WithConstructorsSqliteTest.WithConstructorsSqliteFixture>
+    {
+        public WithConstructorsSqliteTest(WithConstructorsSqliteFixture fixture)
+            : base(fixture)
+        {
+        }
+
+        protected override void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
+            => facade.UseTransaction(transaction.GetDbTransaction());
+
+        public class WithConstructorsSqliteFixture : WithConstructorsFixtureBase
+        {
+            protected override ITestStoreFactory TestStoreFactory => SqliteTestStoreFactory.Instance;
+        }
+    }
+}

--- a/test/EFCore.Sqlite.Tests/Migrations/SqliteMigrationAnnotationProviderTest.cs
+++ b/test/EFCore.Sqlite.Tests/Migrations/SqliteMigrationAnnotationProviderTest.cs
@@ -22,9 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         {
             _modelBuilder
                 = new ModelBuilder(
-                    new CoreConventionSetBuilder(
-                            new CoreConventionSetBuilderDependencies(
-                                TestServiceFactory.Instance.Create<CoreTypeMapper>()))
+                    TestServiceFactory.Instance.Create<CoreConventionSetBuilder>()
                         .CreateConventionSet());
 
             _provider = new SqliteMigrationsAnnotationProvider(new MigrationsAnnotationProviderDependencies());

--- a/test/EFCore.Sqlite.Tests/SqliteModelValidatorTest.cs
+++ b/test/EFCore.Sqlite.Tests/SqliteModelValidatorTest.cs
@@ -20,9 +20,7 @@ namespace Microsoft.EntityFrameworkCore
         public override void Detects_duplicate_column_names()
         {
             var modelBuilder = new ModelBuilder(
-                new CoreConventionSetBuilder(
-                    new CoreConventionSetBuilderDependencies(
-                        TestServiceFactory.Instance.Create<CoreTypeMapper>())).CreateConventionSet());
+                TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
 
             GenerateMapping(modelBuilder.Entity<Animal>().Property(b => b.Id).HasColumnName("Name").Metadata);
             GenerateMapping(modelBuilder.Entity<Animal>().Property(d => d.Name).HasColumnName("Name").Metadata);
@@ -54,9 +52,7 @@ namespace Microsoft.EntityFrameworkCore
         public override void Detects_incompatible_shared_columns_with_shared_table()
         {
             var modelBuilder = new ModelBuilder(
-                new CoreConventionSetBuilder(
-                    new CoreConventionSetBuilderDependencies(
-                        TestServiceFactory.Instance.Create<CoreTypeMapper>())).CreateConventionSet());
+                TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
 
             modelBuilder.Entity<A>().HasOne<B>().WithOne().IsRequired().HasForeignKey<A>(a => a.Id).HasPrincipalKey<B>(b => b.Id);
             modelBuilder.Entity<A>().Property(a => a.P0).HasColumnName(nameof(A.P0)).HasColumnType("someInt");

--- a/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/ChangeTrackerTest.cs
@@ -1345,14 +1345,14 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
             }
         }
 
-        [Fact] // Issue #743
-        public void Throws_when_instance_of_unmapped_derived_type_is_used()
+        [Fact]
+        public void Does_not_throw_when_instance_of_unmapped_derived_type_is_used()
         {
             using (var context = new EarlyLearningCenter())
             {
-                Assert.Equal(
-                    CoreStrings.EntityTypeNotFound(typeof(SpecialProduct).Name),
-                    Assert.Throws<InvalidOperationException>(() => context.Add(new SpecialProduct())).Message);
+                Assert.Same(
+                    context.Model.FindEntityType(typeof(Product)),
+                    context.Add(new SpecialProduct()).Metadata);
             }
         }
 

--- a/test/EFCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
@@ -771,14 +771,15 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             Assert.Empty(stateManager.GetDependents(categoryEntry4, fk).ToArray());
         }
 
-        [Fact] // Issue #743
-        public void Throws_when_instance_of_unmapped_derived_type_is_used()
+        [Fact]
+        public void Does_not_throws_when_instance_of_unmapped_derived_type_is_used()
         {
             var model = BuildModel();
             var stateManager = CreateStateManager(model);
-            Assert.Equal(
-                CoreStrings.EntityTypeNotFound(typeof(SpecialProduct).Name),
-                Assert.Throws<InvalidOperationException>(() => stateManager.GetOrCreateEntry(new SpecialProduct())).Message);
+
+            var entry = stateManager.GetOrCreateEntry(new SpecialProduct());
+
+            Assert.Same(model.FindEntityType(typeof(Product)), entry.EntityType);
         }
 
         private static IStateManager CreateStateManager(IModel model)
@@ -820,11 +821,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
         private static IMutableModel BuildModel()
         {
-            var builder = new ModelBuilder(
-                new CoreConventionSetBuilder(
-                    new CoreConventionSetBuilderDependencies(
-                        TestServiceFactory.Instance.Create<CoreTypeMapper>())).CreateConventionSet());
-
+            var builder = new ModelBuilder(TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
             var model = builder.Model;
 
             builder.Entity<Product>().HasOne<Category>().WithOne()

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -621,7 +621,7 @@ namespace Microsoft.EntityFrameworkCore
             await Assert.ThrowsAsync<ObjectDisposedException>(() => context.FindAsync(typeof(Random), 77));
 
             var methodCount = typeof(DbContext).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly).Count();
-            var expectedMethodCount = 40;
+            var expectedMethodCount = 41;
             Assert.True(
                 methodCount == expectedMethodCount,
                 userMessage: $"Expected {expectedMethodCount} methods on DbContext but found {methodCount}. " +
@@ -631,7 +631,13 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Throws<ObjectDisposedException>(() => context.ChangeTracker);
             Assert.Throws<ObjectDisposedException>(() => context.Model);
 
-            var expectedProperties = new List<string> { "ChangeTracker", "Database", "Model" };
+            var expectedProperties = new List<string>
+            {
+                nameof(DbContext.ChangeTracker),
+                nameof(DbContext.Database),
+                nameof(DbContext.IsDisposed),
+                nameof(DbContext.Model)
+            };
 
             Assert.True(
                 expectedProperties.SequenceEqual(

--- a/test/EFCore.Tests/Metadata/Conventions/ConventionSetBuilderTests.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/ConventionSetBuilderTests.cs
@@ -24,9 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         }
 
         protected virtual ConventionSet GetConventionSet()
-            => new CoreConventionSetBuilder(
-                new CoreConventionSetBuilderDependencies(
-                    TestServiceFactory.Instance.Create<CoreTypeMapper>())).CreateConventionSet();
+            => TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet();
 
         [Table("ProductTable")]
         protected class Product

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/CascadeDeleteConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/CascadeDeleteConventionTest.cs
@@ -127,9 +127,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
         private static ModelBuilder CreateModelBuilder()
             => new ModelBuilder(
-                new CoreConventionSetBuilder(
-                        new CoreConventionSetBuilderDependencies(
-                            TestServiceFactory.Instance.Create<CoreTypeMapper>()))
-                    .CreateConventionSet());
+                TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
     }
 }

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/ConstructorBindingConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/ConstructorBindingConventionTest.cs
@@ -1,0 +1,464 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
+{
+    public class ConstructorBindingConventionTest
+    {
+        [Fact]
+        public void Can_bind_parameterless_constructor()
+        {
+            var constructorBinding = GetBinding<BlogParameterless>();
+
+            Assert.NotNull(constructorBinding);
+            Assert.Empty(constructorBinding.Constructor.GetParameters());
+            Assert.Empty(constructorBinding.ParameterBindings);
+        }
+
+        private class BlogParameterless : Blog
+        {
+        }
+
+        [Fact]
+        public void Binds_to_most_parameters_that_resolve()
+        {
+            var constructorBinding = GetBinding<BlogSeveral>();
+
+            Assert.NotNull(constructorBinding);
+
+            var parameters = constructorBinding.Constructor.GetParameters();
+            var bindings = constructorBinding.ParameterBindings;
+
+            Assert.Equal(3, parameters.Length);
+            Assert.Equal(3, bindings.Count);
+
+            Assert.Equal("title", parameters[0].Name);
+            Assert.Equal("shadow", parameters[1].Name);
+            Assert.Equal("id", parameters[2].Name);
+
+            Assert.Equal("Title", bindings[0].ConsumedProperty.Name);
+            Assert.Equal("Shadow", bindings[1].ConsumedProperty.Name);
+            Assert.Equal("Id", bindings[2].ConsumedProperty.Name);
+        }
+
+        private class BlogSeveral : Blog
+        {
+            public BlogSeveral()
+            {
+            }
+
+            public BlogSeveral(string title, int id)
+            {
+            }
+
+            public BlogSeveral(string title, Guid? shadow, int id)
+            {
+            }
+
+            public BlogSeveral(string title, Guid? shadow, bool dummy, int id)
+            {
+            }
+        }
+
+        [Fact]
+        public void Throws_if_two_constructors_with_same_number_of_parameters_could_be_used()
+        {
+            Assert.Equal(
+                CoreStrings.ConstructorConflict(
+                    "BlogConflict(string, int)",
+                    "BlogConflict(string, Nullable<Guid>)"),
+                Assert.Throws<InvalidOperationException>(
+                    () => GetBinding<BlogConflict>()).Message);
+        }
+
+        private class BlogConflict : Blog
+        {
+            public BlogConflict()
+            {
+            }
+
+            public BlogConflict(string title, int id)
+            {
+            }
+
+            public BlogConflict(string title, Guid? shadow)
+            {
+            }
+
+            public BlogConflict(string title, Guid? shadow, bool dummy, int id)
+            {
+            }
+        }
+
+        [Fact]
+        public void Resolvess_properties_with_different_kinds_of_name()
+        {
+            var constructorBinding = GetBinding<BlogSpanner>();
+
+            Assert.NotNull(constructorBinding);
+
+            var parameters = constructorBinding.Constructor.GetParameters();
+            var bindings = constructorBinding.ParameterBindings;
+
+            Assert.Equal(9, parameters.Length);
+            Assert.Equal(9, bindings.Count);
+
+            Assert.Equal("fooBaar1", parameters[0].Name);
+            Assert.Equal("fooBaar2", parameters[1].Name);
+            Assert.Equal("fooBaar3", parameters[2].Name);
+            Assert.Equal("fooBaar4", parameters[3].Name);
+            Assert.Equal("fooBaar5", parameters[4].Name);
+            Assert.Equal("fooBaar6", parameters[5].Name);
+            Assert.Equal("FooBaar1", parameters[6].Name);
+            Assert.Equal("FooBaar5", parameters[7].Name);
+            Assert.Equal("FooBaar6", parameters[8].Name);
+
+            Assert.Equal("FooBaar1", bindings[0].ConsumedProperty.Name);
+            Assert.Equal("fooBaar2", bindings[1].ConsumedProperty.Name);
+            Assert.Equal("_fooBaar3", bindings[2].ConsumedProperty.Name);
+            Assert.Equal("m_fooBaar4", bindings[3].ConsumedProperty.Name);
+            Assert.Equal("_FooBaar5", bindings[4].ConsumedProperty.Name);
+            Assert.Equal("m_FooBaar6", bindings[5].ConsumedProperty.Name);
+            Assert.Equal("FooBaar1", bindings[6].ConsumedProperty.Name);
+            Assert.Equal("_FooBaar5", bindings[7].ConsumedProperty.Name);
+            Assert.Equal("m_FooBaar6", bindings[8].ConsumedProperty.Name);
+        }
+
+        private class BlogSpanner : Blog
+        {
+            public BlogSpanner(
+                string fooBaar1,
+                string fooBaar2,
+                string fooBaar3,
+                string fooBaar4,
+                string fooBaar5,
+                string fooBaar6,
+                // ReSharper disable once InconsistentNaming
+                string FooBaar1,
+                // ReSharper disable once InconsistentNaming
+                string FooBaar5,
+                // ReSharper disable once InconsistentNaming
+                string FooBaar6)
+            {
+            }
+        }
+
+        [Fact]
+        public void Binds_to_partial_set_of_parameters_that_resolve()
+        {
+            var constructorBinding = GetBinding<BlogWierdScience>();
+
+            Assert.NotNull(constructorBinding);
+
+            var parameters = constructorBinding.Constructor.GetParameters();
+            var bindings = constructorBinding.ParameterBindings;
+
+            Assert.Equal(2, parameters.Length);
+            Assert.Equal(2, bindings.Count);
+
+            Assert.Equal("content", parameters[0].Name);
+            Assert.Equal("follows", parameters[1].Name);
+
+            Assert.Equal("_content", bindings[0].ConsumedProperty.Name);
+            Assert.Equal("m_follows", bindings[1].ConsumedProperty.Name);
+        }
+
+        private class BlogWierdScience : Blog
+        {
+            public BlogWierdScience(string content, int follows)
+            {
+            }
+        }
+
+        [Fact]
+        public void Binds_to_context()
+        {
+            var constructorBinding = GetBinding<BlogWithContext>();
+
+            Assert.NotNull(constructorBinding);
+
+            var parameters = constructorBinding.Constructor.GetParameters();
+            var bindings = constructorBinding.ParameterBindings;
+
+            Assert.Equal(2, parameters.Length);
+            Assert.Equal(2, bindings.Count);
+
+            Assert.Equal("id", parameters[0].Name);
+            Assert.Equal("context", parameters[1].Name);
+
+            Assert.IsType<PropertyParameterBinding>(bindings[0]);
+            Assert.Equal("Id", bindings[0].ConsumedProperty.Name);
+
+            Assert.IsType<ContextParameterBinding>(bindings[1]);
+            Assert.Null(bindings[1].ConsumedProperty);
+            Assert.Same(typeof(DbContext), ((ContextParameterBinding)bindings[1]).ContextType);
+        }
+
+        private class BlogWithContext : Blog
+        {
+            public BlogWithContext(int id, DbContext context)
+            {
+            }
+        }
+
+        [Fact]
+        public void Binds_to_context_typed()
+        {
+            var constructorBinding = GetBinding<BlogWithTypedContext>();
+
+            Assert.NotNull(constructorBinding);
+
+            var parameters = constructorBinding.Constructor.GetParameters();
+            var bindings = constructorBinding.ParameterBindings;
+
+            Assert.Equal(1, parameters.Length);
+            Assert.Equal(1, bindings.Count);
+
+            Assert.Equal("context", parameters[0].Name);
+
+            Assert.IsType<ContextParameterBinding>(bindings[0]);
+            Assert.Null(bindings[0].ConsumedProperty);
+            Assert.Same(typeof(TypedContext), ((ContextParameterBinding)bindings[0]).ContextType);
+        }
+
+        private class BlogWithTypedContext : Blog
+        {
+            public BlogWithTypedContext(TypedContext context)
+            {
+            }
+        }
+
+        [Fact]
+        public void Binds_to_ILazyLoader()
+        {
+            var constructorBinding = GetBinding<BlogWithLazyLoader>();
+
+            Assert.NotNull(constructorBinding);
+
+            var parameters = constructorBinding.Constructor.GetParameters();
+            var bindings = constructorBinding.ParameterBindings;
+
+            Assert.Equal(1, parameters.Length);
+            Assert.Equal(1, bindings.Count);
+
+            Assert.Equal("loader", parameters[0].Name);
+
+            Assert.IsType<ServiceParameterBinding>(bindings[0]);
+            Assert.Null(bindings[0].ConsumedProperty);
+            Assert.Same(typeof(ILazyLoader), ((ServiceParameterBinding)bindings[0]).ServiceType);
+        }
+
+        private class BlogWithLazyLoader : Blog
+        {
+            public BlogWithLazyLoader(ILazyLoader loader)
+            {
+            }
+        }
+
+        [Fact]
+        public void Binds_to_delegate_parameter_called_lazyLoader()
+        {
+            var constructorBinding = GetBinding<BlogWithLazyLoaderMethod>();
+
+            Assert.NotNull(constructorBinding);
+
+            var parameters = constructorBinding.Constructor.GetParameters();
+            var bindings = constructorBinding.ParameterBindings;
+
+            Assert.Equal(1, parameters.Length);
+            Assert.Equal(1, bindings.Count);
+
+            Assert.Equal("lazyLoader", parameters[0].Name);
+
+            Assert.IsType<ServiceMethodParameterBinding>(bindings[0]);
+            Assert.Null(bindings[0].ConsumedProperty);
+            Assert.Same(typeof(ILazyLoader), ((ServiceMethodParameterBinding)bindings[0]).ServiceType);
+        }
+
+        private class BlogWithLazyLoaderMethod : Blog
+        {
+            public BlogWithLazyLoaderMethod(Action<object, string> lazyLoader)
+            {
+            }
+        }
+
+        [Fact]
+        public void Binds_to_IEntityType()
+        {
+            var constructorBinding = GetBinding<BlogWithEntityType>();
+
+            Assert.NotNull(constructorBinding);
+
+            var parameters = constructorBinding.Constructor.GetParameters();
+            var bindings = constructorBinding.ParameterBindings;
+
+            Assert.Equal(1, parameters.Length);
+            Assert.Equal(1, bindings.Count);
+
+            Assert.Equal("entityType", parameters[0].Name);
+
+            Assert.IsType<EntityTypeParameterBinding>(bindings[0]);
+            Assert.Null(bindings[0].ConsumedProperty);
+        }
+
+        private class BlogWithEntityType : Blog
+        {
+            public BlogWithEntityType(IEntityType entityType)
+            {
+            }
+        }
+
+        [Fact]
+        public void Does_not_bind_to_delegate_parameter_not_called_lazyLoader()
+        {
+            var constructorBinding = GetBinding<BlogWithOtherMethod>();
+
+            Assert.NotNull(constructorBinding);
+
+            var parameters = constructorBinding.Constructor.GetParameters();
+            var bindings = constructorBinding.ParameterBindings;
+
+            Assert.Equal(0, parameters.Length);
+            Assert.Equal(0, bindings.Count);
+        }
+
+        private class BlogWithOtherMethod : Blog
+        {
+            public BlogWithOtherMethod()
+            {
+            }
+
+            public BlogWithOtherMethod(Action<object, string> loader)
+            {
+            }
+        }
+
+        private class TypedContext : DbContext
+        {
+        }
+
+        [Fact]
+        public void Throws_if_no_usable_constructor()
+        {
+            Assert.Equal(
+                CoreStrings.ConstructorNotFound(nameof(BlogNone), "dummy', 'notTitle', 'did"),
+                Assert.Throws<InvalidOperationException>(() => GetBinding<BlogNone>()).Message);
+        }
+
+        private class BlogNone : Blog
+        {
+            public BlogNone(string title, int did)
+            {
+            }
+
+            public BlogNone(string notTitle, Guid? shadow, int id)
+            {
+            }
+
+            public BlogNone(string title, Guid? shadow, bool dummy, int id)
+            {
+            }
+        }
+
+        [Fact]
+        public void Throws_if_no_usable_constructor_due_to_bad_type()
+        {
+            Assert.Equal(
+                CoreStrings.ConstructorNotFound(nameof(BlogBadType), "shadow"),
+                Assert.Throws<InvalidOperationException>(() => GetBinding<BlogBadType>()).Message);
+        }
+
+        private class BlogBadType : Blog
+        {
+            public BlogBadType(Guid shadow, int id)
+            {
+            }
+        }
+
+        [Fact]
+        public void Throws_in_validation_if_field_not_found()
+        {
+            using (var context = new NoFieldContext())
+            {
+                Assert.Equal(
+                    CoreStrings.NoBackingFieldLazyLoading("NoFieldRelated", "NoField"),
+                    Assert.Throws<InvalidOperationException>(() => context.Model).Message);
+            }
+        }
+
+        private class NoFieldContext : DbContext
+        {
+            protected internal override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+                => optionsBuilder.UseInMemoryDatabase(Guid.NewGuid().ToString());
+
+            public DbSet<NoField> NoFields { get; }
+            public DbSet<NoFieldRelated> NoFieldRelateds { get; }
+        }
+
+        private class NoField
+        {
+            private readonly Action<object, string> _loader;
+            private ICollection<NoFieldRelated> _hidden_noFieldRelated;
+            public int Id { get; set; }
+
+            public NoField(Action<object, string> lazyLoader)
+            {
+                _loader = lazyLoader;
+            }
+
+            public ICollection<NoFieldRelated> NoFieldRelated
+            {
+                get => _loader.Load(this, ref _hidden_noFieldRelated);
+                set => _hidden_noFieldRelated = value;
+            }
+        }
+
+        private class NoFieldRelated
+        {
+            public int Id { get; set; }
+            public NoField NoField { get; set; }
+        }
+
+        private static DirectConstructorBinding GetBinding<TEntity>()
+        {
+            var convention = TestServiceFactory.Instance.Create<ConstructorBindingConvention>();
+
+            var entityType = new Model().AddEntityType(typeof(TEntity));
+            entityType.AddProperty(nameof(Blog.Id), typeof(int));
+            entityType.AddProperty(nameof(Blog.Title), typeof(string));
+            entityType.AddProperty(nameof(Blog._content), typeof(string));
+            entityType.AddProperty(nameof(Blog.m_follows), typeof(int));
+            entityType.AddProperty("Shadow", typeof(Guid?));
+            entityType.AddProperty("FooBaar1", typeof(string));
+            entityType.AddProperty("fooBaar2", typeof(string));
+            entityType.AddProperty("_fooBaar3", typeof(string));
+            entityType.AddProperty("m_fooBaar4", typeof(string));
+            entityType.AddProperty("_FooBaar5", typeof(string));
+            entityType.AddProperty("m_FooBaar6", typeof(string));
+
+            convention.Apply(entityType.Model.Builder);
+
+            return (DirectConstructorBinding)entityType[CoreAnnotationNames.ConstructorBinding];
+        }
+
+        private abstract class Blog
+        {
+#pragma warning disable 649
+            public string _content;
+
+            // ReSharper disable once InconsistentNaming
+            public int m_follows;
+#pragma warning restore 649
+
+            public int Id { get; set; }
+            public string Title { get; set; }
+        }
+    }
+}

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/EntityTypeAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/EntityTypeAttributeConventionTest.cs
@@ -42,9 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         public void NotMappedAttribute_ignores_entityTypes_with_conventional_builder()
         {
             var modelBuilder = new ModelBuilder(
-                new CoreConventionSetBuilder(
-                        new CoreConventionSetBuilderDependencies(
-                            TestServiceFactory.Instance.Create<CoreTypeMapper>()))
+                TestServiceFactory.Instance.Create<CoreConventionSetBuilder>()
                     .CreateConventionSet());
 
             modelBuilder.Entity<B>();

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/ForeignKeyIndexConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/ForeignKeyIndexConventionTest.cs
@@ -14,9 +14,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             var modelBuilder
                 = new ModelBuilder(
-                    new CoreConventionSetBuilder(
-                        new CoreConventionSetBuilderDependencies(
-                            TestServiceFactory.Instance.Create<CoreTypeMapper>())).CreateConventionSet());
+                    TestServiceFactory.Instance.Create<CoreConventionSetBuilder>()
+                        .CreateConventionSet());
 
             var principalTypeBuilder = modelBuilder.Entity<PrincipalEntity>();
             var dependentTypeBuilder = modelBuilder.Entity<DependentEntity>();

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/NavigationAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/NavigationAttributeConventionTest.cs
@@ -69,10 +69,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         [Fact]
         public void NotMappedAttribute_ignores_navigation_with_conventional_builder()
         {
-            var modelBuilder = new ModelBuilder(
-                new CoreConventionSetBuilder(
-                    new CoreConventionSetBuilderDependencies(CreateTypeMapper())).CreateConventionSet());
-
+            var modelBuilder = new ModelBuilder(TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
             var model = modelBuilder.Model;
             modelBuilder.Entity<BlogDetails>();
 
@@ -180,10 +177,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         [Fact]
         public void RequiredAttribute_sets_is_required_with_conventional_builder()
         {
-            var modelBuilder = new ModelBuilder(
-                new CoreConventionSetBuilder(
-                    new CoreConventionSetBuilderDependencies(CreateTypeMapper())).CreateConventionSet());
-
+            var modelBuilder = new ModelBuilder(TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
             var model = (Model)modelBuilder.Model;
             modelBuilder.Entity<BlogDetails>();
 
@@ -549,10 +543,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         [Fact]
         public void Navigation_attribute_convention_runs_for_private_property()
         {
-            var modelBuilder = new ModelBuilder(
-                new CoreConventionSetBuilder(
-                    new CoreConventionSetBuilderDependencies(CreateTypeMapper())).CreateConventionSet());
-
+            var modelBuilder = new ModelBuilder(TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
             var referenceBuilder = modelBuilder.Entity<BlogDetails>().HasOne(typeof(Post), "Post").WithOne();
 
             Assert.False(referenceBuilder.Metadata.Properties.First().IsNullable);

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyAttributeConventionTest.cs
@@ -49,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         [Fact]
         public void ConcurrencyCheckAttribute_sets_concurrency_token_with_conventional_builder()
         {
-            var modelBuilder = new ModelBuilder(new CoreConventionSetBuilder(new CoreConventionSetBuilderDependencies(CreateTypeMapper())).CreateConventionSet());
+            var modelBuilder = new ModelBuilder(TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
             var entityTypeBuilder = modelBuilder.Entity<A>();
 
             Assert.True(entityTypeBuilder.Property(e => e.RowVersion).Metadata.IsConcurrencyToken);
@@ -58,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         [Fact]
         public void ConcurrencyCheckAttribute_on_field_sets_concurrency_token_with_conventional_builder()
         {
-            var modelBuilder = new ModelBuilder(new CoreConventionSetBuilder(new CoreConventionSetBuilderDependencies(CreateTypeMapper())).CreateConventionSet());
+            var modelBuilder = new ModelBuilder(TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
             var entityTypeBuilder = modelBuilder.Entity<F>();
 
             Assert.True(entityTypeBuilder.Property<Guid>(nameof(F.RowVersion)).Metadata.IsConcurrencyToken);
@@ -99,7 +99,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         [Fact]
         public void DatabaseGeneratedAttribute_sets_store_generated_pattern_with_conventional_builder()
         {
-            var modelBuilder = new ModelBuilder(new CoreConventionSetBuilder(new CoreConventionSetBuilderDependencies(CreateTypeMapper())).CreateConventionSet());
+            var modelBuilder = new ModelBuilder(TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
             var entityTypeBuilder = modelBuilder.Entity<A>();
 
             Assert.Equal(ValueGenerated.OnAddOrUpdate, entityTypeBuilder.Property(e => e.Id).Metadata.ValueGenerated);
@@ -108,7 +108,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         [Fact]
         public void DatabaseGeneratedAttribute_in_field_sets_store_generated_pattern_with_conventional_builder()
         {
-            var modelBuilder = new ModelBuilder(new CoreConventionSetBuilder(new CoreConventionSetBuilderDependencies(CreateTypeMapper())).CreateConventionSet());
+            var modelBuilder = new ModelBuilder(TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
             var entityTypeBuilder = modelBuilder.Entity<F>();
 
             Assert.Equal(ValueGenerated.OnAddOrUpdate, entityTypeBuilder.Property<int>(nameof(F.Id)).Metadata.ValueGenerated);
@@ -229,7 +229,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         [Fact]
         public void KeyAttribute_on_field_sets_primary_key()
         {
-            var modelBuilder = new ModelBuilder(new CoreConventionSetBuilder(new CoreConventionSetBuilderDependencies(CreateTypeMapper())).CreateConventionSet());
+            var modelBuilder = new ModelBuilder(TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
             var entityTypeBuilder = modelBuilder.Entity<F>();
             entityTypeBuilder.Property<int>(nameof(F.MyPrimaryKey));
 
@@ -271,7 +271,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         [Fact]
         public void MaxLengthAttribute_sets_max_length_with_conventional_builder()
         {
-            var modelBuilder = new ModelBuilder(new CoreConventionSetBuilder(new CoreConventionSetBuilderDependencies(CreateTypeMapper())).CreateConventionSet());
+            var modelBuilder = new ModelBuilder(TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
             var entityTypeBuilder = modelBuilder.Entity<A>();
 
             Assert.Equal(10, entityTypeBuilder.Property(e => e.MaxLengthProperty).Metadata.GetMaxLength());
@@ -280,7 +280,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         [Fact]
         public void MaxLengthAttribute_on_field_sets_max_length_with_conventional_builder()
         {
-            var modelBuilder = new ModelBuilder(new CoreConventionSetBuilder(new CoreConventionSetBuilderDependencies(CreateTypeMapper())).CreateConventionSet());
+            var modelBuilder = new ModelBuilder(TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
             var entityTypeBuilder = modelBuilder.Entity<F>();
 
             Assert.Equal(10, entityTypeBuilder.Property<string>(nameof(F.MaxLengthProperty)).Metadata.GetMaxLength());
@@ -315,7 +315,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         [Fact]
         public void NotMappedAttribute_ignores_property_with_conventional_builder()
         {
-            var modelBuilder = new ModelBuilder(new CoreConventionSetBuilder(new CoreConventionSetBuilderDependencies(CreateTypeMapper())).CreateConventionSet());
+            var modelBuilder = new ModelBuilder(TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
             var entityTypeBuilder = modelBuilder.Entity<A>();
 
             Assert.False(entityTypeBuilder.Metadata.GetProperties().Any(p => p.Name == "IgnoredProperty"));
@@ -324,7 +324,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         [Fact]
         public void NotMappedAttribute_on_field_does_not_ignore_property_with_conventional_builder()
         {
-            var modelBuilder = new ModelBuilder(new CoreConventionSetBuilder(new CoreConventionSetBuilderDependencies(CreateTypeMapper())).CreateConventionSet());
+            var modelBuilder = new ModelBuilder(TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
             var entityTypeBuilder = modelBuilder.Entity<F>();
             entityTypeBuilder.Property<string>(nameof(F.IgnoredProperty));
 
@@ -378,7 +378,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         [Fact]
         public void RequiredAttribute_sets_is_nullable_with_conventional_builder()
         {
-            var modelBuilder = new ModelBuilder(new CoreConventionSetBuilder(new CoreConventionSetBuilderDependencies(CreateTypeMapper())).CreateConventionSet());
+            var modelBuilder = new ModelBuilder(TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
             var entityTypeBuilder = modelBuilder.Entity<A>();
 
             Assert.False(entityTypeBuilder.Property(e => e.Name).Metadata.IsNullable);
@@ -387,7 +387,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         [Fact]
         public void RequiredAttribute_on_field_sets_is_nullable_with_conventional_builder()
         {
-            var modelBuilder = new ModelBuilder(new CoreConventionSetBuilder(new CoreConventionSetBuilderDependencies(CreateTypeMapper())).CreateConventionSet());
+            var modelBuilder = new ModelBuilder(TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
             var entityTypeBuilder = modelBuilder.Entity<F>();
 
             Assert.False(entityTypeBuilder.Property<string>(nameof(F.Name)).Metadata.IsNullable);
@@ -428,7 +428,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         [Fact]
         public void StringLengthAttribute_sets_max_length_with_conventional_builder()
         {
-            var modelBuilder = new ModelBuilder(new CoreConventionSetBuilder(new CoreConventionSetBuilderDependencies(CreateTypeMapper())).CreateConventionSet());
+            var modelBuilder = new ModelBuilder(TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
             var entityTypeBuilder = modelBuilder.Entity<A>();
 
             Assert.Equal(20, entityTypeBuilder.Property(e => e.StringLengthProperty).Metadata.GetMaxLength());
@@ -437,7 +437,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         [Fact]
         public void StringLengthAttribute_on_field_sets_max_length_with_conventional_builder()
         {
-            var modelBuilder = new ModelBuilder(new CoreConventionSetBuilder(new CoreConventionSetBuilderDependencies(CreateTypeMapper())).CreateConventionSet());
+            var modelBuilder = new ModelBuilder(TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
             var entityTypeBuilder = modelBuilder.Entity<F>();
 
             Assert.Equal(20, entityTypeBuilder.Property<string>(nameof(F.StringLengthProperty)).Metadata.GetMaxLength());
@@ -482,7 +482,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         [Fact]
         public void TimestampAttribute_sets_concurrency_token_with_conventional_builder()
         {
-            var modelBuilder = new ModelBuilder(new CoreConventionSetBuilder(new CoreConventionSetBuilderDependencies(CreateTypeMapper())).CreateConventionSet());
+            var modelBuilder = new ModelBuilder(TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
             var entityTypeBuilder = modelBuilder.Entity<A>();
 
             Assert.Equal(ValueGenerated.OnAddOrUpdate, entityTypeBuilder.Property(e => e.Timestamp).Metadata.ValueGenerated);
@@ -492,7 +492,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         [Fact]
         public void TimestampAttribute_on_field_sets_concurrency_token_with_conventional_builder()
         {
-            var modelBuilder = new ModelBuilder(new CoreConventionSetBuilder(new CoreConventionSetBuilderDependencies(CreateTypeMapper())).CreateConventionSet());
+            var modelBuilder = new ModelBuilder(TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
             var entityTypeBuilder = modelBuilder.Entity<F>();
 
             Assert.Equal(ValueGenerated.OnAddOrUpdate, entityTypeBuilder.Property<byte[]>(nameof(F.Timestamp)).Metadata.ValueGenerated);
@@ -504,7 +504,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         [Fact]
         public void Property_attribute_convention_runs_for_private_property()
         {
-            var modelBuilder = new ModelBuilder(new CoreConventionSetBuilder(new CoreConventionSetBuilderDependencies(CreateTypeMapper())).CreateConventionSet());
+            var modelBuilder = new ModelBuilder(TestServiceFactory.Instance.Create<CoreConventionSetBuilder>().CreateConventionSet());
             var propertyBuilder = modelBuilder.Entity<A>().Property<int?>("PrivateProperty");
 
             Assert.False(propertyBuilder.Metadata.IsNullable);

--- a/test/EFCore.Tests/ModelSourceTest.cs
+++ b/test/EFCore.Tests/ModelSourceTest.cs
@@ -8,7 +8,6 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
-using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -106,13 +105,9 @@ namespace Microsoft.EntityFrameworkCore
             public ConcreteModelSource(IDbSetFinder setFinder)
                 : base(
                     new ModelSourceDependencies(
-                        new CoreConventionSetBuilder(
-                            new CoreConventionSetBuilderDependencies(
-                                TestServiceFactory.Instance.Create<CoreTypeMapper>())),
-                        new ModelCustomizer(
-                            new ModelCustomizerDependencies(setFinder)),
-                        new ModelCacheKeyFactory(
-                            new ModelCacheKeyFactoryDependencies())))
+                        TestServiceFactory.Instance.Create<CoreConventionSetBuilder>(),
+                        new ModelCustomizer(new ModelCustomizerDependencies(setFinder)),
+                        new ModelCacheKeyFactory(new ModelCacheKeyFactoryDependencies())))
             {
             }
         }


### PR DESCRIPTION
Parts of issues #3342, #240, #10509, #3797

The main things here are:
- Support for injecting values into parameterized entity constructors
  - Property values are injected if the parameter type and name matches
  - The current DbContext as DbContext or a derived DbContext type
  - A service from the internal or external service provider
  - A delegate to a method of a service
- Use of the above to inject lazy loading capabilities into entities

For lazy loading, either the ILazyLoader service can be injected directly, or a delegate can be injected if the entity class cannot take a dependency on the EF assembly--see the examples below.

Currently all constructor injection is done by convention.

Remaining work includes:
- API/attributes to configure the constructor binding
- Allow factory to be used instead of using the constructor directly. (Functional already, but no API or convention to configure it.)
- Allow property injection for services
- Configuration of which entities/properties should be lazy loaded and which should not

### Examples

In this example EF will use the private constructor passing in values from the database when creating entity instances. (Note that it is assumed that _blogId has been configured as the key.)

```C#
public class Blog
{
    private int _blogId;

    // This constructor used by EF Core
    private Blog(
        int blogId,
        string title,
        int? monthlyRevenue)
    {
        _blogId = blogId;
        Title = title;
        MonthlyRevenue = monthlyRevenue;
    }

    public Blog(
        string title,
        int? monthlyRevenue = null)
        : this(0, title, monthlyRevenue)
    {
    }

    public string Title { get; }
    public int? MonthlyRevenue { get; set; }
}
```

In this example, EF will inject the ILazyLoader instance, which is then used to enable lazy-loading on navigation properties. Note that the navigation properties must have backing fields and all access by EF will go through the backing fields to prevent EF triggering lazy loading itself.

```C#
public class LazyBlog
{
    private readonly ILazyLoader _loader;
    private ICollection<LazyPost> _lazyPosts = new List<LazyPost>();

    public LazyBlog()
    {
    }

    private LazyBlog(ILazyLoader loader)
    {
        _loader = loader;
    }

    public int Id { get; set; }

    public ICollection<LazyPost> LazyPosts
        => _loader.Load(this, ref _lazyPosts);
}

public class LazyPost
{
    private readonly ILazyLoader _loader;
    private LazyBlog _lazyBlog;

    public LazyPost()
    {
    }

    private LazyPost(ILazyLoader loader)
    {
        _loader = loader;
    }

    public int Id { get; set; }

    public LazyBlog LazyBlog
    {
        get => _loader.Load(this, ref _lazyBlog);
        set => _lazyBlog = value;
    }
}
```

This example is the same as the last example, except EF is matching the delegate type and parameter name and injecting a delegate for the ILazyLoader.Load method so that the entity class does not need to reference the EF assembly. A small extension method can be included in the entity assembly to make it a bit easier to use the delegate.

```C#
public class LazyPocoBlog
{
    private readonly Action<object, string> _loader;
    private ICollection<LazyPocoPost> _lazyPocoPosts = new List<LazyPocoPost>();

    public LazyPocoBlog()
    {
    }

    private LazyPocoBlog(Action<object, string> lazyLoader)
    {
        _loader = lazyLoader;
    }

    public int Id { get; set; }

    public ICollection<LazyPocoPost> LazyPocoPosts
        => _loader.Load(this, ref _lazyPocoPosts);
}

public class LazyPocoPost
{
    private readonly Action<object, string> _loader;
    private LazyPocoBlog _lazyPocoBlog;

    public LazyPocoPost()
    {
    }

    private LazyPocoPost(Action<object, string> lazyLoader)
    {
        _loader = lazyLoader;
    }

    public int Id { get; set; }

    public LazyPocoBlog LazyPocoBlog
    {
        get => _loader.Load(this, ref _lazyPocoBlog);
        set => _lazyPocoBlog = value;
    }
}

public static class TestPocoLoadingExtensions
{
    public static TRelated Load<TRelated>(
        this Action<object, string> loader,
        object entity,
        ref TRelated navigationField,
        [CallerMemberName] string navigationName = null)
        where TRelated : class
    {
        loader?.Invoke(entity, navigationName);

        return navigationField;
    }
}
```
