### PR TITLE
Fix to #10988 - Query: accessing property on a required navigation defined on a derived type produces INNER JOIN

### DIFF
--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryFixtureBase.cs
@@ -29,7 +29,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 { typeof(Mission), e => e?.Id },
                 { typeof(Squad), e => e?.Id },
                 { typeof(SquadMission), e => e?.SquadId + " " + e?.MissionId },
-                { typeof(Weapon), e => e?.Id }
+                { typeof(Weapon), e => e?.Id },
+                { typeof(LocustHighCommand), e => e?.Id },
             };
 
             var entityAsserters = new Dictionary<Type, Action<dynamic, dynamic>>
@@ -272,11 +273,16 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             modelBuilder.Entity<LocustHorde>().HasBaseType<Faction>();
             modelBuilder.Entity<LocustHorde>().HasMany(h => h.Leaders).WithOne();
-            modelBuilder.Entity<LocustHorde>().HasOne(h => h.Commander).WithOne(c => c.CommandingFaction);
+
+            // TODO: explicit FK declaration can be removed once #11019 is fixed
+            modelBuilder.Entity<LocustHorde>().HasOne(h => h.Commander).WithOne(c => c.CommandingFaction).HasForeignKey<LocustHorde>(k => k.CommanderName); 
 
             modelBuilder.Entity<LocustLeader>().HasKey(l => l.Name);
             modelBuilder.Entity<LocustCommander>().HasBaseType<LocustLeader>();
             modelBuilder.Entity<LocustCommander>().HasOne(c => c.DefeatedBy).WithOne().HasForeignKey<LocustCommander>(c => new { c.DefeatedByNickname, c.DefeatedBySquadId });
+
+            modelBuilder.Entity<LocustHighCommand>().HasKey(l => l.Id);
+            modelBuilder.Entity<LocustHighCommand>().Property(l => l.Id).ValueGeneratedNever();
         }
 
         protected override void Seed(GearsOfWarContext context) => GearsOfWarContext.Seed(context);

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -4243,6 +4243,22 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.Name);
         }
 
+        [ConditionalFact]
+        public virtual void Select_required_navigation_on_derived_type()
+        {
+            AssertQuery<LocustLeader>(
+                lls => lls.Select(ll => ((LocustCommander)ll).HighCommand.Name),
+                lls => lls.Select(ll => ll is LocustCommander ? ((LocustCommander)ll).HighCommand.Name : null));
+        }
+
+        [ConditionalFact]
+        public virtual void Where_required_navigation_on_derived_type()
+        {
+            AssertQuery<LocustLeader>(
+                lls => lls.Where(ll => ((LocustCommander)ll).HighCommand.IsOperational),
+                lls => lls.Where(ll => ll is LocustCommander ? ((LocustCommander)ll).HighCommand.IsOperational : false));
+        }
+
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();
 
         protected virtual void ClearLog()

--- a/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarContext.cs
+++ b/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarContext.cs
@@ -21,6 +21,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
         public DbSet<SquadMission> SquadMissions { get; set; }
         public DbSet<Faction> Factions { get; set; }
         public DbSet<LocustLeader> LocustLeaders { get; set; }
+        public DbSet<LocustHighCommand> LocustHighCommands { get; set; }
 
         public static void Seed(GearsOfWarContext context)
         {
@@ -33,8 +34,9 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
             var gears = GearsOfWarData.CreateGears();
             var locustLeaders = GearsOfWarData.CreateLocustLeaders();
             var factions = GearsOfWarData.CreateFactions();
+            var locustHighCommands = GearsOfWarData.CreateHighCommands();
 
-            GearsOfWarData.WireUp(squads, missions, squadMissions, cities, weapons, tags, gears, locustLeaders, factions);
+            GearsOfWarData.WireUp(squads, missions, squadMissions, cities, weapons, tags, gears, locustLeaders, factions, locustHighCommands);
 
             context.Squads.AddRange(squads);
             context.Missions.AddRange(missions);
@@ -45,6 +47,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
             context.Gears.AddRange(gears);
             context.LocustLeaders.AddRange(locustLeaders);
             context.Factions.AddRange(factions);
+            context.LocustHighCommands.AddRange(locustHighCommands);
             context.SaveChanges();
 
             GearsOfWarData.WireUp2(locustLeaders, factions);

--- a/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarData.cs
+++ b/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarData.cs
@@ -19,6 +19,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
         public IReadOnlyList<SquadMission> SquadMissions { get; }
         public IReadOnlyList<Weapon> Weapons { get; }
         public IReadOnlyList<LocustLeader> LocustLeaders { get; }
+        public IReadOnlyList<LocustHighCommand> LocustHighCommands { get; }
 
         public GearsOfWarData()
         {
@@ -31,8 +32,9 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
             Gears = CreateGears();
             LocustLeaders = CreateLocustLeaders();
             Factions = CreateFactions();
+            LocustHighCommands = CreateHighCommands();
 
-            WireUp(Squads, Missions, SquadMissions, Cities, Weapons, Tags, Gears, LocustLeaders, Factions);
+            WireUp(Squads, Missions, SquadMissions, Cities, Weapons, Tags, Gears, LocustLeaders, Factions, LocustHighCommands);
             WireUp2(LocustLeaders, Factions);
         }
 
@@ -82,6 +84,11 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
             if (typeof(TEntity) == typeof(LocustLeader))
             {
                 return (IQueryable<TEntity>)LocustLeaders.AsQueryable();
+            }
+
+            if (typeof(TEntity) == typeof(LocustHighCommand))
+            {
+                return (IQueryable<TEntity>)LocustHighCommands.AsQueryable();
             }
 
             throw new InvalidOperationException("Invalid entity type: " + typeof(TEntity));
@@ -221,6 +228,12 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
                 new LocustHorde { Id = 2, Name = "Swarm", Eradicated = false, CommanderName = "Unknown" }
             };
 
+        public static IReadOnlyList<LocustHighCommand> CreateHighCommands()
+            => new List<LocustHighCommand>
+            {
+                new LocustHighCommand { Id = 1, Name = "Locust Main Command", IsOperational = true },
+            };
+        
         public static void WireUp(
             IReadOnlyList<Squad> squads,
             IReadOnlyList<Mission> missions,
@@ -230,7 +243,8 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
             IReadOnlyList<CogTag> tags,
             IReadOnlyList<Gear> gears,
             IReadOnlyList<LocustLeader> locustLeaders,
-            IReadOnlyList<Faction> factions)
+            IReadOnlyList<Faction> factions,
+            IReadOnlyList<LocustHighCommand> locustHighCommands)
         {
             squadMissions[0].Mission = missions[0];
             squadMissions[0].MissionId = missions[0].Id;
@@ -351,6 +365,14 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
 
             ((LocustHorde)factions[0]).Commander = ((LocustCommander)locustLeaders[3]);
             ((LocustHorde)factions[1]).Commander = ((LocustCommander)locustLeaders[5]);
+
+            locustHighCommands[0].Commanders = new List<LocustCommander> { (LocustCommander)locustLeaders[3], (LocustCommander)locustLeaders[5] };
+
+            ((LocustCommander)locustLeaders[3]).HighCommand = locustHighCommands[0];
+            ((LocustCommander)locustLeaders[3]).HighCommandId = 1;
+
+            ((LocustCommander)locustLeaders[5]).HighCommand = locustHighCommands[0];
+            ((LocustCommander)locustLeaders[5]).HighCommandId = 1;
         }
 
         public static void WireUp2(

--- a/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/LocustCommander.cs
+++ b/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/LocustCommander.cs
@@ -10,5 +10,8 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
         public string DefeatedByNickname { get; set; }
         public int? DefeatedBySquadId { get; set; }
         public Gear DefeatedBy { get; set; }
+
+        public LocustHighCommand HighCommand { get; set; }
+        public int HighCommandId { get; set; }
     }
 }

--- a/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/LocustHighCommand.cs
+++ b/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/LocustHighCommand.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
+{
+    public class LocustHighCommand
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+        public bool IsOperational { get; set; }
+
+        public List<LocustCommander> Commanders { get; set; }
+    }
+}

--- a/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -77,11 +77,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             return builder.ToString();
         }
 
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static IEnumerable<IEntityType> GetAllBaseTypesInclusive([NotNull] this IEntityType entityType)
+            => new List<IEntityType>(GetAllBaseTypes(entityType)) { entityType };
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static IEnumerable<IEntityType> GetAllBaseTypes([NotNull] this IEntityType entityType)
         {
             var baseTypes = new List<IEntityType>();
             var currentEntityType = entityType;
@@ -92,7 +100,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             baseTypes.Reverse();
-            baseTypes.Add(entityType);
 
             return baseTypes;
         }

--- a/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
@@ -1000,7 +1000,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 var addNullCheckToOuterKeySelector = optionalNavigationInChain;
 
                 if (!navigation.ForeignKey.IsRequired
-                    || !navigation.IsDependentToPrincipal())
+                    || !navigation.IsDependentToPrincipal()
+                    || (navigation.DeclaringEntityType.ClrType != querySourceReferenceExpression.Type
+                        && navigation.DeclaringEntityType.GetAllBaseTypes().Any(t => t.ClrType == querySourceReferenceExpression.Type)))
                 {
                     optionalNavigationInChain = true;
                 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -3647,7 +3647,7 @@ ORDER BY [LeaderName]");
             base.Include_on_derived_entity_using_OfType();
 
             AssertSql(
-                @"SELECT [lh].[Id], [lh].[CapitalName], [lh].[Discriminator], [lh].[Name], [lh].[CommanderName], [lh].[Eradicated], [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId]
+                @"SELECT [lh].[Id], [lh].[CapitalName], [lh].[Discriminator], [lh].[Name], [lh].[CommanderName], [lh].[Eradicated], [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId]
 FROM [Factions] AS [lh]
 LEFT JOIN (
     SELECT [lh.Commander].*
@@ -3657,7 +3657,7 @@ LEFT JOIN (
 WHERE [lh].[Discriminator] = N'LocustHorde'
 ORDER BY [lh].[Name], [lh].[Id]",
                 //
-                @"SELECT [lh.Leaders].[Name], [lh.Leaders].[Discriminator], [lh.Leaders].[LocustHordeId], [lh.Leaders].[ThreatLevel], [lh.Leaders].[DefeatedByNickname], [lh.Leaders].[DefeatedBySquadId]
+                @"SELECT [lh.Leaders].[Name], [lh.Leaders].[Discriminator], [lh.Leaders].[LocustHordeId], [lh.Leaders].[ThreatLevel], [lh.Leaders].[DefeatedByNickname], [lh.Leaders].[DefeatedBySquadId], [lh.Leaders].[HighCommandId]
 FROM [LocustLeaders] AS [lh.Leaders]
 INNER JOIN (
     SELECT DISTINCT [lh0].[Id], [lh0].[Name]
@@ -3678,7 +3678,7 @@ ORDER BY [t1].[Name], [t1].[Id]");
             base.Include_on_derived_entity_using_subquery_with_cast();
 
             AssertSql(
-                @"SELECT [f].[Id], [f].[CapitalName], [f].[Discriminator], [f].[Name], [f].[CommanderName], [f].[Eradicated], [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId]
+                @"SELECT [f].[Id], [f].[CapitalName], [f].[Discriminator], [f].[Name], [f].[CommanderName], [f].[Eradicated], [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId]
 FROM [Factions] AS [f]
 LEFT JOIN (
     SELECT [f.Commander].*
@@ -3691,7 +3691,7 @@ END = [t].[Name]
 WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')
 ORDER BY [f].[Name], [f].[Id]",
                 //
-                @"SELECT [f.Leaders].[Name], [f.Leaders].[Discriminator], [f.Leaders].[LocustHordeId], [f.Leaders].[ThreatLevel], [f.Leaders].[DefeatedByNickname], [f.Leaders].[DefeatedBySquadId]
+                @"SELECT [f.Leaders].[Name], [f.Leaders].[Discriminator], [f.Leaders].[LocustHordeId], [f.Leaders].[ThreatLevel], [f.Leaders].[DefeatedByNickname], [f.Leaders].[DefeatedBySquadId], [f.Leaders].[HighCommandId]
 FROM [LocustLeaders] AS [f.Leaders]
 INNER JOIN (
     SELECT DISTINCT [f0].[Id], [f0].[Name]
@@ -3715,7 +3715,7 @@ ORDER BY [t1].[Name], [t1].[Id]");
             base.Include_on_derived_entity_using_subquery_with_cast_AsNoTracking();
 
             AssertSql(
-                @"SELECT [f].[Id], [f].[CapitalName], [f].[Discriminator], [f].[Name], [f].[CommanderName], [f].[Eradicated], [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId]
+                @"SELECT [f].[Id], [f].[CapitalName], [f].[Discriminator], [f].[Name], [f].[CommanderName], [f].[Eradicated], [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId]
 FROM [Factions] AS [f]
 LEFT JOIN (
     SELECT [f.Commander].*
@@ -3728,7 +3728,7 @@ END = [t].[Name]
 WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'LocustHorde')
 ORDER BY [f].[Name], [f].[Id]",
                 //
-                @"SELECT [f.Leaders].[Name], [f.Leaders].[Discriminator], [f.Leaders].[LocustHordeId], [f.Leaders].[ThreatLevel], [f.Leaders].[DefeatedByNickname], [f.Leaders].[DefeatedBySquadId]
+                @"SELECT [f.Leaders].[Name], [f.Leaders].[Discriminator], [f.Leaders].[LocustHordeId], [f.Leaders].[ThreatLevel], [f.Leaders].[DefeatedByNickname], [f.Leaders].[DefeatedBySquadId], [f.Leaders].[HighCommandId]
 FROM [LocustLeaders] AS [f.Leaders]
 INNER JOIN (
     SELECT DISTINCT [f0].[Id], [f0].[Name]
@@ -3752,7 +3752,7 @@ ORDER BY [t1].[Name], [t1].[Id]");
             base.Include_on_derived_entity_using_subquery_with_cast_cross_product_base_entity();
 
             AssertSql(
-                @"SELECT [f2].[Id], [f2].[CapitalName], [f2].[Discriminator], [f2].[Name], [f2].[CommanderName], [f2].[Eradicated], [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [ff].[Id], [ff].[CapitalName], [ff].[Discriminator], [ff].[Name], [ff].[CommanderName], [ff].[Eradicated], [ff.Capital].[Name], [ff.Capital].[Location]
+                @"SELECT [f2].[Id], [f2].[CapitalName], [f2].[Discriminator], [f2].[Name], [f2].[CommanderName], [f2].[Eradicated], [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [ff].[Id], [ff].[CapitalName], [ff].[Discriminator], [ff].[Name], [ff].[CommanderName], [ff].[Eradicated], [ff.Capital].[Name], [ff.Capital].[Location]
 FROM [Factions] AS [f2]
 LEFT JOIN (
     SELECT [f2.Commander].*
@@ -3767,7 +3767,7 @@ LEFT JOIN [Cities] AS [ff.Capital] ON [ff].[CapitalName] = [ff.Capital].[Name]
 WHERE ([f2].[Discriminator] = N'LocustHorde') AND ([f2].[Discriminator] = N'LocustHorde')
 ORDER BY [f2].[Name], [ff].[Name], [f2].[Id]",
                 //
-                @"SELECT [f2.Leaders].[Name], [f2.Leaders].[Discriminator], [f2.Leaders].[LocustHordeId], [f2.Leaders].[ThreatLevel], [f2.Leaders].[DefeatedByNickname], [f2.Leaders].[DefeatedBySquadId]
+                @"SELECT [f2.Leaders].[Name], [f2.Leaders].[Discriminator], [f2.Leaders].[LocustHordeId], [f2.Leaders].[ThreatLevel], [f2.Leaders].[DefeatedByNickname], [f2.Leaders].[DefeatedBySquadId], [f2.Leaders].[HighCommandId]
 FROM [LocustLeaders] AS [f2.Leaders]
 INNER JOIN (
     SELECT DISTINCT [f20].[Id], [f20].[Name], [ff0].[Name] AS [Name0]
@@ -3927,7 +3927,7 @@ LEFT JOIN (
 WHERE [h].[Discriminator] = N'LocustHorde'
 ORDER BY [h].[Id], [t0].[Id]",
                 //
-                @"SELECT [h.Commander.CommandingFaction.Leaders].[Name], [h.Commander.CommandingFaction.Leaders].[Discriminator], [h.Commander.CommandingFaction.Leaders].[LocustHordeId], [h.Commander.CommandingFaction.Leaders].[ThreatLevel], [h.Commander.CommandingFaction.Leaders].[DefeatedByNickname], [h.Commander.CommandingFaction.Leaders].[DefeatedBySquadId], [t3].[Id], [t3].[Id0]
+                @"SELECT [h.Commander.CommandingFaction.Leaders].[Name], [h.Commander.CommandingFaction.Leaders].[Discriminator], [h.Commander.CommandingFaction.Leaders].[LocustHordeId], [h.Commander.CommandingFaction.Leaders].[ThreatLevel], [h.Commander.CommandingFaction.Leaders].[DefeatedByNickname], [h.Commander.CommandingFaction.Leaders].[DefeatedBySquadId], [h.Commander.CommandingFaction.Leaders].[HighCommandId], [t3].[Id], [t3].[Id0]
 FROM [LocustLeaders] AS [h.Commander.CommandingFaction.Leaders]
 INNER JOIN (
     SELECT [h0].[Id], [t2].[Id] AS [Id0]
@@ -4041,7 +4041,7 @@ ORDER BY [t3].[Id], [t3].[Nickname], [t3].[SquadId]");
             base.Include_reference_on_derived_type_using_string();
 
             AssertSql(
-                @"SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
+                @"SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
 FROM [LocustLeaders] AS [l]
 LEFT JOIN (
     SELECT [l.DefeatedBy].*
@@ -4062,7 +4062,7 @@ WHERE [l].[Discriminator] IN (N'LocustCommander', N'LocustLeader')");
             base.Include_reference_on_derived_type_using_string_nested1();
 
             AssertSql(
-                @"SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [l.DefeatedBy.Squad].[Id], [l.DefeatedBy.Squad].[InternalNumber], [l.DefeatedBy.Squad].[Name]
+                @"SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank], [l.DefeatedBy.Squad].[Id], [l.DefeatedBy.Squad].[InternalNumber], [l.DefeatedBy.Squad].[Name]
 FROM [LocustLeaders] AS [l]
 LEFT JOIN (
     SELECT [l.DefeatedBy].*
@@ -4084,7 +4084,7 @@ WHERE [l].[Discriminator] IN (N'LocustCommander', N'LocustLeader')");
             base.Include_reference_on_derived_type_using_string_nested2();
 
             AssertSql(
-                @"SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
+                @"SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
 FROM [LocustLeaders] AS [l]
 LEFT JOIN (
     SELECT [l.DefeatedBy].*
@@ -4128,7 +4128,7 @@ ORDER BY [t1].[Nickname], [t1].[SquadId]");
             base.Include_reference_on_derived_type_using_lambda();
 
             AssertSql(
-                @"SELECT [ll].[Name], [ll].[Discriminator], [ll].[LocustHordeId], [ll].[ThreatLevel], [ll].[DefeatedByNickname], [ll].[DefeatedBySquadId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
+                @"SELECT [ll].[Name], [ll].[Discriminator], [ll].[LocustHordeId], [ll].[ThreatLevel], [ll].[DefeatedByNickname], [ll].[DefeatedBySquadId], [ll].[HighCommandId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
 FROM [LocustLeaders] AS [ll]
 LEFT JOIN (
     SELECT [ll.DefeatedBy].*
@@ -4149,7 +4149,7 @@ WHERE [ll].[Discriminator] IN (N'LocustCommander', N'LocustLeader')");
             base.Include_reference_on_derived_type_using_lambda_with_soft_cast();
 
             AssertSql(
-                @"SELECT [ll].[Name], [ll].[Discriminator], [ll].[LocustHordeId], [ll].[ThreatLevel], [ll].[DefeatedByNickname], [ll].[DefeatedBySquadId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
+                @"SELECT [ll].[Name], [ll].[Discriminator], [ll].[LocustHordeId], [ll].[ThreatLevel], [ll].[DefeatedByNickname], [ll].[DefeatedBySquadId], [ll].[HighCommandId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
 FROM [LocustLeaders] AS [ll]
 LEFT JOIN (
     SELECT [ll.DefeatedBy].*
@@ -4170,7 +4170,7 @@ WHERE [ll].[Discriminator] IN (N'LocustCommander', N'LocustLeader')");
             base.Include_reference_on_derived_type_using_lambda_with_tracking();
 
             AssertSql(
-                @"SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
+                @"SELECT [l].[Name], [l].[Discriminator], [l].[LocustHordeId], [l].[ThreatLevel], [l].[DefeatedByNickname], [l].[DefeatedBySquadId], [l].[HighCommandId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
 FROM [LocustLeaders] AS [l]
 LEFT JOIN (
     SELECT [l.DefeatedBy].*
@@ -4304,7 +4304,7 @@ ORDER BY [t3].[FullName]");
             base.ThenInclude_collection_on_derived_after_derived_reference();
 
             AssertSql(
-                @"SELECT [f].[Id], [f].[CapitalName], [f].[Discriminator], [f].[Name], [f].[CommanderName], [f].[Eradicated], [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank]
+                @"SELECT [f].[Id], [f].[CapitalName], [f].[Discriminator], [f].[Name], [f].[CommanderName], [f].[Eradicated], [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank]
 FROM [Factions] AS [f]
 LEFT JOIN (
     SELECT [f.Commander].*
@@ -4392,7 +4392,7 @@ FROM [Factions] AS [f]
 WHERE [f].[Discriminator] = N'LocustHorde'
 ORDER BY [f].[Id]",
                 //
-                @"SELECT [f.Leaders].[Name], [f.Leaders].[Discriminator], [f.Leaders].[LocustHordeId], [f.Leaders].[ThreatLevel], [f.Leaders].[DefeatedByNickname], [f.Leaders].[DefeatedBySquadId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
+                @"SELECT [f.Leaders].[Name], [f.Leaders].[Discriminator], [f.Leaders].[LocustHordeId], [f.Leaders].[ThreatLevel], [f.Leaders].[DefeatedByNickname], [f.Leaders].[DefeatedBySquadId], [f.Leaders].[HighCommandId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
 FROM [LocustLeaders] AS [f.Leaders]
 LEFT JOIN (
     SELECT [l.DefeatedBy].*
@@ -4419,7 +4419,7 @@ ORDER BY [t0].[Id]");
             base.Multiple_derived_included_on_one_method();
 
             AssertSql(
-                @"SELECT [f].[Id], [f].[CapitalName], [f].[Discriminator], [f].[Name], [f].[CommanderName], [f].[Eradicated], [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank]
+                @"SELECT [f].[Id], [f].[CapitalName], [f].[Discriminator], [f].[Name], [f].[CommanderName], [f].[Eradicated], [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank]
 FROM [Factions] AS [f]
 LEFT JOIN (
     SELECT [f.Commander].*
@@ -6004,7 +6004,7 @@ WHERE [ll].[Discriminator] IN (N'LocustCommander', N'LocustLeader') AND (([t].[E
             AssertSql(
                 @"@__p_0='10'
 
-SELECT TOP(@__p_0) [ll].[Name], [ll].[Discriminator], [ll].[LocustHordeId], [ll].[ThreatLevel], [ll].[DefeatedByNickname], [ll].[DefeatedBySquadId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
+SELECT TOP(@__p_0) [ll].[Name], [ll].[Discriminator], [ll].[LocustHordeId], [ll].[ThreatLevel], [ll].[DefeatedByNickname], [ll].[DefeatedBySquadId], [ll].[HighCommandId], [t].[Nickname], [t].[SquadId], [t].[AssignedCityName], [t].[CityOrBirthName], [t].[Discriminator], [t].[FullName], [t].[HasSoulPatch], [t].[LeaderNickname], [t].[LeaderSquadId], [t].[Rank]
 FROM [LocustLeaders] AS [ll]
 LEFT JOIN (
     SELECT [ll.DefeatedBy].*
@@ -6047,6 +6047,34 @@ INNER JOIN (
     ) AS [t1]
 ) AS [t2] ON [ll.DefeatedBy.Weapons].[OwnerFullName] = [t2].[FullName]
 ORDER BY [t2].[Note], [t2].[FullName]");
+        }
+
+        public override void Select_required_navigation_on_derived_type()
+        {
+            base.Select_required_navigation_on_derived_type();
+
+            AssertSql(
+                @"SELECT [ll.HighCommand].[Name]
+FROM [LocustLeaders] AS [ll]
+LEFT JOIN [LocustHighCommands] AS [ll.HighCommand] ON CASE
+    WHEN [ll].[Discriminator] = N'LocustCommander'
+    THEN [ll].[HighCommandId] ELSE NULL
+END = [ll.HighCommand].[Id]
+WHERE [ll].[Discriminator] IN (N'LocustCommander', N'LocustLeader')");
+        }
+
+        public override void Where_required_navigation_on_derived_type()
+        {
+            base.Where_required_navigation_on_derived_type();
+
+            AssertSql(
+                @"SELECT [ll].[Name], [ll].[Discriminator], [ll].[LocustHordeId], [ll].[ThreatLevel], [ll].[DefeatedByNickname], [ll].[DefeatedBySquadId], [ll].[HighCommandId]
+FROM [LocustLeaders] AS [ll]
+LEFT JOIN [LocustHighCommands] AS [ll.HighCommand] ON CASE
+    WHEN [ll].[Discriminator] = N'LocustCommander'
+    THEN [ll].[HighCommandId] ELSE NULL
+END = [ll.HighCommand].[Id]
+WHERE [ll].[Discriminator] IN (N'LocustCommander', N'LocustLeader') AND ([ll.HighCommand].[IsOperational] = 1)");
         }
 
         private void AssertSql(params string[] expected)


### PR DESCRIPTION
Problem was that when determining whether given navigation should be represented by INNER JOIN we were looking if it was required and its direction (dependent to principal). However if navigation is defined on derived type in TPH, it can be required and dependent to principal, and should still be represented as LEFT JOIN, because base types don't have the relationship defined for them.

Fix is to check whether navigation is not defined on derived type on top of previous checks.