### PR TITLE
Fix some optimizations not being applied to weak entities

### DIFF
--- a/src/EFCore.Specification.Tests/Query/ComplexNavigationsOwnedQueryFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/Query/ComplexNavigationsOwnedQueryFixtureBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.TestModels.ComplexNavigationsModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
@@ -27,15 +28,23 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             modelBuilder.Entity<Level1>().Property(e => e.Id).ValueGeneratedNever();
 
-            modelBuilder.Entity<Level1>()
+            var level1Builder = modelBuilder.Entity<Level1>()
                 .Ignore(e => e.OneToOne_Optional_Self)
                 .Ignore(e => e.OneToMany_Required_Self)
                 .Ignore(e => e.OneToMany_Required_Self_Inverse)
                 .Ignore(e => e.OneToMany_Optional_Self)
                 .Ignore(e => e.OneToMany_Optional_Self_Inverse)
                 .Ignore(e => e.OneToMany_Required)
-                .Ignore(e => e.OneToMany_Optional)
-                .OwnsOne(e => e.OneToOne_Required_PK, Configure);
+                .Ignore(e => e.OneToMany_Optional);
+
+            var level1 = level1Builder.Metadata;
+            var level2 = level1.Model.AddEntityType(typeof(Level2), nameof(Level1.OneToOne_Required_PK), level1);
+            var level2Fk = level2.AddForeignKey(level2.FindProperty(nameof(Level2.Id)), level1.FindPrimaryKey(), level1);
+            level2Fk.HasPrincipalToDependent(nameof(Level1.OneToOne_Required_PK));
+            level2Fk.IsUnique = true;
+            level2Fk.DeleteBehavior = DeleteBehavior.Restrict;
+
+            Configure(new ReferenceOwnershipBuilder<Level1, Level2>((EntityType)level1, (EntityType)level2, ((ForeignKey)level2Fk).Builder));
 
             modelBuilder.Entity<InheritanceBase1>().Property(e => e.Id).ValueGeneratedNever();
             modelBuilder.Entity<InheritanceBase2>().Property(e => e.Id).ValueGeneratedNever();
@@ -75,7 +84,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         protected virtual void Configure(ReferenceOwnershipBuilder<Level1, Level2> l2)
         {
-            l2.Ignore(e => e.OneToOne_Optional_Self)
+            var level2 = l2.Ignore(e => e.OneToOne_Optional_Self)
                 .Ignore(e => e.OneToMany_Required_Self)
                 .Ignore(e => e.OneToMany_Required_Self_Inverse)
                 .Ignore(e => e.OneToMany_Optional_Self)
@@ -83,16 +92,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .Ignore(e => e.OneToMany_Required)
                 .Ignore(e => e.OneToMany_Required_Inverse)
                 .Ignore(e => e.OneToMany_Optional)
-                .Ignore(e => e.OneToMany_Optional_Inverse);
-
-            l2.HasForeignKey(e => e.Id)
-                .OnDelete(DeleteBehavior.Restrict);
+                .Ignore(e => e.OneToMany_Optional_Inverse).OwnedEntityType;
 
             l2.Property(e => e.Id).ValueGeneratedNever();
-
-            l2.HasOne(e => e.OneToOne_Required_PK_Inverse)
-                .WithOne(e => e.OneToOne_Required_PK)
-                .Metadata.IsOwnership = false; // #9093
 
             l2.HasOne(e => e.OneToOne_Optional_PK_Inverse)
                 .WithOne(e => e.OneToOne_Optional_PK)
@@ -110,12 +112,18 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .HasForeignKey<Level2>(e => e.Level1_Optional_Id)
                 .IsRequired(false);
 
-            l2.OwnsOne(e => e.OneToOne_Required_PK, Configure);
+            var level3 = level2.Model.AddEntityType(typeof(Level3), nameof(Level2.OneToOne_Required_PK), level2);
+            var level3Fk = level3.AddForeignKey(level3.FindProperty(nameof(Level3.Id)), level2.FindPrimaryKey(), level2);
+            level3Fk.HasPrincipalToDependent(nameof(Level2.OneToOne_Required_PK));
+            level3Fk.IsUnique = true;
+            level3Fk.DeleteBehavior = DeleteBehavior.Restrict;
+
+            Configure(new ReferenceOwnershipBuilder<Level2, Level3>((EntityType)level2, (EntityType)level3, ((ForeignKey)level3Fk).Builder));
         }
 
         protected virtual void Configure(ReferenceOwnershipBuilder<Level2, Level3> l3)
         {
-            l3.Ignore(e => e.OneToOne_Optional_Self)
+            var level3 = l3.Ignore(e => e.OneToOne_Optional_Self)
                 .Ignore(e => e.OneToMany_Required_Self)
                 .Ignore(e => e.OneToMany_Required_Self_Inverse)
                 .Ignore(e => e.OneToMany_Optional_Self)
@@ -123,16 +131,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .Ignore(e => e.OneToMany_Required)
                 .Ignore(e => e.OneToMany_Required_Inverse)
                 .Ignore(e => e.OneToMany_Optional)
-                .Ignore(e => e.OneToMany_Optional_Inverse);
-
-            l3.HasForeignKey(e => e.Id)
-                .OnDelete(DeleteBehavior.Restrict);
+                .Ignore(e => e.OneToMany_Optional_Inverse).OwnedEntityType;
 
             l3.Property(e => e.Id).ValueGeneratedNever();
-
-            l3.HasOne(e => e.OneToOne_Required_PK_Inverse)
-                .WithOne(e => e.OneToOne_Required_PK)
-                .Metadata.IsOwnership = false; // #9093
 
             l3.HasOne(e => e.OneToOne_Optional_PK_Inverse)
                 .WithOne(e => e.OneToOne_Optional_PK)
@@ -150,7 +151,13 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .HasForeignKey<Level3>(e => e.Level2_Optional_Id)
                 .IsRequired(false);
 
-            l3.OwnsOne(e => e.OneToOne_Required_PK, Configure);
+            var level4 = level3.Model.AddEntityType(typeof(Level4), nameof(Level3.OneToOne_Required_PK), level3);
+            var level4Fk = level4.AddForeignKey(level4.FindProperty(nameof(Level4.Id)), level3.FindPrimaryKey(), level3);
+            level4Fk.HasPrincipalToDependent(nameof(Level3.OneToOne_Required_PK));
+            level4Fk.IsUnique = true;
+            level4Fk.DeleteBehavior = DeleteBehavior.Restrict;
+
+            Configure(new ReferenceOwnershipBuilder<Level3, Level4>((EntityType)level3, (EntityType)level4, ((ForeignKey)level4Fk).Builder));
         }
 
         protected virtual void Configure(ReferenceOwnershipBuilder<Level3, Level4> l4)
@@ -163,14 +170,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .Ignore(e => e.OneToMany_Required_Inverse)
                 .Ignore(e => e.OneToMany_Optional_Inverse);
 
-            l4.HasForeignKey(e => e.Id)
-                .OnDelete(DeleteBehavior.Restrict);
-
             l4.Property(e => e.Id).ValueGeneratedNever();
-
-            l4.HasOne(e => e.OneToOne_Required_PK_Inverse)
-                .WithOne(e => e.OneToOne_Required_PK)
-                .Metadata.IsOwnership = false; // #9093
 
             l4.HasOne(e => e.OneToOne_Optional_PK_Inverse)
                 .WithOne(e => e.OneToOne_Optional_PK)

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
@@ -365,6 +365,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             Check.NullButNotEmpty(navigationName, nameof(navigationName));
 
             var relatedEntityType = Builder.Metadata.FindInDefinitionPath(relatedType) ??
+                                    Builder.ModelBuilder.Metadata.FindEntityType(relatedType, navigationName, Builder.Metadata) ??
                                     Builder.ModelBuilder.Entity(relatedType, ConfigurationSource.Explicit).Metadata;
 
             return new ReferenceNavigationBuilder(
@@ -404,6 +405,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             Check.NullButNotEmpty(navigationName, nameof(navigationName));
 
             var relatedEntityType = Builder.Metadata.FindInDefinitionPath(relatedTypeName) ??
+                                    Builder.ModelBuilder.Metadata.FindEntityType(relatedTypeName, navigationName, Builder.Metadata) ??
                                     Builder.ModelBuilder.Entity(relatedTypeName, ConfigurationSource.Explicit).Metadata;
 
             return new ReferenceNavigationBuilder(

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
@@ -275,9 +275,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             [CanBeNull] Expression<Func<TEntity, TRelatedEntity>> navigationExpression = null)
             where TRelatedEntity : class
         {
-            var relatedEntityType = Builder.Metadata.FindInDefinitionPath(typeof(TRelatedEntity)) ??
-                                    Builder.ModelBuilder.Entity(typeof(TRelatedEntity), ConfigurationSource.Explicit).Metadata;
             var navigation = navigationExpression?.GetPropertyAccess();
+            var relatedEntityType =
+                Builder.Metadata.FindInDefinitionPath(typeof(TRelatedEntity)) ??
+                Builder.ModelBuilder.Metadata.FindEntityType(typeof(TRelatedEntity), navigation?.Name, Builder.Metadata) ??
+                Builder.ModelBuilder.Entity(typeof(TRelatedEntity), ConfigurationSource.Explicit).Metadata;
 
             return new ReferenceNavigationBuilder<TEntity, TRelatedEntity>(
                 Builder.Metadata,

--- a/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -64,31 +65,31 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             Builder = builder;
         }
 
-        private InternalRelationshipBuilder Builder { get; }
+        private InternalRelationshipBuilder Builder { [DebuggerStepThrough] get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual string ReferenceName { get; }
+        protected virtual string ReferenceName { [DebuggerStepThrough] get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual PropertyInfo ReferenceProperty { get; }
+        protected virtual PropertyInfo ReferenceProperty { [DebuggerStepThrough] get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual EntityType RelatedEntityType { get; }
+        protected virtual EntityType RelatedEntityType { [DebuggerStepThrough] get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual EntityType DeclaringEntityType { get; }
+        protected virtual EntityType DeclaringEntityType { [DebuggerStepThrough] get; }
 
         /// <summary>
         ///     Gets the internal builder being used to configure the relationship.
@@ -276,13 +277,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             throw new InvalidOperationException(
                 CoreStrings.ConflictingRelationshipNavigation(
                     foreignKey.PrincipalEntityType.DisplayName(),
-                    newToPrincipal ? foreignKey.PrincipalToDependent.Name : newInverseName,
+                    newToPrincipal ? foreignKey.PrincipalToDependent?.Name : newInverseName,
                     foreignKey.DeclaringEntityType.DisplayName(),
-                    newToPrincipal ? newInverseName : foreignKey.DependentToPrincipal.Name,
+                    newToPrincipal ? newInverseName : foreignKey.DependentToPrincipal?.Name,
                     foreignKey.PrincipalEntityType.DisplayName(),
-                    foreignKey.PrincipalToDependent.Name,
+                    foreignKey.PrincipalToDependent?.Name,
                     foreignKey.DeclaringEntityType.DisplayName(),
-                    foreignKey.DependentToPrincipal.Name));
+                    foreignKey.DependentToPrincipal?.Name));
         }
 
         #region Hidden System.Object members

--- a/src/EFCore/Metadata/Builders/ReferenceOwnershipBuilder.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceOwnershipBuilder.cs
@@ -414,8 +414,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             Check.NotNull(relatedType, nameof(relatedType));
             Check.NullButNotEmpty(navigationName, nameof(navigationName));
 
-            var relatedEntityType = RelatedEntityType.FindInDefinitionPath(relatedType) ??
-                                    RelatedEntityType.Builder.ModelBuilder.Entity(relatedType, ConfigurationSource.Explicit).Metadata;
+            var relatedEntityType =
+                RelatedEntityType.FindInDefinitionPath(relatedType) ??
+                Builder.ModelBuilder.Metadata.FindEntityType(relatedType, navigationName, RelatedEntityType) ??
+                RelatedEntityType.Builder.ModelBuilder.Entity(relatedType, ConfigurationSource.Explicit).Metadata;
 
             return new ReferenceNavigationBuilder(
                 RelatedEntityType,
@@ -453,8 +455,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             Check.NotEmpty(relatedTypeName, nameof(relatedTypeName));
             Check.NullButNotEmpty(navigationName, nameof(navigationName));
 
-            var relatedEntityType = RelatedEntityType.FindInDefinitionPath(relatedTypeName) ??
-                                    RelatedEntityType.Builder.ModelBuilder.Entity(relatedTypeName, ConfigurationSource.Explicit).Metadata;
+            var relatedEntityType =
+                RelatedEntityType.FindInDefinitionPath(relatedTypeName) ??
+                Builder.ModelBuilder.Metadata.FindEntityType(relatedTypeName, navigationName, RelatedEntityType) ??
+                RelatedEntityType.Builder.ModelBuilder.Entity(relatedTypeName, ConfigurationSource.Explicit).Metadata;
 
             return new ReferenceNavigationBuilder(
                 RelatedEntityType,

--- a/src/EFCore/Metadata/Builders/ReferenceOwnershipBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceOwnershipBuilder`.cs
@@ -380,9 +380,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             [CanBeNull] Expression<Func<TRelatedEntity, TNewRelatedEntity>> navigationExpression = null)
             where TNewRelatedEntity : class
         {
-            var relatedEntityType = RelatedEntityType.FindInDefinitionPath(typeof(TNewRelatedEntity)) ??
-                                    Builder.ModelBuilder.Entity(typeof(TNewRelatedEntity), ConfigurationSource.Explicit).Metadata;
             var navigation = navigationExpression?.GetPropertyAccess();
+            var relatedEntityType =
+                RelatedEntityType.FindInDefinitionPath(typeof(TNewRelatedEntity)) ??
+                Builder.ModelBuilder.Metadata.FindEntityType(typeof(TNewRelatedEntity), navigation?.Name, RelatedEntityType) ??
+                Builder.ModelBuilder.Entity(typeof(TNewRelatedEntity), ConfigurationSource.Explicit).Metadata;
 
             return new ReferenceNavigationBuilder<TRelatedEntity, TNewRelatedEntity>(
                 RelatedEntityType,

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -306,9 +306,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             _modelExpressionApplyingExpressionVisitor.ApplyModelExpressions(queryModel);
 
             // Second pass of optimizations
-            
+
             ExtractQueryAnnotations(queryModel);
-            
+
             navigationRewritingExpressionVisitor.Rewrite(queryModel, parentQueryModel: null);
 
             _queryOptimizer.Optimize(QueryCompilationContext, queryModel);

--- a/src/EFCore/Query/ExpressionVisitors/Internal/EntityEqualityRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/EntityEqualityRewritingExpressionVisitor.cs
@@ -113,13 +113,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     }
                     else
                     {
-                        var properties = MemberAccessBindingExpressionVisitor.GetPropertyPath(
-                            nonNullExpression, _queryCompilationContext, out qsre);
-                        if (properties.Count > 0
-                            && properties[properties.Count - 1] is INavigation navigation)
-                        {
-                            entityType = navigation.GetTargetType();
-                        }
+                        entityType = MemberAccessBindingExpressionVisitor.GetEntityType(
+                            nonNullExpression, _queryCompilationContext);
                     }
                 }
 

--- a/src/EFCore/Query/ExpressionVisitors/Internal/MemberAccessBindingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/MemberAccessBindingExpressionVisitor.cs
@@ -460,6 +460,29 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             return innerProperties;
         }
 
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static IEntityType GetEntityType([NotNull] Expression expression, [NotNull] QueryCompilationContext queryCompilationContext)
+        {
+            IEntityType entityType = null;
+            var properties = GetPropertyPath(expression, queryCompilationContext, out var qsre);
+            if (properties.Count > 0)
+            {
+                if (properties[properties.Count - 1] is INavigation navigation)
+                {
+                    entityType = navigation.GetTargetType();
+                }
+            }
+            else if (qsre != null)
+            {
+                entityType = queryCompilationContext.FindEntityType(qsre.ReferencedQuerySource);
+            }
+
+            return entityType;
+        }
+
         private static readonly MethodInfo _getValueMethodInfo
             = typeof(MemberAccessBindingExpressionVisitor)
                 .GetTypeInfo().GetDeclaredMethod(nameof(GetValue));

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsOwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsOwnedQuerySqlServerTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -65,24 +64,16 @@ LEFT JOIN [Level1] AS [OneToOne_Required_PK.OneToOne_Required_PK.OneToOne_Requir
 WHERE ([l1].[Id] IS NOT NULL AND [l1].[Id] IS NOT NULL) AND [l1].[Id] IS NOT NULL");
         }
 
-        [Fact(Skip = "#9093")]
         public override void Nested_group_join_with_take()
         {
             base.Nested_group_join_with_take();
 
             AssertContainsSql(
-                @"SELECT [t3].[Level1_Optional_Id], [t3].[Level2_Name]
-FROM (
-    SELECT [t2].*
-    FROM [Level1] AS [t2]
-    WHERE [t2].[Id] IS NOT NULL
-) AS [t3]",
-                //
                 @"@__p_0='2'
 
-SELECT [t1].[Id], [t1].[OneToOne_Required_PK_Date], [t1].[Level1_Optional_Id], [t1].[Level1_Required_Id], [t1].[Level2_Name], [t1].[OneToOne_Optional_PK_InverseId]
+SELECT [t3].[Level2_Name]
 FROM (
-    SELECT TOP(@__p_0) [t0].[Id], [t0].[OneToOne_Required_PK_Date], [t0].[Level1_Optional_Id], [t0].[Level1_Required_Id], [t0].[Level2_Name], [t0].[OneToOne_Optional_PK_InverseId]
+    SELECT TOP(@__p_0) [t0].*
     FROM [Level1] AS [l1_inner]
     LEFT JOIN (
         SELECT [t].[Id], [t].[OneToOne_Required_PK_Date], [t].[Level1_Optional_Id], [t].[Level1_Required_Id], [t].[Level2_Name], [t].[OneToOne_Optional_PK_InverseId]
@@ -90,7 +81,12 @@ FROM (
         WHERE [t].[Id] IS NOT NULL
     ) AS [t0] ON [l1_inner].[Id] = [t0].[Level1_Optional_Id]
     ORDER BY [l1_inner].[Id]
-) AS [t1]");
+) AS [t1]
+LEFT JOIN (
+    SELECT [t2].*
+    FROM [Level1] AS [t2]
+    WHERE [t2].[Id] IS NOT NULL
+) AS [t3] ON [t1].[Id] = [t3].[Level1_Optional_Id]");
         }
 
         public override void Explicit_GroupJoin_in_subquery_with_unrelated_projection2()


### PR DESCRIPTION
Record the EntityType when visiting the MainFromClause.

Allow to use the ModelBuilder API to configure weak entity types added using the Model API.
