### PR TITLE
Change to handling value conversion annotations in code generation and more tests

### DIFF
--- a/src/EFCore/Storage/Converters/ConverterMappingHints.cs
+++ b/src/EFCore/Storage/Converters/ConverterMappingHints.cs
@@ -68,6 +68,17 @@ namespace Microsoft.EntityFrameworkCore.Storage.Converters
         }
 
         /// <summary>
+        ///     Returns <c>true</c> if all properties are <c>null</c>.
+        /// </summary>
+        public bool IsEmpty
+            => Size == null
+               && Precision == null
+               && Scale == null
+               && IsUnicode == null
+               && IsFixedLength == null
+               && SizeFunction == null;
+
+        /// <summary>
         ///     The suggested size of the mapped data type.
         /// </summary>
         public int? Size { get; }

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -42,6 +42,117 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         }
 
         [Fact]
+        public void Model_differ_detects_adding_store_type()
+        {
+            Execute(
+                _ => { },
+                modelBuilder =>
+                {
+                    modelBuilder.Entity(
+                        "Cat",
+                        x => { x.Property<short>("Id"); });
+                },
+                modelBuilder =>
+                {
+                    modelBuilder.Entity(
+                        "Cat",
+                        x => { x.Property<short>("Id").HasConversion<int>(); });
+                },
+                upOps => Assert.Collection(
+                    upOps,
+                    o =>
+                    {
+                        var m = Assert.IsType<AlterColumnOperation>(o);
+                        Assert.Equal("Id", m.Name);
+                        Assert.Equal("Cat", m.Table);
+                        Assert.Same(typeof(int), m.ClrType);
+                    }),
+                downOps => Assert.Collection(
+                    downOps,
+                    o =>
+                    {
+                        var m = Assert.IsType<AlterColumnOperation>(o);
+                        Assert.Equal("Id", m.Name);
+                        Assert.Equal("Cat", m.Table);
+                        Assert.Same(typeof(short), m.ClrType);
+                    }));
+        }
+
+        [Fact]
+        public void Model_differ_detects_adding_value_converter()
+        {
+            Execute(
+                _ => { },
+                modelBuilder =>
+                {
+                    modelBuilder.Entity(
+                        "Cat",
+                        x => { x.Property<short>("Id"); });
+                },
+                modelBuilder =>
+                {
+                    modelBuilder.Entity(
+                        "Cat",
+                        x => { x.Property<short>("Id").HasConversion(v => (long)v, v => (short)v); });
+                },
+                upOps => Assert.Collection(
+                    upOps,
+                    o =>
+                    {
+                        var m = Assert.IsType<AlterColumnOperation>(o);
+                        Assert.Equal("Id", m.Name);
+                        Assert.Equal("Cat", m.Table);
+                        Assert.Same(typeof(long), m.ClrType);
+                    }),
+                downOps => Assert.Collection(
+                    downOps,
+                    o =>
+                    {
+                        var m = Assert.IsType<AlterColumnOperation>(o);
+                        Assert.Equal("Id", m.Name);
+                        Assert.Equal("Cat", m.Table);
+                        Assert.Same(typeof(short), m.ClrType);
+                    }));
+        }
+
+        [Fact]
+        public void Model_differ_detects_changing_store_type_to_conversions()
+        {
+            Execute(
+                _ => { },
+                modelBuilder =>
+                {
+                    modelBuilder.Entity(
+                        "Cat",
+                        x => { x.Property<short>("Id").HasConversion<int>(); });
+                },
+                modelBuilder =>
+                {
+                    modelBuilder.Entity(
+                        "Cat",
+                        x => { x.Property<short>("Id").HasConversion(v => (long)v, v => (short)v); });
+                },
+                upOps => Assert.Collection(
+                    upOps,
+                    o =>
+                    {
+                        var m = Assert.IsType<AlterColumnOperation>(o);
+                        Assert.Equal("Id", m.Name);
+                        Assert.Equal("Cat", m.Table);
+                        Assert.Same(typeof(long), m.ClrType);
+                    }),
+                downOps => Assert.Collection(
+                    downOps,
+                    o =>
+                    {
+                        var m = Assert.IsType<AlterColumnOperation>(o);
+                        Assert.Equal("Id", m.Name);
+                        Assert.Equal("Cat", m.Table);
+                        Assert.Same(typeof(int), m.ClrType);
+                    }));
+        }
+
+        [Fact]
         public void Model_differ_breaks_foreign_key_cycles_in_create_table_operations()
         {
             Execute(

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
@@ -141,7 +141,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                 = new Dictionary<Type, RelationalTypeMapping>
                 {
                     { typeof(int), new IntTypeMapping("int") },
-                    { typeof(bool), new BoolTypeMapping("boolean") }
+                    { typeof(short), new ShortTypeMapping("smallint") },
+                    { typeof(long), new ShortTypeMapping("bigint") },
+                    { typeof(bool), new BoolTypeMapping("boolean") },
+                    { typeof(DateTime), new DateTimeTypeMapping("datetime2") }
                 };
 
             private readonly IReadOnlyDictionary<string, IList<RelationalTypeMapping>> _simpleNameMappings


### PR DESCRIPTION
Issue #10638

Change to serialize an actual, but non-functional, ValueConverter so that the type mapper works the same on the snapshot model as it does on the original model.
