### PR TITLE
Add a CSharpModelGenerator test

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -205,6 +206,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             _sb.Append("{");
 
             var annotations = model.GetAnnotations().ToList();
+            RemoveAnnotation(ref annotations, ChangeDetector.SkipDetectChangesAnnotation);
+            RemoveAnnotation(ref annotations, RelationalAnnotationNames.MaxIdentifierLength);
             RemoveAnnotation(ref annotations, ScaffoldingAnnotationNames.DatabaseName);
             RemoveAnnotation(ref annotations, ScaffoldingAnnotationNames.EntityTypeErrors);
 

--- a/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
+++ b/src/EFCore.SqlServer/Design/Internal/SqlServerAnnotationCodeGenerator.cs
@@ -33,10 +33,13 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             Check.NotNull(model, nameof(model));
             Check.NotNull(annotation, nameof(annotation));
 
-            if (annotation.Name == RelationalAnnotationNames.DefaultSchema
-                && string.Equals("dbo", (string)annotation.Value))
+            if (annotation.Name == RelationalAnnotationNames.DefaultSchema)
             {
-                return true;
+                return string.Equals("dbo", (string)annotation.Value);
+            }
+            if (annotation.Name == SqlServerAnnotationNames.ValueGenerationStrategy)
+            {
+                return (SqlServerValueGenerationStrategy)annotation.Value == SqlServerValueGenerationStrategy.IdentityColumn;
             }
 
             return false;

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpDbContextGeneratorTest.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Design.Internal;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
+{
+    public class CSharpDbContextGeneratorTest
+    {
+        [Fact]
+        public void Empty_model()
+        {
+            Test(
+                modelBuilder => { },
+                /* dataAnnotations: */ false,
+                code =>
+                {
+                    Assert.Equal(
+                        @"using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace TestNamespace
+{
+    public partial class TestDbContext : DbContext
+    {
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+#warning " + DesignStrings.SensitiveInformationWarning + @"
+                optionsBuilder.UseSqlServer(@""Initial Catalog=TestDatabase"");
+            }
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {}
+    }
+}
+",
+                        code.ContextFile.Code,
+                        ignoreLineEndingDifferences: true);
+
+                    Assert.Empty(code.AdditionalFiles);
+                },
+                model =>
+                {
+                    Assert.Empty(model.GetEntityTypes());
+                });
+        }
+
+        private void Test(
+            Action<ModelBuilder> buildModel,
+            bool dataAnnotations,
+            Action<ScaffoldedModel> assertScaffold,
+            Action<IModel> assertModel)
+        {
+            var modelBuilder = new ModelBuilder(SqlServerConventionSetBuilder.Build());
+            buildModel(modelBuilder);
+            modelBuilder.GetInfrastructure().Metadata.Validate();
+
+            var model = modelBuilder.Model;
+
+            var generator = new ServiceCollection()
+                .AddEntityFrameworkDesignTimeServices()
+                .AddSingleton<IProviderCodeGenerator, SqlServerCodeGenerator>()
+                .AddSingleton<IAnnotationCodeGenerator, SqlServerAnnotationCodeGenerator>()
+                .BuildServiceProvider()
+                .GetRequiredService<IModelCodeGenerator>();
+
+            var scaffoldedModel = generator.GenerateModel(
+                model,
+                "TestNamespace",
+                /*contextDir:*/ string.Empty,
+                "TestDbContext",
+                "Initial Catalog=TestDatabase",
+                dataAnnotations);
+            assertScaffold(scaffoldedModel);
+
+            var build = new BuildSource
+            {
+                References =
+                {
+                    BuildReference.ByName("Microsoft.EntityFrameworkCore"),
+                    BuildReference.ByName("Microsoft.EntityFrameworkCore.Relational"),
+                    BuildReference.ByName("Microsoft.EntityFrameworkCore.SqlServer")
+                },
+                Sources = new List<string>(
+                    Enumerable.Concat(
+                        new[] { scaffoldedModel.ContextFile.Code },
+                        scaffoldedModel.AdditionalFiles.Select(f => f.Code)))
+            };
+
+            var assembly = build.BuildInMemory();
+            var context = (DbContext)assembly.CreateInstance("TestNamespace.TestDbContext");
+            var compiledModel = context.Model;
+            assertModel(compiledModel);
+        }
+    }
+}

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpModelGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpModelGeneratorTest.cs
@@ -39,53 +39,11 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 dataAnnotations: true);
 
             Assert.Equal(Path.Combine("..", "TestContextDir", "TestContext.cs"), result.ContextFile.Path);
-            Assert.Equal(
-                @"using System;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Metadata;
-
-namespace TestNamespace
-{
-    public partial class TestContext : DbContext
-    {
-        public virtual DbSet<TestEntity>  { get; set; }
-
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        {
-            if (!optionsBuilder.IsConfigured)
-            {
-#warning To protect potentially sensitive information in your connection string, you should move it out of source code. See http://go.microsoft.com/fwlink/?LinkId=723263 for guidance on storing connection strings.
-                optionsBuilder.UseTestProvider(@""Data Source=Test"");
-            }
-        }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {}
-    }
-}
-",
-                result.ContextFile.Code,
-                ignoreLineEndingDifferences: true);
+            Assert.NotEmpty(result.ContextFile.Code);
 
             Assert.Equal(1, result.AdditionalFiles.Count);
             Assert.Equal("TestEntity.cs", result.AdditionalFiles[0].Path);
-            Assert.Equal(
-                @"using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
-
-namespace TestNamespace
-{
-    [Table(""TestEntity"")]
-    public partial class TestEntity
-    {
-        public int Id { get; set; }
-    }
-}
-",
-                result.AdditionalFiles[0].Code,
-                ignoreLineEndingDifferences: true);
+            Assert.NotEmpty(result.AdditionalFiles[0].Code);
         }
 
         private static IModelCodeGenerator CreateGenerator()


### PR DESCRIPTION
Establishes a pattern for reverse engineering code scaffolding tests. The code is generated, compiled, and loaded. Both the C# and loaded model are asserted.

This test should help us catch the usual regressions until we can add more.

Part of #9111