### PR TITLE
Fix #10740: Repair the database name with apostrophe

### DIFF
--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -657,20 +657,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             builder
                 .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator)
                 .EndCommand(suppressTransaction: true)
-                .AppendLine("IF SERVERPROPERTY('EngineEdition') <> 5")
-                .AppendLine("BEGIN");
-
-            using (builder.Indent())
-            {
-                builder
-                    .Append("ALTER DATABASE ")
-                    .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
-                    .Append(" SET READ_COMMITTED_SNAPSHOT ON")
-                    .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);
-            }
-
-            builder
-                .Append("END")
+                .Append("IF SERVERPROPERTY('EngineEdition') <> 5 EXEC(N'ALTER DATABASE ")
+                .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
+                .Append(" SET READ_COMMITTED_SNAPSHOT ON")
+                .Append(Dependencies.SqlGenerationHelper.StatementTerminator)
+                .Append("')")
+                .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator)
                 .EndCommand(suppressTransaction: true);
         }
 

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -657,12 +657,20 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             builder
                 .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator)
                 .EndCommand(suppressTransaction: true)
-                .Append("IF SERVERPROPERTY('EngineEdition') <> 5 EXEC(N'ALTER DATABASE ")
-                .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
-                .Append(" SET READ_COMMITTED_SNAPSHOT ON")
-                .Append(Dependencies.SqlGenerationHelper.StatementTerminator)
-                .Append("')")
-                .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator)
+                .AppendLine("IF SERVERPROPERTY('EngineEdition') <> 5")
+                .AppendLine("BEGIN");
+
+            using (builder.Indent())
+            {
+                builder
+                    .Append("ALTER DATABASE ")
+                    .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
+                    .Append(" SET READ_COMMITTED_SNAPSHOT ON")
+                    .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);
+            }
+
+            builder
+                .Append("END")
                 .EndCommand(suppressTransaction: true);
         }
 

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -517,12 +517,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             var nullableColumns = operation.Columns
                 .Where(
                     c =>
-                        {
-                            var property = FindProperty(model, operation.Schema, operation.Table, c);
+                    {
+                        var property = FindProperty(model, operation.Schema, operation.Table, c);
 
-                            return property == null // Couldn't bind column to property
-                                   || property.IsColumnNullable();
-                        })
+                        return property == null // Couldn't bind column to property
+                               || property.IsColumnNullable();
+                    })
                 .ToList();
 
             var memoryOptimized = IsMemoryOptimized(operation, model, operation.Schema, operation.Table);
@@ -657,11 +657,20 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             builder
                 .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator)
                 .EndCommand(suppressTransaction: true)
-                .Append("IF SERVERPROPERTY('EngineEdition') <> 5 EXEC(N'ALTER DATABASE ")
-                .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
-                .Append(" SET READ_COMMITTED_SNAPSHOT ON")
-                .Append(Dependencies.SqlGenerationHelper.StatementTerminator)
-                .Append("')")
+                .AppendLine("IF SERVERPROPERTY('EngineEdition') <> 5")
+                .AppendLine("BEGIN");
+
+            using (builder.Indent())
+            {
+                builder
+                    .Append("ALTER DATABASE ")
+                    .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
+                    .Append(" SET READ_COMMITTED_SNAPSHOT ON")
+                    .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);
+            }
+
+            builder
+                .Append("END")
                 .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator)
                 .EndCommand(suppressTransaction: true);
         }
@@ -700,11 +709,20 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             Check.NotNull(builder, nameof(builder));
 
             builder
-                .Append("IF SERVERPROPERTY('EngineEdition') <> 5 EXEC(N'ALTER DATABASE ")
-                .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
-                .Append(" SET SINGLE_USER WITH ROLLBACK IMMEDIATE")
-                .Append(Dependencies.SqlGenerationHelper.StatementTerminator)
-                .Append("')")
+                .AppendLine("IF SERVERPROPERTY('EngineEdition') <> 5")
+                .AppendLine("BEGIN");
+
+            using (builder.Indent())
+            {
+                builder
+                    .Append("ALTER DATABASE ")
+                    .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
+                    .Append(" SET SINGLE_USER WITH ROLLBACK IMMEDIATE")
+                    .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator);
+            }
+
+            builder
+                .Append("END")
                 .AppendLine(Dependencies.SqlGenerationHelper.StatementTerminator)
                 .EndCommand(suppressTransaction: true)
                 .Append("DROP DATABASE ")

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
@@ -294,10 +294,10 @@ namespace Microsoft.EntityFrameworkCore
                     .HasAnnotation(CoreAnnotationNames.ProductVersionAnnotation, "1.1.0")
                     .Entity(
                         "Person", x =>
-                            {
-                                x.Property<string>("FullName").HasComputedColumnSql("[FirstName] + ' ' + [LastName]");
-                                x.HasIndex("FullName");
-                            }),
+                        {
+                            x.Property<string>("FullName").HasComputedColumnSql("[FirstName] + ' ' + [LastName]");
+                            x.HasIndex("FullName");
+                        }),
                 new AlterColumnOperation
                 {
                     Table = "Person",
@@ -333,11 +333,11 @@ namespace Microsoft.EntityFrameworkCore
                     .HasAnnotation(CoreAnnotationNames.ProductVersionAnnotation, "1.1.0")
                     .Entity(
                         "Person", x =>
-                            {
-                                x.ForSqlServerIsMemoryOptimized();
-                                x.Property<string>("Name");
-                                x.HasIndex("Name");
-                            }),
+                        {
+                            x.ForSqlServerIsMemoryOptimized();
+                            x.Property<string>("Name");
+                            x.HasIndex("Name");
+                        }),
                 new AlterColumnOperation
                 {
                     Table = "Person",
@@ -371,10 +371,10 @@ namespace Microsoft.EntityFrameworkCore
                     .HasAnnotation(CoreAnnotationNames.ProductVersionAnnotation, "1.1.0")
                     .Entity(
                         "Person", x =>
-                            {
-                                x.Property<string>("Name");
-                                x.HasIndex("Name");
-                            }),
+                        {
+                            x.Property<string>("Name");
+                            x.HasIndex("Name");
+                        }),
                 new AlterColumnOperation
                 {
                     Table = "Person",
@@ -407,10 +407,10 @@ namespace Microsoft.EntityFrameworkCore
                     .HasAnnotation(CoreAnnotationNames.ProductVersionAnnotation, "1.1.0")
                     .Entity(
                         "Person", x =>
-                            {
-                                x.Property<string>("Name").HasMaxLength(30);
-                                x.HasIndex("Name");
-                            }),
+                        {
+                            x.Property<string>("Name").HasMaxLength(30);
+                            x.HasIndex("Name");
+                        }),
                 new AlterColumnOperation
                 {
                     Table = "Person",
@@ -446,10 +446,10 @@ namespace Microsoft.EntityFrameworkCore
                     .HasAnnotation(CoreAnnotationNames.ProductVersionAnnotation, "1.0.0-rtm")
                     .Entity(
                         "Person", x =>
-                            {
-                                x.Property<string>("Name").HasMaxLength(30);
-                                x.HasIndex("Name");
-                            }),
+                        {
+                            x.Property<string>("Name").HasMaxLength(30);
+                            x.HasIndex("Name");
+                        }),
                 new AlterColumnOperation
                 {
                     Table = "Person",
@@ -479,11 +479,11 @@ namespace Microsoft.EntityFrameworkCore
                     .HasAnnotation(CoreAnnotationNames.ProductVersionAnnotation, "1.1.0")
                     .Entity(
                         "Person", x =>
-                            {
-                                x.Property<string>("FirstName").IsRequired();
-                                x.Property<string>("LastName");
-                                x.HasIndex("FirstName", "LastName");
-                            }),
+                        {
+                            x.Property<string>("FirstName").IsRequired();
+                            x.Property<string>("LastName");
+                            x.HasIndex("FirstName", "LastName");
+                        }),
                 new AlterColumnOperation
                 {
                     Table = "Person",
@@ -518,10 +518,10 @@ namespace Microsoft.EntityFrameworkCore
                     .HasAnnotation(CoreAnnotationNames.ProductVersionAnnotation, "1.1.0")
                     .Entity(
                         "Person", x =>
-                            {
-                                x.Property<string>("Name").HasMaxLength(30);
-                                x.HasIndex("Name");
-                            }),
+                        {
+                            x.Property<string>("Name").HasMaxLength(30);
+                            x.HasIndex("Name");
+                        }),
                 new AlterColumnOperation
                 {
                     Table = "Person",
@@ -636,7 +636,10 @@ namespace Microsoft.EntityFrameworkCore
                 "CREATE DATABASE [Northwind];" + EOL +
                 "GO" + EOL +
                 EOL +
-                "IF SERVERPROPERTY('EngineEdition') <> 5 EXEC(N'ALTER DATABASE [Northwind] SET READ_COMMITTED_SNAPSHOT ON;');" + EOL,
+                "IF SERVERPROPERTY('EngineEdition') <> 5" + EOL +
+                "BEGIN" + EOL +
+                "    ALTER DATABASE [Northwind] SET READ_COMMITTED_SNAPSHOT ON;" + EOL +
+                "END;" + EOL,
                 Sql);
         }
 
@@ -654,7 +657,10 @@ namespace Microsoft.EntityFrameworkCore
                 "LOG ON (NAME = 'Narf_log', FILENAME = '" + expectedLog + "');" + EOL +
                 "GO" + EOL +
                 EOL +
-                "IF SERVERPROPERTY('EngineEdition') <> 5 EXEC(N'ALTER DATABASE [Northwind] SET READ_COMMITTED_SNAPSHOT ON;');" + EOL,
+                "IF SERVERPROPERTY('EngineEdition') <> 5" + EOL +
+                "BEGIN" + EOL +
+                "    ALTER DATABASE [Northwind] SET READ_COMMITTED_SNAPSHOT ON;" + EOL +
+                "END;" + EOL,
                 Sql);
         }
 
@@ -674,7 +680,10 @@ namespace Microsoft.EntityFrameworkCore
                 "LOG ON (NAME = 'Narf_log', FILENAME = '" + expectedLog + "');" + EOL +
                 "GO" + EOL +
                 EOL +
-                "IF SERVERPROPERTY('EngineEdition') <> 5 EXEC(N'ALTER DATABASE [Northwind] SET READ_COMMITTED_SNAPSHOT ON;');" + EOL,
+                "IF SERVERPROPERTY('EngineEdition') <> 5" + EOL +
+                "BEGIN" + EOL +
+                "    ALTER DATABASE [Northwind] SET READ_COMMITTED_SNAPSHOT ON;" + EOL +
+                "END;" + EOL,
                 Sql);
         }
 
@@ -699,7 +708,10 @@ namespace Microsoft.EntityFrameworkCore
                 "LOG ON (NAME = 'Narf_log', FILENAME = '" + expectedLog + "');" + EOL +
                 "GO" + EOL +
                 EOL +
-                "IF SERVERPROPERTY('EngineEdition') <> 5 EXEC(N'ALTER DATABASE [Northwind] SET READ_COMMITTED_SNAPSHOT ON;');" + EOL,
+                "IF SERVERPROPERTY('EngineEdition') <> 5" + EOL +
+                "BEGIN" + EOL +
+                "    ALTER DATABASE [Northwind] SET READ_COMMITTED_SNAPSHOT ON;" + EOL +
+                "END;" + EOL,
                 Sql);
         }
 
@@ -881,7 +893,11 @@ namespace Microsoft.EntityFrameworkCore
             Generate(new SqlServerDropDatabaseOperation { Name = "Northwind" });
 
             Assert.Equal(
-                "IF SERVERPROPERTY('EngineEdition') <> 5 EXEC(N'ALTER DATABASE [Northwind] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;');" + EOL +
+
+                "IF SERVERPROPERTY('EngineEdition') <> 5" + EOL +
+                "BEGIN" + EOL +
+                "    ALTER DATABASE [Northwind] SET SINGLE_USER WITH ROLLBACK IMMEDIATE;" + EOL +
+                "END;" + EOL +
                 "GO" + EOL +
                 EOL +
                 "DROP DATABASE [Northwind];" + EOL,


### PR DESCRIPTION
Fixes #10740 

* Solve apostrophe problem in database name

New SQL output:

```sql
IF SERVERPROPERTY('EngineEdition') <> 5
BEGIN
    ALTER DATABASE [Migrations'Test] SET READ_COMMITTED_SNAPSHOT ON;
END;
```
