### PR TITLE
Query: Materialize entity if used in top level Contains

### DIFF
--- a/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -15,7 +15,6 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
-using Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal;
 using Remotion.Linq;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.ResultOperators;

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
@@ -911,7 +911,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             var ids = new[] { new { Id1 = 1, Id2 = 2 }, new { Id1 = 10248, Id2 = 11 } };
 
             AssertQuery<OrderDetail>(
-                od => od.Where(o => ids.Contains(new { Id1 = o.OrderID, Id2 = o.ProductID})), entryCount: 1);
+                od => od.Where(o => ids.Contains(new { Id1 = o.OrderID, Id2 = o.ProductID })), entryCount: 1);
 
             ids = new[] { new { Id1 = 1, Id2 = 2 } };
 
@@ -1171,6 +1171,17 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Skip(20)
                     .Last(),
                 entryCount: 1);
+        }
+
+        [ConditionalFact]
+        public virtual void Contains_over_entityType_should_materialize()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Orders.Where(o => o.CustomerID == "VINET").Contains(context.Orders.Single(o => o.OrderID == 10248));
+
+                Assert.True(query);
+            }
         }
     }
 }

--- a/src/EFCore/Query/ExpressionVisitors/Internal/RequiresMaterializationExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/RequiresMaterializationExpressionVisitor.cs
@@ -401,9 +401,16 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             {
                 // This is a top-level query that was not Single/First/Last
                 // but returns a single/scalar value (Avg/Min/Max/etc.)
-                // or a subquery that belongs to some outer-level query that returns 
-                // a single or scalar value. The referenced query source should be 
+                // or a subquery that belongs to some outer-level query that returns
+                // a single or scalar value. The referenced query source should be
                 // re-promoted later if necessary.
+
+                // For top-level Contains we cannot translate it since Item is not Expression
+                if (!isSubQuery && finalResultOperator is ContainsResultOperator containsResultOperator)
+                {
+                    return;
+                }
+
                 DemoteQuerySourceAndUnderlyingFromClause(referencedQuerySource);
                 return;
             }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
@@ -973,5 +973,19 @@ FROM (
 ) AS [t]
 ORDER BY [t].[CustomerID] DESC");
         }
+
+        public override void Contains_over_entityType_should_materialize()
+        {
+            base.Contains_over_entityType_should_materialize();
+
+            AssertSql(
+                @"SELECT TOP(2) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderID] = 10248",
+                //
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] = N'VINET'");
+        }
     }
 }


### PR DESCRIPTION
Contains on top-level cannot be translated (since we don't have it inside lambda and don't have expression tree for Item)
This caused to throw exception because we did not mark the QSRE for materialization.
Fix is to mark the naked QSRE for materialization if in top level Contains

Resolves #10868
