### PR TITLE
[TINY] Fix to #10284 - EF Core does not cast from Nullable to underlying type

### DIFF
--- a/src/EFCore.Relational/Query/Expressions/SqlFunctionExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SqlFunctionExpression.cs
@@ -176,7 +176,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         protected override Expression VisitChildren(ExpressionVisitor visitor)
         {
             var newInstance = Instance != null ? visitor.Visit(Instance) : null;
-            var newArguments = visitor.VisitAndConvert(_arguments, "VisitChildren");
+            var newArguments = visitor.VisitAndConvert(_arguments, nameof(VisitChildren));
 
             return newInstance != Instance || newArguments != _arguments
                 ? new SqlFunctionExpression(newInstance, FunctionName, Schema, Type, newArguments)

--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -916,7 +916,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 _insideShapedQueryMethod = methodCallExpression.Method.MethodIsClosedFormOf(
                     _relationalQueryCompilationContext.QueryMethodProvider.ShapedQueryMethod);
 
-                var arguments = VisitAndConvert(methodCallExpression.Arguments, "VisitMethodCall");
+                var arguments = VisitAndConvert(methodCallExpression.Arguments, nameof(VisitMethodCall));
 
                 if (arguments != methodCallExpression.Arguments)
                 {

--- a/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -3876,5 +3876,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                     new ExpectedInclude<Level2>(e => e.OneToMany_Optional, "OneToMany_Optional", "OneToOne_Optional_FK")
                 });
         }
+
+        [ConditionalFact]
+        public virtual void Nav_rewrite_doesnt_apply_null_protection_for_function_arguments()
+        {
+            AssertQueryScalar<Level1>(
+                l1s => l1s.Where(l1 => l1.OneToOne_Optional_PK != null).Select(l1 => Math.Max(l1.OneToOne_Optional_PK.Level1_Required_Id, 7)));
+        }
     }
 }

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -587,7 +587,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 if (methodCallExpression.Method
                     .MethodIsClosedFormOf(TaskBlockingExpressionVisitor.ResultMethodInfo))
                 {
-                    var newArguments = VisitAndConvert(methodCallExpression.Arguments, "VisitMethodCall");
+                    var newArguments = VisitAndConvert(methodCallExpression.Arguments, nameof(VisitMethodCall));
 
                     if (newArguments != methodCallExpression.Arguments)
                     {

--- a/src/EFCore/Query/ExpressionVisitors/Internal/MemberAccessBindingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/MemberAccessBindingExpressionVisitor.cs
@@ -114,7 +114,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 newRight = _queryModelVisitor.BindReadValueMethod(node.Right.Type, newRight, 0);
             }
 
-            var newConversion = VisitAndConvert(node.Conversion, "VisitBinary");
+            var newConversion = VisitAndConvert(node.Conversion, nameof(VisitBinary));
 
             return node.Update(newLeft, newConversion, newRight);
         }
@@ -307,7 +307,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                             methodCallExpression.Arguments[0],
                             methodCallExpression.Arguments[1]
                         }.AsReadOnly(),
-                        "VisitMethodCall");
+                        nameof(VisitMethodCall));
 
                 if (newArguments[0].Type == typeof(ValueBuffer))
                 {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -3467,7 +3467,7 @@ ORDER BY [t5].[Id0], [t5].[Id]");
             base.Include_reference_collection_order_by_reference_navigation();
 
             AssertSql(
-    @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToOne_Optional_FK].[Id], [l1.OneToOne_Optional_FK].[Date], [l1.OneToOne_Optional_FK].[Level1_Optional_Id], [l1.OneToOne_Optional_FK].[Level1_Required_Id], [l1.OneToOne_Optional_FK].[Name], [l1.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToOne_Optional_FK].[Id], [l1.OneToOne_Optional_FK].[Date], [l1.OneToOne_Optional_FK].[Level1_Optional_Id], [l1.OneToOne_Optional_FK].[Level1_Required_Id], [l1.OneToOne_Optional_FK].[Name], [l1.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
 FROM [LevelOne] AS [l1]
 LEFT JOIN [LevelTwo] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
 ORDER BY [l1.OneToOne_Optional_FK].[Id]",
@@ -3480,6 +3480,17 @@ INNER JOIN (
     LEFT JOIN [LevelTwo] AS [l1.OneToOne_Optional_FK0] ON [l10].[Id] = [l1.OneToOne_Optional_FK0].[Level1_Optional_Id]
 ) AS [t] ON [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
 ORDER BY [t].[Id]");
+        }
+
+        public override void Nav_rewrite_doesnt_apply_null_protection_for_function_arguments()
+        {
+            base.Nav_rewrite_doesnt_apply_null_protection_for_function_arguments();
+
+            AssertSql(
+                @"SELECT [l1.OneToOne_Optional_PK].[Level1_Required_Id]
+FROM [LevelOne] AS [l1]
+LEFT JOIN [LevelTwo] AS [l1.OneToOne_Optional_PK] ON [l1].[Id] = [l1.OneToOne_Optional_PK].[OneToOne_Optional_PK_InverseId]
+WHERE [l1.OneToOne_Optional_PK].[Id] IS NOT NULL");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
@@ -570,7 +570,7 @@ WHERE [o].[CustomerID] = N'ALFKI'");
             base.Projection_in_a_subquery_should_be_liftable();
 
             AssertSql(
-    @"@__p_0='1'
+                @"@__p_0='1'
 
 SELECT [e].[EmployeeID]
 FROM [Employees] AS [e]


### PR DESCRIPTION
Problem was that we were too aggressive in applying null compensation during navigation rewrite. This could lead to type change of an argument to a function - if the argument was a non-nullable property accessed via optional navigation). This in turn causes issues during compilation, because new method arguments must match method signature.

Fix is to unwrap null compensation for arguments of the function.