### PR TITLE
Fix to #10627 - Query: compilation error for queries accessing null-protected property inside subquery produced by All/Any result operator

### DIFF
--- a/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -3883,5 +3883,14 @@ namespace Microsoft.EntityFrameworkCore.Query
             AssertQueryScalar<Level1>(
                 l1s => l1s.Where(l1 => l1.OneToOne_Optional_PK != null).Select(l1 => Math.Max(l1.OneToOne_Optional_PK.Level1_Required_Id, 7)));
         }
+
+        [ConditionalFact]
+        public virtual void Accessing_optional_property_inside_result_operator_subquery()
+        {
+            var names = new[] { "Name1", "Name2" };
+            AssertQuery<Level1>(
+                l1s => l1s.Where(l1 => names.All(n => l1.OneToOne_Optional_FK.Name != n)),
+                l1s => l1s.Where(l1 => names.All(n => Maybe(l1.OneToOne_Optional_FK, () => l1.OneToOne_Optional_FK.Name) != n)));
+        }
     }
 }

--- a/src/EFCore/Query/ExpressionVisitors/Internal/MemberAccessBindingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/MemberAccessBindingExpressionVisitor.cs
@@ -198,8 +198,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             {
                 var newCaller = Visit(nullConditionalExpression.Caller);
 
-                if (newCaller != nullConditionalExpression.Caller
-                    && newCaller.Type == typeof(ValueBuffer))
+                if (newCaller.Type == typeof(ValueBuffer))
                 {
                     var newAccessOperation = Visit(nullConditionalExpression.AccessOperation);
                     if (newAccessOperation != nullConditionalExpression.AccessOperation)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -3493,6 +3493,16 @@ LEFT JOIN [LevelTwo] AS [l1.OneToOne_Optional_PK] ON [l1].[Id] = [l1.OneToOne_Op
 WHERE [l1.OneToOne_Optional_PK].[Id] IS NOT NULL");
         }
 
+        public override void Accessing_optional_property_inside_result_operator_subquery()
+        {
+            base.Accessing_optional_property_inside_result_operator_subquery();
+
+            AssertSql(
+                @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l1.OneToOne_Optional_FK].[Name]
+FROM [LevelOne] AS [l1]
+LEFT JOIN [LevelTwo] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]");
+        }
+
         private void AssertSql(params string[] expected)
         {
             Fixture.TestSqlLoggerFactory.AssertBaseline(expected);


### PR DESCRIPTION
Problem was in the binding logic for NullConditionalExpression - as part of the binding we are rewriting TryReadValue method if it originally was created for non-nullable type. Without the rewrite it can sometimes throw because null would be materialized where non-nullable value was expected.
However, we only perform the rewrite if the Caller of the NCE was modified during the same visit (e.g. from qsre to t.Inner).

If the NCE is accessed from within result operator subquery, we hit a problem. During ReplaceClauseReferences in the EntityQueryableExpressionVisitor we can translate NCE caller (qsre), but we fail to translate AccessOperation (member access) because there are not QueriesBySource available in the QMV that is processing the result operator supbquery (the correct entry is stored on the parent QM instead).

EntityQueryableExpressionVisitor flattens the structure to a MethodCall, so MemberAccessBindingExpression can successfully translate the NCE's AccessOperation.

Fix is to perform TryReadValue rewrite during NCE binding if the caller ValueBuffer, even if the caller was translated to said value buffer earlier.