### PR TITLE
Fix to #10805 - Investigate skipped tests: InheritanceRelationshipsQuerySqlServerTest

### DIFF
--- a/src/EFCore.Specification.Tests/Query/InheritanceRelationshipsQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/InheritanceRelationshipsQueryTestBase.cs
@@ -89,18 +89,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Test does not pass.")] // TODO: See issue#7160
-        public virtual void Include_reference_with_inheritance2()
-        {
-            using (var context = CreateContext())
-            {
-                var query = context.BaseEntities.Include(e => e.DerivedReferenceOnBase);
-                var result = query.ToList();
-
-                Assert.Equal(6, result.Count);
-            }
-        }
-
         [Fact]
         public virtual void Include_reference_with_inheritance_reverse()
         {
@@ -143,18 +131,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var query = context.BaseEntities.Include(e => e.BaseReferenceOnBase).Where(e => e.Name != "Bar");
-                var result = query.ToList();
-
-                Assert.Equal(6, result.Count);
-            }
-        }
-
-        [ConditionalFact(Skip = "Test does not pass.")] // TODO: See issue#7160
-        public virtual void Include_reference_with_inheritance_with_filter2()
-        {
-            using (var context = CreateContext())
-            {
-                var query = context.BaseEntities.Include(e => e.DerivedReferenceOnBase).Where(e => e.Name != "Bar");
                 var result = query.ToList();
 
                 Assert.Equal(6, result.Count);
@@ -234,18 +210,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Test does not pass.")] // TODO: See issue#7160
-        public virtual void Include_collection_with_inheritance2()
-        {
-            using (var context = CreateContext())
-            {
-                var query = context.BaseEntities.Include(e => e.DerivedCollectionOnBase);
-                var result = query.ToList();
-
-                Assert.Equal(6, result.Count);
-            }
-        }
-
         [Fact]
         public virtual void Include_collection_with_inheritance_reverse()
         {
@@ -268,18 +232,6 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 Assert.Equal(6, result.Count);
                 Assert.Equal(3, result.SelectMany(e => e.BaseCollectionOnBase.OfType<DerivedCollectionOnBase>()).Count(e => e.DerivedProperty != 0));
-            }
-        }
-
-        [ConditionalFact(Skip = "Test does not pass.")] // TODO: See issue#7160
-        public virtual void Include_collection_with_inheritance_with_filter2()
-        {
-            using (var context = CreateContext())
-            {
-                var query = context.BaseEntities.Include(e => e.DerivedCollectionOnBase).Where(e => e.Name != "Bar");
-                var result = query.ToList();
-
-                Assert.Equal(6, result.Count);
             }
         }
 
@@ -367,18 +319,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Test does not pass.")] // TODO: See issue#7160
-        public virtual void Include_reference_with_inheritance_on_derived3()
-        {
-            using (var context = CreateContext())
-            {
-                var query = context.DerivedEntities.Include(e => e.DerivedReferenceOnBase);
-                var result = query.ToList();
-
-                Assert.Equal(3, result.Count);
-            }
-        }
-
         [Fact]
         public virtual void Include_reference_with_inheritance_on_derived4()
         {
@@ -421,18 +361,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var query = context.DerivedEntities.Include(e => e.BaseReferenceOnDerived).Where(e => e.Name != "Bar");
-                var result = query.ToList();
-
-                Assert.Equal(3, result.Count);
-            }
-        }
-
-        [ConditionalFact(Skip = "Test does not pass.")] // TODO: See issue#7160
-        public virtual void Include_reference_with_inheritance_on_derived_with_filter3()
-        {
-            using (var context = CreateContext())
-            {
-                var query = context.DerivedEntities.Include(e => e.DerivedReferenceOnBase).Where(e => e.Name != "Bar");
                 var result = query.ToList();
 
                 Assert.Equal(3, result.Count);
@@ -524,20 +452,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Test does not pass.")] // TODO: See issue#7160
+        [Fact]
         public virtual void Include_collection_with_inheritance_on_derived3()
-        {
-            using (var context = CreateContext())
-            {
-                var query = context.DerivedEntities.Include(e => e.DerivedCollectionOnBase);
-                var result = query.ToList();
-
-                Assert.Equal(3, result.Count);
-            }
-        }
-
-        [ConditionalFact(Skip = "Test does not pass.")] // TODO: See issue#7160
-        public virtual void Include_collection_with_inheritance_on_derived4()
         {
             using (var context = CreateContext())
             {
@@ -572,36 +488,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Test does not pass.")] // TODO: See issue#7160
-        public virtual void Nested_include_with_inheritance_reference_reference2()
-        {
-            using (var context = CreateContext())
-            {
-                var query = context.BaseEntities.Include(e => e.DerivedReferenceOnBase.NestedReference);
-                var result = query.ToList();
-
-                Assert.Equal(6, result.Count);
-            }
-        }
-
         [Fact]
         public virtual void Nested_include_with_inheritance_reference_reference3()
         {
             using (var context = CreateContext())
             {
                 var query = context.DerivedEntities.Include(e => e.BaseReferenceOnBase.NestedReference);
-                var result = query.ToList();
-
-                Assert.Equal(3, result.Count);
-            }
-        }
-
-        [ConditionalFact(Skip = "Test does not pass.")] // TODO: See issue#7160
-        public virtual void Nested_include_with_inheritance_reference_reference4()
-        {
-            using (var context = CreateContext())
-            {
-                var query = context.DerivedEntities.Include(e => e.DerivedReferenceOnBase.NestedReference);
                 var result = query.ToList();
 
                 Assert.Equal(3, result.Count);
@@ -632,36 +524,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Test does not pass.")] // TODO: See issue#7160
-        public virtual void Nested_include_with_inheritance_reference_collection2()
-        {
-            using (var context = CreateContext())
-            {
-                var query = context.BaseEntities.Include(e => e.DerivedReferenceOnBase.NestedCollection);
-                var result = query.ToList();
-
-                Assert.Equal(6, result.Count);
-            }
-        }
-
         [Fact]
         public virtual void Nested_include_with_inheritance_reference_collection3()
         {
             using (var context = CreateContext())
             {
                 var query = context.DerivedEntities.Include(e => e.BaseReferenceOnBase.NestedCollection);
-                var result = query.ToList();
-
-                Assert.Equal(3, result.Count);
-            }
-        }
-
-        [ConditionalFact(Skip = "Test does not pass.")] // TODO: See issue#7160
-        public virtual void Nested_include_with_inheritance_reference_collection4()
-        {
-            using (var context = CreateContext())
-            {
-                var query = context.DerivedEntities.Include(e => e.DerivedReferenceOnBase.NestedCollection);
                 var result = query.ToList();
 
                 Assert.Equal(3, result.Count);
@@ -693,42 +561,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        [ConditionalFact(Skip = "Test does not pass.")] // TODO: See issue#7160
-        public virtual void Nested_include_with_inheritance_collection_reference2()
-        {
-            using (var context = CreateContext())
-            {
-                var query = context.BaseEntities.Include(e => e.DerivedCollectionOnBase).ThenInclude(e => e.NestedReference);
-                var result = query.ToList();
-
-                Assert.Equal(6, result.Count);
-            }
-        }
-
-        [ConditionalFact(Skip = "Test does not pass.")] // TODO: See issue#7160
-        public virtual void Nested_include_with_inheritance_collection_reference3()
-        {
-            using (var context = CreateContext())
-            {
-                var query = context.DerivedEntities.Include(e => e.DerivedCollectionOnBase).ThenInclude(e => e.NestedReference);
-                var result = query.ToList();
-
-                Assert.Equal(3, result.Count);
-            }
-        }
-
-        [ConditionalFact(Skip = "Test does not pass.")] // TODO: See issue#7160
-        public virtual void Nested_include_with_inheritance_collection_reference4()
-        {
-            using (var context = CreateContext())
-            {
-                var query = context.DerivedEntities.Include(e => e.DerivedCollectionOnBase).ThenInclude(e => e.NestedReference);
-                var result = query.ToList();
-
-                Assert.Equal(3, result.Count);
-            }
-        }
-
         [Fact]
         public virtual void Nested_include_with_inheritance_collection_reference_reverse()
         {
@@ -751,42 +583,6 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 Assert.Equal(6, result.Count);
                 Assert.Equal(3, result.SelectMany(e => e.BaseCollectionOnBase.OfType<DerivedCollectionOnBase>()).Count(e => e.DerivedProperty != 0));
-            }
-        }
-
-        [ConditionalFact(Skip = "Test does not pass.")] // TODO: See issue#7160
-        public virtual void Nested_include_with_inheritance_collection_collection2()
-        {
-            using (var context = CreateContext())
-            {
-                var query = context.BaseEntities.Include(e => e.DerivedCollectionOnBase).ThenInclude(e => e.NestedCollection);
-                var result = query.ToList();
-
-                Assert.Equal(6, result.Count);
-            }
-        }
-
-        [ConditionalFact(Skip = "Test does not pass.")] // TODO: See issue#7160
-        public virtual void Nested_include_with_inheritance_collection_collection3()
-        {
-            using (var context = CreateContext())
-            {
-                var query = context.DerivedEntities.Include(e => e.DerivedCollectionOnBase).ThenInclude(e => e.NestedCollection);
-                var result = query.ToList();
-
-                Assert.Equal(3, result.Count);
-            }
-        }
-
-        [ConditionalFact(Skip = "Test does not pass.")] // TODO: See issue#7160
-        public virtual void Nested_include_with_inheritance_collection_collection4()
-        {
-            using (var context = CreateContext())
-            {
-                var query = context.DerivedEntities.Include(e => e.DerivedCollectionOnBase).ThenInclude(e => e.NestedCollection);
-                var result = query.ToList();
-
-                Assert.Equal(3, result.Count);
             }
         }
 

--- a/src/EFCore.Specification.Tests/TestModels/InheritanceRelationships/BaseInheritanceRelationshipEntity.cs
+++ b/src/EFCore.Specification.Tests/TestModels/InheritanceRelationships/BaseInheritanceRelationshipEntity.cs
@@ -20,16 +20,10 @@ namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceRelationships
         public BaseReferenceOnBase BaseReferenceOnBase { get; set; }
 
         [NotMapped]
-        public DerivedReferenceOnBase DerivedReferenceOnBase { get; set; }
-
-        [NotMapped]
         public ReferenceOnBase ReferenceOnBase { get; set; }
 
         [NotMapped]
         public List<BaseCollectionOnBase> BaseCollectionOnBase { get; set; }
-
-        [NotMapped]
-        public List<DerivedCollectionOnBase> DerivedCollectionOnBase { get; set; }
 
         [NotMapped]
         public List<CollectionOnBase> CollectionOnBase { get; set; }

--- a/src/EFCore.Specification.Tests/TestModels/InheritanceRelationships/InheritanceRelationshipsContext.cs
+++ b/src/EFCore.Specification.Tests/TestModels/InheritanceRelationships/InheritanceRelationshipsContext.cs
@@ -162,10 +162,8 @@ namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceRelationships
             {
                 Name = "Base1",
                 BaseReferenceOnBase = brob1,
-                DerivedReferenceOnBase = drob1,
                 ReferenceOnBase = rob1,
                 BaseCollectionOnBase = new List<BaseCollectionOnBase> { bcob11 },
-                DerivedCollectionOnBase = new List<DerivedCollectionOnBase> { dcob11 },
                 CollectionOnBase = new List<CollectionOnBase> { cob11, cob12 }
             };
 
@@ -180,9 +178,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceRelationships
             var baseEntity3 = new BaseInheritanceRelationshipEntity
             {
                 Name = "Base3",
-                DerivedReferenceOnBase = drob2,
                 BaseCollectionOnBase = new List<BaseCollectionOnBase> { dcob21 },
-                DerivedCollectionOnBase = new List<DerivedCollectionOnBase> { dcob21 }
             };
 
             context.BaseEntities.AddRange(baseEntity1, baseEntity2, baseEntity3);
@@ -192,10 +188,8 @@ namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceRelationships
                 Name = "Derived1(4)",
                 BaseSelfRerefenceOnDerived = baseEntity1,
                 BaseReferenceOnBase = drob1,
-                DerivedReferenceOnBase = drob3,
                 ReferenceOnBase = rob3,
                 BaseCollectionOnBase = new List<BaseCollectionOnBase> { dcob11, dcob12 },
-                DerivedCollectionOnBase = new List<DerivedCollectionOnBase> { dcob31, dcob32 },
                 CollectionOnBase = new List<CollectionOnBase> { cob31, cob32 },
                 BaseReferenceOnDerived = brod1,
                 DerivedReferenceOnDerived = drod1,
@@ -221,9 +215,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.InheritanceRelationships
             {
                 Name = "Derived3(6)",
                 BaseSelfRerefenceOnDerived = baseEntity3,
-                DerivedReferenceOnBase = drob4,
                 BaseCollectionOnBase = new List<BaseCollectionOnBase> { bcob21 },
-                DerivedCollectionOnBase = new List<DerivedCollectionOnBase> { dcob41 },
                 DerivedReferenceOnDerived = drod2,
                 BaseCollectionOnDerived = new List<BaseCollectionOnDerived> { dcod11, dcod12 },
                 DerivedCollectionOnDerived = new List<DerivedCollectionOnDerived> { dcod21 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceRelationshipsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceRelationshipsQuerySqlServerTest.cs
@@ -29,14 +29,6 @@ LEFT JOIN (
 WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity')");
         }
 
-        public override void Include_reference_with_inheritance2()
-        {
-            base.Include_reference_with_inheritance2();
-
-            AssertSql(
-                @"");
-        }
-
         public override void Include_reference_with_inheritance_reverse()
         {
             base.Include_reference_with_inheritance_reverse();
@@ -95,14 +87,6 @@ LEFT JOIN (
     WHERE [e.BaseReferenceOnBase].[Discriminator] IN (N'DerivedReferenceOnBase', N'BaseReferenceOnBase')
 ) AS [t] ON [e].[Id] = [t].[BaseParentId]
 WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity') AND (([e].[Name] <> N'Bar') OR [e].[Name] IS NULL)");
-        }
-
-        public override void Include_reference_with_inheritance_with_filter2()
-        {
-            base.Include_reference_with_inheritance_with_filter2();
-
-            AssertSql(
-                @"");
         }
 
         public override void Include_reference_with_inheritance_with_filter_reverse()
@@ -192,14 +176,6 @@ WHERE [e.BaseCollectionOnBase].[Discriminator] IN (N'DerivedCollectionOnBase', N
 ORDER BY [t].[Id]");
         }
 
-        public override void Include_collection_with_inheritance2()
-        {
-            base.Include_collection_with_inheritance2();
-
-            AssertSql(
-                @"");
-        }
-
         public override void Include_collection_with_inheritance_reverse()
         {
             base.Include_collection_with_inheritance_reverse();
@@ -234,14 +210,6 @@ INNER JOIN (
 ) AS [t] ON [e.BaseCollectionOnBase].[BaseParentId] = [t].[Id]
 WHERE [e.BaseCollectionOnBase].[Discriminator] IN (N'DerivedCollectionOnBase', N'BaseCollectionOnBase')
 ORDER BY [t].[Id]");
-        }
-
-        public override void Include_collection_with_inheritance_with_filter2()
-        {
-            base.Include_collection_with_inheritance_with_filter2();
-
-            AssertSql(
-                @"");
         }
 
         public override void Include_collection_with_inheritance_with_filter_reverse()
@@ -358,14 +326,6 @@ LEFT JOIN (
 WHERE [e].[Discriminator] = N'DerivedInheritanceRelationshipEntity'");
         }
 
-        public override void Include_reference_with_inheritance_on_derived3()
-        {
-            base.Include_reference_with_inheritance_on_derived3();
-
-            AssertSql(
-                @"");
-        }
-
         public override void Include_reference_with_inheritance_on_derived4()
         {
             base.Include_reference_with_inheritance_on_derived4();
@@ -424,14 +384,6 @@ LEFT JOIN (
     WHERE [e.BaseReferenceOnDerived].[Discriminator] IN (N'DerivedReferenceOnDerived', N'BaseReferenceOnDerived')
 ) AS [t] ON [e].[Id] = [t].[BaseParentId]
 WHERE ([e].[Discriminator] = N'DerivedInheritanceRelationshipEntity') AND (([e].[Name] <> N'Bar') OR [e].[Name] IS NULL)");
-        }
-
-        public override void Include_reference_with_inheritance_on_derived_with_filter3()
-        {
-            base.Include_reference_with_inheritance_on_derived_with_filter3();
-
-            AssertSql(
-                @"");
         }
 
         public override void Include_reference_with_inheritance_on_derived_with_filter4()
@@ -547,15 +499,20 @@ ORDER BY [t].[Id]");
             base.Include_collection_with_inheritance_on_derived3();
 
             AssertSql(
-                @"");
-        }
-
-        public override void Include_collection_with_inheritance_on_derived4()
-        {
-            base.Include_collection_with_inheritance_on_derived4();
-
-            AssertSql(
-                @"");
+                @"SELECT [e].[Id], [e].[Discriminator], [e].[Name], [e].[BaseId]
+FROM [BaseEntities] AS [e]
+WHERE [e].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
+ORDER BY [e].[Id]",
+                //
+                @"SELECT [e.DerivedCollectionOnDerived].[Id], [e.DerivedCollectionOnDerived].[Discriminator], [e.DerivedCollectionOnDerived].[Name], [e.DerivedCollectionOnDerived].[ParentId], [e.DerivedCollectionOnDerived].[DerivedInheritanceRelationshipEntityId]
+FROM [BaseCollectionsOnDerived] AS [e.DerivedCollectionOnDerived]
+INNER JOIN (
+    SELECT [e0].[Id]
+    FROM [BaseEntities] AS [e0]
+    WHERE [e0].[Discriminator] = N'DerivedInheritanceRelationshipEntity'
+) AS [t] ON [e.DerivedCollectionOnDerived].[DerivedInheritanceRelationshipEntityId] = [t].[Id]
+WHERE [e.DerivedCollectionOnDerived].[Discriminator] = N'DerivedCollectionOnDerived'
+ORDER BY [t].[Id]");
         }
 
         public override void Include_collection_with_inheritance_on_derived_reverse()
@@ -593,14 +550,6 @@ LEFT JOIN (
 WHERE [e].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity')");
         }
 
-        public override void Nested_include_with_inheritance_reference_reference2()
-        {
-            base.Nested_include_with_inheritance_reference_reference2();
-
-            AssertSql(
-                @"");
-        }
-
         public override void Nested_include_with_inheritance_reference_reference3()
         {
             base.Nested_include_with_inheritance_reference_reference3();
@@ -619,14 +568,6 @@ LEFT JOIN (
     WHERE [e.BaseReferenceOnBase.NestedReference].[Discriminator] IN (N'NestedReferenceDerived', N'NestedReferenceBase')
 ) AS [t0] ON [t].[Id] = [t0].[ParentReferenceId]
 WHERE [e].[Discriminator] = N'DerivedInheritanceRelationshipEntity'");
-        }
-
-        public override void Nested_include_with_inheritance_reference_reference4()
-        {
-            base.Nested_include_with_inheritance_reference_reference4();
-
-            AssertSql(
-                @"");
         }
 
         public override void Nested_include_with_inheritance_reference_reference_reverse()
@@ -680,14 +621,6 @@ WHERE [e.BaseReferenceOnBase.NestedCollection].[Discriminator] IN (N'NestedColle
 ORDER BY [t1].[Id]");
         }
 
-        public override void Nested_include_with_inheritance_reference_collection2()
-        {
-            base.Nested_include_with_inheritance_reference_collection2();
-
-            AssertSql(
-                @"");
-        }
-
         public override void Nested_include_with_inheritance_reference_collection3()
         {
             base.Nested_include_with_inheritance_reference_collection3();
@@ -717,14 +650,6 @@ INNER JOIN (
 ) AS [t1] ON [e.BaseReferenceOnBase.NestedCollection].[ParentReferenceId] = [t1].[Id]
 WHERE [e.BaseReferenceOnBase.NestedCollection].[Discriminator] IN (N'NestedCollectionDerived', N'NestedCollectionBase')
 ORDER BY [t1].[Id]");
-        }
-
-        public override void Nested_include_with_inheritance_reference_collection4()
-        {
-            base.Nested_include_with_inheritance_reference_collection4();
-
-            AssertSql(
-                @"");
         }
 
         public override void Nested_include_with_inheritance_reference_collection_reverse()
@@ -771,30 +696,6 @@ INNER JOIN (
 ) AS [t0] ON [e.BaseCollectionOnBase].[BaseParentId] = [t0].[Id]
 WHERE [e.BaseCollectionOnBase].[Discriminator] IN (N'DerivedCollectionOnBase', N'BaseCollectionOnBase')
 ORDER BY [t0].[Id]");
-        }
-
-        public override void Nested_include_with_inheritance_collection_reference2()
-        {
-            base.Nested_include_with_inheritance_collection_reference2();
-
-            AssertSql(
-                @"");
-        }
-
-        public override void Nested_include_with_inheritance_collection_reference3()
-        {
-            base.Nested_include_with_inheritance_collection_reference3();
-
-            AssertSql(
-                @"");
-        }
-
-        public override void Nested_include_with_inheritance_collection_reference4()
-        {
-            base.Nested_include_with_inheritance_collection_reference4();
-
-            AssertSql(
-                @"");
         }
 
         public override void Nested_include_with_inheritance_collection_reference_reverse()
@@ -851,30 +752,6 @@ INNER JOIN (
 ) AS [t1] ON [e.BaseCollectionOnBase.NestedCollection].[ParentCollectionId] = [t1].[Id]
 WHERE [e.BaseCollectionOnBase.NestedCollection].[Discriminator] IN (N'NestedCollectionDerived', N'NestedCollectionBase')
 ORDER BY [t1].[Id0], [t1].[Id]");
-        }
-
-        public override void Nested_include_with_inheritance_collection_collection2()
-        {
-            base.Nested_include_with_inheritance_collection_collection2();
-
-            AssertSql(
-                @"");
-        }
-
-        public override void Nested_include_with_inheritance_collection_collection3()
-        {
-            base.Nested_include_with_inheritance_collection_collection3();
-
-            AssertSql(
-                @"");
-        }
-
-        public override void Nested_include_with_inheritance_collection_collection4()
-        {
-            base.Nested_include_with_inheritance_collection_collection4();
-
-            AssertSql(
-                @"");
         }
 
         public override void Nested_include_with_inheritance_collection_collection_reverse()


### PR DESCRIPTION
Removing tests that are covered by GearsOfWar test suite:

DerivedReferenceOnBase: LocustCommander -> CommandingFaction
DerivedCollectionOnBase: LocustHighCommand -> Commanders
BaseCollectionOnDerived: LocustHorde -> Leaders

Also, enabling some additional tests that are no longer broken.