### PR TITLE
Pass enum literals to type mapper for value conversion

### DIFF
--- a/samples/OracleProvider/test/OracleProvider.FunctionalTests/BuiltInDataTypesOracleTest.cs
+++ b/samples/OracleProvider/test/OracleProvider.FunctionalTests/BuiltInDataTypesOracleTest.cs
@@ -73,15 +73,6 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [Fact]
-        public virtual void Can_perform_query_with_ansi_strings()
-        {
-            Can_perform_query_with_ansi_strings_test(
-                supportsAnsi: true,
-                supportsUnicodeToAnsiConversion: false,
-                supportsLargeStringComparisons: false);
-        }
-
-        [Fact]
         public void Sql_translation_uses_type_mapping_when_constant()
         {
             using (var context = CreateContext())
@@ -360,12 +351,6 @@ WHERE ""e"".""Time"" = :timeSpan_0",
                 decimal? param40 = null;
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.Numeric == param40));
             }
-        }
-
-        [Fact]
-        public virtual void Can_query_using_any_nullable_data_type_as_literal()
-        {
-            Can_query_using_any_nullable_data_type_as_literal_helper(strictEquality: false);
         }
 
         [Fact]
@@ -2133,6 +2118,14 @@ UnicodeDataTypes.StringUnicode ---> [NVARCHAR2] [MaxLength = 4000]
 
         public class BuiltInDataTypesOracleFixture : BuiltInDataTypesFixtureBase
         {
+            public override bool StrictEquality => false;
+
+            public override bool SupportsAnsi => true;
+
+            public override bool SupportsUnicodeToAnsiConversion => false;
+
+            public override bool SupportsLargeStringComparisons => false;
+
             protected override ITestStoreFactory TestStoreFactory => OracleTestStoreFactory.Instance;
             public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ServiceProvider.GetRequiredService<ILoggerFactory>();
 

--- a/samples/OracleProvider/test/OracleProvider.FunctionalTests/ConvertToStoreTypesOracleTest.cs
+++ b/samples/OracleProvider/test/OracleProvider.FunctionalTests/ConvertToStoreTypesOracleTest.cs
@@ -26,6 +26,14 @@ namespace Microsoft.EntityFrameworkCore
 
         public class ConvertToStoreTypesOracleFixture : ConvertToStoreTypesFixtureBase
         {
+            public override bool StrictEquality => false;
+
+            public override bool SupportsAnsi => true;
+
+            public override bool SupportsUnicodeToAnsiConversion => false;
+
+            public override bool SupportsLargeStringComparisons => false;
+
             protected override ITestStoreFactory TestStoreFactory => OracleTestStoreFactory.Instance;
             public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ServiceProvider.GetRequiredService<ILoggerFactory>();
 

--- a/samples/OracleProvider/test/OracleProvider.FunctionalTests/CustomConvertersOracleTest.cs
+++ b/samples/OracleProvider/test/OracleProvider.FunctionalTests/CustomConvertersOracleTest.cs
@@ -21,6 +21,14 @@ namespace Microsoft.EntityFrameworkCore
 
         public class CustomConvertersOracleFixture : CustomConvertersFixtureBase
         {
+            public override bool StrictEquality => false;
+
+            public override bool SupportsAnsi => true;
+
+            public override bool SupportsUnicodeToAnsiConversion => false;
+
+            public override bool SupportsLargeStringComparisons => false;
+
             protected override ITestStoreFactory TestStoreFactory => OracleTestStoreFactory.Instance;
 
             public override bool SupportsBinaryKeys => true;

--- a/src/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
+++ b/src/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
@@ -60,10 +60,10 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        protected virtual void Can_perform_query_with_ansi_strings_test(
-            bool supportsAnsi, bool supportsUnicodeToAnsiConversion = true, bool supportsLargeStringComparisons = true)
+        [Fact]
+        public virtual void Can_perform_query_with_ansi_strings_test()
         {
-            var shortString = supportsUnicodeToAnsiConversion ? "Ϩky" : "sky";
+            var shortString = Fixture.SupportsUnicodeToAnsiConversion ? "Ϩky" : "sky";
             var longString = new string('Ϩ', Fixture.LongStringLength);
 
             using (var context = CreateContext())
@@ -88,7 +88,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.NotNull(context.Set<UnicodeDataTypes>().Where(e => e.Id == 799 && e.StringAnsi == shortString).ToList().SingleOrDefault());
                 Assert.NotNull(context.Set<UnicodeDataTypes>().Where(e => e.Id == 799 && e.StringAnsi3 == shortString).ToList().SingleOrDefault());
 
-                if (supportsLargeStringComparisons)
+                if (Fixture.SupportsLargeStringComparisons)
                 {
                     Assert.NotNull(context.Set<UnicodeDataTypes>().Where(e => e.Id == 799 && e.StringAnsi9000 == longString).ToList().SingleOrDefault());
                 }
@@ -100,7 +100,7 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Equal(shortString, entity.StringDefault);
                 Assert.Equal(shortString, entity.StringUnicode);
 
-                if (supportsAnsi && supportsUnicodeToAnsiConversion)
+                if (Fixture.SupportsAnsi && Fixture.SupportsUnicodeToAnsiConversion)
                 {
                     Assert.NotEqual(shortString, entity.StringAnsi);
                     Assert.NotEqual(shortString, entity.StringAnsi3);
@@ -503,7 +503,8 @@ namespace Microsoft.EntityFrameworkCore
             return entityEntry;
         }
 
-        protected virtual void Can_query_using_any_nullable_data_type_as_literal_helper(bool strictEquality)
+        [Fact]
+        public virtual void Can_query_using_any_nullable_data_type_as_literal()
         {
             using (var context = CreateContext())
             {
@@ -554,7 +555,7 @@ namespace Microsoft.EntityFrameworkCore
 
                 Assert.Same(
                     entity,
-                    strictEquality
+                    Fixture.StrictEquality
                         ? context.Set<BuiltInNullableDataTypes>().Where(e => e.Id == 12 && e.TestNullableDouble == -1.23456789).ToList().Single()
                         : context.Set<BuiltInNullableDataTypes>().Where(e => e.Id == 12 && -e.TestNullableDouble + -1.23456789 < 1E-5).ToList().Single());
 
@@ -578,7 +579,7 @@ namespace Microsoft.EntityFrameworkCore
 
                 Assert.Same(
                     entity,
-                    strictEquality
+                    Fixture.StrictEquality
                         ? context.Set<BuiltInNullableDataTypes>().Where(e => e.Id == 12 && e.TestNullableSingle == -1.234F).ToList().Single()
                         : context.Set<BuiltInNullableDataTypes>().Where(e => e.Id == 12 && -e.TestNullableSingle + -1.234F < 1E-5).ToList().Single());
 
@@ -1203,9 +1204,18 @@ namespace Microsoft.EntityFrameworkCore
                 }
             }
 
+            public abstract bool StrictEquality { get; }
+
+            public abstract bool SupportsAnsi { get; }
+
+            public abstract bool SupportsUnicodeToAnsiConversion { get; }
+
+            public abstract bool SupportsLargeStringComparisons { get; }
+
             public abstract bool SupportsBinaryKeys { get; }
 
             public abstract DateTime DefaultDateTime { get; }
+
         }
 
         protected class BuiltInDataTypesBase

--- a/test/EFCore.InMemory.FunctionalTests/BuiltInDataTypesInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/BuiltInDataTypesInMemoryTest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.EntityFrameworkCore.TestUtilities;
-using Xunit;
 
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore
@@ -15,15 +14,17 @@ namespace Microsoft.EntityFrameworkCore
         {
         }
 
-        [Fact]
-        public virtual void Can_perform_query_with_ansi_strings()
-        {
-            Can_perform_query_with_ansi_strings_test(supportsAnsi: false);
-        }
-
         public class BuiltInDataTypesInMemoryFixture : BuiltInDataTypesFixtureBase
         {
             protected override ITestStoreFactory TestStoreFactory => InMemoryTestStoreFactory.Instance;
+
+            public override bool StrictEquality => true;
+
+            public override bool SupportsAnsi => false;
+
+            public override bool SupportsUnicodeToAnsiConversion => true;
+
+            public override bool SupportsLargeStringComparisons => true;
 
             public override bool SupportsBinaryKeys => false;
 

--- a/test/EFCore.InMemory.FunctionalTests/ConvertToStoreTypesInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ConvertToStoreTypesInMemoryTest.cs
@@ -17,6 +17,14 @@ namespace Microsoft.EntityFrameworkCore
         {
             protected override ITestStoreFactory TestStoreFactory => InMemoryTestStoreFactory.Instance;
 
+            public override bool StrictEquality => true;
+
+            public override bool SupportsAnsi => false;
+
+            public override bool SupportsUnicodeToAnsiConversion => true;
+
+            public override bool SupportsLargeStringComparisons => true;
+
             public override bool SupportsBinaryKeys => false;
 
             public override DateTime DefaultDateTime => new DateTime();

--- a/test/EFCore.InMemory.FunctionalTests/CustomConvertersInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/CustomConvertersInMemoryTest.cs
@@ -15,6 +15,14 @@ namespace Microsoft.EntityFrameworkCore
 
         public class CustomConvertersInMemoryFixture : CustomConvertersFixtureBase
         {
+            public override bool StrictEquality => true;
+
+            public override bool SupportsAnsi => false;
+
+            public override bool SupportsUnicodeToAnsiConversion => true;
+
+            public override bool SupportsLargeStringComparisons => true;
+
             protected override ITestStoreFactory TestStoreFactory => InMemoryTestStoreFactory.Instance;
 
             public override bool SupportsBinaryKeys => false;

--- a/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BuiltInDataTypesSqlServerTest.cs
@@ -36,12 +36,6 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [Fact]
-        public virtual void Can_perform_query_with_ansi_strings()
-        {
-            Can_perform_query_with_ansi_strings_test(supportsAnsi: true);
-        }
-
-        [Fact]
         public void Sql_translation_uses_type_mapper_when_constant()
         {
             using (var context = CreateContext())
@@ -468,12 +462,6 @@ WHERE [e].[TimeSpanAsTime] = @__timeSpan_0",
                 object param62 = null;
                 Assert.Same(entity, context.Set<MappedNullableDataTypes>().Single(e => e.Int == 911 && e.SqlVariantInt == param62));
             }
-        }
-
-        [Fact]
-        public virtual void Can_query_using_any_nullable_data_type_as_literal()
-        {
-            Can_query_using_any_nullable_data_type_as_literal_helper(strictEquality: true);
         }
 
         [Fact]
@@ -2827,6 +2815,14 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
 
         public class BuiltInDataTypesSqlServerFixture : BuiltInDataTypesFixtureBase
         {
+            public override bool StrictEquality => true;
+
+            public override bool SupportsAnsi => true;
+
+            public override bool SupportsUnicodeToAnsiConversion => true;
+
+            public override bool SupportsLargeStringComparisons => true;
+
             protected override ITestStoreFactory TestStoreFactory
                 => SqlServerTestStoreFactory.Instance;
 

--- a/test/EFCore.SqlServer.FunctionalTests/ConvertToStoreTypesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ConvertToStoreTypesSqlServerTest.cs
@@ -155,6 +155,14 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
 
         public class ConvertToStoreTypesSqlServerFixture : ConvertToStoreTypesFixtureBase
         {
+            public override bool StrictEquality => true;
+
+            public override bool SupportsAnsi => true;
+
+            public override bool SupportsUnicodeToAnsiConversion => true;
+
+            public override bool SupportsLargeStringComparisons => true;
+
             protected override ITestStoreFactory TestStoreFactory => SqlServerTestStoreFactory.Instance;
 
             public override bool SupportsBinaryKeys => true;

--- a/test/EFCore.SqlServer.FunctionalTests/CustomConvertersSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/CustomConvertersSqlServerTest.cs
@@ -157,6 +157,14 @@ User.Id ---> [uniqueidentifier]
 
         public class CustomConvertersSqlServerFixture : CustomConvertersFixtureBase
         {
+            public override bool StrictEquality => true;
+
+            public override bool SupportsAnsi => true;
+
+            public override bool SupportsUnicodeToAnsiConversion => true;
+
+            public override bool SupportsLargeStringComparisons => true;
+
             protected override ITestStoreFactory TestStoreFactory => SqlServerTestStoreFactory.Instance;
 
             public override bool SupportsBinaryKeys => true;

--- a/test/EFCore.SqlServer.FunctionalTests/EverythingIsBytesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/EverythingIsBytesSqlServerTest.cs
@@ -160,6 +160,14 @@ UnicodeDataTypes.StringUnicode ---> [nullable varbinary] [MaxLength = -1]
 
         public class EverythingIsBytesSqlServerFixture : BuiltInDataTypesFixtureBase
         {
+            public override bool StrictEquality => true;
+
+            public override bool SupportsAnsi => true;
+
+            public override bool SupportsUnicodeToAnsiConversion => false;
+
+            public override bool SupportsLargeStringComparisons => true;
+
             protected override string StoreName { get; } = "EverythingIsBytes";
 
             protected override ITestStoreFactory TestStoreFactory => SqlServerBytesTestStoreFactory.Instance;

--- a/test/EFCore.SqlServer.FunctionalTests/EverythingIsStringsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/EverythingIsStringsSqlServerTest.cs
@@ -160,6 +160,14 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
 
         public class EverythingIsStringsSqlServerFixture : BuiltInDataTypesFixtureBase
         {
+            public override bool StrictEquality => true;
+
+            public override bool SupportsAnsi => true;
+
+            public override bool SupportsUnicodeToAnsiConversion => true;
+
+            public override bool SupportsLargeStringComparisons => true;
+
             protected override string StoreName { get; } = "EverythingIsStrings";
 
             protected override ITestStoreFactory TestStoreFactory => SqlServerStringsTestStoreFactory.Instance;

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdatesSqlServerTest.cs
@@ -63,7 +63,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Optional_One_to_one_relationships_are_one_to_one();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("IX_OptionalSingle1_RootId", updateException.InnerException.Message);
 
                 return updateException;
@@ -73,7 +73,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_One_to_one_relationships_are_one_to_one();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("PK_RequiredSingle1", updateException.InnerException.Message);
 
                 return updateException;
@@ -83,7 +83,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Optional_One_to_one_with_AK_relationships_are_one_to_one();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("IX_OptionalSingleAk1_RootId", updateException.InnerException.Message);
 
                 return updateException;
@@ -93,7 +93,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_One_to_one_with_AK_relationships_are_one_to_one();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("IX_RequiredSingleAk1_RootId", updateException.InnerException.Message);
 
                 return updateException;
@@ -103,7 +103,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Save_required_one_to_one_changed_by_reference(changeMechanism);
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredSingle2_RequiredSingle1_Id", updateException.InnerException.Message);
 
                 return updateException;
@@ -113,7 +113,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Sever_required_one_to_one(changeMechanism);
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredSingle2_RequiredSingle1_Id", updateException.InnerException.Message);
 
                 return updateException;
@@ -123,7 +123,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_many_to_one_dependents_are_cascade_deleted();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_Required2_Required1_ParentId", updateException.InnerException.Message);
 
                 return updateException;
@@ -133,7 +133,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Optional_many_to_one_dependents_are_orphaned();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_Optional2_Optional1_ParentId", updateException.InnerException.Message);
 
                 return updateException;
@@ -143,7 +143,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Optional_one_to_one_are_orphaned();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_OptionalSingle2_OptionalSingle1_BackId", updateException.InnerException.Message);
 
                 return updateException;
@@ -153,7 +153,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_one_to_one_are_cascade_deleted();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredSingle2_RequiredSingle1_Id", updateException.InnerException.Message);
 
                 return updateException;
@@ -163,7 +163,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_non_PK_one_to_one_are_cascade_deleted();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredNonPkSingle2_RequiredNonPkSingle1_BackId", updateException.InnerException.Message);
 
                 return updateException;
@@ -173,7 +173,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Optional_many_to_one_dependents_with_alternate_key_are_orphaned();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_OptionalAk2_OptionalAk1_ParentId", updateException.InnerException.Message);
 
                 return updateException;
@@ -183,7 +183,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_many_to_one_dependents_with_alternate_key_are_cascade_deleted();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredAk2_RequiredAk1_ParentId", updateException.InnerException.Message);
 
                 return updateException;
@@ -193,7 +193,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Optional_one_to_one_with_alternate_key_are_orphaned();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_OptionalSingleAk2_OptionalSingleAk1_BackId", updateException.InnerException.Message);
 
                 return updateException;
@@ -203,7 +203,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_one_to_one_with_alternate_key_are_cascade_deleted();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredSingleAk2_RequiredSingleAk1_BackId", updateException.InnerException.Message);
 
                 return updateException;
@@ -213,7 +213,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_non_PK_one_to_one_with_alternate_key_are_cascade_deleted();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredNonPkSingleAk2_RequiredNonPkSingleAk1_BackId", updateException.InnerException.Message);
 
                 return updateException;
@@ -223,7 +223,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_many_to_one_dependents_are_cascade_deleted_in_store();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_Required2_Required1_ParentId", updateException.InnerException.Message);
 
                 return updateException;
@@ -233,7 +233,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_one_to_one_are_cascade_deleted_in_store();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredSingle2_RequiredSingle1_Id", updateException.InnerException.Message);
 
                 return updateException;
@@ -243,7 +243,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_non_PK_one_to_one_are_cascade_deleted_in_store();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredNonPkSingle2_RequiredNonPkSingle1_BackId", updateException.InnerException.Message);
 
                 return updateException;
@@ -253,7 +253,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_many_to_one_dependents_with_alternate_key_are_cascade_deleted_in_store();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredAk2_RequiredAk1_ParentId", updateException.InnerException.Message);
 
                 return updateException;
@@ -263,7 +263,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_one_to_one_with_alternate_key_are_cascade_deleted_in_store();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredSingleAk2_RequiredSingleAk1_BackId", updateException.InnerException.Message);
 
                 return updateException;
@@ -273,7 +273,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_non_PK_one_to_one_with_alternate_key_are_cascade_deleted_in_store();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredNonPkSingleAk2_RequiredNonPkSingleAk1_BackId", updateException.InnerException.Message);
 
                 return updateException;
@@ -283,7 +283,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Optional_many_to_one_dependents_are_orphaned_in_store();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_Optional2_Optional1_ParentId", updateException.InnerException.Message);
 
                 return updateException;
@@ -293,7 +293,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Optional_one_to_one_are_orphaned_in_store();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_OptionalSingle2_OptionalSingle1_BackId", updateException.InnerException.Message);
 
                 return updateException;
@@ -303,7 +303,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Optional_many_to_one_dependents_with_alternate_key_are_orphaned_in_store();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_OptionalAk2_OptionalAk1_ParentId", updateException.InnerException.Message);
 
                 return updateException;
@@ -313,7 +313,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Optional_one_to_one_with_alternate_key_are_orphaned_in_store();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_OptionalSingleAk2_OptionalSingleAk1_BackId", updateException.InnerException.Message);
 
                 return updateException;
@@ -323,7 +323,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_many_to_one_dependents_are_cascade_deleted_starting_detached();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_Required2_Required1_ParentId", updateException.InnerException.Message);
 
                 return updateException;
@@ -333,7 +333,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Optional_many_to_one_dependents_are_orphaned_starting_detached();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_Optional2_Optional1_ParentId", updateException.InnerException.Message);
 
                 return updateException;
@@ -343,7 +343,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Optional_one_to_one_are_orphaned_starting_detached();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_OptionalSingle2_OptionalSingle1_BackId", updateException.InnerException.Message);
 
                 return updateException;
@@ -353,7 +353,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_one_to_one_are_cascade_deleted_starting_detached();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredSingle2_RequiredSingle1_Id", updateException.InnerException.Message);
 
                 return updateException;
@@ -363,7 +363,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_non_PK_one_to_one_are_cascade_deleted_starting_detached();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredNonPkSingle2_RequiredNonPkSingle1_BackId", updateException.InnerException.Message);
 
                 return updateException;
@@ -373,7 +373,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Optional_many_to_one_dependents_with_alternate_key_are_orphaned_starting_detached();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_OptionalAk2_OptionalAk1_ParentId", updateException.InnerException.Message);
 
                 return updateException;
@@ -383,7 +383,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_many_to_one_dependents_with_alternate_key_are_cascade_deleted_starting_detached();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredAk2_RequiredAk1_ParentId", updateException.InnerException.Message);
 
                 return updateException;
@@ -393,7 +393,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Optional_one_to_one_with_alternate_key_are_orphaned_starting_detached();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_OptionalSingleAk2_OptionalSingleAk1_BackId", updateException.InnerException.Message);
 
                 return updateException;
@@ -403,7 +403,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_one_to_one_with_alternate_key_are_cascade_deleted_starting_detached();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredSingleAk2_RequiredSingleAk1_BackId", updateException.InnerException.Message);
 
                 return updateException;
@@ -413,7 +413,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_non_PK_one_to_one_with_alternate_key_are_cascade_deleted_starting_detached();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredNonPkSingleAk2_RequiredNonPkSingleAk1_BackId", updateException.InnerException.Message);
 
                 return updateException;
@@ -423,7 +423,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_many_to_one_dependents_are_cascade_detached_when_Added();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_Required2_Required1_ParentId", updateException.InnerException.Message);
 
                 return updateException;
@@ -433,7 +433,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_one_to_one_are_cascade_detached_when_Added();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredSingle2_RequiredSingle1_Id", updateException.InnerException.Message);
 
                 return updateException;
@@ -443,7 +443,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_non_PK_one_to_one_are_cascade_detached_when_Added();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredNonPkSingle2_RequiredNonPkSingle1_BackId", updateException.InnerException.Message);
 
                 return updateException;
@@ -453,7 +453,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_many_to_one_dependents_with_alternate_key_are_cascade_detached_when_Added();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredAk2_RequiredAk1_ParentId", updateException.InnerException.Message);
 
                 return updateException;
@@ -463,7 +463,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_one_to_one_with_alternate_key_are_cascade_detached_when_Added();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredSingleAk2_RequiredSingleAk1_BackId", updateException.InnerException.Message);
 
                 return updateException;
@@ -473,7 +473,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 var updateException = base.Required_non_PK_one_to_one_with_alternate_key_are_cascade_detached_when_Added();
 
-                // Disabled check -- see issue #1103
+                // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredNonPkSingleAk2_RequiredNonPkSingleAk1_BackId", updateException.InnerException.Message);
 
                 return updateException;

--- a/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
@@ -27,18 +27,6 @@ namespace Microsoft.EntityFrameworkCore
             //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
-        [Fact]
-        public virtual void Can_perform_query_with_ansi_strings()
-        {
-            Can_perform_query_with_ansi_strings_test(supportsAnsi: false);
-        }
-
-        [Fact]
-        public virtual void Can_query_using_any_nullable_data_type_as_literal()
-        {
-            Can_query_using_any_nullable_data_type_as_literal_helper(strictEquality: false);
-        }
-
         [Fact(Skip = "See issue #8205")]
         public virtual void Can_insert_and_query_decimal()
         {
@@ -863,6 +851,14 @@ namespace Microsoft.EntityFrameworkCore
 
         public class BuiltInDataTypesSqliteFixture : BuiltInDataTypesFixtureBase
         {
+            public override bool StrictEquality => false;
+
+            public override bool SupportsAnsi => false;
+
+            public override bool SupportsUnicodeToAnsiConversion => true;
+
+            public override bool SupportsLargeStringComparisons => true;
+
             protected override ITestStoreFactory TestStoreFactory => SqliteTestStoreFactory.Instance;
             public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ServiceProvider.GetRequiredService<ILoggerFactory>();
 

--- a/test/EFCore.Sqlite.FunctionalTests/ConvertToStoreTypesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/ConvertToStoreTypesSqliteTest.cs
@@ -21,6 +21,14 @@ namespace Microsoft.EntityFrameworkCore
 
         public class ConvertToStoreTypesSqliteFixture : ConvertToStoreTypesFixtureBase
         {
+            public override bool StrictEquality => false;
+
+            public override bool SupportsAnsi => false;
+
+            public override bool SupportsUnicodeToAnsiConversion => true;
+
+            public override bool SupportsLargeStringComparisons => true;
+
             protected override ITestStoreFactory TestStoreFactory => SqliteTestStoreFactory.Instance;
             public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ServiceProvider.GetRequiredService<ILoggerFactory>();
 
@@ -31,6 +39,14 @@ namespace Microsoft.EntityFrameworkCore
             public override bool SupportsBinaryKeys => true;
 
             public override DateTime DefaultDateTime => new DateTime();
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+            {
+                base.OnModelCreating(modelBuilder, context);
+
+                // Issue #11036
+                modelBuilder.Entity<BuiltInNullableDataTypes>().Ignore(e => e.TestNullableUnsignedInt64);
+            }
         }
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/CustomConvertersSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/CustomConvertersSqliteTest.cs
@@ -16,6 +16,14 @@ namespace Microsoft.EntityFrameworkCore
 
         public class CustomConvertersSqliteFixture : CustomConvertersFixtureBase
         {
+            public override bool StrictEquality => false;
+
+            public override bool SupportsAnsi => false;
+
+            public override bool SupportsUnicodeToAnsiConversion => true;
+
+            public override bool SupportsLargeStringComparisons => true;
+
             protected override ITestStoreFactory TestStoreFactory => SqliteTestStoreFactory.Instance;
 
             public override bool SupportsBinaryKeys => true;


### PR DESCRIPTION
Part of #3620

Also, changed test pattern for BuiltInDataTypes tests to have configuration in the fixture which is used by tests that always run by default. This is consistent with what we do elsewhere and prevents subclasses from forgetting to add a new test method to call the base.ls.