### PR TITLE
Query: Allow QueryFilter defined in EntityTypeConfiguration to use cu…

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/Query/QueryFilterFuncletizationRelationalFixture.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/QueryFilterFuncletizationRelationalFixture.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public abstract class QueryFilterFuncletizationRelationalFixture : QueryFilterFuncletizationFixtureBase
+    {
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+        {
+            base.AddOptions(builder);
+            return builder.ConfigureWarnings(w => w.Ignore(RelationalEventId.QueryClientEvaluationWarning));
+        }
+
+        public TestSqlLoggerFactory TestSqlLoggerFactory
+            => (TestSqlLoggerFactory)ServiceProvider.GetRequiredService<ILoggerFactory>();
+    }
+}

--- a/src/EFCore.Specification.Tests/Query/QueryFilterFuncletizationFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/Query/QueryFilterFuncletizationFixtureBase.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public abstract class QueryFilterFuncletizationFixtureBase : SharedStoreFixtureBase<QueryFilterFuncletizationContext>
+    {
+        protected override string StoreName { get; } = "QueryFilterFuncletizationTest";
+
+        protected override void Seed(QueryFilterFuncletizationContext context)
+            => QueryFilterFuncletizationContext.SeedData(context);
+    }
+}

--- a/src/EFCore.Specification.Tests/Query/QueryFilterFuncletizationTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/QueryFilterFuncletizationTestBase.cs
@@ -1,0 +1,395 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Internal;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public abstract class QueryFilterFuncletizationTestBase<TFixture> : IClassFixture<TFixture>
+        where TFixture : QueryFilterFuncletizationFixtureBase, new()
+    {
+        public QueryFilterFuncletizationTestBase(TFixture fixture) => Fixture = fixture;
+
+        protected TFixture Fixture { get; }
+
+        protected QueryFilterFuncletizationContext CreateContext() => Fixture.CreateContext();
+
+        [Fact]
+        public virtual void DbContext_property_parameter_does_not_clash_with_closure_parameter_name()
+        {
+            using (var context = CreateContext())
+            {
+                var Field = false;
+                Assert.Single(context.Set<FieldFilter>().Where(e => e.IsEnabled == Field).ToList());
+            }
+        }
+
+        [Fact]
+        public virtual void DbContext_field_is_parametrized()
+        {
+            using (var context = CreateContext())
+            {
+                var entity = Assert.Single(context.Set<FieldFilter>().ToList());
+                Assert.False(entity.IsEnabled);
+
+                context.Field = true;
+
+                entity = Assert.Single(context.Set<FieldFilter>().ToList());
+                Assert.True(entity.IsEnabled);
+            }
+        }
+
+        [Fact]
+        public virtual void DbContext_property_is_parametrized()
+        {
+            using (var context = CreateContext())
+            {
+                var entity = Assert.Single(context.Set<PropertyFilter>().ToList());
+                Assert.False(entity.IsEnabled);
+
+                context.Property = true;
+
+                entity = Assert.Single(context.Set<PropertyFilter>().ToList());
+                Assert.True(entity.IsEnabled);
+            }
+        }
+
+        [Fact]
+        public virtual void DbContext_method_call_is_parametrized()
+        {
+            using (var context = CreateContext())
+            {
+                var entity = Assert.Single(context.Set<MethodCallFilter>().ToList());
+                Assert.Equal(2, entity.Tenant);
+            }
+        }
+
+        [Fact]
+        public virtual void DbContext_list_is_parametrized()
+        {
+            using (var context = CreateContext())
+            {
+                // This throws because the default value of TenantIds is null which is NRE
+                Assert.Throws<InvalidOperationException>(() => context.Set<ListFilter>().ToList());
+
+                context.TenantIds = new List<int>();
+                var query = context.Set<ListFilter>().ToList();
+                Assert.Empty(query);
+
+                context.TenantIds = new List<int> { 1 };
+                query = context.Set<ListFilter>().ToList();
+                Assert.Single(query);
+
+                context.TenantIds = new List<int> { 2, 3 };
+                query = context.Set<ListFilter>().ToList();
+                Assert.Equal(2, query.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void DbContext_property_chain_is_parametrized()
+        {
+            using (var context = CreateContext())
+            {
+                // This throws because IndirectionFlag is null
+                Assert.Throws<NullReferenceException>(() => context.Set<PropertyChainFilter>().ToList());
+
+                context.IndirectionFlag = new Indirection { Enabled = false };
+                var entity = Assert.Single(context.Set<PropertyChainFilter>().ToList());
+                Assert.False(entity.IsEnabled);
+
+                context.IndirectionFlag = new Indirection { Enabled = true };
+                entity = Assert.Single(context.Set<PropertyChainFilter>().ToList());
+                Assert.True(entity.IsEnabled);
+            }
+        }
+
+        [Fact]
+        public virtual void DbContext_property_method_call_is_parametrized()
+        {
+            using (var context = CreateContext())
+            {
+                // This throws because IndirectionFlag is null
+                Assert.Throws<NullReferenceException>(() => context.Set<PropertyMethodCallFilter>().ToList());
+
+                context.IndirectionFlag = new Indirection();
+                var entity = Assert.Single(context.Set<PropertyMethodCallFilter>().ToList());
+                Assert.Equal(2, entity.Tenant);
+            }
+        }
+
+        [Fact]
+        public virtual void DbContext_method_call_chain_is_parametrized()
+        {
+            using (var context = CreateContext())
+            {
+                var entity = Assert.Single(context.Set<MethodCallChainFilter>().ToList());
+                Assert.Equal(2, entity.Tenant);
+            }
+        }
+
+        [Fact]
+        public virtual void DbContext_complex_expression_is_parametrized()
+        {
+            using (var context = CreateContext())
+            {
+                var entity = Assert.Single(context.Set<ComplexFilter>().ToList());
+                Assert.False(entity.IsEnabled);
+
+                context.Property = true;
+
+                entity = Assert.Single(context.Set<ComplexFilter>().ToList());
+                Assert.True(entity.IsEnabled);
+
+                context.Tenant = -3;
+                Assert.Empty(context.Set<ComplexFilter>().ToList());
+            }
+        }
+
+        [Fact]
+        public virtual void DbContext_property_based_filter_does_not_short_circuit()
+        {
+            using (var context = CreateContext())
+            {
+                context.IsModerated = true;
+                Assert.Single(context.Set<ShortCircuitFilter>().ToList());
+
+                context.IsModerated = false;
+                Assert.Single(context.Set<ShortCircuitFilter>().ToList());
+
+                context.IsModerated = null;
+                var query = context.Set<ShortCircuitFilter>().ToList();
+                Assert.Equal(2, query.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void EntityTypeConfiguration_DbContext_field_is_parametrized()
+        {
+            using (var context = CreateContext())
+            {
+                var entity = Assert.Single(context.Set<EntityTypeConfigurationFieldFilter>().ToList());
+                Assert.False(entity.IsEnabled);
+
+                context.Field = true;
+
+                entity = Assert.Single(context.Set<EntityTypeConfigurationFieldFilter>().ToList());
+                Assert.True(entity.IsEnabled);
+            }
+        }
+
+        [Fact]
+        public virtual void EntityTypeConfiguration_DbContext_property_is_parametrized()
+        {
+            using (var context = CreateContext())
+            {
+                var entity = Assert.Single(context.Set<EntityTypeConfigurationPropertyFilter>().ToList());
+                Assert.False(entity.IsEnabled);
+
+                context.Property = true;
+
+                entity = Assert.Single(context.Set<EntityTypeConfigurationPropertyFilter>().ToList());
+                Assert.True(entity.IsEnabled);
+            }
+        }
+
+        [Fact]
+        public virtual void EntityTypeConfiguration_DbContext_method_call_is_parametrized()
+        {
+            using (var context = CreateContext())
+            {
+                var entity = Assert.Single(context.Set<EntityTypeConfigurationMethodCallFilter>().ToList());
+                Assert.Equal(2, entity.Tenant);
+            }
+        }
+
+        [Fact]
+        public virtual void EntityTypeConfiguration_DbContext_property_chain_is_parametrized()
+        {
+            using (var context = CreateContext())
+            {
+                // This throws because IndirectionFlag is null
+                Assert.Throws<NullReferenceException>(() => context.Set<EntityTypeConfigurationPropertyChainFilter>().ToList());
+
+                context.IndirectionFlag = new Indirection { Enabled = false };
+                var entity = Assert.Single(context.Set<EntityTypeConfigurationPropertyChainFilter>().ToList());
+                Assert.False(entity.IsEnabled);
+
+                context.IndirectionFlag = new Indirection { Enabled = true };
+                entity = Assert.Single(context.Set<EntityTypeConfigurationPropertyChainFilter>().ToList());
+                Assert.True(entity.IsEnabled);
+            }
+        }
+
+        [Fact]
+        public virtual void Local_method_DbContext_field_is_parametrized()
+        {
+            using (var context = CreateContext())
+            {
+                var entity = Assert.Single(context.Set<LocalMethodFilter>().ToList());
+                Assert.False(entity.IsEnabled);
+
+                context.Field = true;
+
+                entity = Assert.Single(context.Set<LocalMethodFilter>().ToList());
+                Assert.True(entity.IsEnabled);
+            }
+        }
+
+        [Fact]
+        public virtual void Local_static_method_DbContext_property_is_parametrized()
+        {
+            using (var context = CreateContext())
+            {
+                var entity = Assert.Single(context.Set<LocalMethodParamsFilter>().ToList());
+                Assert.False(entity.IsEnabled);
+
+                context.Property = true;
+
+                entity = Assert.Single(context.Set<LocalMethodParamsFilter>().ToList());
+                Assert.True(entity.IsEnabled);
+            }
+        }
+
+        [Fact]
+        public virtual void Remote_method_DbContext_property_method_call_is_parametrized()
+        {
+            using (var context = CreateContext())
+            {
+                // This throws because IndirectionFlag is null
+                Assert.Throws<NullReferenceException>(() => context.Set<RemoteMethodParamsFilter>().ToList());
+
+                context.IndirectionFlag = new Indirection();
+                var entity = Assert.Single(context.Set<RemoteMethodParamsFilter>().ToList());
+                Assert.Equal(2, entity.Tenant);
+            }
+        }
+
+        [Fact]
+        public virtual void Extension_method_DbContext_field_is_parametrized()
+        {
+            using (var context = CreateContext())
+            {
+                var entity = Assert.Single(context.Set<ExtensionBuilderFilter>().ToList());
+                Assert.False(entity.IsEnabled);
+
+                context.Field = true;
+
+                entity = Assert.Single(context.Set<ExtensionBuilderFilter>().ToList());
+                Assert.True(entity.IsEnabled);
+            }
+        }
+
+        [Fact]
+        public virtual void Extension_method_DbContext_property_chain_is_parametrized()
+        {
+            using (var context = CreateContext())
+            {
+                // This throws because IndirectionFlag is null
+                Assert.Throws<NullReferenceException>(() => context.Set<ExtensionContextFilter>().ToList());
+
+                context.IndirectionFlag = new Indirection { Enabled = false };
+                var entity = Assert.Single(context.Set<ExtensionContextFilter>().ToList());
+                Assert.False(entity.IsEnabled);
+
+                context.IndirectionFlag = new Indirection { Enabled = true };
+                entity = Assert.Single(context.Set<ExtensionContextFilter>().ToList());
+                Assert.True(entity.IsEnabled);
+            }
+        }
+
+        [Fact]
+        public virtual void Using_DbSet_in_filter_works()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Single(context.Set<PrincipalSetFilter>().ToList());
+            }
+        }
+
+        [Fact]
+        public virtual void Using_Context_set_method_in_filter_works()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Dependents.ToList();
+
+                Assert.Equal(2, query.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Static_member_from_dbContext_is_inlined()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Set<DbContextStaticMemberFilter>().ToList();
+
+                Assert.Equal(2, query.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Static_member_from_non_dbContext_is_inlined()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Set<StaticMemberFilter>().ToList();
+
+                var entity = Assert.Single(query);
+            }
+        }
+
+        [Fact]
+        public virtual void Local_variable_from_OnModelCreating_is_inlined()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Set<LocalVariableFilter>().ToList();
+
+                var entity = Assert.Single(query);
+            }
+        }
+
+        [Fact]
+        public virtual void Local_variable_from_OnModelCreating_can_throw_exception()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Equal(
+                    CoreStrings.ExpressionParameterizationExceptionSensitive(
+                        "value(Microsoft.EntityFrameworkCore.Query.QueryFilterFuncletizationContext+<>c__DisplayClass29_0).flag.Enabled"),
+                    Assert.Throws<InvalidOperationException>(
+                        () => context.Set<LocalVariableErrorFilter>().ToList()).Message);
+            }
+        }
+
+        [Fact]
+        public virtual void Method_parameter_is_inlined()
+        {
+            using (var context = CreateContext())
+            {
+                Assert.Empty(context.Set<ParameterFilter>().ToList());
+            }
+        }
+
+        [Fact]
+        public virtual void Using_multiple_context_in_filter_parametrize_only_current_context()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.Set<MultiContextFilter>().ToList();
+                Assert.Equal(1, query.Count);
+
+                context.Property = true;
+
+                query = context.Set<MultiContextFilter>().ToList();
+                Assert.Equal(2, query.Count);
+            }
+        }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestModels/QueryFilterFuncletizationContext.cs
+++ b/src/EFCore.Specification.Tests/TestModels/QueryFilterFuncletizationContext.cs
@@ -1,0 +1,429 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class QueryFilterFuncletizationContext : DbContext
+    {
+        public static int AdminId = 1;
+        public QueryFilterFuncletizationContext(DbContextOptions options)
+            : base(options)
+        {
+        }
+
+        public bool Field;
+        public bool Property { get; set; }
+        public bool? IsModerated { get; set; }
+        public int Tenant { get; set; }
+        public int GetId() => 2;
+        public Indirection GetFlag() => new Indirection();
+        public List<int> TenantIds { get; set; }
+        public Indirection IndirectionFlag { get; set; }
+
+        public DbSet<DependentSetFilter> Dependents { get; set; }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            // Parametrize
+            // Filters defined in OnModelCreating
+            modelBuilder.Entity<FieldFilter>().HasQueryFilter(e => e.IsEnabled == Field);
+            modelBuilder.Entity<PropertyFilter>().HasQueryFilter(e => e.IsEnabled == Property);
+            modelBuilder.Entity<MethodCallFilter>().HasQueryFilter(e => e.Tenant == GetId());
+            modelBuilder.Entity<ListFilter>().HasQueryFilter(e => TenantIds.Contains(e.Tenant));
+            modelBuilder.Entity<PropertyChainFilter>().HasQueryFilter(e => e.IsEnabled == IndirectionFlag.Enabled);
+            modelBuilder.Entity<PropertyMethodCallFilter>().HasQueryFilter(e => e.Tenant == IndirectionFlag.GetId());
+            modelBuilder.Entity<MethodCallChainFilter>().HasQueryFilter(e => e.Tenant == GetFlag().GetId());
+            modelBuilder.Entity<ComplexFilter>().HasQueryFilter(x => x.IsEnabled == Property && (Tenant + GetId() > 0));
+            modelBuilder.Entity<ShortCircuitFilter>()
+                .HasQueryFilter(x => !x.IsDeleted && (IsModerated == null || IsModerated == x.IsModerated));
+            modelBuilder.Entity<PrincipalSetFilter>()
+                .HasQueryFilter(p => Dependents.Any(d => d.PrincipalSetFilterId == p.Id));
+
+            // Filters defined through EntityTypeConfiguration
+            modelBuilder.ApplyConfiguration(new FieldConfiguration(this));
+            modelBuilder.ApplyConfiguration(new PropertyConfiguration(this));
+            modelBuilder.ApplyConfiguration(new MethodCallConfiguration(new DbContextWrapper(this)));
+            modelBuilder.ApplyConfiguration(new PropertyChainConfiguration(new DbContextWrapper(this)));
+
+            // Filters defined through methods (local/remote/extensions)
+            ConfigureFilter(modelBuilder.Entity<LocalMethodFilter>());
+            ConfigureFilterParams(modelBuilder.Entity<LocalMethodParamsFilter>(), this);
+            Indirection.ConfigureFilter(modelBuilder.Entity<RemoteMethodParamsFilter>(), new DbContextWrapper(this));
+            modelBuilder.Entity<ExtensionBuilderFilter>().BuilderFilter(this);
+            new DbContextWrapper(this).ContextFilter(modelBuilder.Entity<ExtensionContextFilter>());
+            SetDependentFilter(modelBuilder, this);
+
+            // Inline
+            modelBuilder.Entity<DbContextStaticMemberFilter>().HasQueryFilter(e => e.UserId != AdminId);
+            modelBuilder.Entity<StaticMemberFilter>()
+                .HasQueryFilter(b => b.IsEnabled == StaticMemberFilter.DefaultEnabled);
+            var enabled = true;
+            modelBuilder.Entity<LocalVariableFilter>().HasQueryFilter(e => e.IsEnabled == enabled);
+            Indirection flag = null;
+            modelBuilder.Entity<LocalVariableErrorFilter>().HasQueryFilter(e => e.IsEnabled == flag.Enabled);
+            IncorrectFilter(modelBuilder.Entity<ParameterFilter>(), Tenant);
+
+            // Multiple context used in filter
+            modelBuilder.Entity<MultiContextFilter>()
+                .HasQueryFilter(e => e.IsEnabled == Property && e.BossId == new IncorrectDbContext().BossId);
+        }
+
+        private void ConfigureFilter(EntityTypeBuilder<LocalMethodFilter> builder)
+        {
+            builder.HasQueryFilter(e => e.IsEnabled == Field);
+        }
+
+        private static void ConfigureFilterParams(
+            EntityTypeBuilder<LocalMethodParamsFilter> builder, QueryFilterFuncletizationContext context)
+        {
+            builder.HasQueryFilter(e => e.IsEnabled == context.Property);
+        }
+
+        private static void IncorrectFilter(EntityTypeBuilder<ParameterFilter> builder, int tenant)
+        {
+            builder.HasQueryFilter(e => e.Tenant == tenant);
+        }
+
+        private static void SetDependentFilter(ModelBuilder modelBuilder, DbContext context)
+        {
+            modelBuilder.Entity<DependentSetFilter>()
+                .HasQueryFilter(p => context.Set<PrincipalSetFilter>().Any(b => b.Id == p.PrincipalSetFilterId));
+        }
+
+        #region EntityTypeConfigs
+
+        public class FieldConfiguration : IEntityTypeConfiguration<EntityTypeConfigurationFieldFilter>
+        {
+            public FieldConfiguration(QueryFilterFuncletizationContext context)
+            {
+                Context = context;
+            }
+            public QueryFilterFuncletizationContext Context { get; }
+            public void Configure(EntityTypeBuilder<EntityTypeConfigurationFieldFilter> builder)
+            {
+                builder.HasQueryFilter(e => e.IsEnabled == Context.Field);
+            }
+        }
+
+        public class PropertyConfiguration : IEntityTypeConfiguration<EntityTypeConfigurationPropertyFilter>
+        {
+            private readonly QueryFilterFuncletizationContext _context;
+            public PropertyConfiguration(QueryFilterFuncletizationContext context)
+            {
+                _context = context;
+            }
+            public void Configure(EntityTypeBuilder<EntityTypeConfigurationPropertyFilter> builder)
+            {
+                builder.HasQueryFilter(e => e.IsEnabled == _context.Property);
+            }
+        }
+
+        public class MethodCallConfiguration : IEntityTypeConfiguration<EntityTypeConfigurationMethodCallFilter>
+        {
+            public MethodCallConfiguration(DbContextWrapper wrapper)
+            {
+                Wrapper = wrapper;
+            }
+            public DbContextWrapper Wrapper { get; }
+            public void Configure(EntityTypeBuilder<EntityTypeConfigurationMethodCallFilter> builder)
+            {
+                builder.HasQueryFilter(e => e.Tenant == Wrapper.Context.GetId());
+            }
+        }
+
+        public class PropertyChainConfiguration : IEntityTypeConfiguration<EntityTypeConfigurationPropertyChainFilter>
+        {
+            private readonly DbContextWrapper _wrapper;
+            public PropertyChainConfiguration(DbContextWrapper wrapper)
+            {
+                _wrapper = wrapper;
+            }
+            public void Configure(EntityTypeBuilder<EntityTypeConfigurationPropertyChainFilter> builder)
+            {
+                builder.HasQueryFilter(e => e.IsEnabled == _wrapper.Context.IndirectionFlag.Enabled);
+            }
+        }
+
+        #endregion
+
+        public static void SeedData(QueryFilterFuncletizationContext context)
+        {
+            context.AddRange(
+                new FieldFilter { IsEnabled = true },
+                new FieldFilter { IsEnabled = false },
+                new PropertyFilter { IsEnabled = true },
+                new PropertyFilter { IsEnabled = false },
+                new MethodCallFilter { Tenant = 1 },
+                new MethodCallFilter { Tenant = 2 },
+                new ListFilter { Tenant = 1 },
+                new ListFilter { Tenant = 2 },
+                new ListFilter { Tenant = 3 },
+                new ListFilter { Tenant = 4 },
+                new PropertyChainFilter { IsEnabled = true },
+                new PropertyChainFilter { IsEnabled = false },
+                new PropertyMethodCallFilter { Tenant = 1 },
+                new PropertyMethodCallFilter { Tenant = 2 },
+                new MethodCallChainFilter { Tenant = 1 },
+                new MethodCallChainFilter { Tenant = 2 },
+                new ComplexFilter { IsEnabled = true },
+                new ComplexFilter { IsEnabled = false },
+                new ShortCircuitFilter { IsDeleted = false, IsModerated = false },
+                new ShortCircuitFilter { IsDeleted = true, IsModerated = false },
+                new ShortCircuitFilter { IsDeleted = false, IsModerated = true },
+                new ShortCircuitFilter { IsDeleted = true, IsModerated = true },
+                new DbContextStaticMemberFilter { UserId = 1 },
+                new DbContextStaticMemberFilter { UserId = 2 },
+                new DbContextStaticMemberFilter { UserId = 3 },
+                new StaticMemberFilter { IsEnabled = true },
+                new StaticMemberFilter { IsEnabled = false },
+                new LocalVariableFilter { IsEnabled = true },
+                new LocalVariableFilter { IsEnabled = false },
+                new EntityTypeConfigurationFieldFilter { IsEnabled = true },
+                new EntityTypeConfigurationFieldFilter { IsEnabled = false },
+                new EntityTypeConfigurationPropertyFilter { IsEnabled = true },
+                new EntityTypeConfigurationPropertyFilter { IsEnabled = false },
+                new EntityTypeConfigurationMethodCallFilter { Tenant = 1 },
+                new EntityTypeConfigurationMethodCallFilter { Tenant = 2 },
+                new EntityTypeConfigurationPropertyChainFilter { IsEnabled = true },
+                new EntityTypeConfigurationPropertyChainFilter { IsEnabled = false },
+                new LocalMethodFilter { IsEnabled = true },
+                new LocalMethodFilter { IsEnabled = false },
+                new LocalMethodParamsFilter { IsEnabled = true },
+                new LocalMethodParamsFilter { IsEnabled = false },
+                new RemoteMethodParamsFilter { Tenant = 1 },
+                new RemoteMethodParamsFilter { Tenant = 2 },
+                new ExtensionBuilderFilter { IsEnabled = true },
+                new ExtensionBuilderFilter { IsEnabled = false },
+                new ExtensionContextFilter { IsEnabled = true },
+                new ExtensionContextFilter { IsEnabled = false },
+                new ParameterFilter { Tenant = 1 },
+                new ParameterFilter { Tenant = 2 },
+                new PrincipalSetFilter
+                {
+                    Dependents = new List<DependentSetFilter>
+                    {
+                        new DependentSetFilter(),
+                        new DependentSetFilter()
+                    }
+                },
+                new PrincipalSetFilter(),
+                new MultiContextFilter { BossId = 1, IsEnabled = true},
+                new MultiContextFilter { BossId = 1, IsEnabled = false},
+                new MultiContextFilter { BossId = 1, IsEnabled = true},
+                new MultiContextFilter { BossId = 2, IsEnabled = true},
+                new MultiContextFilter { BossId = 2, IsEnabled = false}
+                );
+
+            context.SaveChanges();
+        }
+    }
+
+    #region HelperClasses
+
+    public class DbContextWrapper
+    {
+        public DbContextWrapper(QueryFilterFuncletizationContext context)
+        {
+            Context = context;
+        }
+        public QueryFilterFuncletizationContext Context { get; }
+    }
+
+    public static class FilterExtensions
+    {
+        public static void BuilderFilter(
+            this EntityTypeBuilder<ExtensionBuilderFilter> builder, QueryFilterFuncletizationContext context)
+        {
+            builder.HasQueryFilter(e => e.IsEnabled == context.Field);
+        }
+
+        public static void ContextFilter(
+            this DbContextWrapper wrapper, EntityTypeBuilder<ExtensionContextFilter> builder)
+        {
+            builder.HasQueryFilter(e => e.IsEnabled == wrapper.Context.IndirectionFlag.Enabled);
+        }
+    }
+    public class Indirection
+    {
+        public bool Enabled { get; set; }
+        public int GetId() => 2;
+
+        public static void ConfigureFilter(EntityTypeBuilder<RemoteMethodParamsFilter> builder, DbContextWrapper wrapper)
+        {
+            builder.HasQueryFilter(e => e.Tenant == wrapper.Context.IndirectionFlag.GetId());
+        }
+    }
+
+    public class IncorrectDbContext : DbContext
+    {
+        public int BossId => 1;
+    }
+
+    #endregion
+
+    #region EntityTypes
+
+    public class FieldFilter
+    {
+        public int Id { get; set; }
+        public bool IsEnabled { get; set; }
+    }
+
+    public class PropertyFilter
+    {
+        public int Id { get; set; }
+        public bool IsEnabled { get; set; }
+    }
+
+    public class MethodCallFilter
+    {
+        public int Id { get; set; }
+        public int Tenant { get; set; }
+    }
+
+    public class ListFilter
+    {
+        public int Id { get; set; }
+        public int Tenant { get; set; }
+    }
+
+    public class PropertyChainFilter
+    {
+        public int Id { get; set; }
+        public bool IsEnabled { get; set; }
+    }
+
+    public class PropertyMethodCallFilter
+    {
+        public int Id { get; set; }
+        public int Tenant { get; set; }
+    }
+
+    public class MethodCallChainFilter
+    {
+        public int Id { get; set; }
+        public int Tenant { get; set; }
+    }
+
+    public class ComplexFilter
+    {
+        public int Id { get; set; }
+        public bool IsEnabled { get; set; }
+    }
+
+    public class ShortCircuitFilter
+    {
+        public int Id { get; set; }
+        public bool IsDeleted { get; set; }
+        public bool IsModerated { get; set; }
+    }
+
+    public class EntityTypeConfigurationFieldFilter
+    {
+        public int Id { get; set; }
+        public bool IsEnabled { get; set; }
+    }
+
+    public class EntityTypeConfigurationPropertyFilter
+    {
+        public int Id { get; set; }
+        public bool IsEnabled { get; set; }
+    }
+
+    public class EntityTypeConfigurationMethodCallFilter
+    {
+        public int Id { get; set; }
+        public int Tenant { get; set; }
+    }
+
+    public class EntityTypeConfigurationPropertyChainFilter
+    {
+        public int Id { get; set; }
+        public bool IsEnabled { get; set; }
+    }
+
+    public class LocalMethodFilter
+    {
+        public int Id { get; set; }
+        public bool IsEnabled { get; set; }
+    }
+
+    public class LocalMethodParamsFilter
+    {
+        public int Id { get; set; }
+        public bool IsEnabled { get; set; }
+    }
+
+    public class RemoteMethodParamsFilter
+    {
+        public int Id { get; set; }
+        public int Tenant { get; set; }
+    }
+
+    public class ExtensionBuilderFilter
+    {
+        public int Id { get; set; }
+        public bool IsEnabled { get; set; }
+    }
+
+    public class ExtensionContextFilter
+    {
+        public int Id { get; set; }
+        public bool IsEnabled { get; set; }
+    }
+
+    public class DbContextStaticMemberFilter
+    {
+        public int Id { get; set; }
+        public int UserId { get; set; }
+    }
+
+    public class StaticMemberFilter
+    {
+        public static bool DefaultEnabled = true;
+        public int Id { get; set; }
+        public bool IsEnabled { get; set; }
+    }
+
+    public class LocalVariableFilter
+    {
+        public int Id { get; set; }
+        public bool IsEnabled { get; set; }
+    }
+
+    public class LocalVariableErrorFilter
+    {
+        public int Id { get; set; }
+        public bool IsEnabled { get; set; }
+    }
+    public class ParameterFilter
+    {
+        public int Id { get; set; }
+        public int Tenant { get; set; }
+    }
+
+    public class PrincipalSetFilter
+    {
+        public int Id { get; set; }
+        public ICollection<DependentSetFilter> Dependents { get; set; }
+    }
+
+    public class DependentSetFilter
+    {
+        public int Id { get; set; }
+        public int PrincipalSetFilterId { get; set; }
+    }
+
+    public class MultiContextFilter
+    {
+        public int Id { get; set; }
+        public int BossId { get; set; }
+        public bool IsEnabled { get; set; }
+    }
+
+    #endregion
+}

--- a/src/EFCore/Query/ExpressionVisitors/Internal/ModelExpressionApplyingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/ModelExpressionApplyingExpressionVisitor.cs
@@ -78,7 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         public virtual void ApplyModelExpressions([NotNull] QueryModel queryModel)
         {
             Check.NotNull(queryModel, nameof(queryModel));
-            
+
             _querySource = queryModel.MainFromClause;
 
             queryModel.TransformExpressions(Visit);
@@ -114,6 +114,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                                         _queryCompilationContext.Logger,
                                         query.Body,
                                         _parameters,
+                                        _queryCompilationContext.ContextType,
                                         parameterize: false,
                                         generateContextAccessors: true);
 
@@ -132,6 +133,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                                     _queryCompilationContext.Logger,
                                     entityType.QueryFilter,
                                     _parameters,
+                                    _queryCompilationContext.ContextType,
                                     parameterize: false,
                                     generateContextAccessors: true);
 

--- a/src/EFCore/Query/Internal/IQueryModelGenerator.cs
+++ b/src/EFCore/Query/Internal/IQueryModelGenerator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -28,6 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger,
             [NotNull] Expression query,
             [NotNull] IParameterValues parameterValues,
+            [NotNull] Type contextType,
             bool parameterize = true,
             bool generateContextAccessors = false);
     }

--- a/src/EFCore/Query/Internal/QueryCompiler.cs
+++ b/src/EFCore/Query/Internal/QueryCompiler.cs
@@ -82,7 +82,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             var queryContext = _queryContextFactory.Create();
 
-            query = _queryModelGenerator.ExtractParameters(_logger, query, queryContext);
+            query = _queryModelGenerator.ExtractParameters(_logger, query, queryContext, _contextType);
 
             var compiledQuery
                 = _compiledQueryCache
@@ -101,7 +101,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         {
             Check.NotNull(query, nameof(query));
 
-            query = _queryModelGenerator.ExtractParameters(_logger, query, _queryContextFactory.Create(), parameterize: false);
+            query = _queryModelGenerator.ExtractParameters(
+                _logger, query, _queryContextFactory.Create(), _contextType,  parameterize: false);
 
             return CompileQueryCore<TResult>(query, _queryModelGenerator, _database, _logger, _contextType);
         }
@@ -163,7 +164,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             var queryContext = _queryContextFactory.Create();
 
-            query = _queryModelGenerator.ExtractParameters(_logger, query, queryContext);
+            query = _queryModelGenerator.ExtractParameters(_logger, query, queryContext, _contextType);
 
             return CompileAsyncQuery<TResult>(query)(queryContext);
         }
@@ -172,11 +173,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Func<QueryContext, IAsyncEnumerable<TResult>> CreateCompiledAsyncEnumerableQuery<TResult>(Expression query)
+        public virtual Func<QueryContext, IAsyncEnumerable<TResult>> CreateCompiledAsyncEnumerableQuery<TResult>(
+            Expression query)
         {
             Check.NotNull(query, nameof(query));
 
-            query = _queryModelGenerator.ExtractParameters(_logger, query, _queryContextFactory.Create(), parameterize: false);
+            query = _queryModelGenerator.ExtractParameters(
+                _logger, query, _queryContextFactory.Create(), _contextType, parameterize: false);
 
             return CompileAsyncQueryCore<TResult>(query, _queryModelGenerator, _database);
         }
@@ -189,7 +192,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         {
             Check.NotNull(query, nameof(query));
 
-            query = _queryModelGenerator.ExtractParameters(_logger, query, _queryContextFactory.Create(), parameterize: false);
+            query = _queryModelGenerator.ExtractParameters(
+                _logger, query, _queryContextFactory.Create(), _contextType, parameterize: false);
 
             var compiledQuery = CompileAsyncQueryCore<TResult>(query, _queryModelGenerator, _database);
 
@@ -197,7 +201,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         }
 
         private static Func<QueryContext, Task<TResult>> CreateCompiledSingletonAsyncQuery<TResult>(
-            Func<QueryContext, IAsyncEnumerable<TResult>> compiledQuery, IDiagnosticsLogger<DbLoggerCategory.Query> logger, Type contextType)
+            Func<QueryContext, IAsyncEnumerable<TResult>> compiledQuery,
+            IDiagnosticsLogger<DbLoggerCategory.Query> logger, Type contextType)
             => qc => ExecuteSingletonAsyncQuery(qc, compiledQuery, logger, contextType);
 
         /// <summary>
@@ -212,7 +217,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             queryContext.CancellationToken = cancellationToken;
 
-            query = _queryModelGenerator.ExtractParameters(_logger, query, queryContext);
+            query = _queryModelGenerator.ExtractParameters(_logger, query, queryContext, _contextType);
 
             var compiledQuery = CompileAsyncQuery<TResult>(query);
 
@@ -248,7 +253,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected virtual Func<QueryContext, IAsyncEnumerable<TResult>> CompileAsyncQuery<TResult>([NotNull] Expression query)
+        protected virtual Func<QueryContext, IAsyncEnumerable<TResult>> CompileAsyncQuery<TResult>(
+            [NotNull] Expression query)
         {
             Check.NotNull(query, nameof(query));
 

--- a/src/EFCore/Query/Internal/QueryModelGenerator.cs
+++ b/src/EFCore/Query/Internal/QueryModelGenerator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -46,6 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             IDiagnosticsLogger<DbLoggerCategory.Query> logger,
             Expression query,
             IParameterValues parameterValues,
+            Type contextType,
             bool parameterize = true,
             bool generateContextAccessors = false)
         {
@@ -57,6 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     _evaluatableExpressionFilter,
                     parameterValues,
                     logger,
+                    contextType,
                     parameterize,
                     generateContextAccessors);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryFilterFuncletizationSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryFilterFuncletizationSqlServerTest.cs
@@ -1,0 +1,440 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit.Abstractions;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class QueryFilterFuncletizationSqlServerTest
+        : QueryFilterFuncletizationTestBase<QueryFilterFuncletizationSqlServerTest.QueryFilterFuncletizationSqlServerFixture>
+    {
+        public QueryFilterFuncletizationSqlServerTest(
+            QueryFilterFuncletizationSqlServerFixture fixture,
+            ITestOutputHelper testOutputHelper)
+            : base(fixture)
+        {
+            Fixture.TestSqlLoggerFactory.Clear();
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        }
+
+        public override void DbContext_property_parameter_does_not_clash_with_closure_parameter_name()
+        {
+            base.DbContext_property_parameter_does_not_clash_with_closure_parameter_name();
+
+            AssertSql(
+                @"@__ef_filter__Field_0='False'
+@__Field_0='False'
+
+SELECT [e].[Id], [e].[IsEnabled]
+FROM [FieldFilter] AS [e]
+WHERE ([e].[IsEnabled] = @__ef_filter__Field_0) AND ([e].[IsEnabled] = @__Field_0)");
+        }
+
+        public override void DbContext_field_is_parametrized()
+        {
+            base.DbContext_field_is_parametrized();
+
+            AssertSql(
+                @"@__ef_filter__Field_0='False'
+
+SELECT [e].[Id], [e].[IsEnabled]
+FROM [FieldFilter] AS [e]
+WHERE [e].[IsEnabled] = @__ef_filter__Field_0",
+                //
+                @"@__ef_filter__Field_0='True'
+
+SELECT [e].[Id], [e].[IsEnabled]
+FROM [FieldFilter] AS [e]
+WHERE [e].[IsEnabled] = @__ef_filter__Field_0");
+        }
+
+        public override void DbContext_property_is_parametrized()
+        {
+            base.DbContext_property_is_parametrized();
+
+            AssertSql(
+                @"@__ef_filter__Property_0='False'
+
+SELECT [e].[Id], [e].[IsEnabled]
+FROM [PropertyFilter] AS [e]
+WHERE [e].[IsEnabled] = @__ef_filter__Property_0",
+                //
+                @"@__ef_filter__Property_0='True'
+
+SELECT [e].[Id], [e].[IsEnabled]
+FROM [PropertyFilter] AS [e]
+WHERE [e].[IsEnabled] = @__ef_filter__Property_0");
+        }
+
+        public override void DbContext_method_call_is_parametrized()
+        {
+            base.DbContext_method_call_is_parametrized();
+
+            AssertSql(
+                @"@__ef_filter__ef_filter_0='2'
+
+SELECT [e].[Id], [e].[Tenant]
+FROM [MethodCallFilter] AS [e]
+WHERE [e].[Tenant] = @__ef_filter__ef_filter_0");
+        }
+
+        public override void DbContext_list_is_parametrized()
+        {
+            base.DbContext_list_is_parametrized();
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[Tenant]
+FROM [ListFilter] AS [e]
+WHERE 0 = 1",
+                //
+                @"SELECT [e].[Id], [e].[Tenant]
+FROM [ListFilter] AS [e]
+WHERE [e].[Tenant] IN (1)",
+                //
+                @"SELECT [e].[Id], [e].[Tenant]
+FROM [ListFilter] AS [e]
+WHERE [e].[Tenant] IN (2, 3)");
+        }
+
+        public override void DbContext_property_chain_is_parametrized()
+        {
+            base.DbContext_property_chain_is_parametrized();
+
+            AssertSql(
+                @"@__ef_filter__Enabled_0='False'
+
+SELECT [e].[Id], [e].[IsEnabled]
+FROM [PropertyChainFilter] AS [e]
+WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0",
+                //
+                @"@__ef_filter__Enabled_0='True'
+
+SELECT [e].[Id], [e].[IsEnabled]
+FROM [PropertyChainFilter] AS [e]
+WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0");
+        }
+
+        public override void DbContext_property_method_call_is_parametrized()
+        {
+            base.DbContext_property_method_call_is_parametrized();
+
+            AssertSql(
+                @"@__ef_filter__ef_filter_0='2'
+
+SELECT [e].[Id], [e].[Tenant]
+FROM [PropertyMethodCallFilter] AS [e]
+WHERE [e].[Tenant] = @__ef_filter__ef_filter_0");
+        }
+
+        public override void DbContext_method_call_chain_is_parametrized()
+        {
+            base.DbContext_method_call_chain_is_parametrized();
+
+            AssertSql(
+                @"@__ef_filter__ef_filter_0='2'
+
+SELECT [e].[Id], [e].[Tenant]
+FROM [MethodCallChainFilter] AS [e]
+WHERE [e].[Tenant] = @__ef_filter__ef_filter_0");
+        }
+
+        public override void DbContext_complex_expression_is_parametrized()
+        {
+            base.DbContext_complex_expression_is_parametrized();
+
+            AssertSql(
+                @"@__ef_filter__Property_0='False'
+@__ef_filter__Tenant_1='0'
+@__ef_filter__ef_filter_2='2'
+
+SELECT [x].[Id], [x].[IsEnabled]
+FROM [ComplexFilter] AS [x]
+WHERE ([x].[IsEnabled] = @__ef_filter__Property_0) AND ((@__ef_filter__Tenant_1 + @__ef_filter__ef_filter_2) > 0)",
+                //
+                @"@__ef_filter__Property_0='True'
+@__ef_filter__Tenant_1='0'
+@__ef_filter__ef_filter_2='2'
+
+SELECT [x].[Id], [x].[IsEnabled]
+FROM [ComplexFilter] AS [x]
+WHERE ([x].[IsEnabled] = @__ef_filter__Property_0) AND ((@__ef_filter__Tenant_1 + @__ef_filter__ef_filter_2) > 0)",
+                //
+                @"@__ef_filter__Property_0='True'
+@__ef_filter__Tenant_1='-3'
+@__ef_filter__ef_filter_2='2'
+
+SELECT [x].[Id], [x].[IsEnabled]
+FROM [ComplexFilter] AS [x]
+WHERE ([x].[IsEnabled] = @__ef_filter__Property_0) AND ((@__ef_filter__Tenant_1 + @__ef_filter__ef_filter_2) > 0)");
+        }
+
+        public override void DbContext_property_based_filter_does_not_short_circuit()
+        {
+            base.DbContext_property_based_filter_does_not_short_circuit();
+
+            AssertSql(
+                @"@__ef_filter__IsModerated_0='True' (Nullable = true)
+@__ef_filter__IsModerated_1='True' (Nullable = true)
+
+SELECT [x].[Id], [x].[IsDeleted], [x].[IsModerated]
+FROM [ShortCircuitFilter] AS [x]
+WHERE ([x].[IsDeleted] = 0) AND (@__ef_filter__IsModerated_0 IS NULL OR (@__ef_filter__IsModerated_1 = [x].[IsModerated]))",
+                //
+                @"@__ef_filter__IsModerated_0='False' (Nullable = true)
+@__ef_filter__IsModerated_1='False' (Nullable = true)
+
+SELECT [x].[Id], [x].[IsDeleted], [x].[IsModerated]
+FROM [ShortCircuitFilter] AS [x]
+WHERE ([x].[IsDeleted] = 0) AND (@__ef_filter__IsModerated_0 IS NULL OR (@__ef_filter__IsModerated_1 = [x].[IsModerated]))",
+                //
+                @"@__ef_filter__IsModerated_0=''
+
+SELECT [x].[Id], [x].[IsDeleted], [x].[IsModerated]
+FROM [ShortCircuitFilter] AS [x]
+WHERE ([x].[IsDeleted] = 0) AND (@__ef_filter__IsModerated_0 IS NULL OR [x].[IsModerated] IS NULL)");
+        }
+
+        public override void EntityTypeConfiguration_DbContext_field_is_parametrized()
+        {
+            base.EntityTypeConfiguration_DbContext_field_is_parametrized();
+
+            AssertSql(
+                @"@__ef_filter__Field_0='False'
+
+SELECT [e].[Id], [e].[IsEnabled]
+FROM [EntityTypeConfigurationFieldFilter] AS [e]
+WHERE [e].[IsEnabled] = @__ef_filter__Field_0",
+                //
+                @"@__ef_filter__Field_0='True'
+
+SELECT [e].[Id], [e].[IsEnabled]
+FROM [EntityTypeConfigurationFieldFilter] AS [e]
+WHERE [e].[IsEnabled] = @__ef_filter__Field_0");
+        }
+
+        public override void EntityTypeConfiguration_DbContext_property_is_parametrized()
+        {
+            base.EntityTypeConfiguration_DbContext_property_is_parametrized();
+
+            AssertSql(
+                @"@__ef_filter__Property_0='False'
+
+SELECT [e].[Id], [e].[IsEnabled]
+FROM [EntityTypeConfigurationPropertyFilter] AS [e]
+WHERE [e].[IsEnabled] = @__ef_filter__Property_0",
+                //
+                @"@__ef_filter__Property_0='True'
+
+SELECT [e].[Id], [e].[IsEnabled]
+FROM [EntityTypeConfigurationPropertyFilter] AS [e]
+WHERE [e].[IsEnabled] = @__ef_filter__Property_0");
+        }
+
+        public override void EntityTypeConfiguration_DbContext_method_call_is_parametrized()
+        {
+            base.EntityTypeConfiguration_DbContext_method_call_is_parametrized();
+
+            AssertSql(
+                @"@__ef_filter__ef_filter_0='2'
+
+SELECT [e].[Id], [e].[Tenant]
+FROM [EntityTypeConfigurationMethodCallFilter] AS [e]
+WHERE [e].[Tenant] = @__ef_filter__ef_filter_0");
+        }
+
+        public override void EntityTypeConfiguration_DbContext_property_chain_is_parametrized()
+        {
+            base.EntityTypeConfiguration_DbContext_property_chain_is_parametrized();
+
+            AssertSql(
+                @"@__ef_filter__Enabled_0='False'
+
+SELECT [e].[Id], [e].[IsEnabled]
+FROM [EntityTypeConfigurationPropertyChainFilter] AS [e]
+WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0",
+                //
+                @"@__ef_filter__Enabled_0='True'
+
+SELECT [e].[Id], [e].[IsEnabled]
+FROM [EntityTypeConfigurationPropertyChainFilter] AS [e]
+WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0");
+        }
+
+        public override void Local_method_DbContext_field_is_parametrized()
+        {
+            base.Local_method_DbContext_field_is_parametrized();
+
+            AssertSql(
+                @"@__ef_filter__Field_0='False'
+
+SELECT [e].[Id], [e].[IsEnabled]
+FROM [LocalMethodFilter] AS [e]
+WHERE [e].[IsEnabled] = @__ef_filter__Field_0",
+                //
+                @"@__ef_filter__Field_0='True'
+
+SELECT [e].[Id], [e].[IsEnabled]
+FROM [LocalMethodFilter] AS [e]
+WHERE [e].[IsEnabled] = @__ef_filter__Field_0");
+        }
+
+        public override void Local_static_method_DbContext_property_is_parametrized()
+        {
+            base.Local_static_method_DbContext_property_is_parametrized();
+
+            AssertSql(
+                @"@__ef_filter__Property_0='False'
+
+SELECT [e].[Id], [e].[IsEnabled]
+FROM [LocalMethodParamsFilter] AS [e]
+WHERE [e].[IsEnabled] = @__ef_filter__Property_0",
+                //
+                @"@__ef_filter__Property_0='True'
+
+SELECT [e].[Id], [e].[IsEnabled]
+FROM [LocalMethodParamsFilter] AS [e]
+WHERE [e].[IsEnabled] = @__ef_filter__Property_0");
+        }
+
+        public override void Remote_method_DbContext_property_method_call_is_parametrized()
+        {
+            base.Remote_method_DbContext_property_method_call_is_parametrized();
+
+            AssertSql(
+                @"@__ef_filter__ef_filter_0='2'
+
+SELECT [e].[Id], [e].[Tenant]
+FROM [RemoteMethodParamsFilter] AS [e]
+WHERE [e].[Tenant] = @__ef_filter__ef_filter_0");
+        }
+
+        public override void Extension_method_DbContext_field_is_parametrized()
+        {
+            base.Extension_method_DbContext_field_is_parametrized();
+
+            AssertSql(
+                @"@__ef_filter__Field_0='False'
+
+SELECT [e].[Id], [e].[IsEnabled]
+FROM [ExtensionBuilderFilter] AS [e]
+WHERE [e].[IsEnabled] = @__ef_filter__Field_0",
+                //
+                @"@__ef_filter__Field_0='True'
+
+SELECT [e].[Id], [e].[IsEnabled]
+FROM [ExtensionBuilderFilter] AS [e]
+WHERE [e].[IsEnabled] = @__ef_filter__Field_0");
+        }
+
+        public override void Extension_method_DbContext_property_chain_is_parametrized()
+        {
+            base.Extension_method_DbContext_property_chain_is_parametrized();
+
+            AssertSql(
+                @"@__ef_filter__Enabled_0='False'
+
+SELECT [e].[Id], [e].[IsEnabled]
+FROM [ExtensionContextFilter] AS [e]
+WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0",
+                //
+                @"@__ef_filter__Enabled_0='True'
+
+SELECT [e].[Id], [e].[IsEnabled]
+FROM [ExtensionContextFilter] AS [e]
+WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0");
+        }
+
+        public override void Using_DbSet_in_filter_works()
+        {
+            base.Using_DbSet_in_filter_works();
+
+            AssertSql(
+                @"SELECT [p].[Id]
+FROM [PrincipalSetFilter] AS [p]
+WHERE EXISTS (
+    SELECT 1
+    FROM [Dependents] AS [d]
+    WHERE [d].[PrincipalSetFilterId] = [p].[Id])");
+        }
+
+        public override void Using_Context_set_method_in_filter_works()
+        {
+            base.Using_Context_set_method_in_filter_works();
+
+            AssertSql(
+                @"SELECT [p].[Id], [p].[PrincipalSetFilterId]
+FROM [Dependents] AS [p]
+WHERE EXISTS (
+    SELECT 1
+    FROM [PrincipalSetFilter] AS [b]
+    WHERE [b].[Id] = [p].[PrincipalSetFilterId])");
+        }
+
+        public override void Static_member_from_dbContext_is_inlined()
+        {
+            base.Static_member_from_dbContext_is_inlined();
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[UserId]
+FROM [DbContextStaticMemberFilter] AS [e]
+WHERE [e].[UserId] <> 1");
+        }
+
+        public override void Static_member_from_non_dbContext_is_inlined()
+        {
+            base.Static_member_from_non_dbContext_is_inlined();
+
+            AssertSql(
+                @"SELECT [b].[Id], [b].[IsEnabled]
+FROM [StaticMemberFilter] AS [b]
+WHERE [b].[IsEnabled] = 1");
+        }
+
+        public override void Local_variable_from_OnModelCreating_is_inlined()
+        {
+            base.Local_variable_from_OnModelCreating_is_inlined();
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[IsEnabled]
+FROM [LocalVariableFilter] AS [e]
+WHERE [e].[IsEnabled] = 1");
+        }
+
+        public override void Method_parameter_is_inlined()
+        {
+            base.Method_parameter_is_inlined();
+
+            AssertSql(
+                @"SELECT [e].[Id], [e].[Tenant]
+FROM [ParameterFilter] AS [e]
+WHERE [e].[Tenant] = 0");
+        }
+
+        public override void Using_multiple_context_in_filter_parametrize_only_current_context()
+        {
+            base.Using_multiple_context_in_filter_parametrize_only_current_context();
+
+            AssertSql(
+                @"@__ef_filter__Property_0='False'
+
+SELECT [e].[Id], [e].[BossId], [e].[IsEnabled]
+FROM [MultiContextFilter] AS [e]
+WHERE ([e].[IsEnabled] = @__ef_filter__Property_0) AND ([e].[BossId] = 1)",
+                //
+                @"@__ef_filter__Property_0='True'
+
+SELECT [e].[Id], [e].[BossId], [e].[IsEnabled]
+FROM [MultiContextFilter] AS [e]
+WHERE ([e].[IsEnabled] = @__ef_filter__Property_0) AND ([e].[BossId] = 1)");
+        }
+
+        private void AssertSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+        public class QueryFilterFuncletizationSqlServerFixture : QueryFilterFuncletizationRelationalFixture
+        {
+            protected override ITestStoreFactory TestStoreFactory => SqlServerTestStoreFactory.Instance;
+        }
+    }
+}


### PR DESCRIPTION
…rrent context values

Resolves #10301

Expression of current derived DbContext type (or its basetype) will be replaced will be captured and replaced with current context at runtime.

Filter configuration patterns which would be parametrized for current context:
- Defining filter in OnModelCreating
- Defining filter in EntityTypeConfiguration by passing context through constructor
- Defining filter using method (inside/outside DbContext or extension method) where context is passed as parameter.
- Any of above where context is wrapped inside another object type and that type is being passed around.

Any expression chaining after context (Property/Field access, MethodCall, multiple level of above) would be parametrized.

Any derived DbContext which is not in BaseType chain of current context would get evaluated and inlined.