### PR TITLE
Change parameter log formatting to not show DbType = String when it isn't

### DIFF
--- a/samples/OracleProvider/test/OracleProvider.FunctionalTests/BuiltInDataTypesOracleTest.cs
+++ b/samples/OracleProvider/test/OracleProvider.FunctionalTests/BuiltInDataTypesOracleTest.cs
@@ -518,14 +518,14 @@ WHERE ""e"".""Time"" = :timeSpan_0",
 :p14='anyone!' (Size = 2000)
 :p15='Gumball Rules OK!' (Size = 2000)
 :p16='103.3' (Nullable = true)
-:p17='' (Size = 2000) (DbType = String)
+:p17='' (Size = 2000)
 :p18='84.4' (Nullable = true)
 :p19='79' (Nullable = true)
 :p20='Gumball Rules!' (Size = 2000)
 :p21='11:15:12' (Nullable = true) (DbType = Object)
 :p22='80' (Nullable = true)
 :p23='0x595A5B5C' (Size = 2000)
-:p24='' (Size = 2000)",
+:p24='' (Size = 2000) (DbType = AnsiString)",
                 parameters,
                 ignoreLineEndingDifferences: true);
 
@@ -619,28 +619,28 @@ WHERE ""e"".""Time"" = :timeSpan_0",
                 @":p0='78'
 :p1='' (DbType = Int64)
 :p2='' (DbType = Int32)
-:p3='' (Size = 2000) (DbType = String)
-:p4='' (Size = 2000) (DbType = String)
+:p3='' (Size = 2000)
+:p4='' (Size = 2000)
 :p5='' (DbType = DateTime)
 :p6='' (DbType = DateTime)
-:p7='' (DbType = String)
-:p8='' (DbType = String)
-:p9='' (DbType = String)
-:p10='' (DbType = String)
+:p7=''
+:p8=''
+:p9=''
+:p10=''
 :p11='' (Size = 8000) (DbType = Binary)
-:p12='' (DbType = String)
-:p13='' (Size = 2000) (DbType = String)
-:p14='' (Size = 2000) (DbType = String)
-:p15='' (Size = 2000) (DbType = String)
-:p16='' (DbType = String)
-:p17='' (Size = 2000) (DbType = String)
-:p18='' (DbType = String)
+:p12=''
+:p13='' (Size = 2000)
+:p14='' (Size = 2000)
+:p15='' (Size = 2000)
+:p16=''
+:p17='' (Size = 2000)
+:p18=''
 :p19='' (DbType = Int16)
-:p20='' (Size = 2000) (DbType = String)
-:p21='' (DbType = String)
+:p20='' (Size = 2000)
+:p21=''
 :p22='' (DbType = Byte)
 :p23='' (Size = 2000) (DbType = Binary)
-:p24='' (Size = 2000)",
+:p24='' (Size = 2000) (DbType = AnsiString)",
                 parameters,
                 ignoreLineEndingDifferences: true);
 
@@ -769,17 +769,17 @@ WHERE ""e"".""Time"" = :timeSpan_0",
             Assert.Equal(
                 @":p0='78'
 :p1='' (Size = 3) (DbType = Binary)
-:p2='' (Size = 3)
-:p3='' (Size = 2000) (DbType = String)
-:p4='' (Size = 2000) (DbType = String)
-:p5='' (Size = 2000) (DbType = String)
-:p6='' (Size = 2000) (DbType = String)
-:p7='' (Size = 2000) (DbType = String)
-:p8='' (Size = 2000) (DbType = String)
-:p9='' (Size = 3) (DbType = String)
-:p10='' (Size = 3) (DbType = String)
+:p2='' (Size = 3) (DbType = AnsiString)
+:p3='' (Size = 2000)
+:p4='' (Size = 2000)
+:p5='' (Size = 2000)
+:p6='' (Size = 2000)
+:p7='' (Size = 2000)
+:p8='' (Size = 2000)
+:p9='' (Size = 3)
+:p10='' (Size = 3)
 :p11='' (Size = 3) (DbType = Binary)
-:p12='' (Size = 3)",
+:p12='' (Size = 3) (DbType = AnsiString)",
                 parameters,
                 ignoreLineEndingDifferences: true);
 
@@ -1149,29 +1149,29 @@ cur1='' (Nullable = false) (Direction = Output) (DbType = Object)",
             Assert.Equal(
                 @":p0='' (DbType = Int64)
 :p1='' (DbType = Int32)
-:p2='' (Size = 2000) (DbType = String)
-:p3='' (Size = 2000) (DbType = String)
+:p2='' (Size = 2000)
+:p3='' (Size = 2000)
 :p4='' (DbType = DateTime)
 :p5='' (DbType = DateTime)
-:p6='' (DbType = String)
-:p7='' (DbType = String)
-:p8='' (DbType = String)
-:p9='' (DbType = String)
+:p6=''
+:p7=''
+:p8=''
+:p9=''
 :p10='' (Size = 8000) (DbType = Binary)
 :p11='78' (Nullable = true)
-:p12='' (DbType = String)
-:p13='' (Size = 2000) (DbType = String)
-:p14='' (Size = 2000) (DbType = String)
-:p15='' (Size = 2000) (DbType = String)
-:p16='' (DbType = String)
-:p17='' (Size = 2000) (DbType = String)
-:p18='' (DbType = String)
+:p12=''
+:p13='' (Size = 2000)
+:p14='' (Size = 2000)
+:p15='' (Size = 2000)
+:p16=''
+:p17='' (Size = 2000)
+:p18=''
 :p19='' (DbType = Int16)
-:p20='' (Size = 2000) (DbType = String)
-:p21='' (DbType = String)
+:p20='' (Size = 2000)
+:p21=''
 :p22='' (DbType = Byte)
 :p23='' (Size = 2000) (DbType = Binary)
-:p24='' (Size = 2000)
+:p24='' (Size = 2000) (DbType = AnsiString)
 cur1='' (Nullable = false) (Direction = Output) (DbType = Object)",
                 parameters,
                 ignoreLineEndingDifferences: true);
@@ -1302,18 +1302,18 @@ cur1='' (Nullable = false) (Direction = Output) (DbType = Object)",
             var parameters = DumpParameters();
             Assert.Equal(
                 @":p0='' (Size = 3) (DbType = Binary)
-:p1='' (Size = 3)
-:p2='' (Size = 2000) (DbType = String)
-:p3='' (Size = 2000) (DbType = String)
-:p4='' (Size = 2000) (DbType = String)
+:p1='' (Size = 3) (DbType = AnsiString)
+:p2='' (Size = 2000)
+:p3='' (Size = 2000)
+:p4='' (Size = 2000)
 :p5='78'
-:p6='' (Size = 2000) (DbType = String)
-:p7='' (Size = 2000) (DbType = String)
-:p8='' (Size = 2000) (DbType = String)
-:p9='' (Size = 3) (DbType = String)
-:p10='' (Size = 3) (DbType = String)
+:p6='' (Size = 2000)
+:p7='' (Size = 2000)
+:p8='' (Size = 2000)
+:p9='' (Size = 3)
+:p10='' (Size = 3)
 :p11='' (Size = 3) (DbType = Binary)
-:p12='' (Size = 3)
+:p12='' (Size = 3) (DbType = AnsiString)
 cur1='' (Nullable = false) (Direction = Output) (DbType = Object)",
                 parameters,
                 ignoreLineEndingDifferences: true);

--- a/samples/OracleProvider/test/OracleProvider.FunctionalTests/DataAnnotationOracleTest.cs
+++ b/samples/OracleProvider/test/OracleProvider.FunctionalTests/DataAnnotationOracleTest.cs
@@ -202,7 +202,7 @@ END;",
             base.DatabaseGeneratedAttribute_autogenerates_values_when_set_to_identity();
 
             Assert.Equal(
-                @":p0='' (Size = 10) (DbType = String)
+                @":p0='' (Size = 10)
 :p1='Third' (Nullable = false) (Size = 2000)
 :p2='0x00000000000000000000000000000003' (Nullable = false) (Size = 16)
 :p3='Third Additional Name' (Size = 2000)
@@ -306,7 +306,7 @@ END;",
             base.RequiredAttribute_for_property_throws_while_inserting_null_value();
 
             Assert.Equal(
-                @":p0='' (Size = 10) (DbType = String)
+                @":p0='' (Size = 10)
 :p1='ValidString' (Nullable = false) (Size = 2000)
 :p2='0x00000000000000000000000000000001' (Nullable = false) (Size = 16)
 :p3='Two' (Size = 2000)
@@ -331,8 +331,8 @@ RETURNING ""UniqueNo"" INTO listSample_0(1);
 OPEN :cur1 FOR SELECT listSample_0(1).UniqueNo FROM DUAL;
 END;
 
-:p0='' (Size = 10) (DbType = String)
-:p1='' (Nullable = false) (Size = 2000) (DbType = String)
+:p0='' (Size = 10)
+:p1='' (Nullable = false) (Size = 2000)
 :p2='0x00000000000000000000000000000002' (Nullable = false) (Size = 16)
 :p3='Two' (Size = 2000)
 :p4='One' (Size = 2000)

--- a/src/EFCore.Relational/Storage/Internal/DbParameterCollectionExtensions.cs
+++ b/src/EFCore.Relational/Storage/Internal/DbParameterCollectionExtensions.cs
@@ -114,8 +114,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                     .Append(')');
             }
 
-            if (hasValue
-                && !IsNormalDbType(dbType, clrType))
+            if (ShouldShowDbType(hasValue, dbType, clrType))
             {
                 builder
                     .Append(" (DbType = ")
@@ -168,57 +167,58 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             builder.Append('\'');
         }
 
-        private static bool IsNormalDbType(DbType dbType, Type clrType)
+        private static bool ShouldShowDbType(bool hasValue, DbType dbType, Type clrType)
         {
-            if (clrType == null)
+            if (!hasValue
+                || clrType == null
+                || clrType == typeof(DBNull))
             {
-                return false;
+                return dbType != DbType.String;
             }
 
             clrType = clrType.UnwrapNullableType().UnwrapEnumType();
 
             switch (dbType)
             {
-                case DbType.AnsiString: // Zero
-                    return clrType != typeof(string);
                 case DbType.Binary:
-                    return clrType == typeof(byte[]);
+                    return clrType != typeof(byte[]);
                 case DbType.Byte:
-                    return clrType == typeof(byte);
+                    return clrType != typeof(byte);
                 case DbType.Boolean:
-                    return clrType == typeof(bool);
+                    return clrType != typeof(bool);
                 case DbType.Decimal:
-                    return clrType == typeof(decimal);
+                    return clrType != typeof(decimal);
                 case DbType.Double:
-                    return clrType == typeof(double);
+                    return clrType != typeof(double);
                 case DbType.Guid:
-                    return clrType == typeof(Guid);
+                    return clrType != typeof(Guid);
                 case DbType.Int16:
-                    return clrType == typeof(short);
+                    return clrType != typeof(short);
                 case DbType.Int32:
-                    return clrType == typeof(int);
+                    return clrType != typeof(int);
                 case DbType.Int64:
-                    return clrType == typeof(long);
+                    return clrType != typeof(long);
                 case DbType.Object:
-                    return clrType == typeof(object);
+                    return clrType != typeof(object);
                 case DbType.SByte:
-                    return clrType == typeof(sbyte);
+                    return clrType != typeof(sbyte);
                 case DbType.Single:
-                    return clrType == typeof(float);
+                    return clrType != typeof(float);
                 case DbType.String:
-                    return clrType == typeof(string);
+                    return clrType != typeof(string);
                 case DbType.Time:
-                    return clrType == typeof(TimeSpan);
+                    return clrType != typeof(TimeSpan);
                 case DbType.UInt16:
-                    return clrType == typeof(ushort);
+                    return clrType != typeof(ushort);
                 case DbType.UInt32:
-                    return clrType == typeof(uint);
+                    return clrType != typeof(uint);
                 case DbType.UInt64:
-                    return clrType == typeof(ulong);
+                    return clrType != typeof(ulong);
                 case DbType.DateTime2:
-                    return clrType == typeof(DateTime);
+                    return clrType != typeof(DateTime);
                 case DbType.DateTimeOffset:
-                    return clrType == typeof(DateTimeOffset);
+                    return clrType != typeof(DateTimeOffset);
+                //case DbType.AnsiString:
                 //case DbType.VarNumeric:
                 //case DbType.AnsiStringFixedLength:
                 //case DbType.StringFixedLength:
@@ -227,7 +227,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                 //case DbType.Date:
                 //case DbType.DateTime:
                 default:
-                    return false;
+                    return true;
             }
         }
     }

--- a/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalCommandTest.cs
@@ -935,7 +935,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             foreach (var (Level, Id, Message) in log)
             {
                 Assert.EndsWith(
-                    @"[Parameters=[FirstParameter='?'], CommandType='0', CommandTimeout='30']" + EOL +
+                    @"[Parameters=[FirstParameter='?' (DbType = Int32)], CommandType='0', CommandTimeout='30']" + EOL +
                     @"Logged Command",
                     Message);
             }

--- a/test/EFCore.Relational.Tests/Utilities/DbParameterCollectionExtensionsTest.cs
+++ b/test/EFCore.Relational.Tests/Utilities/DbParameterCollectionExtensionsTest.cs
@@ -99,7 +99,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_null_string_parameter()
         {
             Assert.Equal(
-                "@param='' (DbType = String)",
+                "@param=''",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", null, true, ParameterDirection.Input, DbType.String, true, 0, 0, 0));
         }
@@ -162,7 +162,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_int_parameter_with_no_type()
         {
             Assert.Equal(
-                "@param='777'",
+                "@param='777' (DbType = AnsiString)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", 777, true, ParameterDirection.Input, 0, false, 0, 0, 0));
         }
@@ -180,7 +180,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_sensitive_int_parameter()
         {
             Assert.Equal(
-                "@param='?'",
+                "@param='?' (DbType = Int32)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", "?", false, ParameterDirection.Input, DbType.Int32, false, 0, 0, 0));
         }
@@ -189,7 +189,7 @@ namespace Microsoft.EntityFrameworkCore.Utilities
         public void Formats_sensitive_nullable_int_parameter()
         {
             Assert.Equal(
-                "@param='?'",
+                "@param='?' (DbType = Int32)",
                 DbParameterCollectionExtensions.FormatParameter(
                     "@param", "?", false, ParameterDirection.Input, DbType.Int32, true, 0, 0, 0));
         }

--- a/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -866,57 +866,57 @@ WHERE [e].[TimeSpanAsTime] = @__timeSpan_0",
             var parameters = DumpParameters();
             Assert.Equal(
                 @"@p0='78'
-@p1='' (DbType = String)
+@p1=''
 @p2='' (DbType = Byte)
 @p3='' (Size = 8000) (DbType = Binary)
 @p4='' (Size = 8000) (DbType = Binary)
 @p5='' (Size = 8000) (DbType = Binary)
-@p6='' (Size = 8000)
-@p7='' (Size = 8000)
+@p6='' (Size = 8000) (DbType = AnsiString)
+@p7='' (Size = 8000) (DbType = AnsiString)
 @p8='' (DbType = Int32)
-@p9='' (Size = 4000) (DbType = String)
-@p10='' (Size = 4000) (DbType = String)
-@p11='' (Size = 4000) (DbType = String)
-@p12='' (Size = 4000) (DbType = String)
-@p13='' (Size = 8000)
-@p14='' (Size = 8000)
+@p9='' (Size = 4000)
+@p10='' (Size = 4000)
+@p11='' (Size = 4000)
+@p12='' (Size = 4000)
+@p13='' (Size = 8000) (DbType = AnsiString)
+@p14='' (Size = 8000) (DbType = AnsiString)
 @p15='' (DbType = Date)
 @p16='' (DbType = DateTime)
 @p17='' (DbType = DateTime2)
 @p18='' (DbType = DateTime)
 @p19='' (DbType = DateTimeOffset)
-@p20='' (DbType = String)
-@p21='' (DbType = String)
-@p22='' (DbType = String)
-@p23='' (DbType = String)
-@p24='' (DbType = String)
-@p25='' (DbType = String)
-@p26='' (DbType = String)
-@p27='' (Size = 20) (DbType = String)
-@p28='' (Size = 8000)
-@p29='' (DbType = String)
+@p20=''
+@p21=''
+@p22=''
+@p23=''
+@p24=''
+@p25=''
+@p26=''
+@p27='' (Size = 20)
+@p28='' (Size = 8000) (DbType = AnsiString)
+@p29=''
 @p30='' (DbType = Guid)
 @p31='' (DbType = Int64)
 @p32='' (DbType = Int16)
 @p33='' (DbType = Byte)
 @p34='' (DbType = Int16)
-@p35='' (DbType = String)
-@p36='' (DbType = String)
-@p37='' (Size = 8000)
-@p38='' (Size = 8000)
-@p39='' (Size = 4000) (DbType = String)
-@p40='' (Size = 4000) (DbType = String)
-@p41='' (Size = 4000) (DbType = String)
-@p42='' (Size = 4000) (DbType = String)
-@p43='' (Size = 8000)
-@p44='' (Size = 8000)
-@p45='' (DbType = String)
+@p35=''
+@p36=''
+@p37='' (Size = 8000) (DbType = AnsiString)
+@p38='' (Size = 8000) (DbType = AnsiString)
+@p39='' (Size = 4000)
+@p40='' (Size = 4000)
+@p41='' (Size = 4000)
+@p42='' (Size = 4000)
+@p43='' (Size = 8000) (DbType = AnsiString)
+@p44='' (Size = 8000) (DbType = AnsiString)
+@p45=''
 @p46='' (DbType = Int32)
 @p47='' (DbType = Int16)
 @p48='' (DbType = Int64)
 @p49='' (DbType = Int32)
 @p50='' (DbType = Int64)
-@p51='' (DbType = String)",
+@p51=''",
                 parameters,
                 ignoreLineEndingDifferences: true);
 
@@ -1088,22 +1088,22 @@ WHERE [e].[TimeSpanAsTime] = @__timeSpan_0",
 @p1='' (Size = 3) (DbType = Binary)
 @p2='' (Size = 3) (DbType = Binary)
 @p3='' (Size = 3) (DbType = Binary)
-@p4='' (Size = 3)
-@p5='' (Size = 3)
-@p6='' (Size = 3) (DbType = String)
-@p7='' (Size = 3) (DbType = String)
-@p8='' (Size = 3) (DbType = String)
-@p9='' (Size = 3)
-@p10='' (Size = 3)
-@p11='' (Size = 3)
-@p12='' (Size = 3)
-@p13='' (Size = 3)
-@p14='' (Size = 3) (DbType = String)
-@p15='' (Size = 3) (DbType = String)
-@p16='' (Size = 3) (DbType = String)
-@p17='' (Size = 3) (DbType = String)
-@p18='' (Size = 3) (DbType = String)
-@p19='' (Size = 3)",
+@p4='' (Size = 3) (DbType = AnsiString)
+@p5='' (Size = 3) (DbType = AnsiString)
+@p6='' (Size = 3)
+@p7='' (Size = 3)
+@p8='' (Size = 3)
+@p9='' (Size = 3) (DbType = AnsiString)
+@p10='' (Size = 3) (DbType = AnsiString)
+@p11='' (Size = 3) (DbType = AnsiString)
+@p12='' (Size = 3) (DbType = AnsiString)
+@p13='' (Size = 3) (DbType = AnsiString)
+@p14='' (Size = 3)
+@p15='' (Size = 3)
+@p16='' (Size = 3)
+@p17='' (Size = 3)
+@p18='' (Size = 3)
+@p19='' (Size = 3) (DbType = AnsiString)",
                 parameters,
                 ignoreLineEndingDifferences: true);
 
@@ -1623,57 +1623,57 @@ WHERE [e].[TimeSpanAsTime] = @__timeSpan_0",
 
             var parameters = DumpParameters();
             Assert.Equal(
-                @"@p0='' (DbType = String)
+                @"@p0=''
 @p1='' (DbType = Byte)
 @p2='' (Size = 8000) (DbType = Binary)
 @p3='' (Size = 8000) (DbType = Binary)
 @p4='' (Size = 8000) (DbType = Binary)
-@p5='' (Size = 8000)
-@p6='' (Size = 8000)
+@p5='' (Size = 8000) (DbType = AnsiString)
+@p6='' (Size = 8000) (DbType = AnsiString)
 @p7='' (DbType = Int32)
-@p8='' (Size = 4000) (DbType = String)
-@p9='' (Size = 4000) (DbType = String)
-@p10='' (Size = 4000) (DbType = String)
-@p11='' (Size = 4000) (DbType = String)
-@p12='' (Size = 8000)
-@p13='' (Size = 8000)
+@p8='' (Size = 4000)
+@p9='' (Size = 4000)
+@p10='' (Size = 4000)
+@p11='' (Size = 4000)
+@p12='' (Size = 8000) (DbType = AnsiString)
+@p13='' (Size = 8000) (DbType = AnsiString)
 @p14='' (DbType = Date)
 @p15='' (DbType = DateTime)
 @p16='' (DbType = DateTime2)
 @p17='' (DbType = DateTime)
 @p18='' (DbType = DateTimeOffset)
-@p19='' (DbType = String)
-@p20='' (DbType = String)
-@p21='' (DbType = String)
-@p22='' (DbType = String)
-@p23='' (DbType = String)
-@p24='' (DbType = String)
-@p25='' (DbType = String)
-@p26='' (Size = 20) (DbType = String)
-@p27='' (Size = 8000)
-@p28='' (DbType = String)
+@p19=''
+@p20=''
+@p21=''
+@p22=''
+@p23=''
+@p24=''
+@p25=''
+@p26='' (Size = 20)
+@p27='' (Size = 8000) (DbType = AnsiString)
+@p28=''
 @p29='' (DbType = Guid)
 @p30='78' (Nullable = true)
 @p31='' (DbType = Int64)
 @p32='' (DbType = Int16)
 @p33='' (DbType = Byte)
 @p34='' (DbType = Int16)
-@p35='' (DbType = String)
-@p36='' (DbType = String)
-@p37='' (Size = 8000)
-@p38='' (Size = 8000)
-@p39='' (Size = 4000) (DbType = String)
-@p40='' (Size = 4000) (DbType = String)
-@p41='' (Size = 4000) (DbType = String)
-@p42='' (Size = 4000) (DbType = String)
-@p43='' (Size = 8000)
-@p44='' (Size = 8000)
-@p45='' (DbType = String)
+@p35=''
+@p36=''
+@p37='' (Size = 8000) (DbType = AnsiString)
+@p38='' (Size = 8000) (DbType = AnsiString)
+@p39='' (Size = 4000)
+@p40='' (Size = 4000)
+@p41='' (Size = 4000)
+@p42='' (Size = 4000)
+@p43='' (Size = 8000) (DbType = AnsiString)
+@p44='' (Size = 8000) (DbType = AnsiString)
+@p45=''
 @p46='' (DbType = Int32)
 @p47='' (DbType = Int64)
 @p48='' (DbType = Int32)
 @p49='' (DbType = Int64)
-@p50='' (DbType = String)
+@p50=''
 @p51='' (DbType = Int16)",
                 parameters,
                 ignoreLineEndingDifferences: true);
@@ -1846,23 +1846,23 @@ WHERE [e].[TimeSpanAsTime] = @__timeSpan_0",
                 @"@p0='' (Size = 3) (DbType = Binary)
 @p1='' (Size = 3) (DbType = Binary)
 @p2='' (Size = 3) (DbType = Binary)
-@p3='' (Size = 3)
-@p4='' (Size = 3)
-@p5='' (Size = 3) (DbType = String)
-@p6='' (Size = 3) (DbType = String)
-@p7='' (Size = 3) (DbType = String)
-@p8='' (Size = 3)
+@p3='' (Size = 3) (DbType = AnsiString)
+@p4='' (Size = 3) (DbType = AnsiString)
+@p5='' (Size = 3)
+@p6='' (Size = 3)
+@p7='' (Size = 3)
+@p8='' (Size = 3) (DbType = AnsiString)
 @p9='78'
-@p10='' (Size = 3)
-@p11='' (Size = 3)
-@p12='' (Size = 3)
-@p13='' (Size = 3)
-@p14='' (Size = 3) (DbType = String)
-@p15='' (Size = 3) (DbType = String)
-@p16='' (Size = 3) (DbType = String)
-@p17='' (Size = 3) (DbType = String)
-@p18='' (Size = 3) (DbType = String)
-@p19='' (Size = 3)",
+@p10='' (Size = 3) (DbType = AnsiString)
+@p11='' (Size = 3) (DbType = AnsiString)
+@p12='' (Size = 3) (DbType = AnsiString)
+@p13='' (Size = 3) (DbType = AnsiString)
+@p14='' (Size = 3)
+@p15='' (Size = 3)
+@p16='' (Size = 3)
+@p17='' (Size = 3)
+@p18='' (Size = 3)
+@p19='' (Size = 3) (DbType = AnsiString)",
                 parameters,
                 ignoreLineEndingDifferences: true);
 

--- a/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DataAnnotationSqlServerTest.cs
@@ -189,7 +189,7 @@ SELECT @@ROWCOUNT;",
             base.DatabaseGeneratedAttribute_autogenerates_values_when_set_to_identity();
 
             Assert.Equal(
-                @"@p0='' (Size = 10) (DbType = String)
+                @"@p0='' (Size = 10)
 @p1='Third' (Nullable = false) (Size = 4000)
 @p2='00000000-0000-0000-0000-000000000003'
 @p3='Third Additional Name' (Size = 4000)
@@ -257,7 +257,7 @@ WHERE @@ROWCOUNT = 1 AND [UniqueNo] = scope_identity();",
             base.RequiredAttribute_for_property_throws_while_inserting_null_value();
 
             Assert.Equal(
-                @"@p0='' (Size = 10) (DbType = String)
+                @"@p0='' (Size = 10)
 @p1='ValidString' (Nullable = false) (Size = 4000)
 @p2='00000000-0000-0000-0000-000000000001'
 @p3='Two' (Size = 4000)
@@ -270,8 +270,8 @@ SELECT [UniqueNo]
 FROM [Sample]
 WHERE @@ROWCOUNT = 1 AND [UniqueNo] = scope_identity();
 
-@p0='' (Size = 10) (DbType = String)
-@p1='' (Nullable = false) (Size = 4000) (DbType = String)
+@p0='' (Size = 10)
+@p1='' (Nullable = false) (Size = 4000)
 @p2='00000000-0000-0000-0000-000000000002'
 @p3='Two' (Size = 4000)
 @p4='One' (Size = 4000)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
@@ -284,7 +284,7 @@ WHERE [c].[CustomerID] = [o].[CustomerID]");
             base.From_sql_queryable_with_null_parameter();
 
             AssertSql(
-                @"@p0='' (Nullable = false) (DbType = String)
+                @"@p0='' (Nullable = false)
 
 SELECT * FROM ""Employees"" WHERE ""ReportsTo"" = @p0 OR (""ReportsTo"" IS NULL AND @p0 IS NULL)");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceSqlServerTest.cs
@@ -378,7 +378,7 @@ WHERE [c].[Id] = 1",
 @p1='1'
 @p2='Kiwi' (Nullable = false) (Size = 4000)
 @p3='Little spotted kiwi' (Size = 4000)
-@p4='' (Size = 100) (DbType = String)
+@p4='' (Size = 100)
 @p5='True'
 @p6='0' (Size = 1)
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -1026,7 +1026,7 @@ WHERE [e].[NullableBoolA] IS NOT NULL AND ([e].[NullableBoolA] = 1)");
             base.Where_equal_using_relational_null_semantics_with_parameter();
 
             AssertSql(
-                @"@__prm_0='' (DbType = String)
+                @"@__prm_0=''
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
@@ -1058,7 +1058,7 @@ WHERE [e].[NullableBoolA] <> [e].[NullableBoolB]");
             base.Where_not_equal_using_relational_null_semantics_with_parameter();
 
             AssertSql(
-                @"@__prm_0='' (DbType = String)
+                @"@__prm_0=''
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
@@ -1080,13 +1080,13 @@ WHERE [e].[NullableBoolA] <> [e].[NullableBoolB]");
             base.Where_comparison_null_constant_and_null_parameter();
 
             AssertSql(
-                @"@__prm_0='' (Size = 4000) (DbType = String)
+                @"@__prm_0='' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]
 WHERE @__prm_0 IS NULL",
                 //
-                @"@__prm_0='' (Size = 4000) (DbType = String)
+                @"@__prm_0='' (Size = 4000)
 
 SELECT [e].[Id]
 FROM [Entities1] AS [e]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -2854,7 +2854,7 @@ SELECT [x].[Id], [x].[IsDeleted], [x].[IsModerated]
 FROM [Users] AS [x]
 WHERE ([x].[IsDeleted] = 0) AND (@__ef_filter__IsModerated_0 IS NULL OR (@__ef_filter__IsModerated_1 = [x].[IsModerated]))",
                     //
-                    @"@__ef_filter__IsModerated_0='' (DbType = String)
+                    @"@__ef_filter__IsModerated_0=''
 
 SELECT [x].[Id], [x].[IsDeleted], [x].[IsModerated]
 FROM [Users] AS [x]
@@ -2935,7 +2935,7 @@ WHERE @__ef_filter__Enabled_0 = [x].[IsDeleted]");
                     Assert.Single(query);
 
                     AssertSql(
-                        @"@__ef_filter__IsModerated_0='' (DbType = String)
+                        @"@__ef_filter__IsModerated_0=''
 @__IsModerated_0='False'
 
 SELECT [x].[Id], [x].[IsDeleted], [x].[IsModerated]
@@ -3616,8 +3616,8 @@ ORDER BY [t].[Id]");
                 queryableObj.Skip(0).Take(100).ToList();
 
                 AssertSql(
-                    @"@__p_0='?'
-@__p_1='?'
+                    @"@__p_0='?' (DbType = Int32)
+@__p_1='?' (DbType = Int32)
 
 SELECT [t].[Id], [t].[Text], [t].[Id0], [t].[User_Email], [t].[User_Fullname]
 FROM (

--- a/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
@@ -142,7 +142,7 @@ namespace Microsoft.EntityFrameworkCore
             base.DatabaseGeneratedAttribute_autogenerates_values_when_set_to_identity();
 
             Assert.Contains(
-                @"@p0='' (DbType = String)" + _eol +
+                @"@p0=''" + _eol +
                 @"@p1='Third' (Nullable = false) (Size = 5)" + _eol +
                 @"@p2='00000000-0000-0000-0000-000000000003' (DbType = String)" + _eol +
                 @"@p3='Third Additional Name' (Size = 21)" + _eol +
@@ -175,7 +175,7 @@ namespace Microsoft.EntityFrameworkCore
                 Sql);
 
             Assert.Contains(
-                @"@p1='' (Nullable = false) (DbType = String)" + _eol,
+                @"@p1='' (Nullable = false)" + _eol,
                 Sql);
         }
 
@@ -186,7 +186,7 @@ namespace Microsoft.EntityFrameworkCore
             base.RequiredAttribute_for_property_throws_while_inserting_null_value();
 
             Assert.Contains(
-                @"@p0='' (DbType = String)" + _eol +
+                @"@p0=''" + _eol +
                 @"@p1='ValidString' (Nullable = false) (Size = 11)" + _eol +
                 @"@p2='00000000-0000-0000-0000-000000000001' (DbType = String)" + _eol +
                 @"@p3='Two' (Size = 3)" + _eol +
@@ -200,8 +200,8 @@ namespace Microsoft.EntityFrameworkCore
                 Sql);
 
             Assert.Contains(
-                @"@p0='' (DbType = String)" + _eol +
-                @"@p1='' (Nullable = false) (DbType = String)" + _eol +
+                @"@p0=''" + _eol +
+                @"@p1='' (Nullable = false)" + _eol +
                 @"@p2='00000000-0000-0000-0000-000000000002' (DbType = String)" + _eol +
                 @"@p3='Two' (Size = 3)" + _eol +
                 @"@p4='One' (Size = 3)" + _eol +


### PR DESCRIPTION
And show AnsiString when we know it is.

Issue #10634