### PR TITLE
Fix to #10785 - Model Query Filter generates incorrect SQL

### DIFF
--- a/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryFixtureBase.cs
@@ -19,16 +19,16 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             var entitySorters = new Dictionary<Type, Func<dynamic, object>>
             {
-                { typeof(Level1), e => e.Id },
-                { typeof(Level2), e => e.Id },
-                { typeof(Level3), e => e.Id },
-                { typeof(Level4), e => e.Id },
-                { typeof(InheritanceBase1), e => e.Id },
-                { typeof(InheritanceBase2), e => e.Id },
-                { typeof(InheritanceDerived1), e => e.Id },
-                { typeof(InheritanceDerived2), e => e.Id },
-                { typeof(InheritanceLeaf1), e => e.Id },
-                { typeof(InheritanceLeaf2), e => e.Id }
+                { typeof(Level1), e => e?.Id },
+                { typeof(Level2), e => e?.Id },
+                { typeof(Level3), e => e?.Id },
+                { typeof(Level4), e => e?.Id },
+                { typeof(InheritanceBase1), e => e?.Id },
+                { typeof(InheritanceBase2), e => e?.Id },
+                { typeof(InheritanceDerived1), e => e?.Id },
+                { typeof(InheritanceDerived2), e => e?.Id },
+                { typeof(InheritanceLeaf1), e => e?.Id },
+                { typeof(InheritanceLeaf2), e => e?.Id }
             };
 
             var entityAsserters = new Dictionary<Type, Action<dynamic, dynamic>>
@@ -37,88 +37,138 @@ namespace Microsoft.EntityFrameworkCore.Query
                     typeof(Level1),
                     (e, a) =>
                         {
-                            Assert.Equal(e.Id, a.Id);
-                            Assert.Equal(e.Name, a.Name);
-                            Assert.Equal(e.Date, a.Date);
+                            Assert.Equal(e == null, a == null);
+
+                            if (a != null)
+                            {
+                                Assert.Equal(e.Id, a.Id);
+                                Assert.Equal(e.Name, a.Name);
+                                Assert.Equal(e.Date, a.Date);
+                            }
                         }
                 },
                 {
                     typeof(Level2),
                     (e, a) =>
                         {
-                            Assert.Equal(e.Id, a.Id);
-                            Assert.Equal(e.Name, a.Name);
-                            Assert.Equal(e.Date, a.Date);
-                            Assert.Equal(e.Level1_Optional_Id, a.Level1_Optional_Id);
-                            Assert.Equal(e.Level1_Required_Id, a.Level1_Required_Id);
+                            Assert.Equal(e == null, a == null);
+
+                            if (a != null)
+                            {
+                                Assert.Equal(e.Id, a.Id);
+                                Assert.Equal(e.Name, a.Name);
+                                Assert.Equal(e.Date, a.Date);
+                                Assert.Equal(e.Level1_Optional_Id, a.Level1_Optional_Id);
+                                Assert.Equal(e.Level1_Required_Id, a.Level1_Required_Id);
+                            }
                         }
                 },
                 {
                     typeof(Level3),
                     (e, a) =>
                         {
-                            Assert.Equal(e.Id, a.Id);
-                            Assert.Equal(e.Name, a.Name);
-                            Assert.Equal(e.Level2_Optional_Id, a.Level2_Optional_Id);
-                            Assert.Equal(e.Level2_Required_Id, a.Level2_Required_Id);
+                            Assert.Equal(e == null, a == null);
+
+                            if (a != null)
+                            {
+                                Assert.Equal(e.Id, a.Id);
+                                Assert.Equal(e.Name, a.Name);
+                                Assert.Equal(e.Level2_Optional_Id, a.Level2_Optional_Id);
+                                Assert.Equal(e.Level2_Required_Id, a.Level2_Required_Id);
+                            }
                         }
                 },
                 {
                     typeof(Level4),
                     (e, a) =>
                         {
-                            Assert.Equal(e.Id, a.Id);
-                            Assert.Equal(e.Name, a.Name);
-                            Assert.Equal(e.Level3_Optional_Id, a.Level3_Optional_Id);
-                            Assert.Equal(e.Level3_Required_Id, a.Level3_Required_Id);
+                            Assert.Equal(e == null, a == null);
+
+                            if (a != null)
+                            {
+                                Assert.Equal(e.Id, a.Id);
+                                Assert.Equal(e.Name, a.Name);
+                                Assert.Equal(e.Level3_Optional_Id, a.Level3_Optional_Id);
+                                Assert.Equal(e.Level3_Required_Id, a.Level3_Required_Id);
+                            }
                         }
                 },
                 {
                     typeof(InheritanceBase1),
                     (e, a) =>
                         {
-                            Assert.Equal(e.Id, a.Id);
-                            Assert.Equal(e.Name, a.Name);
-                }
+                            Assert.Equal(e == null, a == null);
+
+                            if (a != null)
+                            {
+                                Assert.Equal(e.Id, a.Id);
+                                Assert.Equal(e.Name, a.Name);
+                            }
+                        }
                 },
                 {
                     typeof(InheritanceBase2),
                     (e, a) =>
                         {
-                            Assert.Equal(e.Id, a.Id);
-                            Assert.Equal(e.Name, a.Name);
+                            Assert.Equal(e == null, a == null);
+
+                            if (a != null)
+                            {
+                                Assert.Equal(e.Id, a.Id);
+                                Assert.Equal(e.Name, a.Name);
+                            }
                         }
                 },
                 {
                     typeof(InheritanceDerived1),
                     (e, a) =>
                         {
-                            Assert.Equal(e.Id, a.Id);
-                            Assert.Equal(e.Name, a.Name);
+                            Assert.Equal(e == null, a == null);
+
+                            if (a != null)
+                            {
+                                Assert.Equal(e.Id, a.Id);
+                                Assert.Equal(e.Name, a.Name);
+                            }
                         }
                 },
                 {
                     typeof(InheritanceDerived2),
                     (e, a) =>
                         {
-                            Assert.Equal(e.Id, a.Id);
-                            Assert.Equal(e.Name, a.Name);
+                            Assert.Equal(e == null, a == null);
+
+                            if (a != null)
+                            {
+                                Assert.Equal(e.Id, a.Id);
+                                Assert.Equal(e.Name, a.Name);
+                            }
                         }
                 },
                 {
                     typeof(InheritanceLeaf1),
                     (e, a) =>
                         {
-                            Assert.Equal(e.Id, a.Id);
-                            Assert.Equal(e.Name, a.Name);
+                            Assert.Equal(e == null, a == null);
+
+                            if (a != null)
+                            {
+                                Assert.Equal(e.Id, a.Id);
+                                Assert.Equal(e.Name, a.Name);
+                            }
                         }
                 },
                 {
                     typeof(InheritanceLeaf2),
                     (e, a) =>
                         {
-                            Assert.Equal(e.Id, a.Id);
-                            Assert.Equal(e.Name, a.Name);
+                            Assert.Equal(e == null, a == null);
+
+                            if (a != null)
+                            {
+                                Assert.Equal(e.Id, a.Id);
+                                Assert.Equal(e.Name, a.Name);
+                            }
                         }
                 }
             };

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryFixtureBase.cs
@@ -18,18 +18,18 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             var entitySorters = new Dictionary<Type, Func<dynamic, object>>
             {
-                { typeof(City), e => e.Name },
-                { typeof(CogTag), e => e.Id },
-                { typeof(Faction), e => e.Id },
-                { typeof(LocustHorde), e => e.Id },
-                { typeof(Gear), e => e.SquadId + " " + e.Nickname },
-                { typeof(Officer), e => e.SquadId + " " + e.Nickname },
-                { typeof(LocustLeader), e => e.Name },
-                { typeof(LocustCommander), e => e.Name },
-                { typeof(Mission), e => e.Id },
-                { typeof(Squad), e => e.Id },
-                { typeof(SquadMission), e => e.SquadId + " " + e.MissionId },
-                { typeof(Weapon), e => e.Id }
+                { typeof(City), e => e?.Name },
+                { typeof(CogTag), e => e?.Id },
+                { typeof(Faction), e => e?.Id },
+                { typeof(LocustHorde), e => e?.Id },
+                { typeof(Gear), e => e?.SquadId + " " + e?.Nickname },
+                { typeof(Officer), e => e?.SquadId + " " + e?.Nickname },
+                { typeof(LocustLeader), e => e?.Name },
+                { typeof(LocustCommander), e => e?.Name },
+                { typeof(Mission), e => e?.Id },
+                { typeof(Squad), e => e?.Id },
+                { typeof(SquadMission), e => e?.SquadId + " " + e?.MissionId },
+                { typeof(Weapon), e => e?.Id }
             };
 
             var entityAsserters = new Dictionary<Type, Action<dynamic, dynamic>>
@@ -38,120 +38,180 @@ namespace Microsoft.EntityFrameworkCore.Query
                     typeof(City),
                     (e, a) =>
                         {
-                            Assert.Equal(e.Name, a.Name);
-                            Assert.Equal(e.Location, a.Location);
+                            Assert.Equal(e == null, a == null);
+
+                            if (a != null)
+                            {
+                                Assert.Equal(e.Name, a.Name);
+                                Assert.Equal(e.Location, a.Location);
+                            }
                         }
                 },
                 {
                     typeof(CogTag),
                     (e, a) =>
                         {
-                            Assert.Equal(e.Id, a.Id);
-                            Assert.Equal(e.Note, a.Note);
-                            Assert.Equal(e.GearNickName, a.GearNickName);
-                            Assert.Equal(e.GearSquadId, a.GearSquadId);
+                            Assert.Equal(e == null, a == null);
+
+                            if (a != null)
+                            {
+                                Assert.Equal(e.Id, a.Id);
+                                Assert.Equal(e.Note, a.Note);
+                                Assert.Equal(e.GearNickName, a.GearNickName);
+                                Assert.Equal(e.GearSquadId, a.GearSquadId);
+                            }
                         }
                 },
                 {
                     typeof(Faction),
                     (e, a) =>
                         {
-                            Assert.Equal(e.Id, a.Id);
-                            Assert.Equal(e.Name, a.Name);
-                            Assert.Equal(e.CapitalName, a.CapitalName);
+                            Assert.Equal(e == null, a == null);
+
+                            if (a != null)
+                            {
+                                Assert.Equal(e.Id, a.Id);
+                                Assert.Equal(e.Name, a.Name);
+                                Assert.Equal(e.CapitalName, a.CapitalName);
+                            }
                         }
                 },
                 {
                     typeof(Gear),
                     (e, a) =>
                         {
-                            Assert.Equal(e.Nickname, a.Nickname);
-                            Assert.Equal(e.SquadId, a.SquadId);
-                            Assert.Equal(e.CityOrBirthName, a.CityOrBirthName);
-                            Assert.Equal(e.FullName, a.FullName);
-                            Assert.Equal(e.HasSoulPatch, a.HasSoulPatch);
-                            Assert.Equal(e.LeaderNickname, a.LeaderNickname);
-                            Assert.Equal(e.LeaderSquadId, a.LeaderSquadId);
-                            Assert.Equal(e.Rank, a.Rank);
+                            Assert.Equal(e == null, a == null);
+
+                            if (a != null)
+                            {
+                                Assert.Equal(e.Nickname, a.Nickname);
+                                Assert.Equal(e.SquadId, a.SquadId);
+                                Assert.Equal(e.CityOrBirthName, a.CityOrBirthName);
+                                Assert.Equal(e.FullName, a.FullName);
+                                Assert.Equal(e.HasSoulPatch, a.HasSoulPatch);
+                                Assert.Equal(e.LeaderNickname, a.LeaderNickname);
+                                Assert.Equal(e.LeaderSquadId, a.LeaderSquadId);
+                                Assert.Equal(e.Rank, a.Rank);
+                            }
                         }
                 },
                 {
                     typeof(LocustCommander),
                     (e, a) =>
                         {
-                            Assert.Equal(e.Name, a.Name);
-                            Assert.Equal(e.ThreatLevel, a.ThreatLevel);
-                            Assert.Equal(e.DefeatedByNickname, a.DefeatedByNickname);
-                            Assert.Equal(e.DefeatedBySquadId, a.DefeatedBySquadId);
+                            Assert.Equal(e == null, a == null);
+
+                            if (a != null)
+                            {
+                                Assert.Equal(e.Name, a.Name);
+                                Assert.Equal(e.ThreatLevel, a.ThreatLevel);
+                                Assert.Equal(e.DefeatedByNickname, a.DefeatedByNickname);
+                                Assert.Equal(e.DefeatedBySquadId, a.DefeatedBySquadId);
+                            }
                         }
                 },
                 {
                     typeof(LocustHorde),
                     (e, a) =>
                         {
-                            Assert.Equal(e.Id, a.Id);
-                            Assert.Equal(e.Name, a.Name);
-                            Assert.Equal(e.CapitalName, a.CapitalName);
-                            Assert.Equal(e.CommanderName, a.CommanderName);
-                            Assert.Equal(e.Eradicated, a.Eradicated);
+                            Assert.Equal(e == null, a == null);
+
+                            if (a != null)
+                            {
+                                Assert.Equal(e.Id, a.Id);
+                                Assert.Equal(e.Name, a.Name);
+                                Assert.Equal(e.CapitalName, a.CapitalName);
+                                Assert.Equal(e.CommanderName, a.CommanderName);
+                                Assert.Equal(e.Eradicated, a.Eradicated);
+                            }
                         }
                 },
                 {
                     typeof(LocustLeader),
                     (e, a) =>
                         {
-                            Assert.Equal(e.Name, a.Name);
-                            Assert.Equal(e.ThreatLevel, a.ThreatLevel);
+                            Assert.Equal(e == null, a == null);
+
+                            if (a != null)
+                            {
+                                Assert.Equal(e.Name, a.Name);
+                                Assert.Equal(e.ThreatLevel, a.ThreatLevel);
+                            }
                         }
                 },
                 {
                     typeof(Mission),
                     (e, a) =>
                         {
-                            Assert.Equal(e.Id, a.Id);
-                            Assert.Equal(e.CodeName, a.CodeName);
-                            Assert.Equal(e.Timeline, a.Timeline);
+                            Assert.Equal(e == null, a == null);
+
+                            if (a != null)
+                            {
+                                Assert.Equal(e.Id, a.Id);
+                                Assert.Equal(e.CodeName, a.CodeName);
+                                Assert.Equal(e.Timeline, a.Timeline);
+                            }
                         }
                 },
                 {
                     typeof(Officer),
                     (e, a) =>
                         {
-                            Assert.Equal(e.Nickname, a.Nickname);
-                            Assert.Equal(e.SquadId, a.SquadId);
-                            Assert.Equal(e.CityOrBirthName, a.CityOrBirthName);
-                            Assert.Equal(e.FullName, a.FullName);
-                            Assert.Equal(e.HasSoulPatch, a.HasSoulPatch);
-                            Assert.Equal(e.LeaderNickname, a.LeaderNickname);
-                            Assert.Equal(e.LeaderSquadId, a.LeaderSquadId);
-                            Assert.Equal(e.Rank, a.Rank);
+                            Assert.Equal(e == null, a == null);
+
+                            if (a != null)
+                            {
+                                Assert.Equal(e.Nickname, a.Nickname);
+                                Assert.Equal(e.SquadId, a.SquadId);
+                                Assert.Equal(e.CityOrBirthName, a.CityOrBirthName);
+                                Assert.Equal(e.FullName, a.FullName);
+                                Assert.Equal(e.HasSoulPatch, a.HasSoulPatch);
+                                Assert.Equal(e.LeaderNickname, a.LeaderNickname);
+                                Assert.Equal(e.LeaderSquadId, a.LeaderSquadId);
+                                Assert.Equal(e.Rank, a.Rank);
+                            }
                         }
                 },
                 {
                     typeof(Squad),
                     (e, a) =>
                         {
-                            Assert.Equal(e.Id, a.Id);
-                            Assert.Equal(e.Name, a.Name);
+                            Assert.Equal(e == null, a == null);
+
+                            if (a != null)
+                            {
+                                Assert.Equal(e.Id, a.Id);
+                                Assert.Equal(e.Name, a.Name);
+                            }
                         }
                 },
                 {
                     typeof(SquadMission),
                     (e, a) =>
                         {
-                            Assert.Equal(e.SquadId, a.SquadId);
-                            Assert.Equal(e.MissionId, a.MissionId);
+                            Assert.Equal(e == null, a == null);
+
+                            if (a != null)
+                            {
+                                Assert.Equal(e.SquadId, a.SquadId);
+                                Assert.Equal(e.MissionId, a.MissionId);
+                            }
                         }
                 },
                 {
                     typeof(Weapon),
                     (e, a) =>
                         {
-                            Assert.Equal(e.Id, a.Id);
-                            Assert.Equal(e.IsAutomatic, a.IsAutomatic);
-                            Assert.Equal(e.Name, a.Name);
-                            Assert.Equal(e.OwnerFullName, a.OwnerFullName);
-                            Assert.Equal(e.SynergyWithId, a.SynergyWithId);
+                            Assert.Equal(e == null, a == null);
+
+                            if (a != null)
+                            {
+                                Assert.Equal(e.Id, a.Id);
+                                Assert.Equal(e.IsAutomatic, a.IsAutomatic);
+                                Assert.Equal(e.Name, a.Name);
+                                Assert.Equal(e.OwnerFullName, a.OwnerFullName);
+                                Assert.Equal(e.SynergyWithId, a.SynergyWithId);
+                            }
                         }
                 }
             };

--- a/src/EFCore.Specification.Tests/Query/NorthwindQueryFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/Query/NorthwindQueryFixtureBase.cs
@@ -17,13 +17,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             var entitySorters = new Dictionary<Type, Func<dynamic, object>>
             {
-                { typeof(Customer), e => e.CustomerID },
-                { typeof(CustomerView), e => e.CompanyName },
-                { typeof(Order), e => e.OrderID },
-                { typeof(OrderQuery), e => e.CustomerID },
-                { typeof(Employee), e => e.EmployeeID },
-                { typeof(Product), e => e.ProductID },
-                { typeof(OrderDetail), e => e.OrderID.ToString() + " " + e.ProductID.ToString() }
+                { typeof(Customer), e => e?.CustomerID },
+                { typeof(CustomerView), e => e?.CompanyName },
+                { typeof(Order), e => e?.OrderID },
+                { typeof(OrderQuery), e => e?.CustomerID },
+                { typeof(Employee), e => e?.EmployeeID },
+                { typeof(Product), e => e?.ProductID },
+                { typeof(OrderDetail), e => e?.OrderID.ToString() + " " + e?.ProductID.ToString() }
             };
 
             var entityAsserters = new Dictionary<Type, Action<dynamic, dynamic>>();

--- a/src/EFCore.Specification.Tests/TestUtilities/QueryAsserter.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/QueryAsserter.cs
@@ -336,19 +336,18 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
                 var expected = expectedQuery(ExpectedData.Set<TItem1>()).ToArray();
 
-                if (!assertOrder
-                    && elementSorter == null
-                    && expected.Length > 0
-                    && expected[0] != null)
+                var firstNonNullableElement = expected.FirstOrDefault(e => e != null);
+                if (firstNonNullableElement != null)
                 {
-                    _entitySorters.TryGetValue(expected[0].GetType(), out elementSorter);
-                }
+                    if (!assertOrder && elementSorter == null)
+                    {
+                        _entitySorters.TryGetValue(firstNonNullableElement.GetType(), out elementSorter);
+                    }
 
-                if (elementAsserter == null
-                    && expected.Length > 0
-                    && expected[0] != null)
-                {
-                    _entityAsserters.TryGetValue(expected[0].GetType(), out elementAsserter);
+                    if (elementAsserter == null)
+                    {
+                        _entityAsserters.TryGetValue(firstNonNullableElement.GetType(), out elementAsserter);
+                    }
                 }
 
                 TestHelpers.AssertResults(
@@ -398,19 +397,18 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                     ExpectedData.Set<TItem1>(),
                     ExpectedData.Set<TItem2>()).ToArray();
 
-                if (!assertOrder
-                    && elementSorter == null
-                    && expected.Length > 0
-                    && expected[0] != null)
+                var firstNonNullableElement = expected.FirstOrDefault(e => e != null);
+                if (firstNonNullableElement != null)
                 {
-                    _entitySorters.TryGetValue(expected[0].GetType(), out elementSorter);
-                }
+                    if (!assertOrder && elementSorter == null)
+                    {
+                        _entitySorters.TryGetValue(firstNonNullableElement.GetType(), out elementSorter);
+                    }
 
-                if (elementAsserter == null
-                    && expected.Length > 0
-                    && expected[0] != null)
-                {
-                    _entityAsserters.TryGetValue(expected[0].GetType(), out elementAsserter);
+                    if (elementAsserter == null)
+                    {
+                        _entityAsserters.TryGetValue(firstNonNullableElement.GetType(), out elementAsserter);
+                    }
                 }
 
                 TestHelpers.AssertResults(
@@ -463,19 +461,18 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                     ExpectedData.Set<TItem2>(),
                     ExpectedData.Set<TItem3>()).ToArray();
 
-                if (!assertOrder
-                    && elementSorter == null
-                    && expected.Length > 0
-                    && expected[0] != null)
+                var firstNonNullableElement = expected.FirstOrDefault(e => e != null);
+                if (firstNonNullableElement != null)
                 {
-                    _entitySorters.TryGetValue(expected[0].GetType(), out elementSorter);
-                }
+                    if (!assertOrder && elementSorter == null)
+                    {
+                        _entitySorters.TryGetValue(firstNonNullableElement.GetType(), out elementSorter);
+                    }
 
-                if (elementAsserter == null
-                    && expected.Length > 0
-                    && expected[0] != null)
-                {
-                    _entityAsserters.TryGetValue(expected[0].GetType(), out elementAsserter);
+                    if (elementAsserter == null)
+                    {
+                        _entityAsserters.TryGetValue(firstNonNullableElement.GetType(), out elementAsserter);
+                    }
                 }
 
                 TestHelpers.AssertResults(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -5960,6 +5960,36 @@ INNER JOIN (
 ORDER BY [t].[Nickname], [t].[FullName]");
         }
 
+        public override void Null_semantics_on_nullable_bool_from_inner_join_subuery_is_fully_applied()
+        {
+            base.Null_semantics_on_nullable_bool_from_inner_join_subuery_is_fully_applied();
+
+            AssertSql(
+                @"SELECT [t].[Id], [t].[CapitalName], [t].[Discriminator], [t].[Name], [t].[CommanderName], [t].[Eradicated]
+FROM [LocustLeaders] AS [ll]
+INNER JOIN (
+    SELECT [f].[Id], [f].[CapitalName], [f].[Discriminator], [f].[Name], [f].[CommanderName], [f].[Eradicated]
+    FROM [Factions] AS [f]
+    WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Name] = N'Swarm')
+) AS [t] ON [ll].[Name] = [t].[CommanderName]
+WHERE [ll].[Discriminator] IN (N'LocustCommander', N'LocustLeader') AND (([t].[Eradicated] <> 1) OR [t].[Eradicated] IS NULL)");
+        }
+
+        public override void Null_semantics_on_nullable_bool_from_left_join_subuery_is_fully_applied()
+        {
+            base.Null_semantics_on_nullable_bool_from_left_join_subuery_is_fully_applied();
+
+            AssertSql(
+                @"SELECT [t].[Id], [t].[CapitalName], [t].[Discriminator], [t].[Name], [t].[CommanderName], [t].[Eradicated]
+FROM [LocustLeaders] AS [ll]
+LEFT JOIN (
+    SELECT [f].[Id], [f].[CapitalName], [f].[Discriminator], [f].[Name], [f].[CommanderName], [f].[Eradicated]
+    FROM [Factions] AS [f]
+    WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Name] = N'Swarm')
+) AS [t] ON [ll].[Name] = [t].[CommanderName]
+WHERE [ll].[Discriminator] IN (N'LocustCommander', N'LocustLeader') AND (([t].[Eradicated] <> 1) OR [t].[Eradicated] IS NULL)");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Problem was that we would not apply null semantics properly to ColumnReference expressions - we were not detecting that the column behind it is actually nullable and IS NULL term needs to be generated for it.
Also as part of this change improved test infrastructure for cases when some of the results are null.