### PR TITLE
Analyzers: Part of #10080 - Adds potential SQL injection analysis.

### DIFF
--- a/EFCore.sln
+++ b/EFCore.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27110.0
+VisualStudioVersion = 15.0.27130.2027
 MinimumVisualStudioVersion = 15.0.26730.03
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{C41FD56B-38CD-40E3-89E6-071A6C58E36C}"
 EndProject
@@ -94,6 +94,10 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EFCore.SqlServer.Tests", "test\EFCore.SqlServer.Tests\EFCore.SqlServer.Tests.csproj", "{7D1C4E40-0DE6-4C50-AB84-CA8647EA92DF}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EFCore.Tests", "test\EFCore.Tests\EFCore.Tests.csproj", "{313F46FE-9962-4A15-805F-FCBDF5A6181E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EFCore.Analyzers", "src\EFCore.Analyzers\EFCore.Analyzers.csproj", "{C0D4A199-3ED4-447B-8657-0502493294E7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EFCore.Analyzers.Test", "test\EFCore.Analyzers.Tests\EFCore.Analyzers.Test.csproj", "{7BC66E5C-BAA3-420B-8331-22821EBA361A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -233,6 +237,14 @@ Global
 		{313F46FE-9962-4A15-805F-FCBDF5A6181E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{313F46FE-9962-4A15-805F-FCBDF5A6181E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{313F46FE-9962-4A15-805F-FCBDF5A6181E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C0D4A199-3ED4-447B-8657-0502493294E7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C0D4A199-3ED4-447B-8657-0502493294E7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C0D4A199-3ED4-447B-8657-0502493294E7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C0D4A199-3ED4-447B-8657-0502493294E7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7BC66E5C-BAA3-420B-8331-22821EBA361A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7BC66E5C-BAA3-420B-8331-22821EBA361A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7BC66E5C-BAA3-420B-8331-22821EBA361A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7BC66E5C-BAA3-420B-8331-22821EBA361A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -274,6 +286,8 @@ Global
 		{87AB43B7-767B-467B-9AA9-47BADF850D6A} = {258D5057-81B9-40EC-A872-D21E27452749}
 		{7D1C4E40-0DE6-4C50-AB84-CA8647EA92DF} = {258D5057-81B9-40EC-A872-D21E27452749}
 		{313F46FE-9962-4A15-805F-FCBDF5A6181E} = {258D5057-81B9-40EC-A872-D21E27452749}
+		{C0D4A199-3ED4-447B-8657-0502493294E7} = {CE6B50B2-34AE-44C9-940A-4E48C3E1B3BC}
+		{7BC66E5C-BAA3-420B-8331-22821EBA361A} = {258D5057-81B9-40EC-A872-D21E27452749}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {285A5EB4-BCF4-40EB-B9E1-DF6DBCB5E705}

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -9,6 +9,7 @@
     <MicrosoftAspNetCoreHostingWebHostBuilderFactorySourcesPackageVersion>2.1.0-preview2-30131</MicrosoftAspNetCoreHostingWebHostBuilderFactorySourcesPackageVersion>
     <MicrosoftAzureDocumentDBCorePackageVersion>1.7.1</MicrosoftAzureDocumentDBCorePackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>2.6.1</MicrosoftCodeAnalysisCSharpPackageVersion>
+    <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>2.6.1</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
     <MicrosoftCSharpPackageVersion>4.5.0-preview2-26130-01</MicrosoftCSharpPackageVersion>
     <MicrosoftDataSqliteCorePackageVersion>2.1.0-preview2-30131</MicrosoftDataSqliteCorePackageVersion>
     <MicrosoftExtensionsCachingMemoryPackageVersion>2.1.0-preview2-30131</MicrosoftExtensionsCachingMemoryPackageVersion>

--- a/src/EFCore.Analyzers/EFCore.Analyzers.csproj
+++ b/src/EFCore.Analyzers/EFCore.Analyzers.csproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <Description>CSharp Analyzers for Entity Framework Core.</Description>
+        <PackageTags>efcore</PackageTags>
+
+        <VerifyVersion>false</VerifyVersion>
+        <VersionPrefix>$(ExperimentalVersionPrefix)</VersionPrefix>
+        <VersionSuffix>$(ExperimentalVersionSuffix)</VersionSuffix>
+        <PackageVersion>$(ExperimentalPackageVersion)</PackageVersion>
+
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <IncludeBuildOutput>false</IncludeBuildOutput>
+        <EnableApiCheck>false</EnableApiCheck>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Include="..\Shared\CodeAnnotations.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion)" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="analyzers\dotnet\cs\" />
+    </ItemGroup>
+
+</Project>

--- a/src/EFCore.Analyzers/Extensions.cs
+++ b/src/EFCore.Analyzers/Extensions.cs
@@ -1,0 +1,18 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace EFCore.Analyzers
+{
+    internal static class Extensions
+    {
+        [CanBeNull]
+        public static ISymbol GetSymbol(this SyntaxNodeAnalysisContext analysisContext, SyntaxNode syntaxNode)
+            => analysisContext.SemanticModel
+                .GetSymbolInfo(syntaxNode, analysisContext.CancellationToken)
+                .Symbol;
+    }
+}

--- a/src/EFCore.Analyzers/SqlInjectionDiagnosticAnalyzer.cs
+++ b/src/EFCore.Analyzers/SqlInjectionDiagnosticAnalyzer.cs
@@ -1,0 +1,240 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace EFCore.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class SqlInjectionDiagnosticAnalyzer : DiagnosticAnalyzer
+    {
+        public const string Id = "EF1000";
+
+        public const string MessageFormat
+            = "The SQL expression passed to '{0}' embeds data that will not be parameterized. Review for potential SQL injection vulnerability.";
+
+        private static readonly DiagnosticDescriptor _descriptor
+            = new DiagnosticDescriptor(
+                Id,
+                title: "Possible SQL injection vulnerability.",
+                messageFormat: MessageFormat,
+                category: "Security",
+                defaultSeverity: DiagnosticSeverity.Warning,
+                isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+            => ImmutableArray.Create(_descriptor);
+
+        public override void Initialize(AnalysisContext analysisContext)
+            => analysisContext.RegisterSyntaxNodeAction(
+                AnalyzeSimpleMemberAccessExpressionSyntaxNode, SyntaxKind.SimpleMemberAccessExpression);
+
+        private static void AnalyzeSimpleMemberAccessExpressionSyntaxNode(SyntaxNodeAnalysisContext analysisContext)
+        {
+            if (!(analysisContext.Node is MemberAccessExpressionSyntax memberAccessExpressionSyntax))
+            {
+                return;
+            }
+
+            var identifierValueText = memberAccessExpressionSyntax.Name.Identifier.ValueText;
+
+            if (identifierValueText == "FromSql"
+                || identifierValueText == "ExecuteSqlCommand"
+                || identifierValueText == "ExecuteSqlCommandAsync"
+                || identifierValueText == "CommandText")
+            {
+                var symbol = analysisContext.GetSymbol(memberAccessExpressionSyntax);
+
+                if (symbol == null)
+                {
+                    return;
+                }
+
+                var containingType = symbol.ContainingType;
+                var containingTypeName = containingType.Name;
+
+                if ((containingTypeName == "RelationalQueryableExtensions"
+                     || containingTypeName == "RelationalDatabaseFacadeExtensions")
+                    && containingType.ContainingNamespace.Name == "EntityFrameworkCore"
+                    && memberAccessExpressionSyntax.Parent is InvocationExpressionSyntax invocationExpressionSyntax
+                    && symbol is IMethodSymbol methodSymbol)
+                {
+                    // FromSql, ExecuteSqlCommand/Async
+
+                    // Extension method vs static invocation
+                    var sqlArgumentIndex = methodSymbol.ReducedFrom == null ? 1 : 0;
+
+                    var sqlArgumentExpressionSyntax
+                        = invocationExpressionSyntax.ArgumentList.Arguments[sqlArgumentIndex].Expression;
+
+                    // Skip safe FromSql/ExecuteSqlCommand usage - string literal or interpolated string
+                    switch (sqlArgumentExpressionSyntax)
+                    {
+                        case LiteralExpressionSyntax _:
+                            return;
+                        case InterpolatedStringExpressionSyntax _:
+                            return;
+                    }
+
+                    CheckPossibleInjection(
+                        analysisContext,
+                        sqlArgumentExpressionSyntax,
+                        identifierValueText,
+                        invocationExpressionSyntax.GetLocation());
+                }
+                else if (symbol is IPropertySymbol propertySymbol)
+                {
+                    // DbCommand.CommandText
+
+                    var overriddenPropertyContainingType = propertySymbol.OverriddenProperty.ContainingType;
+
+                    if (overriddenPropertyContainingType.Name == "DbCommand"
+                        && overriddenPropertyContainingType.ContainingNamespace.Name == "Common"
+                        && memberAccessExpressionSyntax.Parent is AssignmentExpressionSyntax assignmentExpressionSyntax)
+                    {
+                        CheckPossibleInjection(
+                            analysisContext,
+                            assignmentExpressionSyntax.Right,
+                            identifierValueText,
+                            assignmentExpressionSyntax.GetLocation());
+                    }
+                }
+            }
+        }
+
+        private static bool CheckPossibleInjection(
+            SyntaxNodeAnalysisContext analysisContext, SyntaxNode syntaxNode, string identifier, Location location)
+        {
+            if (UsesUnsafeInterpolation(analysisContext, syntaxNode)
+                || UsesUnsafeStringOperation(analysisContext, syntaxNode))
+            {
+                analysisContext.ReportDiagnostic(
+                    Diagnostic.Create(_descriptor, location, identifier));
+
+                return true;
+            }
+
+            var rootSyntaxNode
+                = syntaxNode.Ancestors().First(n => n is MemberDeclarationSyntax);
+
+            foreach (var identifierNameSyntax in syntaxNode.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>())
+            {
+                var symbol = analysisContext.GetSymbol(identifierNameSyntax);
+
+                if (symbol is ILocalSymbol
+                    || symbol is IParameterSymbol)
+                {
+                    foreach (var descendantNode in rootSyntaxNode.DescendantNodes())
+                    {
+                        if (descendantNode == syntaxNode)
+                        {
+                            break;
+                        }
+
+                        switch (descendantNode)
+                        {
+                            case AssignmentExpressionSyntax assignmentExpressionSyntax
+                                when assignmentExpressionSyntax.Left is IdentifierNameSyntax
+                                     && Equals(analysisContext.GetSymbol(assignmentExpressionSyntax.Left), symbol):
+                                {
+                                    if (CheckPossibleInjection(
+                                        analysisContext,
+                                        assignmentExpressionSyntax.Right,
+                                        identifier,
+                                        location))
+                                    {
+                                        return true;
+                                    }
+
+                                    break;
+                                }
+                            case VariableDeclaratorSyntax variableDeclaratorSyntax
+                                when Equals(analysisContext.SemanticModel.GetDeclaredSymbol(variableDeclaratorSyntax), symbol):
+                                {
+                                    if (CheckPossibleInjection(
+                                        analysisContext,
+                                        variableDeclaratorSyntax.Initializer,
+                                        identifier,
+                                        location))
+                                    {
+                                        return true;
+                                    }
+
+                                    break;
+                                }
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
+
+        private static bool UsesUnsafeInterpolation(
+            SyntaxNodeAnalysisContext analysisContext, SyntaxNode syntaxNode)
+            => syntaxNode
+                .DescendantNodesAndSelf()
+                .Any(
+                    sn => sn is InterpolatedStringExpressionSyntax interpolatedStringExpressionSyntax
+                          && interpolatedStringExpressionSyntax
+                              .DescendantNodes()
+                              .OfType<InterpolationSyntax>()
+                              .SelectMany(i => i.DescendantNodesAndSelf())
+                              .Any(n => IsLocalOrParameterSymbol(analysisContext, n)));
+
+        private static bool UsesUnsafeStringOperation(
+            SyntaxNodeAnalysisContext analysisContext, SyntaxNode syntaxNode)
+            => syntaxNode
+                .DescendantNodesAndSelf()
+                .Any(
+                    sn =>
+                    {
+                        if (
+                            // Test for various string methods
+                            sn is InvocationExpressionSyntax invocationExpressionSyntax
+                            && invocationExpressionSyntax.Expression is MemberAccessExpressionSyntax memberAccessExpressionSyntax
+                            && memberAccessExpressionSyntax.Name.Identifier.ValueText is string identifier
+                            && (identifier == "Format"
+                                || identifier == "Concat"
+                                || identifier == "Insert"
+                                || identifier == "Replace"
+                                || identifier == "Join")
+
+                            // Test for string '+' operator
+                            || sn is BinaryExpressionSyntax binaryExpressionSyntax
+                            && binaryExpressionSyntax.OperatorToken.Kind() == SyntaxKind.PlusToken)
+                        {
+                            var memberSymbol = analysisContext.GetSymbol(sn);
+
+                            if (memberSymbol != null)
+                            {
+                                var containingType = memberSymbol.ContainingType;
+                                var containingTypeName = containingType.Name;
+
+                                if (containingTypeName == "String"
+                                    && containingType.ContainingNamespace.Name == "System")
+                                {
+                                    return sn
+                                        .DescendantNodes()
+                                        .Any(n => IsLocalOrParameterSymbol(analysisContext, n));
+                                }
+                            }
+                        }
+
+                        return false;
+                    });
+
+        private static bool IsLocalOrParameterSymbol(
+            SyntaxNodeAnalysisContext analysisContext, SyntaxNode syntaxNode)
+        {
+            var symbol = analysisContext.GetSymbol(syntaxNode);
+
+            return symbol is ILocalSymbol || symbol is IParameterSymbol;
+        }
+    }
+}

--- a/test/EFCore.Analyzers.Tests/EFCore.Analyzers.Test.csproj
+++ b/test/EFCore.Analyzers.Tests/EFCore.Analyzers.Test.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <PreserveCompilationContext>true</PreserveCompilationContext>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\EFCore.Analyzers\EFCore.Analyzers.csproj" />
+    <ProjectReference Include="..\..\src\EFCore.Relational\EFCore.Relational.csproj" />
+    <PackageReference Include="System.Data.SqlClient" Version="$(SystemDataSqlClientPackageVersion)" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelPackageVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/test/EFCore.Analyzers.Tests/SqlInjectionDiagnosticAnalyzerTest.cs
+++ b/test/EFCore.Analyzers.Tests/SqlInjectionDiagnosticAnalyzerTest.cs
@@ -1,0 +1,295 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using EFCore.Analyzers.Test.TestUtilities;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+
+namespace EFCore.Analyzers.Test
+{
+    public class SqlInjectionDiagnosticAnalyzerTest : DiagnosticAnalyzerTestBase
+    {
+        [Fact]
+        public async Task No_warning_when_string_literal_passed_to_from_sql()
+        {
+            var diagnostics
+                = await GetDiagnosticsAsync(
+                    "RelationalQueryableExtensions.FromSql<object>(null, \"select * from Customers\");");
+
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task No_warning_when_string_literal_passed_to_execute_sql_command()
+        {
+            var diagnostics
+                = await GetDiagnosticsAsync(
+                    "RelationalDatabaseFacadeExtensions.ExecuteSqlCommand(null, \"select * from Customers\");");
+
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task No_warning_when_string_literal_passed_to_execute_sql_command_async()
+        {
+            var diagnostics
+                = await GetDiagnosticsAsync(
+                    "RelationalDatabaseFacadeExtensions.ExecuteSqlCommandAsync(null, \"select * from Customers\");");
+
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task No_warning_when_interpolated_string_passed_to_from_sql()
+        {
+            var diagnostics
+                = await GetDiagnosticsAsync(
+                    "RelationalQueryableExtensions.FromSql<object>(null, $\"select {'*'} from Customers\");");
+
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task No_warning_when_interpolated_string_passed_to_execute_sql_command()
+        {
+            var diagnostics
+                = await GetDiagnosticsAsync(
+                    "RelationalDatabaseFacadeExtensions.ExecuteSqlCommand(null, $\"select {'*'} from Customers\");");
+
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task No_warning_when_interpolated_string_passed_to_execute_sql_command_async()
+        {
+            var diagnostics
+                = await GetDiagnosticsAsync(
+                    "RelationalDatabaseFacadeExtensions.ExecuteSqlCommandAsync(null, $\"select {'*'} from Customers\");");
+
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task No_warning_when_interpolated_string_coerced_to_string_from_sql_when_no_interpolation()
+        {
+            var diagnostics
+                = await GetDiagnosticsAsync(
+                    @"var maybe = true;
+                      new DbContext(null).Set<object>().FromSql(maybe ? $""bad"" : $""worse"");");
+
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task No_warning_when_interpolated_string_coerced_to_string_from_sql_when_safe_interpolation()
+        {
+            var diagnostics
+                = await GetDiagnosticsAsync(
+                    @"var maybe = true;
+                      new DbContext(null).Set<object>().FromSql(maybe ? $""{'a'}"" : $""{123}"");");
+
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task Warning_when_string_format_with_arg_passed_to_from_sql()
+        {
+            var diagnostics
+                = await GetDiagnosticsAsync(
+                    @"var danger = ""boom!"";
+                      new DbContext(null).Set<object>().FromSql(string.Format(""blah"", danger));");
+
+            var diagnostic = diagnostics.Single();
+
+            Assert.Equal(SqlInjectionDiagnosticAnalyzer.Id, diagnostic.Id);
+            Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+            Assert.Equal(1, diagnostic.Location.GetLineSpan().StartLinePosition.Line);
+            Assert.Equal(22, diagnostic.Location.GetLineSpan().StartLinePosition.Character);
+            Assert.Equal(string.Format(SqlInjectionDiagnosticAnalyzer.MessageFormat, "FromSql"), diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task Warning_when_string_format_with_arg_passed_to_execute_sql_command()
+        {
+            var diagnostics
+                = await GetDiagnosticsAsync(
+                    @"var danger = ""boom!"";
+                      new DbContext(null).Database.ExecuteSqlCommand(string.Format(""blah"", danger));");
+
+            var diagnostic = diagnostics.Single();
+
+            Assert.Equal(SqlInjectionDiagnosticAnalyzer.Id, diagnostic.Id);
+            Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+            Assert.Equal(1, diagnostic.Location.GetLineSpan().StartLinePosition.Line);
+            Assert.Equal(22, diagnostic.Location.GetLineSpan().StartLinePosition.Character);
+            Assert.Equal(string.Format(SqlInjectionDiagnosticAnalyzer.MessageFormat, "ExecuteSqlCommand"), diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task Warning_when_string_format_with_arg_passed_to_execute_sql_command_async()
+        {
+            var diagnostics
+                = await GetDiagnosticsAsync(
+                    @"var danger = ""boom!"";
+                      new DbContext(null).Database.ExecuteSqlCommandAsync(string.Format(""blah"", danger));");
+
+            var diagnostic = diagnostics.Single();
+
+            Assert.Equal(SqlInjectionDiagnosticAnalyzer.Id, diagnostic.Id);
+            Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+            Assert.Equal(1, diagnostic.Location.GetLineSpan().StartLinePosition.Line);
+            Assert.Equal(22, diagnostic.Location.GetLineSpan().StartLinePosition.Character);
+            Assert.Equal(string.Format(SqlInjectionDiagnosticAnalyzer.MessageFormat, "ExecuteSqlCommandAsync"), diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task Warning_when_string_format_with_arg_passed_to_command_text_deep()
+        {
+            var diagnostics
+                = await GetDiagnosticsAsync(
+                    @"var b = true;
+                      var danger = ""boom!"";
+                      new SqlCommand().CommandText = b ? string.Format(""blah"", danger) : ""doof doof"";");
+
+            var diagnostic = diagnostics.Single();
+
+            Assert.Equal(SqlInjectionDiagnosticAnalyzer.Id, diagnostic.Id);
+            Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+            Assert.Equal(2, diagnostic.Location.GetLineSpan().StartLinePosition.Line);
+            Assert.Equal(22, diagnostic.Location.GetLineSpan().StartLinePosition.Character);
+            Assert.Equal(string.Format(SqlInjectionDiagnosticAnalyzer.MessageFormat, "CommandText"), diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task Warning_when_string_concat_op_with_arg_passed_to_command_text_deep()
+        {
+            var diagnostics
+                = await GetDiagnosticsAsync(
+                    @"var b = true;
+                      var danger = ""boom!"";
+                      new SqlCommand().CommandText = b ? ""select"" + danger : ""doof doof"";");
+
+            var diagnostic = diagnostics.Single();
+
+            Assert.Equal(SqlInjectionDiagnosticAnalyzer.Id, diagnostic.Id);
+            Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+            Assert.Equal(2, diagnostic.Location.GetLineSpan().StartLinePosition.Line);
+            Assert.Equal(22, diagnostic.Location.GetLineSpan().StartLinePosition.Character);
+            Assert.Equal(string.Format(SqlInjectionDiagnosticAnalyzer.MessageFormat, "CommandText"), diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task Warning_when_string_concat_with_arg_passed_to_command_text_deep()
+        {
+            var diagnostics
+                = await GetDiagnosticsAsync(
+                    @"var b = true;
+                      var danger = ""boom!"";
+                      new SqlCommand().CommandText = b ? string.Concat(""select"", danger) : ""doof doof"";");
+
+            var diagnostic = diagnostics.Single();
+
+            Assert.Equal(SqlInjectionDiagnosticAnalyzer.Id, diagnostic.Id);
+            Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+            Assert.Equal(2, diagnostic.Location.GetLineSpan().StartLinePosition.Line);
+            Assert.Equal(22, diagnostic.Location.GetLineSpan().StartLinePosition.Character);
+            Assert.Equal(string.Format(SqlInjectionDiagnosticAnalyzer.MessageFormat, "CommandText"), diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task Warning_when_string_insert_with_arg_passed_to_command_text_deep()
+        {
+            var diagnostics
+                = await GetDiagnosticsAsync(
+                    @"var b = true;
+                      var danger = ""boom!"";
+                      new SqlCommand().CommandText = b ? ""select"".Insert(0, danger) : ""doof doof"";");
+
+            var diagnostic = diagnostics.Single();
+
+            Assert.Equal(SqlInjectionDiagnosticAnalyzer.Id, diagnostic.Id);
+            Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+            Assert.Equal(2, diagnostic.Location.GetLineSpan().StartLinePosition.Line);
+            Assert.Equal(22, diagnostic.Location.GetLineSpan().StartLinePosition.Character);
+            Assert.Equal(string.Format(SqlInjectionDiagnosticAnalyzer.MessageFormat, "CommandText"), diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task Warning_when_interpolated_string_coerced_to_string_passed_to_execute_sql_command_async()
+        {
+            var diagnostics
+                = await GetDiagnosticsAsync(
+                    @"var danger = ""boom!"";
+                      new DbContext(null).Database.ExecuteSqlCommandAsync((string)$""{danger}"");");
+
+            var diagnostic = diagnostics.Single();
+
+            Assert.Equal(SqlInjectionDiagnosticAnalyzer.Id, diagnostic.Id);
+            Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+            Assert.Equal(1, diagnostic.Location.GetLineSpan().StartLinePosition.Line);
+            Assert.Equal(22, diagnostic.Location.GetLineSpan().StartLinePosition.Character);
+            Assert.Equal(string.Format(SqlInjectionDiagnosticAnalyzer.MessageFormat, "ExecuteSqlCommandAsync"), diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task Warning_when_interpolated_string_coerced_to_string_passed_to_execute_sql_command_async_deep()
+        {
+            var diagnostics
+                = await GetDiagnosticsAsync(
+                    @"var b = true;
+                      var danger = ""boom!"";
+                      new DbContext(null).Database.ExecuteSqlCommandAsync((string)$""{(!b ? danger : ""good"")}"");");
+
+            var diagnostic = diagnostics.Single();
+
+            Assert.Equal(SqlInjectionDiagnosticAnalyzer.Id, diagnostic.Id);
+            Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+            Assert.Equal(2, diagnostic.Location.GetLineSpan().StartLinePosition.Line);
+            Assert.Equal(22, diagnostic.Location.GetLineSpan().StartLinePosition.Character);
+            Assert.Equal(string.Format(SqlInjectionDiagnosticAnalyzer.MessageFormat, "ExecuteSqlCommandAsync"), diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task Warning_when_interpolated_string_from_var_passed_to_execute_sql_command()
+        {
+            var diagnostics
+                = await GetDiagnosticsAsync(
+                    @"var boom = 123;
+                      var danger = $""boom! {boom}"";
+                      new DbContext(null).Database.ExecuteSqlCommandAsync(danger);");
+
+            var diagnostic = diagnostics.Single();
+
+            Assert.Equal(SqlInjectionDiagnosticAnalyzer.Id, diagnostic.Id);
+            Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+            Assert.Equal(2, diagnostic.Location.GetLineSpan().StartLinePosition.Line);
+            Assert.Equal(22, diagnostic.Location.GetLineSpan().StartLinePosition.Character);
+            Assert.Equal(string.Format(SqlInjectionDiagnosticAnalyzer.MessageFormat, "ExecuteSqlCommandAsync"), diagnostic.GetMessage());
+        }
+
+        [Fact]
+        public async Task Warning_when_interpolated_string_from_var_passed_to_execute_sql_command_transitive()
+        {
+            var diagnostics
+                = await GetDiagnosticsAsync(
+                    @"var boom = 123;
+                      var danger = $""boom! {boom}"";
+                      var extreme = danger;
+                      new DbContext(null).Database.ExecuteSqlCommandAsync(extreme);");
+
+            var diagnostic = diagnostics.Single();
+
+            Assert.Equal(SqlInjectionDiagnosticAnalyzer.Id, diagnostic.Id);
+            Assert.Equal(DiagnosticSeverity.Warning, diagnostic.Severity);
+            Assert.Equal(3, diagnostic.Location.GetLineSpan().StartLinePosition.Line);
+            Assert.Equal(22, diagnostic.Location.GetLineSpan().StartLinePosition.Character);
+            Assert.Equal(string.Format(SqlInjectionDiagnosticAnalyzer.MessageFormat, "ExecuteSqlCommandAsync"), diagnostic.GetMessage());
+        }
+
+        protected override DiagnosticAnalyzer CreateDiagnosticAnalyzer()
+            => new SqlInjectionDiagnosticAnalyzer();
+    }
+}

--- a/test/EFCore.Analyzers.Tests/TestUtilities/DiagnosticAnalyzerTestBase.cs
+++ b/test/EFCore.Analyzers.Tests/TestUtilities/DiagnosticAnalyzerTestBase.cs
@@ -1,0 +1,66 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.DependencyModel;
+using Xunit;
+
+namespace EFCore.Analyzers.Test.TestUtilities
+{
+    public abstract class DiagnosticAnalyzerTestBase
+    {
+        protected abstract DiagnosticAnalyzer CreateDiagnosticAnalyzer();
+
+        protected async Task<Diagnostic[]> GetDiagnosticsAsync(string source)
+        {
+            var compilation = await CreateProject(source).GetCompilationAsync();
+            var errors = compilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error);
+
+            Assert.Empty(errors);
+
+            var compilationWithAnalyzers
+                = compilation.WithAnalyzers(ImmutableArray.Create(CreateDiagnosticAnalyzer()));
+
+            var diagnostics = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+
+            return diagnostics.OrderBy(d => d.Location.SourceSpan.Start).ToArray();
+        }
+
+        private Project CreateProject(string source)
+        {
+            const string fileName = "Test.cs";
+
+            source = $@"using Microsoft.EntityFrameworkCore;using System.Data.SqlClient;class C {{ void M() {{ {source} }} }}";
+
+            //Debugger.Launch();
+            
+            var projectId = ProjectId.CreateNewId(debugName: "TestProject");
+            var documentId = DocumentId.CreateNewId(projectId, fileName);
+
+            var metadataReferences
+                = DependencyContext.Load(GetType().Assembly)
+                    .CompileLibraries
+                    .SelectMany(c => c.ResolveReferencePaths())
+                    .Select(path => MetadataReference.CreateFromFile(path))
+                    .Cast<MetadataReference>()
+                    .ToList();
+
+            var solution = new AdhocWorkspace()
+                .CurrentSolution
+                .AddProject(projectId, "TestProject", "TestProject", LanguageNames.CSharp)
+                .AddMetadataReferences(projectId, metadataReferences)
+                .AddDocument(documentId, fileName, SourceText.From(source));
+
+            return solution.GetProject(projectId)
+                .WithCompilationOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        }
+    }
+}


### PR DESCRIPTION
A new EF Core Analyzer that detects some common potential SQL injection patterns. Currently looks at ```FromSql```, ```ExecuteSqlCommand/Async``` and ```DbCommand.CommandText``` APIs.

Works by inspecting the SQL argument expression (either passed directly, or by walking up any local variable chain), and pattern matching the expression for:

- Calls to String.Format, Concat, '+', Insert, Replace, Join involving any local variable or parameter data.
- Uses of interpolated strings that use local variable or parameter data in places that don't end up resolving to an overload that accepts ```FormattableString```.

See unit tests for examples of patterns.

TBD: Figure out packaging of this.

cc @blowdart 

