### PR TITLE
RevEng: Support named connection strings

### DIFF
--- a/src/EFCore.Design/Design/DbContextActivator.cs
+++ b/src/EFCore.Design/Design/DbContextActivator.cs
@@ -33,7 +33,8 @@ namespace Microsoft.EntityFrameworkCore.Design
             return new DbContextOperations(
                     new OperationReporter(reportHandler),
                     contextType.Assembly,
-                    startupAssembly ?? contextType.Assembly)
+                    startupAssembly ?? contextType.Assembly,
+                    args: Array.Empty<string>()) // TODO: Issue #8332
                 .CreateContext(contextType.FullName);
         }
     }

--- a/src/EFCore.Design/Design/Internal/DatabaseOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DatabaseOperations.cs
@@ -33,20 +33,22 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             [NotNull] Assembly startupAssembly,
             [NotNull] string projectDir,
             [NotNull] string rootNamespace,
-            [NotNull] string language)
+            [NotNull] string language,
+            [NotNull] string[] args)
         {
             Check.NotNull(reporter, nameof(reporter));
             Check.NotNull(startupAssembly, nameof(startupAssembly));
             Check.NotNull(projectDir, nameof(projectDir));
             Check.NotNull(rootNamespace, nameof(rootNamespace));
             Check.NotNull(language, nameof(language));
+            Check.NotNull(args, nameof(args));
 
             _reporter = reporter;
             _projectDir = projectDir;
             _rootNamespace = rootNamespace;
             _language = language;
 
-            _servicesBuilder = new DesignTimeServicesBuilder(startupAssembly, reporter);
+            _servicesBuilder = new DesignTimeServicesBuilder(startupAssembly, reporter, args);
         }
 
         /// <summary>
@@ -98,8 +100,8 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                 _language,
                 MakeDirRelative(outputDir, outputContextDir),
                 dbContextClassName,
-                useDataAnnotations,
-                useDatabaseNames);
+                new ModelReverseEngineerOptions { UseDatabaseNames = useDatabaseNames },
+                new ModelCodeGenerationOptions { UseDataAnnotations = useDataAnnotations });
 
             return scaffolder.Save(
                 scaffoldedModel,

--- a/src/EFCore.Design/Design/Internal/DbContextOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DbContextOperations.cs
@@ -23,24 +23,22 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
     /// </summary>
     public class DbContextOperations
     {
-        // TODO: Flow in from tools (issue #8332)
-        private static readonly string[] _args = Array.Empty<string>();
-
         private readonly IOperationReporter _reporter;
         private readonly Assembly _assembly;
         private readonly Assembly _startupAssembly;
+        private readonly string[] _args;
         private readonly AppServiceProviderFactory _appServicesFactory;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        // NB: Used by Scaffolding. Break with care.
         public DbContextOperations(
             [NotNull] IOperationReporter reporter,
             [NotNull] Assembly assembly,
-            [NotNull] Assembly startupAssembly)
-            : this(reporter, assembly, startupAssembly, new AppServiceProviderFactory(startupAssembly, reporter))
+            [NotNull] Assembly startupAssembly,
+            [NotNull] string[] args)
+            : this(reporter, assembly, startupAssembly, args, new AppServiceProviderFactory(startupAssembly, reporter))
         {
         }
 
@@ -52,15 +50,18 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             [NotNull] IOperationReporter reporter,
             [NotNull] Assembly assembly,
             [NotNull] Assembly startupAssembly,
+            [NotNull] string[] args,
             [NotNull] AppServiceProviderFactory appServicesFactory)
         {
             Check.NotNull(reporter, nameof(reporter));
             Check.NotNull(assembly, nameof(assembly));
             Check.NotNull(startupAssembly, nameof(startupAssembly));
+            Check.NotNull(args, nameof(args));
 
             _reporter = reporter;
             _assembly = assembly;
             _startupAssembly = startupAssembly;
+            _args = args;
             _appServicesFactory = appServicesFactory;
         }
 

--- a/src/EFCore.Design/Design/Internal/DesignTimeConnectionStringResolver.cs
+++ b/src/EFCore.Design/Design/Internal/DesignTimeConnectionStringResolver.cs
@@ -1,27 +1,27 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage.Internal;
 
-namespace Microsoft.EntityFrameworkCore.Storage.Internal
+namespace Microsoft.EntityFrameworkCore.Design.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class NamedConnectionStringResolver : NamedConnectionStringResolverBase
+    public class DesignTimeConnectionStringResolver : NamedConnectionStringResolverBase
     {
-        private readonly IDbContextOptions _options;
+        private readonly Func<IServiceProvider> _applicationServiceProviderAccessor;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public NamedConnectionStringResolver([NotNull] IDbContextOptions options)
+        public DesignTimeConnectionStringResolver([CanBeNull] Func<IServiceProvider> applicationServiceProviderAccessor)
         {
-            _options = options;
+            _applicationServiceProviderAccessor = applicationServiceProviderAccessor;
         }
 
         /// <summary>
@@ -29,7 +29,6 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected override IServiceProvider ApplicationServiceProvider
-            => _options.FindExtension<CoreOptionsExtension>()
-                ?.ApplicationServiceProvider;
+            => _applicationServiceProviderAccessor?.Invoke();
     }
 }

--- a/src/EFCore.Design/Design/Internal/DesignTimeServicesBuilder.cs
+++ b/src/EFCore.Design/Design/Internal/DesignTimeServicesBuilder.cs
@@ -22,15 +22,20 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
     {
         private readonly Assembly _startupAssembly;
         private readonly IOperationReporter _reporter;
+        private readonly string[] _args;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public DesignTimeServicesBuilder([NotNull] Assembly startupAssembly, [NotNull] IOperationReporter reporter)
+        public DesignTimeServicesBuilder(
+            [NotNull] Assembly startupAssembly,
+            [NotNull] IOperationReporter reporter,
+            [NotNull] string[] args)
         {
             _startupAssembly = startupAssembly;
             _reporter = reporter;
+            _args = args;
         }
 
         /// <summary>
@@ -60,13 +65,16 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             Check.NotEmpty(provider, nameof(provider));
 
             var services = new ServiceCollection()
-                .AddEntityFrameworkDesignTimeServices(_reporter);
+                .AddEntityFrameworkDesignTimeServices(_reporter, GetApplicationServices);
             ConfigureProviderServices(provider, services, throwOnError: true);
             ConfigureReferencedServices(services);
             ConfigureUserServices(services);
 
             return services.BuildServiceProvider();
         }
+
+        private IServiceProvider GetApplicationServices()
+            => new AppServiceProviderFactory(_startupAssembly, _reporter).Create(_args);
 
         private void ConfigureUserServices(IServiceCollection services)
         {

--- a/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
+++ b/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
@@ -41,7 +41,8 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             [NotNull] Assembly startupAssembly,
             [NotNull] string projectDir,
             [NotNull] string rootNamespace,
-            [NotNull] string language)
+            [NotNull] string language,
+            [NotNull] string[] args)
         {
             Check.NotNull(reporter, nameof(reporter));
             Check.NotNull(assembly, nameof(assembly));
@@ -49,6 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             Check.NotNull(projectDir, nameof(projectDir));
             Check.NotNull(rootNamespace, nameof(rootNamespace));
             Check.NotNull(language, nameof(language));
+            Check.NotNull(args, nameof(args));
 
             _reporter = reporter;
             _assembly = assembly;
@@ -58,9 +60,10 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             _contextOperations = new DbContextOperations(
                 reporter,
                 assembly,
-                startupAssembly);
+                startupAssembly,
+                args);
 
-            _servicesBuilder = new DesignTimeServicesBuilder(startupAssembly, reporter);
+            _servicesBuilder = new DesignTimeServicesBuilder(startupAssembly, reporter, args);
         }
 
         /// <summary>

--- a/src/EFCore.Design/Design/OperationExecutor.cs
+++ b/src/EFCore.Design/Design/OperationExecutor.cs
@@ -54,6 +54,9 @@ namespace Microsoft.EntityFrameworkCore.Design
             var rootNamespace = (string)args["rootNamespace"];
             var language = (string)args["language"];
 
+            // TODO: Flow in from tools (issue #8332)
+            var designArgs = Array.Empty<string>();
+
             // NOTE: LazyRef is used so any exceptions get passed to the resultHandler
             var startupAssembly = new LazyRef<Assembly>(
                 () => Assembly.Load(new AssemblyName(startupTargetName)));
@@ -75,14 +78,16 @@ namespace Microsoft.EntityFrameworkCore.Design
                 () => new DbContextOperations(
                     reporter,
                     assembly.Value,
-                    startupAssembly.Value));
+                    startupAssembly.Value,
+                    designArgs));
             _databaseOperations = new LazyRef<DatabaseOperations>(
                 () => new DatabaseOperations(
                     reporter,
                     startupAssembly.Value,
                     _projectDir,
                     rootNamespace,
-                    language));
+                    language,
+                    designArgs));
             _migrationsOperations = new LazyRef<MigrationsOperations>(
                 () => new MigrationsOperations(
                     reporter,
@@ -90,7 +95,8 @@ namespace Microsoft.EntityFrameworkCore.Design
                     startupAssembly.Value,
                     _projectDir,
                     rootNamespace,
-                    language));
+                    language,
+                    designArgs));
         }
 
         /// <summary>

--- a/src/EFCore.Design/Scaffolding/IModelCodeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/IModelCodeGenerator.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
         /// <param name="contextDir"> The directory of the <see cref="DbContext"/>. </param>
         /// <param name="contextName"> The name of the <see cref="DbContext"/>. </param>
         /// <param name="connectionString"> The connection string. </param>
-        /// <param name="dataAnnotations"> A value indicating whether to use data annotations. </param>
+        /// <param name="options"> The options to use during generation. </param>
         /// <returns> The generated model. </returns>
         ScaffoldedModel GenerateModel(
             [NotNull] IModel model,
@@ -28,6 +28,6 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
             [NotNull] string contextDir,
             [NotNull] string contextName,
             [NotNull] string connectionString,
-            bool dataAnnotations);
+            [NotNull] ModelCodeGenerationOptions options);
     }
 }

--- a/src/EFCore.Design/Scaffolding/IReverseEngineerScaffolder.cs
+++ b/src/EFCore.Design/Scaffolding/IReverseEngineerScaffolder.cs
@@ -21,8 +21,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
         /// <param name="language"> The programming language to scaffold for. </param>
         /// <param name="contextDir"> The DbContext output dirctory. </param>
         /// <param name="contextName"> The <see cref="DbContext"/> name. </param>
-        /// <param name="useDataAnnotations"> True to scaffold data annotations. </param>
-        /// <param name="useDatabaseNames"> True to use the database schema names directly. </param>
+        /// <param name="modelOptions"> The options to use when reverse engineering a model from the database. </param>
+        /// <param name="codeOptions"> The options to use when generating code for the model. </param>
         /// <returns> The scaffolded model. </returns>
         ScaffoldedModel ScaffoldModel(
             [NotNull] string connectionString,
@@ -32,8 +32,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
             [NotNull] string language,
             [CanBeNull] string contextDir,
             [CanBeNull] string contextName,
-            bool useDataAnnotations,
-            bool useDatabaseNames);
+            [NotNull] ModelReverseEngineerOptions modelOptions,
+            [NotNull] ModelCodeGenerationOptions codeOptions);
 
         /// <summary>
         ///     Saves a scaffolded model to disk.

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpModelGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpModelGenerator.cs
@@ -62,17 +62,18 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             string contextDir,
             string contextName,
             string connectionString,
-            bool useDataAnnotations)
+            ModelCodeGenerationOptions options)
         {
             Check.NotNull(model, nameof(model));
             Check.NotEmpty(@namespace, nameof(@namespace));
             Check.NotNull(contextDir, nameof(contextDir));
             Check.NotEmpty(contextName, nameof(contextName));
             Check.NotEmpty(connectionString, nameof(connectionString));
+            Check.NotNull(options, nameof(options));
 
             var resultingFiles = new ScaffoldedModel();
 
-            var generatedCode = CSharpDbContextGenerator.WriteCode(model, @namespace, contextName, connectionString, useDataAnnotations);
+            var generatedCode = CSharpDbContextGenerator.WriteCode(model, @namespace, contextName, connectionString, options.UseDataAnnotations, options.SuppressConnectionStringWarning);
 
             // output DbContext .cs file
             var dbContextFileName = contextName + FileExtension;
@@ -80,7 +81,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
             foreach (var entityType in model.GetEntityTypes())
             {
-                generatedCode = CSharpEntityTypeGenerator.WriteCode(entityType, @namespace, useDataAnnotations);
+                generatedCode = CSharpEntityTypeGenerator.WriteCode(entityType, @namespace, options.UseDataAnnotations);
 
                 // output EntityType poco .cs file
                 var entityTypeFileName = entityType.DisplayName() + FileExtension;

--- a/src/EFCore.Design/Scaffolding/Internal/ICSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/ICSharpDbContextGenerator.cs
@@ -21,6 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             [NotNull] string @namespace,
             [NotNull] string contextName,
             [NotNull] string connectionString,
-            bool useDataAnnotations);
+            bool useDataAnnotations,
+            bool suppressConnectionStringWarning);
     }
 }

--- a/src/EFCore.Design/Scaffolding/ModelCodeGenerationOptions.cs
+++ b/src/EFCore.Design/Scaffolding/ModelCodeGenerationOptions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Scaffolding
+{
+    /// <summary>
+    ///     Represents the options to use while generating code for a model.
+    /// </summary>
+    public class ModelCodeGenerationOptions
+    {
+        /// <summary>
+        ///     Gets or sets a value indicating whether to use data annotations.
+        /// </summary>
+        /// <value> A value indicating whether to use data annotations. </value>
+        public virtual bool UseDataAnnotations { get; set; }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether to suppress the connection string sensitive information warning.
+        /// </summary>
+        /// <value> A value indicating whether to suppress the connection string sensitive information warning. </value>
+        public virtual bool SuppressConnectionStringWarning { get; set; }
+    }
+}

--- a/src/EFCore.Design/Scaffolding/ModelCodeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/ModelCodeGenerator.cs
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
         /// <param name="contextDir"> The directory of the <see cref="DbContext"/>. </param>
         /// <param name="contextName"> The name of the <see cref="DbContext"/>. </param>
         /// <param name="connectionString"> The connection string. </param>
-        /// <param name="dataAnnotations"> A value indicating whether to use data annotations. </param>
+        /// <param name="options"> The options to use during generation. </param>
         /// <returns> The generated model. </returns>
         public abstract ScaffoldedModel GenerateModel(
             IModel model,
@@ -46,6 +46,6 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
             string contextDir,
             string contextName,
             string connectionString,
-            bool dataAnnotations);
+            ModelCodeGenerationOptions options);
     }
 }

--- a/src/EFCore.Design/Scaffolding/ModelReverseEngineerOptions.cs
+++ b/src/EFCore.Design/Scaffolding/ModelReverseEngineerOptions.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Scaffolding
+{
+    /// <summary>
+    ///     Represents the options to use while reverse engineering a model from the database.
+    /// </summary>
+    public class ModelReverseEngineerOptions
+    {
+        /// <summary>
+        ///     Gets or sets a value indicating whether to use the database schema names directly.
+        /// </summary>
+        /// <value> A value indicating whether to use the database schema names directly. </value>
+        public virtual bool UseDatabaseNames { get; set; }
+    }
+}

--- a/src/EFCore.Relational/Storage/Internal/NamedConnectionStringResolverBase.cs
+++ b/src/EFCore.Relational/Storage/Internal/NamedConnectionStringResolverBase.cs
@@ -1,0 +1,76 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Microsoft.EntityFrameworkCore.Storage.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public abstract class NamedConnectionStringResolverBase : INamedConnectionStringResolver
+    {
+        private const string DefaultSection = "ConnectionStrings:";
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected abstract IServiceProvider ApplicationServiceProvider { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual string ResolveConnectionString(string connectionString)
+        {
+            var connectionName = TryGetConnectionName(connectionString);
+
+            if (connectionName == null)
+            {
+                return connectionString;
+            }
+
+            var configuration = ApplicationServiceProvider
+                ?.GetService<IConfiguration>();
+
+            var resolved = configuration?[connectionName]
+                           ?? configuration?[DefaultSection + connectionName];
+
+            if (resolved == null)
+            {
+                throw new InvalidOperationException(
+                    RelationalStrings.NamedConnectionStringNotFound(connectionName));
+            }
+
+            return resolved;
+        }
+
+        private static string TryGetConnectionName(string connectionString)
+        {
+            var firstEquals = connectionString.IndexOf('=');
+            if (firstEquals < 0)
+            {
+                return null;
+            }
+
+            if (connectionString.IndexOf('=', firstEquals + 1) >= 0)
+            {
+                return null;
+            }
+
+            if (connectionString.Substring(0, firstEquals).Trim().Equals(
+                "name", StringComparison.OrdinalIgnoreCase))
+            {
+                return connectionString.Substring(firstEquals + 1).Trim();
+            }
+
+            return null;
+        }
+    }
+}

--- a/test/EFCore.Design.Tests/Design/Internal/DbContextOperationsTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/DbContextOperationsTest.cs
@@ -18,6 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
                 new TestOperationReporter(),
                 assembly,
                 assembly,
+                /* args: */ Array.Empty<string>(),
                 new TestAppServiceProviderFactory(assembly, typeof(TestProgram)));
 
             operations.CreateContext(typeof(TestContext).FullName);

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpModelGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpModelGeneratorTest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 Path.Combine("..", "TestContextDir" + Path.DirectorySeparatorChar),
                 "TestContext",
                 "Data Source=Test",
-                dataAnnotations: true);
+                new ModelCodeGenerationOptions());
 
             Assert.Equal(Path.Combine("..", "TestContextDir", "TestContext.cs"), result.ContextFile.Path);
             Assert.NotEmpty(result.ContextFile.Code);

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ReverseEngineeringConfigurationTests.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ReverseEngineeringConfigurationTests.cs
@@ -38,15 +38,15 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 DesignStrings.ContextClassNotValidCSharpIdentifier(contextName),
                 Assert.Throws<ArgumentException>(
                         () => reverseEngineer.ScaffoldModel(
-                            connectionString: "connectionstring",
-                            tables: Enumerable.Empty<string>(),
-                            schemas: Enumerable.Empty<string>(),
-                            @namespace: "FakeNamespace",
-                            language: "",
-                            contextDir: null,
-                            contextName: contextName,
-                            useDataAnnotations: false,
-                            useDatabaseNames: false))
+                            "connectionstring",
+                            /* tables: */ Enumerable.Empty<string>(),
+                            /* schemas: */ Enumerable.Empty<string>(),
+                            "FakeNamespace",
+                            /* language: */ "",
+                            /* contextDir: */ null,
+                            contextName,
+                            new ModelReverseEngineerOptions(),
+                            new ModelCodeGenerationOptions()))
                     .Message);
         }
 

--- a/test/EFCore.Design.Tests/TestUtilities/TestDbContextOperations.cs
+++ b/test/EFCore.Design.Tests/TestUtilities/TestDbContextOperations.cs
@@ -12,8 +12,9 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             IOperationReporter reporter,
             Assembly assembly,
             Assembly startupAssembly,
+            string[] args,
             AppServiceProviderFactory appServicesFactory)
-            : base(reporter, assembly, startupAssembly, appServicesFactory)
+            : base(reporter, assembly, startupAssembly, args, appServicesFactory)
         {
         }
     }


### PR DESCRIPTION
This extends support for the "name=" connection string format to the Scaffold-DbContext and `ef dbcontext scaffold` commands. Obviously, the tools will need to be able to access your application services at design time (via Program.BuildWebHost, etc.) and get the IConfiguration service.

Resolves #2464