### PR TITLE
Fix #9558 - Relational: UDF calls are generated unquoted

### DIFF
--- a/src/EFCore.Relational/DbFunctionAttribute.cs
+++ b/src/EFCore.Relational/DbFunctionAttribute.cs
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         public virtual string FunctionName
         {
-            get { return _functionName; }
+            get => _functionName;
             [param: NotNull]
             set
             {
@@ -57,8 +57,9 @@ namespace Microsoft.EntityFrameworkCore
         /// </summary>
         public virtual string Schema
         {
-            get { return _schema; }
-            [param: CanBeNull] set { _schema = value; }
+            get => _schema;
+            [param: CanBeNull]
+            set => _schema = value;
         }
     }
 }

--- a/src/EFCore.Relational/Query/Expressions/SqlFunctionExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SqlFunctionExpression.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
     /// <summary>
     ///     Represents a SQL function call expression.
     /// </summary>
-    [DebuggerDisplay("{ToString()}")]
+    [DebuggerDisplay("{" + nameof(ToString) + "()}")]
     public class SqlFunctionExpression : Expression
     {
         private readonly ReadOnlyCollection<Expression> _arguments;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -2245,7 +2245,7 @@ ORDER BY [t].[Id]");
                     Assert.Equal(2, result);
 
                     AssertSql(
-                        @"SELECT TOP(2) [foo].AddOne([w].[Val])
+                        @"SELECT TOP(2) [foo].[AddOne]([w].[Val])
 FROM [foo].[Widgets] AS [w]
 WHERE [w].[Val] = 1");
                 }
@@ -2264,7 +2264,7 @@ WHERE [w].[Val] = 1");
                     Assert.Equal(3, result);
 
                     AssertSql(
-                        @"SELECT TOP(2) [dbo].AddTwo([w].[Val])
+                        @"SELECT TOP(2) [dbo].[AddTwo]([w].[Val])
 FROM [foo].[Widgets] AS [w]
 WHERE [w].[Val] = 1");
                 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/UdfDbFunctionSqlServerTests.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/UdfDbFunctionSqlServerTests.cs
@@ -313,7 +313,7 @@ WHERE [c].[Id] = @__customerId_0");
                 AssertSql(
                     @"@__customerId_0='1'
 
-SELECT [dbo].CustomerOrderCount(@__customerId_0)
+SELECT [dbo].[CustomerOrderCount](@__customerId_0)
 FROM [Customers] AS [c]");
             }
         }
@@ -335,7 +335,7 @@ FROM [Customers] AS [c]");
                 Assert.Equal(3, cust.OrderCount);
 
                 AssertSql(
-                    @"SELECT TOP(2) [c].[LastName], [dbo].CustomerOrderCount([c].[Id]) AS [OrderCount]
+                    @"SELECT TOP(2) [c].[LastName], [dbo].[CustomerOrderCount]([c].[Id]) AS [OrderCount]
 FROM [Customers] AS [c]
 WHERE [c].[Id] = 1");
             }
@@ -358,7 +358,7 @@ WHERE [c].[Id] = 1");
                 Assert.Equal(3, cust.OrderCount);
 
                 AssertSql(
-                    @"SELECT TOP(2) [c].[LastName], [dbo].CustomerOrderCount(1) AS [OrderCount]
+                    @"SELECT TOP(2) [c].[LastName], [dbo].[CustomerOrderCount](1) AS [OrderCount]
 FROM [Customers] AS [c]
 WHERE [c].[Id] = 1");
             }
@@ -386,7 +386,7 @@ WHERE [c].[Id] = 1");
                     @"@__customerId_1='1'
 @__customerId_0='1'
 
-SELECT TOP(2) [c].[LastName], [dbo].CustomerOrderCount(@__customerId_1) AS [OrderCount]
+SELECT TOP(2) [c].[LastName], [dbo].[CustomerOrderCount](@__customerId_1) AS [OrderCount]
 FROM [Customers] AS [c]
 WHERE [c].[Id] = @__customerId_0");
             }
@@ -416,7 +416,7 @@ WHERE [c].[Id] = @__customerId_0");
 @__customerId_2='3'
 @__customerId_0='3'
 
-SELECT TOP(2) [c].[LastName], [dbo].StarValue(@__starCount_1, [dbo].CustomerOrderCount(@__customerId_2)) AS [OrderCount]
+SELECT TOP(2) [c].[LastName], [dbo].[StarValue](@__starCount_1, [dbo].[CustomerOrderCount](@__customerId_2)) AS [OrderCount]
 FROM [Customers] AS [c]
 WHERE [c].[Id] = @__customerId_0");
             }
@@ -436,7 +436,7 @@ WHERE [c].[Id] = @__customerId_0");
                 AssertSql(
                     @"SELECT LOWER(CONVERT(VARCHAR(11), [c].[Id]))
 FROM [Customers] AS [c]
-WHERE [dbo].IsTopCustomer([c].[Id]) = 1");
+WHERE [dbo].[IsTopCustomer]([c].[Id]) = 1");
             }
         }
 
@@ -458,7 +458,7 @@ WHERE [dbo].IsTopCustomer([c].[Id]) = 1");
 
 SELECT TOP(2) [c].[Id]
 FROM [Customers] AS [c]
-WHERE [dbo].GetCustomerWithMostOrdersAfterDate(@__startDate_0) = [c].[Id]");
+WHERE [dbo].[GetCustomerWithMostOrdersAfterDate](@__startDate_0) = [c].[Id]");
             }
         }
 
@@ -481,7 +481,7 @@ WHERE [dbo].GetCustomerWithMostOrdersAfterDate(@__startDate_0) = [c].[Id]");
 
 SELECT TOP(2) [c].[Id]
 FROM [Customers] AS [c]
-WHERE [c].[Id] = [dbo].GetCustomerWithMostOrdersAfterDate([dbo].GetReportingPeriodStartDate(@__period_0))");
+WHERE [c].[Id] = [dbo].[GetCustomerWithMostOrdersAfterDate]([dbo].[GetReportingPeriodStartDate](@__period_0))");
             }
         }
 
@@ -501,7 +501,7 @@ WHERE [c].[Id] = [dbo].GetCustomerWithMostOrdersAfterDate([dbo].GetReportingPeri
                 AssertSql(
                     @"SELECT TOP(2) [c].[Id]
 FROM [Customers] AS [c]
-WHERE [c].[Id] = [dbo].GetCustomerWithMostOrdersAfterDate([dbo].GetReportingPeriodStartDate(0))");
+WHERE [c].[Id] = [dbo].[GetCustomerWithMostOrdersAfterDate]([dbo].[GetReportingPeriodStartDate](0))");
             }
         }
 
@@ -523,7 +523,7 @@ WHERE [c].[Id] = [dbo].GetCustomerWithMostOrdersAfterDate([dbo].GetReportingPeri
                 Assert.Equal(2, cust.OrderCount);
 
                 AssertSql(
-                    @"SELECT TOP(2) [c].[LastName], [dbo].CustomerOrderCount([c].[Id]) AS [OrderCount]
+                    @"SELECT TOP(2) [c].[LastName], [dbo].[CustomerOrderCount]([c].[Id]) AS [OrderCount]
 FROM [Customers] AS [c]
 WHERE [c].[Id] = 2");
             }
@@ -547,7 +547,7 @@ WHERE [c].[Id] = 2");
                 Assert.Equal(2, cust.OrderCount);
 
                 AssertSql(
-                    @"SELECT TOP(2) [c].[LastName], [dbo].CustomerOrderCount(2) AS [OrderCount]
+                    @"SELECT TOP(2) [c].[LastName], [dbo].[CustomerOrderCount](2) AS [OrderCount]
 FROM [Customers] AS [c]
 WHERE [c].[Id] = 2");
             }
@@ -576,7 +576,7 @@ WHERE [c].[Id] = 2");
                     @"@__customerId_0='2'
 @__customerId_1='2'
 
-SELECT TOP(2) [c].[LastName], [dbo].CustomerOrderCount(@__customerId_0) AS [OrderCount]
+SELECT TOP(2) [c].[LastName], [dbo].[CustomerOrderCount](@__customerId_0) AS [OrderCount]
 FROM [Customers] AS [c]
 WHERE [c].[Id] = @__customerId_1");
             }
@@ -607,7 +607,7 @@ WHERE [c].[Id] = @__customerId_1");
 @__customerId_1='1'
 @__customerId_2='1'
 
-SELECT TOP(2) [c].[LastName], [dbo].StarValue(@__starCount_0, [dbo].CustomerOrderCount(@__customerId_1)) AS [OrderCount]
+SELECT TOP(2) [c].[LastName], [dbo].[StarValue](@__starCount_0, [dbo].[CustomerOrderCount](@__customerId_1)) AS [OrderCount]
 FROM [Customers] AS [c]
 WHERE [c].[Id] = @__customerId_2");
             }
@@ -823,7 +823,7 @@ FROM [Customers] AS [c]");
                 AssertSql(
                     @"SELECT TOP(2) [c].[Id]
 FROM [Customers] AS [c]
-WHERE 3 = ABS([dbo].CustomerOrderCount([c].[Id]))");
+WHERE 3 = ABS([dbo].[CustomerOrderCount]([c].[Id]))");
             }
         }
 
@@ -857,7 +857,7 @@ FROM [Customers] AS [c]");
                 AssertSql(
                     @"SELECT TOP(2) [c].[Id]
 FROM [Customers] AS [c]
-WHERE 3 = [dbo].CustomerOrderCount(ABS([c].[Id]))");
+WHERE 3 = [dbo].[CustomerOrderCount](ABS([c].[Id]))");
             }
         }
 
@@ -873,7 +873,7 @@ WHERE 3 = [dbo].CustomerOrderCount(ABS([c].[Id]))");
 
                 Assert.Equal("Customer", result);
                 AssertSql(
-                    @"SELECT TOP(1) [dbo].IdentityString([o.Customer].[FirstName])
+                    @"SELECT TOP(1) [dbo].[IdentityString]([o.Customer].[FirstName])
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerId] = [o.Customer].[Id]
 ORDER BY [o].[Id]");
@@ -900,7 +900,7 @@ ORDER BY [o].[Id]");
                 Assert.Equal(custName.LastName, "$$One");
 
                 AssertSql(
-                    @"SELECT TOP(2) [dbo].StarValue(4, [c].[Id]) AS [Id], [dbo].DollarValue(2, [c].[LastName]) AS [LastName]
+                    @"SELECT TOP(2) [dbo].[StarValue](4, [c].[Id]) AS [Id], [dbo].[DollarValue](2, [c].[LastName]) AS [LastName]
 FROM [Customers] AS [c]
 WHERE [c].[Id] = 1");
             }
@@ -977,7 +977,7 @@ WHERE [c].[Id] = @__customerId_0");
                 AssertSql(
                     @"@__customerId_1='1'
 
-SELECT [dbo].CustomerOrderCount(@__customerId_1)
+SELECT [dbo].[CustomerOrderCount](@__customerId_1)
 FROM [Customers] AS [c]");
             }
         }
@@ -999,7 +999,7 @@ FROM [Customers] AS [c]");
                 Assert.Equal(3, cust.OrderCount);
 
                 AssertSql(
-                    @"SELECT TOP(2) [c].[LastName], [dbo].CustomerOrderCount([c].[Id]) AS [OrderCount]
+                    @"SELECT TOP(2) [c].[LastName], [dbo].[CustomerOrderCount]([c].[Id]) AS [OrderCount]
 FROM [Customers] AS [c]
 WHERE [c].[Id] = 1");
             }
@@ -1022,7 +1022,7 @@ WHERE [c].[Id] = 1");
                 Assert.Equal(3, cust.OrderCount);
 
                 AssertSql(
-                    @"SELECT TOP(2) [c].[LastName], [dbo].CustomerOrderCount(1) AS [OrderCount]
+                    @"SELECT TOP(2) [c].[LastName], [dbo].[CustomerOrderCount](1) AS [OrderCount]
 FROM [Customers] AS [c]
 WHERE [c].[Id] = 1");
             }
@@ -1050,7 +1050,7 @@ WHERE [c].[Id] = 1");
                     @"@__customerId_2='1'
 @__customerId_0='1'
 
-SELECT TOP(2) [c].[LastName], [dbo].CustomerOrderCount(@__customerId_2) AS [OrderCount]
+SELECT TOP(2) [c].[LastName], [dbo].[CustomerOrderCount](@__customerId_2) AS [OrderCount]
 FROM [Customers] AS [c]
 WHERE [c].[Id] = @__customerId_0");
             }
@@ -1080,7 +1080,7 @@ WHERE [c].[Id] = @__customerId_0");
 @__customerId_4='3'
 @__customerId_0='3'
 
-SELECT TOP(2) [c].[LastName], [dbo].StarValue(@__starCount_2, [dbo].CustomerOrderCount(@__customerId_4)) AS [OrderCount]
+SELECT TOP(2) [c].[LastName], [dbo].[StarValue](@__starCount_2, [dbo].[CustomerOrderCount](@__customerId_4)) AS [OrderCount]
 FROM [Customers] AS [c]
 WHERE [c].[Id] = @__customerId_0");
             }
@@ -1100,7 +1100,7 @@ WHERE [c].[Id] = @__customerId_0");
                 AssertSql(
                     @"SELECT LOWER(CONVERT(VARCHAR(11), [c].[Id]))
 FROM [Customers] AS [c]
-WHERE [dbo].IsTopCustomer([c].[Id]) = 1");
+WHERE [dbo].[IsTopCustomer]([c].[Id]) = 1");
             }
         }
 
@@ -1122,7 +1122,7 @@ WHERE [dbo].IsTopCustomer([c].[Id]) = 1");
 
 SELECT TOP(2) [c].[Id]
 FROM [Customers] AS [c]
-WHERE [dbo].GetCustomerWithMostOrdersAfterDate(@__startDate_1) = [c].[Id]");
+WHERE [dbo].[GetCustomerWithMostOrdersAfterDate](@__startDate_1) = [c].[Id]");
             }
         }
 
@@ -1145,7 +1145,7 @@ WHERE [dbo].GetCustomerWithMostOrdersAfterDate(@__startDate_1) = [c].[Id]");
 
 SELECT TOP(2) [c].[Id]
 FROM [Customers] AS [c]
-WHERE [c].[Id] = [dbo].GetCustomerWithMostOrdersAfterDate([dbo].GetReportingPeriodStartDate(@__period_2))");
+WHERE [c].[Id] = [dbo].[GetCustomerWithMostOrdersAfterDate]([dbo].[GetReportingPeriodStartDate](@__period_2))");
             }
         }
 
@@ -1165,7 +1165,7 @@ WHERE [c].[Id] = [dbo].GetCustomerWithMostOrdersAfterDate([dbo].GetReportingPeri
                 AssertSql(
                     @"SELECT TOP(2) [c].[Id]
 FROM [Customers] AS [c]
-WHERE [c].[Id] = [dbo].GetCustomerWithMostOrdersAfterDate([dbo].GetReportingPeriodStartDate(0))");
+WHERE [c].[Id] = [dbo].[GetCustomerWithMostOrdersAfterDate]([dbo].[GetReportingPeriodStartDate](0))");
             }
         }
 
@@ -1187,7 +1187,7 @@ WHERE [c].[Id] = [dbo].GetCustomerWithMostOrdersAfterDate([dbo].GetReportingPeri
                 Assert.Equal(2, cust.OrderCount);
 
                 AssertSql(
-                    @"SELECT TOP(2) [c].[LastName], [dbo].CustomerOrderCount([c].[Id]) AS [OrderCount]
+                    @"SELECT TOP(2) [c].[LastName], [dbo].[CustomerOrderCount]([c].[Id]) AS [OrderCount]
 FROM [Customers] AS [c]
 WHERE [c].[Id] = 2");
             }
@@ -1211,7 +1211,7 @@ WHERE [c].[Id] = 2");
                 Assert.Equal(2, cust.OrderCount);
 
                 AssertSql(
-                    @"SELECT TOP(2) [c].[LastName], [dbo].CustomerOrderCount(2) AS [OrderCount]
+                    @"SELECT TOP(2) [c].[LastName], [dbo].[CustomerOrderCount](2) AS [OrderCount]
 FROM [Customers] AS [c]
 WHERE [c].[Id] = 2");
             }
@@ -1240,7 +1240,7 @@ WHERE [c].[Id] = 2");
                     @"@__8__locals1_customerId_1='2'
 @__8__locals1_customerId_2='2'
 
-SELECT TOP(2) [c].[LastName], [dbo].CustomerOrderCount(@__8__locals1_customerId_1) AS [OrderCount]
+SELECT TOP(2) [c].[LastName], [dbo].[CustomerOrderCount](@__8__locals1_customerId_1) AS [OrderCount]
 FROM [Customers] AS [c]
 WHERE [c].[Id] = @__8__locals1_customerId_2");
             }
@@ -1271,7 +1271,7 @@ WHERE [c].[Id] = @__8__locals1_customerId_2");
 @__customerId_3='1'
 @__customerId_4='1'
 
-SELECT TOP(2) [c].[LastName], [dbo].StarValue(@__starCount_1, [dbo].CustomerOrderCount(@__customerId_3)) AS [OrderCount]
+SELECT TOP(2) [c].[LastName], [dbo].[StarValue](@__starCount_1, [dbo].[CustomerOrderCount](@__customerId_3)) AS [OrderCount]
 FROM [Customers] AS [c]
 WHERE [c].[Id] = @__customerId_4");
             }
@@ -1487,7 +1487,7 @@ FROM [Customers] AS [c]");
                 AssertSql(
                     @"SELECT TOP(2) [c].[Id]
 FROM [Customers] AS [c]
-WHERE 3 = ABS([dbo].CustomerOrderCount([c].[Id]))");
+WHERE 3 = ABS([dbo].[CustomerOrderCount]([c].[Id]))");
             }
         }
 
@@ -1521,7 +1521,7 @@ FROM [Customers] AS [c]");
                 AssertSql(
                     @"SELECT TOP(2) [c].[Id]
 FROM [Customers] AS [c]
-WHERE 3 = [dbo].CustomerOrderCount(ABS([c].[Id]))");
+WHERE 3 = [dbo].[CustomerOrderCount](ABS([c].[Id]))");
             }
         }
 


### PR DESCRIPTION
Tweak SQL gen to delimit function calls that have a schema.

