### PR TITLE
Make IEntityEntryGraphIterator public and add overload for TrackGraph

### DIFF
--- a/src/EFCore/ChangeTracking/IEntityEntryGraphIterator.cs
+++ b/src/EFCore/ChangeTracking/IEntityEntryGraphIterator.cs
@@ -6,7 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 
-namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
+namespace Microsoft.EntityFrameworkCore.ChangeTracking
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -18,7 +18,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        void TraverseGraph([NotNull] EntityEntryGraphNode node, [NotNull] Func<EntityEntryGraphNode, bool> handleNode);
+        void TraverseGraph(
+            [NotNull] EntityEntryGraphNode node,
+            [CanBeNull] object state,
+            [NotNull] Func<EntityEntryGraphNode, object, bool> handleNode);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -26,7 +29,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         /// </summary>
         Task TraverseGraphAsync(
             [NotNull] EntityEntryGraphNode node,
-            [NotNull] Func<EntityEntryGraphNode, CancellationToken, Task<bool>> handleNode,
+            [CanBeNull] object state,
+            [NotNull] Func<EntityEntryGraphNode, object, CancellationToken, Task<bool>> handleNode,
             CancellationToken cancellationToken = default);
     }
 }

--- a/src/EFCore/ChangeTracking/Internal/EntityEntryGraphIterator.cs
+++ b/src/EFCore/ChangeTracking/Internal/EntityEntryGraphIterator.cs
@@ -20,9 +20,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual void TraverseGraph(EntityEntryGraphNode node, Func<EntityEntryGraphNode, bool> handleNode)
+        public virtual void TraverseGraph(
+            EntityEntryGraphNode node,
+            object state,
+            Func<EntityEntryGraphNode, object, bool> handleNode)
         {
-            if (!handleNode(node))
+            if (!handleNode(node, state))
             {
                 return;
             }
@@ -43,6 +46,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         {
                             TraverseGraph(
                                 node.CreateNode(node, stateManager.GetOrCreateEntry(relatedEntity), navigation),
+                                state,
                                 handleNode);
                         }
                     }
@@ -52,7 +56,10 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         var targetEntry = targetEntityType.HasDefiningNavigation()
                             ? stateManager.GetOrCreateEntry(navigationValue, targetEntityType)
                             : stateManager.GetOrCreateEntry(navigationValue);
-                        TraverseGraph(node.CreateNode(node, targetEntry, navigation), handleNode);
+                        TraverseGraph(
+                            node.CreateNode(node, targetEntry, navigation),
+                            state,
+                            handleNode);
                     }
                 }
             }
@@ -64,10 +71,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         /// </summary>
         public virtual async Task TraverseGraphAsync(
             EntityEntryGraphNode node,
-            Func<EntityEntryGraphNode, CancellationToken, Task<bool>> handleNode,
+            object state,
+            Func<EntityEntryGraphNode, object, CancellationToken, Task<bool>> handleNode,
             CancellationToken cancellationToken = default)
         {
-            if (!await handleNode(node, cancellationToken))
+            if (!await handleNode(node, state, cancellationToken))
             {
                 return;
             }
@@ -88,6 +96,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         {
                             await TraverseGraphAsync(
                                 node.CreateNode(node, stateManager.GetOrCreateEntry(relatedEntity), navigation),
+                                state,
                                 handleNode,
                                 cancellationToken);
                         }
@@ -100,6 +109,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                             : stateManager.GetOrCreateEntry(navigationValue);
                         await TraverseGraphAsync(
                             node.CreateNode(node, entry, navigation),
+                            state,
                             handleNode,
                             cancellationToken);
                     }

--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;


### PR DESCRIPTION
Issues #10540 #8226

The overload required a new argument somewhere to avoid a breaking change, so I took the opportunity to add a state parameter to the API to allow state to be passed in without capturing.