### PR TITLE
Fix to #10101 - Query: Select.Include.OrderBy ignores the include

### DIFF
--- a/src/EFCore.Specification.Tests/Query/ComplexNavigationsOwnedQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/ComplexNavigationsOwnedQueryTestBase.cs
@@ -40,7 +40,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
         }
 
-        // #8172 - One-to-many not supported yet
+        #region #8172 - One-to-many not supported yet
+
         public override void Multiple_SelectMany_with_string_based_Include()
         {
         }
@@ -389,5 +390,23 @@ namespace Microsoft.EntityFrameworkCore.Query
         public override void Include_reference_collection_order_by_reference_navigation()
         {
         }
+
+        public override void Optional_navigation_with_order_by_and_Include()
+        {
+        }
+
+        public override void Optional_navigation_with_Include_and_order()
+        {
+        }
+
+        public override void SelectMany_with_order_by_and_Include()
+        {
+        }
+
+        public override void SelectMany_with_Include_and_order_by()
+        {
+        }
+
+        #endregion
     }
 }

--- a/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -2255,6 +2255,66 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void Optional_navigation_with_order_by_and_Include()
+        {
+            AssertIncludeQuery<Level1>(
+                l1s => l1s
+                    .Select(l1 => l1.OneToOne_Optional_FK)
+                    .OrderBy(l2 => l2.Name)
+                    .Include(l2 => l2.OneToMany_Optional),
+                l1s => l1s
+                    .Select(l1 => l1.OneToOne_Optional_FK)
+                    .OrderBy(l2 => Maybe(l2, () => l2.Name)),
+                expectedIncludes: new List<IExpectedInclude> { new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional, "OneToMany_Optional") },
+                assertOrder: true);
+        }
+
+        [ConditionalFact]
+        public virtual void Optional_navigation_with_Include_and_order()
+        {
+            AssertIncludeQuery<Level1>(
+                l1s => l1s
+                    .Select(l1 => l1.OneToOne_Optional_FK)
+                    .Include(l2 => l2.OneToMany_Optional)
+                    .OrderBy(l2 => l2.Name),
+                l1s => l1s
+                    .Select(l1 => l1.OneToOne_Optional_FK)
+                    .OrderBy(l2 => Maybe(l2, () => l2.Name)),
+                expectedIncludes: new List<IExpectedInclude> { new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional, "OneToMany_Optional") },
+                assertOrder: true);
+        }
+
+        [ConditionalFact]
+        public virtual void SelectMany_with_order_by_and_Include()
+        {
+            AssertIncludeQuery<Level1>(
+                l1s => l1s
+                    .SelectMany(l1 => l1.OneToMany_Optional)
+                    .OrderBy(l2 => l2.Name)
+                    .Include(l2 => l2.OneToMany_Optional),
+                l1s => l1s
+                    .SelectMany(l1 => l1.OneToMany_Optional)
+                    .OrderBy(l2 => Maybe(l2, () => l2.Name)),
+                expectedIncludes: new List<IExpectedInclude> { new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional, "OneToMany_Optional") },
+                assertOrder: true);
+        }
+
+        [ConditionalFact]
+        public virtual void SelectMany_with_Include_and_order_by()
+        {
+            AssertIncludeQuery<Level1>(
+                l1s => l1s
+                    .SelectMany(l1 => l1.OneToMany_Optional)
+                    .Include(l2 => l2.OneToMany_Optional)
+                    .OrderBy(l2 => l2.Name),
+                l1s => l1s
+                    .SelectMany(l1 => l1.OneToMany_Optional)
+                    .OrderBy(l2 => Maybe(l2, () => l2.Name)),
+                expectedIncludes: new List<IExpectedInclude> { new ExpectedInclude<Level2>(l2 => l2.OneToMany_Optional, "OneToMany_Optional") },
+                assertOrder: true);
+        }
+
+        [ConditionalFact]
         public virtual void SelectMany_with_navigation_and_explicit_DefaultIfEmpty()
         {
             AssertQuery<Level1>(

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -4227,6 +4227,22 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
+        [ConditionalFact]
+        public virtual void Include_on_derived_type_with_order_by_and_paging()
+        {
+            var expectedIncludes = new List<IExpectedInclude>
+            {
+                new ExpectedInclude<LocustCommander>(e => e.DefeatedBy, "DefeatedBy"),
+                new ExpectedInclude<Gear>(e => e.Weapons, "Weapons", "DefeatedBy"),
+            };
+
+            AssertIncludeQuery<LocustLeader>(
+                lls => lls.Include(ll => ((LocustCommander)ll).DefeatedBy).ThenInclude(g => g.Weapons).OrderBy(ll => ((LocustCommander)ll).DefeatedBy.Tag.Note).Take(10),
+                lls => lls.Take(10),
+                expectedIncludes,
+                elementSorter: e => e.Name);
+        }
+
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();
 
         protected virtual void ClearLog()

--- a/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
@@ -32,6 +32,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
     /// </summary>
     public class NavigationRewritingExpressionVisitor : RelinqExpressionVisitor
     {
+        private static readonly ExpressionEqualityComparer _expressionEqualityComparer = new ExpressionEqualityComparer();
+
         private readonly EntityQueryModelVisitor _queryModelVisitor;
         private readonly NavigationJoins _navigationJoins = new NavigationJoins();
         private readonly NavigationRewritingQueryModelVisitor _navigationRewritingQueryModelVisitor;
@@ -739,7 +741,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 {
                     foreach (var includeResultOperator in _queryModelVisitor.QueryCompilationContext.QueryAnnotations
                         .OfType<IncludeResultOperator>()
-                        .Where(o => o.PathFromQuerySource == expression))
+                        .Where(o => _expressionEqualityComparer.Equals(o.PathFromQuerySource, expression)))
                     {
                         includeResultOperator.PathFromQuerySource = resultQsre;
                         includeResultOperator.QuerySource = resultQsre.ReferencedQuerySource;

--- a/src/EFCore/Query/Internal/QueryOptimizer.cs
+++ b/src/EFCore/Query/Internal/QueryOptimizer.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using Microsoft.EntityFrameworkCore.Extensions.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
+using Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal;
 using Remotion.Linq;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.Expressions;
@@ -392,6 +393,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 {
                     queryAnnotation.QuerySource = newQuerySource;
                     queryAnnotation.QueryModel = queryModel;
+
+                    if (queryAnnotation is IncludeResultOperator includeAnnotation
+                        && includeAnnotation.PathFromQuerySource != null)
+                    {
+                        includeAnnotation.PathFromQuerySource
+                            = ReferenceReplacingExpressionVisitor
+                              .ReplaceClauseReferences(includeAnnotation.PathFromQuerySource, querySourceMapping, throwOnUnmappedReferences: false);
+                    }
                 }
             }
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -2044,6 +2044,86 @@ INNER JOIN (
 ORDER BY [t].[Id]");
         }
 
+        public override void Optional_navigation_with_order_by_and_Include()
+        {
+            base.Optional_navigation_with_order_by_and_Include();
+
+            AssertSql(
+                @"SELECT [l1.OneToOne_Optional_FK].[Id], [l1.OneToOne_Optional_FK].[Date], [l1.OneToOne_Optional_FK].[Level1_Optional_Id], [l1.OneToOne_Optional_FK].[Level1_Required_Id], [l1.OneToOne_Optional_FK].[Name], [l1.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+FROM [LevelOne] AS [l1]
+LEFT JOIN [LevelTwo] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
+ORDER BY [l1.OneToOne_Optional_FK].[Name], [l1.OneToOne_Optional_FK].[Id]",
+                //
+                @"SELECT [l1.OneToOne_Optional_FK.OneToMany_Optional].[Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Optional_Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Required_Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Name], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [LevelThree] AS [l1.OneToOne_Optional_FK.OneToMany_Optional]
+INNER JOIN (
+    SELECT DISTINCT [l1.OneToOne_Optional_FK0].[Id], [l1.OneToOne_Optional_FK0].[Name]
+    FROM [LevelOne] AS [l10]
+    LEFT JOIN [LevelTwo] AS [l1.OneToOne_Optional_FK0] ON [l10].[Id] = [l1.OneToOne_Optional_FK0].[Level1_Optional_Id]
+) AS [t] ON [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
+ORDER BY [t].[Name], [t].[Id]");
+        }
+
+        public override void Optional_navigation_with_Include_and_order()
+        {
+            base.Optional_navigation_with_Include_and_order();
+
+            AssertSql(
+                @"SELECT [l1.OneToOne_Optional_FK].[Id], [l1.OneToOne_Optional_FK].[Date], [l1.OneToOne_Optional_FK].[Level1_Optional_Id], [l1.OneToOne_Optional_FK].[Level1_Required_Id], [l1.OneToOne_Optional_FK].[Name], [l1.OneToOne_Optional_FK].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK].[OneToOne_Optional_SelfId]
+FROM [LevelOne] AS [l1]
+LEFT JOIN [LevelTwo] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
+ORDER BY [l1.OneToOne_Optional_FK].[Name], [l1.OneToOne_Optional_FK].[Id]",
+                //
+                @"SELECT [l1.OneToOne_Optional_FK.OneToMany_Optional].[Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Optional_Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Level2_Required_Id], [l1.OneToOne_Optional_FK.OneToMany_Optional].[Name], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [LevelThree] AS [l1.OneToOne_Optional_FK.OneToMany_Optional]
+INNER JOIN (
+    SELECT DISTINCT [l1.OneToOne_Optional_FK0].[Id], [l1.OneToOne_Optional_FK0].[Name]
+    FROM [LevelOne] AS [l10]
+    LEFT JOIN [LevelTwo] AS [l1.OneToOne_Optional_FK0] ON [l10].[Id] = [l1.OneToOne_Optional_FK0].[Level1_Optional_Id]
+) AS [t] ON [l1.OneToOne_Optional_FK.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
+ORDER BY [t].[Name], [t].[Id]");
+        }
+
+        public override void SelectMany_with_order_by_and_Include()
+        {
+            base.SelectMany_with_order_by_and_Include();
+
+            AssertSql(
+                @"SELECT [l1.OneToMany_Optional].[Id], [l1.OneToMany_Optional].[Date], [l1.OneToMany_Optional].[Level1_Optional_Id], [l1.OneToMany_Optional].[Level1_Required_Id], [l1.OneToMany_Optional].[Name], [l1.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [LevelOne] AS [l1]
+INNER JOIN [LevelTwo] AS [l1.OneToMany_Optional] ON [l1].[Id] = [l1.OneToMany_Optional].[OneToMany_Optional_InverseId]
+ORDER BY [l1.OneToMany_Optional].[Name], [l1.OneToMany_Optional].[Id]",
+                //
+                @"SELECT [l1.OneToMany_Optional.OneToMany_Optional].[Id], [l1.OneToMany_Optional.OneToMany_Optional].[Level2_Optional_Id], [l1.OneToMany_Optional.OneToMany_Optional].[Level2_Required_Id], [l1.OneToMany_Optional.OneToMany_Optional].[Name], [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [LevelThree] AS [l1.OneToMany_Optional.OneToMany_Optional]
+INNER JOIN (
+    SELECT DISTINCT [l1.OneToMany_Optional0].[Id], [l1.OneToMany_Optional0].[Name]
+    FROM [LevelOne] AS [l10]
+    INNER JOIN [LevelTwo] AS [l1.OneToMany_Optional0] ON [l10].[Id] = [l1.OneToMany_Optional0].[OneToMany_Optional_InverseId]
+) AS [t] ON [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
+ORDER BY [t].[Name], [t].[Id]");
+        }
+
+        public override void SelectMany_with_Include_and_order_by()
+        {
+            base.SelectMany_with_Include_and_order_by();
+
+            AssertSql(
+                @"SELECT [l1.OneToMany_Optional].[Id], [l1.OneToMany_Optional].[Date], [l1.OneToMany_Optional].[Level1_Optional_Id], [l1.OneToMany_Optional].[Level1_Required_Id], [l1.OneToMany_Optional].[Name], [l1.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [LevelOne] AS [l1]
+INNER JOIN [LevelTwo] AS [l1.OneToMany_Optional] ON [l1].[Id] = [l1.OneToMany_Optional].[OneToMany_Optional_InverseId]
+ORDER BY [l1.OneToMany_Optional].[Name], [l1.OneToMany_Optional].[Id]",
+                //
+                @"SELECT [l1.OneToMany_Optional.OneToMany_Optional].[Id], [l1.OneToMany_Optional.OneToMany_Optional].[Level2_Optional_Id], [l1.OneToMany_Optional.OneToMany_Optional].[Level2_Required_Id], [l1.OneToMany_Optional.OneToMany_Optional].[Name], [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [LevelThree] AS [l1.OneToMany_Optional.OneToMany_Optional]
+INNER JOIN (
+    SELECT DISTINCT [l1.OneToMany_Optional0].[Id], [l1.OneToMany_Optional0].[Name]
+    FROM [LevelOne] AS [l10]
+    INNER JOIN [LevelTwo] AS [l1.OneToMany_Optional0] ON [l10].[Id] = [l1.OneToMany_Optional0].[OneToMany_Optional_InverseId]
+) AS [t] ON [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
+ORDER BY [t].[Name], [t].[Id]");
+        }
+
         public override void SelectMany_with_navigation_and_explicit_DefaultIfEmpty()
         {
             base.SelectMany_with_navigation_and_explicit_DefaultIfEmpty();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -5997,6 +5997,58 @@ WHERE [ll].[Discriminator] IN (N'LocustCommander', N'LocustLeader') AND (([t].[E
             AssertSql(" ");
         }
 
+        public override void Include_on_derived_type_with_order_by_and_paging()
+        {
+            base.Include_on_derived_type_with_order_by_and_paging();
+
+            AssertSql(
+                @"@__p_0='10'
+
+SELECT TOP(@__p_0) [ll].[Name], [ll].[Discriminator], [ll].[LocustHordeId], [ll].[ThreatLevel], [ll].[DefeatedByNickname], [ll].[DefeatedBySquadId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
+FROM [LocustLeaders] AS [ll]
+LEFT JOIN (
+    SELECT [ll.DefeatedBy].*
+    FROM [Gears] AS [ll.DefeatedBy]
+    WHERE [ll.DefeatedBy].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON (CASE
+    WHEN [ll].[Discriminator] = N'LocustCommander'
+    THEN [ll].[DefeatedByNickname] ELSE NULL
+END = [t].[Nickname]) AND (CASE
+    WHEN [ll].[Discriminator] = N'LocustCommander'
+    THEN [ll].[DefeatedBySquadId] ELSE NULL
+END = [t].[SquadId])
+LEFT JOIN [Tags] AS [ll.DefeatedBy.Tag] ON (([t].[Nickname] = [ll.DefeatedBy.Tag].[GearNickName]) OR ([t].[Nickname] IS NULL AND [ll.DefeatedBy.Tag].[GearNickName] IS NULL)) AND (([t].[SquadId] = [ll.DefeatedBy.Tag].[GearSquadId]) OR ([t].[SquadId] IS NULL AND [ll.DefeatedBy.Tag].[GearSquadId] IS NULL))
+WHERE [ll].[Discriminator] IN (N'LocustCommander', N'LocustLeader')
+ORDER BY [ll.DefeatedBy.Tag].[Note], [t].[FullName]",
+                //
+                @"@__p_0='10'
+
+SELECT [ll.DefeatedBy.Weapons].[Id], [ll.DefeatedBy.Weapons].[AmmunitionType], [ll.DefeatedBy.Weapons].[IsAutomatic], [ll.DefeatedBy.Weapons].[Name], [ll.DefeatedBy.Weapons].[OwnerFullName], [ll.DefeatedBy.Weapons].[SynergyWithId]
+FROM [Weapons] AS [ll.DefeatedBy.Weapons]
+INNER JOIN (
+    SELECT DISTINCT [t1].*
+    FROM (
+        SELECT TOP(@__p_0) [t0].[FullName], [ll.DefeatedBy.Tag0].[Note]
+        FROM [LocustLeaders] AS [ll0]
+        LEFT JOIN (
+            SELECT [ll.DefeatedBy0].*
+            FROM [Gears] AS [ll.DefeatedBy0]
+            WHERE [ll.DefeatedBy0].[Discriminator] IN (N'Officer', N'Gear')
+        ) AS [t0] ON (CASE
+            WHEN [ll0].[Discriminator] = N'LocustCommander'
+            THEN [ll0].[DefeatedByNickname] ELSE NULL
+        END = [t0].[Nickname]) AND (CASE
+            WHEN [ll0].[Discriminator] = N'LocustCommander'
+            THEN [ll0].[DefeatedBySquadId] ELSE NULL
+        END = [t0].[SquadId])
+        LEFT JOIN [Tags] AS [ll.DefeatedBy.Tag0] ON (([t0].[Nickname] = [ll.DefeatedBy.Tag0].[GearNickName]) OR ([t0].[Nickname] IS NULL AND [ll.DefeatedBy.Tag0].[GearNickName] IS NULL)) AND (([t0].[SquadId] = [ll.DefeatedBy.Tag0].[GearSquadId]) OR ([t0].[SquadId] IS NULL AND [ll.DefeatedBy.Tag0].[GearSquadId] IS NULL))
+        WHERE [ll0].[Discriminator] IN (N'LocustCommander', N'LocustLeader')
+        ORDER BY [ll.DefeatedBy.Tag0].[Note], [t0].[FullName]
+    ) AS [t1]
+) AS [t2] ON [ll.DefeatedBy.Weapons].[OwnerFullName] = [t2].[FullName]
+ORDER BY [t2].[Note], [t2].[FullName]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Problem was that in QueryOptimizer, if we flattened redundant subquery (Include result operator was the only element on that subquery and we strip those out) we did not update PathFromQuerySource on the IncludeResultOperator annotations with the new Qsre.
Also, in nav rewrite we were trying to match PathFromQuerySource with regular comparison, rather than using ExpressionComparer.