### PR TITLE
Allow properties to be defined/configured before their final types are known

### DIFF
--- a/src/EFCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
@@ -665,6 +665,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 return false;
             }
 
+            if (sourceEntityTypeBuilder.Metadata.FindProperty(navigationName) != null)
+            {
+                return false;
+            }
+
             return true;
         }
 

--- a/src/EFCore/Storage/Internal/FallbackCoreTypeMapper.cs
+++ b/src/EFCore/Storage/Internal/FallbackCoreTypeMapper.cs
@@ -40,8 +40,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         {
             Check.NotNull(mappingInfo, nameof(mappingInfo));
 
-            return _typeMapper.IsTypeMapped(mappingInfo.ModelClrType)
-                ? new CoreTypeMapping(mappingInfo.ModelClrType)
+            return _typeMapper.IsTypeMapped(mappingInfo.TargetClrType)
+                ? new CoreTypeMapping(mappingInfo.TargetClrType)
                 : null;
         }
     }

--- a/test/EFCore.SqlServer.FunctionalTests/CustomConvertersSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/CustomConvertersSqlServerTest.cs
@@ -148,6 +148,8 @@ UnicodeDataTypes.StringAnsi3 ---> [nullable varchar] [MaxLength = 3]
 UnicodeDataTypes.StringAnsi9000 ---> [nullable varchar] [MaxLength = -1]
 UnicodeDataTypes.StringDefault ---> [nullable nvarchar] [MaxLength = -1]
 UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
+User.Email ---> [nullable nvarchar] [MaxLength = -1]
+User.Id ---> [uniqueidentifier]
 ";
 
             Assert.Equal(expected, actual, ignoreLineEndingDifferences: true);


### PR DESCRIPTION
Issue #10765

Because until the call to HasConversion is made we can't know whether or not the property can be mapped.
