### PR TITLE
Migrations: Fix missing schema values

### DIFF
--- a/src/EFCore.Relational/Migrations/MigrationBuilder.cs
+++ b/src/EFCore.Relational/Migrations/MigrationBuilder.cs
@@ -1240,7 +1240,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 new[] { Check.NotEmpty(keyColumn, nameof(keyColumn)) },
                 new[] { keyValue },
                 columns,
-                values);
+                values,
+                schema);
 
         /// <summary>
         ///     Builds an <see cref="UpdateDataOperation" /> to update a single row of seed data for a table with

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -529,7 +529,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             if (memoryOptimized)
             {
                 builder.Append("ALTER TABLE ")
-                    .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Table))
+                    .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Table, operation.Schema))
                     .Append(" ADD INDEX ")
                     .Append(Dependencies.SqlGenerationHelper.DelimitIdentifier(operation.Name))
                     .Append(" ");

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationOperationGeneratorTest.cs
@@ -2345,6 +2345,48 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         }
 
         [Fact]
+        public void UpdateDataOperation_all_args_multi()
+        {
+            Test(
+                new UpdateDataOperation
+                {
+
+                    Schema = "dbo",
+                    Table = "People",
+                    KeyColumns = new[] { "Full Name" },
+                    KeyValues = new object[,]
+                    {
+                        { "Daenerys Targaryen" }
+                    },
+                    Columns = new[] { "Birthplace", "House Allegiance", "Culture" },
+                    Values = new object[,]
+                    {
+                        { "Dragonstone", "Targaryen", "Valyrian" }
+                    }
+                },
+                "mb.UpdateData(" + EOL +
+                "    schema: \"dbo\"," + EOL +
+                "    table: \"People\"," + EOL +
+                "    keyColumn: \"Full Name\"," + EOL +
+                "    keyValue: \"Daenerys Targaryen\"," + EOL +
+                "    columns: new[] { \"Birthplace\", \"House Allegiance\", \"Culture\" }," + EOL +
+                "    values: new object[] { \"Dragonstone\", \"Targaryen\", \"Valyrian\" });",
+                o =>
+                {
+                    Assert.Equal("dbo", o.Schema);
+                    Assert.Equal("People", o.Table);
+                    Assert.Equal(1, o.KeyColumns.Length);
+                    Assert.Equal(1, o.KeyValues.GetLength(0));
+                    Assert.Equal(1, o.KeyValues.GetLength(1));
+                    Assert.Equal("Daenerys Targaryen", o.KeyValues[0, 0]);
+                    Assert.Equal(3, o.Columns.Length);
+                    Assert.Equal(1, o.Values.GetLength(0));
+                    Assert.Equal(3, o.Values.GetLength(1));
+                    Assert.Equal("Targaryen", o.Values[0, 1]);
+                });
+        }
+
+        [Fact]
         public void UpdateDataOperation_required_args()
         {
             Test(

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
@@ -798,17 +798,18 @@ namespace Microsoft.EntityFrameworkCore
         public virtual void CreateIndexOperation_memoryOptimized_unique_nullable()
         {
             Generate(
-                modelBuilder => modelBuilder.Entity("People").ForSqlServerIsMemoryOptimized().Property<string>("Name"),
+                modelBuilder => modelBuilder.Entity("People").ToTable("People", "dbo").ForSqlServerIsMemoryOptimized().Property<string>("Name"),
                 new CreateIndexOperation
                 {
                     Name = "IX_People_Name",
+                    Schema = "dbo",
                     Table = "People",
                     Columns = new[] { "Name" },
                     IsUnique = true
                 });
 
             Assert.Equal(
-                "ALTER TABLE [People] ADD INDEX [IX_People_Name] ([Name]);" + EOL,
+                "ALTER TABLE [dbo].[People] ADD INDEX [IX_People_Name] ([Name]);" + EOL,
                 Sql);
         }
 


### PR DESCRIPTION
This was happening in two places:
- An overload of MigrationBuilder.UpdateData() (fixes #10115)
- When generating SQL for SQL Server memory-optimized indexes (fixes #10402)
