### PR TITLE
Don't discover base or derived types for owned types

### DIFF
--- a/src/EFCore.Relational/Metadata/Conventions/Internal/DiscriminatorConvention.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/DiscriminatorConvention.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class DiscriminatorConvention : IBaseTypeChangedConvention
+    public class DiscriminatorConvention : IBaseTypeChangedConvention, IEntityTypeRemovedConvention
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -22,10 +22,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             if (oldBaseType != null
                 && oldBaseType.BaseType == null
-                && !oldBaseType.GetDerivedTypes().Any())
+                && oldBaseType.GetDirectlyDerivedTypes().Count == 0)
             {
-                var oldBaseTypeBuilder = oldBaseType.Builder;
-                oldBaseTypeBuilder?.Relational(ConfigurationSource.Convention).HasDiscriminator(propertyInfo: null);
+                oldBaseType.Builder?.Relational(ConfigurationSource.Convention).HasDiscriminator(propertyInfo: null);
             }
 
             var entityType = entityTypeBuilder.Metadata;
@@ -63,6 +62,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             {
                 discriminator.HasValue(entityTypeBuilder.Metadata.Name, entityTypeBuilder.Metadata.ShortName());
                 SetDefaultDiscriminatorValues(derivedEntityTypes, discriminator);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual bool Apply(InternalModelBuilder modelBuilder, EntityType type)
+        {
+            var oldBaseType = type.BaseType;
+            if (oldBaseType != null
+                && oldBaseType.BaseType == null
+                && oldBaseType.GetDirectlyDerivedTypes().Count == 0)
+            {
+                oldBaseType.Builder?.Relational(ConfigurationSource.Convention).HasDiscriminator(propertyInfo: null);
             }
 
             return true;

--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -203,7 +203,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             }
 
             if (!entityType.HasDefiningNavigation()
-                && entityType.FindDeclaredOwnership() == null)
+                && entityType.FindDeclaredOwnership() == null
+                && entityType.BaseType != null)
             {
                 var baseClrType = entityType.ClrType?.GetTypeInfo().BaseType;
                 while (baseClrType != null)
@@ -216,7 +217,6 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                             throw new InvalidOperationException(
                                 CoreStrings.InconsistentInheritance(entityType.DisplayName(), baseEntityType.DisplayName()));
                         }
-                        ValidateClrInheritance(model, baseEntityType, validEntityTypes);
                         break;
                     }
                     baseClrType = baseClrType.GetTypeInfo().BaseType;
@@ -269,7 +269,9 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
                 if (ownerships.Count == 1)
                 {
-                    if (entityType.BaseType != null)
+                    var ownership = ownerships[0];
+                    if (entityType.BaseType != null
+                        && ownership.DeclaringEntityType == entityType)
                     {
                         throw new InvalidOperationException(CoreStrings.OwnedDerivedType(entityType.DisplayName()));
                     }
@@ -296,7 +298,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                                 fk.PrincipalEntityType.DisplayName(),
                                 fk.PrincipalToDependent.Name,
                                 entityType.DisplayName(),
-                                ownerships[0].PrincipalEntityType.DisplayName()));
+                                ownership.PrincipalEntityType.DisplayName()));
                     }
                 }
             }

--- a/src/EFCore/Metadata/Conventions/ConventionSet.cs
+++ b/src/EFCore/Metadata/Conventions/ConventionSet.cs
@@ -22,6 +22,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         public virtual IList<IEntityTypeIgnoredConvention> EntityTypeIgnoredConventions { get; } = new List<IEntityTypeIgnoredConvention>();
 
         /// <summary>
+        ///     Conventions to run when an entity type is removed.
+        /// </summary>
+        public virtual IList<IEntityTypeRemovedConvention> EntityTypeRemovedConventions { get; } = new List<IEntityTypeRemovedConvention>();
+
+        /// <summary>
         ///     Conventions to run when a property is ignored.
         /// </summary>
         public virtual IList<IEntityTypeMemberIgnoredConvention> EntityTypeMemberIgnoredConventions { get; } = new List<IEntityTypeMemberIgnoredConvention>();

--- a/src/EFCore/Metadata/Conventions/Internal/BaseTypeDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/BaseTypeDiscoveryConvention.cs
@@ -27,6 +27,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             }
 
             var baseEntityType = FindClosestBaseType(entityType);
+            if (baseEntityType == null
+                || baseEntityType.FindOwnership() != null)
+            {
+                return entityTypeBuilder;
+            }
+
             return entityTypeBuilder.HasBaseType(baseEntityType, ConfigurationSource.Convention);
         }
     }

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.cs
@@ -58,6 +58,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public virtual bool OnEntityTypeRemoved([NotNull] InternalModelBuilder modelBuilder, [NotNull] EntityType type)
+            => _scope.OnEntityTypeRemoved(Check.NotNull(modelBuilder, nameof(modelBuilder)), Check.NotNull(type, nameof(type)));
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual InternalEntityTypeBuilder OnEntityTypeMemberIgnored(
             [NotNull] InternalEntityTypeBuilder entityTypeBuilder,
             [NotNull] string ignoredMemberName)

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionNode.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionNode.cs
@@ -107,6 +107,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 return true;
             }
 
+            public virtual bool OnEntityTypeRemoved([NotNull] InternalModelBuilder modelBuilder, [NotNull] EntityType type)
+            {
+                Add(new OnEntityTypeRemovedNode(modelBuilder, type));
+                return true;
+            }
+
             public virtual InternalEntityTypeBuilder OnEntityTypeMemberIgnored(
                 [NotNull] InternalEntityTypeBuilder entityTypeBuilder,
                 [NotNull] string ignoredMemberName)
@@ -287,6 +293,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 foreach (var entityTypeIgnoredConvention in _conventionSet.EntityTypeIgnoredConventions)
                 {
                     if (!entityTypeIgnoredConvention.Apply(modelBuilder, name, type))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            public override bool OnEntityTypeRemoved(InternalModelBuilder modelBuilder, EntityType type)
+            {
+                foreach (var entityTypeRemovedConvention in _conventionSet.EntityTypeRemovedConventions)
+                {
+                    if (!entityTypeRemovedConvention.Apply(modelBuilder, type))
                     {
                         return false;
                     }
@@ -770,6 +789,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public Type Type { get; }
 
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnEntityTypeIgnored(this);
+        }
+
+        private class OnEntityTypeRemovedNode : ConventionNode
+        {
+            public OnEntityTypeRemovedNode(InternalModelBuilder modelBuilder, EntityType type)
+            {
+                ModelBuilder = modelBuilder;
+                Type = type;
+            }
+
+            public InternalModelBuilder ModelBuilder { get; }
+            public EntityType Type { get; }
+
+            public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnEntityTypeRemoved(this);
         }
 
         private class OnEntityTypeMemberIgnoredNode : ConventionNode

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionVisitor.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionVisitor.cs
@@ -37,6 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             public virtual OnEntityTypeAddedNode VisitOnEntityTypeAdded(OnEntityTypeAddedNode node) => node;
             public virtual OnEntityTypeIgnoredNode VisitOnEntityTypeIgnored(OnEntityTypeIgnoredNode node) => node;
+            public virtual OnEntityTypeRemovedNode VisitOnEntityTypeRemoved(OnEntityTypeRemovedNode node) => node;
             public virtual OnEntityTypeMemberIgnoredNode VisitOnEntityTypeMemberIgnored(OnEntityTypeMemberIgnoredNode node) => node;
             public virtual OnBaseEntityTypeChangedNode VisitOnBaseEntityTypeChanged(OnBaseEntityTypeChangedNode node) => node;
             public virtual OnEntityTypeAnnotationChangedNode VisitOnEntityTypeAnnotationChanged(OnEntityTypeAnnotationChangedNode node) => node;
@@ -77,6 +78,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override OnEntityTypeIgnoredNode VisitOnEntityTypeIgnored(OnEntityTypeIgnoredNode node)
             {
                 Dispatcher._immediateConventionScope.OnEntityTypeIgnored(node.ModelBuilder, node.Name, node.Type);
+                return null;
+            }
+
+            public override OnEntityTypeRemovedNode VisitOnEntityTypeRemoved(OnEntityTypeRemovedNode node)
+            {
+                Dispatcher._immediateConventionScope.OnEntityTypeRemoved(node.ModelBuilder, node.Type);
                 return null;
             }
 

--- a/src/EFCore/Metadata/Conventions/Internal/DerivedTypeDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/DerivedTypeDiscoveryConvention.cs
@@ -22,7 +22,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityType = entityTypeBuilder.Metadata;
             var clrType = entityType.ClrType;
             if (clrType == null
-                || entityType.HasDefiningNavigation())
+                || entityType.HasDefiningNavigation()
+                || entityType.FindOwnership() != null)
             {
                 return entityTypeBuilder;
             }
@@ -31,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 t => t != entityType
                      && t.HasClrType()
                      && !t.HasDefiningNavigation()
-                     && t.FindDeclaredOwnership() == null
+                     && t.FindOwnership() == null
                      && ((t.BaseType == null && clrType.GetTypeInfo().IsAssignableFrom(t.ClrType.GetTypeInfo()))
                          || (t.BaseType == entityType.BaseType && FindClosestBaseType(t) == entityType)))
                 .ToList();

--- a/src/EFCore/Metadata/Conventions/Internal/IEntityTypeRemovedConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/IEntityTypeRemovedConvention.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public interface IEntityTypeRemovedConvention
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        bool Apply([NotNull] InternalModelBuilder modelBuilder, [NotNull] EntityType type);
+    }
+}

--- a/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -484,8 +484,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public static IEnumerable<INavigation> FindDerivedNavigations(
             [NotNull] this IEntityType entityType, [NotNull] string navigationName)
             => entityType.GetDerivedTypes().SelectMany(
-                et =>
-                    et.GetDeclaredNavigations().Where(navigation => navigationName == navigation.Name));
+                et => et.GetDeclaredNavigations().Where(navigation => navigationName == navigation.Name));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -508,8 +507,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public static IEnumerable<IProperty> FindDerivedProperties(
             [NotNull] this IEntityType entityType, [NotNull] string propertyName)
             => entityType.GetDerivedTypes().SelectMany(
-                et =>
-                    et.GetDeclaredProperties().Where(property => propertyName.Equals(property.Name)));
+                et => et.GetDeclaredProperties().Where(property => propertyName.Equals(property.Name)));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -923,12 +923,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         newRelationshipBuilder.Metadata.DeclaringEntityType.Builder.HasBaseType((Type)null, configurationSource);
                     }
 
-                    // TODO: Move to a convention
                     newRelationshipBuilder.Metadata.DeclaringEntityType.Builder.PrimaryKey(
                         newRelationshipBuilder.Metadata.Properties.Select(p => p.Name).ToList(), ConfigurationSource.Convention);
                 }
 
                 newRelationshipBuilder.Metadata.SetIsOwnership(ownership, configurationSource);
+
+                foreach (var directlyDerivedType in newRelationshipBuilder.Metadata.DeclaringEntityType.GetDirectlyDerivedTypes().ToList())
+                {
+                    directlyDerivedType.Builder.HasBaseType((string)null, ConfigurationSource.Convention);
+                }
 
                 return batch.Run(newRelationshipBuilder);
             }

--- a/src/EFCore/Metadata/Internal/Model.cs
+++ b/src/EFCore/Metadata/Internal/Model.cs
@@ -289,6 +289,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             entityType.Builder = null;
+
+            ConventionDispatcher.OnEntityTypeRemoved(Builder, entityType);
+
             return entityType;
         }
 

--- a/test/EFCore.Tests/Infrastructure/CoreModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/CoreModelValidatorTest.cs
@@ -260,15 +260,17 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         }
 
         [Fact]
-        public virtual void Detects_base_type_not_set()
+        public virtual void Detects_skipped_base_type()
         {
             var model = new Model();
             var entityA = model.AddEntityType(typeof(A));
             SetPrimaryKey(entityA);
             var entityD = model.AddEntityType(typeof(D));
-            SetPrimaryKey(entityD);
+            SetBaseType(entityD, entityA);
+            var entityF = model.AddEntityType(typeof(F));
+            SetBaseType(entityF, entityA);
 
-            VerifyError(CoreStrings.InconsistentInheritance(entityD.DisplayName(), entityA.DisplayName()), model);
+            VerifyError(CoreStrings.InconsistentInheritance(nameof(F), nameof(D)), model);
         }
 
         [Fact]

--- a/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/ModelValidatorTest.cs
@@ -80,6 +80,10 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         {
         }
 
+        protected class F : D
+        {
+        }
+
         protected abstract class Abstract : A
         {
         }

--- a/test/EFCore.Tests/ModelBuilding/InheritanceTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/InheritanceTestBase.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
+// ReSharper disable MemberHidesStaticFromOuterClass
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.ModelBuilding
 {
@@ -322,6 +323,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 var principalEntityBuilder = modelBuilder.Entity<OrderCombination>();
                 principalEntityBuilder.Ignore(nameof(OrderCombination.SpecialOrder));
+                principalEntityBuilder.Ignore(nameof(OrderCombination.Details));
                 var dependentEntityBuilder = modelBuilder.Entity<Order>();
                 var derivedDependentEntityBuilder = modelBuilder.Entity<SpecialOrder>();
                 derivedDependentEntityBuilder.Ignore(nameof(SpecialOrder.BackOrder));
@@ -513,7 +515,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 modelBuilder.Ignore<SpecialCustomer>();
                 modelBuilder.Ignore<SpecialOrder>();
 
-                var principalEntityBuilder = modelBuilder.Entity<Customer>();
+                modelBuilder.Entity<Customer>();
                 var derivedPrincipalEntityBuilder = modelBuilder.Entity<OtherCustomer>();
                 var dependentEntityBuilder = modelBuilder.Entity<Order>();
                 var derivedDependentEntityBuilder = modelBuilder.Entity<BackOrder>();
@@ -695,13 +697,13 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
-                var derivedEntityType = modelBuilder.Entity<DerivedTypeWithKeyAnnotation>().Metadata;
+                var derivedEntityType = (EntityType)modelBuilder.Entity<DerivedTypeWithKeyAnnotation>().Metadata;
                 var baseEntityType = (EntityType)modelBuilder.Entity<BaseTypeWithKeyAnnotation>().Metadata;
 
                 Assert.Equal(baseEntityType, derivedEntityType.BaseType);
                 Assert.Equal(ConfigurationSource.DataAnnotation, baseEntityType.GetPrimaryKeyConfigurationSource());
                 Assert.Equal(ConfigurationSource.DataAnnotation, baseEntityType.FindNavigation(nameof(BaseTypeWithKeyAnnotation.Navigation)).ForeignKey.GetConfigurationSource());
-                Assert.Equal(ConfigurationSource.Convention, baseEntityType.GetBaseTypeConfigurationSource());
+                Assert.Equal(ConfigurationSource.Convention, derivedEntityType.GetBaseTypeConfigurationSource());
             }
 
             [Fact]

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Reflection;
+// ReSharper disable UnusedAutoPropertyAccessor.Local
 
 namespace Microsoft.EntityFrameworkCore.ModelBuilding
 {
@@ -104,9 +105,13 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         {
         }
 
-        protected class CustomerDetails
+        protected class DetailsBase
         {
             public int Id { get; set; }
+        }
+
+        protected class CustomerDetails : DetailsBase
+        {
             public int CustomerId { get; set; }
 
             public Customer Customer { get; set; }
@@ -150,13 +155,12 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public Order Order { get; set; }
             public int SpecialOrderId { get; set; }
             public SpecialOrder SpecialOrder { get; set; }
+            public DetailsBase Details { get; set; }
         }
 
-        protected class OrderDetails
+        protected class OrderDetails : DetailsBase
         {
             public static readonly PropertyInfo OrderIdProperty = typeof(OrderDetails).GetProperty("OrderId");
-
-            public int Id { get; set; }
 
             public int OrderId { get; set; }
             public Order Order { get; set; }
@@ -173,15 +177,15 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             // ReSharper disable once ConvertToAutoProperty
             public int Up
             {
-                get { return _forUp; }
-                set { _forUp = value; }
+                get => _forUp;
+                set => _forUp = value;
             }
 
             // ReSharper disable once ConvertToAutoProperty
             public string Down
             {
-                get { return _forDown; }
-                set { _forDown = value; }
+                get => _forDown;
+                set => _forDown = value;
             }
 
 #pragma warning disable 67
@@ -247,10 +251,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public BookDetails Details { get; set; }
         }
 
-        protected abstract class BookDetailsBase
+        protected abstract class BookDetailsBase : DetailsBase
         {
-            public int Id { get; set; }
-
             public int AnotherBookId { get; set; }
 
             public Book AnotherBook { get; set; }


### PR DESCRIPTION
Validate owned type inheritance
Allow to disconnect mapped base type

Fixes #10200
Fixes #10715
