### PR TITLE
[TINY] Fix to #10743 - Query: order by property's length twice throws NRE exception during query compilation

### DIFF
--- a/src/EFCore.Relational/Query/Expressions/SqlFunctionExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SqlFunctionExpression.cs
@@ -209,8 +209,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             => Type == other.Type
                && string.Equals(FunctionName, other.FunctionName)
                && string.Equals(Schema, other.Schema)
-               && Instance.Equals(other.Instance)
-               && _arguments.SequenceEqual(other._arguments);
+               && _arguments.SequenceEqual(other._arguments)
+               && (Instance == null && other.Instance == null
+                    || Instance?.Equals(other.Instance) == true);
+
+            
 
         /// <summary>
         ///     Returns a hash code for this object.

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Functions.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Functions.cs
@@ -998,5 +998,13 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs => cs.Where(c => c.ContactTitle.Trim('O', 'r') == "wne"),
                 entryCount: 17);
         }
+
+        [ConditionalFact]
+        public virtual void Order_by_length_twice()
+        {
+            AssertQuery<Customer>(
+                cs => cs.OrderBy(c => c.CustomerID.Length).ThenBy(c => c.CustomerID.Length).ThenBy(c => c.CustomerID),
+                entryCount: 91);
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Functions.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Functions.cs
@@ -1260,5 +1260,15 @@ FROM [Customers] AS [c]");
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]");
         }
+
+        public override void Order_by_length_twice()
+        {
+            base.Order_by_length_twice();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY CAST(LEN([c].[CustomerID]) AS int), [c].[CustomerID]");
+        }
     }
 }


### PR DESCRIPTION
Problem was that when comparing sql functions (to look for duplicate orderby's) we were not taking into account situation when instance for the function was null.