### PR TITLE
Metadata: Run SqlServerIndexConvention when changing base type

### DIFF
--- a/src/EFCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
+++ b/src/EFCore.SqlServer/Metadata/Conventions/SqlServerConventionSetBuilder.cs
@@ -59,6 +59,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             ReplaceConvention(conventionSet.ForeignKeyRemovedConventions, valueGeneratorConvention);
 
             var sqlServerIndexConvention = new SqlServerIndexConvention(_sqlGenerationHelper);
+
+            conventionSet.BaseEntityTypeChangedConventions.Add(sqlServerIndexConvention);
+
             conventionSet.IndexAddedConventions.Add(sqlServerInMemoryTablesConvention);
             conventionSet.IndexAddedConventions.Add(sqlServerIndexConvention);
 
@@ -91,7 +94,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
 
             var convertingTypeMapper = new FallbackRelationalCoreTypeMapper(
                 coreTypeMapperDependencies,
-                new RelationalTypeMapperDependencies(), 
+                new RelationalTypeMapperDependencies(),
                 sqlServerTypeMapper);
 
             return new SqlServerConventionSetBuilder(


### PR DESCRIPTION
SqlServerIndexConvention sets filter on unique index based on column null-ability.
When changing base type, the column null-ability in derived type changes so we need to update the filter.
Fix is to trigger convention for BaseTypeChanged

Resolves #10659
