### PR TITLE
Fix some compat issues running 2.1 EF with 2.0 provider

### DIFF
--- a/samples/OracleProvider/src/OracleProvider/Extensions/OracleServiceCollectionExtensions.cs
+++ b/samples/OracleProvider/src/OracleProvider/Extensions/OracleServiceCollectionExtensions.cs
@@ -75,6 +75,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAdd<IModelValidator, OracleModelValidator>()
                 .TryAdd<IConventionSetBuilder, OracleConventionSetBuilder>()
                 .TryAdd<IUpdateSqlGenerator, OracleUpdateSqlGenerator>()
+                .TryAdd<ISingletonUpdateSqlGenerator, OracleUpdateSqlGenerator>()
                 .TryAdd<IModificationCommandBatchFactory, OracleModificationCommandBatchFactory>()
                 .TryAdd<IValueGeneratorSelector, OracleValueGeneratorSelector>()
                 .TryAdd<IRelationalConnection>(p => p.GetService<IOracleConnection>())

--- a/src/EFCore.InMemory/Extensions/InMemoryServiceCollectionExtensions.cs
+++ b/src/EFCore.InMemory/Extensions/InMemoryServiceCollectionExtensions.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Extensions.DependencyInjection
                         .TryAddSingleton<IInMemoryStoreCache, InMemoryStoreCache>()
                         .TryAddSingleton<IInMemoryTableFactory, InMemoryTableFactory>()
                         .TryAddScoped<IInMemoryDatabase, InMemoryDatabase>()
-                        .TryAddScoped<IMaterializerFactory, MaterializerFactory>());
+                        .TryAddScoped<IInMemoryMaterializerFactory, InMemoryMaterializerFactory>());
 
             builder.TryAddCoreServices();
 

--- a/src/EFCore.InMemory/Query/ExpressionVisitors/Internal/InMemoryEntityQueryableExpressionVisitor.cs
+++ b/src/EFCore.InMemory/Query/ExpressionVisitors/Internal/InMemoryEntityQueryableExpressionVisitor.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
     public class InMemoryEntityQueryableExpressionVisitor : EntityQueryableExpressionVisitor
     {
         private readonly IModel _model;
-        private readonly IMaterializerFactory _materializerFactory;
+        private readonly IInMemoryMaterializerFactory _materializerFactory;
         private readonly IQuerySource _querySource;
 
         /// <summary>
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         /// </summary>
         public InMemoryEntityQueryableExpressionVisitor(
             [NotNull] IModel model,
-            [NotNull] IMaterializerFactory materializerFactory,
+            [NotNull] IInMemoryMaterializerFactory materializerFactory,
             [NotNull] EntityQueryModelVisitor entityQueryModelVisitor,
             [CanBeNull] IQuerySource querySource)
             : base(Check.NotNull(entityQueryModelVisitor, nameof(entityQueryModelVisitor)))

--- a/src/EFCore.InMemory/Query/ExpressionVisitors/Internal/InMemoryEntityQueryableExpressionVisitorFactory.cs
+++ b/src/EFCore.InMemory/Query/ExpressionVisitors/Internal/InMemoryEntityQueryableExpressionVisitorFactory.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
     public class InMemoryEntityQueryableExpressionVisitorFactory : IEntityQueryableExpressionVisitorFactory
     {
         private readonly IModel _model;
-        private readonly IMaterializerFactory _materializerFactory;
+        private readonly IInMemoryMaterializerFactory _materializerFactory;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         /// </summary>
         public InMemoryEntityQueryableExpressionVisitorFactory(
             [NotNull] IModel model,
-            [NotNull] IMaterializerFactory materializerFactory)
+            [NotNull] IInMemoryMaterializerFactory materializerFactory)
         {
             Check.NotNull(model, nameof(model));
             Check.NotNull(materializerFactory, nameof(materializerFactory));

--- a/src/EFCore.InMemory/Query/Internal/IInMemoryMaterializerFactory.cs
+++ b/src/EFCore.InMemory/Query/Internal/IInMemoryMaterializerFactory.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IMaterializerFactory
+    public interface IInMemoryMaterializerFactory
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.InMemory/Query/Internal/InMemoryMaterializerFactory.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryMaterializerFactory.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class MaterializerFactory : IMaterializerFactory
+    public class InMemoryMaterializerFactory : IInMemoryMaterializerFactory
     {
         private readonly IEntityMaterializerSource _entityMaterializerSource;
 
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public MaterializerFactory([NotNull] IEntityMaterializerSource entityMaterializerSource)
+        public InMemoryMaterializerFactory([NotNull] IEntityMaterializerSource entityMaterializerSource)
         {
             Check.NotNull(entityMaterializerSource, nameof(entityMaterializerSource));
 

--- a/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
@@ -73,7 +73,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(ISelectExpressionFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IExpressionFragmentTranslator), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(ISqlTranslatingExpressionVisitorFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
-                { typeof(IUpdateSqlGenerator), new ServiceCharacteristics(ServiceLifetime.Singleton) },
+                { typeof(IUpdateSqlGenerator), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+                { typeof(ISingletonUpdateSqlGenerator), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IMemberTranslator), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(ICompositeMethodCallTranslator), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IQuerySqlGeneratorFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
@@ -163,6 +164,14 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<INamedConnectionStringResolver, NamedConnectionStringResolver>();
             TryAdd<IEvaluatableExpressionFilter, RelationalEvaluatableExpressionFilter>();
             TryAdd<IRelationalTransactionFactory, RelationalTransactionFactory>();
+
+            TryAdd<ISingletonUpdateSqlGenerator>(p =>
+            {
+                using (var scope = p.CreateScope())
+                {
+                    return scope.ServiceProvider.GetService<IUpdateSqlGenerator>();
+                }
+            });
 
             ServiceCollectionMap.GetInfrastructure()
                 .AddDependencySingleton<RelationalCompositeMemberTranslatorDependencies>()

--- a/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
+++ b/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
@@ -14,6 +14,7 @@ using Microsoft.EntityFrameworkCore.Migrations.Operations;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 using System.Text;
+using Microsoft.EntityFrameworkCore.Update;
 
 namespace Microsoft.EntityFrameworkCore.Migrations
 {
@@ -78,6 +79,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         ///     Parameter object containing dependencies for this service.
         /// </summary>
         protected virtual MigrationsSqlGeneratorDependencies Dependencies { get; }
+
+        /// <summary>
+        ///     The <see cref="IUpdateSqlGenerator"/>.
+        /// </summary>
+        protected virtual IUpdateSqlGenerator SqlGenerator
+            => (IUpdateSqlGenerator)Dependencies.UpdateSqlGenerator;
 
         /// <summary>
         ///     Generates commands from a list of operations.
@@ -1004,7 +1011,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             var sqlBuilder = new StringBuilder();
             foreach (var modificationCommand in operation.GenerateModificationCommands())
             {
-                Dependencies.UpdateSqlGenerator.AppendInsertOperation(
+                SqlGenerator.AppendInsertOperation(
                     sqlBuilder,
                     modificationCommand,
                     0);
@@ -1036,7 +1043,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             var sqlBuilder = new StringBuilder();
             foreach (var modificationCommand in operation.GenerateModificationCommands())
             {
-                Dependencies.UpdateSqlGenerator.AppendDeleteOperation(
+                SqlGenerator.AppendDeleteOperation(
                     sqlBuilder,
                     modificationCommand,
                     0);
@@ -1064,7 +1071,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             var sqlBuilder = new StringBuilder();
             foreach (var modificationCommand in operation.GenerateModificationCommands())
             {
-                Dependencies.UpdateSqlGenerator.AppendUpdateOperation(
+                SqlGenerator.AppendUpdateOperation(
                     sqlBuilder,
                     modificationCommand,
                     0);

--- a/src/EFCore.Relational/Migrations/MigrationsSqlGeneratorDependencies.cs
+++ b/src/EFCore.Relational/Migrations/MigrationsSqlGeneratorDependencies.cs
@@ -3,7 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
-using Microsoft.EntityFrameworkCore.Update;
+using Microsoft.EntityFrameworkCore.Update.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Migrations
@@ -50,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// <param name="typeMapper"> The type mapper being used. </param>
         public MigrationsSqlGeneratorDependencies(
             [NotNull] IRelationalCommandBuilderFactory commandBuilderFactory,
-            [NotNull] IUpdateSqlGenerator updateSqlGenerator,
+            [NotNull] ISingletonUpdateSqlGenerator updateSqlGenerator,
             [NotNull] ISqlGenerationHelper sqlGenerationHelper,
             [NotNull] IRelationalTypeMapper typeMapper)
         {
@@ -73,7 +73,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// <summary>
         ///     High level SQL generator.
         /// </summary>
-        public IUpdateSqlGenerator UpdateSqlGenerator { get; }
+        public ISingletonUpdateSqlGenerator UpdateSqlGenerator { get; }
 
         /// <summary>
         ///     Helpers for SQL generation.
@@ -102,7 +102,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         /// </summary>
         /// <param name="updateSqlGenerator"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
-        public MigrationsSqlGeneratorDependencies With([NotNull] IUpdateSqlGenerator updateSqlGenerator)
+        public MigrationsSqlGeneratorDependencies With([NotNull] ISingletonUpdateSqlGenerator updateSqlGenerator)
             => new MigrationsSqlGeneratorDependencies(
                 CommandBuilderFactory,
                 updateSqlGenerator,

--- a/src/EFCore.Relational/Storage/TypedRelationalValueBufferFactoryFactory.cs
+++ b/src/EFCore.Relational/Storage/TypedRelationalValueBufferFactoryFactory.cs
@@ -138,14 +138,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         private Expression CreateGetValueExpression(
-            Expression dataReaderExpression, 
+            Expression dataReaderExpression,
             Expression indexExpression,
             TypeMaterializationInfo materializationInfo)
         {
-            var storeType = materializationInfo.StoreType;
-            var underlyingStoreType = storeType.UnwrapNullableType().UnwrapEnumType();
-
-            var getMethod = Dependencies.TypeMapper.GetDataReaderMethod(underlyingStoreType);
+            var getMethod = Dependencies.TypeMapper.GetDataReaderMethod(materializationInfo.StoreType);
 
             Expression expression
                 = Expression.Call(
@@ -160,9 +157,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
             if (converter != null)
             {
                 expression = ReplacingExpressionVisitor.Replace(
-                        converter.ConvertFromStoreExpression.Parameters.Single(),
-                        expression,
-                        converter.ConvertFromStoreExpression.Body);
+                    converter.ConvertFromStoreExpression.Parameters.Single(),
+                    expression,
+                    converter.ConvertFromStoreExpression.Body);
             }
 
             if (expression.Type != materializationInfo.ModelType)
@@ -195,14 +192,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 expression = Expression.Convert(expression, typeof(object));
             }
 
-            if (expression.Type.IsNullableType())
-            {
-                expression
-                    = Expression.Condition(
-                        Expression.Call(dataReaderExpression, _isDbNullMethod, indexExpression),
-                        Expression.Default(expression.Type),
-                        expression);
-            }
+            expression
+                = Expression.Condition(
+                    Expression.Call(dataReaderExpression, _isDbNullMethod, indexExpression),
+                    Expression.Default(expression.Type),
+                    expression);
 
             return expression;
         }

--- a/src/EFCore.Relational/Update/IUpdateSqlGenerator.cs
+++ b/src/EFCore.Relational/Update/IUpdateSqlGenerator.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Update.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Update
 {
@@ -15,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Update
     ///         This type is typically used by database providers; it is generally not used in application code.
     ///     </para>
     /// </summary>
-    public interface IUpdateSqlGenerator
+    public interface IUpdateSqlGenerator : ISingletonUpdateSqlGenerator
     {
         /// <summary>
         ///     Generates SQL that will obtain the next value in the given sequence.

--- a/src/EFCore.Relational/Update/Internal/ISingletonUpdateSqlGenerator.cs
+++ b/src/EFCore.Relational/Update/Internal/ISingletonUpdateSqlGenerator.cs
@@ -1,0 +1,13 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Update.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public interface ISingletonUpdateSqlGenerator
+    {
+    }
+}

--- a/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerServiceCollectionExtensions.cs
@@ -76,6 +76,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAdd<IModelValidator, SqlServerModelValidator>()
                 .TryAdd<IConventionSetBuilder, SqlServerConventionSetBuilder>()
                 .TryAdd<IUpdateSqlGenerator>(p => p.GetService<ISqlServerUpdateSqlGenerator>())
+                .TryAdd<ISingletonUpdateSqlGenerator>(p => p.GetService<ISqlServerUpdateSqlGenerator>())
                 .TryAdd<IModificationCommandBatchFactory, SqlServerModificationCommandBatchFactory>()
                 .TryAdd<IValueGeneratorSelector, SqlServerValueGeneratorSelector>()
                 .TryAdd<IRelationalConnection>(p => p.GetService<ISqlServerConnection>())

--- a/src/EFCore.Sqlite.Core/Infrastructure/SqliteServiceCollectionExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Infrastructure/SqliteServiceCollectionExtensions.cs
@@ -70,6 +70,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAdd<IModelValidator, SqliteModelValidator>()
                 .TryAdd<IConventionSetBuilder, SqliteConventionSetBuilder>()
                 .TryAdd<IUpdateSqlGenerator, SqliteUpdateSqlGenerator>()
+                .TryAdd<ISingletonUpdateSqlGenerator, SqliteUpdateSqlGenerator>()
                 .TryAdd<IModificationCommandBatchFactory, SqliteModificationCommandBatchFactory>()
                 .TryAdd<IRelationalConnection>(p => p.GetService<ISqliteRelationalConnection>())
                 .TryAdd<IMigrationsSqlGenerator, SqliteMigrationsSqlGenerator>()

--- a/src/EFCore/Infrastructure/AccessorExtensions.cs
+++ b/src/EFCore/Infrastructure/AccessorExtensions.cs
@@ -2,11 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.Infrastructure
 {
@@ -43,25 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <param name="accessor"> The object exposing the service provider. </param>
         /// <returns> The requested service. </returns>
         public static TService GetService<TService>([NotNull] this IInfrastructure<IServiceProvider> accessor)
-        {
-            Check.NotNull(accessor, nameof(accessor));
-
-            var internalServiceProvider = accessor.Instance;
-
-            var service = internalServiceProvider.GetService(typeof(TService))
-                          ?? internalServiceProvider.GetService<IDbContextOptions>()
-                              ?.Extensions.OfType<CoreOptionsExtension>().FirstOrDefault()
-                              ?.ApplicationServiceProvider
-                              ?.GetService(typeof(TService));
-
-            if (service == null)
-            {
-                throw new InvalidOperationException(
-                    CoreStrings.NoProviderConfiguredFailedToResolveService(typeof(TService).DisplayName()));
-            }
-
-            return (TService)service;
-        }
+            => (TService)InternalAccessorExtensions.GetService<TService>(Check.NotNull(accessor, nameof(accessor)));
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/Internal/InternalAccessorExtensions.cs
+++ b/src/EFCore/Internal/InternalAccessorExtensions.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public static class InternalAccessorExtensions
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static TService GetService<TService>([CanBeNull] IInfrastructure<IServiceProvider> accessor)
+        {
+            object service = null;
+
+            if (accessor != null)
+            {
+                var internalServiceProvider = accessor.Instance;
+
+                service = internalServiceProvider.GetService(typeof(TService))
+                          ?? internalServiceProvider.GetService<IDbContextOptions>()
+                              ?.Extensions.OfType<CoreOptionsExtension>().FirstOrDefault()
+                              ?.ApplicationServiceProvider
+                              ?.GetService(typeof(TService));
+
+                if (service == null)
+                {
+                    throw new InvalidOperationException(
+                        CoreStrings.NoProviderConfiguredFailedToResolveService(typeof(TService).DisplayName()));
+                }
+            }
+
+            return (TService)service;
+        }
+    }
+}

--- a/src/EFCore/Metadata/Internal/EntityMaterializerSource.cs
+++ b/src/EFCore/Metadata/Internal/EntityMaterializerSource.cs
@@ -117,6 +117,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        [Obsolete("Use CreateMaterializeExpression taking a contextExpression.")]
+        public virtual Expression CreateMaterializeExpression(
+            IEntityType entityType,
+            Expression valueBufferExpression,
+            int[] indexMap = null) =>
+            CreateMaterializeExpression(
+                entityType,
+                valueBufferExpression,
+                Expression.Constant(null, typeof(DbContext)),
+                indexMap);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual Expression CreateMaterializeExpression(
             IEntityType entityType,
             Expression valueBufferExpression,

--- a/src/EFCore/Metadata/Internal/IEntityMaterializerSource.cs
+++ b/src/EFCore/Metadata/Internal/IEntityMaterializerSource.cs
@@ -45,6 +45,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        [Obsolete("Use CreateMaterializeExpression taking a contextExpression.")]
+        Expression CreateMaterializeExpression(
+            [NotNull] IEntityType entityType,
+            [NotNull] Expression valueBufferExpression,
+            [CanBeNull] int[] indexMap = null);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         Func<ValueBuffer, DbContext, object> GetMaterializer([NotNull] IEntityType entityType);
     }
 }

--- a/src/EFCore/Metadata/Internal/ServiceParameterBinding.cs
+++ b/src/EFCore/Metadata/Internal/ServiceParameterBinding.cs
@@ -6,6 +6,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
@@ -16,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     public class ServiceParameterBinding : ParameterBinding
     {
         private static readonly MethodInfo _getServiceMethod
-            = typeof(AccessorExtensions).GetMethod(nameof(AccessorExtensions.GetService));
+            = typeof(InternalAccessorExtensions).GetMethod(nameof(InternalAccessorExtensions.GetService));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/test/EFCore.InMemory.FunctionalTests/Query/WarningsTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/WarningsTest.cs
@@ -130,6 +130,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
+#if !Test20 // Uses lazy-loading (doesn't work with 2.0 in-memory provider)
         [Fact]
         public void Throws_by_default_for_lazy_load_with_disposed_context()
         {
@@ -217,6 +218,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     messages);
             }
         }
+#endif
 
         [Fact]
         public void No_throw_when_event_id_not_registered()

--- a/test/EFCore.SqlServer.FunctionalTests/ConvertToStoreTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ConvertToStoreTypesSqlServerTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if !Test20
 using System;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -169,3 +170,4 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
         }
     }
 }
+#endif

--- a/test/EFCore.SqlServer.FunctionalTests/CustomConvertersSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/CustomConvertersSqlServerTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if !Test20
 using System;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -169,3 +170,4 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
         }
     }
 }
+#endif

--- a/test/EFCore.SqlServer.FunctionalTests/EverythingIsBytesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/EverythingIsBytesSqlServerTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if !Test20
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -254,3 +255,4 @@ UnicodeDataTypes.StringUnicode ---> [nullable varbinary] [MaxLength = -1]
         }
     }
 }
+#endif

--- a/test/EFCore.SqlServer.FunctionalTests/EverythingIsStringsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/EverythingIsStringsSqlServerTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if !Test20
 using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -278,3 +279,4 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
         }
     }
 }
+#endif


### PR DESCRIPTION
Addresses #10545 plus some more newer breaks

* Added a workaround for IUpdateSqlGenerator scope change to singleton
* Added back internal method on IEntityMaterializerSource that in-memory provider is calling directly and renamed classes to avoid future confusion (I have some other changes coming to help mitigate this in the future.)
* Made constructor injection of services behave better if context is not injected (only a problem for in-memory, due to above internal call issue)
* Disabled some tests that can only work with a provider that supports type conversions
