### PR TITLE
Fix #10501 - Inconsistent SQL queries in inheritance + FromSql scenarios

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/Query/InheritanceRelationalTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/InheritanceRelationalTestBase.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using Microsoft.EntityFrameworkCore.TestModels.Inheritance;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class InheritanceRelationalTestBase<TFixture> : InheritanceTestBase<TFixture>
+        where TFixture : InheritanceFixtureBase, new()
+    {
+        protected InheritanceRelationalTestBase(TFixture fixture) : base(fixture)
+        {
+        }
+
+        [Fact]
+        public virtual void FromSql_on_root()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<Animal>().FromSql(@"select * from ""Animal""").ToList();
+            }
+        }
+
+        [Fact]
+        public virtual void FromSql_on_derived()
+        {
+            using (var context = CreateContext())
+            {
+                context.Set<Eagle>().FromSql(@"select * from ""Animal""").ToList();
+            }
+        }
+    }
+}

--- a/src/EFCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
@@ -207,7 +207,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 if (useQueryComposition
                     && fromSqlAnnotation.QueryModel.IsIdentityQuery()
                     && !fromSqlAnnotation.QueryModel.ResultOperators.Any()
-                    && !relationalQueryCompilationContext.IsIncludeQuery)
+                    && !relationalQueryCompilationContext.IsIncludeQuery
+                    && entityType.BaseType == null
+                    && !entityType.GetDerivedTypes().Any())
                 {
                     useQueryComposition = false;
                 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceSqlServerTest.cs
@@ -9,7 +9,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    public class InheritanceSqlServerTest : InheritanceTestBase<InheritanceSqlServerFixture>
+    public class InheritanceSqlServerTest : InheritanceRelationalTestBase<InheritanceSqlServerFixture>
     {
         public InheritanceSqlServerTest(InheritanceSqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
@@ -55,6 +55,30 @@ WHERE [d].[Discriminator] = N'Lilt'",
                 @"SELECT TOP(2) [d].[Id], [d].[Discriminator], [d].[CaffeineGrams], [d].[HasMilk]
 FROM [Drink] AS [d]
 WHERE [d].[Discriminator] = N'Tea'");
+        }
+
+        public override void FromSql_on_root()
+        {
+            base.FromSql_on_root();
+
+            AssertSql(
+                @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group], [a].[FoundOn]
+FROM (
+    select * from ""Animal""
+) AS [a]
+WHERE [a].[Discriminator] IN (N'Kiwi', N'Eagle')");
+        }
+
+        public override void FromSql_on_derived()
+        {
+            base.FromSql_on_derived();
+
+            AssertSql(
+                @"SELECT [a].[Species], [a].[CountryId], [a].[Discriminator], [a].[Name], [a].[EagleId], [a].[IsFlightless], [a].[Group]
+FROM (
+    select * from ""Animal""
+) AS [a]
+WHERE [a].[Discriminator] = N'Eagle'");
         }
 
         public override void Can_query_all_types_when_shared_column()

--- a/test/EFCore.Sqlite.FunctionalTests/Query/InheritanceSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/InheritanceSqliteTest.cs
@@ -7,7 +7,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    public class InheritanceSqliteTest : InheritanceTestBase<InheritanceSqliteFixture>
+    public class InheritanceSqliteTest : InheritanceRelationalTestBase<InheritanceSqliteFixture>
     {
         public InheritanceSqliteTest(InheritanceSqliteFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)


### PR DESCRIPTION
Force query composition if target entity is part of an inheritance hierarchy.

