### PR TITLE
Query: Don't funcletize DbSet/InternalDbSet

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -374,12 +374,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                                     switch (tableExpressionBase)
                                     {
                                         case PredicateJoinExpressionBase predicateJoinExpressionBase:
-                                        {
                                             predicateJoinExpressionBase.Predicate
                                                 = sqlTableReferenceReplacingVisitor.Visit(predicateJoinExpressionBase.Predicate);
 
                                             break;
-                                        }
+
 
                                         // TODO: Visit sub-query (SelectExpression) here?
                                     }
@@ -419,10 +418,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     {
                         case ColumnExpression columnExpression
                         when ReferenceEquals(columnExpression.Table, _oldTableExpression):
-                        {
                             return new ColumnExpression(
                                 columnExpression.Name, columnExpression.Property, _newTableExpression);
-                        }
                     }
 
                     return base.Visit(expression);
@@ -434,7 +431,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 switch (expression)
                 {
                     case ColumnExpression columnExpression:
-                    {
                         if (columnExpression.Table is TableExpression tableExpression)
                         {
                             _tables.Add(tableExpression);
@@ -442,20 +438,17 @@ namespace Microsoft.EntityFrameworkCore.Query
                         }
 
                         return expression;
-                    }
+
                     case BinaryExpression binaryExpression:
-                    {
                         return base.Visit(binaryExpression);
-                    }
+
                     case NullableExpression nullableExpression:
-                    {
                         return base.Visit(nullableExpression);
-                    }
+
                     case UnaryExpression unaryExpression
                     when unaryExpression.NodeType == ExpressionType.Convert:
-                    {
                         return base.Visit(unaryExpression);
-                    }
+
                 }
 
                 _canEliminate = false;
@@ -1331,12 +1324,8 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             protected override Expression VisitTypeBinary(TypeBinaryExpression typeBinaryExpression)
             {
-                if (typeBinaryExpression.NodeType != ExpressionType.TypeIs)
-                {
-                    return base.VisitTypeBinary(typeBinaryExpression);
-                }
-
-                if (!(typeBinaryExpression.Expression is QuerySourceReferenceExpression qsre))
+                if (typeBinaryExpression.NodeType != ExpressionType.TypeIs
+                    || !(typeBinaryExpression.Expression is QuerySourceReferenceExpression qsre))
                 {
                     return base.VisitTypeBinary(typeBinaryExpression);
                 }

--- a/test/EFCore.Tests/QueryProviderTest.cs
+++ b/test/EFCore.Tests/QueryProviderTest.cs
@@ -11,8 +11,19 @@ namespace Microsoft.EntityFrameworkCore
 {
     public class QueryProviderTest
     {
-        [Fact(Skip = "Issue#11043")]
+        [Fact]
         public void Non_generic_ExecuteQuery_does_not_throw()
+        {
+            var context = new TestContext();
+            Func<IQueryable<TestEntity>, int> func = Queryable.Count;
+            IQueryable q = context.TestEntities;
+            var expr = Expression.Call(null, func.GetMethodInfo(), q.Expression);
+            Assert.Equal(0, q.Provider.Execute<int>(expr));
+            Assert.Equal(0, (int)q.Provider.Execute(expr));
+        }
+
+        [Fact]
+        public void Non_generic_ExecuteQuery_does_not_throw_incorrect_pattern()
         {
             var context = new TestContext();
             Func<IQueryable<TestEntity>, int> func = Queryable.Count;


### PR DESCRIPTION
Issue: A linq query starting from DbSet always has EntityQueryable. But for a manually created query incorrectly passes Constant(IQueryable) rather than IQueryable.Expression then we try to parametrize it and cause multiple running queries.
The fix is to not funcletize it. The Constant(DbSet) gets converted to EntityQueryable during ReLinq query parsing.
This is a negative case. The query is malformed. We would leak context instance in this case. Since it is hot path, we are not going to add overhead for all other cases.

Resolves #11043
