### PR TITLE
Don't log convention info for temporary keys

### DIFF
--- a/src/EFCore.Specification.Tests/LazyLoadProxyTestBase.cs
+++ b/src/EFCore.Specification.Tests/LazyLoadProxyTestBase.cs
@@ -11,6 +11,7 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore
 {
     public abstract class LazyLoadProxyTestBase<TFixture> : IClassFixture<TFixture>
@@ -46,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore
                     }
                 }
 
-                if (useDetach) 
+                if (useDetach)
                 {
                     Assert.Null(parent.Children);
                 }
@@ -55,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.Equal(
                         CoreStrings.WarningAsErrorTemplate(
                             CoreEventId.LazyLoadOnDisposedContextWarning.ToString(),
-                            CoreStrings.LogLazyLoadOnDisposedContextWarning.GenerateMessage("Children", "ParentProxy")),
+                            CoreStrings.LogLazyLoadOnDisposedContext.GenerateMessage("Children", "ParentProxy")),
                         Assert.Throws<InvalidOperationException>(
                             () => parent.Children).Message);
                 }
@@ -113,7 +114,7 @@ namespace Microsoft.EntityFrameworkCore
                     }
                 }
 
-                if (useDetach) 
+                if (useDetach)
                 {
                     Assert.Null(child.Parent);
                 }
@@ -122,7 +123,7 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.Equal(
                         CoreStrings.WarningAsErrorTemplate(
                             CoreEventId.LazyLoadOnDisposedContextWarning.ToString(),
-                            CoreStrings.LogLazyLoadOnDisposedContextWarning.GenerateMessage("Parent", "ChildProxy")),
+                            CoreStrings.LogLazyLoadOnDisposedContext.GenerateMessage("Parent", "ChildProxy")),
                         Assert.Throws<InvalidOperationException>(
                             () => child.Parent).Message);
                 }
@@ -182,7 +183,7 @@ namespace Microsoft.EntityFrameworkCore
                     }
                 }
 
-                if (useDetach) 
+                if (useDetach)
                 {
                     Assert.Null(single.Parent);
                 }
@@ -191,7 +192,7 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.Equal(
                         CoreStrings.WarningAsErrorTemplate(
                             CoreEventId.LazyLoadOnDisposedContextWarning.ToString(),
-                            CoreStrings.LogLazyLoadOnDisposedContextWarning.GenerateMessage("Parent", "SingleProxy")),
+                            CoreStrings.LogLazyLoadOnDisposedContext.GenerateMessage("Parent", "SingleProxy")),
                         Assert.Throws<InvalidOperationException>(
                             () => single.Parent).Message);
                 }
@@ -251,7 +252,7 @@ namespace Microsoft.EntityFrameworkCore
                     }
                 }
 
-                if (useDetach) 
+                if (useDetach)
                 {
                     Assert.Null(parent.Single);
                 }
@@ -260,7 +261,7 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.Equal(
                         CoreStrings.WarningAsErrorTemplate(
                             CoreEventId.LazyLoadOnDisposedContextWarning.ToString(),
-                            CoreStrings.LogLazyLoadOnDisposedContextWarning.GenerateMessage("Single", "ParentProxy")),
+                            CoreStrings.LogLazyLoadOnDisposedContext.GenerateMessage("Single", "ParentProxy")),
                         Assert.Throws<InvalidOperationException>(
                             () => parent.Single).Message);
                 }

--- a/src/EFCore/Extensions/Internal/CoreLoggerExtensions.cs
+++ b/src/EFCore/Extensions/Internal/CoreLoggerExtensions.cs
@@ -661,7 +661,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             [NotNull] object entityType,
             [NotNull] string navigationName)
         {
-            var definition = CoreStrings.LogLazyLoadOnDisposedContextWarning;
+            var definition = CoreStrings.LogLazyLoadOnDisposedContext;
 
             var warningBehavior = definition.GetLogBehavior(diagnostics);
             if (warningBehavior != WarningBehavior.Ignore)

--- a/src/EFCore/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
@@ -330,7 +330,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 dependentEntityType,
                 false))
             {
-                _logger.IncompatibleMatchingForeignKeyProperties(foreignKeyProperties, propertiesToReference);
+                if (propertiesToReference.All(p => !p.IsShadowProperty
+                                                   || p.GetConfigurationSource().Overrides(ConfigurationSource.DataAnnotation)))
+                {
+                    _logger.IncompatibleMatchingForeignKeyProperties(foreignKeyProperties, propertiesToReference);
+                }
+
                 return new Property[0];
             }
 

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2019,14 +2019,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
         /// <summary>
         ///     An attempt was made to lazy-load navigation property '{navigation}' on entity type '{entityType}' after the associated DbContext was disposed.
         /// </summary>
-        public static readonly EventDefinition<string, string> LogLazyLoadOnDisposedContextWarning
+        public static readonly EventDefinition<string, string> LogLazyLoadOnDisposedContext
             = new EventDefinition<string, string>(
                 CoreEventId.LazyLoadOnDisposedContextWarning,
                 LogLevel.Warning,
                 LoggerMessage.Define<string, string>(
                     LogLevel.Warning,
                     CoreEventId.LazyLoadOnDisposedContextWarning,
-                    _resourceManager.GetString("LogLazyLoadOnDisposedContextWarning")));
+                    _resourceManager.GetString("LogLazyLoadOnDisposedContext")));
 
         /// <summary>
         ///     Cannot create a DbSet for '{typeName}' because it is a query type. Use the DbContext.Query method to create a DbQuery instead.

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -871,7 +871,7 @@
     <value>Navigation property '{navigation}' of entity type '{entityType}' is being lazy-loaded.</value>
     <comment>Information CoreEventId.NavigationLazyLoading string string</comment>
   </data>
-  <data name="LogLazyLoadOnDisposedContextWarning" xml:space="preserve">
+  <data name="LogLazyLoadOnDisposedContext" xml:space="preserve">
     <value>An attempt was made to lazy-load navigation property '{navigation}' on entity type '{entityType}' after the associated DbContext was disposed.</value>
     <comment>Warning CoreEventId.LazyLoadOnDisposedContextWarning string string</comment>
   </data>

--- a/test/EFCore.InMemory.FunctionalTests/Query/WarningsTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/WarningsTest.cs
@@ -156,7 +156,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Equal(
                 CoreStrings.WarningAsErrorTemplate(
                     CoreEventId.LazyLoadOnDisposedContextWarning.ToString(),
-                    CoreStrings.LogLazyLoadOnDisposedContextWarning.GenerateMessage("Nav", "WarningAsErrorEntity")),
+                    CoreStrings.LogLazyLoadOnDisposedContext.GenerateMessage("Nav", "WarningAsErrorEntity")),
                 Assert.Throws<InvalidOperationException>(
                     () => entity.Nav).Message);
         }
@@ -189,7 +189,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.Null(entity.Nav);
 
             Assert.Contains(
-                CoreStrings.LogLazyLoadOnDisposedContextWarning.GenerateMessage("Nav", "WarningAsErrorEntity"),
+                CoreStrings.LogLazyLoadOnDisposedContext.GenerateMessage("Nav", "WarningAsErrorEntity"),
                 Log.Select(l => l.Message));
         }
 

--- a/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
+++ b/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
@@ -297,7 +297,7 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(
                 CoreStrings.WarningAsErrorTemplate(
                     CoreEventId.LazyLoadOnDisposedContextWarning.ToString(),
-                    CoreStrings.LogLazyLoadOnDisposedContextWarning.GenerateMessage("Texts", "PhoneProxy")),
+                    CoreStrings.LogLazyLoadOnDisposedContext.GenerateMessage("Texts", "PhoneProxy")),
                 Assert.Throws<InvalidOperationException>(
                     () => phone.Texts).Message);
         }


### PR DESCRIPTION
Normalize warning event id names

Fixes #10918
