### PR TITLE
Don't remove FKs when the referenced key is removed.

### DIFF
--- a/src/EFCore.Specification.Tests/DataAnnotationTestBase.cs
+++ b/src/EFCore.Specification.Tests/DataAnnotationTestBase.cs
@@ -1671,6 +1671,50 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [Fact]
+        public virtual void InversePropertyAttribute_removes_ambiguity_when_combined_with_other_attributes()
+        {
+            var modelBuilder = CreateModelBuilder();
+            var model = modelBuilder.Model;
+            modelBuilder.Entity<Relation>();
+
+            var accountNavigation = model.FindEntityType(typeof(Relation)).FindNavigation(nameof(Relation.AccountManager));
+            Assert.Equal(nameof(User.AccountManagerRelations), accountNavigation?.FindInverse()?.Name);
+            Assert.Equal(nameof(Relation.AccountId), accountNavigation?.ForeignKey.Properties.First().Name);
+
+            var salesNavigation = model.FindEntityType(typeof(Relation)).FindNavigation(nameof(Relation.SalesManager));
+            Assert.Equal(nameof(User.SalesManagerRelations), salesNavigation?.FindInverse()?.Name);
+            Assert.Equal(nameof(Relation.SalesId), salesNavigation?.ForeignKey.Properties.First().Name);
+
+            Validate(modelBuilder);
+        }
+
+        public class User
+        {
+            [Key]
+            public int UserUId { get; set; }
+
+            [InverseProperty(nameof(Relation.AccountManager))]
+            public virtual ICollection<Relation> AccountManagerRelations { get; set; }
+
+            public virtual ICollection<Relation> SalesManagerRelations { get; set; }
+        }
+
+        public class Relation
+        {
+            public string Id { get; set; }
+
+            public int AccountId { get; set; }
+
+            [ForeignKey(nameof(AccountId))]
+            public virtual User AccountManager { get; set; }
+
+            public int SalesId { get; set; }
+
+            [ForeignKey(nameof(SalesId))]
+            public virtual User SalesManager { get; set; }
+        }
+
+        [Fact]
         public virtual void InversePropertyAttribute_removes_ambiguity_with_base_type_bidirectional()
         {
             var modelBuilder = CreateModelBuilder();

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryFixtureBase.cs
@@ -274,8 +274,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             modelBuilder.Entity<LocustHorde>().HasBaseType<Faction>();
             modelBuilder.Entity<LocustHorde>().HasMany(h => h.Leaders).WithOne();
 
-            // TODO: explicit FK declaration can be removed once #11019 is fixed
-            modelBuilder.Entity<LocustHorde>().HasOne(h => h.Commander).WithOne(c => c.CommandingFaction).HasForeignKey<LocustHorde>(k => k.CommanderName); 
+            modelBuilder.Entity<LocustHorde>().HasOne(h => h.Commander).WithOne(c => c.CommandingFaction);
 
             modelBuilder.Entity<LocustLeader>().HasKey(l => l.Name);
             modelBuilder.Entity<LocustCommander>().HasBaseType<LocustLeader>();

--- a/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
@@ -109,6 +109,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             conventionSet.PropertyAddedConventions.Add(foreignKeyPropertyDiscoveryConvention);
             conventionSet.PropertyAddedConventions.Add(keyAttributeConvention);
 
+            conventionSet.PrimaryKeyChangedConventions.Add(foreignKeyPropertyDiscoveryConvention);
             conventionSet.PrimaryKeyChangedConventions.Add(valueGeneratorConvention);
 
             conventionSet.KeyAddedConventions.Add(foreignKeyPropertyDiscoveryConvention);

--- a/src/EFCore/Metadata/Conventions/Internal/KeyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/KeyAttributeConvention.cs
@@ -45,8 +45,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     currentKey.Properties
                         .Where(p => !p.Name.Equals(propertyBuilder.Metadata.Name, StringComparison.OrdinalIgnoreCase))
                         .Select(p => p.Name));
-                properties.Sort(StringComparer.OrdinalIgnoreCase);
-                entityTypeBuilder.RemoveKey(currentKey, ConfigurationSource.DataAnnotation);
+                if (properties.Count > 1)
+                {
+                    properties.Sort(StringComparer.OrdinalIgnoreCase);
+                    entityTypeBuilder.RemoveKey(currentKey, ConfigurationSource.DataAnnotation);
+                }
             }
 
             entityTypeBuilder.PrimaryKey(properties, ConfigurationSource.DataAnnotation);

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -977,6 +977,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public virtual IEnumerable<ForeignKey> GetForeignKeys()
+            => _baseType?.GetForeignKeys().Concat(_foreignKeys) ?? _foreignKeys;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual IEnumerable<ForeignKey> FindDeclaredForeignKeys([NotNull] IReadOnlyList<IProperty> properties)
         {
             Check.NotEmpty(properties, nameof(properties));
@@ -1133,14 +1140,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual IEnumerable<ForeignKey> GetDeclaredReferencingForeignKeys()
             => DeclaredReferencingForeignKeys ?? Enumerable.Empty<ForeignKey>();
 
-        private SortedSet<ForeignKey> DeclaredReferencingForeignKeys { get; set; }
-
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual IEnumerable<ForeignKey> GetForeignKeys()
-            => _baseType?.GetForeignKeys().Concat(_foreignKeys) ?? _foreignKeys;
+        public virtual IEnumerable<ForeignKey> GetDerivedReferencingForeignKeysInclusive()
+            => GetDeclaredReferencingForeignKeys().Concat(GetDerivedTypes().SelectMany(et => et.GetDeclaredReferencingForeignKeys()));
+
+        private SortedSet<ForeignKey> DeclaredReferencingForeignKeys { get; set; }
 
         #endregion
 

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -215,14 +215,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             using (Metadata.Model.ConventionDispatcher.StartBatch())
             {
-                foreach (var foreignKey in key.GetReferencingForeignKeys().ToList())
-                {
-                    var removed = foreignKey.DeclaringEntityType.Builder.RemoveForeignKey(foreignKey, configurationSource);
-                    Debug.Assert(removed.HasValue);
-                }
+                var detachedRelationships = key.GetReferencingForeignKeys().ToList().Select(DetachRelationship).ToList();
 
                 var removedKey = Metadata.RemoveKey(key.Properties);
                 Debug.Assert(removedKey == key);
+
+                foreach (var detachedRelationship in detachedRelationships)
+                {
+                    detachedRelationship.Item1.Attach(detachedRelationship.Item1.Metadata.DeclaringEntityType.Builder);
+                }
 
                 RemoveShadowPropertiesIfUnused(key.Properties);
                 foreach (var property in key.Properties)

--- a/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -1017,32 +1017,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         [Fact]
-        public void Removing_key_removes_referencing_foreign_key_of_lower_or_equal_source()
-        {
-            var modelBuilder = CreateModelBuilder();
-            var dependentEntityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
-            var principalEntityBuilder = modelBuilder.Entity(typeof(Customer), ConfigurationSource.Explicit);
-            var key = principalEntityBuilder.HasKey(new[] { Customer.IdProperty, Customer.UniqueProperty }, ConfigurationSource.Convention);
-            dependentEntityBuilder.HasForeignKey(
-                    principalEntityBuilder,
-                    new[]
-                    {
-                        dependentEntityBuilder.Property(Order.CustomerIdProperty, ConfigurationSource.Convention).Metadata,
-                        dependentEntityBuilder.Property(Order.CustomerUniqueProperty, ConfigurationSource.Convention).Metadata
-                    }, ConfigurationSource.DataAnnotation)
-                .HasPrincipalKey(key.Metadata.Properties, ConfigurationSource.DataAnnotation);
-
-            Assert.Null(principalEntityBuilder.RemoveKey(key.Metadata, ConfigurationSource.Convention));
-            Assert.Equal(ConfigurationSource.DataAnnotation, principalEntityBuilder.RemoveKey(key.Metadata, ConfigurationSource.DataAnnotation));
-
-            Assert.Equal(
-                new[] { Order.CustomerIdProperty.Name, Order.CustomerUniqueProperty.Name },
-                dependentEntityBuilder.Metadata.GetProperties().Select(p => p.Name));
-            Assert.Empty(dependentEntityBuilder.Metadata.GetForeignKeys());
-            Assert.Empty(principalEntityBuilder.Metadata.GetKeys());
-        }
-
-        [Fact]
         public void PrimaryKey_returns_same_instance_for_clr_properties()
         {
             var modelBuilder = CreateModelBuilder();


### PR DESCRIPTION
Run ForeignKeyPropertyDiscoveryConvention when the PK is changed.

Fixes #9180
Fixes #11019
