### PR TITLE
 ContextInfo will not be called second time in a forced drop command.

### DIFF
--- a/src/ef/Commands/DatabaseDropCommand.cs
+++ b/src/ef/Commands/DatabaseDropCommand.cs
@@ -13,20 +13,24 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
         {
             var executor = CreateExecutor();
 
-            var result = executor.GetContextInfo(Context.Value());
-            var databaseName = result["DatabaseName"] as string;
-            var dataSource = result["DataSource"] as string;
+            void LogDropCommand(Func<object, object, string> resource)
+            {
+                var result = executor.GetContextInfo(Context.Value());
+                var databaseName = result["DatabaseName"] as string;
+                var dataSource = result["DataSource"] as string;
+                Reporter.WriteInformation(resource(databaseName, dataSource));
+            }
 
             if (_dryRun.HasValue())
             {
-                Reporter.WriteInformation(Resources.DatabaseDropDryRun(databaseName, dataSource));
+                LogDropCommand(Resources.DatabaseDropDryRun);
 
                 return 0;
             }
 
             if (!_force.HasValue())
             {
-                Reporter.WriteInformation(Resources.DatabaseDropPrompt(databaseName, dataSource));
+                LogDropCommand(Resources.DatabaseDropPrompt);
                 var response = Console.ReadLine().Trim().ToUpperInvariant();
                 if (response != "Y")
                 {


### PR DESCRIPTION
Fix #10636 so that `ConfigurationServices` will not be called second time when the drop command is executed with _--force_ option.