### PR TITLE
Fix to #10813 - Query: correlated collection optimization is broken for queries containing top level First/FirstOrDefault/Single/SingleOrDefault

### DIFF
--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -4014,6 +4014,74 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void Correlated_collection_with_top_level_FirstOrDefault()
+        {
+            using (var ctx = CreateContext())
+            {
+                var actual = ctx.Gears.OrderBy(g => g.Nickname).Select(g => g.Weapons).FirstOrDefault();
+                var expected = Fixture.QueryAsserter.ExpectedData.Set<Gear>().OrderBy(g => g.Nickname).Select(g => g.Weapons).FirstOrDefault();
+
+                Assert.Equal(expected.Count, actual.Count);
+
+                var actualList = actual.ToList();
+                var expectedList = expected.ToList();
+                for (var i = 0; i < expected.Count; i++)
+                {
+                    Assert.Equal(expectedList[i].Id, actualList[i].Id);
+                    Assert.Equal(expectedList[i].Name, actualList[i].Name);
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Correlated_collection_with_top_level_Count()
+        {
+            AssertSingleResult<Gear>(
+                gs => gs.Select(g => g.Weapons).Count());
+        }
+
+        [ConditionalFact]
+        public virtual void Correlated_collection_with_top_level_Last_with_orderby_on_outer()
+        {
+            using (var ctx = CreateContext())
+            {
+                var actual = ctx.Gears.OrderByDescending(g => g.FullName).Select(g => g.Weapons).Last();
+                var expected = Fixture.QueryAsserter.ExpectedData.Set<Gear>().OrderByDescending(g => g.FullName).Select(g => g.Weapons).Last();
+
+                Assert.Equal(expected.Count, actual.Count);
+
+                var actualList = actual.ToList();
+                var expectedList = expected.ToList();
+                for (var i = 0; i < expected.Count; i++)
+                {
+                    Assert.Equal(expectedList[i].Id, actualList[i].Id);
+                    Assert.Equal(expectedList[i].Name, actualList[i].Name);
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Correlated_collection_with_top_level_Last_with_order_by_on_inner()
+        {
+            using (var ctx = CreateContext())
+            {
+                var actual = ctx.Gears.OrderBy(g => g.FullName).Select(g => g.Weapons.OrderBy(w => w.Name).ToList()).Last();
+                var expected = Fixture.QueryAsserter.ExpectedData.Set<Gear>().OrderBy(g => g.FullName).Select(g => g.Weapons.OrderBy(w => w.Name).ToList()).Last();
+
+                Assert.Equal(expected.Count, actual.Count);
+
+                var actualList = actual.ToList();
+                var expectedList = expected.ToList();
+                for (var i = 0; i < expected.Count; i++)
+                {
+                    Assert.Equal(expectedList[i].Id, actualList[i].Id);
+                    Assert.Equal(expectedList[i].Name, actualList[i].Name);
+                }
+            }
+        }
+
+
+        [ConditionalFact]
         public virtual void Include_with_group_by_and_last()
         {
             using (var ctx = CreateContext())

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -301,7 +301,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             navigationRewritingExpressionVisitor.InjectSubqueryToCollectionsInProjection(queryModel);
 
             var correlatedCollectionFinder = new CorrelatedCollectionFindingExpressionVisitor(this, TrackResults(queryModel));
-            queryModel.SelectClause.TransformExpressions(correlatedCollectionFinder.Visit);
+
+            if (!queryModel.ResultOperators.Any(r => r is GroupResultOperator))
+            {
+                queryModel.SelectClause.TransformExpressions(correlatedCollectionFinder.Visit);
+            }
 
             navigationRewritingExpressionVisitor.Rewrite(queryModel, parentQueryModel: null);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -5802,6 +5802,79 @@ WHERE [w.Owner.Squad.Members].[Discriminator] IN (N'Officer', N'Gear')
 ORDER BY [t6].[Nickname], [t6].[SquadId], [t6].[Nickname0], [t6].[SquadId0], [t6].[FullName], [t6].[Id], [t6].[Id0], [Nickname1]");
         }
 
+        public override void Correlated_collection_with_top_level_FirstOrDefault()
+        {
+            base.Correlated_collection_with_top_level_FirstOrDefault();
+
+            AssertSql(
+                @"SELECT TOP(1) [g].[FullName]
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [g].[Nickname], [g].[SquadId], [g].[FullName]",
+                //
+                @"SELECT [g.Weapons].[Id], [g.Weapons].[AmmunitionType], [g.Weapons].[IsAutomatic], [g.Weapons].[Name], [g.Weapons].[OwnerFullName], [g.Weapons].[SynergyWithId], [t].[Nickname], [t].[SquadId], [t].[FullName]
+FROM [Weapons] AS [g.Weapons]
+INNER JOIN (
+    SELECT TOP(1) [g0].[Nickname], [g0].[SquadId], [g0].[FullName]
+    FROM [Gears] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')
+    ORDER BY [g0].[Nickname], [g0].[SquadId], [g0].[FullName]
+) AS [t] ON [g.Weapons].[OwnerFullName] = [t].[FullName]
+ORDER BY [t].[Nickname], [t].[SquadId], [t].[FullName]");
+        }
+
+        public override void Correlated_collection_with_top_level_Count()
+        {
+            base.Correlated_collection_with_top_level_Count();
+
+            AssertSql(
+                @"SELECT COUNT(*)
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
+        }
+
+        public override void Correlated_collection_with_top_level_Last_with_orderby_on_outer()
+        {
+            base.Correlated_collection_with_top_level_Last_with_orderby_on_outer();
+
+            AssertSql(
+                @"SELECT TOP(1) [g].[FullName]
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [g].[FullName], [g].[Nickname] DESC, [g].[SquadId] DESC",
+                //
+                @"SELECT [g.Weapons].[Id], [g.Weapons].[AmmunitionType], [g.Weapons].[IsAutomatic], [g.Weapons].[Name], [g.Weapons].[OwnerFullName], [g.Weapons].[SynergyWithId], [t].[FullName], [t].[Nickname], [t].[SquadId]
+FROM [Weapons] AS [g.Weapons]
+INNER JOIN (
+    SELECT TOP(1) [g0].[FullName], [g0].[Nickname], [g0].[SquadId]
+    FROM [Gears] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')
+    ORDER BY [g0].[FullName], [g0].[Nickname] DESC, [g0].[SquadId] DESC
+) AS [t] ON [g.Weapons].[OwnerFullName] = [t].[FullName]
+ORDER BY [t].[FullName], [t].[Nickname] DESC, [t].[SquadId] DESC");
+        }
+
+        public override void Correlated_collection_with_top_level_Last_with_order_by_on_inner()
+        {
+            base.Correlated_collection_with_top_level_Last_with_order_by_on_inner();
+
+            AssertSql(
+                @"SELECT TOP(1) [g].[FullName]
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [g].[FullName] DESC, [g].[Nickname] DESC, [g].[SquadId] DESC",
+                //
+                @"SELECT [g.Weapons].[Id], [g.Weapons].[AmmunitionType], [g.Weapons].[IsAutomatic], [g.Weapons].[Name], [g.Weapons].[OwnerFullName], [g.Weapons].[SynergyWithId], [t].[FullName], [t].[Nickname], [t].[SquadId]
+FROM [Weapons] AS [g.Weapons]
+INNER JOIN (
+    SELECT TOP(1) [g0].[FullName], [g0].[Nickname], [g0].[SquadId]
+    FROM [Gears] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')
+    ORDER BY [g0].[FullName] DESC, [g0].[Nickname] DESC, [g0].[SquadId] DESC
+) AS [t] ON [g.Weapons].[OwnerFullName] = [t].[FullName]
+ORDER BY [t].[FullName] DESC, [t].[Nickname] DESC, [t].[SquadId] DESC, [g.Weapons].[Name]");
+        }
+
         public override void Include_with_group_by_and_last()
         {
             base.Include_with_group_by_and_last();
@@ -5885,7 +5958,6 @@ INNER JOIN (
     WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')
 ) AS [t] ON [g.Weapons].[OwnerFullName] = [t].[FullName]
 ORDER BY [t].[Nickname], [t].[FullName]");
-
         }
 
         private void AssertSql(params string[] expected)


### PR DESCRIPTION
Problem was that correlated collection optimization rewrite wasn't properly handling result operators that could be part of the parent query model. Parent QM is cloned, rewritten and then used as part of the inner collection query.

Fix is to properly compensate for result operators that change the cardinality of the result (specifically First/Single/Last), similarly to what we do in the include pipeline.