### PR TITLE
SQL Server: Use SqlServerCoreTypeMapper at design-time

### DIFF
--- a/src/EFCore.SqlServer/Design/Internal/SqlServerDesignTimeServices.cs
+++ b/src/EFCore.SqlServer/Design/Internal/SqlServerDesignTimeServices.cs
@@ -21,6 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         /// </summary>
         public virtual void ConfigureDesignTimeServices(IServiceCollection serviceCollection)
             => serviceCollection
+                .AddSingleton<IRelationalCoreTypeMapper, SqlServerCoreTypeMapper>()
                 .AddSingleton<IRelationalTypeMapper, SqlServerTypeMapper>()
                 .AddSingleton<IDatabaseModelFactory, SqlServerDatabaseModelFactory>()
                 .AddSingleton<IProviderCodeGenerator, SqlServerCodeGenerator>()

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerCoreTypeMapper.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerCoreTypeMapper.cs
@@ -44,7 +44,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         {
             var targetClrType = mappingInfo.TargetClrType;
 
-            if (_namedClrMappings.TryGetValue(targetClrType.FullName, out var mappingFunc))
+            if (targetClrType != null
+                && _namedClrMappings.TryGetValue(targetClrType.FullName, out var mappingFunc))
             {
                 return mappingFunc(targetClrType);
             }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ReverseEngineerScaffolderTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ReverseEngineerScaffolderTest.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.IO;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -171,6 +172,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         private static IReverseEngineerScaffolder CreateScaffolder()
             => new ServiceCollection()
                 .AddEntityFrameworkDesignTimeServices()
+                .AddSingleton<IRelationalTypeMapper, TestRelationalTypeMapper>()
                 .AddSingleton<IAnnotationCodeGenerator, AnnotationCodeGenerator>()
                 .AddSingleton<IDatabaseModelFactory, FakeDatabaseModelFactory>()
                 .AddSingleton<IProviderCodeGenerator, TestProviderCodeGenerator>()

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ReverseEngineeringConfigurationTests.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ReverseEngineeringConfigurationTests.cs
@@ -4,9 +4,8 @@
 using System;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Design;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
-using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -27,7 +26,8 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         {
             var reverseEngineer = new ServiceCollection()
                 .AddEntityFrameworkDesignTimeServices()
-                .AddSingleton<IAnnotationCodeGenerator, FakeAnnotationCodeGenerator>()
+                .AddSingleton<IRelationalTypeMapper, TestRelationalTypeMapper>()
+                .AddSingleton<IAnnotationCodeGenerator, AnnotationCodeGenerator>()
                 .AddSingleton<IDatabaseModelFactory, FakeDatabaseModelFactory>()
                 .AddSingleton<IProviderCodeGenerator, TestProviderCodeGenerator>()
                 .AddSingleton<IScaffoldingModelFactory, FakeScaffoldingModelFactory>()
@@ -48,99 +48,6 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                             new ModelReverseEngineerOptions(),
                             new ModelCodeGenerationOptions()))
                     .Message);
-        }
-
-        public class FakeAnnotationCodeGenerator : IAnnotationCodeGenerator
-        {
-            public MethodCallCodeFragment GenerateFluentApi(IModel model, IAnnotation annotation)
-            {
-                throw new NotImplementedException();
-            }
-
-            string IAnnotationCodeGenerator.GenerateFluentApi(IModel model, IAnnotation annotation, string language)
-            {
-                throw new NotImplementedException();
-            }
-
-            public MethodCallCodeFragment GenerateFluentApi(IEntityType entityType, IAnnotation annotation)
-            {
-                throw new NotImplementedException();
-            }
-
-            string IAnnotationCodeGenerator.GenerateFluentApi(IEntityType entityType, IAnnotation annotation, string language)
-            {
-                throw new NotImplementedException();
-            }
-
-            public MethodCallCodeFragment GenerateFluentApi(IKey key, IAnnotation annotation)
-            {
-                throw new NotImplementedException();
-            }
-
-            string IAnnotationCodeGenerator.GenerateFluentApi(IKey key, IAnnotation annotation, string language)
-            {
-                throw new NotImplementedException();
-            }
-
-            public MethodCallCodeFragment GenerateFluentApi(IProperty property, IAnnotation annotation)
-            {
-                throw new NotImplementedException();
-            }
-
-            string IAnnotationCodeGenerator.GenerateFluentApi(IProperty property, IAnnotation annotation, string language)
-            {
-                throw new NotImplementedException();
-            }
-
-            public MethodCallCodeFragment GenerateFluentApi(IForeignKey foreignKey, IAnnotation annotation)
-            {
-                throw new NotImplementedException();
-            }
-
-            string IAnnotationCodeGenerator.GenerateFluentApi(IForeignKey foreignKey, IAnnotation annotation, string language)
-            {
-                throw new NotImplementedException();
-            }
-
-            public MethodCallCodeFragment GenerateFluentApi(IIndex index, IAnnotation annotation)
-            {
-                throw new NotImplementedException();
-            }
-
-            string IAnnotationCodeGenerator.GenerateFluentApi(IIndex index, IAnnotation annotation, string language)
-            {
-                throw new NotImplementedException();
-            }
-
-            public bool IsHandledByConvention(IModel model, IAnnotation annotation)
-            {
-                throw new NotImplementedException();
-            }
-
-            public bool IsHandledByConvention(IEntityType entityType, IAnnotation annotation)
-            {
-                throw new NotImplementedException();
-            }
-
-            public bool IsHandledByConvention(IKey key, IAnnotation annotation)
-            {
-                throw new NotImplementedException();
-            }
-
-            public bool IsHandledByConvention(IProperty property, IAnnotation annotation)
-            {
-                throw new NotImplementedException();
-            }
-
-            public bool IsHandledByConvention(IForeignKey foreignKey, IAnnotation annotation)
-            {
-                throw new NotImplementedException();
-            }
-
-            public bool IsHandledByConvention(IIndex index, IAnnotation annotation)
-            {
-                throw new NotImplementedException();
-            }
         }
     }
 }

--- a/test/EFCore.Design.Tests/TestUtilities/FakeScaffoldingModelFactory.cs
+++ b/test/EFCore.Design.Tests/TestUtilities/FakeScaffoldingModelFactory.cs
@@ -6,14 +6,22 @@ using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
 using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
-using Microsoft.EntityFrameworkCore.Storage;
-using Microsoft.EntityFrameworkCore.Storage.Internal;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities
 {
     public class FakeScaffoldingModelFactory : RelationalScaffoldingModelFactory
     {
-        public override IModel Create(DatabaseModel databaseModel, bool useDatabaseNames = false)
+        public FakeScaffoldingModelFactory(
+            IOperationReporter reporter,
+            ICandidateNamingService candidateNamingService,
+            IPluralizer pluralizer,
+            ICSharpUtilities cSharpUtilities,
+            IScaffoldingTypeMapper scaffoldingTypeMapper)
+            : base(reporter, candidateNamingService, pluralizer, cSharpUtilities, scaffoldingTypeMapper)
+        {
+        }
+
+        public override IModel Create(DatabaseModel databaseModel, bool useDatabaseNames)
         {
             foreach (var sequence in databaseModel.Sequences)
             {
@@ -51,28 +59,6 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             }
 
             return base.Create(databaseModel, useDatabaseNames);
-        }
-
-        public FakeScaffoldingModelFactory(
-            IOperationReporter reporter)
-            : this(reporter, new NullPluralizer())
-        {
-        }
-
-        public FakeScaffoldingModelFactory(
-            IOperationReporter reporter,
-            IPluralizer pluralizer)
-            : base(
-                reporter,
-                new CandidateNamingService(),
-                pluralizer,
-                new CSharpUtilities(),
-                new ScaffoldingTypeMapper(
-                    new FallbackRelationalCoreTypeMapper(
-                        TestServiceFactory.Instance.Create<CoreTypeMapperDependencies>(),
-                        TestServiceFactory.Instance.Create<RelationalTypeMapperDependencies>(),
-                        TestServiceFactory.Instance.Create<SqlServerTypeMapper>())))
-        {
         }
     }
 }


### PR DESCRIPTION
Also updates the tests to catch more missing design-time services.