### PR TITLE
Fix to #10202 - Query: ExpressionPrinter is not flexible

### DIFF
--- a/src/EFCore/Query/Expressions/Internal/IPrintable.cs
+++ b/src/EFCore/Query/Expressions/Internal/IPrintable.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Query.Expressions.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public interface IPrintable
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        void Print([NotNull] ExpressionPrinter expressionPrinter);
+    }
+}

--- a/src/EFCore/Query/Expressions/Internal/NullConditionalEqualExpression.cs
+++ b/src/EFCore/Query/Expressions/Internal/NullConditionalEqualExpression.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Query.Expressions.Internal
@@ -12,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class NullConditionalEqualExpression : Expression
+    public class NullConditionalEqualExpression : Expression, IPrintable
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -105,6 +106,17 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions.Internal
             return newOuterCaller != OuterNullProtection || newOuterKey != OuterKey || newInnerKey != InnerKey
                 ? new NullConditionalEqualExpression(newOuterCaller, newOuterKey, newInnerKey)
                 : this;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void Print(ExpressionPrinter expressionPrinter)
+        {
+            expressionPrinter.Visit(OuterKey);
+            expressionPrinter.StringBuilder.Append(" ?= ");
+            expressionPrinter.Visit(InnerKey);
         }
 
         /// <summary>


### PR DESCRIPTION
Added IPrintable interface to our custom expression nodes that takes ExpressionPrinter argument and knows how to properly print a given node.
Also improved printing of GroupResultOperator - we now properly print it's arguments, rather than just using ToString()