### PR TITLE
Enable property injection of services, mostly for lazy-loading

### DIFF
--- a/samples/OracleProvider/src/OracleProvider/Metadata/Conventions/OracleConventionSetBuilder.cs
+++ b/samples/OracleProvider/src/OracleProvider/Metadata/Conventions/OracleConventionSetBuilder.cs
@@ -60,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 new RelationalConventionSetBuilderDependencies(convertingMapper, null, null, null))
                 .AddConventions(
                     new CoreConventionSetBuilder(
-                        new CoreConventionSetBuilderDependencies(convertingMapper, null, null))
+                        new CoreConventionSetBuilderDependencies(convertingMapper, null, null, null))
                         .CreateConventionSet());
         }
     }

--- a/samples/OracleProvider/test/OracleProvider.FunctionalTests/WithConstructorsOracleTest.cs
+++ b/samples/OracleProvider/test/OracleProvider.FunctionalTests/WithConstructorsOracleTest.cs
@@ -34,6 +34,12 @@ namespace Microsoft.EntityFrameworkCore
                 modelBuilder.Entity<HasContext<DbContext>>().ToTable("HasContext_DbContext");
                 modelBuilder.Entity<HasContext<WithConstructorsContext>>().ToTable("HasContext_WithConstructorsContext");
                 modelBuilder.Entity<HasContext<OtherContext>>().ToTable("HasContext_OtherContext");
+                modelBuilder.Entity<HasContextProperty<DbContext>>().ToTable("HasContextP_DbContext");
+                modelBuilder.Entity<HasContextProperty<WithConstructorsContext>>().ToTable("HasContextP_WithConstructorsContext");
+                modelBuilder.Entity<HasContextProperty<OtherContext>>().ToTable("HasContextP_OtherContext");
+                modelBuilder.Entity<HasContextPc<DbContext>>().ToTable("HasContextPc_DbContext");
+                modelBuilder.Entity<HasContextPc<WithConstructorsContext>>().ToTable("HasContextPc_WithConstructorsContext");
+                modelBuilder.Entity<HasContextPc<OtherContext>>().ToTable("HasContextPc_OtherContext");
 
                 modelBuilder.Entity<Blog>(
                     b => { b.Property("_blogId").HasColumnName("BlogId"); });

--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -512,6 +512,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             IgnoreAnnotations(
                 annotations,
                 CoreAnnotationNames.ValueGeneratorFactoryAnnotation,
+                CoreAnnotationNames.PropertyAccessModeAnnotation,
                 CoreAnnotationNames.TypeMapping);
 
             GenerateAnnotations(annotations, stringBuilder);
@@ -746,6 +747,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 RelationshipDiscoveryConvention.NavigationCandidatesAnnotationName,
                 RelationshipDiscoveryConvention.AmbiguousNavigationsAnnotationName,
                 InversePropertyAttributeConvention.InverseNavigationsAnnotationName,
+                CoreAnnotationNames.NavigationAccessModeAnnotation,
+                CoreAnnotationNames.PropertyAccessModeAnnotation,
                 CoreAnnotationNames.ConstructorBinding);
 
             if (annotations.Any())

--- a/src/EFCore.Proxies/Proxies/Internal/IProxyFactory.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/IProxyFactory.cs
@@ -26,6 +26,12 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        Type CreateLazyLoadingProxyType([NotNull] IEntityType entityType);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         object Create(
             [NotNull] DbContext context,
             [NotNull] Type entityClrType,

--- a/src/EFCore.Proxies/Proxies/Internal/IProxyLazyLoader.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/IProxyLazyLoader.cs
@@ -1,0 +1,20 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Proxies.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public interface IProxyLazyLoader
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        ILazyLoader LazyLoader { get; [param: CanBeNull] set; }
+    }
+}

--- a/src/EFCore.Proxies/Proxies/Internal/ProxyBindingRewriter.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/ProxyBindingRewriter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -17,6 +18,9 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
     /// </summary>
     public class ProxyBindingRewriter : IModelBuiltConvention
     {
+        private static readonly PropertyInfo _lazyLoaderProperty
+            = typeof(IProxyLazyLoader).GetProperty(nameof(IProxyLazyLoader.LazyLoader));
+
         private readonly ConstructorBindingConvention _directBindingConvention;
         private readonly IProxyFactory _proxyFactory;
         private readonly ProxiesOptionsExtension _options;
@@ -53,6 +57,19 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
                             throw new InvalidOperationException(ProxiesStrings.ItsASeal(entityType.DisplayName()));
                         }
 
+                        var proxyType = _proxyFactory.CreateLazyLoadingProxyType(entityType);
+
+                        var serviceProperty = entityType.GetServiceProperties().FirstOrDefault(e => e.ClrType == typeof(ILazyLoader));
+                        if (serviceProperty == null)
+                        {
+                            serviceProperty = entityType.AddServiceProperty(_lazyLoaderProperty);
+                            serviceProperty.SetParameterBinding(
+                                (ServiceParameterBinding)new LazyLoaderParameterBindingFactory().Bind(
+                                    entityType,
+                                    typeof(ILazyLoader),
+                                    nameof(IProxyLazyLoader.LazyLoader)));
+                        }
+
                         var binding = (ConstructorBinding)entityType[CoreAnnotationNames.ConstructorBinding];
                         if (binding == null)
                         {
@@ -61,7 +78,17 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
 
                         binding = (ConstructorBinding)entityType[CoreAnnotationNames.ConstructorBinding];
 
-                        entityType[CoreAnnotationNames.ConstructorBinding] = RewriteToFactoryBinding(binding);
+                        entityType[CoreAnnotationNames.ConstructorBinding]
+                            = new FactoryMethodConstructorBinding(
+                                _proxyFactory,
+                                typeof(IProxyFactory).GetTypeInfo().GetDeclaredMethod(nameof(IProxyFactory.CreateLazyLoadingProxy)),
+                                new List<ParameterBinding>
+                                {
+                                    new EntityTypeParameterBinding(),
+                                    new DefaultServiceParameterBinding(typeof(ILazyLoader), typeof(ILazyLoader), serviceProperty),
+                                    new ObjectArrayParameterBinding(binding.ParameterBindings)
+                                },
+                                proxyType);
 
                         foreach (var navigation in entityType.GetNavigations())
                         {
@@ -85,17 +112,5 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
 
             return modelBuilder;
         }
-
-        private FactoryMethodConstructorBinding RewriteToFactoryBinding(ConstructorBinding currentBinding)
-            => new FactoryMethodConstructorBinding(
-                _proxyFactory,
-                typeof(ProxyFactory).GetTypeInfo().GetDeclaredMethod(nameof(ProxyFactory.CreateLazyLoadingProxy)),
-                new List<ParameterBinding>
-                {
-                    new EntityTypeParameterBinding(),
-                    new ServiceParameterBinding(typeof(ILazyLoader), typeof(ILazyLoader)),
-                    new ObjectArrayParameterBinding(currentBinding.ParameterBindings)
-                }
-            );
     }
 }

--- a/src/EFCore.Proxies/Proxies/Internal/ProxyFactory.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/ProxyFactory.cs
@@ -39,12 +39,23 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public virtual Type CreateLazyLoadingProxyType(IEntityType entityType)
+            => _generator.ProxyBuilder.CreateClassProxyType(
+                entityType.ClrType,
+                new []{ typeof(IProxyLazyLoader) },
+                ProxyGenerationOptions.Default);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual object CreateLazyLoadingProxy(
             IEntityType entityType,
             ILazyLoader loader,
             object[] constructorArguments)
             => _generator.CreateClassProxy(
                 entityType.ClrType,
+                new []{ typeof(IProxyLazyLoader) },
                 ProxyGenerationOptions.Default,
                 constructorArguments,
                 new LazyLoadingInterceptor(entityType, loader));

--- a/src/EFCore.Specification.Tests/ProxyGraphUpdatesTestBase.cs
+++ b/src/EFCore.Specification.Tests/ProxyGraphUpdatesTestBase.cs
@@ -630,13 +630,17 @@ namespace Microsoft.EntityFrameworkCore
 
             RequiredSingle1 old1 = null;
             RequiredSingle2 old2 = null;
+            Root oldRoot = null;
             ExecuteWithStrategyInTransaction(
                 context =>
                     {
-                        var oldRoot = LoadRoot(context);
-
+                        oldRoot = LoadRoot(context);
                         old1 = oldRoot.RequiredSingle;
                         old2 = oldRoot.RequiredSingle.Single;
+
+                        context.Entry(oldRoot).State = EntityState.Detached;
+                        context.Entry(old1).State = EntityState.Detached;
+                        context.Entry(old2).State = EntityState.Detached;
                     });
 
             var new2 = new RequiredSingle2();
@@ -683,11 +687,10 @@ namespace Microsoft.EntityFrameworkCore
                         Assert.Same(root, new1.Root);
                         Assert.Same(new1, new2.Back);
 
-                            // TODO: When nulling out loader on detach is supported
-                            //Assert.Same(oldRoot, old1.Root);
-                            //Assert.Same(old1, old2.Back);
-                            //Assert.Equal(old1.Id, old2.Id);
-                        });
+                        Assert.Same(oldRoot, old1.Root);
+                        Assert.Same(old1, old2.Back);
+                        Assert.Equal(old1.Id, old2.Id);
+                    });
         }
 
         [ConditionalTheory]
@@ -4018,10 +4021,9 @@ namespace Microsoft.EntityFrameworkCore
                         Assert.Equal(EntityState.Detached, context.Entry(removed).State);
                         Assert.True(cascadeRemoved.All(e => context.Entry(e).State == EntityState.Detached));
 
-                            // TODO: After detach
-                            //Assert.Same(root, removed.Parent);
-                            //Assert.Equal(2, removed.Children.Count());
-                        },
+                        Assert.Same(root, removed.Parent);
+                        Assert.Equal(2, removed.Children.Count());
+                    },
                 context =>
                     {
                         root = LoadRoot(context);
@@ -4073,10 +4075,9 @@ namespace Microsoft.EntityFrameworkCore
                         Assert.Equal(EntityState.Detached, context.Entry(removed).State);
                         Assert.True(orphaned.All(e => context.Entry(e).State == EntityState.Unchanged));
 
-                            // TODO when nulling ILazyLoader on detach
-                            //Assert.Same(root, removed.Parent);
-                            //Assert.Equal(2, removed.Children.Count());
-                        },
+                        Assert.Same(root, removed.Parent);
+                        Assert.Equal(2, removed.Children.Count());
+                    },
                 context =>
                     {
                         root = LoadRoot(context);
@@ -4125,10 +4126,9 @@ namespace Microsoft.EntityFrameworkCore
                         Assert.Equal(EntityState.Detached, context.Entry(removed).State);
                         Assert.Equal(EntityState.Unchanged, context.Entry(orphaned).State);
 
-                            // TODO: After detach
-                            //Assert.Same(root, removed.Root);
-                            //Assert.Same(orphaned, removed.Single);
-                        },
+                        Assert.Same(root, removed.Root);
+                        Assert.Same(orphaned, removed.Single);
+                    },
                 context =>
                     {
                         root = LoadRoot(context);
@@ -4175,10 +4175,9 @@ namespace Microsoft.EntityFrameworkCore
                         Assert.Equal(EntityState.Detached, context.Entry(removed).State);
                         Assert.Equal(EntityState.Detached, context.Entry(orphaned).State);
 
-                            // TODO: After detach
-                            //Assert.Same(root, removed.Root);
-                            //Assert.Same(orphaned, removed.Single);
-                        },
+                        Assert.Same(root, removed.Root);
+                        Assert.Same(orphaned, removed.Single);
+                    },
                 context =>
                 {
                     root = LoadRoot(context);
@@ -4224,10 +4223,9 @@ namespace Microsoft.EntityFrameworkCore
                         Assert.Equal(EntityState.Detached, context.Entry(removed).State);
                         Assert.Equal(EntityState.Detached, context.Entry(orphaned).State);
 
-                            // TODO: After detach
-                            //Assert.Same(root, removed.Root);
-                            //Assert.Same(orphaned, removed.Single);
-                        },
+                        Assert.Same(root, removed.Root);
+                        Assert.Same(orphaned, removed.Single);
+                    },
                 context =>
                     {
                         root = LoadRoot(context);
@@ -4285,10 +4283,9 @@ namespace Microsoft.EntityFrameworkCore
                         Assert.True(orphaned.All(e => context.Entry(e).State == EntityState.Unchanged));
                         Assert.True(orphanedC.All(e => context.Entry(e).State == EntityState.Unchanged));
 
-                            // TODO: After detach
-                            //Assert.Same(root, removed.Parent);
-                            //Assert.Equal(2, removed.Children.Count());
-                        },
+                        Assert.Same(root, removed.Parent);
+                        Assert.Equal(2, removed.Children.Count());
+                    },
                 context =>
                     {
                         root = LoadRoot(context);
@@ -4347,10 +4344,9 @@ namespace Microsoft.EntityFrameworkCore
                         Assert.True(cascadeRemoved.All(e => context.Entry(e).State == EntityState.Detached));
                         Assert.True(cascadeRemovedC.All(e => context.Entry(e).State == EntityState.Detached));
 
-                            // TODO: After detach
-                            //Assert.Same(root, removed.Parent);
-                            //Assert.Equal(2, removed.Children.Count());
-                        },
+                        Assert.Same(root, removed.Parent);
+                        Assert.Equal(2, removed.Children.Count());
+                    },
                 context =>
                     {
                         root = LoadRoot(context);
@@ -4405,10 +4401,9 @@ namespace Microsoft.EntityFrameworkCore
                         Assert.Equal(EntityState.Unchanged, context.Entry(orphaned).State);
                         Assert.Equal(EntityState.Unchanged, context.Entry(orphanedC).State);
 
-                            // TODO: After detach
-                            //Assert.Same(root, removed.Root);
-                            //Assert.Same(orphaned, removed.Single);
-                        },
+                        Assert.Same(root, removed.Root);
+                        Assert.Same(orphaned, removed.Single);
+                    },
                 context =>
                     {
                         root = LoadRoot(context);
@@ -4462,10 +4457,9 @@ namespace Microsoft.EntityFrameworkCore
                         Assert.Equal(EntityState.Detached, context.Entry(orphaned).State);
                         Assert.Equal(EntityState.Detached, context.Entry(orphanedC).State);
 
-                            // TODO: After detach
-                            //Assert.Same(root, removed.Root);
-                            //Assert.Same(orphaned, removed.Single);
-                        },
+                        Assert.Same(root, removed.Root);
+                        Assert.Same(orphaned, removed.Single);
+                    },
                 context =>
                     {
                         root = LoadRoot(context);
@@ -4513,10 +4507,9 @@ namespace Microsoft.EntityFrameworkCore
                         Assert.Equal(EntityState.Detached, context.Entry(removed).State);
                         Assert.Equal(EntityState.Detached, context.Entry(orphaned).State);
 
-                            // TODO: After detach
-                            //Assert.Same(root, removed.Root);
-                            //Assert.Same(orphaned, removed.Single);
-                        },
+                        Assert.Same(root, removed.Root);
+                        Assert.Same(orphaned, removed.Single);
+                    },
                 context =>
                     {
                         root = LoadRoot(context);

--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
@@ -99,7 +99,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 new SqlServerSqlGenerationHelper(new RelationalSqlGenerationHelperDependencies()))
                 .AddConventions(
                     new CoreConventionSetBuilder(
-                        new CoreConventionSetBuilderDependencies(convertingTypeMapper, null, null))
+                        new CoreConventionSetBuilderDependencies(convertingTypeMapper, null, null, null))
                         .CreateConventionSet());
         }
     }

--- a/src/EFCore.Sqlite.Core/Metadata/Conventions/SqliteConventionSetBuilder.cs
+++ b/src/EFCore.Sqlite.Core/Metadata/Conventions/SqliteConventionSetBuilder.cs
@@ -46,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
                 new RelationalConventionSetBuilderDependencies(convertingTypeMapper, null, null, null))
                 .AddConventions(
                     new CoreConventionSetBuilder(
-                        new CoreConventionSetBuilderDependencies(convertingTypeMapper, null, null))
+                        new CoreConventionSetBuilderDependencies(convertingTypeMapper, null, null, null))
                         .CreateConventionSet());
         }
     }

--- a/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
+++ b/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
@@ -42,7 +42,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         /// </summary>
         public virtual void PropertyChanged(InternalEntityEntry entry, IPropertyBase propertyBase, bool setModified)
         {
-            if (_suspended || entry.EntityState == EntityState.Detached)
+            if (_suspended
+                || entry.EntityState == EntityState.Detached
+                || propertyBase is IServiceProperty)
             {
                 return;
             }
@@ -69,7 +71,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         /// </summary>
         public virtual void PropertyChanging(InternalEntityEntry entry, IPropertyBase propertyBase)
         {
-            if (_suspended || entry.EntityState == EntityState.Detached)
+            if (_suspended
+                || entry.EntityState == EntityState.Detached
+                || propertyBase is IServiceProperty)
             {
                 return;
             }

--- a/src/EFCore/ChangeTracking/Internal/StateData.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateData.cs
@@ -53,8 +53,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             public EntityState EntityState
             {
-                get { return (EntityState)(_bits[0] & EntityStateMask); }
-                set { _bits[0] = (_bits[0] & ~EntityStateMask) | (int)value; }
+                get => (EntityState)(_bits[0] & EntityStateMask);
+                set => _bits[0] = (_bits[0] & ~EntityStateMask) | (int)value;
             }
 
             public bool IsPropertyFlagged(int propertyIndex, PropertyFlag propertyFlag)

--- a/src/EFCore/Extensions/MutableEntityTypeExtensions.cs
+++ b/src/EFCore/Extensions/MutableEntityTypeExtensions.cs
@@ -391,11 +391,11 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     <para>
-        ///         Sets the <see cref="PropertyAccessMode" /> to use for properties of this entity type.
+        ///         Sets the <see cref="PropertyAccessMode" /> to use for properties and navigations of this entity type.
         ///     </para>
         ///     <para>
-        ///         Note that individual properties can override this access mode. The value set here will
-        ///         be used for any property for which no override has been specified.
+        ///         Note that individual properties and navigations can override this access mode. The value set here will
+        ///         be used for any property or navigation for which no override has been specified.
         ///     </para>
         /// </summary>
         /// <param name="entityType"> The entity type for which to set the access mode. </param>
@@ -406,6 +406,25 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(entityType, nameof(entityType));
 
             entityType[CoreAnnotationNames.PropertyAccessModeAnnotation] = propertyAccessMode;
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Sets the <see cref="PropertyAccessMode" /> to use for navigations of this entity type.
+        ///     </para>
+        ///     <para>
+        ///         Note that individual navigations can override this access mode. The value set here will
+        ///         be used for any navigation for which no override has been specified.
+        ///     </para>
+        /// </summary>
+        /// <param name="entityType"> The entity type for which to set the access mode. </param>
+        /// <param name="propertyAccessMode"> The <see cref="PropertyAccessMode" />, or null to clear the mode set.</param>
+        public static void SetNavigationAccessMode(
+            [NotNull] this IMutableEntityType entityType, PropertyAccessMode? propertyAccessMode)
+        {
+            Check.NotNull(entityType, nameof(entityType));
+
+            entityType[CoreAnnotationNames.NavigationAccessModeAnnotation] = propertyAccessMode;
         }
     }
 }

--- a/src/EFCore/Extensions/PropertyBaseExtensions.cs
+++ b/src/EFCore/Extensions/PropertyBaseExtensions.cs
@@ -33,6 +33,8 @@ namespace Microsoft.EntityFrameworkCore
         public static PropertyAccessMode? GetPropertyAccessMode(
             [NotNull] this IPropertyBase propertyBase)
             => (PropertyAccessMode?)Check.NotNull(propertyBase, nameof(propertyBase))[CoreAnnotationNames.PropertyAccessModeAnnotation]
-               ?? propertyBase.DeclaringType.GetPropertyAccessMode();
+               ?? (propertyBase is INavigation
+                   ? propertyBase.DeclaringType.GetNavigationAccessMode()
+                   : propertyBase.DeclaringType.GetPropertyAccessMode());
     }
 }

--- a/src/EFCore/Extensions/TypeBaseExtensions.cs
+++ b/src/EFCore/Extensions/TypeBaseExtensions.cs
@@ -15,12 +15,12 @@ namespace Microsoft.EntityFrameworkCore
     {
         /// <summary>
         ///     <para>
-        ///         Gets the <see cref="PropertyAccessMode" /> being used for properties of this type.
+        ///         Gets the <see cref="PropertyAccessMode" /> being used for properties and navigations of this type.
         ///         Null indicates that the default property access mode is being used.
         ///     </para>
         ///     <para>
-        ///         Note that individual properties can override this access mode. The value returned here will
-        ///         be used for any property for which no override has been specified.
+        ///         Note that individual properties and navigations can override this access mode. The value returned here will
+        ///         be used for any property or navigation for which no override has been specified.
         ///     </para>
         /// </summary>
         /// <param name="typeBase"> The type for which to get the access mode. </param>
@@ -28,6 +28,24 @@ namespace Microsoft.EntityFrameworkCore
         public static PropertyAccessMode? GetPropertyAccessMode(
             [NotNull] this ITypeBase typeBase)
             => (PropertyAccessMode?)Check.NotNull(typeBase, nameof(typeBase))[CoreAnnotationNames.PropertyAccessModeAnnotation]
+               ?? typeBase.Model.GetPropertyAccessMode();
+
+        /// <summary>
+        ///     <para>
+        ///         Gets the <see cref="PropertyAccessMode" /> being used for navigations of this type.
+        ///         Null indicates that the default property access mode is being used.
+        ///     </para>
+        ///     <para>
+        ///         Note that individual navigations can override this access mode. The value returned here will
+        ///         be used for any navigation for which no override has been specified.
+        ///     </para>
+        /// </summary>
+        /// <param name="typeBase"> The type for which to get the access mode. </param>
+        /// <returns> The access mode being used, or null if the default access mode is being used. </returns>
+        public static PropertyAccessMode? GetNavigationAccessMode(
+            [NotNull] this ITypeBase typeBase)
+            => (PropertyAccessMode?)Check.NotNull(typeBase, nameof(typeBase))[CoreAnnotationNames.NavigationAccessModeAnnotation]
+               ?? typeBase.GetPropertyAccessMode()
                ?? typeBase.Model.GetPropertyAccessMode();
     }
 }

--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -92,6 +93,9 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(IDiagnosticsLogger<>), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IValueConverterSelector), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IConstructorBindingFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
+                { typeof(IRegisteredServices), new ServiceCharacteristics(ServiceLifetime.Singleton) },
+                { typeof(IPropertyParameterBindingFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
+                { typeof(IParameterBindingFactories), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(IEntityGraphAttacher), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IKeyPropagator), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(INavigationFixer), new ServiceCharacteristics(ServiceLifetime.Scoped) },
@@ -127,6 +131,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(IEntityQueryableExpressionVisitorFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IEntityQueryModelVisitorFactory), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(ILazyLoader), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+                { typeof(IParameterBindingFactory), new ServiceCharacteristics(ServiceLifetime.Singleton, multipleRegistrations: true) },
                 { typeof(IConventionSetBuilder), new ServiceCharacteristics(ServiceLifetime.Scoped, multipleRegistrations: true) },
                 { typeof(IEntityStateListener), new ServiceCharacteristics(ServiceLifetime.Scoped, multipleRegistrations: true) },
                 { typeof(INavigationListener), new ServiceCharacteristics(ServiceLifetime.Scoped, multipleRegistrations: true) },
@@ -267,6 +272,11 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<IValueConverterSelector, ValueConverterSelector>();
             TryAdd<IConstructorBindingFactory, ConstructorBindingFactory>();
             TryAdd<ILazyLoader, LazyLoader>();
+            TryAdd<IParameterBindingFactories, ParameterBindingFactories>();
+            TryAdd<IPropertyParameterBindingFactory, PropertyParameterBindingFactory>();
+            TryAdd<IParameterBindingFactory, LazyLoaderParameterBindingFactory>();
+            TryAdd<IParameterBindingFactory, ContextParameterBindingFactory>();
+            TryAdd<IParameterBindingFactory, EntityTypeParameterBindingFactory>();
 
             ServiceCollectionMap
                 .TryAddSingleton<DiagnosticSource>(new DiagnosticListener(DbLoggerCategory.Name));
@@ -292,6 +302,9 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 .AddDependencyScoped<QueryCompilationContextDependencies>()
                 .ServiceCollection.AddMemoryCache();
 
+            ServiceCollectionMap.TryAddSingleton<IRegisteredServices>(
+                new RegisteredServices(ServiceCollectionMap.ServiceCollection.Select(s => s.ServiceType)));
+            
             return this;
         }
 

--- a/src/EFCore/Internal/IRegisteredServices.cs
+++ b/src/EFCore/Internal/IRegisteredServices.cs
@@ -1,23 +1,21 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Reflection;
-using JetBrains.Annotations;
+using System;
+using System.Collections.Generic;
 
-namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+namespace Microsoft.EntityFrameworkCore.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public abstract class ParameterBindingFactory
+    public interface IRegisteredServices
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public abstract ParameterBinding TryBindParameter(
-            [NotNull] IMutableEntityType entityType,
-            [NotNull] ParameterInfo parameter);
+        ISet<Type> Services { get; }
     }
 }

--- a/src/EFCore/Internal/RegisteredServices.cs
+++ b/src/EFCore/Internal/RegisteredServices.cs
@@ -2,35 +2,30 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
+using System.Collections.Generic;
+using JetBrains.Annotations;
 
-namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+namespace Microsoft.EntityFrameworkCore.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class ContextParameterBindingFactory : IParameterBindingFactory
+    public class RegisteredServices : IRegisteredServices
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual bool CanBind(
-            Type parameterType,
-            string parameterName)
-            => typeof(DbContext).IsAssignableFrom(parameterType);
+        public RegisteredServices([NotNull] IEnumerable<Type> services)
+        {
+            Services = new HashSet<Type>(services);
+        }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual ParameterBinding Bind(
-            IMutableEntityType entityType,
-            Type parameterType,
-            string parameterName)
-            => new ContextParameterBinding(
-                parameterType,
-                entityType.GetServiceProperties().FirstOrDefault(p => p.ClrType == parameterType));
+        public virtual ISet<Type> Services { get; }
     }
 }

--- a/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
@@ -36,11 +36,25 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             var conventionSet = new ConventionSet();
 
-            var propertyDiscoveryConvention = new PropertyDiscoveryConvention(Dependencies.TypeMapper);
-            var keyDiscoveryConvention = new KeyDiscoveryConvention(Dependencies.Logger);
-            var inversePropertyAttributeConvention =
-                new InversePropertyAttributeConvention(Dependencies.TypeMapper, Dependencies.Logger);
-            var relationshipDiscoveryConvention = new RelationshipDiscoveryConvention(Dependencies.TypeMapper, Dependencies.Logger);
+            var propertyDiscoveryConvention
+                = new PropertyDiscoveryConvention(
+                    Dependencies.TypeMapper,
+                    Dependencies.ParameterBindingFactories);
+
+            var keyDiscoveryConvention
+                = new KeyDiscoveryConvention(Dependencies.Logger);
+
+            var inversePropertyAttributeConvention
+                = new InversePropertyAttributeConvention(
+                    Dependencies.TypeMapper,
+                    Dependencies.ParameterBindingFactories,
+                    Dependencies.Logger);
+
+            var relationshipDiscoveryConvention
+                = new RelationshipDiscoveryConvention(
+                    Dependencies.TypeMapper,
+                    Dependencies.ParameterBindingFactories,
+                    Dependencies.Logger);
 
             conventionSet.EntityTypeAddedConventions.Add(new NotMappedEntityTypeAttributeConvention());
             conventionSet.EntityTypeAddedConventions.Add(new OwnedEntityTypeAttributeConvention());
@@ -51,6 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             conventionSet.EntityTypeAddedConventions.Add(inversePropertyAttributeConvention);
             conventionSet.EntityTypeAddedConventions.Add(relationshipDiscoveryConvention);
             conventionSet.EntityTypeAddedConventions.Add(new DerivedTypeDiscoveryConvention());
+
             conventionSet.EntityTypeIgnoredConventions.Add(inversePropertyAttributeConvention);
 
             var foreignKeyIndexConvention = new ForeignKeyIndexConvention(Dependencies.Logger);
@@ -99,7 +114,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var cascadeDeleteConvention = new CascadeDeleteConvention();
 
-            conventionSet.ForeignKeyAddedConventions.Add(new ForeignKeyAttributeConvention(Dependencies.TypeMapper, Dependencies.Logger));
+            conventionSet.ForeignKeyAddedConventions.Add(
+                new ForeignKeyAttributeConvention(
+                    Dependencies.TypeMapper,
+                    Dependencies.ParameterBindingFactories,
+                    Dependencies.Logger));
+
             conventionSet.ForeignKeyAddedConventions.Add(foreignKeyPropertyDiscoveryConvention);
             conventionSet.ForeignKeyAddedConventions.Add(keyDiscoveryConvention);
             conventionSet.ForeignKeyAddedConventions.Add(valueGeneratorConvention);
@@ -118,7 +138,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             conventionSet.ModelBuiltConventions.Add(new ModelCleanupConvention());
             conventionSet.ModelBuiltConventions.Add(keyAttributeConvention);
             conventionSet.ModelBuiltConventions.Add(new IgnoredMembersValidationConvention());
-            conventionSet.ModelBuiltConventions.Add(new PropertyMappingValidationConvention(Dependencies.TypeMapper));
+
+            conventionSet.ModelBuiltConventions.Add(
+                new PropertyMappingValidationConvention(
+                    Dependencies.TypeMapper,
+                    Dependencies.ParameterBindingFactories));
+
             conventionSet.ModelBuiltConventions.Add(new RelationshipValidationConvention());
             conventionSet.ModelBuiltConventions.Add(foreignKeyPropertyDiscoveryConvention);
             conventionSet.ModelBuiltConventions.Add(new ChangeTrackingStrategyConvention());

--- a/src/EFCore/Metadata/Conventions/Internal/ForeignKeyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ForeignKeyAttributeConvention.cs
@@ -22,6 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     public class ForeignKeyAttributeConvention : IForeignKeyAddedConvention
     {
         private readonly ICoreTypeMapper _typeMapper;
+        private readonly IParameterBindingFactories _parameterBindingFactories;
         private readonly IDiagnosticsLogger<DbLoggerCategory.Model> _logger;
 
         /// <summary>
@@ -30,11 +31,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         /// </summary>
         public ForeignKeyAttributeConvention(
             [NotNull] ICoreTypeMapper typeMapper,
+            [NotNull] IParameterBindingFactories parameterBindingFactories,
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
         {
             Check.NotNull(typeMapper, nameof(typeMapper));
+            Check.NotNull(parameterBindingFactories, nameof(parameterBindingFactories));
 
             _typeMapper = typeMapper;
+            _parameterBindingFactories = parameterBindingFactories;
             _logger = logger;
         }
 
@@ -298,8 +302,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             Check.NotNull(propertyInfo, nameof(propertyInfo));
 
-            return propertyInfo.FindCandidateNavigationPropertyType(
-                m => _typeMapper.FindMapping(m) != null);
+            return propertyInfo.FindCandidateNavigationPropertyType(_typeMapper, _parameterBindingFactories);
         }
 
         private static IReadOnlyList<string> FindCandidateDependentPropertiesThroughNavigation(

--- a/src/EFCore/Metadata/Conventions/Internal/InversePropertyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/InversePropertyAttributeConvention.cs
@@ -31,8 +31,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         /// </summary>
         public InversePropertyAttributeConvention(
             [NotNull] ICoreTypeMapper typeMapper,
+            [NotNull] IParameterBindingFactories parameterBindingFactories,
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
-            : base(typeMapper)
+            : base(typeMapper, parameterBindingFactories)
         {
             _logger = logger;
         }

--- a/src/EFCore/Metadata/Conventions/Internal/NavigationAttributeEntityTypeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/NavigationAttributeEntityTypeConvention.cs
@@ -24,17 +24,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         where TAttribute : Attribute
     {
         private readonly ICoreTypeMapper _typeMapper;
+        private readonly IParameterBindingFactories _parameterBindingFactories;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected NavigationAttributeEntityTypeConvention(
-            [NotNull] ICoreTypeMapper typeMapper)
+            [NotNull] ICoreTypeMapper typeMapper,
+            [NotNull] IParameterBindingFactories parameterBindingFactories)
         {
             Check.NotNull(typeMapper, nameof(typeMapper));
+            Check.NotNull(parameterBindingFactories, nameof(parameterBindingFactories));
 
             _typeMapper = typeMapper;
+            _parameterBindingFactories = parameterBindingFactories;
         }
 
         /// <summary>
@@ -213,8 +217,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             Check.NotNull(propertyInfo, nameof(propertyInfo));
 
-            return propertyInfo.FindCandidateNavigationPropertyType(
-                m => _typeMapper.FindMapping(m) != null);
+            return propertyInfo.FindCandidateNavigationPropertyType(_typeMapper, _parameterBindingFactories);
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Conventions/Internal/PropertyMappingValidationConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/PropertyMappingValidationConvention.cs
@@ -20,17 +20,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     public class PropertyMappingValidationConvention : IModelBuiltConvention
     {
         private readonly ICoreTypeMapper _typeMapper;
+        private readonly IParameterBindingFactories _parameterBindingFactories;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public PropertyMappingValidationConvention(
-            [NotNull] ICoreTypeMapper typeMapper)
+            [NotNull] ICoreTypeMapper typeMapper,
+            [NotNull] IParameterBindingFactories parameterBindingFactories)
         {
             Check.NotNull(typeMapper, nameof(typeMapper));
+            Check.NotNull(parameterBindingFactories, nameof(parameterBindingFactories));
 
             _typeMapper = typeMapper;
+            _parameterBindingFactories = parameterBindingFactories;
         }
 
         /// <summary>
@@ -63,6 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
                     clrProperties.ExceptWith(entityType.GetProperties().Select(p => p.Name));
                     clrProperties.ExceptWith(entityType.GetNavigations().Select(p => p.Name));
+                    clrProperties.ExceptWith(entityType.GetServiceProperties().Select(p => p.Name));
                     clrProperties.RemoveWhere(p => entityType.Builder.IsIgnored(p, ConfigurationSource.Convention));
 
                     if (clrProperties.Count > 0)
@@ -145,8 +150,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             Check.NotNull(propertyInfo, nameof(propertyInfo));
 
-            return propertyInfo.FindCandidateNavigationPropertyType(
-                t => _typeMapper.FindMapping(t) != null);
+            return propertyInfo.FindCandidateNavigationPropertyType(_typeMapper, _parameterBindingFactories);
         }
     }
 }

--- a/src/EFCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
@@ -28,6 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         INavigationAddedConvention
     {
         private readonly ICoreTypeMapper _typeMapper;
+        private readonly IParameterBindingFactories _parameterBindingFactories;
         private readonly IDiagnosticsLogger<DbLoggerCategory.Model> _logger;
 
         /// <summary>
@@ -36,11 +37,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         /// </summary>
         public RelationshipDiscoveryConvention(
             [NotNull] ICoreTypeMapper typeMapper,
+            [NotNull] IParameterBindingFactories parameterBindingFactories,
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.Model> logger)
         {
             Check.NotNull(typeMapper, nameof(typeMapper));
+            Check.NotNull(parameterBindingFactories, nameof(parameterBindingFactories));
 
             _typeMapper = typeMapper;
+            _parameterBindingFactories = parameterBindingFactories;
             _logger = logger;
         }
 
@@ -700,6 +704,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 return false;
             }
 
+            if (sourceEntityTypeBuilder.Metadata.FindServiceProperty(navigationName) != null)
+            {
+                return false;
+            }
+
             return true;
         }
 
@@ -781,8 +790,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual Type FindCandidateNavigationPropertyType([NotNull] PropertyInfo propertyInfo)
-            => Check.NotNull(propertyInfo, nameof(propertyInfo)).FindCandidateNavigationPropertyType(
-                t => _typeMapper.FindMapping(t) != null);
+            => Check.NotNull(propertyInfo, nameof(propertyInfo)).FindCandidateNavigationPropertyType(_typeMapper, _parameterBindingFactories);
 
         private ImmutableSortedDictionary<PropertyInfo, Type> GetNavigationCandidates(EntityType entityType)
         {

--- a/src/EFCore/Metadata/IEntityType.cs
+++ b/src/EFCore/Metadata/IEntityType.cs
@@ -129,5 +129,28 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <returns> The properties defined on this entity. </returns>
         IEnumerable<IProperty> GetProperties();
+
+        /// <summary>
+        ///     <para>
+        ///         Gets the <see cref="IServiceProperty"/> with a given name. Returns null if no property with the given name is defined.
+        ///     </para>
+        ///     <para>
+        ///         This API only finds service properties and does not find scalar or navigation properties.
+        ///     </para>
+        /// </summary>
+        /// <param name="name"> The name of the property. </param>
+        /// <returns> The service property, or null if none is found. </returns>
+        IServiceProperty FindServiceProperty([NotNull] string name);
+
+        /// <summary>
+        ///     <para>
+        ///         Gets all the <see cref="IServiceProperty"/> defined on this entity.
+        ///     </para>
+        ///     <para>
+        ///         This API only returns service properties and does not return scalar or navigation properties.
+        ///     </para>
+        /// </summary>
+        /// <returns> The service properties defined on this entity. </returns>
+        IEnumerable<IServiceProperty> GetServiceProperties();
     }
 }

--- a/src/EFCore/Metadata/IMutableEntityType.cs
+++ b/src/EFCore/Metadata/IMutableEntityType.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Reflection;
 using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Metadata
@@ -215,5 +216,42 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <param name="name"> The name of the property to remove. </param>
         /// <returns> The property that was removed. </returns>
         IMutableProperty RemoveProperty([NotNull] string name);
+
+        /// <summary>
+        ///     Adds a <see cref="IMutableServiceProperty"/> to this entity.
+        /// </summary>
+        /// <param name="memberInfo"> The <see cref="PropertyInfo"/> or <see cref="FieldInfo"/> of the property to add. </param>
+        /// <returns> The newly created property. </returns>
+        IMutableServiceProperty AddServiceProperty([NotNull] MemberInfo memberInfo);
+
+        /// <summary>
+        ///     <para>
+        ///         Gets the <see cref="IMutableServiceProperty"/> with a given name. Returns null if no property with the given name is defined.
+        ///     </para>
+        ///     <para>
+        ///         This API only finds service properties and does not find scalar or navigation properties.
+        ///     </para>
+        /// </summary>
+        /// <param name="name"> The name of the property. </param>
+        /// <returns> The service property, or null if none is found. </returns>
+        new IMutableServiceProperty FindServiceProperty([NotNull] string name);
+
+        /// <summary>
+        ///     <para>
+        ///         Gets all the <see cref="IMutableServiceProperty"/> defined on this entity.
+        ///     </para>
+        ///     <para>
+        ///         This API only returns service properties and does not return scalar or navigation properties.
+        ///     </para>
+        /// </summary>
+        /// <returns> The service properties defined on this entity. </returns>
+        new IEnumerable<IMutableServiceProperty> GetServiceProperties();
+
+        /// <summary>
+        ///     Removes an <see cref="IMutableServiceProperty"/> from this entity.
+        /// </summary>
+        /// <param name="name"> The name of the property to remove. </param>
+        /// <returns> The property that was removed. </returns>
+        IMutableServiceProperty RemoveServiceProperty([NotNull] string name);
     }
 }

--- a/src/EFCore/Metadata/IMutableServiceProperty.cs
+++ b/src/EFCore/Metadata/IMutableServiceProperty.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Metadata
+{
+    /// <summary>
+    ///     A <see cref="IPropertyBase"/> in the Entity Framework model that represents an
+    ///     injected service from the <see cref="DbContext"/>.
+    /// </summary>
+    public interface IMutableServiceProperty : IServiceProperty, IMutablePropertyBase
+    {
+        /// <summary>
+        ///     Gets the type that this property belongs to.
+        /// </summary>
+        new IMutableEntityType DeclaringEntityType { get; }
+    }
+}

--- a/src/EFCore/Metadata/IServiceProperty.cs
+++ b/src/EFCore/Metadata/IServiceProperty.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Metadata
+{
+    /// <summary>
+    ///     A <see cref="IPropertyBase"/> in the Entity Framework model that represents an
+    ///     injected service from the <see cref="DbContext"/>.
+    /// </summary>
+    public interface IServiceProperty : IPropertyBase
+    {
+        /// <summary>
+        ///     Gets the entity type that this property belongs to.
+        /// </summary>
+        IEntityType DeclaringEntityType { get; }
+    }
+}

--- a/src/EFCore/Metadata/Internal/ClrPropertySetterFactory.cs
+++ b/src/EFCore/Metadata/Internal/ClrPropertySetterFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -33,10 +34,35 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var entityParameter = Expression.Parameter(typeof(TEntity), "entity");
             var valueParameter = Expression.Parameter(typeof(TValue), "value");
 
-            var setter = Expression.Lambda<Action<TEntity, TValue>>(
-                Expression.Assign(
+            Expression writeExpression;
+            if (memberInfo.DeclaringType == typeof(TEntity))
+            {
+                writeExpression = Expression.Assign(
                     Expression.MakeMemberAccess(entityParameter, memberInfo),
-                    valueParameter),
+                    valueParameter);
+            }
+            else
+            {
+                // This path handles properties that exist only on proxy types and so only exist if the instance is a proxy
+                var converted = Expression.Variable(memberInfo.DeclaringType, "converted");
+
+                writeExpression = Expression.Block(
+                    new[] { converted }, 
+                    new List<Expression>
+                    {
+                        Expression.Assign(
+                            converted,
+                            Expression.TypeAs(entityParameter, memberInfo.DeclaringType)),
+                        Expression.IfThen(
+                            Expression.ReferenceNotEqual(converted, Expression.Constant(null)),
+                            Expression.Assign(
+                                Expression.MakeMemberAccess(converted, memberInfo),
+                                valueParameter))
+                    });
+            }
+
+            var setter = Expression.Lambda<Action<TEntity, TValue>>(
+                writeExpression,
                 entityParameter,
                 valueParameter).Compile();
 

--- a/src/EFCore/Metadata/Internal/ConstructorBinding.cs
+++ b/src/EFCore/Metadata/Internal/ConstructorBinding.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
@@ -34,5 +35,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual IReadOnlyList<ParameterBinding> ParameterBindings { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public abstract Type RuntimeType { get; }
     }
 }

--- a/src/EFCore/Metadata/Internal/DirectConstructorBinding.cs
+++ b/src/EFCore/Metadata/Internal/DirectConstructorBinding.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -41,5 +42,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             => Expression.New(
                 Constructor,
                 ParameterBindings.Select(b => b.BindToParameter(bindingInfo)));
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override Type RuntimeType => Constructor.DeclaringType;
     }
 }

--- a/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -498,6 +498,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public static IEnumerable<IServiceProperty> GetDeclaredServiceProperties([NotNull] this IEntityType entityType)
+            => entityType.GetServiceProperties().Where(p => p.DeclaringEntityType == entityType);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public static IEnumerable<IProperty> FindDerivedProperties(
             [NotNull] this IEntityType entityType, [NotNull] string propertyName)
             => entityType.GetDerivedTypes().SelectMany(
@@ -630,6 +637,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     foreach (var navigation in navigations)
                     {
                         builder.AppendLine().Append(navigation.ToDebugString(false, indent + "    "));
+                    }
+                }
+
+                var serviceProperties = entityType.GetDeclaredServiceProperties().ToList();
+                if (serviceProperties.Count != 0)
+                {
+                    builder.AppendLine().Append(indent).Append("  Service properties: ");
+                    foreach (var serviceProperty in serviceProperties)
+                    {
+                        builder.AppendLine().Append(serviceProperty.ToDebugString(false, indent + "    "));
                     }
                 }
 

--- a/src/EFCore/Metadata/Internal/EntityTypeParameterBinding.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeParameterBinding.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq.Expressions;
+using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
@@ -9,14 +10,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class EntityTypeParameterBinding : ParameterBinding
+    public class EntityTypeParameterBinding : ServiceParameterBinding
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public EntityTypeParameterBinding()
-            : base(typeof(IEntityType))
+        public EntityTypeParameterBinding([CanBeNull] IPropertyBase consumedProperty = null)
+            : base(typeof(IEntityType), typeof(IEntityType), consumedProperty)
         {
         }
 
@@ -24,7 +25,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override Expression BindToParameter(ParameterBindingInfo bindingInfo)
-            => Expression.Constant(bindingInfo.EntityType, typeof(IEntityType));
+        public override Expression BindToParameter(
+            Expression contextExpression,
+            Expression entityTypeExpression,
+            Expression entityExpression)
+            => entityTypeExpression;
     }
 }

--- a/src/EFCore/Metadata/Internal/EntityTypeParameterBindingFactory.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeParameterBindingFactory.cs
@@ -1,7 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Reflection;
+using System;
+using System.Linq;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
@@ -9,15 +10,25 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class EntityTypeParameterBindingFactory : ParameterBindingFactory
+    public class EntityTypeParameterBindingFactory : IParameterBindingFactory
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override ParameterBinding TryBindParameter(IMutableEntityType entityType, ParameterInfo parameter)
-            => parameter.ParameterType == typeof(IEntityType)
-                ? new EntityTypeParameterBinding()
-                : null;
+        public virtual bool CanBind(
+            Type parameterType,
+            string parameterName)
+            => parameterType == typeof(IEntityType);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual ParameterBinding Bind(
+            IMutableEntityType entityType,
+            Type parameterType,
+            string parameterName)
+            => new EntityTypeParameterBinding(entityType.GetServiceProperties().FirstOrDefault(p => p.ClrType == parameterType));
     }
 }

--- a/src/EFCore/Metadata/Internal/FactoryMethodConstructorBinding.cs
+++ b/src/EFCore/Metadata/Internal/FactoryMethodConstructorBinding.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -24,10 +25,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public FactoryMethodConstructorBinding(
             [NotNull] MethodInfo factoryMethod,
-            [NotNull] IReadOnlyList<ParameterBinding> parameterBindings)
+            [NotNull] IReadOnlyList<ParameterBinding> parameterBindings,
+            [NotNull] Type runtimeType)
             : base(parameterBindings)
         {
             _factoryMethod = factoryMethod;
+            RuntimeType = runtimeType;
         }
 
         /// <summary>
@@ -37,8 +40,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public FactoryMethodConstructorBinding(
             [NotNull] object factoryInstance,
             [NotNull] MethodInfo factoryMethod,
-            [NotNull] IReadOnlyList<ParameterBinding> parameterBindings)
-            : this(factoryMethod, parameterBindings)
+            [NotNull] IReadOnlyList<ParameterBinding> parameterBindings,
+            [NotNull] Type runtimeType)
+            : this(factoryMethod, parameterBindings, runtimeType)
         {
             _factoryInstance = factoryInstance;
         }
@@ -61,12 +65,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         _factoryMethod,
                         arguments);
 
-            if (_factoryMethod.ReturnType != bindingInfo.EntityType.ClrType)
+            if (_factoryMethod.ReturnType != RuntimeType)
             {
-                expression = Expression.Convert(expression, bindingInfo.EntityType.ClrType);
+                expression = Expression.Convert(expression, RuntimeType);
             }
 
             return expression;
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override Type RuntimeType { get; }
     }
 }

--- a/src/EFCore/Metadata/Internal/IEntityMaterializerSource.cs
+++ b/src/EFCore/Metadata/Internal/IEntityMaterializerSource.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [NotNull] Expression valueBuffer,
             [NotNull] Type type,
             int index,
-            [CanBeNull] IProperty property);
+            [CanBeNull] IPropertyBase property);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/Internal/IParameterBindingFactories.cs
+++ b/src/EFCore/Metadata/Internal/IParameterBindingFactories.cs
@@ -1,0 +1,21 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public interface IParameterBindingFactories
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        IParameterBindingFactory FindFactory([NotNull] Type type, [NotNull] string name);
+    }
+}

--- a/src/EFCore/Metadata/Internal/IParameterBindingFactory.cs
+++ b/src/EFCore/Metadata/Internal/IParameterBindingFactory.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq;
+using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
@@ -10,27 +10,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class ContextParameterBindingFactory : IParameterBindingFactory
+    public interface IParameterBindingFactory
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual bool CanBind(
-            Type parameterType,
-            string parameterName)
-            => typeof(DbContext).IsAssignableFrom(parameterType);
+        bool CanBind(
+            [NotNull] Type parameterType,
+            [NotNull] string parameterName);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual ParameterBinding Bind(
-            IMutableEntityType entityType,
-            Type parameterType,
-            string parameterName)
-            => new ContextParameterBinding(
-                parameterType,
-                entityType.GetServiceProperties().FirstOrDefault(p => p.ClrType == parameterType));
+        ParameterBinding Bind(
+            [NotNull] IMutableEntityType entityType,
+            [NotNull] Type parameterType,
+            [NotNull] string parameterName);
     }
 }

--- a/src/EFCore/Metadata/Internal/IPropertyParameterBindingFactory.cs
+++ b/src/EFCore/Metadata/Internal/IPropertyParameterBindingFactory.cs
@@ -1,0 +1,24 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public interface IPropertyParameterBindingFactory
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        ParameterBinding TryBindParameter(
+            [NotNull] IMutableEntityType entityType,
+            [NotNull] Type parameterType,
+            [NotNull] string parameterName);
+    }
+}

--- a/src/EFCore/Metadata/Internal/MutableServicePropertyExtensions.cs
+++ b/src/EFCore/Metadata/Internal/MutableServicePropertyExtensions.cs
@@ -1,8 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Linq;
+using System.Runtime.CompilerServices;
+using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
@@ -10,27 +10,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class ContextParameterBindingFactory : IParameterBindingFactory
+    public static class MutableServicePropertyExtensions
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual bool CanBind(
-            Type parameterType,
-            string parameterName)
-            => typeof(DbContext).IsAssignableFrom(parameterType);
+        public static void SetParameterBinding([NotNull] this IMutableServiceProperty serviceProperty, [NotNull] ServiceParameterBinding parameterBinding)
+            => serviceProperty.AsServiceProperty().ParameterBinding = parameterBinding;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual ParameterBinding Bind(
-            IMutableEntityType entityType,
-            Type parameterType,
-            string parameterName)
-            => new ContextParameterBinding(
-                parameterType,
-                entityType.GetServiceProperties().FirstOrDefault(p => p.ClrType == parameterType));
+        public static ServiceProperty AsServiceProperty([NotNull] this IMutableServiceProperty serviceProperty, [NotNull] [CallerMemberName] string methodName = "")
+            => MetadataExtensions.AsConcreteMetadataType<IMutableServiceProperty, ServiceProperty>(serviceProperty, methodName);
     }
 }

--- a/src/EFCore/Metadata/Internal/ParameterBindingFactories.cs
+++ b/src/EFCore/Metadata/Internal/ParameterBindingFactories.cs
@@ -2,8 +2,10 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq.Expressions;
+using System.Collections.Generic;
+using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
@@ -11,27 +13,33 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class ContextParameterBinding : ServiceParameterBinding
+    public class ParameterBindingFactories : IParameterBindingFactories
     {
+        private readonly IRegisteredServices _registeredServices;
+        private readonly List<IParameterBindingFactory> _parameterBindingFactories;
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public ContextParameterBinding(
-            [NotNull] Type contextType,
-            [CanBeNull] IPropertyBase consumedProperty = null)
-            : base(contextType, contextType, consumedProperty)
+        public ParameterBindingFactories(
+            [CanBeNull] IEnumerable<IParameterBindingFactory> registeredFactories,
+            [NotNull] IRegisteredServices registeredServices)
         {
+            _registeredServices = registeredServices;
+
+            _parameterBindingFactories
+                = registeredFactories?.ToList() ?? new List<IParameterBindingFactory>();
         }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override Expression BindToParameter(
-            Expression contextExpression,
-            Expression entityTypeExpression,
-            Expression entityExpression)
-            => Expression.TypeAs(contextExpression, ServiceType);
+        public virtual IParameterBindingFactory FindFactory(Type type, string name)
+            => _parameterBindingFactories.FirstOrDefault(f => f.CanBind(type, name))
+               ?? (_registeredServices.Services.Contains(type)
+                   ? new ServiceParameterBindingFactory(type)
+                   : null);
     }
 }

--- a/src/EFCore/Metadata/Internal/PropertyParameterBindingFactory.cs
+++ b/src/EFCore/Metadata/Internal/PropertyParameterBindingFactory.cs
@@ -13,34 +13,36 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class PropertyParameterBindingFactory : ParameterBindingFactory
+    public class PropertyParameterBindingFactory : IPropertyParameterBindingFactory
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override ParameterBinding TryBindParameter(IMutableEntityType entityType, ParameterInfo parameter)
+        public virtual ParameterBinding TryBindParameter(
+            IMutableEntityType entityType,
+            Type parameterType,
+            string parameterName)
         {
-            var candidateNames = GetCandidatePropertyNames(parameter);
+            var candidateNames = GetCandidatePropertyNames(parameterName);
 
             return entityType.GetProperties().Where(
-                p => p.ClrType == parameter.ParameterType
+                p => p.ClrType == parameterType
                      && candidateNames.Any(c => c.Equals(p.Name, StringComparison.Ordinal)))
                 .Select(p => new PropertyParameterBinding(p)).FirstOrDefault();
         }
 
-        private static IList<string> GetCandidatePropertyNames([NotNull] ParameterInfo parameter)
+        private static IList<string> GetCandidatePropertyNames(string parameterName)
         {
-            var name = parameter.Name;
-            var pascalized = char.ToUpperInvariant(name[0]) + name.Substring(1);
+            var pascalized = char.ToUpperInvariant(parameterName[0]) + parameterName.Substring(1);
 
             return new List<string>
             {
-                name,
+                parameterName,
                 pascalized,
-                "_" + name,
+                "_" + parameterName,
                 "_" + pascalized,
-                "m_" + name,
+                "m_" + parameterName,
                 "m_" + pascalized
             };
         }

--- a/src/EFCore/Metadata/Internal/ServiceMethodParameterBinding.cs
+++ b/src/EFCore/Metadata/Internal/ServiceMethodParameterBinding.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class ServiceMethodParameterBinding : ServiceParameterBinding
+    public class ServiceMethodParameterBinding : DefaultServiceParameterBinding
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -23,8 +23,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public ServiceMethodParameterBinding(
             [NotNull] Type parameterType,
             [NotNull] Type serviceType,
-            [NotNull] MethodInfo method)
-            : base(parameterType, serviceType)
+            [NotNull] MethodInfo method,
+            [CanBeNull] IPropertyBase consumedProperty = null)
+            : base(parameterType, serviceType, consumedProperty)
         {
             Method = method;
         }
@@ -39,7 +40,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override Expression BindToParameter(ParameterBindingInfo bindingInfo)
+        public override Expression BindToParameter(
+            Expression contextExpression,
+            Expression entityTypeExpression,
+            Expression entityExpression)
         {
             var parameters = Method.GetParameters().Select(
                 (p, i) => Expression.Parameter(p.ParameterType, "param" + i)).ToArray();
@@ -53,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 {
                     Expression.Assign(
                         serviceVariable,
-                        base.BindToParameter(bindingInfo)),
+                        base.BindToParameter(contextExpression, entityTypeExpression, entityExpression)),
                     Expression.Assign(
                         delegateVariable,
                         Expression.Condition(

--- a/src/EFCore/Metadata/Internal/ServiceParameterBinding.cs
+++ b/src/EFCore/Metadata/Internal/ServiceParameterBinding.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Linq.Expressions;
-using System.Reflection;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
@@ -14,19 +12,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class ServiceParameterBinding : ParameterBinding
+    public abstract class ServiceParameterBinding : ParameterBinding
     {
-        private static readonly MethodInfo _getServiceMethod
-            = typeof(InternalAccessorExtensions).GetMethod(nameof(InternalAccessorExtensions.GetService));
+        private Func<DbContext, IEntityType, object, object> _serviceDelegate;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public ServiceParameterBinding(
+        protected ServiceParameterBinding(
             [NotNull] Type parameterType,
-            [NotNull] Type serviceType)
-            : base(parameterType)
+            [NotNull] Type serviceType,
+            [CanBeNull] IPropertyBase consumedProperty = null)
+            : base(parameterType, consumedProperty != null ? new[] { consumedProperty } : new IPropertyBase[0])
         {
             ServiceType = serviceType;
         }
@@ -42,8 +40,37 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override Expression BindToParameter(ParameterBindingInfo bindingInfo)
-            => Expression.Call(
-                _getServiceMethod.MakeGenericMethod(ServiceType),
-                Expression.Convert(bindingInfo.ContextExpression, typeof(IInfrastructure<IServiceProvider>)));
+            => BindToParameter(
+                bindingInfo.ContextExpression,
+                Expression.Constant(bindingInfo.EntityType),
+                null);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public abstract Expression BindToParameter(
+            [NotNull] Expression contextExpression,
+            [NotNull] Expression entityTypeExpression,
+            [CanBeNull] Expression entityExpression);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Func<DbContext, IEntityType, object, object> ServiceDelegate
+            => NonCapturingLazyInitializer.EnsureInitialized(
+                ref _serviceDelegate, this, b =>
+                {
+                    var contextParam = Expression.Parameter(typeof(DbContext));
+                    var entityTypeParam = Expression.Parameter(typeof(IEntityType));
+                    var entityParam = Expression.Parameter(typeof(object));
+
+                    return Expression.Lambda<Func<DbContext, IEntityType, object, object>>(
+                        b.BindToParameter(contextParam, entityTypeParam, entityParam),
+                        contextParam,
+                        entityTypeParam,
+                        entityParam).Compile();
+                });
     }
 }

--- a/src/EFCore/Metadata/Internal/ServiceParameterBindingFactory.cs
+++ b/src/EFCore/Metadata/Internal/ServiceParameterBindingFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
@@ -10,8 +11,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class ContextParameterBindingFactory : IParameterBindingFactory
+    public class ServiceParameterBindingFactory : IParameterBindingFactory
     {
+        private readonly Type _serviceType;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public ServiceParameterBindingFactory([NotNull] Type serviceType)
+        {
+            _serviceType = serviceType;
+        }
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
@@ -19,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual bool CanBind(
             Type parameterType,
             string parameterName)
-            => typeof(DbContext).IsAssignableFrom(parameterType);
+            => parameterType == _serviceType;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -29,8 +41,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             IMutableEntityType entityType,
             Type parameterType,
             string parameterName)
-            => new ContextParameterBinding(
-                parameterType,
-                entityType.GetServiceProperties().FirstOrDefault(p => p.ClrType == parameterType));
+            => new DefaultServiceParameterBinding(
+                _serviceType,
+                _serviceType,
+                entityType.GetServiceProperties().FirstOrDefault(p => p.ClrType == _serviceType));
     }
 }

--- a/src/EFCore/Metadata/Internal/ServiceProperty.cs
+++ b/src/EFCore/Metadata/Internal/ServiceProperty.cs
@@ -1,78 +1,82 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public static class CoreAnnotationNames
+    public class ServiceProperty : PropertyBase, IMutableServiceProperty
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public const string MaxLengthAnnotation = "MaxLength";
+        public ServiceProperty(
+            [NotNull] string name,
+            [CanBeNull] PropertyInfo propertyInfo,
+            [CanBeNull] FieldInfo fieldInfo,
+            [NotNull] EntityType declaringEntityType)
+            : base(name, propertyInfo, fieldInfo)
+        {
+            Check.NotNull(declaringEntityType, nameof(declaringEntityType));
+
+            DeclaringEntityType = declaringEntityType;
+            ClrType = propertyInfo?.PropertyType ?? fieldInfo?.FieldType;
+        }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public const string UnicodeAnnotation = "Unicode";
+        public virtual EntityType DeclaringEntityType { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public const string ProductVersionAnnotation = "ProductVersion";
+        public new virtual EntityType DeclaringType => DeclaringEntityType;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public const string ValueGeneratorFactoryAnnotation = "ValueGeneratorFactory";
+        protected override void PropertyMetadataChanged() => DeclaringType.PropertyMetadataChanged();
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public const string PropertyAccessModeAnnotation = "PropertyAccessMode";
+        public override Type ClrType { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public const string NavigationAccessModeAnnotation = "NavigationAccessMode";
+        public virtual ServiceParameterBinding ParameterBinding { get; [param: NotNull] set; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public const string OwnedTypesAnnotation = "OwnedTypes";
+        public override string ToString() => this.ToDebugString();
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public const string ConstructorBinding = "ConstructorBinding";
+        public virtual DebugView<ServiceProperty> DebugView
+            => new DebugView<ServiceProperty>(this, m => m.ToDebugString(false));
 
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public const string TypeMapping = "Relational:TypeMapping"; // "Relational:" prefix to prevent breaking changes from 2.0
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public const string ValueConverter = "ValueConverter";
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public const string StoreClrType = "StoreClrType";
+        IEntityType IServiceProperty.DeclaringEntityType => DeclaringEntityType;
+        IMutableEntityType IMutableServiceProperty.DeclaringEntityType => DeclaringEntityType;
+        ITypeBase IPropertyBase.DeclaringType => DeclaringType;
+        IMutableTypeBase IMutablePropertyBase.DeclaringType => DeclaringType;
     }
 }

--- a/src/EFCore/Metadata/Internal/ServicePropertyExtensions.cs
+++ b/src/EFCore/Metadata/Internal/ServicePropertyExtensions.cs
@@ -1,0 +1,67 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Runtime.CompilerServices;
+using System.Text;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public static class ServicePropertyExtensions
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static ServiceParameterBinding GetParameterBinding([NotNull] this IServiceProperty serviceProperty)
+            => serviceProperty.AsServiceProperty().ParameterBinding;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string ToDebugString([NotNull] this IServiceProperty serviceProperty, bool singleLine = true, [NotNull] string indent = "")
+        {
+            var builder = new StringBuilder();
+
+            builder.Append(indent);
+
+            if (singleLine)
+            {
+                builder.Append("Service property: ").Append(serviceProperty.DeclaringType.DisplayName()).Append(".");
+            }
+
+            builder.Append(serviceProperty.Name);
+
+            if (serviceProperty.GetFieldName() == null)
+            {
+                builder.Append(" (no field, ");
+            }
+            else
+            {
+                builder.Append(" (").Append(serviceProperty.GetFieldName()).Append(", ");
+            }
+
+            builder.Append(serviceProperty.ClrType?.ShortDisplayName()).Append(")");
+
+            if (!singleLine)
+            {
+                builder.Append(serviceProperty.AnnotationsToDebugString(indent + "  "));
+            }
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static ServiceProperty AsServiceProperty([NotNull] this IServiceProperty serviceProperty, [NotNull] [CallerMemberName] string methodName = "")
+            => MetadataExtensions.AsConcreteMetadataType<IServiceProperty, ServiceProperty>(serviceProperty, methodName);
+    }
+}

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -573,6 +573,22 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 navigation, entityType, duplicateEntityType);
 
         /// <summary>
+        ///     The service property '{property}' cannot be added to the entity type '{entityType}' because a service property with the same name already exists on entity type '{duplicateEntityType}'.
+        /// </summary>
+        public static string DuplicateServiceProperty([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object duplicateEntityType)
+            => string.Format(
+                GetString("DuplicateServiceProperty", nameof(property), nameof(entityType), nameof(duplicateEntityType)),
+                property, entityType, duplicateEntityType);
+
+        /// <summary>
+        ///     The service property '{property}' of type '{serviceType}' cannot be added to the entity type '{entityType}' because service property '{duplicateName}' of the same type already exists on entity type '{duplicateEntityType}'.
+        /// </summary>
+        public static string DuplicateServicePropertyType([CanBeNull] object property, [CanBeNull] object serviceType, [CanBeNull] object entityType, [CanBeNull] object duplicateName, [CanBeNull] object duplicateEntityType)
+            => string.Format(
+                GetString("DuplicateServicePropertyType", nameof(property), nameof(serviceType), nameof(entityType), nameof(duplicateName), nameof(duplicateEntityType)),
+                property, serviceType, entityType, duplicateName, duplicateEntityType);
+
+        /// <summary>
         ///     The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because there is no corresponding CLR property on the underlying type and navigations properties cannot be added to shadow state.
         /// </summary>
         public static string NoClrNavigation([CanBeNull] object navigation, [CanBeNull] object entityType)
@@ -1183,6 +1199,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
             => string.Format(
                 GetString("ConflictingProperty", nameof(navigation), nameof(entityType), nameof(duplicateEntityType)),
                 navigation, entityType, duplicateEntityType);
+
+        /// <summary>
+        ///     The property or navigation '{property}' cannot be added to the entity type '{entityType}' because a service property with the same name already exists on entity type '{duplicateEntityType}'.
+        /// </summary>
+        public static string ConflictingServiceProperty([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object duplicateEntityType)
+            => string.Format(
+                GetString("ConflictingServiceProperty", nameof(property), nameof(entityType), nameof(duplicateEntityType)),
+                property, entityType, duplicateEntityType);
 
         /// <summary>
         ///     The specified entity type '{entityType}' is invalid. It should be either the dependent entity type '{dependentType}' or the principal entity type '{principalType}'.

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -326,6 +326,12 @@
   <data name="DuplicateNavigation" xml:space="preserve">
     <value>The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because a navigation property with the same name already exists on entity type '{duplicateEntityType}'.</value>
   </data>
+  <data name="DuplicateServiceProperty" xml:space="preserve">
+    <value>The service property '{property}' cannot be added to the entity type '{entityType}' because a service property with the same name already exists on entity type '{duplicateEntityType}'.</value>
+  </data>
+  <data name="DuplicateServicePropertyType" xml:space="preserve">
+    <value>The service property '{property}' of type '{serviceType}' cannot be added to the entity type '{entityType}' because service property '{duplicateName}' of the same type already exists on entity type '{duplicateEntityType}'.</value>
+  </data>
   <data name="NoClrNavigation" xml:space="preserve">
     <value>The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because there is no corresponding CLR property on the underlying type and navigations properties cannot be added to shadow state.</value>
   </data>
@@ -557,6 +563,9 @@
   </data>
   <data name="ConflictingProperty" xml:space="preserve">
     <value>The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because a property with the same name already exists on entity type '{duplicateEntityType}'.</value>
+  </data>
+  <data name="ConflictingServiceProperty" xml:space="preserve">
+    <value>The property or navigation '{property}' cannot be added to the entity type '{entityType}' because a service property with the same name already exists on entity type '{duplicateEntityType}'.</value>
   </data>
   <data name="EntityTypeNotInRelationshipStrict" xml:space="preserve">
     <value>The specified entity type '{entityType}' is invalid. It should be either the dependent entity type '{dependentType}' or the principal entity type '{principalType}'.</value>

--- a/src/EFCore/breakingchanges.netcore.json
+++ b/src/EFCore/breakingchanges.netcore.json
@@ -78,5 +78,35 @@
     "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType : Microsoft.EntityFrameworkCore.Metadata.IEntityType, Microsoft.EntityFrameworkCore.Metadata.IMutableTypeBase",
     "MemberId": "System.Void set_IsQueryType(System.Boolean value)",
     "Kind": "Addition"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType : Microsoft.EntityFrameworkCore.Metadata.IEntityType, Microsoft.EntityFrameworkCore.Metadata.IMutableTypeBase",
+    "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IMutableServiceProperty AddServiceProperty(System.Reflection.MemberInfo memberInfo)",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType : Microsoft.EntityFrameworkCore.Metadata.IEntityType, Microsoft.EntityFrameworkCore.Metadata.IMutableTypeBase",
+    "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IMutableServiceProperty FindServiceProperty(System.String name)",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType : Microsoft.EntityFrameworkCore.Metadata.IEntityType, Microsoft.EntityFrameworkCore.Metadata.IMutableTypeBase",
+    "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IMutableServiceProperty RemoveServiceProperty(System.String name)",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType : Microsoft.EntityFrameworkCore.Metadata.IEntityType, Microsoft.EntityFrameworkCore.Metadata.IMutableTypeBase",
+    "MemberId": "System.Collections.Generic.IEnumerable<Microsoft.EntityFrameworkCore.Metadata.IMutableServiceProperty> GetServiceProperties()",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IEntityType : Microsoft.EntityFrameworkCore.Metadata.ITypeBase",
+    "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IServiceProperty FindServiceProperty(System.String name)",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IEntityType : Microsoft.EntityFrameworkCore.Metadata.ITypeBase",
+    "MemberId": "System.Collections.Generic.IEnumerable<Microsoft.EntityFrameworkCore.Metadata.IServiceProperty> GetServiceProperties()",
+    "Kind": "Addition"
   }
 ]

--- a/src/Shared/PropertyInfoExtensions.cs
+++ b/src/Shared/PropertyInfoExtensions.cs
@@ -4,7 +4,8 @@
 using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Utilities;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
 
 // ReSharper disable once CheckNamespace
 namespace System.Reflection
@@ -15,14 +16,17 @@ namespace System.Reflection
         public static bool IsStatic(this PropertyInfo property)
             => (property.GetMethod ?? property.SetMethod).IsStatic;
 
-        public static bool IsCandidateProperty(this PropertyInfo propertyInfo, bool needsWrite = true)
+        public static bool IsCandidateProperty(this PropertyInfo propertyInfo, bool needsWrite = true, bool publicOnly = true)
             => !propertyInfo.IsStatic()
                && propertyInfo.GetIndexParameters().Length == 0
                && propertyInfo.CanRead
                && (!needsWrite || propertyInfo.CanWrite)
-               && propertyInfo.GetMethod != null && propertyInfo.GetMethod.IsPublic;
+               && propertyInfo.GetMethod != null && (!publicOnly || propertyInfo.GetMethod.IsPublic);
 
-        public static Type FindCandidateNavigationPropertyType(this PropertyInfo propertyInfo, Func<MemberInfo, bool> isPrimitiveProperty)
+        public static Type FindCandidateNavigationPropertyType(
+            this PropertyInfo propertyInfo,
+            ICoreTypeMapper typeMapper,
+            IParameterBindingFactories parameterBindingFactories)
         {
             var targetType = propertyInfo.PropertyType;
             var targetSequenceType = targetType.TryGetSequenceType();
@@ -34,10 +38,11 @@ namespace System.Reflection
             targetType = targetSequenceType ?? targetType;
             targetType = targetType.UnwrapNullableType();
 
-            if (isPrimitiveProperty(propertyInfo)
+            if (typeMapper.FindMapping(propertyInfo) != null
                 || targetType.GetTypeInfo().IsInterface
                 || targetType.GetTypeInfo().IsValueType
-                || targetType == typeof(object))
+                || targetType == typeof(object)
+                || parameterBindingFactories.FindFactory(propertyInfo.PropertyType, propertyInfo.Name) != null)
             {
                 return null;
             }

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -67,10 +67,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             var forEntityType = new Dictionary<string, (object, string)>
             {
                 {
-                    CoreAnnotationNames.PropertyAccessModeAnnotation,
-                    (PropertyAccessMode.Property, _toTable + _nl2 + @"modelBuilder.HasAnnotation(""PropertyAccessMode"", PropertyAccessMode.Property);" + _nl)
-                },
-                {
                     RelationalAnnotationNames.TableName,
                     ("MyTable", _nl2 + "modelBuilder." + nameof(RelationalEntityTypeBuilderExtensions.ToTable) + @"(""MyTable"");" + _nl)
                 },
@@ -108,6 +104,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 CoreAnnotationNames.ProductVersionAnnotation,
                 CoreAnnotationNames.OwnedTypesAnnotation,
                 CoreAnnotationNames.ConstructorBinding,
+                CoreAnnotationNames.NavigationAccessModeAnnotation,
                 RelationalAnnotationNames.TableName,
                 RelationalAnnotationNames.Schema,
                 RelationalAnnotationNames.DefaultSchema,
@@ -124,10 +121,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             // Note that other tests should be added to check code is generated correctly
             var forProperty = new Dictionary<string, (object, string)>
             {
-                {
-                    CoreAnnotationNames.PropertyAccessModeAnnotation,
-                    (PropertyAccessMode.Property, _nl + @".HasAnnotation(""PropertyAccessMode"", PropertyAccessMode.Property)")
-                },
                 {
                     CoreAnnotationNames.MaxLengthAnnotation,
                     (256, _nl + "." + nameof(PropertyBuilder.HasMaxLength) + "(256)")

--- a/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
+++ b/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
@@ -238,7 +238,7 @@ namespace Microsoft.EntityFrameworkCore
         [Fact]
         public void Throws_if_create_proxy_for_non_mapped_type()
         {
-            using (var context = new NeweyContextN4())
+            using (var context = new NeweyContextN())
             {
                 Assert.Equal(
                     CoreStrings.EntityTypeNotFound(nameof(March82GGtp)),

--- a/test/EFCore.Relational.Tests/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConventionTest.cs
@@ -44,6 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 new FallbackRelationalCoreTypeMapper(
                     TestServiceFactory.Instance.Create<CoreTypeMapperDependencies>(),
                     TestServiceFactory.Instance.Create<RelationalTypeMapperDependencies>(),
-                    TestServiceFactory.Instance.Create<TestRelationalTypeMapper>()));
+                    TestServiceFactory.Instance.Create<TestRelationalTypeMapper>()),
+                TestServiceFactory.Instance.Create<IParameterBindingFactories>());
     }
 }

--- a/test/EFCore.Relational.Tests/Metadata/RelationalEntityTypeAttributeConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalEntityTypeAttributeConventionTest.cs
@@ -63,7 +63,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                     new FallbackRelationalCoreTypeMapper(
                         TestServiceFactory.Instance.Create<CoreTypeMapperDependencies>(),
                         TestServiceFactory.Instance.Create<RelationalTypeMapperDependencies>(),
-                        TestServiceFactory.Instance.Create<FakeRelationalTypeMapper>())));
+                        TestServiceFactory.Instance.Create<FakeRelationalTypeMapper>()),
+                    TestServiceFactory.Instance.Create<IParameterBindingFactories>()));
 
             var modelBuilder = new InternalModelBuilder(new Model(conventionSet));
 

--- a/test/EFCore.Relational.Tests/Metadata/RelationalPropertyAttributeConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalPropertyAttributeConventionTest.cs
@@ -78,7 +78,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                     new FallbackRelationalCoreTypeMapper(
                         TestServiceFactory.Instance.Create<CoreTypeMapperDependencies>(),
                         TestServiceFactory.Instance.Create<RelationalTypeMapperDependencies>(),
-                        TestServiceFactory.Instance.Create<FakeRelationalTypeMapper>())));
+                        TestServiceFactory.Instance.Create<FakeRelationalTypeMapper>()),
+                    TestServiceFactory.Instance.Create<IParameterBindingFactories>()));
 
             var modelBuilder = new InternalModelBuilder(new Model(conventionSet));
 

--- a/test/EFCore.SqlServer.FunctionalTests/LazyLoadProxySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/LazyLoadProxySqlServerTest.cs
@@ -15,9 +15,9 @@ namespace Microsoft.EntityFrameworkCore
             fixture.TestSqlLoggerFactory.Clear();
         }
 
-        public override void Lazy_load_collection(EntityState state)
+        public override void Lazy_load_collection(EntityState state, bool useAttach, bool useDetach)
         {
-            base.Lazy_load_collection(state);
+            base.Lazy_load_collection(state, useAttach, useDetach);
 
             Assert.Equal(
                 @"@__get_Item_0='707' (Nullable = true)
@@ -29,9 +29,9 @@ WHERE [e].[ParentId] = @__get_Item_0",
                 ignoreLineEndingDifferences: true);
         }
 
-        public override void Lazy_load_many_to_one_reference_to_principal(EntityState state)
+        public override void Lazy_load_many_to_one_reference_to_principal(EntityState state, bool useAttach, bool useDetach)
         {
-            base.Lazy_load_many_to_one_reference_to_principal(state);
+            base.Lazy_load_many_to_one_reference_to_principal(state, useAttach, useDetach);
 
             Assert.Equal(
                 @"@__get_Item_0='707'
@@ -43,9 +43,9 @@ WHERE [e].[Id] = @__get_Item_0",
                 ignoreLineEndingDifferences: true);
         }
 
-        public override void Lazy_load_one_to_one_reference_to_principal(EntityState state)
+        public override void Lazy_load_one_to_one_reference_to_principal(EntityState state, bool useAttach, bool useDetach)
         {
-            base.Lazy_load_one_to_one_reference_to_principal(state);
+            base.Lazy_load_one_to_one_reference_to_principal(state, useAttach, useDetach);
 
             Assert.Equal(
                 @"@__get_Item_0='707'
@@ -57,9 +57,9 @@ WHERE [e].[Id] = @__get_Item_0",
                 ignoreLineEndingDifferences: true);
         }
 
-        public override void Lazy_load_one_to_one_reference_to_dependent(EntityState state)
+        public override void Lazy_load_one_to_one_reference_to_dependent(EntityState state, bool useAttach, bool useDetach)
         {
-            base.Lazy_load_one_to_one_reference_to_dependent(state);
+            base.Lazy_load_one_to_one_reference_to_dependent(state, useAttach, useDetach);
 
             Assert.Equal(
                 @"@__get_Item_0='707' (Nullable = true)

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/ConstructorBindingConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/ConstructorBindingConventionTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -199,7 +200,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             Assert.IsType<ContextParameterBinding>(bindings[1]);
             Assert.Empty(bindings[1].ConsumedProperties);
-            Assert.Same(typeof(DbContext), ((ContextParameterBinding)bindings[1]).ContextType);
+            Assert.Same(typeof(DbContext), ((ContextParameterBinding)bindings[1]).ServiceType);
         }
 
         private class BlogWithContext : Blog
@@ -226,7 +227,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             Assert.IsType<ContextParameterBinding>(bindings[0]);
             Assert.Empty(bindings[0].ConsumedProperties);
-            Assert.Same(typeof(TypedContext), ((ContextParameterBinding)bindings[0]).ContextType);
+            Assert.Same(typeof(TypedContext), ((ContextParameterBinding)bindings[0]).ServiceType);
         }
 
         private class BlogWithTypedContext : Blog
@@ -251,9 +252,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             Assert.Equal("loader", parameters[0].Name);
 
-            Assert.IsType<ServiceParameterBinding>(bindings[0]);
+            Assert.IsType<DefaultServiceParameterBinding>(bindings[0]);
             Assert.Empty(bindings[0].ConsumedProperties);
-            Assert.Same(typeof(ILazyLoader), ((ServiceParameterBinding)bindings[0]).ServiceType);
+            Assert.Same(typeof(ILazyLoader), ((DefaultServiceParameterBinding)bindings[0]).ServiceType);
         }
 
         private class BlogWithLazyLoader : Blog

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/KeyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/KeyDiscoveryConventionTest.cs
@@ -152,7 +152,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityBuilder = modelBuilder.Entity(typeof(T), ConfigurationSource.Convention);
 
             new PropertyDiscoveryConvention(
-                TestServiceFactory.Instance.Create<FallbackCoreTypeMapper>()).Apply(entityBuilder);
+                    TestServiceFactory.Instance.Create<FallbackCoreTypeMapper>(),
+                    TestServiceFactory.Instance.Create<IParameterBindingFactories>())
+                .Apply(entityBuilder);
 
             return entityBuilder;
         }

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/NavigationAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/NavigationAttributeConventionTest.cs
@@ -48,7 +48,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Assert.DoesNotContain(principalEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Blog.BlogDetails));
             Assert.DoesNotContain(dependentEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(BlogDetails.Blog));
 
-            new RelationshipDiscoveryConvention(CreateTypeMapper(), CreateLogger()).Apply(dependentEntityTypeBuilder);
+            new RelationshipDiscoveryConvention(
+                CreateTypeMapper(),
+                TestServiceFactory.Instance.Create<IParameterBindingFactories>(),
+                CreateLogger()).Apply(dependentEntityTypeBuilder);
 
             Assert.DoesNotContain(principalEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(Blog.BlogDetails));
             Assert.Contains(dependentEntityTypeBuilder.Metadata.GetNavigations(), nav => nav.Name == nameof(BlogDetails.Blog));
@@ -269,7 +272,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         }
 
         private InversePropertyAttributeConvention CreateInversePropertyAttributeConvention()
-            => new InversePropertyAttributeConvention(CreateTypeMapper(), CreateLogger());
+            => new InversePropertyAttributeConvention(
+                CreateTypeMapper(),
+                TestServiceFactory.Instance.Create<IParameterBindingFactories>(),
+                CreateLogger());
 
         [Fact]
         public void InversePropertyAttribute_does_not_override_configuration_from_explicit_source()
@@ -492,7 +498,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         }
 
         private ForeignKeyAttributeConvention CreateForeignKeyAttributeConvention()
-            => new ForeignKeyAttributeConvention(CreateTypeMapper(), CreateLogger());
+            => new ForeignKeyAttributeConvention(
+                CreateTypeMapper(),
+                TestServiceFactory.Instance.Create<IParameterBindingFactories>(),
+                CreateLogger());
 
         [Fact]
         public void ForeignKeyAttribute_sets_foreign_key_properties_when_applied_on_property_on_dependent_side()
@@ -694,7 +703,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         private InternalEntityTypeBuilder CreateInternalEntityTypeBuilder<T>()
         {
             var conventionSet = new ConventionSet();
-            conventionSet.EntityTypeAddedConventions.Add(new PropertyDiscoveryConvention(CreateTypeMapper()));
+            conventionSet.EntityTypeAddedConventions.Add(
+                new PropertyDiscoveryConvention(
+                    CreateTypeMapper(),
+                    TestServiceFactory.Instance.Create<IParameterBindingFactories>()));
 
             conventionSet.EntityTypeAddedConventions.Add(new KeyDiscoveryConvention(CreateLogger()));
 

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyAttributeConventionTest.cs
@@ -518,7 +518,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         private InternalEntityTypeBuilder CreateInternalEntityTypeBuilder<T>()
         {
             var conventionSet = new ConventionSet();
-            conventionSet.EntityTypeAddedConventions.Add(new PropertyDiscoveryConvention(CreateTypeMapper()));
+            conventionSet.EntityTypeAddedConventions.Add(
+                new PropertyDiscoveryConvention(
+                    CreateTypeMapper(),
+                    TestServiceFactory.Instance.Create<IParameterBindingFactories>()));
 
             var modelBuilder = new InternalModelBuilder(new Model(conventionSet));
 

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyDiscoveryConventionTest.cs
@@ -42,7 +42,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             Assert.Same(
                 entityBuilder, new PropertyDiscoveryConvention(
-                    TestServiceFactory.Instance.Create<FallbackCoreTypeMapper>()).Apply(entityBuilder));
+                    TestServiceFactory.Instance.Create<FallbackCoreTypeMapper>(),
+                    TestServiceFactory.Instance.Create<IParameterBindingFactories>()).Apply(entityBuilder));
 
             Assert.Empty(entityBuilder.Metadata.GetProperties());
         }
@@ -102,7 +103,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             Assert.Same(
                 entityBuilder, new PropertyDiscoveryConvention(
-                    TestServiceFactory.Instance.Create<FallbackCoreTypeMapper>()).Apply(entityBuilder));
+                        TestServiceFactory.Instance.Create<FallbackCoreTypeMapper>(),
+                        TestServiceFactory.Instance.Create<IParameterBindingFactories>())
+                    .Apply(entityBuilder));
 
             Assert.Equal(
                 typeof(EntityWithEveryPrimitive)
@@ -123,7 +126,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             Assert.Same(
                 entityBuilder, new PropertyDiscoveryConvention(
-                    TestServiceFactory.Instance.Create<FallbackCoreTypeMapper>()).Apply(entityBuilder));
+                        TestServiceFactory.Instance.Create<FallbackCoreTypeMapper>(),
+                        TestServiceFactory.Instance.Create<IParameterBindingFactories>())
+                    .Apply(entityBuilder));
 
             Assert.Empty(entityBuilder.Metadata.GetProperties());
         }

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyMappingValidationConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyMappingValidationConventionTest.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Threading;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
-using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -169,7 +168,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
         protected virtual PropertyMappingValidationConvention CreateConvention()
             => new PropertyMappingValidationConvention(
-                TestServiceFactory.Instance.Create<FallbackCoreTypeMapper>());
+                TestServiceFactory.Instance.Create<FallbackCoreTypeMapper>(),
+                TestServiceFactory.Instance.Create<IParameterBindingFactories>());
 
         protected class NonPrimitiveNonNavigationAsPropertyEntity
         {

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/RelationshipDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/RelationshipDiscoveryConventionTest.cs
@@ -37,7 +37,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         }
 
         private RelationshipDiscoveryConvention CreateRelationshipDiscoveryConvention()
-            => new RelationshipDiscoveryConvention(CreateTypeMapper(), CreateLogger());
+            => new RelationshipDiscoveryConvention(
+                CreateTypeMapper(),
+                TestServiceFactory.Instance.Create<IParameterBindingFactories>(),
+                CreateLogger());
 
         [Fact]
         public void Entity_type_is_not_discovered_if_navigation_is_ignored()

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/ValueGeneratorConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/ValueGeneratorConventionTest.cs
@@ -441,7 +441,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var conventions = new ConventionSet();
 
             conventions.EntityTypeAddedConventions.Add(new PropertyDiscoveryConvention(
-                TestServiceFactory.Instance.Create<FallbackCoreTypeMapper>()));
+                TestServiceFactory.Instance.Create<FallbackCoreTypeMapper>(),
+                TestServiceFactory.Instance.Create<IParameterBindingFactories>()));
             conventions.EntityTypeAddedConventions.Add(new KeyDiscoveryConvention(new TestLogger<DbLoggerCategory.Model>()));
 
             var keyConvention = new ValueGeneratorConvention();

--- a/test/EFCore.Tests/Metadata/Internal/EntityMaterializerSourceTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityMaterializerSourceTest.cs
@@ -62,8 +62,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     {
                         new PropertyParameterBinding(entityType.FindProperty(nameof(SomeEntity.Id))),
                         new PropertyParameterBinding(entityType.FindProperty(nameof(SomeEntity.Goo)))
-                    }
-                );
+                    },
+                    entityType.ClrType);
 
             var factory = GetMaterializer(new EntityMaterializerSource(), entityType);
 
@@ -98,8 +98,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                                 new PropertyParameterBinding(entityType.FindProperty(nameof(SomeEntity.Id))),
                                 new PropertyParameterBinding(entityType.FindProperty(nameof(SomeEntity.Goo)))
                             })
-                    }
-                );
+                    },
+                    entityType.ClrType);
 
             var factory = GetMaterializer(new EntityMaterializerSource(), entityType);
 
@@ -130,7 +130,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     new List<ParameterBinding>
                     {
                         new EntityTypeParameterBinding()
-                    });
+                    },
+                    entityType.ClrType);
 
             var factory = GetMaterializer(new EntityMaterializerSource(), entityType);
 


### PR DESCRIPTION
Part of issues #10509 #3797

This change introduces a new kind of property: IServiceProperty. These properties are bound to some service of the context, such as ILazyLoader. They can be constructor injected as before, but can also be set as a property both in materialization and on Attach/Detach. When attaching, the service property is set to the service from the current context. When detaching, the service is set to null.

Lazy-loading proxies add an ILazyLoader property to the proxied entity. These means that lazy-loading is disabled when the entity is detached and can then be safely used after the context has been disposed. (It is also possible to disable the context disposed warning for this.) Also, if a proxy is attached to a new context, then it will start doing lazy-loading using that new context.

The service property can also be used when doing lazy-loading without proxies to get the same behavior on detach/attach. In this case it needs to be added to the entity explicitly, but then can be discovered by convention.