### PR TITLE
Support change tracking of non-primitive types

### DIFF
--- a/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleByteArrayTypeMapping.cs
+++ b/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleByteArrayTypeMapping.cs
@@ -7,6 +7,7 @@ using System.Data.Common;
 using System.Globalization;
 using System.Text;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
@@ -19,16 +20,17 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = System.Data.DbType.Binary,
             int? size = null)
-            : this(storeType, null, dbType, size)
+            : this(storeType, null, null, dbType, size)
         {
         }
 
         public OracleByteArrayTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             [CanBeNull] DbType? dbType = System.Data.DbType.Binary,
             int? size = null)
-            : base(storeType, converter, dbType, size)
+            : base(storeType, converter, comparer, dbType, size)
         {
             _maxSpecificSize = CalculateSize(size);
         }
@@ -37,10 +39,10 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             => size.HasValue && size < 8000 ? size.Value : 8000;
 
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new OracleByteArrayTypeMapping(storeType, Converter, DbType, size);
+            => new OracleByteArrayTypeMapping(storeType, Converter, Comparer, DbType, size);
 
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new OracleByteArrayTypeMapping(StoreType, ComposeConverter(converter), DbType, Size);
+            => new OracleByteArrayTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType, Size);
 
         protected override void ConfigureParameter(DbParameter parameter)
         {

--- a/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleDateTimeOffsetTypeMapping.cs
+++ b/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleDateTimeOffsetTypeMapping.cs
@@ -5,6 +5,7 @@ using System;
 using System.Data.Common;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 using Oracle.ManagedDataAccess.Client;
 using Oracle.ManagedDataAccess.Types;
@@ -28,16 +29,18 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
 
         public OracleDateTimeOffsetTypeMapping(
             [NotNull] string storeType,
-            [CanBeNull] ValueConverter converter)
-            : base(storeType, converter)
+            [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer = null)
+
+            : base(storeType, converter, comparer)
         {
         }
 
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new OracleDateTimeOffsetTypeMapping(storeType, Converter);
+            => new OracleDateTimeOffsetTypeMapping(storeType, Converter, Comparer);
 
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new OracleDateTimeOffsetTypeMapping(StoreType, ComposeConverter(converter));
+            => new OracleDateTimeOffsetTypeMapping(StoreType, ComposeConverter(converter), Comparer);
 
         protected override string SqlLiteralFormatString => "'" + DateTimeOffsetFormatConst + "'";
 

--- a/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleDateTimeTypeMapping.cs
+++ b/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleDateTimeTypeMapping.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
@@ -14,23 +15,24 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public OracleDateTimeTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
         public OracleDateTimeTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, converter, dbType)
+            : base(storeType, converter, comparer, dbType)
         {
         }
 
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new OracleDateTimeTypeMapping(storeType, Converter, DbType);
+            => new OracleDateTimeTypeMapping(storeType, Converter, Comparer, DbType);
 
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new OracleDateTimeTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new OracleDateTimeTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
 
         protected override string SqlLiteralFormatString => DateTimeFormatConst;
     }

--- a/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleDoubleTypeMapping.cs
+++ b/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleDoubleTypeMapping.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
@@ -12,23 +13,24 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public OracleDoubleTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
         public OracleDoubleTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, converter, dbType)
+            : base(storeType, converter, comparer, dbType)
         {
         }
 
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new OracleDoubleTypeMapping(storeType, Converter, DbType);
+            => new OracleDoubleTypeMapping(storeType, Converter, Comparer, DbType);
 
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new OracleDoubleTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new OracleDoubleTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
 
         protected override string GenerateNonNullSqlLiteral(object value)
         {

--- a/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleFloatTypeMapping.cs
+++ b/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleFloatTypeMapping.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
@@ -12,23 +13,24 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public OracleFloatTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
         public OracleFloatTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, converter, dbType)
+            : base(storeType, converter, comparer, dbType)
         {
         }
 
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new OracleFloatTypeMapping(storeType, Converter, DbType);
+            => new OracleFloatTypeMapping(storeType, Converter, Comparer, DbType);
 
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new OracleFloatTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new OracleFloatTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
 
         protected override string GenerateNonNullSqlLiteral(object value)
         {

--- a/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleStringTypeMapping.cs
+++ b/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleStringTypeMapping.cs
@@ -5,6 +5,7 @@ using System;
 using System.Data;
 using System.Data.Common;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
@@ -18,17 +19,18 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [CanBeNull] DbType? dbType,
             bool unicode = false,
             int? size = null)
-            : this(storeType, null, dbType, unicode, size)
+            : this(storeType, null, null, dbType, unicode, size)
         {
         }
 
         public OracleStringTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             [CanBeNull] DbType? dbType,
             bool unicode = false,
             int? size = null)
-            : base(storeType, converter, dbType, unicode, size)
+            : base(storeType, converter, comparer, dbType, unicode, size)
         {
             _maxSpecificSize = CalculateSize(unicode, size);
         }
@@ -43,10 +45,10 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                     : 4000;
 
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new OracleStringTypeMapping(storeType, Converter, DbType, IsUnicode, size);
+            => new OracleStringTypeMapping(storeType, Converter, Comparer, DbType, IsUnicode, size);
 
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new OracleStringTypeMapping(StoreType, ComposeConverter(converter), DbType, IsUnicode, Size);
+            => new OracleStringTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType, IsUnicode, Size);
 
         protected override void ConfigureParameter(DbParameter parameter)
         {

--- a/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleTimeSpanTypeMapping.cs
+++ b/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleTimeSpanTypeMapping.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
@@ -11,23 +12,24 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
     public class OracleTimeSpanTypeMapping : TimeSpanTypeMapping
     {
         public OracleTimeSpanTypeMapping([NotNull] string storeType, [CanBeNull] DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
         public OracleTimeSpanTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, converter, dbType)
+            : base(storeType, converter, comparer, dbType)
         {
         }
 
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new OracleTimeSpanTypeMapping(storeType, Converter, DbType);
+            => new OracleTimeSpanTypeMapping(storeType, Converter, Comparer, DbType);
 
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new OracleTimeSpanTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new OracleTimeSpanTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
 
         protected override string GenerateNonNullSqlLiteral(object value)
         {

--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -527,7 +527,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 annotations,
                 CoreAnnotationNames.ValueGeneratorFactoryAnnotation,
                 CoreAnnotationNames.PropertyAccessModeAnnotation,
-                CoreAnnotationNames.TypeMapping);
+                CoreAnnotationNames.TypeMapping,
+                CoreAnnotationNames.ValueComparer);
 
             GenerateAnnotations(annotations, stringBuilder);
         }

--- a/src/EFCore.Relational/Storage/BoolTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/BoolTypeMapping.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -26,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public BoolTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -35,12 +36,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
+        /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public BoolTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null)
-            : base(storeType, typeof(bool), converter, dbType)
+            : base(storeType, typeof(bool), converter, comparer, dbType)
         {
         }
 
@@ -51,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new BoolTypeMapping(storeType, Converter, DbType);
+            => new BoolTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -60,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new BoolTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new BoolTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
 
         /// <summary>
         ///     Generates the SQL representation of a literal value.

--- a/src/EFCore.Relational/Storage/ByteArrayTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/ByteArrayTypeMapping.cs
@@ -5,6 +5,7 @@ using System.Data;
 using System.Globalization;
 using System.Text;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -31,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             [NotNull] string storeType,
             DbType? dbType = null,
             int? size = null)
-            : this(storeType, null, dbType, size)
+            : this(storeType, null, null, dbType, size)
         {
         }
 
@@ -40,14 +41,16 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
+        /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         public ByteArrayTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null,
             int? size = null)
-            : base(storeType, typeof(byte[]), converter, dbType, size: size)
+            : base(storeType, typeof(byte[]), converter, comparer, dbType, size: size)
         {
         }
 
@@ -58,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new ByteArrayTypeMapping(storeType, Converter, DbType, size);
+            => new ByteArrayTypeMapping(storeType, Converter, Comparer, DbType, size);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -67,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new ByteArrayTypeMapping(StoreType, ComposeConverter(converter), DbType, Size);
+            => new ByteArrayTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType, Size);
 
         /// <summary>
         ///     Generates the SQL representation of a literal value.

--- a/src/EFCore.Relational/Storage/ByteTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/ByteTypeMapping.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -26,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public ByteTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -35,12 +36,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
+        /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public ByteTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null)
-            : base(storeType, typeof(byte), converter, dbType)
+            : base(storeType, typeof(byte), converter, comparer, dbType)
         {
         }
 
@@ -51,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new ByteTypeMapping(storeType, Converter, DbType);
+            => new ByteTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -60,6 +63,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new ByteTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new ByteTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
     }
 }

--- a/src/EFCore.Relational/Storage/CharTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/CharTypeMapping.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -26,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public CharTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -35,12 +36,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
+        /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public CharTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null)
-            : base(storeType, typeof(char), converter, dbType)
+            : base(storeType, typeof(char), converter, comparer, dbType)
         {
         }
 
@@ -51,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new CharTypeMapping(storeType, Converter, DbType);
+            => new CharTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -60,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new CharTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new CharTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
 
         /// <summary>
         ///     Gets the string format to be used to generate SQL literals of this type.

--- a/src/EFCore.Relational/Storage/DateTimeOffsetTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/DateTimeOffsetTypeMapping.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -29,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public DateTimeOffsetTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -38,12 +39,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts types to and from the store whenever this mapping is used. </param>
+        /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public DateTimeOffsetTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null)
-            : base(storeType, typeof(DateTimeOffset), converter, dbType)
+            : base(storeType, typeof(DateTimeOffset), converter, comparer, dbType)
         {
         }
 
@@ -54,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new DateTimeOffsetTypeMapping(storeType, Converter, DbType);
+            => new DateTimeOffsetTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -63,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new DateTimeOffsetTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new DateTimeOffsetTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
 
         /// <summary>
         ///     Gets the string format to be used to generate SQL literals of this type.

--- a/src/EFCore.Relational/Storage/DateTimeTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/DateTimeTypeMapping.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -29,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public DateTimeTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -38,12 +39,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
+        /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public DateTimeTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null)
-            : base(storeType, typeof(DateTime), converter, dbType)
+            : base(storeType, typeof(DateTime), converter, comparer, dbType)
         {
         }
 
@@ -54,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new DateTimeTypeMapping(storeType, Converter, DbType);
+            => new DateTimeTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -63,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new DateTimeTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new DateTimeTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
 
         /// <summary>
         ///     Gets the string format to be used to generate SQL literals of this type.

--- a/src/EFCore.Relational/Storage/DecimalTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/DecimalTypeMapping.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -28,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public DecimalTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -37,12 +38,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
+        /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public DecimalTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null)
-            : base(storeType, typeof(decimal), converter, dbType)
+            : base(storeType, typeof(decimal), converter, comparer, dbType)
         {
         }
 
@@ -53,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new DecimalTypeMapping(storeType, Converter, DbType);
+            => new DecimalTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -62,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new DecimalTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new DecimalTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
 
         /// <summary>
         ///     Gets the string format to be used to generate SQL literals of this type.

--- a/src/EFCore.Relational/Storage/DoubleTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/DoubleTypeMapping.cs
@@ -4,6 +4,7 @@
 using System.Data;
 using System.Globalization;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -27,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public DoubleTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -36,12 +37,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
+        /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public DoubleTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null)
-            : base(storeType, typeof(double), converter, dbType)
+            : base(storeType, typeof(double), converter, comparer, dbType)
         {
         }
 
@@ -52,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new DoubleTypeMapping(storeType, Converter, DbType);
+            => new DoubleTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -61,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new DoubleTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new DoubleTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
 
         /// <summary>
         ///     Generates the SQL representation of a literal value.

--- a/src/EFCore.Relational/Storage/FloatTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/FloatTypeMapping.cs
@@ -4,6 +4,7 @@
 using System.Data;
 using System.Globalization;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -27,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public FloatTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -36,12 +37,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
+        /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public FloatTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null)
-            : base(storeType, typeof(float), converter, dbType)
+            : base(storeType, typeof(float), converter, comparer, dbType)
         {
         }
 
@@ -52,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new FloatTypeMapping(storeType, Converter, DbType);
+            => new FloatTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -61,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new FloatTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new FloatTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
 
         /// <summary>
         ///     Generates the SQL representation of a literal value.

--- a/src/EFCore.Relational/Storage/GuidTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/GuidTypeMapping.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -27,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public GuidTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -36,12 +37,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts types to and from the store whenever this mapping is used. </param>
+        /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public GuidTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null)
-            : base(storeType, typeof(Guid), converter, dbType)
+            : base(storeType, typeof(Guid), converter, comparer, dbType)
         {
         }
 
@@ -52,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new GuidTypeMapping(storeType, Converter, DbType);
+            => new GuidTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -61,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new GuidTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new GuidTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
 
         /// <summary>
         ///     Gets the string format to be used to generate SQL literals of this type.

--- a/src/EFCore.Relational/Storage/IntTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/IntTypeMapping.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -26,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public IntTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -35,12 +36,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
+        /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public IntTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null)
-            : base(storeType, typeof(int), converter, dbType)
+            : base(storeType, typeof(int), converter, comparer, dbType)
         {
         }
 
@@ -51,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new IntTypeMapping(storeType, Converter, DbType);
+            => new IntTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -60,6 +63,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new IntTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new IntTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
     }
 }

--- a/src/EFCore.Relational/Storage/LongTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/LongTypeMapping.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -26,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public LongTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -35,12 +36,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
+        /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public LongTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null)
-            : base(storeType, typeof(long), converter, dbType)
+            : base(storeType, typeof(long), converter, comparer, dbType)
         {
         }
 
@@ -51,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new LongTypeMapping(storeType, Converter, DbType);
+            => new LongTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -60,6 +63,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new LongTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new LongTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
     }
 }

--- a/src/EFCore.Relational/Storage/RelationalCoreTypeMapperBase.cs
+++ b/src/EFCore.Relational/Storage/RelationalCoreTypeMapperBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -75,7 +76,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="property"> The property. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
         public override CoreTypeMapping FindMapping(IProperty property)
-            => FindMappingWithConversion(new ConcreteRelationalTypeMappingInfo(property));
+            => property.FindRelationalMapping()
+               ?? FindMappingWithConversion(new ConcreteRelationalTypeMappingInfo(property));
 
         /// <summary>
         ///     <para>

--- a/src/EFCore.Relational/Storage/RelationalTypeMapperExtensions.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapperExtensions.cs
@@ -83,8 +83,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Check.NotNull(typeMapper, nameof(typeMapper));
             Check.NotNull(property, nameof(property));
 
-            var mapping = property.FindRelationalMapping()
-                          ?? typeMapper.FindMapping(property);
+            var mapping = typeMapper.FindMapping(property);
 
             if (mapping != null)
             {

--- a/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
@@ -8,6 +8,7 @@ using System.Data.Common;
 using System.Globalization;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -78,7 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             DbType? dbType = null,
             bool unicode = false,
             int? size = null)
-            : this(storeType, clrType, null, dbType, unicode, size)
+            : this(storeType, clrType, null, null, dbType, unicode, size)
         {
         }
 
@@ -88,6 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="clrType"> The .NET type. </param>
         /// <param name="converter"> Converts types to and from the store whenever this mapping is used. </param>
+        /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
         /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
         /// <param name="unicode"> A value indicating whether the type should handle Unicode data or not. </param>
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
@@ -95,10 +97,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
             [NotNull] string storeType,
             [NotNull] Type clrType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null,
             bool unicode = false,
             int? size = null)
-            : base(clrType, converter)
+            : base(clrType, converter, comparer)
         {
             Check.NotEmpty(storeType, nameof(storeType));
 

--- a/src/EFCore.Relational/Storage/SByteTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/SByteTypeMapping.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -26,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public SByteTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -35,12 +36,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts types to and from the store whenever this mapping is used. </param>
+        /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public SByteTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null)
-            : base(storeType, typeof(sbyte), converter, dbType)
+            : base(storeType, typeof(sbyte), converter, comparer, dbType)
         {
         }
 
@@ -51,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SByteTypeMapping(storeType, Converter, DbType);
+            => new SByteTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -60,6 +63,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SByteTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new SByteTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
     }
 }

--- a/src/EFCore.Relational/Storage/ShortTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/ShortTypeMapping.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -26,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public ShortTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -35,12 +36,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
+        /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public ShortTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null)
-            : base(storeType, typeof(short), converter, dbType)
+            : base(storeType, typeof(short), converter, comparer, dbType)
         {
         }
 
@@ -51,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new ShortTypeMapping(storeType, Converter, DbType);
+            => new ShortTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -60,6 +63,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new ShortTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new ShortTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
     }
 }

--- a/src/EFCore.Relational/Storage/StringTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/StringTypeMapping.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -31,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             DbType? dbType = null,
             bool unicode = false,
             int? size = null)
-            : this(storeType, null, dbType, unicode, size)
+            : this(storeType, null, null, dbType, unicode, size)
         {
         }
 
@@ -40,16 +41,18 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
+        /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
         /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
         /// <param name="unicode"> A value indicating whether the type should handle Unicode data or not. </param>
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         public StringTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null,
             bool unicode = false,
             int? size = null)
-            : base(storeType, typeof(string), converter, dbType, unicode, size)
+            : base(storeType, typeof(string), converter, comparer, dbType, unicode, size)
         {
         }
 
@@ -60,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new StringTypeMapping(storeType, Converter, DbType, IsUnicode, size);
+            => new StringTypeMapping(storeType, Converter, Comparer, DbType, IsUnicode, size);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -69,7 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new StringTypeMapping(StoreType, ComposeConverter(converter), DbType, IsUnicode, Size);
+            => new StringTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType, IsUnicode, Size);
 
         /// <summary>
         ///     Generates the escaped SQL representation of a literal value.

--- a/src/EFCore.Relational/Storage/TimeSpanTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/TimeSpanTypeMapping.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -27,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public TimeSpanTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -36,12 +37,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
+        /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public TimeSpanTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null)
-            : base(storeType, typeof(TimeSpan), converter, dbType)
+            : base(storeType, typeof(TimeSpan), converter, comparer, dbType)
         {
         }
 
@@ -52,7 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new TimeSpanTypeMapping(storeType, Converter, DbType);
+            => new TimeSpanTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -61,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new TimeSpanTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new TimeSpanTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
 
         /// <summary>
         ///     Gets the string format to be used to generate SQL literals of this type.

--- a/src/EFCore.Relational/Storage/UIntTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/UIntTypeMapping.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -26,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public UIntTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -35,12 +36,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts types to and from the store whenever this mapping is used. </param>
+        /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public UIntTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null)
-            : base(storeType, typeof(uint), converter, dbType)
+            : base(storeType, typeof(uint), converter, comparer, dbType)
         {
         }
 
@@ -51,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new UIntTypeMapping(storeType, Converter, DbType);
+            => new UIntTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -60,6 +63,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new UIntTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new UIntTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
     }
 }

--- a/src/EFCore.Relational/Storage/ULongTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/ULongTypeMapping.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -26,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public ULongTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -35,12 +36,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts types to and from the store whenever this mapping is used. </param>
+        /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public ULongTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null)
-            : base(storeType, typeof(ulong), converter, dbType)
+            : base(storeType, typeof(ulong), converter, comparer, dbType)
         {
         }
 
@@ -51,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new ULongTypeMapping(storeType, Converter, DbType);
+            => new ULongTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -60,6 +63,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new ULongTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new ULongTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
     }
 }

--- a/src/EFCore.Relational/Storage/UShortTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/UShortTypeMapping.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -26,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public UShortTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -35,12 +36,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts types to and from the store whenever this mapping is used. </param>
+        /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public UShortTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null)
-            : base(storeType, typeof(ushort), converter, dbType)
+            : base(storeType, typeof(ushort), converter, comparer, dbType)
         {
         }
 
@@ -51,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new UShortTypeMapping(storeType, Converter, DbType);
+            => new UShortTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -60,6 +63,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new UShortTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new UShortTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
     }
 }

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerByteArrayTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerByteArrayTypeMapping.cs
@@ -7,6 +7,7 @@ using System.Data.Common;
 using System.Globalization;
 using System.Text;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
@@ -25,7 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] string storeType,
             DbType? dbType = System.Data.DbType.Binary,
             int? size = null)
-            : this(storeType, null, dbType, size)
+            : this(storeType, null, null, dbType, size)
         {
         }
 
@@ -36,9 +37,10 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqlServerByteArrayTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = System.Data.DbType.Binary,
             int? size = null)
-            : base(storeType, converter, dbType, size)
+            : base(storeType, converter, comparer, dbType, size)
         {
         }
 
@@ -50,14 +52,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqlServerByteArrayTypeMapping(storeType, Converter, DbType, size);
+            => new SqlServerByteArrayTypeMapping(storeType, Converter, Comparer, DbType, size);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqlServerByteArrayTypeMapping(StoreType, ComposeConverter(converter), DbType, Size);
+            => new SqlServerByteArrayTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType, Size);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerDateTimeOffsetTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerDateTimeOffsetTypeMapping.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
@@ -22,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqlServerDateTimeOffsetTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = System.Data.DbType.DateTimeOffset)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -33,8 +34,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqlServerDateTimeOffsetTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = System.Data.DbType.DateTimeOffset)
-            : base(storeType, converter, dbType)
+            : base(storeType, converter, comparer, dbType)
         {
         }
 
@@ -43,14 +45,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqlServerDateTimeOffsetTypeMapping(storeType, Converter, DbType);
+            => new SqlServerDateTimeOffsetTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqlServerDateTimeOffsetTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new SqlServerDateTimeOffsetTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerDateTimeTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerDateTimeTypeMapping.cs
@@ -5,6 +5,7 @@ using System.Data;
 using System.Data.Common;
 using System.Data.SqlClient;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
@@ -24,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqlServerDateTimeTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -35,8 +36,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqlServerDateTimeTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null)
-            : base(storeType, converter, dbType)
+            : base(storeType, converter, comparer, dbType)
         {
         }
 
@@ -60,14 +62,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqlServerDateTimeTypeMapping(storeType, Converter, DbType);
+            => new SqlServerDateTimeTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqlServerDateTimeTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new SqlServerDateTimeTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerDoubleTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerDoubleTypeMapping.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
@@ -20,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqlServerDoubleTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -31,8 +32,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqlServerDoubleTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null)
-            : base(storeType, converter, dbType)
+            : base(storeType, converter, comparer, dbType)
         {
         }
 
@@ -41,14 +43,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqlServerDoubleTypeMapping(storeType, Converter, DbType);
+            => new SqlServerDoubleTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqlServerDoubleTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new SqlServerDoubleTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerFloatTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerFloatTypeMapping.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
@@ -20,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqlServerFloatTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -31,8 +32,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqlServerFloatTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null)
-            : base(storeType, converter, dbType)
+            : base(storeType, converter, comparer, dbType)
         {
         }
 
@@ -41,14 +43,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqlServerFloatTypeMapping(storeType, Converter, DbType);
+            => new SqlServerFloatTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqlServerFloatTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new SqlServerFloatTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerSqlVariantTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerSqlVariantTypeMapping.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
@@ -18,8 +19,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         /// </summary>
         public SqlServerSqlVariantTypeMapping(
             [NotNull] string storeType,
-            [CanBeNull] ValueConverter converter = null)
-            : base(storeType, typeof(object), converter)
+            [CanBeNull] ValueConverter converter = null,
+            [CanBeNull] ValueComparer comparer = null)
+            : base(storeType, typeof(object), converter, comparer)
         {
         }
 
@@ -28,13 +30,13 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqlServerSqlVariantTypeMapping(storeType, Converter);
+            => new SqlServerSqlVariantTypeMapping(storeType, Converter, Comparer);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqlServerSqlVariantTypeMapping(StoreType, ComposeConverter(converter));
+            => new SqlServerSqlVariantTypeMapping(StoreType, ComposeConverter(converter), Comparer);
     }
 }

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerStringTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerStringTypeMapping.cs
@@ -5,6 +5,7 @@ using System;
 using System.Data;
 using System.Data.Common;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
@@ -26,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             DbType? dbType,
             bool unicode = false,
             int? size = null)
-            : this(storeType, null, dbType, unicode, size)
+            : this(storeType, null, null, dbType, unicode, size)
         {
         }
 
@@ -37,10 +38,11 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqlServerStringTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType,
             bool unicode = false,
             int? size = null)
-            : base(storeType, converter, dbType, unicode, size)
+            : base(storeType, converter, comparer, dbType, unicode, size)
         {
             _maxSpecificSize = CalculateSize(unicode, size);
         }
@@ -59,14 +61,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqlServerStringTypeMapping(storeType, Converter, DbType, IsUnicode, size);
+            => new SqlServerStringTypeMapping(storeType, Converter, Comparer, DbType, IsUnicode, size);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqlServerStringTypeMapping(StoreType, ComposeConverter(converter), DbType, IsUnicode, Size);
+            => new SqlServerStringTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType, IsUnicode, Size);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTimeSpanTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTimeSpanTypeMapping.cs
@@ -5,6 +5,7 @@ using System.Data;
 using System.Data.Common;
 using System.Data.SqlClient;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
@@ -20,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public SqlServerTimeSpanTypeMapping([NotNull] string storeType, DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -31,8 +32,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqlServerTimeSpanTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null)
-            : base(storeType, converter, dbType)
+            : base(storeType, converter, comparer, dbType)
         {
         }
 
@@ -41,14 +43,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqlServerTimeSpanTypeMapping(storeType, Converter, DbType);
+            => new SqlServerTimeSpanTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqlServerTimeSpanTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new SqlServerTimeSpanTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerUdtTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerUdtTypeMapping.cs
@@ -6,6 +6,7 @@ using System.Data;
 using System.Data.Common;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
@@ -28,10 +29,11 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] Type clrType,
             [CanBeNull] string udtTypeName = null,
             [CanBeNull] ValueConverter converter = null,
+            [CanBeNull] ValueComparer comparer = null,
             DbType? dbType = null,
             bool unicode = false,
             int? size = null)
-            : base(storeType, clrType, converter, dbType, unicode, size)
+            : base(storeType, clrType, converter, comparer, dbType, unicode, size)
         {
             UdtTypeName = udtTypeName ?? storeType;
         }
@@ -47,14 +49,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqlServerUdtTypeMapping(storeType, ClrType, UdtTypeName, Converter, DbType, IsUnicode, size);
+            => new SqlServerUdtTypeMapping(storeType, ClrType, UdtTypeName, Converter, Comparer, DbType, IsUnicode, size);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqlServerUdtTypeMapping(StoreType, ClrType, UdtTypeName, ComposeConverter(converter), DbType, IsUnicode, Size);
+            => new SqlServerUdtTypeMapping(StoreType, ClrType, UdtTypeName, ComposeConverter(converter), Comparer, DbType, IsUnicode, Size);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDateTimeOffsetTypeMapping.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDateTimeOffsetTypeMapping.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
@@ -22,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqliteDateTimeOffsetTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -33,8 +34,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqliteDateTimeOffsetTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null)
-            : base(storeType, converter, dbType)
+            : base(storeType, converter, comparer, dbType)
         {
         }
 
@@ -43,14 +45,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqliteDateTimeOffsetTypeMapping(storeType, Converter, DbType);
+            => new SqliteDateTimeOffsetTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqliteDateTimeOffsetTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new SqliteDateTimeOffsetTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDateTimeTypeMapping.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDateTimeTypeMapping.cs
@@ -3,6 +3,7 @@
 
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
@@ -22,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqliteDateTimeTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -33,8 +34,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqliteDateTimeTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null)
-            : base(storeType, converter, dbType)
+            : base(storeType, converter, comparer, dbType)
         {
         }
 
@@ -43,14 +45,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqliteDateTimeTypeMapping(storeType, Converter, DbType);
+            => new SqliteDateTimeTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqliteDateTimeTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new SqliteDateTimeTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteGuidTypeMapping.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteGuidTypeMapping.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Data;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
@@ -21,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqliteGuidTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, dbType)
+            : this(storeType, null, null, dbType)
         {
         }
 
@@ -32,8 +33,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqliteGuidTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
+            [CanBeNull] ValueComparer comparer,
             DbType? dbType = null)
-            : base(storeType, converter, dbType)
+            : base(storeType, converter, comparer, dbType)
         {
         }
 
@@ -42,14 +44,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqliteGuidTypeMapping(storeType, Converter, DbType);
+            => new SqliteGuidTypeMapping(storeType, Converter, Comparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqliteGuidTypeMapping(StoreType, ComposeConverter(converter), DbType);
+            => new SqliteGuidTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
+++ b/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
@@ -122,10 +122,27 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             foreach (var property in entityType.GetProperties())
             {
                 if (property.GetOriginalValueIndex() >= 0
-                    && !entry.IsConceptualNull(property)
-                    && !Equals(entry[property], entry.GetOriginalValue(property)))
+                    && !entry.IsConceptualNull(property))
                 {
-                    entry.SetPropertyModified(property);
+                    var current = entry[property];
+                    var original = entry.GetOriginalValue(property);
+
+                    var comparer = property.GetValueComparer() ?? property.FindMapping()?.Comparer;
+
+                    if (comparer == null)
+                    {
+                        if (!Equals(current, original))
+                        {
+                            entry.SetPropertyModified(property);
+                        }
+                    }
+                    else
+                    {
+                        if (!comparer.CompareFunc(current, original))
+                        {
+                            entry.SetPropertyModified(property);
+                        }
+                    }
                 }
             }
 

--- a/src/EFCore/ChangeTracking/Internal/SnapshotFactoryFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/SnapshotFactoryFactory.cs
@@ -10,6 +10,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Remotion.Linq.Parsing.ExpressionVisitors;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
@@ -111,7 +112,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 }
                 else if (propertyBase.IsShadowProperty)
                 {
-                    arguments[i] = CreateReadShadowValueExpression(parameter, propertyBase);
+                    arguments[i] = CreateSnapshotValueExpression(
+                        CreateReadShadowValueExpression(parameter, propertyBase),
+                        propertyBase);
                 }
                 else
                 {
@@ -123,7 +126,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                             null,
                             _snapshotCollectionMethod,
                             memberAccess)
-                        : (Expression)memberAccess;
+                        : CreateSnapshotValueExpression(memberAccess, propertyBase);
                 }
             }
 
@@ -147,6 +150,24 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         constructorExpression
                     })
                 : constructorExpression;
+        }
+
+        private Expression CreateSnapshotValueExpression(Expression expression, IPropertyBase propertyBase)
+        {
+            if (propertyBase is IProperty property)
+            {
+                var comparer = property.GetValueComparer() ?? property.FindMapping()?.Comparer;
+
+                if (comparer != null)
+                {
+                    expression = ReplacingExpressionVisitor.Replace(
+                        comparer.SnapshotExpression.Parameters.Single(),
+                        expression,
+                        comparer.SnapshotExpression.Body);
+                }
+            }
+
+            return expression;
         }
 
         /// <summary>

--- a/src/EFCore/ChangeTracking/ValueComparer.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer.cs
@@ -1,0 +1,87 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking
+{
+    /// <summary>
+    ///     <para>
+    ///         Specifies custom value snapshotting and comparison for
+    ///         CLR types that cannot be compared with <see cref="object.Equals(object, object)" />
+    ///         and/or need a deep copy when taking a snapshot. For example, arrays of primitive types
+    ///         will require both if mutation is to be detected.
+    ///     </para>
+    ///     <para>
+    ///         Snapshotting is the process of creating a copy of the value into a snapshot so it can
+    ///         later be compared to determine if it has changed. For some types, such as collections,
+    ///         this needs to be a deep copy of the collection rather than just a shallow copy of the
+    ///         reference.
+    ///     </para>
+    /// </summary>
+    public abstract class ValueComparer
+    {
+        /// <summary>
+        ///     Creates a new <see cref="ValueComparer" /> with the given comparison and
+        ///     snapshotting expressions.
+        /// </summary>
+        /// <param name="compareFunc"> The compare expression compiled into a untyped delegate. </param>
+        /// <param name="snapshotFunc"> The snapshot expression compiled into a untyped delegate. </param>
+        /// <param name="compareExpression"> The comparison expression. </param>
+        /// <param name="snapshotExpression"> The snapshot expression. </param>
+        protected ValueComparer(
+            [NotNull] Func<object, object, bool> compareFunc,
+            [NotNull] Func<object, object> snapshotFunc,
+            [NotNull] LambdaExpression compareExpression,
+            [NotNull] LambdaExpression snapshotExpression)
+        {
+            CompareFunc = compareFunc;
+            SnapshotFunc = snapshotFunc;
+            CompareExpression = compareExpression;
+            SnapshotExpression = snapshotExpression;
+        }
+
+        /// <summary>
+        ///     The type.
+        /// </summary>
+        public abstract Type Type { get; }
+
+        /// <summary>
+        ///     The comparison expression compiled into an untyped delegate.
+        /// </summary>
+        public virtual Func<object, object, bool> CompareFunc { get; }
+
+        /// <summary>
+        ///     <para>
+        ///         The snapshot expression compiled into an untyped delegate.
+        ///     </para>
+        ///     <para>
+        ///         Snapshotting is the process of creating a copy of the value into a snapshot so it can
+        ///         later be compared to determine if it has changed. For some types, such as collections,
+        ///         this needs to be a deep copy of the collection rather than just a shallow copy of the
+        ///         reference.
+        ///     </para>
+        /// </summary>
+        public virtual Func<object, object> SnapshotFunc { get; }
+
+        /// <summary>
+        ///     The comparison expression.
+        /// </summary>
+        public virtual LambdaExpression CompareExpression { get; }
+
+        /// <summary>
+        ///     <para>
+        ///         The snapshot expression.
+        ///     </para>
+        ///     <para>
+        ///         Snapshotting is the process of creating a copy of the value into a snapshot so it can
+        ///         later be compared to determine if it has changed. For some types, such as collections,
+        ///         this needs to be a deep copy of the collection rather than just a shallow copy of the
+        ///         reference.
+        ///     </para>
+        /// </summary>
+        public virtual LambdaExpression SnapshotExpression { get; }
+    }
+}

--- a/src/EFCore/ChangeTracking/ValueComparer`.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer`.cs
@@ -1,0 +1,102 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking
+{
+    /// <summary>
+    ///     <para>
+    ///         Specifies custom value snapshotting and comparison for
+    ///         CLR types that cannot be compared with <see cref="object.Equals(object, object)" />
+    ///         and/or need a deep copy when taking a snapshot. For example, arrays of primitive types
+    ///         will require both if mutation is to be detected.
+    ///     </para>
+    ///     <para>
+    ///         Snapshotting is the process of creating a copy of the value into a snapshot so it can
+    ///         later be compared to determine if it has changed. For some types, such as collections,
+    ///         this needs to be a deep copy of the collection rather than just a shallow copy of the
+    ///         reference.
+    ///     </para>
+    /// </summary>
+    /// <typeparam name="T"> The type. </typeparam>
+    public class ValueComparer<T> : ValueComparer
+    {
+        /// <summary>
+        ///     Creates a new <see cref="ValueComparer{T}" /> with the given comparison expression.
+        ///     A shallow copy will be used for the snapshot.
+        /// </summary>
+        /// <param name="compareExpression"> The comparison expression. </param>
+        public ValueComparer(
+            [NotNull] Expression<Func<T, T, bool>> compareExpression)
+            : this(compareExpression, v => v)
+        {
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Creates a new <see cref="ValueComparer{T}" /> with the given comparison and
+        ///         snapshotting expressions.
+        ///     </para>
+        ///     <para>
+        ///         Snapshotting is the process of creating a copy of the value into a snapshot so it can
+        ///         later be compared to determine if it has changed. For some types, such as collections,
+        ///         this needs to be a deep copy of the collection rather than just a shallow copy of the
+        ///         reference.
+        ///     </para>
+        /// </summary>
+        /// <param name="compareExpression"> The comparison expression. </param>
+        /// <param name="snapshotExpression"> The snapshot expression. </param>
+        public ValueComparer(
+            [NotNull] Expression<Func<T, T, bool>> compareExpression,
+            [NotNull] Expression<Func<T, T>> snapshotExpression)
+            : base(
+                Compile(compareExpression),
+                Compile(snapshotExpression),
+                compareExpression,
+                snapshotExpression)
+        {
+        }
+
+        /// <summary>
+        ///     The type.
+        /// </summary>
+        public override Type Type => typeof(T);
+
+        /// <summary>
+        ///     The comparison expression.
+        /// </summary>
+        public new virtual Expression<Func<T, T, bool>> CompareExpression
+            => (Expression<Func<T, T, bool>>)base.CompareExpression;
+
+        /// <summary>
+        ///     <para>
+        ///         The snapshot expression.
+        ///     </para>
+        ///     <para>
+        ///         Snapshotting is the process of creating a copy of the value into a snapshot so it can
+        ///         later be compared to determine if it has changed. For some types, such as collections,
+        ///         this needs to be a deep copy of the collection rather than just a shallow copy of the
+        ///         reference.
+        ///     </para>
+        /// </summary>
+        public new virtual Expression<Func<T, T>> SnapshotExpression
+            => (Expression<Func<T, T>>)base.SnapshotExpression;
+
+        private static Func<object, object, bool> Compile(Expression<Func<T, T, bool>> compareExpression)
+        {
+            var compiled = compareExpression.Compile();
+
+            return (l, r) => compiled((T)l, (T)r);
+        }
+
+        private static Func<object, object> Compile(Expression<Func<T, T>> snapshotExpression)
+        {
+            var compiled = snapshotExpression.Compile();
+
+            return v => compiled((T)v);
+        }
+    }
+}

--- a/src/EFCore/Extensions/MutablePropertyExtensions.cs
+++ b/src/EFCore/Extensions/MutablePropertyExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -64,10 +65,10 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
-        ///     Sets a value indicating whether or not this property can persist unicode characters.
+        ///     Sets a value indicating whether or not this property can persist Unicode characters.
         /// </summary>
         /// <param name="property"> The property to set the value for. </param>
-        /// <param name="unicode"> True if the property accepts unicode characters, false if it does not, null to clear the setting. </param>
+        /// <param name="unicode"> True if the property accepts Unicode characters, false if it does not, null to clear the setting. </param>
         public static void IsUnicode([NotNull] this IMutableProperty property, bool? unicode)
         {
             Check.NotNull(property, nameof(property));
@@ -117,7 +118,7 @@ namespace Microsoft.EntityFrameworkCore
             => property[CoreAnnotationNames.StoreClrType] = storeClrType;
 
         /// <summary>
-        ///     Gets the custom <see cref="ValueConverter"/> set for this property.
+        ///     Sets the custom <see cref="ValueConverter"/> for this property.
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <param name="converter"> The converter, or <c>null</c> to remove any previously set converter. </param>
@@ -134,6 +135,26 @@ namespace Microsoft.EntityFrameworkCore
             }
 
             property[CoreAnnotationNames.ValueConverter] = converter;
+        }
+
+        /// <summary>
+        ///     Sets the custom <see cref="ValueComparer"/> for this property.
+        /// </summary>
+        /// <param name="property"> The property. </param>
+        /// <param name="comparer"> The comparer, or <c>null</c> to remove any previously set comparer. </param>
+        public static void SetValueComparer([NotNull] this IMutableProperty property, [CanBeNull] ValueComparer comparer)
+        {
+            if (comparer != null
+                && comparer.Type != property.ClrType)
+            {
+                throw new ArgumentException(CoreStrings.ComparerPropertyMismatch(
+                    comparer.Type.ShortDisplayName(),
+                    property.DeclaringEntityType.DisplayName(),
+                    property.Name,
+                    property.ClrType.ShortDisplayName()));
+            }
+
+            property[CoreAnnotationNames.ValueComparer] = comparer;
         }
     }
 }

--- a/src/EFCore/Extensions/PropertyExtensions.cs
+++ b/src/EFCore/Extensions/PropertyExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
@@ -159,5 +160,13 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> The converter, or <c>null</c> if none has been set. </returns>
         public static ValueConverter GetValueConverter([NotNull] this IProperty property)
             => (ValueConverter)Check.NotNull(property, nameof(property))[CoreAnnotationNames.ValueConverter];
+
+        /// <summary>
+        ///     Gets the <see cref="ValueComparer"/> for this property, or null if none is set.
+        /// </summary>
+        /// <param name="property"> The property. </param>
+        /// <returns> The comparer, or <c>null</c> if none has been set. </returns>
+        public static ValueComparer GetValueComparer([NotNull] this IProperty property)
+            => (ValueComparer)Check.NotNull(property, nameof(property))[CoreAnnotationNames.ValueComparer];
     }
 }

--- a/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
+++ b/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
@@ -73,6 +73,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public const string ValueComparer = "ValueComparer";
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public const string StoreClrType = "StoreClrType";
     }
 }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1795,6 +1795,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 converterType, entityType, propertyName, propertyType);
 
         /// <summary>
+        ///     Comparer for type '{type}' cannot be used for '{entityType}.{propertyName}' because its type is '{propertyType}'.
+        /// </summary>
+        public static string ComparerPropertyMismatch([CanBeNull] object type, [CanBeNull] object entityType, [CanBeNull] object propertyName, [CanBeNull] object propertyType)
+            => string.Format(
+                GetString("ComparerPropertyMismatch", nameof(type), nameof(entityType), nameof(propertyName), nameof(propertyType)),
+                type, entityType, propertyName, propertyType);
+
+        /// <summary>
         ///     The Include operation '{include}' is not supported. '{invalidNavigation}' must be a navigation property defined on an entity type.
         /// </summary>
         public static string IncludeNotSpecifiedDirectlyOnEntityType([CanBeNull] object include, [CanBeNull] object invalidNavigation)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -790,6 +790,9 @@
   <data name="ConverterPropertyMismatch" xml:space="preserve">
     <value>Converter for model type '{converterType}' cannot be used for '{entityType}.{propertyName}' because its type is '{propertyType}'.</value>
   </data>
+  <data name="ComparerPropertyMismatch" xml:space="preserve">
+    <value>Comparer for type '{type}' cannot be used for '{entityType}.{propertyName}' because its type is '{propertyType}'.</value>
+  </data>
   <data name="IncludeNotSpecifiedDirectlyOnEntityType" xml:space="preserve">
     <value>The Include operation '{include}' is not supported. '{invalidNavigation}' must be a navigation property defined on an entity type.</value>
   </data>

--- a/src/EFCore/Storage/Converters/ValueConverter`.cs
+++ b/src/EFCore/Storage/Converters/ValueConverter`.cs
@@ -37,9 +37,13 @@ namespace Microsoft.EntityFrameworkCore.Storage.Converters
         }
 
         private static Func<object, object> SanitizeConverter<TIn, TOut>(Expression<Func<TIn, TOut>> convertExpression)
-            => v => v == null
+        {
+            var compiled = convertExpression.Compile();
+
+            return v => v == null
                 ? (object)null
-                : convertExpression.Compile()(Sanitize<TIn>(v));
+                : compiled(Sanitize<TIn>(v));
+        }
 
         private static T Sanitize<T>(object value)
         {

--- a/src/EFCore/Storage/CoreTypeMapperBase.cs
+++ b/src/EFCore/Storage/CoreTypeMapperBase.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -141,7 +142,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="property"> The property. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
         public virtual CoreTypeMapping FindMapping(IProperty property)
-            => FindMappingWithConversion(new ConcreteTypeMappingInfo(property));
+            => property.FindMapping()
+               ?? FindMappingWithConversion(new ConcreteTypeMappingInfo(property));
 
         /// <summary>
         ///     <para>

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -49,6 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 CoreAnnotationNames.TypeMapping,
                 CoreAnnotationNames.ValueConverter,
                 CoreAnnotationNames.StoreClrType,
+                CoreAnnotationNames.ValueComparer,
                 RelationalAnnotationNames.ColumnName,
                 RelationalAnnotationNames.ColumnType,
                 RelationalAnnotationNames.DefaultValueSql,

--- a/test/EFCore.Relational.Tests/Storage/RelationalTypeMappingTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalTypeMappingTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
@@ -23,6 +24,16 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             public override Type ModelType { get; } = typeof(object);
             public override Type StoreType { get; } = typeof(object);
+        }
+
+        protected class FakeValueComparer : ValueComparer<object>
+        {
+            public FakeValueComparer()
+                : base((_, __) => true, _ => _)
+            {
+            }
+
+            public override Type Type { get; } = typeof(object);
         }
 
         [Theory]
@@ -49,6 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 mappingType,
                 "<original>",
                 new FakeValueConverter(),
+                new FakeValueComparer(),
                 DbType.VarNumeric);
 
             var clone = mapping.Clone("<clone>", null);
@@ -60,6 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.Null(clone.Size);
             Assert.NotNull(mapping.Converter);
             Assert.Same(mapping.Converter, clone.Converter);
+            Assert.Same(mapping.Comparer, clone.Comparer);
             Assert.Same(typeof(object), clone.ClrType);
 
             var newConverter = new FakeValueConverter();
@@ -71,6 +84,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.Equal(DbType.VarNumeric, clone.DbType);
             Assert.Null(clone.Size);
             Assert.NotSame(mapping.Converter, clone.Converter);
+            Assert.Same(mapping.Comparer, clone.Comparer);
             Assert.Same(typeof(object), clone.ClrType);
         }
 
@@ -82,6 +96,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 mappingType,
                 "<original>",
                 new FakeValueConverter(),
+                new FakeValueComparer(),
                 DbType.VarNumeric,
                 33);
 
@@ -96,6 +111,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.Equal(66, clone.Size);
             Assert.NotNull(mapping.Converter);
             Assert.Same(mapping.Converter, clone.Converter);
+            Assert.Same(mapping.Comparer, clone.Comparer);
             Assert.Same(typeof(object), clone.ClrType);
 
             var newConverter = new FakeValueConverter();
@@ -109,6 +125,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.Equal(33, mapping.Size);
             Assert.Equal(33, clone.Size);
             Assert.NotSame(mapping.Converter, clone.Converter);
+            Assert.Same(mapping.Comparer, clone.Comparer);
             Assert.Same(typeof(object), clone.ClrType);
         }
 
@@ -120,6 +137,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 mappingType,
                 "<original>",
                 new FakeValueConverter(),
+                new FakeValueComparer(),
                 DbType.VarNumeric,
                 false,
                 33);
@@ -137,6 +155,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.False(clone.IsUnicode);
             Assert.NotNull(mapping.Converter);
             Assert.Same(mapping.Converter, clone.Converter);
+            Assert.Same(mapping.Comparer, clone.Comparer);
             Assert.Same(typeof(object), clone.ClrType);
 
             var newConverter = new FakeValueConverter();
@@ -152,6 +171,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.False(mapping.IsUnicode);
             Assert.False(clone.IsUnicode);
             Assert.NotSame(mapping.Converter, clone.Converter);
+            Assert.Same(mapping.Comparer, clone.Comparer);
             Assert.Same(typeof(object), clone.ClrType);
         }
 

--- a/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingTest.cs
+++ b/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingTest.cs
@@ -51,6 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 typeof(object),
                 "udtType",
                 new FakeValueConverter(),
+                new FakeValueComparer(),
                 DbType.VarNumeric,
                 false,
                 33);
@@ -70,6 +71,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.False(clone.IsUnicode);
             Assert.NotNull(mapping.Converter);
             Assert.Same(mapping.Converter, clone.Converter);
+            Assert.Same(mapping.Comparer, clone.Comparer);
             Assert.Same(typeof(object), clone.ClrType);
 
             var newConverter = new FakeValueConverter();
@@ -87,6 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.False(mapping.IsUnicode);
             Assert.False(clone.IsUnicode);
             Assert.NotSame(mapping.Converter, clone.Converter);
+            Assert.Same(mapping.Comparer, clone.Comparer);
             Assert.Same(typeof(object), clone.ClrType);
         }
 


### PR DESCRIPTION
Issue #9753

This is primarily focused at allowing providers to generate type mappings for non-primitive type mappings. It can also be used for non-primitive types that are used through value conversions, but #10961 covers adding fluent API for this. Also, this implementation does not attempt to address perf issues, but I added at note to #9422.

I'm not happy with the name ValueComparer--we should discuss in API review.