### PR TITLE
fixing test verification issue that leads to failing oracle test

### DIFF
--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -3324,7 +3324,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                               where w.IsAutomatic || w.Name != "foo"
                               select w.Name).ToList(),
                 assertOrder: true,
-                elementAsserter: CollectionAsserter<string>());
+                elementAsserter: CollectionAsserter<string>(e => e));
         }
 
         [ConditionalFact]


### PR DESCRIPTION
Oracle returns results in different order than InMemory - test was working "by accident" on SqlServer - adding client side orderby to the results so that they are deterministic on all providers.