### PR TITLE
Specify ordering in OrderBy_Skip_GroupBy

### DIFF
--- a/samples/OracleProvider/test/OracleProvider.FunctionalTests/Query/GroupByQueryOracleTest.cs
+++ b/samples/OracleProvider/test/OracleProvider.FunctionalTests/Query/GroupByQueryOracleTest.cs
@@ -1067,7 +1067,7 @@ SELECT ""t"".""OrderID"", ""t"".""CustomerID"", ""t"".""EmployeeID"", ""t"".""Or
 FROM (
     SELECT ""o"".""OrderID"", ""o"".""CustomerID"", ""o"".""EmployeeID"", ""o"".""OrderDate""
     FROM ""Orders"" ""o""
-    ORDER BY ""o"".""OrderDate"" NULLS FIRST
+    ORDER BY ""o"".""OrderDate"", ""o"".""OrderID"" NULLS FIRST
     OFFSET :p_0 ROWS
 ) ""t""
 ORDER BY ""t"".""CustomerID"" NULLS FIRST");

--- a/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -1126,7 +1126,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void OrderBy_Skip_GroupBy()
         {
             AssertQuery<Order>(
-                os => os.OrderBy(o => o.OrderDate).Skip(800).GroupBy(o => o.CustomerID),
+                os => os.OrderBy(o => o.OrderDate).ThenBy(o => o.OrderID).Skip(800).GroupBy(o => o.CustomerID),
                 elementSorter: GroupingSorter<string, object>(),
                 elementAsserter: GroupingAsserter<string, dynamic>(d => d.OrderDate),
                 entryCount: 30);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
@@ -1062,7 +1062,7 @@ SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
 FROM (
     SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
-    ORDER BY [o].[OrderDate]
+    ORDER BY [o].[OrderDate], [o].[OrderID]
     OFFSET @__p_0 ROWS
 ) AS [t]
 ORDER BY [t].[CustomerID]");


### PR DESCRIPTION
Ordering was not determinstic, passing in SQL Server but failing in PostgreSQL.