### PR TITLE
Migrations: Warn when missing [Migration] attribute

### DIFF
--- a/src/EFCore.Relational/Diagnostics/MigrationTypeEventData.cs
+++ b/src/EFCore.Relational/Diagnostics/MigrationTypeEventData.cs
@@ -1,0 +1,37 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Diagnostics
+{
+    /// <summary>
+    ///     The <see cref="DiagnosticSource" /> event payload for
+    ///     <see cref="RelationalEventId" /> migration events.
+    /// </summary>
+    public class MigrationTypeEventData : EventData
+    {
+        /// <summary>
+        ///     Constructs the event payload.
+        /// </summary>
+        /// <param name="eventDefinition"> The event definition. </param>
+        /// <param name="messageGenerator"> A delegate that generates a log message for this event. </param>
+        /// <param name="migrationType"> The migration type. </param>
+        public MigrationTypeEventData(
+            [NotNull] EventDefinitionBase eventDefinition,
+            [NotNull] Func<EventDefinitionBase, EventData, string> messageGenerator,
+            [NotNull] TypeInfo migrationType)
+            : base(eventDefinition, messageGenerator)
+        {
+            MigrationType = migrationType;
+        }
+
+        /// <summary>
+        ///     The migration type.
+        /// </summary>
+        public virtual TypeInfo MigrationType { get; }
+    }
+}

--- a/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
+++ b/src/EFCore.Relational/Diagnostics/RelationalEventId.cs
@@ -58,6 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             MigrationGeneratingUpScript,
             MigrationsNotApplied,
             MigrationsNotFound,
+            MigrationAttributeMissingWarning,
 
             // Query events
             QueryClientEvaluationWarning = CoreEventId.RelationalBaseId + 500,
@@ -409,6 +410,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     </para>
         /// </summary>
         public static readonly EventId MigrationsNotFound = MakeMigrationsId(Id.MigrationsNotFound);
+
+        /// <summary>
+        ///     <para>
+        ///         A MigrationAttribute isn't specified on the class.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Migrations" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="MigrationTypeEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
+        /// </summary>
+        public static readonly EventId MigrationAttributeMissingWarning = MakeMigrationsId(Id.MigrationAttributeMissingWarning);
 
         private static readonly string _queryPrefix = DbLoggerCategory.Query.Name + ".";
         private static EventId MakeQueryId(Id id) => new EventId((int)id, _queryPrefix + id);

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -938,6 +938,18 @@ namespace Microsoft.EntityFrameworkCore.Internal
                     RelationalEventId.BatchReadyForExecution,
                     _resourceManager.GetString("LogBatchReadyForExecution")));
 
+        /// <summary>
+        ///     A MigrationAttribute isn't specified on the '{class}' class.
+        /// </summary>
+        public static readonly EventDefinition<string> LogMigrationAttributeMissingWarning
+            = new EventDefinition<string>(
+                RelationalEventId.MigrationAttributeMissingWarning,
+                LogLevel.Warning,
+                LoggerMessage.Define<string>(
+                    LogLevel.Warning,
+                    RelationalEventId.MigrationAttributeMissingWarning,
+                    _resourceManager.GetString("LogMigrationAttributeMissingWarning")));
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -459,4 +459,8 @@
     <value>Executing {batchCommandsCount} update commands as a batch.</value>
     <comment>Debug RelationalEventId.BatchReadyForExecution int</comment>
   </data>
+  <data name="LogMigrationAttributeMissingWarning" xml:space="preserve">
+    <value>A MigrationAttribute isn't specified on the '{class}' class.</value>
+    <comment>Warning RelationalEventId.MigrationAttributeMissingWarning string</comment>
+  </data>
 </root>

--- a/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
@@ -56,7 +56,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 = new MigrationsAssembly(
                     currentContext,
                     new DbContextOptions<TContext>().WithExtension(new FakeRelationalOptionsExtension()),
-                    idGenerator);
+                    idGenerator,
+                    new FakeDiagnosticsLogger<DbLoggerCategory.Migrations>());
             var historyRepository = new MockHistoryRepository();
 
             var services = RelationalTestHelpers.Instance.CreateContextServices();

--- a/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
@@ -73,7 +73,8 @@ namespace Microsoft.EntityFrameworkCore
                 { typeof(QueryModel), () => queryModel },
                 { typeof(MethodCallExpression), () => Expression.Call(constantExpression, typeof(object).GetMethod("ToString")) },
                 { typeof(Expression), () => constantExpression },
-                { typeof(IProperty), () => property }
+                { typeof(IProperty), () => property },
+                { typeof(TypeInfo), () => typeof(object).GetTypeInfo() }
             };
 
             TestEventLogging(


### PR DESCRIPTION
This can be useful when manually creating migrations.

Fixes #9920