### PR TITLE
Enforce the dependent requiredness for table splitting more strictly

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/Query/RelationalOwnedQueryTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/RelationalOwnedQueryTestBase.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public abstract class RelationalOwnedQueryTestBase<TFixture> : OwnedQueryTestBase<TFixture>
+        where TFixture : RelationalOwnedQueryTestBase<TFixture>.RelationalOwnedQueryFixture, new()
+    {
+        protected RelationalOwnedQueryTestBase(TFixture fixture)
+            : base(fixture)
+        {
+            fixture.TestSqlLoggerFactory.Clear();
+        }
+
+        public abstract class RelationalOwnedQueryFixture : OwnedQueryFixtureBase
+        {
+            public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ServiceProvider.GetRequiredService<ILoggerFactory>();
+
+            public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+                => base.AddOptions(builder).ConfigureWarnings(c => c.Log(RelationalEventId.QueryClientEvaluationWarning));
+        }
+    }
+}

--- a/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalConventionSetBuilder.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalConventionSetBuilder.cs
@@ -50,9 +50,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var sharedTableConvention = new SharedTableConvention();
 
+            var discriminatorConvention =new DiscriminatorConvention();
             conventionSet.EntityTypeAddedConventions.Add(new RelationalTableAttributeConvention());
             conventionSet.EntityTypeAddedConventions.Add(sharedTableConvention);
-            conventionSet.BaseEntityTypeChangedConventions.Add(new DiscriminatorConvention());
+            conventionSet.EntityTypeRemovedConventions.Add(discriminatorConvention);
+            conventionSet.BaseEntityTypeChangedConventions.Add(discriminatorConvention);
             conventionSet.BaseEntityTypeChangedConventions.Add(
                 new TableNameFromDbSetConvention(Dependencies.Context?.Context, Dependencies.SetFinder));
             conventionSet.EntityTypeAnnotationChangedConventions.Add(sharedTableConvention);

--- a/src/EFCore.Relational/Metadata/Internal/TableMapping.cs
+++ b/src/EFCore.Relational/Metadata/Internal/TableMapping.cs
@@ -50,11 +50,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual IEnumerable<IEntityType> GetRootTypes()
-            => EntityTypes.Where(
+        public virtual IEntityType GetRootType()
+            => EntityTypes.SingleOrDefault(
                 t => t.BaseType == null
-                    && t.FindForeignKeys(t.FindDeclaredPrimaryKey().Properties)
-                        .All(fk => t.Relational().TableName != fk.PrincipalEntityType.Relational().TableName));
+                     && t.FindForeignKeys(t.FindDeclaredPrimaryKey().Properties)
+                         .All(fk => !fk.PrincipalKey.IsPrimaryKey()
+                                    || fk.PrincipalEntityType.RootType() == t
+                                    || t.Relational().TableName != fk.PrincipalEntityType.Relational().TableName
+                                    || t.Relational().Schema != fk.PrincipalEntityType.Relational().Schema));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -647,7 +647,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 firstEntityType, secondEntityType, keyValue, firstConflictingValues, secondConflictingValues, columns);
 
         /// <summary>
-        ///     The entity of '{entityType}' is sharing the table '{tableName}' with '{missingEntityType}', but there is no entity of this type with the same key value that has been marked as '{state}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the key values.
+        ///     The entity of type '{entityType}' is sharing the table '{tableName}' with entities of type '{missingEntityType}', but there is no entity of this type with the same key value that has been marked as '{state}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the key values.
         /// </summary>
         public static string SharedRowEntryCountMismatch([CanBeNull] object entityType, [CanBeNull] object tableName, [CanBeNull] object missingEntityType, [CanBeNull] object state)
             => string.Format(
@@ -655,7 +655,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 entityType, tableName, missingEntityType, state);
 
         /// <summary>
-        ///     The entity of '{entityType}' is sharing the table '{tableName}' with '{missingEntityType}', but there is no entity of this type with the same key value '{keyValue}' that has been marked as '{state}'.
+        ///     The entity of type '{entityType}' is sharing the table '{tableName}' with entities of type '{missingEntityType}', but there is no entity of this type with the same key value '{keyValue}' that has been marked as '{state}'.
         /// </summary>
         public static string SharedRowEntryCountMismatchSensitive([CanBeNull] object entityType, [CanBeNull] object tableName, [CanBeNull] object missingEntityType, [CanBeNull] object keyValue, [CanBeNull] object state)
             => string.Format(

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -350,10 +350,10 @@
     <value>The instance of entity type '{firstEntityType}' and the instance of entity type '{secondEntityType}' are mapped to the same row with the key value '{keyValue}', but have different original property values '{firstConflictingValues}' and '{secondConflictingValues}' mapped to {columns}.</value>
   </data>
   <data name="SharedRowEntryCountMismatch" xml:space="preserve">
-    <value>The entity of '{entityType}' is sharing the table '{tableName}' with '{missingEntityType}', but there is no entity of this type with the same key value that has been marked as '{state}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the key values.</value>
+    <value>The entity of type '{entityType}' is sharing the table '{tableName}' with entities of type '{missingEntityType}', but there is no entity of this type with the same key value that has been marked as '{state}'. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the key values.</value>
   </data>
   <data name="SharedRowEntryCountMismatchSensitive" xml:space="preserve">
-    <value>The entity of '{entityType}' is sharing the table '{tableName}' with '{missingEntityType}', but there is no entity of this type with the same key value '{keyValue}' that has been marked as '{state}'.</value>
+    <value>The entity of type '{entityType}' is sharing the table '{tableName}' with entities of type '{missingEntityType}', but there is no entity of this type with the same key value '{keyValue}' that has been marked as '{state}'.</value>
   </data>
   <data name="IncorrectDefaultValueType" xml:space="preserve">
     <value>Cannot set default value '{value}' of type '{valueType}' on property '{property}' of type '{propertyType}' in entity type '{entityType}'.</value>

--- a/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
@@ -200,15 +200,12 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
             {
                 foreach (var command in modificationCommandIdentityMap.Values)
                 {
-                    if ((command.EntityState != EntityState.Added
+                    if (command.EntityState != EntityState.Added
                          && command.EntityState != EntityState.Deleted)
-                        || (command.Entries.Any(e => modificationCommandIdentityMap.GetPrincipals(e.EntityType).Count == 0)
-                            && command.Entries.Any(e => modificationCommandIdentityMap.GetDependents(e.EntityType).Count == 0)))
                     {
                         continue;
                     }
 
-                    var tableName = (string.IsNullOrEmpty(command.Schema) ? "" : command.Schema + ".") + command.TableName;
                     foreach (var entry in command.Entries)
                     {
                         foreach (var principalEntityType in modificationCommandIdentityMap.GetPrincipals(entry.EntityType))
@@ -217,6 +214,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                                 principalEntry => principalEntry != entry
                                                   && principalEntityType.IsAssignableFrom(principalEntry.EntityType)))
                             {
+                                var tableName = (string.IsNullOrEmpty(command.Schema) ? "" : command.Schema + ".") + command.TableName;
                                 if (_sensitiveLoggingEnabled)
                                 {
                                     throw new InvalidOperationException(
@@ -243,6 +241,7 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                                 dependentEntry => dependentEntry != entry
                                                   && dependentEntityType.IsAssignableFrom(dependentEntry.EntityType)))
                             {
+                                var tableName = (string.IsNullOrEmpty(command.Schema) ? "" : command.Schema + ".") + command.TableName;
                                 if (_sensitiveLoggingEnabled)
                                 {
                                     throw new InvalidOperationException(

--- a/src/EFCore.Specification.Tests/F1FixtureBase.cs
+++ b/src/EFCore.Specification.Tests/F1FixtureBase.cs
@@ -48,9 +48,7 @@ namespace Microsoft.EntityFrameworkCore
 
             modelBuilder.Entity<TestDriver>();
             modelBuilder.Entity<TitleSponsor>()
-                .Ignore(s => s.Details);
-            // #8973
-            //.OwnsOne(s => s.Details);
+                .OwnsOne(s => s.Details);
 
             // TODO: Sponsor * <-> * Team. Many-to-many relationships are not supported without CLR class for join table. See issue #1368
         }

--- a/src/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [Fact(Skip = "Issue#10971")]
+        [Fact]
         public virtual void Query_when_group_by()
         {
             using (var context = CreateContext())

--- a/src/EFCore.Specification.Tests/TestModels/TransportationModel/CombustionEngine.cs
+++ b/src/EFCore.Specification.Tests/TestModels/TransportationModel/CombustionEngine.cs
@@ -3,17 +3,17 @@
 
 namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
 {
-    public class CombustionEngine : Engine
+    public abstract class CombustionEngine : Engine
     {
         public FuelTank FuelTank { get; set; }
 
         public override bool Equals(object obj)
-        {
-            return obj is CombustionEngine other
-                   && base.Equals(other)
-                   && Equals(FuelTank, other.FuelTank);
-        }
+            => obj is CombustionEngine other
+               && base.Equals(other)
+               && Equals(FuelTank, other.FuelTank);
 
-        public override int GetHashCode() => base.GetHashCode();
+        public override int GetHashCode()
+            => base.GetHashCode() * 397
+               ^ FuelTank.GetHashCode();
     }
 }

--- a/src/EFCore.Specification.Tests/TestModels/TransportationModel/ContinuousCombustionEngine.cs
+++ b/src/EFCore.Specification.Tests/TestModels/TransportationModel/ContinuousCombustionEngine.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
+{
+    public class ContinuousCombustionEngine : CombustionEngine
+    {
+    }
+}

--- a/src/EFCore.Specification.Tests/TestModels/TransportationModel/Engine.cs
+++ b/src/EFCore.Specification.Tests/TestModels/TransportationModel/Engine.cs
@@ -10,12 +10,12 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
         public PoweredVehicle Vehicle { get; set; }
 
         public override bool Equals(object obj)
-        {
-            return obj is Engine other
-                   && VehicleName == other.VehicleName
-                   && Description == other.Description;
-        }
+            => obj is Engine other
+               && VehicleName == other.VehicleName
+               && Description == other.Description;
 
-        public override int GetHashCode() => VehicleName.GetHashCode();
+        public override int GetHashCode()
+            => VehicleName.GetHashCode() * 397
+               ^ Description.GetHashCode();
     }
 }

--- a/src/EFCore.Specification.Tests/TestModels/TransportationModel/FuelTank.cs
+++ b/src/EFCore.Specification.Tests/TestModels/TransportationModel/FuelTank.cs
@@ -8,17 +8,19 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
         public string VehicleName { get; set; }
         public string FuelType { get; set; }
         public string Capacity { get; set; }
-        public PoweredVehicle Vehicle { get; set; }
+        // #9005
+        //public PoweredVehicle Vehicle { get; set; }
         public CombustionEngine Engine { get; set; }
 
         public override bool Equals(object obj)
-        {
-            return obj is FuelTank other
-                   && VehicleName == other.VehicleName
-                   && FuelType == other.FuelType
-                   && Capacity == other.Capacity;
-        }
+            => obj is FuelTank other
+               && VehicleName == other.VehicleName
+               && FuelType == other.FuelType
+               && Capacity == other.Capacity;
 
-        public override int GetHashCode() => VehicleName.GetHashCode();
+        public override int GetHashCode()
+            => (VehicleName.GetHashCode() * 397
+                ^ FuelType.GetHashCode()) * 397
+               ^ Capacity.GetHashCode();
     }
 }

--- a/src/EFCore.Specification.Tests/TestModels/TransportationModel/IntermittentCombustionEngine.cs
+++ b/src/EFCore.Specification.Tests/TestModels/TransportationModel/IntermittentCombustionEngine.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
+{
+    public class IntermittentCombustionEngine : CombustionEngine
+    {
+    }
+}

--- a/src/EFCore.Specification.Tests/TestModels/TransportationModel/Operator.cs
+++ b/src/EFCore.Specification.Tests/TestModels/TransportationModel/Operator.cs
@@ -10,12 +10,12 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
         public Vehicle Vehicle { get; set; }
 
         public override bool Equals(object obj)
-        {
-            return obj is Operator other
-                   && VehicleName == other.VehicleName
-                   && Name == other.Name;
-        }
+            => obj is Operator other
+               && VehicleName == other.VehicleName
+               && Name == other.Name;
 
-        public override int GetHashCode() => VehicleName.GetHashCode();
+        public override int GetHashCode()
+            => VehicleName.GetHashCode() * 397
+               ^ Name.GetHashCode();
     }
 }

--- a/src/EFCore.Specification.Tests/TestModels/TransportationModel/SolidFuelTank.cs
+++ b/src/EFCore.Specification.Tests/TestModels/TransportationModel/SolidFuelTank.cs
@@ -1,19 +1,20 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
 {
-    public class PoweredVehicle : Vehicle
+    public class SolidFuelTank : FuelTank
     {
-        public Engine Engine { get; set; }
+        public string GrainGeometry { get; set; }
+        public SolidRocket Rocket { get; set; }
 
         public override bool Equals(object obj)
-            => obj is PoweredVehicle other
+            => obj is SolidFuelTank other
                && base.Equals(other)
-               && Equals(Engine, other.Engine);
+               && GrainGeometry == other.GrainGeometry;
 
         public override int GetHashCode()
             => base.GetHashCode() * 397
-               ^ Engine.GetHashCode();
+               ^ GrainGeometry.GetHashCode();
     }
 }

--- a/src/EFCore.Specification.Tests/TestModels/TransportationModel/SolidRocket.cs
+++ b/src/EFCore.Specification.Tests/TestModels/TransportationModel/SolidRocket.cs
@@ -1,19 +1,18 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
 {
-    public class PoweredVehicle : Vehicle
+    public class SolidRocket : ContinuousCombustionEngine
     {
-        public Engine Engine { get; set; }
+        public SolidFuelTank SolidFuelTank { get; set; }
 
         public override bool Equals(object obj)
-            => obj is PoweredVehicle other
-               && base.Equals(other)
-               && Equals(Engine, other.Engine);
+            => obj is SolidRocket other
+               && base.Equals(other);
 
         public override int GetHashCode()
             => base.GetHashCode() * 397
-               ^ Engine.GetHashCode();
+               ^ SolidFuelTank.GetHashCode();
     }
 }

--- a/src/EFCore.Specification.Tests/TestModels/TransportationModel/TransportationContext.cs
+++ b/src/EFCore.Specification.Tests/TestModels/TransportationModel/TransportationContext.cs
@@ -22,47 +22,52 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
             modelBuilder.Entity<Vehicle>(eb => { eb.HasKey(e => e.Name); });
             modelBuilder.Entity<Engine>(
                 eb =>
-                    {
-                        eb.HasKey(e => e.VehicleName);
-                        eb.HasOne(e => e.Vehicle)
-                            .WithOne(e => e.Engine)
-                            .HasForeignKey<Engine>(e => e.VehicleName);
-                    });
-            modelBuilder.Entity<CombustionEngine>();
+                {
+                    eb.HasKey(e => e.VehicleName);
+                    eb.HasOne(e => e.Vehicle)
+                        .WithOne(e => e.Engine)
+                        .HasForeignKey<Engine>(e => e.VehicleName);
+                });
+
+            modelBuilder.Entity<ContinuousCombustionEngine>();
+            modelBuilder.Entity<IntermittentCombustionEngine>();
+            modelBuilder.Entity<SolidRocket>();
 
             modelBuilder.Entity<Operator>(
                 eb =>
-                    {
-                        eb.HasKey(e => e.VehicleName);
-                        eb.HasOne(e => e.Vehicle)
-                            .WithOne(e => e.Operator)
-                            .HasForeignKey<Operator>(e => e.VehicleName);
-                    });
+                {
+                    eb.HasKey(e => e.VehicleName);
+                    eb.HasOne(e => e.Vehicle)
+                        .WithOne(e => e.Operator)
+                        .HasForeignKey<Operator>(e => e.VehicleName);
+                });
             modelBuilder.Entity<LicensedOperator>();
 
             modelBuilder.Entity<FuelTank>(
                 eb =>
-                    {
-                        eb.HasKey(e => e.VehicleName);
-                        eb.HasOne(e => e.Engine)
-                            .WithOne(e => e.FuelTank)
-                            .HasForeignKey<FuelTank>(e => e.VehicleName);
-                        eb.HasOne(e => e.Vehicle)
-                            .WithOne()
-                            .HasForeignKey<FuelTank>(e => e.VehicleName);
-                    });
+                {
+                    eb.HasKey(e => e.VehicleName);
+                    eb.HasOne(e => e.Engine)
+                        .WithOne(e => e.FuelTank)
+                        .HasForeignKey<FuelTank>(e => e.VehicleName);
+                    // Make dependent optional
+                    // #9005
+                    //eb.HasOne(e => e.Vehicle)
+                    //    .WithOne()
+                    //    .HasForeignKey<FuelTank>(e => e.VehicleName);
+                });
+
+            modelBuilder.Entity<SolidFuelTank>(eb =>
+            {
+                eb.HasOne(e => e.Rocket)
+                    .WithOne(e => e.SolidFuelTank)
+                    .HasForeignKey<SolidFuelTank>(e => e.VehicleName);
+            });
         }
 
         public void Seed()
         {
             Vehicles.AddRange(CreateVehicles());
-            // Following should throw
-            //Add(new FuelTank
-            //{
-            //    Capacity = "Unknown",
-            //    FuelType = "Unknown",
-            //    VehicleName = "1984 California Car"
-            //});
             SaveChanges();
         }
 
@@ -121,30 +126,63 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
                     SeatingCapacity = 1,
                     Operator = new Operator { Name = "Lance Armstrong", VehicleName = "Trek Pro Fit Madone 6 Series" }
                 },
-                new PoweredVehicle
+                // This should be a PoweredVehicle when Engine is made optional
+                // #9005
+                new Vehicle
                 {
                     Name = "1984 California Car",
                     SeatingCapacity = 34,
-                    Operator = new LicensedOperator { Name = "Albert Williams", LicenseType = "Muni Transit", VehicleName = "1984 California Car" }
+                    Operator = new LicensedOperator
+                    {
+                        Name = "Albert Williams", LicenseType = "Muni Transit", VehicleName = "1984 California Car"
+                    }
                 },
                 new PoweredVehicle
                 {
                     Name = "P85 2012 Tesla Model S Performance Edition",
                     SeatingCapacity = 5,
-                    Engine = new Engine { Description = "416 hp three phase, four pole AC induction", VehicleName = "P85 2012 Tesla Model S Performance Edition" },
-                    Operator = new LicensedOperator { Name = "Elon Musk", LicenseType = "Driver", VehicleName = "P85 2012 Tesla Model S Performance Edition" }
+                    Engine = new Engine
+                    {
+                        Description = "416 hp three phase, four pole AC induction", VehicleName = "P85 2012 Tesla Model S Performance Edition"
+                    },
+                    Operator = new LicensedOperator
+                    {
+                        Name = "Elon Musk", LicenseType = "Driver", VehicleName = "P85 2012 Tesla Model S Performance Edition"
+                    }
                 },
                 new PoweredVehicle
                 {
                     Name = "North American X-15A-2",
                     SeatingCapacity = 1,
-                    Engine = new CombustionEngine
+                    Engine = new ContinuousCombustionEngine
                     {
                         Description = "Reaction Motors XLR99 throttleable, restartable liquid-propellant rocket engine",
-                        FuelTank = new FuelTank { FuelType = "Liquid oxygen and anhydrous ammonia", Capacity = "11250 kg", VehicleName = "North American X-15A-2" },
+                        FuelTank = new FuelTank
+                        {
+                            FuelType = "Liquid oxygen and anhydrous ammonia", Capacity = "11250 kg", VehicleName = "North American X-15A-2"
+                        },
                         VehicleName = "North American X-15A-2"
                     },
-                    Operator = new LicensedOperator { Name = "William J. Knight", LicenseType = "Air Force Test Pilot", VehicleName = "North American X-15A-2" }
+                    Operator = new LicensedOperator
+                    {
+                        Name = "William J. Knight", LicenseType = "Air Force Test Pilot", VehicleName = "North American X-15A-2"
+                    }
+                },
+                new PoweredVehicle
+                {
+                    Name = "AIM-9M Sidewinder",
+                    Engine = new SolidRocket
+                    {
+                        Description = "Hercules/Bermite MK 36 Solid-fuel rocket",
+                        FuelTank = new SolidFuelTank
+                        {
+                            FuelType = "Reduced smoke Hydroxyl-Terminated Polybutadiene", Capacity = "22 kg", GrainGeometry = "Cylindrical", VehicleName = "AIM-9M Sidewinder"
+                        },
+                        VehicleName = "AIM-9M Sidewinder"
+                    },
+                    // This should be null
+                    // #9005
+                    Operator = new Operator { Name = "Infrared homing guidance", VehicleName = "AIM-9M Sidewinder" }
                 }
             };
     }

--- a/src/EFCore.Specification.Tests/TestModels/TransportationModel/Vehicle.cs
+++ b/src/EFCore.Specification.Tests/TestModels/TransportationModel/Vehicle.cs
@@ -10,13 +10,14 @@ namespace Microsoft.EntityFrameworkCore.TestModels.TransportationModel
         public Operator Operator { get; set; }
 
         public override bool Equals(object obj)
-        {
-            return obj is Vehicle other
-                   && Name == other.Name
-                   && SeatingCapacity == other.SeatingCapacity
-                   && Equals(Operator, other.Operator);
-        }
+            => obj is Vehicle other
+               && Name == other.Name
+               && SeatingCapacity == other.SeatingCapacity
+               && Equals(Operator, other.Operator);
 
-        public override int GetHashCode() => Name.GetHashCode();
+        public override int GetHashCode()
+            => (Name.GetHashCode() * 397
+                ^ SeatingCapacity.GetHashCode()) * 397
+               ^ Operator.GetHashCode();
     }
 }

--- a/src/EFCore/Internal/Multigraph.cs
+++ b/src/EFCore/Internal/Multigraph.cs
@@ -64,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual void AddEdge([NotNull] TVertex from, [NotNull] TVertex to, [NotNull] TEdge edge)
+        public virtual void AddEdge([NotNull] TVertex from, [NotNull] TVertex to, [CanBeNull] TEdge edge)
             => AddEdges(from, to, new[] { edge });
 
         /// <summary>

--- a/src/EFCore/Metadata/Conventions/Internal/InversePropertyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/InversePropertyAttributeConvention.cs
@@ -128,11 +128,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                         existingInverse.GetIdentifyingMemberInfo(), existingInverseType, entityType.Model, referencingNavigationsWithAttribute))
                 {
                     var fk = existingInverse.ForeignKey;
-                    if (fk.GetConfigurationSource() == ConfigurationSource.DataAnnotation)
-                    {
-                        fk.DeclaringEntityType.Builder.RemoveForeignKey(fk, ConfigurationSource.DataAnnotation);
-                    }
+                    fk.DeclaringEntityType.Builder.RemoveForeignKey(fk, ConfigurationSource.DataAnnotation);
                 }
+
+                var existingRelationship = entityTypeBuilder.Metadata.FindNavigation(navigationMemberInfo)?.ForeignKey;
+                existingRelationship?.DeclaringEntityType.Builder.RemoveForeignKey(existingRelationship, ConfigurationSource.DataAnnotation);
 
                 return entityTypeBuilder.Metadata.FindNavigation(navigationMemberInfo)?.ForeignKey.Builder;
             }

--- a/src/EFCore/Metadata/IEntityType.cs
+++ b/src/EFCore/Metadata/IEntityType.cs
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// </summary>
         /// <returns> true if the entity type is a query type; otherwise false. </returns>
         bool IsQueryType { get; }
-        
+
         /// <summary>
         ///     <para>
         ///         Gets primary key for this entity. Returns null if no primary key is defined.

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -291,6 +291,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public virtual void OnTypeRemoved()
+        {
+            Builder = null;
+            _baseType?._directlyDerivedTypes.Remove(this);
+
+            Model.ConventionDispatcher.OnEntityTypeRemoved(Model.Builder, this);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual ConfigurationSource? GetBaseTypeConfigurationSource() => _baseTypeConfigurationSource;
 
         private void UpdateBaseTypeConfigurationSource(ConfigurationSource configurationSource)

--- a/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
@@ -436,32 +436,28 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return false;
             }
 
-            // Set base type as null to remove the entityType from directly derived types of the base type
-            var baseType = entityType.BaseType;
-            entityType.Builder.HasBaseType((EntityType)null, configurationSource);
-
-            var entityTypeBuilder = entityType.Builder;
-            foreach (var foreignKey in entityType.GetDeclaredForeignKeys().ToList())
-            {
-                var removed = entityTypeBuilder.RemoveForeignKey(foreignKey, configurationSource);
-                Debug.Assert(removed.HasValue);
-            }
-
-            foreach (var foreignKey in entityType.GetDeclaredReferencingForeignKeys().ToList())
-            {
-                var removed = foreignKey.DeclaringEntityType.Builder.RemoveForeignKey(foreignKey, configurationSource);
-                Debug.Assert(removed.HasValue);
-            }
-
-            foreach (var directlyDerivedType in entityType.GetDirectlyDerivedTypes().ToList())
-            {
-                var derivedEntityTypeBuilder = directlyDerivedType.Builder
-                    .HasBaseType(baseType, configurationSource);
-                Debug.Assert(derivedEntityTypeBuilder != null);
-            }
-
             using (Metadata.ConventionDispatcher.StartBatch())
             {
+                var entityTypeBuilder = entityType.Builder;
+                foreach (var foreignKey in entityType.GetDeclaredForeignKeys().ToList())
+                {
+                    var removed = entityTypeBuilder.RemoveForeignKey(foreignKey, configurationSource);
+                    Debug.Assert(removed.HasValue);
+                }
+
+                foreach (var foreignKey in entityType.GetDeclaredReferencingForeignKeys().ToList())
+                {
+                    var removed = foreignKey.DeclaringEntityType.Builder.RemoveForeignKey(foreignKey, configurationSource);
+                    Debug.Assert(removed.HasValue);
+                }
+
+                foreach (var directlyDerivedType in entityType.GetDirectlyDerivedTypes().ToList())
+                {
+                    var derivedEntityTypeBuilder = directlyDerivedType.Builder
+                        .HasBaseType(entityType.BaseType, configurationSource);
+                    Debug.Assert(derivedEntityTypeBuilder != null);
+                }
+
                 foreach (var definedType in Metadata.GetEntityTypes().Where(e => e.DefiningEntityType == entityType).ToList())
                 {
                     RemoveEntityType(definedType, configurationSource);

--- a/src/EFCore/Metadata/Internal/Model.cs
+++ b/src/EFCore/Metadata/Internal/Model.cs
@@ -288,9 +288,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
 
-            entityType.Builder = null;
-
-            ConventionDispatcher.OnEntityTypeRemoved(Builder, entityType);
+            entityType.OnTypeRemoved();
 
             return entityType;
         }

--- a/test/EFCore.Relational.Tests/Update/CommandBatchPreparerTest.cs
+++ b/test/EFCore.Relational.Tests/Update/CommandBatchPreparerTest.cs
@@ -779,7 +779,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             {
                 Assert.Equal(
                     RelationalStrings.SharedRowEntryCountMismatchSensitive(
-                        nameof(FakeEntity), nameof(FakeEntity), nameof(DerivedRelatedFakeEntity), "{Id: 42}", state),
+                        nameof(FakeEntity), nameof(FakeEntity), nameof(RelatedFakeEntity), "{Id: 42}", state),
                     Assert.Throws<InvalidOperationException>(
                         () =>
                             CreateCommandBatchPreparer(stateManager: stateManager, sensitiveLogging: true)
@@ -789,7 +789,7 @@ namespace Microsoft.EntityFrameworkCore.Update
             {
                 Assert.Equal(
                     RelationalStrings.SharedRowEntryCountMismatch(
-                        nameof(FakeEntity), nameof(FakeEntity), nameof(DerivedRelatedFakeEntity), state),
+                        nameof(FakeEntity), nameof(FakeEntity), nameof(RelatedFakeEntity), state),
                     Assert.Throws<InvalidOperationException>(
                         () =>
                             CreateCommandBatchPreparer(stateManager: stateManager, sensitiveLogging: false)

--- a/test/EFCore.SqlServer.FunctionalTests/F1SqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/F1SqlServerFixture.cs
@@ -20,6 +20,10 @@ namespace Microsoft.EntityFrameworkCore
             modelBuilder.Entity<Team>().Property<byte[]>("Version")
                 .ValueGeneratedOnAddOrUpdate()
                 .IsConcurrencyToken();
+
+            modelBuilder.Entity<TitleSponsor>()
+                .OwnsOne(s => s.Details)
+                .Property(d => d.Space).HasColumnType("decimal(18,2)");
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/TableSplittingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TableSplittingSqlServerTest.cs
@@ -25,14 +25,24 @@ FROM [Vehicles] AS [v]
 WHERE [v].[Discriminator] IN (N'PoweredVehicle', N'Vehicle') AND [v].[Operator_Discriminator] IN (N'LicensedOperator', N'Operator')");
         }
 
-        public override void Can_query_shared_derived()
+        public override void Can_query_shared_derived_hierarchy()
         {
-            base.Can_query_shared_derived();
+            base.Can_query_shared_derived_hierarchy();
+
+            AssertSql(
+                @"SELECT [v].[Name], [v].[Capacity], [v].[FuelTank_Discriminator], [v].[FuelType], [v].[GrainGeometry]
+FROM [Vehicles] AS [v]
+WHERE (([v].[Discriminator] = N'PoweredVehicle') AND [v].[Engine_Discriminator] IN (N'SolidRocket', N'IntermittentCombustionEngine', N'ContinuousCombustionEngine')) AND [v].[FuelTank_Discriminator] IN (N'SolidFuelTank', N'FuelTank')");
+        }
+
+        public override void Can_query_shared_derived_nonhierarchy()
+        {
+            base.Can_query_shared_derived_nonhierarchy();
 
             AssertSql(
                 @"SELECT [v].[Name], [v].[Capacity], [v].[FuelType]
 FROM [Vehicles] AS [v]
-WHERE ([v].[Engine_Discriminator] = N'CombustionEngine') AND ([v].[Discriminator] = N'PoweredVehicle')");
+WHERE ([v].[Discriminator] = N'PoweredVehicle') AND [v].[Engine_Discriminator] IN (N'SolidRocket', N'IntermittentCombustionEngine', N'ContinuousCombustionEngine')");
         }
 
         public override void Can_change_dependent_instance_non_derived()

--- a/test/EFCore.Sqlite.FunctionalTests/Query/OwnedQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/OwnedQuerySqliteTest.cs
@@ -2,23 +2,19 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.TestUtilities;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
-    public class OwnedQuerySqliteTest : OwnedQueryTestBase<OwnedQuerySqliteTest.OwnedQuerySqliteFixture>
+    public class OwnedQuerySqliteTest : RelationalOwnedQueryTestBase<OwnedQuerySqliteTest.OwnedQuerySqliteFixture>
     {
         public OwnedQuerySqliteTest(OwnedQuerySqliteFixture fixture)
             : base(fixture)
         {
         }
 
-        public class OwnedQuerySqliteFixture : OwnedQueryFixtureBase
+        public class OwnedQuerySqliteFixture : RelationalOwnedQueryFixture
         {
             protected override ITestStoreFactory TestStoreFactory => SqliteTestStoreFactory.Instance;
-            public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ServiceProvider.GetRequiredService<ILoggerFactory>();
         }
     }
 }

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/ConventionDispatcherTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/ConventionDispatcherTest.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;

--- a/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
@@ -349,6 +349,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 modelBuilder.Owned<BookLabel>();
                 modelBuilder.Entity<Book>().OwnsOne(b => b.Label);
+                modelBuilder.Entity<Book>().OwnsOne(b => b.AlternateLabel);
 
                 modelBuilder.Validate();
 


### PR DESCRIPTION
Remove discriminator column if all derived types ignored
Fix table splitting tests

Fixes #10962
Fixes #10971
