### PR TITLE
[TINY] Fix to #9372 - FirstWithoutOrderByAndFilterWarning logged when querying byte[] property

### DIFF
--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
@@ -1172,5 +1172,15 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Last(),
                 entryCount: 1);
         }
+
+        [ConditionalFact]
+        public virtual void Paging_operation_on_string_doesnt_issue_warning()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Customers.Select(c => c.CustomerID.FirstOrDefault()).ToList();
+                Assert.Equal(91, query.Count);
+            }
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
@@ -973,5 +973,14 @@ FROM (
 ) AS [t]
 ORDER BY [t].[CustomerID] DESC");
         }
+
+        public override void Paging_operation_on_string_doesnt_issue_warning()
+        {
+            base.Paging_operation_on_string_doesnt_issue_warning();
+
+            Assert.DoesNotContain(
+                CoreStrings.LogFirstWithoutOrderByAndFilter.GenerateMessage(
+                    @"(from char <generated>_1 in [c].CustomerID select [<generated>_1]).FirstOrDefault()"), Fixture.TestSqlLoggerFactory.Log);
+        }
     }
 }


### PR DESCRIPTION
Fix is to only issue warning from NondeterministicResultCheckingVisitor if the QM with First/Take/etc and without orderby has MainFromClause that is not string or byte[].