### PR TITLE
Add SetChangeTrackingStrategy methods

### DIFF
--- a/src/EFCore/Extensions/MutableEntityTypeExtensions.cs
+++ b/src/EFCore/Extensions/MutableEntityTypeExtensions.cs
@@ -426,5 +426,16 @@ namespace Microsoft.EntityFrameworkCore
 
             entityType[CoreAnnotationNames.NavigationAccessModeAnnotation] = propertyAccessMode;
         }
+
+        /// <summary>
+        ///     Sets the change tracking strategy to use for this entity type. This strategy indicates how the
+        ///     context detects changes to properties for an instance of the entity type.
+        /// </summary>
+        /// <param name="entityType"> The entity type to set the change tracking strategy for. </param>
+        /// <param name="changeTrackingStrategy"> The strategy to use. </param>
+        public static void SetChangeTrackingStrategy(
+            [NotNull] this IMutableEntityType entityType,
+            ChangeTrackingStrategy changeTrackingStrategy)
+            => Check.NotNull(entityType, nameof(entityType)).AsEntityType().ChangeTrackingStrategy = changeTrackingStrategy;
     }
 }

--- a/src/EFCore/Extensions/MutableModelExtensions.cs
+++ b/src/EFCore/Extensions/MutableModelExtensions.cs
@@ -123,5 +123,16 @@ namespace Microsoft.EntityFrameworkCore
 
             model[CoreAnnotationNames.PropertyAccessModeAnnotation] = propertyAccessMode;
         }
+
+        /// <summary>
+        ///     Sets the default change tracking strategy to use for entities in the model. This strategy indicates how the
+        ///     context detects changes to properties for an instance of an entity type.
+        /// </summary>
+        /// <param name="model"> The model to set the default change tracking strategy for. </param>
+        /// <param name="changeTrackingStrategy"> The strategy to use. </param>
+        public static void SetChangeTrackingStrategy(
+            [NotNull] this IMutableModel model,
+            ChangeTrackingStrategy changeTrackingStrategy)
+            => Check.NotNull(model, nameof(model)).AsModel().ChangeTrackingStrategy = changeTrackingStrategy;
     }
 }

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -3343,22 +3343,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public void Change_tracking_can_be_set_to_anything_for_full_notification_entities()
         {
             var model = BuildFullNotificationEntityModel();
-            model.ChangeTrackingStrategy = ChangeTrackingStrategy.ChangedNotifications;
+            model.SetChangeTrackingStrategy(ChangeTrackingStrategy.ChangedNotifications);
 
             var entityType = model.FindEntityType(typeof(FullNotificationEntity));
 
             Assert.Equal(ChangeTrackingStrategy.ChangedNotifications, entityType.GetChangeTrackingStrategy());
 
-            entityType.ChangeTrackingStrategy = ChangeTrackingStrategy.Snapshot;
+            entityType.SetChangeTrackingStrategy(ChangeTrackingStrategy.Snapshot);
             Assert.Equal(ChangeTrackingStrategy.Snapshot, entityType.GetChangeTrackingStrategy());
 
-            entityType.ChangeTrackingStrategy = ChangeTrackingStrategy.ChangedNotifications;
+            entityType.SetChangeTrackingStrategy(ChangeTrackingStrategy.ChangedNotifications);
             Assert.Equal(ChangeTrackingStrategy.ChangedNotifications, entityType.GetChangeTrackingStrategy());
 
-            entityType.ChangeTrackingStrategy = ChangeTrackingStrategy.ChangingAndChangedNotifications;
+            entityType.SetChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotifications);
             Assert.Equal(ChangeTrackingStrategy.ChangingAndChangedNotifications, entityType.GetChangeTrackingStrategy());
 
-            entityType.ChangeTrackingStrategy = ChangeTrackingStrategy.ChangingAndChangedNotificationsWithOriginalValues;
+            entityType.SetChangeTrackingStrategy(ChangeTrackingStrategy.ChangingAndChangedNotificationsWithOriginalValues);
             Assert.Equal(ChangeTrackingStrategy.ChangingAndChangedNotificationsWithOriginalValues, entityType.GetChangeTrackingStrategy());
         }
 


### PR DESCRIPTION
Issue #9087

I remembered why ChangeTrackingStrategy is not exposed on the interfaces--we decided it wasn't part of the core model definition, and hence should be accessed through extension methods. The Get methods were already there, but the Set methods were missing.