### PR TITLE
Fix to #10807 - Query: Translate string.Equals(a, b)

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
@@ -180,12 +180,30 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [Fact]
+        public virtual void Compare_equals_method_static()
+        {
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => Equals(e.BoolA, e.BoolB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => Equals(e.BoolA, e.NullableBoolB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => Equals(e.NullableBoolA, e.BoolB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => Equals(e.NullableBoolA, e.NullableBoolB)));
+        }
+
+        [Fact]
         public virtual void Compare_equals_method_negated()
         {
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !e.BoolA.Equals(e.BoolB)));
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !e.BoolA.Equals(e.NullableBoolB)));
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !e.NullableBoolA.Equals(e.BoolB)));
             AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !e.NullableBoolA.Equals(e.NullableBoolB)));
+        }
+
+        [Fact]
+        public virtual void Compare_equals_method_negated_static()
+        {
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !Equals(e.BoolA, e.BoolB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !Equals(e.BoolA, e.NullableBoolB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !Equals(e.NullableBoolA, e.BoolB)));
+            AssertQuery<NullSemanticsEntity1>(es => es.Where(e => !Equals(e.NullableBoolA, e.NullableBoolB)));
         }
 
         [Fact]

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Functions.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Functions.cs
@@ -1006,5 +1006,32 @@ namespace Microsoft.EntityFrameworkCore.Query
                 cs => cs.OrderBy(c => c.CustomerID.Length).ThenBy(c => c.CustomerID.Length).ThenBy(c => c.CustomerID),
                 entryCount: 91);
         }
+
+        [ConditionalFact]
+        public virtual void Static_string_equals_in_predicate()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Where(c => string.Equals(c.CustomerID, "ANATR")),
+                entryCount: 1);
+        }
+
+        [ConditionalFact]
+        public virtual void Static_equals_nullable_datetime_compared_to_non_nullable()
+        {
+            var arg = new DateTime(1996, 7, 4);
+
+            AssertQuery<Order>(
+                os => os.Where(o => Equals(o.OrderDate, arg)),
+                entryCount: 1);
+        }
+
+        [ConditionalFact]
+        public virtual void Static_equals_int_compared_to_long()
+        {
+            long arg = 10248;
+
+            AssertQuery<Order>(
+                os => os.Where(o => Equals(o.OrderID, arg)));
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -391,9 +391,53 @@ FROM [Entities1] AS [e]
 WHERE ([e].[NullableBoolA] = [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)");
         }
 
+        public override void Compare_equals_method_static()
+        {
+            base.Compare_equals_method_static();
+
+            AssertSql(
+                @"SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[BoolA] = [e].[BoolB]",
+                //
+                @"SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[BoolA] = [e].[NullableBoolB]",
+                //
+                @"SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[NullableBoolA] = [e].[BoolB]",
+                //
+                @"SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE ([e].[NullableBoolA] = [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL AND [e].[NullableBoolB] IS NULL)");
+        }
+
         public override void Compare_equals_method_negated()
         {
             base.Compare_equals_method_negated();
+
+            AssertSql(
+                @"SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE [e].[BoolA] <> [e].[BoolB]",
+                //
+                @"SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE ([e].[BoolA] <> [e].[NullableBoolB]) OR [e].[NullableBoolB] IS NULL",
+                //
+                @"SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE ([e].[NullableBoolA] <> [e].[BoolB]) OR [e].[NullableBoolA] IS NULL",
+                //
+                @"SELECT [e].[Id]
+FROM [Entities1] AS [e]
+WHERE (([e].[NullableBoolA] <> [e].[NullableBoolB]) OR ([e].[NullableBoolA] IS NULL OR [e].[NullableBoolB] IS NULL)) AND ([e].[NullableBoolA] IS NOT NULL OR [e].[NullableBoolB] IS NOT NULL)");
+        }
+
+        public override void Compare_equals_method_negated_static()
+        {
+            base.Compare_equals_method_negated_static();
 
             AssertSql(
                 @"SELECT [e].[Id]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Functions.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Functions.cs
@@ -1270,5 +1270,37 @@ FROM [Customers] AS [c]");
 FROM [Customers] AS [c]
 ORDER BY CAST(LEN([c].[CustomerID]) AS int), [c].[CustomerID]");
         }
+
+        public override void Static_string_equals_in_predicate()
+        {
+            base.Static_string_equals_in_predicate();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ANATR'");
+        }
+
+        public override void Static_equals_nullable_datetime_compared_to_non_nullable()
+        {
+            base.Static_equals_nullable_datetime_compared_to_non_nullable();
+
+            AssertSql(
+                @"@__arg_0='1996-07-04T00:00:00'
+
+SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderDate] = @__arg_0");
+        }
+
+        public override void Static_equals_int_compared_to_long()
+        {
+            base.Static_equals_int_compared_to_long();
+
+            AssertSql(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE 0 = 1");
+        }
     }
 }


### PR DESCRIPTION
Improving equals translator to handle static Equals