### PR TITLE
Small conventions optimization

### DIFF
--- a/src/EFCore/Metadata/Conventions/Internal/ConventionVisitor.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionVisitor.cs
@@ -13,6 +13,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             public virtual ConventionScope VisitConventionScope(ConventionScope node)
             {
+                if (node.Children == null)
+                {
+                    return null;
+                }
+
                 List<ConventionNode> visitedNodes = null;
                 foreach (var conventionNode in node.Children)
                 {

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -830,7 +830,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
 
-            if (!this.IsQueryType)
+            if (!IsQueryType)
             {
                 if (principalKey.ReferencingForeignKeys == null)
                 {


### PR DESCRIPTION
Reuse last `ConventionNode` when empty
Make read-only check debug-only

