### PR TITLE
Improve exception messages

### DIFF
--- a/src/EFCore.InMemory/Storage/Internal/InMemoryTable.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryTable.cs
@@ -145,7 +145,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                         entry.EntityType.DisplayName(),
                         entry.BuildCurrentValuesString(entry.EntityType.FindPrimaryKey().Properties),
                         entry.BuildOriginalValuesString(concurrencyConflicts.Keys),
-                        string.Join(", ", concurrencyConflicts.Select(c => c.Key.Name + ":" + c.Value))),
+                        "{" + string.Join(", ", concurrencyConflicts.Select(c => c.Key.Name + ": " + c.Value)) + "}"),
                     new[] { entry });
             }
 

--- a/src/EFCore.Relational.Specification.Tests/Query/InheritanceRelationalTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/InheritanceRelationalTestBase.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore.TestModels.Inheritance;
 using Xunit;
 
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Query
 {
     public abstract class InheritanceRelationalTestBase<TFixture> : InheritanceTestBase<TFixture>

--- a/src/EFCore.Specification.Tests/GraphUpdatesTestBase.cs
+++ b/src/EFCore.Specification.Tests/GraphUpdatesTestBase.cs
@@ -413,7 +413,7 @@ namespace Microsoft.EntityFrameworkCore
                             && (changeMechanism & ChangeMechanism.Fk) == 0)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(Optional1), nameof(Optional2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(Optional1), nameof(Optional2), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -497,7 +497,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(Required1), nameof(Required2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(Required1), nameof(Required2), "{Id: 2}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -617,7 +617,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(Root), nameof(OptionalSingle1)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(Root), nameof(OptionalSingle1), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -731,7 +731,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(RequiredSingle1), nameof(RequiredSingle2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(RequiredSingle1), nameof(RequiredSingle2), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -896,7 +896,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(Root), nameof(RequiredNonPkSingle1)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(Root), nameof(RequiredNonPkSingle1), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -995,7 +995,7 @@ namespace Microsoft.EntityFrameworkCore
                             && (changeMechanism & ChangeMechanism.Fk) == 0)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(Root), nameof(OptionalSingle1)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(Root), nameof(OptionalSingle1), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -1070,7 +1070,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(RequiredSingle1), nameof(RequiredSingle2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(RequiredSingle1), nameof(RequiredSingle2), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -1138,7 +1138,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(Root), nameof(RequiredNonPkSingle1)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(Root), nameof(RequiredNonPkSingle1), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -1484,7 +1484,7 @@ namespace Microsoft.EntityFrameworkCore
                             && (changeMechanism & ChangeMechanism.Fk) == 0)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(OptionalAk1), nameof(OptionalComposite2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(OptionalAk1), nameof(OptionalComposite2), "{Id: 3}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -2005,11 +2005,12 @@ namespace Microsoft.EntityFrameworkCore
                     {
                         root = LoadOptionalAkGraph(context);
 
-                        var childCollection = root.OptionalChildrenAk.First().Children;
-                        var childCompositeCollection = root.OptionalChildrenAk.First().CompositeChildren;
-                        var removed2 = childCollection.First();
-                        var removed1 = root.OptionalChildrenAk.Skip(1).First();
-                        var removed2c = childCompositeCollection.First();
+                        var firstChild = root.OptionalChildrenAk.OrderByDescending(c => c.Id).First();
+                        var childCollection = firstChild.Children;
+                        var childCompositeCollection = firstChild.CompositeChildren;
+                        var removed2 = childCollection.OrderByDescending(c => c.Id).First();
+                        var removed1 = root.OptionalChildrenAk.OrderByDescending(c => c.Id).Skip(1).First();
+                        var removed2c = childCompositeCollection.OrderByDescending(c => c.Id).First();
 
                         if ((changeMechanism & ChangeMechanism.Principal) != 0)
                         {
@@ -2037,8 +2038,9 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict
                             && (changeMechanism & ChangeMechanism.Fk) == 0)
                         {
+                            Add(root.OptionalChildrenAk, removed1);
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(OptionalAk1), nameof(OptionalAk2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(OptionalAk1), nameof(OptionalAk2), "{Id: 4}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -2071,7 +2073,7 @@ namespace Microsoft.EntityFrameworkCore
                             AssertNavigations(loadedRoot);
 
                             Assert.Equal(1, loadedRoot.OptionalChildrenAk.Count());
-                            Assert.Equal(1, loadedRoot.OptionalChildrenAk.First().Children.Count());
+                            Assert.Equal(1, loadedRoot.OptionalChildrenAk.OrderBy(c => c.Id).First().Children.Count());
                         }
                     });
         }
@@ -2092,11 +2094,12 @@ namespace Microsoft.EntityFrameworkCore
                     {
                         root = LoadRequiredAkGraph(context);
 
-                        var childCollection = root.RequiredChildrenAk.First().Children;
-                        var childCompositeCollection = root.RequiredChildrenAk.First().CompositeChildren;
-                        removed2 = childCollection.First();
-                        removed2c = childCompositeCollection.First();
-                        removed1 = root.RequiredChildrenAk.Skip(1).First();
+                        var firstChild = root.RequiredChildrenAk.OrderByDescending(c => c.Id).First();
+                        var childCollection = firstChild.Children;
+                        var childCompositeCollection = firstChild.CompositeChildren;
+                        removed2 = childCollection.OrderBy(c => c.Id).First();
+                        removed2c = childCompositeCollection.OrderBy(c => c.Id).First();
+                        removed1 = root.RequiredChildrenAk.OrderByDescending(c => c.Id).Skip(1).First();
 
                         if ((changeMechanism & ChangeMechanism.Principal) != 0)
                         {
@@ -2121,8 +2124,9 @@ namespace Microsoft.EntityFrameworkCore
 
                         if (Fixture.ForceRestrict)
                         {
+                            Add(root.RequiredChildrenAk, removed1);
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(RequiredAk1), nameof(RequiredAk2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(RequiredAk1), nameof(RequiredAk2), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -2154,8 +2158,8 @@ namespace Microsoft.EntityFrameworkCore
                             Assert.False(context.Set<RequiredComposite2>().Any(e => e.Id == removed2c.Id));
 
                             Assert.Equal(1, loadedRoot.RequiredChildrenAk.Count());
-                            Assert.Equal(1, loadedRoot.RequiredChildrenAk.First().Children.Count());
-                            Assert.Equal(1, loadedRoot.RequiredChildrenAk.First().CompositeChildren.Count());
+                            Assert.Equal(1, loadedRoot.RequiredChildrenAk.OrderBy(c => c.Id).First().Children.Count());
+                            Assert.Equal(1, loadedRoot.RequiredChildrenAk.OrderBy(c => c.Id).First().CompositeChildren.Count());
                         }
                     });
         }
@@ -2256,7 +2260,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(Root), nameof(OptionalSingleAk1)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(Root), nameof(OptionalSingleAk1), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -2384,7 +2388,7 @@ namespace Microsoft.EntityFrameworkCore
                             if (Fixture.ForceRestrict)
                             {
                                 Assert.Equal(
-                                    CoreStrings.RelationshipConceptualNull(nameof(Root), nameof(OptionalSingleAk1)),
+                                    CoreStrings.RelationshipConceptualNullSensitive(nameof(Root), nameof(OptionalSingleAk1), "{Id: 1}"),
                                     Assert.Throws<InvalidOperationException>(() => context2.SaveChanges()).Message);
                             }
                             else
@@ -2578,7 +2582,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(Root), nameof(RequiredSingleAk1)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(Root), nameof(RequiredSingleAk1), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -2726,7 +2730,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(Root), nameof(RequiredNonPkSingleAk1)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(Root), nameof(RequiredNonPkSingleAk1), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -2827,7 +2831,7 @@ namespace Microsoft.EntityFrameworkCore
                             && (changeMechanism & ChangeMechanism.Fk) == 0)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(Root), nameof(OptionalSingleAk1)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(Root), nameof(OptionalSingleAk1), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -2911,7 +2915,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(Root), nameof(RequiredSingleAk1)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(Root), nameof(RequiredSingleAk1), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -2985,7 +2989,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(Root), nameof(RequiredNonPkSingleAk1)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(Root), nameof(RequiredNonPkSingleAk1), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -3318,7 +3322,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(Required1), nameof(Required2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(Required1), nameof(Required2), "{Id: 2}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -3383,7 +3387,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(Optional1), nameof(Optional2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(Optional1), nameof(Optional2), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -3444,7 +3448,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(OptionalSingle1), nameof(OptionalSingle2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(OptionalSingle1), nameof(OptionalSingle2), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -3503,7 +3507,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(RequiredSingle1), nameof(RequiredSingle2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(RequiredSingle1), nameof(RequiredSingle2), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -3562,7 +3566,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(RequiredNonPkSingle1), nameof(RequiredNonPkSingle2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(RequiredNonPkSingle1), nameof(RequiredNonPkSingle2), "{Id: 2}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -3610,7 +3614,7 @@ namespace Microsoft.EntityFrameworkCore
 
                         Assert.Equal(2, root.OptionalChildrenAk.Count());
 
-                        var removed = root.OptionalChildrenAk.First();
+                        var removed = root.OptionalChildrenAk.OrderBy(c => c.Id).First();
 
                         removedId = removed.Id;
                         var orphaned = removed.Children.ToList();
@@ -3625,7 +3629,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(OptionalAk1), nameof(OptionalAk2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(OptionalAk1), nameof(OptionalAk2), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -3676,7 +3680,7 @@ namespace Microsoft.EntityFrameworkCore
 
                         Assert.Equal(2, root.RequiredChildrenAk.Count());
 
-                        var removed = root.RequiredChildrenAk.First();
+                        var removed = root.RequiredChildrenAk.OrderBy(c => c.Id).First();
 
                         removedId = removed.Id;
                         var cascadeRemoved = removed.Children.ToList();
@@ -3694,7 +3698,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(RequiredAk1), nameof(RequiredAk2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(RequiredAk1), nameof(RequiredAk2), "{Id: 3}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -3760,7 +3764,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(OptionalSingleAk1), nameof(OptionalSingleAk2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(OptionalSingleAk1), nameof(OptionalSingleAk2), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -3825,7 +3829,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(RequiredSingleAk1), nameof(RequiredSingleAk2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(RequiredSingleAk1), nameof(RequiredSingleAk2), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -3887,7 +3891,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(RequiredNonPkSingleAk1), nameof(RequiredNonPkSingleAk2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(RequiredNonPkSingleAk1), nameof(RequiredNonPkSingleAk2), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -4440,7 +4444,7 @@ namespace Microsoft.EntityFrameworkCore
             ExecuteWithStrategyInTransaction(
                 context =>
                     {
-                        var removed = LoadOptionalAkGraph(context).OptionalChildrenAk.First();
+                        var removed = LoadOptionalAkGraph(context).OptionalChildrenAk.OrderBy(c => c.Id).First();
 
                         removedId = removed.Id;
                         orphanedIds = removed.Children.Select(e => e.Id).ToList();
@@ -4467,7 +4471,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(OptionalAk1), nameof(OptionalComposite2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(OptionalAk1), nameof(OptionalComposite2), "{Id: 3}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -4551,7 +4555,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(OptionalSingleAk1), nameof(OptionalSingleComposite2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(OptionalSingleAk1), nameof(OptionalSingleComposite2), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -4621,7 +4625,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(Required1), nameof(Required2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(Required1), nameof(Required2), "{Id: 2}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -4686,7 +4690,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(Optional1), nameof(Optional2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(Optional1), nameof(Optional2), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -4744,7 +4748,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(OptionalSingle1), nameof(OptionalSingle2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(OptionalSingle1), nameof(OptionalSingle2), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -4801,7 +4805,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(RequiredSingle1), nameof(RequiredSingle2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(RequiredSingle1), nameof(RequiredSingle2), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -4857,7 +4861,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(RequiredNonPkSingle1), nameof(RequiredNonPkSingle2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(RequiredNonPkSingle1), nameof(RequiredNonPkSingle2), "{Id: 2}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -4904,7 +4908,7 @@ namespace Microsoft.EntityFrameworkCore
                     },
                 context =>
                     {
-                        var removed = root.OptionalChildrenAk.First();
+                        var removed = root.OptionalChildrenAk.OrderBy(c => c.Id).First();
 
                         removedId = removed.Id;
                         var orphaned = removed.Children.ToList();
@@ -4926,7 +4930,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(OptionalAk1), nameof(OptionalAk2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(OptionalAk1), nameof(OptionalAk2), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -4976,7 +4980,7 @@ namespace Microsoft.EntityFrameworkCore
                     },
                 context =>
                     {
-                        var removed = root.RequiredChildrenAk.First();
+                        var removed = root.RequiredChildrenAk.OrderBy(c => c.Id).First();
 
                         removedId = removed.Id;
                         var cascadeRemoved = removed.Children.ToList();
@@ -4997,7 +5001,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(RequiredAk1), nameof(RequiredAk2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(RequiredAk1), nameof(RequiredAk2), "{Id: 3}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -5061,7 +5065,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(OptionalSingleAk1), nameof(OptionalSingleAk2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(OptionalSingleAk1), nameof(OptionalSingleAk2), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -5124,7 +5128,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(RequiredSingleAk1), nameof(RequiredSingleAk2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(RequiredSingleAk1), nameof(RequiredSingleAk2), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -5183,7 +5187,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(RequiredNonPkSingleAk1), nameof(RequiredNonPkSingleAk2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(RequiredNonPkSingleAk1), nameof(RequiredNonPkSingleAk2), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -5257,7 +5261,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(Required1), nameof(Required2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(Required1), nameof(Required2), "{Id: 2}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -5321,7 +5325,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(RequiredSingle1), nameof(RequiredSingle2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(RequiredSingle1), nameof(RequiredSingle2), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -5383,7 +5387,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(RequiredNonPkSingle1), nameof(RequiredNonPkSingle2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(RequiredNonPkSingle1), nameof(RequiredNonPkSingle2), "{Id: 2}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -5427,7 +5431,7 @@ namespace Microsoft.EntityFrameworkCore
 
                         Assert.Equal(2, root.RequiredChildrenAk.Count());
 
-                        var removed = root.RequiredChildrenAk.First();
+                        var removed = root.RequiredChildrenAk.OrderBy(c => c.Id).First();
 
                         removedId = removed.Id;
                         var cascadeRemoved = removed.Children.ToList();
@@ -5467,7 +5471,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(RequiredAk1), nameof(RequiredAk2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(RequiredAk1), nameof(RequiredAk2), "{Id: 3}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -5540,7 +5544,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(RequiredSingleAk1), nameof(RequiredSingleAk2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(RequiredSingleAk1), nameof(RequiredSingleAk2), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else
@@ -5604,7 +5608,7 @@ namespace Microsoft.EntityFrameworkCore
                         if (Fixture.ForceRestrict)
                         {
                             Assert.Equal(
-                                CoreStrings.RelationshipConceptualNull(nameof(RequiredNonPkSingleAk1), nameof(RequiredNonPkSingleAk2)),
+                                CoreStrings.RelationshipConceptualNullSensitive(nameof(RequiredNonPkSingleAk1), nameof(RequiredNonPkSingleAk2), "{Id: 1}"),
                                 Assert.Throws<InvalidOperationException>(() => context.SaveChanges()).Message);
                         }
                         else

--- a/src/EFCore.Specification.Tests/Query/InheritanceTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/InheritanceTestBase.cs
@@ -1,8 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestModels.Inheritance;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -521,6 +523,31 @@ namespace Microsoft.EntityFrameworkCore.Query
                 var concat = kiwis.Cast<Bird>().Union(eagles).ToList();
 
                 Assert.Equal(2, concat.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Setting_foreign_key_to_a_different_type_throws()
+        {
+            using (var context = CreateContext())
+            {
+                var kiwi = context.Set<Kiwi>().Single();
+
+                var eagle = new Eagle
+                {
+                    Species = "Haliaeetus leucocephalus",
+                    Name = "Bald eagle",
+                    Group = EagleGroup.Booted,
+                    EagleId = kiwi.Species
+                };
+
+                Assert.Equal(CoreStrings.IncompatiblePrincipalEntrySensitive(
+                    "{EagleId: Apteryx haastii}",
+                    nameof(Eagle),
+                    "{Species: Haliaeetus leucocephalus}",
+                    nameof(Kiwi),
+                    nameof(Eagle)),
+                    Assert.Throws<InvalidOperationException>(() => context.Add(eagle)).Message);
             }
         }
 

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -61,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             => GetString("AlterIdentityColumn");
 
         /// <summary>
-        ///     An exception has been raised that is likely due to a transient failure. If you are connecting to a SQL Azure database consider using SqlAzureExecutionStrategy.
+        ///     An exception has been raised that is likely due to a transient failure. Consider enabling transient error resiliency by adding 'EnableRetryOnFailure()' to the 'UseSqlServer' call.
         /// </summary>
         public static string TransientExceptionDetected
             => GetString("TransientExceptionDetected");

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -136,7 +136,7 @@
     <value>To change the IDENTITY property of a column, the column needs to be dropped and recreated.</value>
   </data>
   <data name="TransientExceptionDetected" xml:space="preserve">
-    <value>An exception has been raised that is likely due to a transient failure. If you are connecting to a SQL Azure database consider using SqlAzureExecutionStrategy.</value>
+    <value>An exception has been raised that is likely due to a transient failure. Consider enabling transient error resiliency by adding 'EnableRetryOnFailure()' to the 'UseSqlServer' call.</value>
   </data>
   <data name="LogDefaultDecimalTypeColumn" xml:space="preserve">
     <value>No type was specified for the decimal column '{property}' on entity type '{entityType}'. This will cause values to be silently truncated if they do not fit in the default precision and scale. Explicitly specify the SQL server column type that can accommodate all the values using 'ForHasColumnType()'.</value>

--- a/src/EFCore/Metadata/Conventions/Internal/PropertyMappingValidationConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/PropertyMappingValidationConvention.cs
@@ -47,7 +47,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
             {
-                var unmappedProperty = entityType.GetProperties().FirstOrDefault(p => !IsMappedPrimitiveProperty(p));
+                var unmappedProperty = entityType.GetProperties().FirstOrDefault(p =>
+                    (!ConfigurationSource.Convention.Overrides(p.GetConfigurationSource()) || !p.IsShadowProperty)
+                    && !IsMappedPrimitiveProperty(p));
 
                 if (unmappedProperty != null)
                 {

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -693,7 +693,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 property, entityType);
 
         /// <summary>
-        ///     The association between entity types '{firstType}' and '{secondType}' has been severed but the foreign key for this relationship cannot be set to null. If the dependent entity should be deleted, then setup the relationship to use cascade deletes.
+        ///     The association between entity types '{firstType}' and '{secondType}' has been severed but the foreign key for this relationship cannot be set to null. If the dependent entity should be deleted, then setup the relationship to use cascade deletes.  Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the key values.
         /// </summary>
         public static string RelationshipConceptualNull([CanBeNull] object firstType, [CanBeNull] object secondType)
             => string.Format(
@@ -701,7 +701,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 firstType, secondType);
 
         /// <summary>
-        ///     The property '{property}' on entity type '{entityType}' is marked as null, but this cannot be saved because the property is marked as required.
+        ///     The property '{property}' on entity type '{entityType}' is marked as null, but this cannot be saved because the property is marked as required.  Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the key values.
         /// </summary>
         public static string PropertyConceptualNull([CanBeNull] object property, [CanBeNull] object entityType)
             => string.Format(
@@ -1577,7 +1577,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 strategy, getExecutionStrategyMethod);
 
         /// <summary>
-        ///     Cannot call Property for the property '{property}' on entity type '{entityType}' because it is configured as a navigation property. Property can only be used to configure scalar properties.
+        ///     '{property}' cannot be used as a property on entity type '{entityType}' because it is configured as a navigation.
         /// </summary>
         public static string PropertyCalledOnNavigation([CanBeNull] object property, [CanBeNull] object entityType)
             => string.Format(
@@ -1911,7 +1911,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 entityType, value, property, type);
 
         /// <summary>
-        ///     The seed entity for entity type '{entityType}' cannot be added because the was no value provided for the required property '{property}'. 
+        ///     The seed entity for entity type '{entityType}' cannot be added because the was no value provided for the required property '{property}'.
         /// </summary>
         public static string SeedDatumMissingValue([CanBeNull] object entityType, [CanBeNull] object property)
             => string.Format(
@@ -2255,6 +2255,38 @@ namespace Microsoft.EntityFrameworkCore.Internal
                     LogLevel.Warning,
                     CoreEventId.NonOwnershipInverseNavigation,
                     _resourceManager.GetString("LogNonOwnershipInverseNavigation")));
+
+        /// <summary>
+        ///     The property '{property}'  is marked as null on entity '{entityType}' with the key value '{keyValue}', but this cannot be saved because the property is marked as required.
+        /// </summary>
+        public static string PropertyConceptualNullSensitive([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object keyValue)
+            => string.Format(
+                GetString("PropertyConceptualNullSensitive", nameof(property), nameof(entityType), nameof(keyValue)),
+                property, entityType, keyValue);
+
+        /// <summary>
+        ///     The association between entities '{firstType}' and '{secondType}' with the key value '{secondKeyValue}' has been severed but the foreign key for this relationship cannot be set to null. If the dependent entity should be deleted, then setup the relationship to use cascade deletes.
+        /// </summary>
+        public static string RelationshipConceptualNullSensitive([CanBeNull] object firstType, [CanBeNull] object secondType, [CanBeNull] object secondKeyValue)
+            => string.Format(
+                GetString("RelationshipConceptualNullSensitive", nameof(firstType), nameof(secondType), nameof(secondKeyValue)),
+                firstType, secondType, secondKeyValue);
+
+        /// <summary>
+        ///     The foreign key {foreignKey} set on '{dependentEntityType}' matches an entity of type '{foundPrincipalEntityType}', however the principal entity type should be assignable to '{principalEntityType}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the key values.
+        /// </summary>
+        public static string IncompatiblePrincipalEntry([CanBeNull] object foreignKey, [CanBeNull] object dependentEntityType, [CanBeNull] object foundPrincipalEntityType, [CanBeNull] object principalEntityType)
+            => string.Format(
+                GetString("IncompatiblePrincipalEntry", nameof(foreignKey), nameof(dependentEntityType), nameof(foundPrincipalEntityType), nameof(principalEntityType)),
+                foreignKey, dependentEntityType, foundPrincipalEntityType, principalEntityType);
+
+        /// <summary>
+        ///     The foreign key '{foreignKeyValues}' set on '{dependentEntityType}' with the key value '{keyValue}' matches an entity of type '{foundPrincipalEntityType}', however the principal entity type should be assignable to '{principalEntityType}'.
+        /// </summary>
+        public static string IncompatiblePrincipalEntrySensitive([CanBeNull] object foreignKeyValues, [CanBeNull] object dependentEntityType, [CanBeNull] object keyValue, [CanBeNull] object foundPrincipalEntityType, [CanBeNull] object principalEntityType)
+            => string.Format(
+                GetString("IncompatiblePrincipalEntrySensitive", nameof(foreignKeyValues), nameof(dependentEntityType), nameof(keyValue), nameof(foundPrincipalEntityType), nameof(principalEntityType)),
+                foreignKeyValues, dependentEntityType, keyValue, foundPrincipalEntityType, principalEntityType);
 
         private static string GetString(string name, params string[] formatterNames)
         {

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -372,10 +372,10 @@
     <value>The property '{property}' on entity type '{entityType}' must be marked as read-only after it has been saved because it is part of a key. Key properties are always read-only once an entity has been saved for the first time.</value>
   </data>
   <data name="RelationshipConceptualNull" xml:space="preserve">
-    <value>The association between entity types '{firstType}' and '{secondType}' has been severed but the foreign key for this relationship cannot be set to null. If the dependent entity should be deleted, then setup the relationship to use cascade deletes.</value>
+    <value>The association between entity types '{firstType}' and '{secondType}' has been severed but the foreign key for this relationship cannot be set to null. If the dependent entity should be deleted, then setup the relationship to use cascade deletes.  Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the key values.</value>
   </data>
   <data name="PropertyConceptualNull" xml:space="preserve">
-    <value>The property '{property}' on entity type '{entityType}' is marked as null, but this cannot be saved because the property is marked as required.</value>
+    <value>The property '{property}' on entity type '{entityType}' is marked as null, but this cannot be saved because the property is marked as required.  Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the key values.</value>
   </data>
   <data name="DuplicateForeignKey" xml:space="preserve">
     <value>The foreign key {foreignKey} cannot be added to the entity type '{entityType}' because a foreign key on the same properties already exists on entity type '{duplicateEntityType}' and also targets the key {key} on '{principalType}'.</value>
@@ -708,7 +708,7 @@
     <value>The configured execution strategy '{strategy}' does not support user initiated transactions. Use the execution strategy returned by '{getExecutionStrategyMethod}' to execute all the operations in the transaction as a retriable unit.</value>
   </data>
   <data name="PropertyCalledOnNavigation" xml:space="preserve">
-    <value>Cannot call Property for the property '{property}' on entity type '{entityType}' because it is configured as a navigation property. Property can only be used to configure scalar properties.</value>
+    <value>'{property}' cannot be used as a property on entity type '{entityType}' because it is configured as a navigation.</value>
   </data>
   <data name="LogRowLimitingOperationWithoutOrderBy" xml:space="preserve">
     <value>Query: '{queryModel}' uses a row limiting operation (Skip/Take) without OrderBy which may lead to unpredictable results.</value>
@@ -833,7 +833,7 @@
     <value>The seed entity for entity type '{entityType}' cannot be added because the value '{value}' provided for the property '{property}' is not of the type '{type}'.</value>
   </data>
   <data name="SeedDatumMissingValue" xml:space="preserve">
-    <value>The seed entity for entity type '{entityType}' cannot be added because the was no value provided for the required property '{property}'. </value>
+    <value>The seed entity for entity type '{entityType}' cannot be added because the was no value provided for the required property '{property}'.</value>
   </data>
   <data name="SeedDatumNavigation" xml:space="preserve">
     <value>The seed entity for entity type '{entityType}' cannot be added because it has the navigation '{navigation}' set. To seed relationships you need to add the related entity seed to '{relatedEntityType}' and specify the foreign key values {foreignKeyProperties}. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the involved property values.</value>
@@ -953,5 +953,17 @@
   <data name="LogNonOwnershipInverseNavigation" xml:space="preserve">
     <value>The navigation '{targetEntityType}.{inverseNavigation}' cannot be used as the inverse of '{ownedEntityType}.{navigation}' because it's not the ownership navigation '{ownershipNavigation}'</value>
     <comment>Warning CoreEventId.NonOwnershipInverseNavigation string string string string string</comment>
+  </data>
+  <data name="PropertyConceptualNullSensitive" xml:space="preserve">
+    <value>The property '{property}'  is marked as null on entity '{entityType}' with the key value '{keyValue}', but this cannot be saved because the property is marked as required.</value>
+  </data>
+  <data name="RelationshipConceptualNullSensitive" xml:space="preserve">
+    <value>The association between entities '{firstType}' and '{secondType}' with the key value '{secondKeyValue}' has been severed but the foreign key for this relationship cannot be set to null. If the dependent entity should be deleted, then setup the relationship to use cascade deletes.</value>
+  </data>
+  <data name="IncompatiblePrincipalEntry" xml:space="preserve">
+    <value>The foreign key {foreignKey} set on '{dependentEntityType}' matches an entity of type '{foundPrincipalEntityType}', however the principal entity type should be assignable to '{principalEntityType}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the key values.</value>
+  </data>
+  <data name="IncompatiblePrincipalEntrySensitive" xml:space="preserve">
+    <value>The foreign key '{foreignKeyValues}' set on '{dependentEntityType}' with the key value '{keyValue}' matches an entity of type '{foundPrincipalEntityType}', however the principal entity type should be assignable to '{principalEntityType}'.</value>
   </data>
 </root>

--- a/src/EFCore/Update/Internal/UpdateEntryExtensions.cs
+++ b/src/EFCore/Update/Internal/UpdateEntryExtensions.cs
@@ -19,13 +19,13 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static string BuildCurrentValuesString([NotNull] this IUpdateEntry entry, [NotNull] IEnumerable<IPropertyBase> properties)
-            => string.Join(", ", properties.Select(p => p.Name + ":" + entry.GetCurrentValue(p)));
+            => "{" + string.Join(", ", properties.Select(p => p.Name + ": " + entry.GetCurrentValue(p))) + "}";
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static string BuildOriginalValuesString([NotNull] this IUpdateEntry entry, [NotNull] IEnumerable<IPropertyBase> properties)
-            => string.Join(", ", properties.Select(p => p.Name + ":" + entry.GetOriginalValue(p)));
+            => "{" + string.Join(", ", properties.Select(p => p.Name + ": " + entry.GetOriginalValue(p))) + "}";
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/InheritanceInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/InheritanceInMemoryTest.cs
@@ -21,8 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Equal(
                 CoreStrings.PropertyNotFound(property: "Discriminator", entityType: "Bird"),
                 Assert.Throws<InvalidOperationException>(
-                    () =>
-                        base.Discriminator_used_when_projection_over_derived_type2()).Message);
+                    () => base.Discriminator_used_when_projection_over_derived_type2()).Message);
         }
 
         public override void Discriminator_with_cast_in_shadow_property()
@@ -30,8 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Equal(
                 CoreStrings.PropertyNotFound(property: "Discriminator", entityType: "Animal"),
                 Assert.Throws<InvalidOperationException>(
-                    () =>
-                        base.Discriminator_with_cast_in_shadow_property()).Message);
+                    () => base.Discriminator_with_cast_in_shadow_property()).Message);
         }
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/UpdatesInMemoryWithSensitiveDataLoggingTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/UpdatesInMemoryWithSensitiveDataLoggingTest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore
 
 #if !Test20
         protected override string UpdateConcurrencyTokenMessage
-            => InMemoryStrings.UpdateConcurrencyTokenExceptionSensitive("Product", "Id:984ade3c-2f7b-4651-a351-642e92ab7146", "Price:3.49", "Price:1.49");
+            => InMemoryStrings.UpdateConcurrencyTokenExceptionSensitive("Product", "{Id: 984ade3c-2f7b-4651-a351-642e92ab7146}", "{Price: 3.49}", "{Price: 1.49}");
 #endif
     }
 }

--- a/test/EFCore.Relational.Tests/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConventionTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/Conventions/Internal/RelationalPropertyMappingValidationConventionTest.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 {
     public class RelationalPropertyMappingValidationConventionTest : PropertyMappingValidationConventionTest
@@ -18,7 +19,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             var modelBuilder = new InternalModelBuilder(new Model());
             var entityTypeBuilder = modelBuilder.Entity(typeof(NonPrimitiveAsPropertyEntity), ConfigurationSource.Convention);
-            entityTypeBuilder.Property("LongProperty", typeof(Tuple<long>), ConfigurationSource.Convention);
+            entityTypeBuilder.Property("LongProperty", typeof(Tuple<long>), ConfigurationSource.Explicit);
+            entityTypeBuilder.Ignore(nameof(NonPrimitiveAsPropertyEntity.Property), ConfigurationSource.Explicit);
 
             Assert.Equal(
                 CoreStrings.PropertyNotMapped(
@@ -31,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             var modelBuilder = new InternalModelBuilder(new Model());
             var entityTypeBuilder = modelBuilder.Entity(typeof(NonPrimitiveNonNavigationAsPropertyEntity), ConfigurationSource.Convention);
-            entityTypeBuilder.Property("LongProperty", typeof(Tuple<long>), ConfigurationSource.Convention).Relational(ConfigurationSource.Convention).HasColumnType("some_int_mapping");
+            entityTypeBuilder.Property("LongProperty", typeof(Tuple<long>), ConfigurationSource.Explicit).Relational(ConfigurationSource.Convention).HasColumnType("some_int_mapping");
 
             Assert.Equal(
                 CoreStrings.PropertyNotMapped(

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalClrEntityEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalClrEntityEntryTest.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
     public class InternalClrEntityEntryTest : InternalEntityEntryTestBase

--- a/test/EFCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/StateManagerTest.cs
@@ -100,7 +100,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 context.Attach(new SingleKey { Id = 77, AlternateId = 66 });
 
                 Assert.Equal(
-                    CoreStrings.IdentityConflictSensitive("SingleKey", "Id:77"),
+                    CoreStrings.IdentityConflictSensitive("SingleKey", "{Id: 77}"),
                     Assert.Throws<InvalidOperationException>(
                         () => context.Attach(new SingleKey { Id = 77, AlternateId = 67 })).Message);
             }
@@ -114,7 +114,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 context.Attach(new SingleKey { Id = 77, AlternateId = 66 });
 
                 Assert.Equal(
-                    CoreStrings.IdentityConflictSensitive("SingleKey", "AlternateId:66"),
+                    CoreStrings.IdentityConflictSensitive("SingleKey", "{AlternateId: 66}"),
                     Assert.Throws<InvalidOperationException>(
                         () => context.Attach(new SingleKey { Id = 78, AlternateId = 66 })).Message);
             }
@@ -128,7 +128,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 context.Attach(new CompositeKey { Id1 = 77, Id2 = 78, AlternateId1 = 66, AlternateId2 = 67 });
 
                 Assert.Equal(
-                    CoreStrings.IdentityConflictSensitive("CompositeKey", "Id1:77, Id2:78"),
+                    CoreStrings.IdentityConflictSensitive("CompositeKey", "{Id1: 77, Id2: 78}"),
                     Assert.Throws<InvalidOperationException>(
                         () => context.Attach(
                             new CompositeKey { Id1 = 77, Id2 = 78, AlternateId1 = 66, AlternateId2 = 68 })).Message);
@@ -143,7 +143,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 context.Attach(new CompositeKey { Id1 = 77, Id2 = 78, AlternateId1 = 66, AlternateId2 = 67 });
 
                 Assert.Equal(
-                    CoreStrings.IdentityConflictSensitive("CompositeKey", "AlternateId1:66, AlternateId2:67"),
+                    CoreStrings.IdentityConflictSensitive("CompositeKey", "{AlternateId1: 66, AlternateId2: 67}"),
                     Assert.Throws<InvalidOperationException>(
                         () => context.Attach(
                             new CompositeKey { Id1 = 77, Id2 = 79, AlternateId1 = 66, AlternateId2 = 67 })).Message);

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyMappingValidationConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/PropertyMappingValidationConventionTest.cs
@@ -20,14 +20,25 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             var modelBuilder = new InternalModelBuilder(new Model());
             var entityTypeBuilder = modelBuilder.Entity(typeof(NonPrimitiveAsPropertyEntity), ConfigurationSource.Convention);
-            entityTypeBuilder.Property("Property", typeof(NavigationAsProperty), ConfigurationSource.Convention);
+            entityTypeBuilder.Property(nameof(NonPrimitiveAsPropertyEntity.Property), typeof(NavigationAsProperty), ConfigurationSource.Convention);
 
             Assert.Equal(
                 CoreStrings.PropertyNotMapped(
                     typeof(NonPrimitiveAsPropertyEntity).ShortDisplayName(),
-                    "Property",
+                    nameof(NonPrimitiveAsPropertyEntity.Property),
                     typeof(NavigationAsProperty).ShortDisplayName()),
                 Assert.Throws<InvalidOperationException>(() => CreateConvention().Apply(modelBuilder)).Message);
+        }
+
+        [Fact]
+        public virtual void Does_not_throw_when_added_shadow_property_by_convention_is_not_of_primitive_type()
+        {
+            var modelBuilder = new InternalModelBuilder(new Model());
+            var entityTypeBuilder = modelBuilder.Entity(typeof(NonPrimitiveAsPropertyEntity), ConfigurationSource.Convention);
+            entityTypeBuilder.Property("ShadowProperty", typeof(NavigationAsProperty), ConfigurationSource.Convention);
+            entityTypeBuilder.Ignore(nameof(NonPrimitiveAsPropertyEntity.Property), ConfigurationSource.Explicit);
+
+            CreateConvention().Apply(modelBuilder);
         }
 
         [Fact]

--- a/test/EFCore.Tests/Metadata/MetadataBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/MetadataBuilderTest.cs
@@ -8,6 +8,10 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
+// ReSharper disable MemberCanBePrivate.Local
+// ReSharper disable CollectionNeverUpdated.Local
+// ReSharper disable UnusedAutoPropertyAccessor.Local
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     public class MetadataBuilderTest

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;


### PR DESCRIPTION
Add key values to SaveChanges circular dependency message
Update transient error message to not reference SqlAzureExecutionStrategy
Add key values to the conceptual null exception
Don't validate mapping for shadow properties created by convention
Add incompatible principal entity during fixup exception
Don't reference 'Property' in property is already a navigation exception

Fixes #8363
Fixes #8365
Fixes #9696
Fixes #9817
Fixes #10135
Fixes #10856
