### PR TITLE
Remove ad-hoc enum conversions

### DIFF
--- a/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleTypeMapper.cs
+++ b/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleTypeMapper.cs
@@ -210,7 +210,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         {
             Check.NotNull(clrType, nameof(clrType));
 
-            var underlyingType = clrType.UnwrapNullableType().UnwrapEnumType();
+            var underlyingType = clrType.UnwrapNullableType();
 
             return underlyingType == typeof(string)
                 ? _defaultUnicodeString

--- a/src/EFCore.Design/Migrations/Design/MigrationsCodeGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsCodeGenerator.cs
@@ -153,7 +153,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         /// <param name="model"> The model. </param>
         /// <returns> The namespaces. </returns>
         protected virtual IEnumerable<string> GetNamespaces([NotNull] IModel model)
-            => model.GetEntityTypes().SelectMany(e => e.GetDeclaredProperties().SelectMany(p => p.ClrType.GetNamespaces()))
+            => model.GetEntityTypes().SelectMany(
+                    e => e.GetDeclaredProperties()
+                        .SelectMany(p => (p.FindMapping()?.Converter?.StoreType ?? p.ClrType).GetNamespaces()))
                 .Concat(GetAnnotationNamespaces(GetAnnotatables(model)));
 
         private static IEnumerable<IAnnotatable> GetAnnotatables(IModel model)

--- a/src/EFCore.Relational/Metadata/RelationalPropertyAnnotations.cs
+++ b/src/EFCore.Relational/Metadata/RelationalPropertyAnnotations.cs
@@ -362,11 +362,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata
                                 value, valueType, Property.Name, Property.ClrType, Property.DeclaringEntityType.DisplayName()));
                     }
                 }
-
-                if (valueType.GetTypeInfo().IsEnum)
-                {
-                    value = Convert.ChangeType(value, valueType.UnwrapEnumType(), CultureInfo.InvariantCulture);
-                }
             }
 
             if (!CanSetDefaultValue(value))

--- a/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -986,10 +986,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
 
         private bool IsStreamedSingleValueSupportedType(IStreamedDataInfo outputDataInfo)
             => outputDataInfo is StreamedSingleValueInfo streamedSingleValueInfo
-               && _typeMapper.FindMapping(
-                   streamedSingleValueInfo.DataType
-                       .UnwrapNullableType()
-                       .UnwrapEnumType()) != null;
+               && _typeMapper.FindMapping(streamedSingleValueInfo.DataType) != null;
 
         /// <summary>
         ///     Visits a constant expression.
@@ -1007,14 +1004,11 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 return expression;
             }
 
-            var underlyingType = expression.Type.UnwrapNullableType().UnwrapEnumType();
+            var type = expression.Type == typeof(Enum)
+                ? expression.Value.GetType()
+                : expression.Type;
 
-            if (underlyingType == typeof(Enum))
-            {
-                underlyingType = expression.Value.GetType();
-            }
-
-            return _typeMapper.FindMapping(underlyingType) != null
+            return _typeMapper.FindMapping(type) != null
                 ? expression
                 : null;
         }
@@ -1030,9 +1024,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         {
             Check.NotNull(expression, nameof(expression));
 
-            var underlyingType = expression.Type.UnwrapNullableType().UnwrapEnumType();
-
-            return _typeMapper.FindMapping(underlyingType) != null
+            return _typeMapper.FindMapping(expression.Type) != null
                 ? expression
                 : null;
         }
@@ -1148,7 +1140,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 }
             }
 
-            var type = expression.ReferencedQuerySource.ItemType.UnwrapNullableType().UnwrapEnumType();
+            var type = expression.ReferencedQuerySource.ItemType;
 
             if (_typeMapper.FindMapping(type) != null)
             {

--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -1588,15 +1588,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
             var mapping = GetTypeMapping(value);
 
-            if (mapping.Converter == null
-                && constantExpression.Type.UnwrapNullableType().IsEnum)
-            {
-                var underlyingType = constantExpression.Type.UnwrapEnumType();
-                value = Convert.ChangeType(value, underlyingType);
-
-                mapping = GetTypeMapping(value);
-            }
-
             _relationalCommandBuilder.Append(
                 value == null
                     ? "NULL"

--- a/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
@@ -206,12 +206,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 value = Converter.ConvertToStore(value);
             }
 
-            if (value != null
-                && value.GetType().UnwrapNullableType().IsEnum)
-            {
-                value = Convert.ChangeType(value, value.GetType().UnwrapEnumType());
-            }
-
             parameter.Value = value ?? DBNull.Value;
 
             if (nullable.HasValue)

--- a/src/EFCore.Relational/Storage/TypeMaterializationInfo.cs
+++ b/src/EFCore.Relational/Storage/TypeMaterializationInfo.cs
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                       ?? typeMapper?.GetMapping(modelType);
 
             StoreType = mapping?.Converter?.StoreType
-                        ?? modelType.UnwrapNullableType().UnwrapEnumType();
+                        ?? modelType;
 
             ModelType = modelType;
             Mapping = mapping;

--- a/src/EFCore.Relational/Storage/UntypedRelationalValueBufferFactoryFactory.cs
+++ b/src/EFCore.Relational/Storage/UntypedRelationalValueBufferFactoryFactory.cs
@@ -122,7 +122,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             for (var i = 0; i < materializationInfo.Count; i++)
             {
-                var modelType = materializationInfo[i].ModelType;
                 var converter = materializationInfo[i].Mapping?.Converter;
 
                 var arrayAccess =
@@ -155,26 +154,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
                             arrayAccess,
                             valueExpression
                         ));
-                }
-
-                if (converter == null
-                    && modelType.UnwrapNullableType().GetTypeInfo().IsEnum)
-                {
-                    conversions.Add(
-                        Expression.IfThen(
-                            Expression.IsFalse(
-                                Expression.ReferenceEqual(
-                                    arrayAccess,
-                                    Expression.Constant(DBNull.Value))),
-                            Expression.Assign(
-                                arrayAccess,
-                                Expression.Convert(
-                                    Expression.Convert(
-                                        Expression.Convert(
-                                            arrayAccess,
-                                            modelType.UnwrapEnumType()),
-                                        modelType),
-                                    typeof(object)))));
                 }
             }
 

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -1131,6 +1131,7 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
 
         b.Property<long>(""Day"")
             .ValueGeneratedOnAdd()
+            .HasConversion(new ValueConverter<long, long>(v => default(long), v => default(long)))
             .HasDefaultValue(3L);
 
         b.HasKey(""Id"");
@@ -2147,6 +2148,7 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     using Microsoft.EntityFrameworkCore;
                     using Microsoft.EntityFrameworkCore.Metadata;
                     using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+                    using Microsoft.EntityFrameworkCore.Storage.Converters;
 
                     public static class ModelSnapshot
                     {
@@ -2194,7 +2196,7 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                         new DiagnosticListener("Fake"))),
                 new RelationalModelValidatorDependencies(
                     TestServiceFactory.Instance.Create<SqlServerTypeMapper>(),
-                    new FallbackRelationalCoreTypeMapper(
+                    new SqlServerCoreTypeMapper(
                         TestServiceFactory.Instance.Create<CoreTypeMapperDependencies>(),
                         TestServiceFactory.Instance.Create<RelationalTypeMapperDependencies>(),
                         TestServiceFactory.Instance.Create<SqlServerTypeMapper>())));

--- a/test/EFCore.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalBuilderExtensionsTest.cs
@@ -190,8 +190,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
             var property = modelBuilder.Model.FindEntityType(typeof(Customer)).FindProperty("EnumValue");
 
-            Assert.Equal(typeof(ulong), property.Relational().DefaultValue.GetType());
-            Assert.Equal((ulong)2, property.Relational().DefaultValue);
+            Assert.Equal(typeof(MyEnum), property.Relational().DefaultValue.GetType());
+            Assert.Equal(MyEnum.Tue, property.Relational().DefaultValue);
             Assert.Equal(ValueGenerated.OnAdd, property.ValueGenerated);
         }
 

--- a/test/EFCore.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Metadata/RelationalMetadataExtensionsTest.cs
@@ -213,8 +213,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
             property.Relational().DefaultValue = MyEnum.Mon;
 
-            Assert.Equal(typeof(byte), property.Relational().DefaultValue.GetType());
-            Assert.Equal((byte)1, property.Relational().DefaultValue);
+            Assert.Equal(typeof(MyEnum), property.Relational().DefaultValue.GetType());
+            Assert.Equal(MyEnum.Mon, property.Relational().DefaultValue);
 
             property.Relational().DefaultValue = null;
 


### PR DESCRIPTION
Issues #10748, #3620

These are now handled by type converters in type mapping, and for providers that can natively handle enums they will not be converted at all.

Also, change the way properties with conversions are stored in the snapshot such that:
- Only "store types" are used
- A dummy value converter is created to preserve any mapping hints, etc.

Note that if the database maps the enum directly, then this means that it is a "store type" and will be used in the snapshot and migrations and these may break if the type is later removed or changed.
