### PR TITLE
[TINY] Migrations: Add missing primary key null check

### DIFF
--- a/src/EFCore.Design/Migrations/Design/MigrationsCodeGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsCodeGenerator.cs
@@ -132,7 +132,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                         yield return column;
                     }
 
-                    yield return createTableOperation.PrimaryKey;
+                    if (createTableOperation.PrimaryKey != null)
+                    {
+                        yield return createTableOperation.PrimaryKey;
+                    }
 
                     foreach (var uniqueConstraint in createTableOperation.UniqueConstraints)
                     {


### PR DESCRIPTION
Note, mainline scenarios won't hit this since code is typically only generated for valid models.

Everywhere else in Migrations we already support having no primary key since it's valid for OOB tables.

Fixes #10571