### PR TITLE
Fix to #10537 - `Specified cast not valid` when using min or max after decimal to float cast

### DIFF
--- a/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -651,7 +651,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 if (!(expression.RemoveConvert() is SelectExpression))
                 {
-                    expression = (expression as ExplicitCastExpression)?.Operand ?? expression;
                     var minExpression = new SqlFunctionExpression("MIN", handlerContext.QueryModel.SelectClause.Selector.Type, new[] { expression });
 
                     handlerContext.SelectExpression.SetProjectionExpression(minExpression);
@@ -678,7 +677,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 if (!(expression.RemoveConvert() is SelectExpression))
                 {
-                    expression = (expression as ExplicitCastExpression)?.Operand ?? expression;
                     var maxExpression = new SqlFunctionExpression("MAX", handlerContext.QueryModel.SelectClause.Selector.Type, new[] { expression });
 
                     handlerContext.SelectExpression.SetProjectionExpression(maxExpression);

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
@@ -1154,6 +1154,25 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void Max_with_non_matching_types_in_projection_introduces_explicit_cast()
+        {
+            AssertSingleResult<Order>(
+                os => os
+                    .Where(o => o.CustomerID.StartsWith("A"))
+                    .OrderBy(o => o.OrderID)
+                    .Select(o => (long)o.OrderID).Max());
+        }
+
+        [ConditionalFact]
+        public virtual void Min_with_non_matching_types_in_projection_introduces_explicit_cast()
+        {
+            AssertSingleResult<Order>(
+                os => os
+                    .Where(o => o.CustomerID.StartsWith("A"))
+                    .Select(o => (long)o.OrderID).Min());
+        }
+
+        [ConditionalFact]
         public virtual void OrderBy_Take_Last_gives_correct_result()
         {
             AssertSingleResult<Customer>(

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -491,7 +491,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
-        public virtual void Select_non_matching_value_types_nullable_int_to_int_doesnt_introduces_explicit_cast()
+        public virtual void Select_non_matching_value_types_nullable_int_to_int_doesnt_introduce_explicit_cast()
         {
             AssertQueryScalar<Order>(
                 os => os

--- a/src/EFCore/Query/Internal/QueryOptimizer.cs
+++ b/src/EFCore/Query/Internal/QueryOptimizer.cs
@@ -276,7 +276,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         public override void VisitResultOperator(ResultOperatorBase resultOperator, QueryModel queryModel, int index)
         {
             if (resultOperator is ValueFromSequenceResultOperatorBase
-                && !(resultOperator is ChoiceResultOperatorBase)
+                && !(resultOperator is FirstResultOperator)
+                && !(resultOperator is SingleResultOperator)
+                && !(resultOperator is LastResultOperator)
                 && !queryModel.ResultOperators
                     .Any(r => r is TakeResultOperator || r is SkipResultOperator))
             {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
@@ -941,6 +941,26 @@ FROM [Orders] AS [o]
 WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) = N'A')");
         }
 
+        public override void Max_with_non_matching_types_in_projection_introduces_explicit_cast()
+        {
+            base.Max_with_non_matching_types_in_projection_introduces_explicit_cast();
+
+            AssertSql(
+                @"SELECT MAX(CAST([o].[OrderID] AS bigint))
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) = N'A')");
+        }
+
+        public override void Min_with_non_matching_types_in_projection_introduces_explicit_cast()
+        {
+            base.Min_with_non_matching_types_in_projection_introduces_explicit_cast();
+
+            AssertSql(
+                @"SELECT MIN(CAST([o].[OrderID] AS bigint))
+FROM [Orders] AS [o]
+WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) = N'A')");
+        }
+
         public override void OrderBy_Take_Last_gives_correct_result()
         {
             base.OrderBy_Take_Last_gives_correct_result();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
@@ -453,9 +453,9 @@ WHERE [o].[CustomerID] = N'ALFKI'
 ORDER BY [o].[OrderID]");
         }
 
-        public override void Select_non_matching_value_types_nullable_int_to_int_doesnt_introduces_explicit_cast()
+        public override void Select_non_matching_value_types_nullable_int_to_int_doesnt_introduce_explicit_cast()
         {
-            base.Select_non_matching_value_types_nullable_int_to_int_doesnt_introduces_explicit_cast();
+            base.Select_non_matching_value_types_nullable_int_to_int_doesnt_introduce_explicit_cast();
 
             AssertSql(
                 @"SELECT [o].[EmployeeID]


### PR DESCRIPTION
Problem was that as part of fixing #8652 we were removing explicit casts when processing result operators. This is fine for most aggregate operators, but is not correct for Min/Max. This is because the final result type is the same as the argument - original type of the argument must be preserved or we risk type mismatches in the final result.

Additionally improved the fix for #1251 - we should be stripping order by clauses for Min/Max operators as well. Previously we exempt all ChoiceResultOperatorBase, instead of correct First/Single/Last.