### PR TITLE
Delimit table name in query type test

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/TestModels/Northwind/NorthwindRelationalContext.cs
+++ b/src/EFCore.Relational.Specification.Tests/TestModels/Northwind/NorthwindRelationalContext.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
             modelBuilder
                 .Query<OrderQuery>()
                 .ToQuery(() => Orders
-                    .FromSql("select * from Orders")
+                    .FromSql("select * from \"Orders\"")
                     .Select(
                         o => new OrderQuery
                         {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.QueryTypes.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.QueryTypes.cs
@@ -63,7 +63,7 @@ FROM [Customers] AS [c]
 CROSS JOIN (
     SELECT [o].[CustomerID]
     FROM (
-        select * from Orders
+        select * from ""Orders""
     ) AS [o]
 ) AS [t]
 WHERE [t].[CustomerID] = [c].[CustomerID]");
@@ -78,7 +78,7 @@ WHERE [t].[CustomerID] = [c].[CustomerID]");
 FROM (
     SELECT [o].[CustomerID]
     FROM (
-        select * from Orders
+        select * from ""Orders""
     ) AS [o]
 ) AS [t]
 WHERE [t].[CustomerID] = N'ALFKI'");
@@ -93,7 +93,7 @@ WHERE [t].[CustomerID] = N'ALFKI'");
 FROM (
     SELECT [o].[CustomerID]
     FROM (
-        select * from Orders
+        select * from ""Orders""
     ) AS [o]
 ) AS [t]
 LEFT JOIN [Customers] AS [ov.Customer] ON [t].[CustomerID] = [ov.Customer].[CustomerID]
@@ -109,7 +109,7 @@ WHERE [t].[CustomerID] = N'ALFKI'");
 FROM (
     SELECT [o].[CustomerID]
     FROM (
-        select * from Orders
+        select * from ""Orders""
     ) AS [o]
 ) AS [t]
 LEFT JOIN [Customers] AS [ov.Customer] ON [t].[CustomerID] = [ov.Customer].[CustomerID]
@@ -123,7 +123,7 @@ INNER JOIN (
     FROM (
         SELECT [o0].[CustomerID]
         FROM (
-            select * from Orders
+            select * from ""Orders""
         ) AS [o0]
     ) AS [t0]
     LEFT JOIN [Customers] AS [ov.Customer0] ON [t0].[CustomerID] = [ov.Customer0].[CustomerID]
@@ -141,7 +141,7 @@ ORDER BY [t1].[CustomerID]");
 FROM (
     SELECT [o].[CustomerID]
     FROM (
-        select * from Orders
+        select * from ""Orders""
     ) AS [o]
 ) AS [t]
 LEFT JOIN [Customers] AS [ov.Customer] ON [t].[CustomerID] = [ov.Customer].[CustomerID]
@@ -157,7 +157,7 @@ WHERE [ov.Customer].[City] = N'Seattle'");
 FROM (
     SELECT [o].[CustomerID]
     FROM (
-        select * from Orders
+        select * from ""Orders""
     ) AS [o]
 ) AS [t]
 LEFT JOIN [Customers] AS [ov.Customer] ON [t].[CustomerID] = [ov.Customer].[CustomerID]


### PR DESCRIPTION
Query type test fails on PostgreSQL because of undelimited table name - get the provider's ISqlGenerationHelper and delimit (hope I did this the right way).

An alternative would be for providers to extend NorthwindRelationalContext and specify their own SQL but that becomes more complicated.