### PR TITLE
Don't throw on missing discriminator in seed data

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -14,7 +14,6 @@ using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage.Converters;
 using Microsoft.EntityFrameworkCore.Utilities;
-using Microsoft.EntityFrameworkCore.ValueGeneration;
 
 namespace Microsoft.EntityFrameworkCore.Migrations.Design
 {
@@ -1133,8 +1132,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
 
             stringBuilder
                 .AppendLine()
-                .AppendLine($"b.{nameof(EntityTypeBuilder.SeedData)}(new[]")
-                .AppendLine("{");
+                .AppendLine($"b.{nameof(EntityTypeBuilder.SeedData)}(");
 
             using (stringBuilder.Indent())
             {
@@ -1179,7 +1177,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
 
             stringBuilder
                 .AppendLine()
-                .AppendLine("});");
+                .AppendLine(");");
         }
     }
 }

--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -483,27 +483,27 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                         if (!seedDatum.TryGetValue(property.Name, out var value)
                             || value == null)
                         {
-                            if (!property.IsNullable)
+                            if (!property.IsNullable
+                                && (!property.RequiresValueGenerator()
+                                    || property.IsKey()))
                             {
                                 throw new InvalidOperationException(CoreStrings.SeedDatumMissingValue(entityType.DisplayName(), property.Name));
                             }
                         } else if (property.RequiresValueGenerator()
+                                   && property.IsKey()
                                    && property.ClrType.IsDefaultValue(value))
                         {
                             throw new InvalidOperationException(CoreStrings.SeedDatumMissingValue(entityType.DisplayName(), property.Name));
                         }
-                        else
+                        else if (!property.ClrType.GetTypeInfo().IsAssignableFrom(value.GetType().GetTypeInfo()))
                         {
-                            if (!property.ClrType.GetTypeInfo().IsAssignableFrom(value.GetType().GetTypeInfo()))
+                            if (sensitiveDataLogged)
                             {
-                                if (sensitiveDataLogged)
-                                {
-                                    throw new InvalidOperationException(CoreStrings.SeedDatumIncompatibleValueSensitive(
-                                        entityType.DisplayName(), value, property.Name, property.ClrType.DisplayName()));
-                                }
-                                throw new InvalidOperationException(CoreStrings.SeedDatumIncompatibleValue(
-                                    entityType.DisplayName(), property.Name, property.ClrType.DisplayName()));
+                                throw new InvalidOperationException(CoreStrings.SeedDatumIncompatibleValueSensitive(
+                                    entityType.DisplayName(), value, property.Name, property.ClrType.DisplayName()));
                             }
+                            throw new InvalidOperationException(CoreStrings.SeedDatumIncompatibleValue(
+                                entityType.DisplayName(), property.Name, property.ClrType.DisplayName()));
                         }
                     }
 

--- a/test/EFCore.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
+++ b/test/EFCore.SqlServer.Tests/Migrations/SqlServerModelDifferTest.cs
@@ -563,7 +563,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     }));
         }
 
-        protected override ModelBuilder CreateModelBuilder() => SqlServerTestHelpers.Instance.CreateConventionBuilder();
+        protected override TestHelpers TestHelpers => SqlServerTestHelpers.Instance;
 
         protected override MigrationsModelDiffer CreateModelDiffer(IModel model)
         {

--- a/test/EFCore.SqlServer.Tests/Scaffolding/SqlServerCodeGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Scaffolding/SqlServerCodeGeneratorTest.cs
@@ -4,6 +4,7 @@
 using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
 using Xunit;
 
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Scaffolding
 {
     public class SqlServerCodeGeneratorTest

--- a/test/EFCore.Tests/ModelBuilding/InheritanceTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/InheritanceTestBase.cs
@@ -77,7 +77,11 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
-                modelBuilder.Entity<SelfRefManyToOneDerived>();
+                modelBuilder.Entity<SelfRefManyToOneDerived>().SeedData(new SelfRefManyToOneDerived
+                {
+                    Id = 1,
+                    SelfRefId = 1
+                });
                 modelBuilder.Entity<SelfRefManyToOne>();
 
                 modelBuilder.Validate();

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderGenericTest.cs
@@ -213,6 +213,9 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestEntityTypeBuilder<TEntity> UsePropertyAccessMode(PropertyAccessMode propertyAccessMode)
                 => Wrap(EntityTypeBuilder.UsePropertyAccessMode(propertyAccessMode));
 
+            public override TestEntityTypeBuilder<TEntity> SeedData(params TEntity[] data)
+                => Wrap(EntityTypeBuilder.SeedData(data));
+
             public EntityTypeBuilder<TEntity> Instance => EntityTypeBuilder;
         }
 

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericTest.cs
@@ -167,6 +167,9 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public override TestEntityTypeBuilder<TEntity> UsePropertyAccessMode(PropertyAccessMode propertyAccessMode)
                 => Wrap(EntityTypeBuilder.UsePropertyAccessMode(propertyAccessMode));
 
+            public override TestEntityTypeBuilder<TEntity> SeedData(params TEntity[] data)
+                => Wrap(EntityTypeBuilder.SeedData(data));
+
             public EntityTypeBuilder Instance => EntityTypeBuilder;
         }
 

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderTestBase.cs
@@ -190,8 +190,12 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             public virtual string GetDisplayName(Type entityType) => entityType.Name;
 
-            public virtual ModelBuilder UsePropertyAccessMode(PropertyAccessMode propertyAccessMode)
-                => ModelBuilder.UsePropertyAccessMode(propertyAccessMode);
+            public virtual TestModelBuilder UsePropertyAccessMode(PropertyAccessMode propertyAccessMode)
+            {
+                ModelBuilder.UsePropertyAccessMode(propertyAccessMode);
+
+                return this;
+            }
         }
 
         public abstract class TestEntityTypeBuilder<TEntity>
@@ -242,6 +246,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public abstract TestEntityTypeBuilder<TEntity> HasChangeTrackingStrategy(ChangeTrackingStrategy changeTrackingStrategy);
 
             public abstract TestEntityTypeBuilder<TEntity> UsePropertyAccessMode(PropertyAccessMode propertyAccessMode);
+
+            public abstract TestEntityTypeBuilder<TEntity> SeedData(params TEntity[] data);
         }
 
         public class TestKeyBuilder

--- a/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
@@ -12,6 +12,7 @@ using Microsoft.EntityFrameworkCore.Storage.Converters;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 using Xunit;
 
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.ModelBuilding
 {
     public abstract partial class ModelBuilderTest
@@ -302,7 +303,6 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public virtual void Can_set_property_annotation_when_no_clr_property()
             {
                 var modelBuilder = CreateModelBuilder();
-                var model = modelBuilder.Model;
 
                 var propertyBuilder = modelBuilder
                     .Entity<Customer>()
@@ -359,7 +359,6 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public virtual void Properties_can_be_ignored()
             {
                 var modelBuilder = CreateModelBuilder();
-                var model = modelBuilder.Model;
 
                 var entityType = (IEntityType)modelBuilder.Entity<Quarks>().Metadata;
 
@@ -664,7 +663,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Equal(PropertyAccessMode.FieldDuringConstruction, quarksType.FindProperty("Down").GetPropertyAccessMode());
                 Assert.Equal(PropertyAccessMode.Property, quarksType.FindProperty("Up").GetPropertyAccessMode());
             }
-            
+
             [Fact]
             public virtual void Properties_can_have_store_type_set()
             {
@@ -689,7 +688,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Null(entityType.FindProperty("Strange").GetProviderClrType());
             }
 
-            
+
             [Fact]
             public virtual void Properties_can_have_value_converter_set_non_generic()
             {


### PR DESCRIPTION
Don't generated implicitly-typed array for seed data in the snapshot

Fixes #11083
Fixes #11097
