### PR TITLE
Tools: Work around more class library limitations

### DIFF
--- a/NuGetPackageVerifier.json
+++ b/NuGetPackageVerifier.json
@@ -4,6 +4,13 @@
             "AdxVerificationCompositeRule"
         ],
         "packages": {
+            "Microsoft.EntityFrameworkCore.Design": {
+                "Exclusions": {
+                    "BUILD_ITEMS_FRAMEWORK": {
+                        "*": "False negative. aspnet/BuildTools#554"
+                    }
+                }
+            },
             "Microsoft.EntityFrameworkCore.Tools.DotNet": {
                 "packageTypes": [
                     "DotnetCliTool"

--- a/src/EFCore.Design/EFCore.Design.csproj
+++ b/src/EFCore.Design/EFCore.Design.csproj
@@ -14,6 +14,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="build\**\*">
+      <Pack>True</Pack>
+      <PackagePath>build</PackagePath>
+    </None>
+  </ItemGroup>
+  
+  <ItemGroup>
     <ProjectReference Include="..\EFCore.Relational\EFCore.Relational.csproj" />
   </ItemGroup>
 

--- a/src/EFCore.Design/build/net461/Microsoft.EntityFrameworkCore.Design.props
+++ b/src/EFCore.Design/build/net461/Microsoft.EntityFrameworkCore.Design.props
@@ -1,0 +1,6 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>True</GenerateBindingRedirectsOutputType>
+  </PropertyGroup>
+</Project>

--- a/src/EFCore.Design/build/netcoreapp2.0/Microsoft.EntityFrameworkCore.Design.props
+++ b/src/EFCore.Design/build/netcoreapp2.0/Microsoft.EntityFrameworkCore.Design.props
@@ -1,0 +1,5 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <GenerateRuntimeConfigurationFiles>True</GenerateRuntimeConfigurationFiles>
+  </PropertyGroup>
+</Project>

--- a/src/EFCore.Tools/EFCore.Tools.nuspec
+++ b/src/EFCore.Tools/EFCore.Tools.nuspec
@@ -13,7 +13,7 @@
     <repository type="git" url="https://github.com/aspnet/EntityFramework.Tools.git" />
     <dependencies>
       <group targetFramework=".NETStandard2.0">
-        <dependency id="Microsoft.EntityFrameworkCore.Design" version="$version$" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.EntityFrameworkCore.Design" version="$version$" exclude="Analyzers" />
       </group>
     </dependencies>
     <licenseUrl>https://raw.githubusercontent.com/aspnet/Home/2.0.0/LICENSE.txt</licenseUrl>

--- a/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
+++ b/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
@@ -761,8 +761,7 @@ function EF($project, $startupProject, $params, [switch] $skipBuild)
     }
 
     $startupProjectDir = GetProperty $startupProject.Properties 'FullPath'
-    $activeConfiguration = $startupProject.ConfigurationManager.ActiveConfiguration
-    $outputPath = GetProperty $activeConfiguration.Properties 'OutputPath'
+    $outputPath = GetProperty $startupProject.ConfigurationManager.ActiveConfiguration.Properties 'OutputPath'
     $targetDir = Join-Path $startupProjectDir $outputPath -Resolve | Convert-Path
     $startupTargetFileName = GetOutputFileName $startupProject
     $startupTargetPath = Join-Path $targetDir $startupTargetFileName
@@ -808,15 +807,6 @@ function EF($project, $startupProject, $params, [switch] $skipBuild)
             $projectAssets.packageFolders.psobject.Properties.Name | %{
                 $dotnetParams += '--additionalprobingpath', $_.TrimEnd('\')
             }
-        }
-
-        if (!(Test-Path $runtimeConfig))
-        {
-            $configuration = $activeConfiguration.ConfigurationName
-            $platformTarget = GetPlatformTarget $startupProject
-            $projectPath = $startupProject.FullName
-
-            dotnet msbuild /t:GenerateBuildRuntimeConfigurationFiles "/p:GenerateRuntimeConfigurationFiles=True;Configuration=$configuration;Platform=$platformTarget" /verbosity:quiet /nologo $projectPath | Out-Null
         }
 
         if (Test-Path $runtimeConfig)

--- a/src/dotnet-ef/Project.cs
+++ b/src/dotnet-ef/Project.cs
@@ -167,7 +167,6 @@ namespace Microsoft.EntityFrameworkCore.Tools
                 args.Add(_runtime);
             }
 
-            args.Add("/p:GenerateRuntimeConfigurationFiles=True");
             args.Add("/verbosity:quiet");
             args.Add("/nologo");
 


### PR DESCRIPTION
Changes our existing workaround to use an MSBuild file in EFCore.Design; adds a workaround for .NET Framework

Fixes #10639