### PR TITLE
Fix #9726 - Max causes QueryClientEvaluationWarning

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/Query/WarningsTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/WarningsTestBase.cs
@@ -112,6 +112,17 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [Fact]
+        public virtual void Max_does_not_issue_client_eval_warning_when_at_top_level()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Orders.Select(o => o.OrderID).Max();
+
+                Assert.NotNull(query);
+            }
+        }
+
+        [Fact]
         public virtual void Last_without_order_by_issues_client_eval_warning()
         {
             using (var context = CreateContext())

--- a/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -697,7 +697,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     .QueryPossibleExceptionWithAggregateOperator();
             }
 
-            handlerContext.QueryModelVisitor.RequiresClientResultOperator = throwOnNullResult;
+            if (handlerContext.QueryModelVisitor.ParentQueryModelVisitor != null)
+            {
+                handlerContext.QueryModelVisitor.RequiresClientResultOperator = throwOnNullResult;
+            }
 
             return throwOnNullResult;
         }


### PR DESCRIPTION
No need to generate a warning unless we are in a subquery.


