### PR TITLE
Ignore collection navigations to owned types

### DIFF
--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -246,6 +246,10 @@ namespace Microsoft.EntityFrameworkCore
             var entityType = Model.FindEntityType(type);
             if (entityType == null)
             {
+                if (Model.HasEntityTypeWithDefiningNavigation(type))
+                {
+                    throw new InvalidOperationException(CoreStrings.InvalidSetTypeWeak(type.ShortDisplayName()));
+                }
                 throw new InvalidOperationException(CoreStrings.InvalidSetType(type.ShortDisplayName()));
             }
 

--- a/src/EFCore/Diagnostics/CoreEventId.cs
+++ b/src/EFCore/Diagnostics/CoreEventId.cs
@@ -80,6 +80,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             MultiplePrimaryKeyCandidates,
             MultipleNavigationProperties,
             MultipleInversePropertiesSameTarget,
+            NonDefiningInverseNavigation,
+            NonOwnershipInverseNavigation,
             ForeignKeyAttributesOnBothProperties,
             ForeignKeyAttributesOnBothNavigations,
             ConflictingForeignKeyAttributesOnNavigationAndProperty
@@ -462,6 +464,34 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     </para>
         /// </summary>
         public static readonly EventId MultipleInversePropertiesSameTarget = MakeModelId(Id.MultipleInversePropertiesSameTarget);
+
+        /// <summary>
+        ///     <para>
+        ///         There navigation that <see cref="InversePropertyAttribute" /> points to is not the defining navigation.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Model" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="TwoUnmappedPropertyCollectionsEventData" /> payload when used with a
+        ///         <see cref="DiagnosticSource" />.
+        ///     </para>
+        /// </summary>
+        public static readonly EventId NonDefiningInverseNavigation = MakeModelId(Id.NonDefiningInverseNavigation);
+
+        /// <summary>
+        ///     <para>
+        ///         There navigation that <see cref="InversePropertyAttribute" /> points to is not the defining navigation.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Model" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="TwoUnmappedPropertyCollectionsEventData" /> payload when used with a
+        ///         <see cref="DiagnosticSource" />.
+        ///     </para>
+        /// </summary>
+        public static readonly EventId NonOwnershipInverseNavigation = MakeModelId(Id.NonOwnershipInverseNavigation);
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/Extensions/Internal/CoreLoggerExtensions.cs
+++ b/src/EFCore/Extensions/Internal/CoreLoggerExtensions.cs
@@ -1120,6 +1120,122 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public static void NonDefiningInverseNavigation(
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Model> diagnostics,
+            [NotNull] IEntityType declaringType,
+            [NotNull] MemberInfo navigation,
+            [NotNull] IEntityType targetType,
+            [NotNull] MemberInfo inverseNavigation,
+            [NotNull] MemberInfo definingNavigation)
+        {
+            var definition = CoreStrings.LogNonDefiningInverseNavigation;
+
+            var warningBehavior = definition.GetLogBehavior(diagnostics);
+            if (warningBehavior != WarningBehavior.Ignore)
+            {
+                definition.Log(
+                    diagnostics,
+                    warningBehavior,
+                    targetType.DisplayName(),
+                    inverseNavigation.Name,
+                    declaringType.DisplayName(),
+                    navigation.Name,
+                    definingNavigation.Name);
+            }
+
+            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            {
+                diagnostics.DiagnosticSource.Write(
+                    definition.EventId.Name,
+                    new TwoUnmappedPropertyCollectionsEventData(
+                        definition,
+                        NonDefiningInverseNavigation,
+                        new[] { new Tuple<MemberInfo, Type>(navigation, declaringType.ClrType) },
+                        new[]
+                        {
+                            new Tuple<MemberInfo, Type>(inverseNavigation, targetType.ClrType),
+                            new Tuple<MemberInfo, Type>(definingNavigation, targetType.ClrType)
+                        }));
+            }
+        }
+
+        private static string NonDefiningInverseNavigation(EventDefinitionBase definition, EventData payload)
+        {
+            var d = (EventDefinition<string, string, string, string, string>)definition;
+            var p = (TwoUnmappedPropertyCollectionsEventData)payload;
+            var navigation = p.FirstPropertyCollection.First();
+            var inverseNavigation = p.SecondPropertyCollection.First();
+            var definingNavigation = p.SecondPropertyCollection.Last();
+            return d.GenerateMessage(
+                inverseNavigation.Item2.ShortDisplayName(),
+                inverseNavigation.Item1.Name,
+                navigation.Item2.ShortDisplayName(),
+                navigation.Item1.Name,
+                definingNavigation.Item1.Name);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static void NonOwnershipInverseNavigation(
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Model> diagnostics,
+            [NotNull] IEntityType declaringType,
+            [NotNull] MemberInfo navigation,
+            [NotNull] IEntityType targetType,
+            [NotNull] MemberInfo inverseNavigation,
+            [NotNull] MemberInfo ownershipNavigation)
+        {
+            var definition = CoreStrings.LogNonOwnershipInverseNavigation;
+
+            var warningBehavior = definition.GetLogBehavior(diagnostics);
+            if (warningBehavior != WarningBehavior.Ignore)
+            {
+                definition.Log(
+                    diagnostics,
+                    warningBehavior,
+                    targetType.DisplayName(),
+                    inverseNavigation.Name,
+                    declaringType.DisplayName(),
+                    navigation.Name,
+                    ownershipNavigation.Name);
+            }
+
+            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            {
+                diagnostics.DiagnosticSource.Write(
+                    definition.EventId.Name,
+                    new TwoUnmappedPropertyCollectionsEventData(
+                        definition,
+                        NonOwnershipInverseNavigation,
+                        new[] { new Tuple<MemberInfo, Type>(navigation, declaringType.ClrType) },
+                        new[]
+                        {
+                            new Tuple<MemberInfo, Type>(inverseNavigation, targetType.ClrType),
+                            new Tuple<MemberInfo, Type>(ownershipNavigation, targetType.ClrType)
+                        }));
+            }
+        }
+
+        private static string NonOwnershipInverseNavigation(EventDefinitionBase definition, EventData payload)
+        {
+            var d = (EventDefinition<string, string, string, string, string>)definition;
+            var p = (TwoUnmappedPropertyCollectionsEventData)payload;
+            var navigation = p.FirstPropertyCollection.First();
+            var inverseNavigation = p.SecondPropertyCollection.First();
+            var ownershipNavigation = p.SecondPropertyCollection.Last();
+            return d.GenerateMessage(
+                inverseNavigation.Item2.ShortDisplayName(),
+                inverseNavigation.Item1.Name,
+                navigation.Item2.ShortDisplayName(),
+                navigation.Item1.Name,
+                ownershipNavigation.Item1.Name);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public static void ForeignKeyAttributesOnBothProperties(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Model> diagnostics,
             [NotNull] INavigation firstNavigation,

--- a/src/EFCore/Internal/InternalDbQuery.cs
+++ b/src/EFCore/Internal/InternalDbQuery.cs
@@ -52,6 +52,10 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
                 if (_entityType == null)
                 {
+                    if (_context.Model.HasEntityTypeWithDefiningNavigation(typeof(TQuery)))
+                    {
+                        throw new InvalidOperationException(CoreStrings.InvalidSetTypeWeak(typeof(TQuery).ShortDisplayName()));
+                    }
                     throw new InvalidOperationException(CoreStrings.InvalidSetType(typeof(TQuery).ShortDisplayName()));
                 }
 

--- a/src/EFCore/Internal/InternalDbSet.cs
+++ b/src/EFCore/Internal/InternalDbSet.cs
@@ -56,6 +56,10 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
                 if (_entityType == null)
                 {
+                    if (_context.Model.HasEntityTypeWithDefiningNavigation(typeof(TEntity)))
+                    {
+                        throw new InvalidOperationException(CoreStrings.InvalidSetTypeWeak(typeof(TEntity).ShortDisplayName()));
+                    }
                     throw new InvalidOperationException(CoreStrings.InvalidSetType(typeof(TEntity).ShortDisplayName()));
                 }
 

--- a/src/EFCore/Metadata/Conventions/Internal/InversePropertyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/InversePropertyAttributeConvention.cs
@@ -137,17 +137,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 return entityTypeBuilder.Metadata.FindNavigation(navigationPropertyInfo)?.ForeignKey.Builder;
             }
 
-            if (entityType.DefiningEntityType == targetEntityTypeBuilder.Metadata
-                && entityType.DefiningNavigationName != inverseNavigationPropertyInfo.Name)
-            {
-                return null;
-            }
-
             var ownership = entityType.FindOwnership();
             if (ownership != null
                 && ownership.PrincipalEntityType == targetEntityTypeBuilder.Metadata
                 && ownership.PrincipalToDependent?.PropertyInfo != inverseNavigationPropertyInfo)
             {
+                _logger.NonOwnershipInverseNavigation(entityType, navigationPropertyInfo,
+                    targetEntityTypeBuilder.Metadata, inverseNavigationPropertyInfo,
+                    ownership.PrincipalToDependent.PropertyInfo);
+                return null;
+            }
+
+            if (entityType.DefiningEntityType == targetEntityTypeBuilder.Metadata
+                && entityType.DefiningNavigationName != inverseNavigationPropertyInfo.Name)
+            {
+                _logger.NonDefiningInverseNavigation(entityType, navigationPropertyInfo,
+                    targetEntityTypeBuilder.Metadata, inverseNavigationPropertyInfo,
+                    targetClrType.GetRuntimeProperties().First(p => p.Name == entityType.DefiningNavigationName));
                 return null;
             }
 

--- a/src/EFCore/Metadata/Conventions/Internal/KeyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/KeyDiscoveryConvention.cs
@@ -54,6 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 var definingFk = entityType.FindDefiningNavigation()?.ForeignKey
                                  ?? entityType.FindOwnership();
                 if (definingFk != null
+                    && definingFk.IsUnique
                     && definingFk.DeclaringEntityType == entityType)
                 {
                     // Make sure that the properties won't be reuniquified

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -77,7 +77,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public EntityType([NotNull] Type clrType, [NotNull] Model model, ConfigurationSource configurationSource)
             : base(clrType, model, configurationSource)
         {
-            Check.ValidEntityType(clrType, nameof(clrType));
+            if (!clrType.IsValidEntityType())
+            {
+                throw new ArgumentException(CoreStrings.InvalidEntityType(clrType, nameof(clrType)));
+            }
 
             _properties = new SortedDictionary<string, Property>(new PropertyComparer(this));
             Builder = new InternalEntityTypeBuilder(this, model.Builder);

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -1087,8 +1087,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
                 var detachedRelationship = DetachRelationship(relationshipToBeDetached);
                 if (detachedRelationship.Item3.Overrides(ConfigurationSource.DataAnnotation)
-                    || relationshipToBeDetached.IsOwnership
-                    || relationshipToBeDetached.DependentToPrincipal == null)
+                    || relationshipToBeDetached.IsOwnership)
                 {
                     detachedRelationships.Add(detachedRelationship);
                 }
@@ -1105,8 +1104,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     }
                     var detachedRelationship = DetachRelationship(relationshipToBeDetached);
                     if (detachedRelationship.Item3.Overrides(ConfigurationSource.DataAnnotation)
-                        || relationshipToBeDetached.IsOwnership
-                        || relationshipToBeDetached.PrincipalToDependent == null)
+                        || relationshipToBeDetached.IsOwnership)
                     {
                         EntityTypeSnapshot weakSnapshot = null;
                         var dependentEntityType = relationshipToBeDetached.DeclaringEntityType;
@@ -1866,15 +1864,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             InternalRelationshipBuilder relationship;
             using (var batch = Metadata.Model.ConventionDispatcher.StartBatch())
             {
-                var existingNavigation = Metadata
-                    .FindNavigationsInHierarchy(navigation.Name)
-                    .SingleOrDefault(n => n.GetTargetType().Name == targetEntityType.Name);
+                var existingNavigation = Metadata.FindNavigation(navigation.Name);
 
                 var ownershipBuilder = existingNavigation?.ForeignKey.Builder;
                 if (ownershipBuilder != null)
                 {
                     ownershipBuilder = ownershipBuilder.RelatedEntityTypes(
-                        Metadata, ownershipBuilder.Metadata.FindNavigationsFrom(Metadata).Single().GetTargetType(),
+                        Metadata, ownershipBuilder.Metadata.FindNavigationsFromInHierarchy(Metadata).Single().GetTargetType(),
                         configurationSource);
                     ownershipBuilder = ownershipBuilder?.Navigations(inverse, navigation, configurationSource);
                     ownershipBuilder = ownershipBuilder?.IsRequired(true, configurationSource);

--- a/src/EFCore/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -923,8 +923,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         newRelationshipBuilder.Metadata.DeclaringEntityType.Builder.HasBaseType((Type)null, configurationSource);
                     }
 
-                    newRelationshipBuilder.Metadata.DeclaringEntityType.Builder.PrimaryKey(
-                        newRelationshipBuilder.Metadata.Properties.Select(p => p.Name).ToList(), ConfigurationSource.Convention);
+                    if (newRelationshipBuilder.Metadata.IsUnique)
+                    {
+                        newRelationshipBuilder.Metadata.DeclaringEntityType.Builder.PrimaryKey(
+                            newRelationshipBuilder.Metadata.Properties.Select(p => p.Name).ToList(), ConfigurationSource.Convention);
+                    }
                 }
 
                 newRelationshipBuilder.Metadata.SetIsOwnership(ownership, configurationSource);

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2224,6 +2224,38 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 GetString("OwnedDerivedType", nameof(entityType)),
                 entityType);
 
+        /// <summary>
+        ///     Cannot create a DbSet for '{typeName}' because it is mapped to mulptiple entity types and should they should be accessed through the defining entities.
+        /// </summary>
+        public static string InvalidSetTypeWeak([CanBeNull] object typeName)
+            => string.Format(
+                GetString("InvalidSetTypeWeak", nameof(typeName)),
+                typeName);
+
+        /// <summary>
+        ///     The navigation '{targetEntityType}.{inverseNavigation}' cannot be used as the inverse of '{weakEntityType}.{navigation}' because it's not the defining navigation '{definingNavigation}'
+        /// </summary>
+        public static readonly EventDefinition<string, string, string, string, string> LogNonDefiningInverseNavigation
+            = new EventDefinition<string, string, string, string, string>(
+                CoreEventId.NonDefiningInverseNavigation,
+                LogLevel.Warning,
+                LoggerMessage.Define<string, string, string, string, string>(
+                    LogLevel.Warning,
+                    CoreEventId.NonDefiningInverseNavigation,
+                    _resourceManager.GetString("LogNonDefiningInverseNavigation")));
+
+        /// <summary>
+        ///     The navigation '{targetEntityType}.{inverseNavigation}' cannot be used as the inverse of '{ownedEntityType}.{navigation}' because it's not the ownership navigation '{ownershipNavigation}'
+        /// </summary>
+        public static readonly EventDefinition<string, string, string, string, string> LogNonOwnershipInverseNavigation
+            = new EventDefinition<string, string, string, string, string>(
+                CoreEventId.NonOwnershipInverseNavigation,
+                LogLevel.Warning,
+                LoggerMessage.Define<string, string, string, string, string>(
+                    LogLevel.Warning,
+                    CoreEventId.NonOwnershipInverseNavigation,
+                    _resourceManager.GetString("LogNonOwnershipInverseNavigation")));
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -943,4 +943,15 @@
   <data name="OwnedDerivedType" xml:space="preserve">
     <value>The owned entity type '{entityType}' cannot have a base type.</value>
   </data>
+  <data name="InvalidSetTypeWeak" xml:space="preserve">
+    <value>Cannot create a DbSet for '{typeName}' because it is mapped to mulptiple entity types and should they should be accessed through the defining entities.</value>
+  </data>
+  <data name="LogNonDefiningInverseNavigation" xml:space="preserve">
+    <value>The navigation '{targetEntityType}.{inverseNavigation}' cannot be used as the inverse of '{weakEntityType}.{navigation}' because it's not the defining navigation '{definingNavigation}'</value>
+    <comment>Warning CoreEventId.NonDefiningInverseNavigation string string string string string</comment>
+  </data>
+  <data name="LogNonOwnershipInverseNavigation" xml:space="preserve">
+    <value>The navigation '{targetEntityType}.{inverseNavigation}' cannot be used as the inverse of '{ownedEntityType}.{navigation}' because it's not the ownership navigation '{ownershipNavigation}'</value>
+    <comment>Warning CoreEventId.NonOwnershipInverseNavigation string string string string string</comment>
+  </data>
 </root>

--- a/src/Shared/Check.cs
+++ b/src/Shared/Check.cs
@@ -94,17 +94,5 @@ namespace Microsoft.EntityFrameworkCore.Utilities
 
             return value;
         }
-
-        public static Type ValidEntityType(Type value, [InvokerParameterName] [NotNull] string parameterName)
-        {
-            if (!value.GetTypeInfo().IsClass)
-            {
-                NotEmpty(parameterName, nameof(parameterName));
-
-                throw new ArgumentException(CoreStrings.InvalidEntityType(value, parameterName));
-            }
-
-            return value;
-        }
     }
 }

--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -23,6 +23,9 @@ namespace System
                    && typeInfo.GetGenericTypeDefinition() == typeof(Nullable<>);
         }
 
+        public static bool IsValidEntityType(this Type type)
+            => type.GetTypeInfo().IsClass;
+
         public static Type MakeNullable(this Type type)
             => type.IsNullableType()
                 ? type

--- a/test/EFCore.Tests/DbSetTest.cs
+++ b/test/EFCore.Tests/DbSetTest.cs
@@ -12,6 +12,11 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
+// ReSharper disable UnusedMember.Local
+// ReSharper disable UnusedAutoPropertyAccessor.Local
+// ReSharper disable ClassNeverInstantiated.Local
+// ReSharper disable ParameterOnlyUsedForPreconditionCheck.Local
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore
 {
     public class DbSetTest

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyMappingValidationConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyMappingValidationConventionTest.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 {
     public class PropertyMappingValidationConventionTest
@@ -212,7 +213,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             public int WriteOnlyProperty
             {
-                set { _writeOnlyField = value; }
+                set => _writeOnlyField = value;
             }
         }
 

--- a/test/EFCore.Tests/Metadata/Internal/InternalModelBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalModelBuilderTest.cs
@@ -300,10 +300,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             Assert.False(model.ShouldBeOwnedType(typeof(Details)));
 
-            Assert.True(modelBuilder.Owned(typeof(Details), ConfigurationSource.Convention));
-
-            Assert.True(model.ShouldBeOwnedType(typeof(Details)));
-
             Assert.NotNull(entityBuilder.Owns(typeof(Details), nameof(Customer.Details), ConfigurationSource.Convention));
 
             Assert.True(modelBuilder.Ignore(typeof(Details), ConfigurationSource.Convention));

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
@@ -6,13 +6,11 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
-using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
@@ -20,6 +18,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
 
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.ModelBuilding
 {
     public abstract partial class ModelBuilderTest

--- a/test/EFCore.Tests/ModelBuilding/OneToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToManyTestBase.cs
@@ -2182,6 +2182,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
                 modelBuilder.Ignore<Delta>();
+                modelBuilder.Ignore<Iota>();
                 modelBuilder.Entity<Theta>().HasOne(e => e.Alpha).WithMany();
 
                 modelBuilder.Validate();

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -381,6 +381,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public Alpha AlphaTwo { get; set; }
         }
 
+        [NotMapped]
         protected class Theta
         {
             public int ThetaId { get; set; }

--- a/test/EFCore.Tests/Utilities/CheckTest.cs
+++ b/test/EFCore.Tests/Utilities/CheckTest.cs
@@ -61,14 +61,5 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         {
             Assert.Throws<ArgumentException>(() => Check.NotEmpty(null, string.Empty));
         }
-
-        [Fact]
-        public void Valid_entity_type_throws_when_type_is_not_class()
-        {
-            Assert.Equal(
-                CoreStrings.InvalidEntityType(typeof(IComparable), "foo"),
-                Assert.Throws<ArgumentException>(
-                    () => Check.ValidEntityType(typeof(IComparable), "foo")).Message);
-        }
     }
 }


### PR DESCRIPTION
Throw better exception for `.Set<WeakType>()`
Log warnings for `InversePropertyAttribute` not working for owned types

Fixes #9265
Fixes #9626
