### PR TITLE
Add support for table valued functions

### DIFF
--- a/samples/OracleProvider/test/OracleProvider.FunctionalTests/Query/UdfDbFunctionOracleTest.cs
+++ b/samples/OracleProvider/test/OracleProvider.FunctionalTests/Query/UdfDbFunctionOracleTest.cs
@@ -1,14 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Xunit;
-using System.Globalization;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -21,7 +15,157 @@ namespace Microsoft.EntityFrameworkCore.Query
             //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
-        public class Oracle : UdfFixtureBase
+
+        #region Table Valued Tests
+
+        [Fact(Skip = "TODO")]
+        public override void TVF_Stand_Alone()
+        {
+            base.TVF_Stand_Alone();
+        }
+
+        [Fact(Skip = "TODO")]
+        public override void TVF_Stand_Alone_With_Translation()
+        {
+            base.TVF_Stand_Alone_With_Translation();
+        }
+
+        [Fact(Skip = "TODO")]
+        public override void TVF_Stand_Alone_Parameter()
+        {
+            base.TVF_Stand_Alone_Parameter();
+        }
+
+        [Fact(Skip = "TODO")]
+        public override void TVF_Stand_Alone_Nested()
+        {
+            base.TVF_Stand_Alone_Nested();
+        }
+
+        [Fact(Skip = "TODO")]
+        public override void TVF_CrossApply_Correlated_Select_Anonymous()
+        {
+            base.TVF_CrossApply_Correlated_Select_Anonymous();
+        }
+
+        [Fact(Skip = "TODO")]
+        public override void TVF_Select_Direct_In_Anonymous()
+        {
+            base.TVF_Select_Direct_In_Anonymous();
+        }
+
+        [Fact(Skip = "TODO")]
+        public override void TVF_Select_Correlated_Direct_In_Anonymous()
+        {
+            base.TVF_Select_Correlated_Direct_In_Anonymous();
+        }
+
+        [Fact(Skip = "TODO")]
+        public override void TVF_Select_Correlated_Direct_With_Function_Query_Parameter_Correlated_In_Anonymous()
+        {
+            base.TVF_Select_Correlated_Direct_With_Function_Query_Parameter_Correlated_In_Anonymous();
+        }
+
+        [Fact(Skip = "TODO")]
+        public override void TVF_Select_Correlated_Subquery_In_Anonymous()
+        {
+            base.TVF_Select_Correlated_Subquery_In_Anonymous();
+        }
+
+        [Fact(Skip = "TODO")]
+        public override void TVF_Select_Correlated_Subquery_In_Anonymous_Nested()
+        {
+            base.TVF_Select_Correlated_Subquery_In_Anonymous_Nested();
+        }
+
+        [Fact(Skip = "TODO")]
+        public override void TVF_Select_NonCorrelated_Subquery_In_Anonymous()
+        {
+            base.TVF_Select_NonCorrelated_Subquery_In_Anonymous();
+        }
+
+        [Fact(Skip = "TODO")]
+        public override void TVF_Select_NonCorrelated_Subquery_In_Anonymous_Parameter()
+        {
+            base.TVF_Select_NonCorrelated_Subquery_In_Anonymous_Parameter();
+        }
+
+        [Fact(Skip = "TODO")]
+        public override void TVF_Correlated_Select_In_Anonymous()
+        {
+            base.TVF_Correlated_Select_In_Anonymous();
+        }
+
+        [Fact(Skip = "TODO")]
+        public override void TVF_CrossApply_Correlated_Select_Result()
+        {
+            base.TVF_CrossApply_Correlated_Select_Result();
+        }
+
+        [Fact(Skip = "TODO")]
+        public override void TVF_CrossJoin_Not_Correlated()
+        {
+            base.TVF_CrossJoin_Not_Correlated();
+        }
+
+        [Fact(Skip = "TODO")]
+        public override void TVF_CrossJoin_Parameter()
+        {
+            base.TVF_CrossJoin_Parameter();
+        }
+
+        [Fact(Skip = "TODO")]
+        public override void TVF_Join()
+        {
+            base.TVF_Join();
+        }
+
+        [Fact(Skip = "TODO")]
+        public override void TVF_LeftJoin_Select_Anonymous()
+        {
+            base.TVF_LeftJoin_Select_Anonymous();
+        }
+
+        [Fact(Skip = "TODO")]
+        public override void TVF_LeftJoin_Select_Result()
+        {
+            base.TVF_LeftJoin_Select_Result();
+        }
+
+        [Fact(Skip = "TODO")]
+        public override void TVF_OuterApply_Correlated_Select_TVF()
+        {
+            base.TVF_OuterApply_Correlated_Select_TVF();
+        }
+
+        [Fact(Skip = "TODO")]
+        public override void TVF_OuterApply_Correlated_Select_DbSet()
+        {
+            base.TVF_OuterApply_Correlated_Select_DbSet();
+        }
+
+        [Fact(Skip = "TODO")]
+        public override void TVF_OuterApply_Correlated_Select_Anonymous()
+        {
+            base.TVF_OuterApply_Correlated_Select_Anonymous();
+        }
+
+        [Fact(Skip = "TODO")]
+        public override void TVF_Nested()
+        {
+            base.TVF_Nested();
+        }
+
+        [Fact(Skip = "TODO")]
+        public override void TVF_Correlated_Nested_Func_Call()
+        {
+            base.TVF_Correlated_Nested_Func_Call();
+        }
+
+        #endregion
+
+
+        public class Oracle : BaseUdfFixture
         {
             protected override string StoreName { get; } = "UDFDbFunctionOracleTests";
             protected override ITestStoreFactory TestStoreFactory => OracleTestStoreFactory.Instance;
@@ -108,8 +252,8 @@ END;");
 RETURN NVARCHAR2 IS
 BEGIN
     RETURN customerName;
-END;");                
-                
+END;");
+
                 context.SaveChanges();
             }
         }

--- a/src/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -34,9 +36,16 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             public int Id { get; set; }
             public string Name { get; set; }
-            public int ItemCount { get; set; }
+            public int QuantitySold { get; set; }
             public DateTime OrderDate { get; set; }
             public Customer Customer { get; set; }
+            public Product Product { get; set; }
+        }
+
+        public class Product
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
         }
 
         protected class UDFSqlContext : PoolableDbContext
@@ -45,10 +54,13 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             public DbSet<Customer> Customers { get; set; }
             public DbSet<Order> Orders { get; set; }
+            public DbSet<Product> Products { get; set; }
 
             #endregion
 
             #region Function Stubs
+
+            #region Static Functions
 
             public enum ReportingPeriod
             {
@@ -94,6 +106,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     case 3:
                         return 1;
                     case 4:
+                        return 0;
+                    case 5:
                         return 0;
                     default:
                         throw new Exception();
@@ -157,6 +171,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                         return 1;
                     case 4:
                         return 0;
+                    case 5:
+                        return 0;
                     default:
                         throw new Exception();
                 }
@@ -193,6 +209,65 @@ namespace Microsoft.EntityFrameworkCore.Query
                 throw new NotImplementedException();
             }
 
+            public string SCHEMA_NAME()
+            {
+                return Execute(() => SCHEMA_NAME());
+            }
+
+            public Task<string> SCHEMA_NAME_Async()
+            {
+                return ExecuteAsync(() => SCHEMA_NAME());
+            }
+
+            public int AddValues(int a, int b)
+            {
+                 return Execute(() => AddValues(a, b));
+            }
+
+            public int AddValues(Expression<Func<int>> a, int b)
+            {
+                  return Execute(() => AddValues(a, b));
+            }
+
+            #endregion
+
+            #region Table Functions
+
+            public class OrderByYear
+            {
+                public int? CustomerId { get; set; }
+                public int? Count { get; set; }
+                public int? Year { get; set; }
+            }
+
+            public IQueryable<OrderByYear> GetCustomerOrderCountByYear(int customerId)
+            {
+                return CreateQuery(() => GetCustomerOrderCountByYear(customerId));
+            }
+
+            public IQueryable<OrderByYear> GetCustomerOrderCountByYear(Expression<Func<int>> customerId)
+            {
+                return CreateQuery(() => GetCustomerOrderCountByYear(customerId));
+            }
+
+            public class TopSellingProduct
+            {
+                public int? ProductId { get; set; }
+                public int? AmountSold { get; set; }
+            }
+
+            public IQueryable<TopSellingProduct> GetTopTwoSellingProducts()
+            {
+                return CreateQuery(() => GetTopTwoSellingProducts());
+            }
+
+            public IQueryable<TopSellingProduct> GetTopTwoSellingProductsCustomTranslation()
+            {
+                return CreateQuery(() => GetTopTwoSellingProductsCustomTranslation());
+            }
+
+            #endregion
+
             #endregion
 
             public UDFSqlContext(DbContextOptions options)
@@ -227,14 +302,25 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 modelBuilder.HasDbFunction(typeof(UDFSqlContext).GetMethod(nameof(DollarValueInstance))).HasName("DollarValue");
 
+                modelBuilder.HasDbFunction(typeof(UDFSqlContext).GetMethod(nameof(AddValues), new[] { typeof(int), typeof(int) }));
+
                 var methodInfo2 = typeof(UDFSqlContext).GetMethod(nameof(MyCustomLengthInstance));
 
                 modelBuilder.HasDbFunction(methodInfo2)
                     .HasTranslation(args => new SqlFunctionExpression("len", methodInfo2.ReturnType, args));
+
+                //Bootstrap
+                modelBuilder.HasDbFunction(typeof(UDFSqlContext).GetMethod(nameof(SCHEMA_NAME))).HasName("SCHEMA_NAME").HasSchema("");
+
+                //Table
+                modelBuilder.HasDbFunction(typeof(UDFSqlContext).GetMethod(nameof(GetCustomerOrderCountByYear), new[] { typeof(int) }));
+                modelBuilder.HasDbFunction(typeof(UDFSqlContext).GetMethod(nameof(GetTopTwoSellingProducts)));
+                modelBuilder.HasDbFunction(typeof(UDFSqlContext).GetMethod(nameof(GetTopTwoSellingProductsCustomTranslation)))
+                    .HasTranslation(args => new SqlFunctionExpression("GetTopTwoSellingProducts", typeof(TopSellingProduct), "dbo", args));
             }
         }
 
-        public abstract class UdfFixtureBase : SharedStoreFixtureBase<DbContext>
+        public abstract class BaseUdfFixture : SharedStoreFixtureBase<DbContext>
         {
             protected override Type ContextType { get; } = typeof(UDFSqlContext);
 
@@ -250,41 +336,68 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 context.Database.EnsureCreatedResiliently();
 
+                var product1 = new Product
+                {
+                    Name = "Product1"
+                };
+                var product2 = new Product
+                {
+                    Name = "Product2"
+                };
+                var product3 = new Product
+                {
+                    Name = "Product3"
+                };
+                var product4 = new Product
+                {
+                    Name = "Product4"
+                };
+                var product5 = new Product
+                {
+                    Name = "Product5"
+                };
+
                 var order11 = new Order
                 {
                     Name = "Order11",
-                    ItemCount = 4,
-                    OrderDate = new DateTime(2000, 1, 20)
+                    QuantitySold = 4,
+                    OrderDate = new DateTime(2000, 1, 20),
+                    Product = product1
                 };
                 var order12 = new Order
                 {
                     Name = "Order12",
-                    ItemCount = 8,
-                    OrderDate = new DateTime(2000, 2, 21)
+                    QuantitySold = 8,
+                    OrderDate = new DateTime(2000, 2, 21),
+                    Product = product2
                 };
                 var order13 = new Order
                 {
                     Name = "Order13",
-                    ItemCount = 15,
-                    OrderDate = new DateTime(2000, 3, 20)
+                    QuantitySold = 15,
+                    OrderDate = new DateTime(2001, 3, 20),
+                    Product = product3
                 };
                 var order21 = new Order
                 {
                     Name = "Order21",
-                    ItemCount = 16,
-                    OrderDate = new DateTime(2000, 4, 21)
+                    QuantitySold = 16,
+                    OrderDate = new DateTime(2000, 4, 21),
+                    Product = product4
                 };
                 var order22 = new Order
                 {
                     Name = "Order22",
-                    ItemCount = 23,
-                    OrderDate = new DateTime(2000, 5, 20)
+                    QuantitySold = 23,
+                    OrderDate = new DateTime(2000, 5, 20),
+                    Product = product1
                 };
                 var order31 = new Order
                 {
                     Name = "Order31",
-                    ItemCount = 42,
-                    OrderDate = new DateTime(2000, 6, 21)
+                    QuantitySold = 42,
+                    OrderDate = new DateTime(2001, 6, 21),
+                    Product = product2
                 };
 
                 var customer1 = new Customer
@@ -317,9 +430,15 @@ namespace Microsoft.EntityFrameworkCore.Query
                         order31
                     }
                 };
+                var customer4 = new Customer
+                {
+                    FirstName = "Customer",
+                    LastName = "Four"
+                };
 
-                ((UDFSqlContext)context).Customers.AddRange(customer1, customer2, customer3);
+                ((UDFSqlContext)context).Customers.AddRange(customer1, customer2, customer3, customer4);
                 ((UDFSqlContext)context).Orders.AddRange(order11, order12, order13, order21, order22, order31);
+                ((UDFSqlContext)context).Products.AddRange(product1, product2, product3, product4, product5);
             }
         }
 
@@ -329,14 +448,14 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region Static
 
-        [Fact]
+       [Fact]
         public virtual void Scalar_Function_Extension_Method_Static()
         {
             using (var context = CreateContext())
             {
                 var len = context.Customers.Count(c => UDFSqlContext.IsDateStatic(c.FirstName) == false);
 
-                Assert.Equal(3, len);
+                Assert.Equal(4, len);
             }
         }
 
@@ -379,7 +498,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 var custs = context.Customers.Select(c => UDFSqlContext.CustomerOrderCountStatic(customerId)).ToList();
 
-                Assert.Equal(3, custs.Count);
+                Assert.Equal(4, custs.Count);
             }
         }
 
@@ -622,8 +741,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                                orderby UDFSqlContext.AddOneStatic(c.Id)
                                select c.Id).ToList();
 
-                Assert.Equal(3, results.Count);
-                Assert.True(results.SequenceEqual(Enumerable.Range(1, 3)));
+                Assert.Equal(4, results.Count);
+                Assert.True(results.SequenceEqual(Enumerable.Range(1, 4)));
             }
         }
 
@@ -636,8 +755,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                                orderby c.Id
                                select UDFSqlContext.AddOneStatic(c.Id)).ToList();
 
-                Assert.Equal(3, results.Count);
-                Assert.True(results.SequenceEqual(Enumerable.Range(2, 3)));
+                Assert.Equal(4, results.Count);
+                Assert.True(results.SequenceEqual(Enumerable.Range(2, 4)));
             }
         }
 
@@ -839,7 +958,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 var len = context.Customers.Count(c => context.IsDateInstance(c.FirstName) == false);
 
-                Assert.Equal(3, len);
+                Assert.Equal(4, len);
             }
         }
 
@@ -882,7 +1001,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 var custs = context.Customers.Select(c => context.CustomerOrderCountInstance(customerId)).ToList();
 
-                Assert.Equal(3, custs.Count);
+                Assert.Equal(4, custs.Count);
             }
         }
 
@@ -1125,8 +1244,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                                orderby context.AddOneInstance(c.Id)
                                select c.Id).ToList();
 
-                Assert.Equal(3, results.Count);
-                Assert.True(results.SequenceEqual(Enumerable.Range(1, 3)));
+                Assert.Equal(4, results.Count);
+                Assert.True(results.SequenceEqual(Enumerable.Range(1, 4)));
             }
         }
 
@@ -1139,8 +1258,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                                orderby c.Id
                                select context.AddOneInstance(c.Id)).ToList();
 
-                Assert.Equal(3, results.Count);
-                Assert.True(results.SequenceEqual(Enumerable.Range(2, 3)));
+                Assert.Equal(4, results.Count);
+                Assert.True(results.SequenceEqual(Enumerable.Range(2, 4)));
             }
         }
 
@@ -1301,6 +1420,675 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         #endregion
+
+        #endregion
+
+        #region BootStrap
+
+        [Fact]
+        public virtual void BootstrapScalarNoParams()
+        {
+            using (var context = CreateContext())
+            {
+                var schame = context.SCHEMA_NAME();
+
+                Assert.Equal("dbo", schame);
+            }
+        }
+
+        [Fact]
+        public virtual async Task BootstrapScalarNoParamsAsync()
+        {
+            using (var context = CreateContext())
+            {
+                var schema = await context.SCHEMA_NAME_Async();
+
+                Assert.Equal("dbo", schema);
+            }
+        }
+
+        [Fact]
+        public virtual void BootstrapScalarParams()
+        {
+            using (var context = CreateContext())
+            {
+                var value = context.AddValues(1, 2);
+
+                Assert.Equal(3, value);
+            }
+        }
+
+        [Fact]
+        public virtual void BootstrapScalarFuncParams()
+        {
+            using (var context = CreateContext())
+            {
+                var value = context.AddValues(() => context.AddValues(1, 2), 2);
+
+                Assert.Equal(5, value);
+            }
+        }
+
+        [Fact]
+        public virtual void BootstrapScalarFuncParamsWithVariable()
+        {
+            using (var context = CreateContext())
+            {
+                var x = 5;
+                var value = context.AddValues(() => context.AddValues(x, 2), 2);
+
+                Assert.Equal(9, value);
+            }
+        }
+
+        [Fact]
+        public virtual void BootstrapScalarFuncParamsConstant()
+        {
+            using (var context = CreateContext())
+            {
+                var value = context.AddValues(() => 1, 2);
+
+                Assert.Equal(3, value);
+            }
+        }
+        #endregion
+
+        #region Table Valued Tests
+
+        [Fact]
+        public virtual void TVF_Stand_Alone()
+        {
+            using (var context = CreateContext())
+            {
+                var products = (from t in context.GetTopTwoSellingProducts()
+                                orderby t.ProductId
+                                select t).ToList();
+
+                Assert.Equal(2, products.Count);
+                Assert.Equal(1, products[0].ProductId);
+                Assert.Equal(27, products[0].AmountSold);
+                Assert.Equal(2, products[1].ProductId);
+                Assert.Equal(50, products[1].AmountSold);
+            }
+        }
+
+        [Fact]
+        public virtual void TVF_Stand_Alone_With_Translation()
+        {
+            using (var context = CreateContext())
+            {
+                var products = (from t in context.GetTopTwoSellingProductsCustomTranslation()
+                                orderby t.ProductId
+                                select t).ToList();
+
+                Assert.Equal(2, products.Count);
+                Assert.Equal(1, products[0].ProductId);
+                Assert.Equal(27, products[0].AmountSold);
+                Assert.Equal(2, products[1].ProductId);
+                Assert.Equal(50, products[1].AmountSold);
+            }
+        }
+
+        [Fact]
+        public virtual void TVF_Stand_Alone_Parameter()
+        {
+            using (var context = CreateContext())
+            {
+                var orders = (from c in context.GetCustomerOrderCountByYear(1)
+                              orderby c.Count descending
+                              select c).ToList();
+
+                Assert.Equal(2, orders.Count);
+                Assert.Equal(2, orders[0].Count);
+                Assert.Equal(2000, orders[0].Year);
+                Assert.Equal(1, orders[1].Count);
+                Assert.Equal(2001, orders[1].Year);
+            }
+        }
+
+        [Fact]
+        public virtual void TVF_Stand_Alone_Nested()
+        {
+            using (var context = CreateContext())
+            {
+                var orders = (from r in context.GetCustomerOrderCountByYear(() => context.AddValues(-2, 3))
+                              orderby r.Count descending
+                              select r).ToList();
+
+                Assert.Equal(2, orders.Count);
+                Assert.Equal(2, orders[0].Count);
+                Assert.Equal(2000, orders[0].Year);
+                Assert.Equal(1, orders[1].Count);
+                Assert.Equal(2001, orders[1].Year);
+            }
+        }
+
+        [Fact]
+        public virtual void TVF_CrossApply_Correlated_Select_Anonymous()
+        {
+            using (var context = CreateContext())
+            {
+                var orders = (from c in context.Customers
+                              from r in context.GetCustomerOrderCountByYear(c.Id)
+                              orderby c.Id, r.Year
+                              select new
+                              {
+                                  c.Id,
+                                  c.LastName,
+                                  r.Year,
+                                  r.Count
+                              }).ToList();
+
+                Assert.Equal(4, orders.Count);
+                Assert.Equal(2, orders[0].Count);
+                Assert.Equal(1, orders[1].Count);
+                Assert.Equal(2, orders[2].Count);
+                Assert.Equal(1, orders[3].Count);
+                Assert.Equal(2000, orders[0].Year);
+                Assert.Equal(2001, orders[1].Year);
+                Assert.Equal(2000, orders[2].Year);
+                Assert.Equal(2001, orders[3].Year);
+                Assert.Equal(1, orders[0].Id);
+                Assert.Equal(1, orders[1].Id);
+                Assert.Equal(2, orders[2].Id);
+                Assert.Equal(3, orders[3].Id);
+            }
+        }
+
+        [Fact]
+        public virtual void TVF_Select_Direct_In_Anonymous()
+        {
+            using (var context = CreateContext())
+            {
+                var results = (from c in context.Customers
+                               select new
+                               {
+                                   c.Id,
+                                   Prods = context.GetTopTwoSellingProducts().ToList(),
+                               }).ToList();
+
+                Assert.Equal(4, results.Count);
+                Assert.Equal(2, results[0].Prods.Count);
+                Assert.Equal(2, results[1].Prods.Count);
+                Assert.Equal(2, results[2].Prods.Count);
+                Assert.Equal(2, results[3].Prods.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void TVF_Select_Correlated_Direct_In_Anonymous()
+        {
+            using (var context = CreateContext())
+            {
+                var results = (from c in context.Customers
+                               select new
+                               {
+                                   c.Id,
+                                   OrderCountYear = context.GetCustomerOrderCountByYear(c.Id).ToList()
+                               }).ToList();
+
+                Assert.Equal(4, results.Count);
+                Assert.Equal(1, results[0].Id);
+                Assert.Equal(2, results[1].Id);
+                Assert.Equal(3, results[2].Id);
+                Assert.Equal(4, results[3].Id);
+                Assert.Equal(2, results[0].OrderCountYear.Count);
+                Assert.Equal(1, results[1].OrderCountYear.Count);
+                Assert.Equal(1, results[2].OrderCountYear.Count);
+                Assert.Equal(0, results[3].OrderCountYear.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void TVF_Select_Correlated_Direct_With_Function_Query_Parameter_Correlated_In_Anonymous()
+        {
+            using (var context = CreateContext())
+            {
+                var results = (from c in context.Customers
+                               where c.Id == 1
+                               select new
+                               {
+                                   c.Id,
+                                   OrderCountYear = context.GetCustomerOrderCountByYear(context.AddValues(c.Id, 1)).ToList()
+                               }).ToList();
+
+                Assert.Equal(1, results.Count);
+                Assert.Equal(1, results[0].Id);
+                Assert.Equal(1, results[0].OrderCountYear.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void TVF_Select_Correlated_Subquery_In_Anonymous()
+        {
+            using (var context = CreateContext())
+            {
+                var results = (from c in context.Customers
+                               select new
+                               {
+                                   c.Id,
+                                   OrderCountYear = context.GetCustomerOrderCountByYear(c.Id).Where(o => o.Year == 2000).ToList()
+                               }).ToList();
+
+                Assert.Equal(4, results.Count);
+                Assert.Equal(1, results[0].Id);
+                Assert.Equal(2, results[1].Id);
+                Assert.Equal(3, results[2].Id);
+                Assert.Equal(4, results[3].Id);
+                Assert.Equal(1, results[0].OrderCountYear.Count);
+                Assert.Equal(1, results[1].OrderCountYear.Count);
+                Assert.Equal(0, results[2].OrderCountYear.Count);
+                Assert.Equal(0, results[3].OrderCountYear.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void TVF_Select_Correlated_Subquery_In_Anonymous_Nested()
+        {
+            using (var context = CreateContext())
+            {
+                var results = (from c in context.Customers
+                               select new
+                               {
+                                   c.Id,
+                                   OrderCountYear = context.GetCustomerOrderCountByYear(1).Where(o => o.Year == 2000).Select(o => new
+                                   {
+                                       OrderCountYearNested = context.GetCustomerOrderCountByYear(2000).Where(o2 => o.Year == 2001).ToList(),
+                                       Prods = context.GetTopTwoSellingProducts().ToList(),
+                                   }).ToList()
+                               }).ToList();
+
+                Assert.Equal(4, results.Count);
+                Assert.Equal(1, results[0].OrderCountYear.Count);
+                Assert.Equal(2, results[0].OrderCountYear[0].Prods.Count);
+                Assert.Equal(0, results[0].OrderCountYear[0].OrderCountYearNested.Count);
+                Assert.Equal(1, results[1].OrderCountYear.Count);
+                Assert.Equal(2, results[1].OrderCountYear[0].Prods.Count);
+                Assert.Equal(0, results[1].OrderCountYear[0].OrderCountYearNested.Count);
+                Assert.Equal(1, results[2].OrderCountYear.Count);
+                Assert.Equal(2, results[2].OrderCountYear[0].Prods.Count);
+                Assert.Equal(0, results[2].OrderCountYear[0].OrderCountYearNested.Count);
+                Assert.Equal(1, results[3].OrderCountYear.Count);
+                Assert.Equal(2, results[3].OrderCountYear[0].Prods.Count);
+                Assert.Equal(0, results[3].OrderCountYear[0].OrderCountYearNested.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void TVF_Select_NonCorrelated_Subquery_In_Anonymous()
+        {
+            using (var context = CreateContext())
+            {
+                var results = (from c in context.Customers
+                               select new
+                               {
+                                   c.Id,
+                                   Prods = context.GetTopTwoSellingProducts().Where(p => p.AmountSold == 27).Select(p => p.ProductId).ToList(),
+                               }).ToList();
+
+                Assert.Equal(4, results.Count);
+                Assert.Equal(1, results[0].Prods.Count);
+                Assert.Equal(1, results[1].Prods.Count);
+                Assert.Equal(1, results[2].Prods.Count);
+                Assert.Equal(1, results[3].Prods.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void TVF_Select_NonCorrelated_Subquery_In_Anonymous_Parameter()
+        {
+            using (var context = CreateContext())
+            {
+                var amount = 27;
+
+                var results = (from c in context.Customers
+                               select new
+                               {
+                                   c.Id,
+                                   Prods = context.GetTopTwoSellingProducts().Where(p => p.AmountSold == amount).Select(p => p.ProductId).ToList(),
+                               }).ToList();
+
+                Assert.Equal(4, results.Count);
+                Assert.Equal(1, results[0].Prods.Count);
+                Assert.Equal(1, results[1].Prods.Count);
+                Assert.Equal(1, results[2].Prods.Count);
+                Assert.Equal(1, results[3].Prods.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void TVF_Correlated_Select_In_Anonymous()
+        {
+            using (var context = CreateContext())
+            {
+                var cust = (from c in context.Customers
+                            orderby c.Id
+                            select new
+                            {
+                                c.Id,
+                                c.LastName,
+                                Orders = context.GetCustomerOrderCountByYear(c.Id).ToList()
+                            }).ToList();
+
+                Assert.Equal(4, cust.Count);
+                Assert.Equal(2, cust[0].Orders[0].Count);
+                Assert.Equal(2, cust[1].Orders[0].Count);
+                Assert.Equal(1, cust[2].Orders[0].Count);
+                Assert.Equal(0, cust[3].Orders.Count);
+                Assert.Equal("One", cust[0].LastName);
+                Assert.Equal("Two", cust[1].LastName);
+                Assert.Equal("Three", cust[2].LastName);
+                Assert.Equal("Four", cust[3].LastName);
+                Assert.Equal(1, cust[0].Id);
+                Assert.Equal(2, cust[1].Id);
+                Assert.Equal(3, cust[2].Id);
+                Assert.Equal(4, cust[3].Id);
+            }
+        }
+
+        [Fact]
+        public virtual void TVF_CrossApply_Correlated_Select_Result()
+        {
+            using (var context = CreateContext())
+            {
+                var orders = (from c in context.Customers
+                              from r in context.GetCustomerOrderCountByYear(c.Id)
+                              orderby r.Count descending, r.Year descending
+                              select r).ToList();
+
+                Assert.Equal(4, orders.Count);
+
+                Assert.Equal(4, orders.Count);
+                Assert.Equal(2, orders[0].Count);
+                Assert.Equal(2, orders[1].Count);
+                Assert.Equal(1, orders[2].Count);
+                Assert.Equal(1, orders[3].Count);
+                Assert.Equal(2000, orders[0].Year);
+                Assert.Equal(2000, orders[1].Year);
+                Assert.Equal(2001, orders[2].Year);
+                Assert.Equal(2001, orders[3].Year);
+            }
+        }
+
+        [Fact]
+        public virtual void TVF_CrossJoin_Not_Correlated()
+        {
+            using (var context = CreateContext())
+            {
+                var orders = (from c in context.Customers
+                              from r in context.GetCustomerOrderCountByYear(2)
+                              where c.Id == 2
+                              orderby r.Count
+                              select new
+                              {
+                                  c.Id,
+                                  c.LastName,
+                                  r.Year,
+                                  r.Count
+                              }).ToList();
+
+                Assert.Equal(1, orders.Count);
+
+                Assert.Equal(2, orders[0].Count);
+                Assert.Equal(2000, orders[0].Year);
+            }
+        }
+
+        [Fact]
+        public virtual void TVF_CrossJoin_Parameter()
+        {
+            using (var context = CreateContext())
+            {
+                var custId = 2;
+
+                var orders = (from c in context.Customers
+                              from r in context.GetCustomerOrderCountByYear(custId)
+                              where c.Id == custId
+                              orderby r.Count
+                              select new
+                              {
+                                  c.Id,
+                                  c.LastName,
+                                  r.Year,
+                                  r.Count
+                              }).ToList();
+
+                Assert.Equal(1, orders.Count);
+
+                Assert.Equal(2, orders[0].Count);
+                Assert.Equal(2000, orders[0].Year);
+            }
+        }
+
+        [Fact]
+        public virtual void TVF_Join()
+        {
+            using (var context = CreateContext())
+            {
+                var products = (from p in context.Products
+                                join r in context.GetTopTwoSellingProducts() on p.Id equals r.ProductId
+                                select new
+                                {
+                                    p.Id,
+                                    p.Name,
+                                    r.AmountSold
+                                }).OrderBy(p => p.Id).ToList();
+
+                Assert.Equal(2, products.Count);
+                Assert.Equal(1, products[0].Id);
+                Assert.Equal("Product1", products[0].Name);
+                Assert.Equal(27, products[0].AmountSold);
+                Assert.Equal(2, products[1].Id);
+                Assert.Equal("Product2", products[1].Name);
+                Assert.Equal(50, products[1].AmountSold);
+            }
+        }
+
+        [Fact]
+        public virtual void TVF_LeftJoin_Select_Anonymous()
+        {
+            using (var context = CreateContext())
+            {
+                var products = (from p in context.Products
+                                join r in context.GetTopTwoSellingProducts() on p.Id equals r.ProductId into joinTable
+                                from j in joinTable.DefaultIfEmpty()
+                                orderby p.Id descending
+                                select new
+                                {
+                                    p.Id,
+                                    p.Name,
+                                    j.AmountSold
+                                }).ToList();
+
+                Assert.Equal(5, products.Count);
+                Assert.Equal(5, products[0].Id);
+                Assert.Equal(null, products[0].AmountSold);
+                Assert.Equal("Product5", products[0].Name);
+                Assert.Equal(4, products[1].Id);
+                Assert.Equal(null, products[1].AmountSold);
+                Assert.Equal("Product4", products[1].Name);
+                Assert.Equal(3, products[2].Id);
+                Assert.Equal(null, products[2].AmountSold);
+                Assert.Equal("Product3", products[2].Name);
+                Assert.Equal(2, products[3].Id);
+                Assert.Equal(50, products[3].AmountSold);
+                Assert.Equal("Product2", products[3].Name);
+                Assert.Equal(1, products[4].Id);
+                Assert.Equal(27, products[4].AmountSold);
+                Assert.Equal("Product1", products[4].Name);
+            }
+        }
+
+        [Fact]
+        public virtual void TVF_LeftJoin_Select_Result()
+        {
+            using (var context = CreateContext())
+            {
+                var products = (from p in context.Products
+                                join r in context.GetTopTwoSellingProducts() on p.Id equals r.ProductId into joinTable
+                                from j in joinTable.DefaultIfEmpty()
+                                orderby p.Id descending
+                                select j).ToList();
+
+                Assert.Equal(5, products.Count);
+                Assert.Equal(null, products[0].ProductId);
+                Assert.Equal(null, products[0].AmountSold);
+                Assert.Equal(null, products[1].ProductId);
+                Assert.Equal(null, products[1].AmountSold);
+                Assert.Equal(null, products[2].ProductId);
+                Assert.Equal(null, products[2].AmountSold);
+                Assert.Equal(2, products[3].ProductId);
+                Assert.Equal(50, products[3].AmountSold);
+                Assert.Equal(1, products[4].ProductId);
+                Assert.Equal(27, products[4].AmountSold);
+            }
+        }
+
+        [Fact]
+        public virtual void TVF_OuterApply_Correlated_Select_TVF()
+        {
+            using (var context = CreateContext())
+            {
+                var orders = (from c in context.Customers
+                              from r in context.GetCustomerOrderCountByYear(c.Id).DefaultIfEmpty()
+                              orderby c.Id, r.Year
+                              select r).ToList();
+
+                Assert.Equal(5, orders.Count);
+
+                Assert.Equal(2, orders[0].Count);
+                Assert.Equal(1, orders[1].Count);
+                Assert.Equal(2, orders[2].Count);
+                Assert.Equal(1, orders[3].Count);
+                Assert.Null(orders[4].Count);
+                Assert.Equal(2000, orders[0].Year);
+                Assert.Equal(2001, orders[1].Year);
+                Assert.Equal(2000, orders[2].Year);
+                Assert.Equal(2001, orders[3].Year);
+                Assert.Null(orders[4].Year);
+                Assert.Equal(1, orders[0].CustomerId);
+                Assert.Equal(1, orders[1].CustomerId);
+                Assert.Equal(2, orders[2].CustomerId);
+                Assert.Equal(3, orders[3].CustomerId);
+                Assert.Null(orders[4].CustomerId);
+            }
+        }
+
+        [Fact]
+        public virtual void TVF_OuterApply_Correlated_Select_DbSet()
+        {
+            using (var context = CreateContext())
+            {
+                var custs = (from c in context.Customers
+                             from r in context.GetCustomerOrderCountByYear(c.Id).DefaultIfEmpty()
+                             orderby c.Id, r.Year
+                             select c).ToList();
+
+                Assert.Equal(5, custs.Count);
+
+                Assert.Equal(1, custs[0].Id);
+                Assert.Equal(1, custs[1].Id);
+                Assert.Equal(2, custs[2].Id);
+                Assert.Equal(3, custs[3].Id);
+                Assert.Equal(4, custs[4].Id);
+                Assert.Equal("One", custs[0].LastName);
+                Assert.Equal("One", custs[1].LastName);
+                Assert.Equal("Two", custs[2].LastName);
+                Assert.Equal("Three", custs[3].LastName);
+                Assert.Equal("Four", custs[4].LastName);
+            }
+        }
+
+        [Fact]
+        public virtual void TVF_OuterApply_Correlated_Select_Anonymous()
+        {
+            using (var context = CreateContext())
+            {
+                var orders = (from c in context.Customers
+                              from r in context.GetCustomerOrderCountByYear(c.Id).DefaultIfEmpty()
+                              orderby c.Id, r.Year
+                              select new
+                              {
+                                  c.Id,
+                                  c.LastName,
+                                  r.Year,
+                                  r.Count
+                              }).ToList();
+
+                Assert.Equal(5, orders.Count);
+
+                Assert.Equal(1, orders[0].Id);
+                Assert.Equal(1, orders[1].Id);
+                Assert.Equal(2, orders[2].Id);
+                Assert.Equal(3, orders[3].Id);
+                Assert.Equal(4, orders[4].Id);
+                Assert.Equal("One", orders[0].LastName);
+                Assert.Equal("One", orders[1].LastName);
+                Assert.Equal("Two", orders[2].LastName);
+                Assert.Equal("Three", orders[3].LastName);
+                Assert.Equal("Four", orders[4].LastName);
+                Assert.Equal(2, orders[0].Count);
+                Assert.Equal(1, orders[1].Count);
+                Assert.Equal(2, orders[2].Count);
+                Assert.Equal(1, orders[3].Count);
+                Assert.Null(orders[4].Count);
+                Assert.Equal(2000, orders[0].Year);
+                Assert.Equal(2001, orders[1].Year);
+                Assert.Equal(2000, orders[2].Year);
+                Assert.Equal(2001, orders[3].Year);
+            }
+        }
+
+        [Fact]
+        public virtual void TVF_Nested()
+        {
+            using (var context = CreateContext())
+            {
+                var custId = 2;
+
+                var orders = (from c in context.Customers
+                              from r in context.GetCustomerOrderCountByYear(context.AddValues(1, 1))
+                              where c.Id == custId
+                              orderby r.Year
+                              select new
+                              {
+                                  c.Id,
+                                  c.LastName,
+                                  r.Year,
+                                  r.Count
+                              }).ToList();
+
+                Assert.Equal(1, orders.Count);
+
+                Assert.Equal(2, orders[0].Count);
+                Assert.Equal(2000, orders[0].Year);
+            }
+        }
+
+
+        [Fact]
+        public virtual void TVF_Correlated_Nested_Func_Call()
+        {
+            var custId = 2;
+
+            using (var context = CreateContext())
+            {
+                var orders = (from c in context.Customers
+                              from r in context.GetCustomerOrderCountByYear(context.AddValues(c.Id, 1))
+                              where c.Id == custId
+                              select new
+                              {
+                                  c.Id,
+                                  r.Count,
+                                  r.Year
+                              }).ToList();
+
+                Assert.Equal(1, orders.Count);
+
+                Assert.Equal(1, orders[0].Count);
+                Assert.Equal(2001, orders[0].Year);
+            }
+        }
 
         #endregion
     }

--- a/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Internal;
@@ -21,6 +22,7 @@ using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.EntityFrameworkCore.Update.Internal;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 using Microsoft.Extensions.DependencyInjection;
+using Remotion.Linq.Parsing.ExpressionVisitors.Transformation;
 using Remotion.Linq.Parsing.ExpressionVisitors.TreeEvaluation;
 
 namespace Microsoft.EntityFrameworkCore.Infrastructure
@@ -175,6 +177,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<INamedConnectionStringResolver, NamedConnectionStringResolver>();
             TryAdd<IEvaluatableExpressionFilter, RelationalEvaluatableExpressionFilter>();
             TryAdd<IRelationalTransactionFactory, RelationalTransactionFactory>();
+            TryAdd<IExpressionTranformationProvider, RelationalIExpressionTranformationProvider>();
+            TryAdd<IDbFunctionSourceFactory, RelationalDbFunctionSourceFactory>();
 
             TryAdd<ISingletonUpdateSqlGenerator>(
                 p =>
@@ -203,6 +207,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 .AddDependencySingleton<RelationalValueBufferFactoryDependencies>()
                 .AddDependencySingleton<RelationalProjectionExpressionVisitorDependencies>()
                 .AddDependencySingleton<RelationalTransactionFactoryDependencies>()
+                .AddDependencySingleton<RelationalDbFunctionSourceFactoryDependencies>()
                 .AddDependencyScoped<RelationalConventionSetBuilderDependencies>()
                 .AddDependencyScoped<CommandBatchPreparerDependencies>()
                 .AddDependencyScoped<RelationalDatabaseCreatorDependencies>()

--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -80,7 +80,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
                 if (dbFunction.Translation == null)
                 {
-                    if (RelationalDependencies.TypeMappingSource.FindMapping(methodInfo.ReturnType) == null)
+                    if (dbFunction.IsIQueryable && model.FindEntityType(dbFunction.MethodInfo.ReturnType.GetGenericArguments()[0]) == null
+                        || !dbFunction.IsIQueryable && RelationalDependencies.TypeMappingSource.FindMapping(methodInfo.ReturnType) == null)
                     {
                         throw new InvalidOperationException(
                             RelationalStrings.DbFunctionInvalidReturnType(

--- a/src/EFCore.Relational/Metadata/IDbFunction.cs
+++ b/src/EFCore.Relational/Metadata/IDbFunction.cs
@@ -29,6 +29,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         MethodInfo MethodInfo { get; }
 
         /// <summary>
+        ///     Whether this method returns IQueryable
+        /// </summary>
+        bool IsIQueryable { get; }
+
+        /// <summary>
         ///     A translation callback for performing custom translation of the method call into a SQL expression fragment.
         /// </summary>
         Func<IReadOnlyCollection<Expression>, Expression> Translation { get; }

--- a/src/EFCore.Relational/Metadata/Internal/DbFunction.cs
+++ b/src/EFCore.Relational/Metadata/Internal/DbFunction.cs
@@ -83,6 +83,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     RelationalStrings.DbFunctionInvalidReturnType(methodInfo.DisplayName(), methodInfo.ReturnType.ShortDisplayName()));
             }
 
+            if (methodInfo.ReturnType.IsGenericType
+                && methodInfo.ReturnType.GetGenericTypeDefinition() == typeof(IQueryable<>))
+            {
+                if (methodInfo.IsStatic)
+                {
+                    throw new ArgumentException(
+                        RelationalStrings.DbFunctionQueryableNotStatic(methodInfo.DisplayName()));
+                }
+
+                IsIQueryable = true;
+
+                if (model.FindEntityType(methodInfo.ReturnType.GetGenericArguments()[0]) == null)
+                {
+                    model.AddQueryType(methodInfo.ReturnType.GetGenericArguments()[0]);
+                }
+            }
+
             MethodInfo = methodInfo;
 
             _model = model;
@@ -186,6 +203,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual Func<IReadOnlyCollection<Expression>, Expression> Translation { get; set; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual bool IsIQueryable { get; set; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -894,6 +894,30 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 function, type);
 
         /// <summary>
+        ///     The DbFunction '{function}' must return IQueryable.
+        /// </summary>
+        public static string DbFunctionQueryableFunctionMustReturnIQueryable([CanBeNull] object function)
+            => string.Format(
+                GetString("DbFunctionQueryableFunctionMustReturnIQueryable", nameof(function)),
+                function);
+
+        /// <summary>
+        ///     The DbFunction '{function}' is not registered with the model.
+        /// </summary>
+        public static string DbFunctionNotFound([CanBeNull] object function)
+                => string.Format(
+                    GetString("DbFunctionNotFound", nameof(function)),
+                    function);
+
+        /// <summary>
+        ///     IQueryable DbFunctions must be instance methods.  '{function}' is static.
+        /// </summary>
+        public static string DbFunctionQueryableNotStatic([CanBeNull] object function)
+                => string.Format(
+                    GetString("DbFunctionQueryableNotStatic", nameof(function)),
+                    function);
+
+        /// <summary>
         ///     An ambient transaction has been detected. The ambient transaction needs to be completed before beginning a transaction on this connection.
         /// </summary>
         public static string ConflictingAmbientTransaction

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -441,6 +441,15 @@
   <data name="DbFunctionInvalidInstanceType" xml:space="preserve">
     <value>The DbFunction '{function}' defined on type '{type}' must be either a static method or an instance method defined on a DbContext subclass. Instance methods on other types are not supported.</value>
   </data>
+  <data name="DbFunctionQueryableFunctionMustReturnIQueryable" xml:space="preserve">
+    <value>The DbFunction '{function}' must return IQueryable.</value>
+  </data>
+    <data name="DbFunctionNotFound" xml:space="preserve">
+    <value>The DbFunction '{function}' is not registered with the model.</value>
+  </data>
+    <data name="DbFunctionQueryableNotStatic" xml:space="preserve">
+    <value>IQueryable DbFunctions must be instance methods.  '{function}' is static.</value>
+  </data>
   <data name="ConflictingAmbientTransaction" xml:space="preserve">
     <value>An ambient transaction has been detected. The ambient transaction needs to be completed before beginning a transaction on this connection.</value>
   </data>

--- a/src/EFCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitorDependencies.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitorDependencies.cs
@@ -47,21 +47,25 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         /// <param name="selectExpressionFactory"> The select expression factory. </param>
         /// <param name="materializerFactory"> The materializer factory. </param>
         /// <param name="shaperCommandContextFactory"> The shaper command context factory. </param>
+        /// <param name="sqlTranslatingExpressionVisitorFactory"> The sql translating expression factory. </param>
         public RelationalEntityQueryableExpressionVisitorDependencies(
             [NotNull] IModel model,
             [NotNull] ISelectExpressionFactory selectExpressionFactory,
             [NotNull] IMaterializerFactory materializerFactory,
-            [NotNull] IShaperCommandContextFactory shaperCommandContextFactory)
+            [NotNull] IShaperCommandContextFactory shaperCommandContextFactory,
+            [NotNull] ISqlTranslatingExpressionVisitorFactory sqlTranslatingExpressionVisitorFactory)
         {
             Check.NotNull(model, nameof(model));
             Check.NotNull(selectExpressionFactory, nameof(selectExpressionFactory));
             Check.NotNull(materializerFactory, nameof(materializerFactory));
             Check.NotNull(shaperCommandContextFactory, nameof(shaperCommandContextFactory));
+            Check.NotNull(sqlTranslatingExpressionVisitorFactory, nameof(sqlTranslatingExpressionVisitorFactory));
 
             Model = model;
             SelectExpressionFactory = selectExpressionFactory;
             MaterializerFactory = materializerFactory;
             ShaperCommandContextFactory = shaperCommandContextFactory;
+            SqlTranslatingExpressionVisitorFactory = sqlTranslatingExpressionVisitorFactory;
         }
 
         /// <summary>
@@ -85,6 +89,11 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         public IShaperCommandContextFactory ShaperCommandContextFactory { get; }
 
         /// <summary>
+        ///     The sql translating expression factory.
+        /// </summary>
+        public ISqlTranslatingExpressionVisitorFactory SqlTranslatingExpressionVisitorFactory { get; }
+
+        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="model"> A replacement for the current dependency of this type. </param>
@@ -94,7 +103,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 model,
                 SelectExpressionFactory,
                 MaterializerFactory,
-                ShaperCommandContextFactory);
+                ShaperCommandContextFactory,
+                SqlTranslatingExpressionVisitorFactory);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -106,7 +116,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 Model,
                 selectExpressionFactory,
                 MaterializerFactory,
-                ShaperCommandContextFactory);
+                ShaperCommandContextFactory,
+                SqlTranslatingExpressionVisitorFactory);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -118,7 +129,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 Model,
                 SelectExpressionFactory,
                 materializerFactory,
-                ShaperCommandContextFactory);
+                ShaperCommandContextFactory,
+                SqlTranslatingExpressionVisitorFactory);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -130,6 +142,20 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 Model,
                 SelectExpressionFactory,
                 MaterializerFactory,
-                shaperCommandContextFactory);
+                shaperCommandContextFactory,
+                SqlTranslatingExpressionVisitorFactory);
+            
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="sqlTranslatingExpressionVisitorFactory"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public RelationalEntityQueryableExpressionVisitorDependencies With([NotNull] ISqlTranslatingExpressionVisitorFactory sqlTranslatingExpressionVisitorFactory)
+            => new RelationalEntityQueryableExpressionVisitorDependencies(
+                Model,
+            SelectExpressionFactory,
+            MaterializerFactory,
+            ShaperCommandContextFactory,
+            sqlTranslatingExpressionVisitorFactory);
     }
 }

--- a/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -1144,7 +1144,14 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                     return newOperand != nullCompensatedExpression.Operand
                         ? new NullCompensatedExpression(newOperand)
                         : nullCompensatedExpression;
+                
+                case DbFunctionSourceExpression dbFunctionExpression:
+                
+                    var newArguments = Visit(dbFunctionExpression.Arguments);
 
+                    return dbFunctionExpression.Translation?.Invoke(newArguments) ??
+                            new SqlFunctionExpression(dbFunctionExpression.Name, dbFunctionExpression.UnwrappedType, dbFunctionExpression.Schema, newArguments);
+                
                 case DiscriminatorPredicateExpression discriminatorPredicateExpression:
                     return new DiscriminatorPredicateExpression(
                         base.VisitExtension(expression), discriminatorPredicateExpression.QuerySource);

--- a/src/EFCore.Relational/Query/Expressions/CrossJoinLateralOuterExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/CrossJoinLateralOuterExpression.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Sql;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Query.Expressions
+{
+    /// <summary>
+    ///     Represents a SQL CROSS JOIN LATERAL OUTER expression.
+    /// </summary>
+    public class CrossJoinLateralOuterExpression : JoinExpressionBase
+    {
+        /// <summary>
+        ///     Creates a new instance of CrossJoinLateralExpression.
+        /// </summary>
+        /// <param name="tableExpression"> The target table expression. </param>
+        public CrossJoinLateralOuterExpression([NotNull] TableExpressionBase tableExpression)
+            : base(Check.NotNull(tableExpression, nameof(tableExpression)))
+        {
+        }
+
+        /// <summary>
+        ///     Dispatches to the specific visit method for this node type.
+        /// </summary>
+        protected override Expression Accept(ExpressionVisitor visitor)
+        {
+            Check.NotNull(visitor, nameof(visitor));
+
+            return visitor is ISqlExpressionVisitor specificVisitor
+                ? specificVisitor.VisitCrossJoinLateralOuter(this)
+                : base.Accept(visitor);
+        }
+
+        /// <summary>
+        ///     Tests if this object is considered equal to another.
+        /// </summary>
+        /// <param name="obj"> The object to compare with the current object. </param>
+        /// <returns>
+        ///     true if the objects are considered equal, false if they are not.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (obj is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            return obj.GetType() == GetType() && Equals((CrossJoinLateralExpression)obj);
+        }
+
+        private bool Equals(CrossJoinLateralExpression other)
+            => string.Equals(Alias, other.Alias)
+               && Equals(QuerySource, other.QuerySource);
+
+        /// <summary>
+        ///     Returns a hash code for this object.
+        /// </summary>
+        /// <returns>
+        ///     A hash code for this object.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Alias?.GetHashCode() ?? 0;
+                hashCode = (hashCode * 397) ^ (QuerySource?.GetHashCode() ?? 0);
+
+                return hashCode;
+            }
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="string" /> representation of the Expression.
+        /// </summary>
+        /// <returns>A <see cref="string" /> representation of the Expression.</returns>
+        public override string ToString() => "CROSS JOIN LATERAL OUTER " + TableExpression;
+    }
+}

--- a/src/EFCore.Relational/Query/Expressions/DbFunctionSourceExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/DbFunctionSourceExpression.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Query.Expressions
+{
+    /// <summary>
+    ///    Represents a Db Function which acts as a query source in the ReLinq parse tree.
+    /// </summary>
+    public class DbFunctionSourceExpression : Expression
+    {
+        private readonly IDbFunction _dbFunction;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override ExpressionType NodeType => ExpressionType.Extension;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override Type Type { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Type ReturnType { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual string Schema => _dbFunction.Schema;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Type UnwrappedType => Type.IsGenericType ? Type.GetGenericArguments()[0] : Type;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual string Name => _dbFunction.FunctionName;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual bool IsIQueryable => _dbFunction.IsIQueryable;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual ReadOnlyCollection<Expression> Arguments { get; [param: NotNull] set; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Func<IReadOnlyCollection<Expression>, Expression> Translation => _dbFunction.Translation ;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public DbFunctionSourceExpression([NotNull] MethodCallExpression expression, [NotNull] IModel model)
+        {
+            Check.NotNull(expression, nameof(expression));
+            Check.NotNull(model, nameof(model));
+
+            _dbFunction = FindDbFunction(expression, model);
+            Arguments = expression.Arguments;
+
+            if (expression.Method.ReturnType.IsGenericType)
+            {
+                if (expression.Method.ReturnType.GetGenericTypeDefinition() != typeof(IQueryable<>))
+                {
+                    throw new InvalidOperationException(
+                        RelationalStrings.DbFunctionQueryableFunctionMustReturnIQueryable(_dbFunction.FunctionName));
+                }
+
+                Type = expression.Method.ReturnType;
+                ReturnType = expression.Method.ReturnType.GetGenericArguments()[0];
+            }
+            else
+            {
+                Type = typeof(IEnumerable<>).MakeGenericType(expression.Method.ReturnType);
+                ReturnType = expression.Method.ReturnType;
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public DbFunctionSourceExpression([NotNull] DbFunctionSourceExpression oldFuncExpression, [NotNull] ReadOnlyCollection<Expression> newArguments)
+        {
+            Check.NotNull(oldFuncExpression, nameof(oldFuncExpression));
+            Check.NotNull(newArguments, nameof(newArguments));
+
+            Arguments = new ReadOnlyCollection<Expression>(newArguments);
+            _dbFunction = oldFuncExpression._dbFunction;
+            ReturnType = oldFuncExpression.ReturnType;
+            Type = oldFuncExpression.Type;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+        {
+            Check.NotNull(visitor, nameof(visitor));
+
+            var newArguments = visitor.Visit(Arguments);
+
+            if (visitor is ParameterExtractingExpressionVisitor)
+            {
+                newArguments = new ReadOnlyCollection<Expression>(newArguments.Select(a => a is LambdaExpression l ? l.Body : a).ToList());
+            }
+
+            return newArguments != Arguments
+                ? new DbFunctionSourceExpression(this, newArguments)
+                : this;
+        }
+
+        private IDbFunction FindDbFunction(MethodCallExpression exp, IModel model)
+        {
+            var method = exp.Method.DeclaringType.GetMethod(
+                exp.Method.Name,
+                exp.Method.GetParameters()
+                    .Select(p => UnwrapParamterType(p.ParameterType))
+                    .ToArray());
+
+            var dbFunction = model.Relational().FindDbFunction(method);
+
+            if (dbFunction == null)
+            {
+                throw new InvalidOperationException(
+                    RelationalStrings.DbFunctionNotFound(method.Name));
+            }
+
+            return dbFunction;
+
+            Type UnwrapParamterType(Type paramType)
+            {
+                if (paramType.IsGenericType
+                    && paramType.GetGenericTypeDefinition() == typeof(Expression<>))
+                {
+                    var expressionType = paramType.GetGenericArguments()[0];
+
+                    if (expressionType.IsGenericType
+                        && expressionType.GetGenericTypeDefinition() == typeof(Func<>))
+                    {
+                        return expressionType.GetGenericArguments().Last();
+                    }
+                }
+
+                return paramType;
+            }
+        }
+    }
+}

--- a/src/EFCore.Relational/Query/Expressions/QuerableSqlFunctionExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/QuerableSqlFunctionExpression.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Sql;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Remotion.Linq.Clauses;
+
+namespace Microsoft.EntityFrameworkCore.Query.Expressions
+{
+    /// <summary>
+    ///     Represents a SQL Table Valued Fuction in the sql generation tree.
+    /// </summary>
+    public class QuerableSqlFunctionExpression : TableExpressionBase
+    {
+        private readonly SqlFunctionExpression _sqlFunctionExpression;
+
+        /// <summary>
+        /// The sql function expression representing the database function
+        /// </summary>
+        public virtual SqlFunctionExpression SqlFunctionExpression => _sqlFunctionExpression;
+
+        /// <summary>
+        /// Creates a new instance of a QuerableSqlFunctionExpression.
+        /// </summary>
+        /// <param name="sqlFunction"> The sqlFunctionExprssion representing the database function. </param>
+        /// <param name="querySource">  The query source. </param>
+        /// <param name="alias"> The alias. </param>
+        public QuerableSqlFunctionExpression([NotNull] SqlFunctionExpression sqlFunction, [NotNull] IQuerySource querySource, [CanBeNull] string alias)
+             : this(sqlFunction.FunctionName, sqlFunction.Type, sqlFunction.Schema, sqlFunction.Arguments, querySource, alias)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of a QuerableSqlFunctionExpression.
+        /// </summary>
+        /// <param name="functionName"> The db function name. </param>
+        /// <param name="returnType"> The db function return type. </param>
+        /// <param name="schema"> The schema. </param>
+        /// <param name="arguments"> The arguemnts to the db function. </param>
+        /// <param name="querySource"> The query source. </param>
+        /// <param name="alias"> The alias. </param>
+        public QuerableSqlFunctionExpression([NotNull] string functionName,
+                [NotNull] Type returnType,
+                [CanBeNull] string schema,
+                [NotNull] IEnumerable<Expression> arguments,
+                [NotNull] IQuerySource querySource,
+                [CanBeNull] string alias)
+            : base(Check.NotNull(querySource, nameof(querySource)), alias)
+        {
+            Check.NotNull(functionName, nameof(functionName));
+            Check.NotNull(returnType, nameof(returnType));
+            Check.NotNull(arguments, nameof(arguments));
+
+            _sqlFunctionExpression = new SqlFunctionExpression(functionName, returnType, schema, arguments);
+        }
+
+        /// <summary>
+        ///   Convert this object into a string representation.
+        /// </summary>
+        /// <returns> A string that represents this object. </returns>
+        public override string ToString()
+        {
+            return _sqlFunctionExpression.ToString();
+        }
+
+        /// <summary>
+        /// Dispatches to the specific visit method for this node type.
+        /// </summary>
+        protected override Expression Accept(ExpressionVisitor visitor)
+        {
+            Check.NotNull(visitor, nameof(visitor));
+
+            return visitor is ISqlExpressionVisitor specificVisitor
+                ? specificVisitor.VisitQueryableSqlFunctionExpression(this)
+                : base.Accept(visitor);
+        }
+
+        /// <summary>
+        ///     Reduces the node and then calls the <see cref="ExpressionVisitor.Visit(Expression)" /> method passing the
+        ///     reduced expression.
+        ///     Throws an exception if the node isn't reducible.
+        /// </summary>
+        /// <param name="visitor"> An instance of <see cref="ExpressionVisitor" />. </param>
+        /// <returns> The expression being visited, or an expression which should replace it in the tree. </returns>
+        /// <remarks>
+        ///     Override this method to provide logic to walk the node's children.
+        ///     A typical implementation will call visitor.Visit on each of its
+        ///     children, and if any of them change, should return a new copy of
+        ///     itself with the modified children.
+        /// </remarks>
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+        {
+            Check.NotNull(visitor, nameof(visitor));
+
+            var newArguments = visitor.Visit(new ReadOnlyCollection<Expression>(_sqlFunctionExpression.Arguments.ToList()));
+
+            return !Equals(newArguments, _sqlFunctionExpression.Arguments)
+                ? new QuerableSqlFunctionExpression(new SqlFunctionExpression(_sqlFunctionExpression.FunctionName, Type, _sqlFunctionExpression.Schema, newArguments), QuerySource, Alias)
+                : this;
+        }
+    }
+}

--- a/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
@@ -1176,6 +1176,32 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         }
 
         /// <summary>
+        ///     Adds a SQL CROSS JOIN LATERAL to this SelectExpression.
+        /// </summary>
+        /// <param name="tableExpression"> The target table expression. </param>
+        /// <param name="projection"> A sequence of expressions that should be added to the projection. </param>
+        public virtual JoinExpressionBase AddCrossJoinLateralOuter(
+            [NotNull] TableExpressionBase tableExpression,
+            [NotNull] IEnumerable<Expression> projection)
+        {
+            Check.NotNull(tableExpression, nameof(tableExpression));
+            Check.NotNull(projection, nameof(projection));
+
+            if (tableExpression is SelectExpression s && s.Tables.First() is QuerableSqlFunctionExpression)
+            {
+                tableExpression = s.Tables.First();
+                projection = s.Projection;
+            }
+
+            var crossJoinLateralOuterExpression = new CrossJoinLateralOuterExpression(tableExpression);
+
+            _tables.Add(crossJoinLateralOuterExpression);
+            _projection.AddRange(projection);
+
+            return crossJoinLateralOuterExpression;
+        }
+
+        /// <summary>
         ///     Adds a SQL INNER JOIN to this SelectExpression.
         /// </summary>
         /// <param name="tableExpression"> The target table expression. </param>

--- a/src/EFCore.Relational/Query/Internal/RelationalDbFunctionTransformer.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalDbFunctionTransformer.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Remotion.Linq.Parsing.ExpressionVisitors.Transformation;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class RelationalDbFunctionTransformer : IExpressionTransformer<MethodCallExpression>
+    {
+        private readonly IModel _model;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public RelationalDbFunctionTransformer([NotNull] IModel model)
+        {
+            Check.NotNull(model, nameof(model));
+
+            _model = model;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Expression Transform(MethodCallExpression expression)
+        {
+            Check.NotNull(expression, nameof(expression));
+
+            if (_model.Relational().FindDbFunction(expression.Method)?.IsIQueryable == true)
+            {
+                return new DbFunctionSourceExpression(expression, _model);
+            }
+
+            return expression;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual ExpressionType[] SupportedExpressionTypes => new[] { ExpressionType.Call };
+    }
+}

--- a/src/EFCore.Relational/Query/Internal/RelationalIExpressionTranformationProvider.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalIExpressionTranformationProvider.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Remotion.Linq.Parsing.ExpressionVisitors.Transformation;
+
+namespace Microsoft.EntityFrameworkCore.Query.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class RelationalIExpressionTranformationProvider : IExpressionTranformationProvider
+    {
+        private readonly ExpressionTransformerRegistry _transformProvider;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public RelationalIExpressionTranformationProvider([NotNull] IModel model)
+        {
+            Check.NotNull(model, nameof(model));
+
+            _transformProvider = ExpressionTransformerRegistry.CreateDefault();
+            _transformProvider.Register(new RelationalDbFunctionTransformer(model));
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual IEnumerable<ExpressionTransformation> GetTransformations(Expression expression)
+        {
+            return _transformProvider.GetTransformations(expression);
+        }
+    }
+}

--- a/src/EFCore.Relational/Query/RelationalDbFunctionSourceFactory.cs
+++ b/src/EFCore.Relational/Query/RelationalDbFunctionSourceFactory.cs
@@ -1,0 +1,41 @@
+﻿using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class RelationalDbFunctionSourceFactory : IDbFunctionSourceFactory
+    {
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="RelationalDbFunctionSourceFactory" /> class.
+        /// </summary>
+        /// <param name="dependencies"> Parameter object containing dependencies for this service. </param>
+        public RelationalDbFunctionSourceFactory([NotNull] RelationalDbFunctionSourceFactoryDependencies dependencies)
+        {
+            Check.NotNull(dependencies, nameof(dependencies));
+
+            Dependencies = dependencies;
+        }
+
+        /// <summary>
+        ///     Parameter object containing dependencies for this service.
+        /// </summary>
+        protected virtual RelationalDbFunctionSourceFactoryDependencies Dependencies { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used 
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Expression GenerateDbFunctionSource(MethodCallExpression methodCall, IModel model)
+            => new DbFunctionSourceExpression(
+                        Check.NotNull(methodCall, nameof(methodCall)),
+                        Check.NotNull(model, nameof(model)));
+    }
+}

--- a/src/EFCore.Relational/Query/RelationalDbFunctionSourceFactoryDependencies.cs
+++ b/src/EFCore.Relational/Query/RelationalDbFunctionSourceFactoryDependencies.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    /// <summary>
+    ///     <para>
+    ///         Service dependencies parameter class for <see cref="RelationalDbFunctionSourceFactory" />.
+    ///     </para>
+    ///     <para>
+    ///         This type is typically used by database providers (and other extensions). It is generally
+    ///         not used in application code.
+    ///     </para>
+    /// </summary>
+    public sealed class RelationalDbFunctionSourceFactoryDependencies
+    {
+    }
+}

--- a/src/EFCore.Relational/Query/RelationalQueryCompilationContext.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryCompilationContext.cs
@@ -79,6 +79,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual bool IsLateralJoinSupported => false;
 
         /// <summary>
+        ///     True if the current provider supports SQL OUTER LATERAL JOIN.
+        /// </summary>
+        public virtual bool IsLateralJoinOuterSupported => false;
+
+        /// <summary>
         ///     Max length of the table alias supported by provider.
         /// </summary>
         public virtual int MaxTableAliasLength => 128;

--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -929,6 +929,24 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         }
 
         /// <summary>
+        ///     Visit a CrossJoinLateralOuterExpression expression.
+        /// </summary>
+        /// <param name="crossJoinLateralOuterExpression"> The cross join lateral outer expression. </param>
+        /// <returns>
+        ///     An Expression.
+        /// </returns>
+        public virtual Expression VisitCrossJoinLateralOuter(CrossJoinLateralOuterExpression crossJoinLateralOuterExpression)
+        {
+            Check.NotNull(crossJoinLateralOuterExpression, nameof(crossJoinLateralOuterExpression));
+
+            _relationalCommandBuilder.Append("CROSS JOIN LATERAL OUTER");
+
+            Visit(crossJoinLateralOuterExpression.TableExpression);
+
+            return crossJoinLateralOuterExpression;
+        }
+
+        /// <summary>
         ///     Visit a SqlFragmentExpression.
         /// </summary>
         /// <param name="sqlFragmentExpression"> The SqlFragmentExpression expression. </param>
@@ -1613,6 +1631,20 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
             _typeMapping = parentTypeMapping;
         }
 
+        /// <summary>
+        ///     Visits a QuerableSqlFunctionExpression.
+        /// </summary>
+        /// <param name="querableSqlFunctionExpression"> The QuerableSqlFunctionExpression. </param>
+        /// <returns>
+        ///     An Expression.
+        /// </returns>
+        public virtual Expression VisitQueryableSqlFunctionExpression(QuerableSqlFunctionExpression querableSqlFunctionExpression)
+        {
+            Check.NotNull(querableSqlFunctionExpression, nameof(querableSqlFunctionExpression));
+
+            return VisitSqlFunction(querableSqlFunctionExpression.SqlFunctionExpression);
+        }
+    
         /// <summary>
         ///     Visit a SQL ExplicitCastExpression.
         /// </summary>

--- a/src/EFCore.Relational/Query/Sql/ISqlExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/Sql/ISqlExpressionVisitor.cs
@@ -94,6 +94,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         Expression VisitCrossJoinLateral([NotNull] CrossJoinLateralExpression crossJoinLateralExpression);
 
         /// <summary>
+        ///     Visit a CrossJoinLateralOuterExpression.
+        /// </summary>
+        /// <param name="crossJoinLateralOuterExpression"> The cross join lateral outer expression. </param>
+        /// <returns>
+        ///     An Expression.
+        /// </returns>
+        Expression VisitCrossJoinLateralOuter([NotNull] CrossJoinLateralOuterExpression crossJoinLateralOuterExpression);
+
+        /// <summary>
         ///     Visit an InnerJoinExpression.
         /// </summary>
         /// <param name="innerJoinExpression"> The inner join expression. </param>
@@ -182,5 +191,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         ///     An Expression.
         /// </returns>
         Expression VisitColumnReference([NotNull] ColumnReferenceExpression columnReferenceExpression);
+
+        /// <summary>
+        ///     Visit a QuerableSqlFunctionExpression.
+        /// </summary>
+        /// <param name="querableSqlFunctionExpression"> The QuerableSqlFunctionExpression </param>
+        /// <returns>
+        ///     An Expression.
+        /// </returns>
+        Expression VisitQueryableSqlFunctionExpression([NotNull] QuerableSqlFunctionExpression querableSqlFunctionExpression);
     }
 }

--- a/src/EFCore.Relational/breakingchanges.netcore.json
+++ b/src/EFCore.Relational/breakingchanges.netcore.json
@@ -1,232 +1,247 @@
-  [
-    {
-      "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Migrations.MigrationsSqlGeneratorDependencies",
-      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalCommandBuilderFactory commandBuilderFactory, Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper sqlGenerationHelper, Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper typeMapper)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Update.UpdateSqlGeneratorDependencies",
-      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper sqlGenerationHelper)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Storage.RelationalConnectionDependencies",
-      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptions contextOptions, Microsoft.EntityFrameworkCore.Diagnostics.IDiagnosticsLogger<Microsoft.EntityFrameworkCore.DbLoggerCategory+Database+Transaction> transactionLogger, Microsoft.EntityFrameworkCore.Diagnostics.IDiagnosticsLogger<Microsoft.EntityFrameworkCore.DbLoggerCategory+Database+Connection> connectionLogger, Microsoft.EntityFrameworkCore.Storage.Internal.INamedConnectionStringResolver connectionStringResolver)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Migrations.HistoryRepositoryDependencies",
-      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalDatabaseCreator databaseCreator, Microsoft.EntityFrameworkCore.Storage.IRawSqlCommandBuilder rawSqlCommandBuilder, Microsoft.EntityFrameworkCore.Storage.IRelationalConnection connection, Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptions options, Microsoft.EntityFrameworkCore.Migrations.IMigrationsModelDiffer modelDiffer, Microsoft.EntityFrameworkCore.Migrations.IMigrationsSqlGenerator migrationsSqlGenerator, Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper sqlGenerationHelper)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Storage.RelationalDatabaseCreatorDependencies",
-      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IModel model, Microsoft.EntityFrameworkCore.Storage.IRelationalConnection connection, Microsoft.EntityFrameworkCore.Migrations.IMigrationsModelDiffer modelDiffer, Microsoft.EntityFrameworkCore.Migrations.IMigrationsSqlGenerator migrationsSqlGenerator, Microsoft.EntityFrameworkCore.Migrations.IMigrationCommandExecutor migrationCommandExecutor, Microsoft.EntityFrameworkCore.Storage.IExecutionStrategyFactory executionStrategyFactory)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Storage.RelationalValueBufferFactoryDependencies",
-      "MemberId": "public .ctor()",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpressionDependencies",
-      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGeneratorFactory querySqlGeneratorFactory)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalValueBufferFactoryFactory",
-      "MemberId": "Microsoft.EntityFrameworkCore.Storage.IRelationalValueBufferFactory Create(System.Collections.Generic.IReadOnlyList<Microsoft.EntityFrameworkCore.Storage.TypeMaterializationInfo> types)",
-      "Kind": "Addition"
-    },
-    {
-      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalDatabaseCreator : Microsoft.EntityFrameworkCore.Storage.IDatabaseCreator",
-      "MemberId": "System.String GenerateCreateScript()",
-      "Kind": "Addition"
-    },
-    {
-      "TypeId": "public interface Microsoft.EntityFrameworkCore.Design.IAnnotationCodeGenerator",
-      "MemberId": "Microsoft.EntityFrameworkCore.Design.MethodCallCodeFragment GenerateFluentApi(Microsoft.EntityFrameworkCore.Metadata.IEntityType entityType, Microsoft.EntityFrameworkCore.Infrastructure.IAnnotation annotation)",
-      "Kind": "Addition"
-    },
-    {
-      "TypeId": "public interface Microsoft.EntityFrameworkCore.Design.IAnnotationCodeGenerator",
-      "MemberId": "Microsoft.EntityFrameworkCore.Design.MethodCallCodeFragment GenerateFluentApi(Microsoft.EntityFrameworkCore.Metadata.IForeignKey foreignKey, Microsoft.EntityFrameworkCore.Infrastructure.IAnnotation annotation)",
-      "Kind": "Addition"
-    },
-    {
-      "TypeId": "public interface Microsoft.EntityFrameworkCore.Design.IAnnotationCodeGenerator",
-      "MemberId": "Microsoft.EntityFrameworkCore.Design.MethodCallCodeFragment GenerateFluentApi(Microsoft.EntityFrameworkCore.Metadata.IIndex index, Microsoft.EntityFrameworkCore.Infrastructure.IAnnotation annotation)",
-      "Kind": "Addition"
-    },
-    {
-      "TypeId": "public interface Microsoft.EntityFrameworkCore.Design.IAnnotationCodeGenerator",
-      "MemberId": "Microsoft.EntityFrameworkCore.Design.MethodCallCodeFragment GenerateFluentApi(Microsoft.EntityFrameworkCore.Metadata.IKey key, Microsoft.EntityFrameworkCore.Infrastructure.IAnnotation annotation)",
-      "Kind": "Addition"
-    },
-    {
-      "TypeId": "public interface Microsoft.EntityFrameworkCore.Design.IAnnotationCodeGenerator",
-      "MemberId": "Microsoft.EntityFrameworkCore.Design.MethodCallCodeFragment GenerateFluentApi(Microsoft.EntityFrameworkCore.Metadata.IModel model, Microsoft.EntityFrameworkCore.Infrastructure.IAnnotation annotation)",
-      "Kind": "Addition"
-    },
-    {
-      "TypeId": "public interface Microsoft.EntityFrameworkCore.Design.IAnnotationCodeGenerator",
-      "MemberId": "Microsoft.EntityFrameworkCore.Design.MethodCallCodeFragment GenerateFluentApi(Microsoft.EntityFrameworkCore.Metadata.IProperty property, Microsoft.EntityFrameworkCore.Infrastructure.IAnnotation annotation)",
-      "Kind": "Addition"
-    },
-    {
-      "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.SqlTranslatingExpressionVisitorDependencies",
-      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.IExpressionFragmentTranslator compositeExpressionFragmentTranslator, Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.ICompositeMethodCallTranslator methodCallTranslator, Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.IMemberTranslator memberTranslator, Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper relationalTypeMapper)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Query.Sql.QuerySqlGeneratorDependencies",
-      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalCommandBuilderFactory commandBuilderFactory, Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper sqlGenerationHelper, Microsoft.EntityFrameworkCore.Storage.IParameterNameGeneratorFactory parameterNameGeneratorFactory, Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper relationalTypeMapper)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Infrastructure.RelationalModelValidatorDependencies",
-      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper typeMapper)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.MigrationBuilder",
-      "MemberId": "public virtual Microsoft.EntityFrameworkCore.Migrations.Operations.Builders.AlterOperationBuilder<Microsoft.EntityFrameworkCore.Migrations.Operations.AlterColumnOperation> AlterColumn<T0>(System.String name, System.String table, System.String type = null, System.Nullable<System.Boolean> unicode = default(System.Nullable<System.Boolean>), System.Nullable<System.Int32> maxLength = default(System.Nullable<System.Int32>), System.Boolean rowVersion = False, System.String schema = null, System.Boolean nullable = False, System.Object defaultValue = null, System.String defaultValueSql = null, System.String computedColumnSql = null, System.Type oldClrType = null, System.String oldType = null, System.Nullable<System.Boolean> oldUnicode = default(System.Nullable<System.Boolean>), System.Nullable<System.Int32> oldMaxLength = default(System.Nullable<System.Int32>), System.Boolean oldRowVersion = False, System.Boolean oldNullable = False, System.Object oldDefaultValue = null, System.String oldDefaultValueSql = null, System.String oldComputedColumnSql = null)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.MigrationBuilder",
-      "MemberId": "public virtual Microsoft.EntityFrameworkCore.Migrations.Operations.Builders.OperationBuilder<Microsoft.EntityFrameworkCore.Migrations.Operations.AddColumnOperation> AddColumn<T0>(System.String name, System.String table, System.String type = null, System.Nullable<System.Boolean> unicode = default(System.Nullable<System.Boolean>), System.Nullable<System.Int32> maxLength = default(System.Nullable<System.Int32>), System.Boolean rowVersion = False, System.String schema = null, System.Boolean nullable = False, System.Object defaultValue = null, System.String defaultValueSql = null, System.String computedColumnSql = null)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.Operations.Builders.ColumnsBuilder",
-      "MemberId": "public virtual Microsoft.EntityFrameworkCore.Migrations.Operations.Builders.OperationBuilder<Microsoft.EntityFrameworkCore.Migrations.Operations.AddColumnOperation> Column<T0>(System.String type = null, System.Nullable<System.Boolean> unicode = default(System.Nullable<System.Boolean>), System.Nullable<System.Int32> maxLength = default(System.Nullable<System.Int32>), System.Boolean rowVersion = False, System.String name = null, System.Boolean nullable = False, System.Object defaultValue = null, System.String defaultValueSql = null, System.String computedColumnSql = null)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IRelationalPropertyAnnotations",
-      "MemberId": "System.Boolean get_IsFixedLength()",
-      "Kind": "Addition"
-    },
-    {
-      "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
-      "MemberId": "System.Reflection.MethodInfo get_FastQueryMethod()",
-      "Kind": "Addition"
-    },    
-    {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.BoolTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
-      "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.ByteArrayTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
-      "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.ByteTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
-      "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.CharTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
-      "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.DateTimeOffsetTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
-      "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.DateTimeTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
-      "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.DecimalTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
-      "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.DoubleTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
-      "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.FloatTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
-      "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.GuidTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
-      "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.IntTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
-      "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.LongTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
-      "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.SByteTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
-      "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.ShortTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
-      "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.StringTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
-      "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.TimeSpanTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
-      "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.UIntTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
-      "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.ULongTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
-      "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.UShortTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
-      "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-      "MemberId": "System.String GenerateParameterNamePlaceholder(System.String name)",
-      "Kind": "Addition"
-    },
-    {
-      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-      "MemberId": "System.Void GenerateParameterNamePlaceholder(System.Text.StringBuilder builder, System.String name)",
-      "Kind": "Addition"
-    },
-    {
-      "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.RelationalCompositeMemberTranslatorDependencies",
-      "MemberId": "public .ctor()",
-      "Kind": "Removal"
-    },
-    {
-      "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.RelationalCompositeMethodCallTranslatorDependencies",
-      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Diagnostics.IDiagnosticsLogger<Microsoft.EntityFrameworkCore.DbLoggerCategory+Query> logger)",
-      "Kind": "Removal"
-    }
+[
+  {
+    "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Migrations.MigrationsSqlGeneratorDependencies",
+    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalCommandBuilderFactory commandBuilderFactory, Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper sqlGenerationHelper, Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper typeMapper)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Update.UpdateSqlGeneratorDependencies",
+    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper sqlGenerationHelper)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Storage.RelationalConnectionDependencies",
+    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptions contextOptions, Microsoft.EntityFrameworkCore.Diagnostics.IDiagnosticsLogger<Microsoft.EntityFrameworkCore.DbLoggerCategory+Database+Transaction> transactionLogger, Microsoft.EntityFrameworkCore.Diagnostics.IDiagnosticsLogger<Microsoft.EntityFrameworkCore.DbLoggerCategory+Database+Connection> connectionLogger, Microsoft.EntityFrameworkCore.Storage.Internal.INamedConnectionStringResolver connectionStringResolver)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Migrations.HistoryRepositoryDependencies",
+    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalDatabaseCreator databaseCreator, Microsoft.EntityFrameworkCore.Storage.IRawSqlCommandBuilder rawSqlCommandBuilder, Microsoft.EntityFrameworkCore.Storage.IRelationalConnection connection, Microsoft.EntityFrameworkCore.Infrastructure.IDbContextOptions options, Microsoft.EntityFrameworkCore.Migrations.IMigrationsModelDiffer modelDiffer, Microsoft.EntityFrameworkCore.Migrations.IMigrationsSqlGenerator migrationsSqlGenerator, Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper sqlGenerationHelper)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Storage.RelationalDatabaseCreatorDependencies",
+    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IModel model, Microsoft.EntityFrameworkCore.Storage.IRelationalConnection connection, Microsoft.EntityFrameworkCore.Migrations.IMigrationsModelDiffer modelDiffer, Microsoft.EntityFrameworkCore.Migrations.IMigrationsSqlGenerator migrationsSqlGenerator, Microsoft.EntityFrameworkCore.Migrations.IMigrationCommandExecutor migrationCommandExecutor, Microsoft.EntityFrameworkCore.Storage.IExecutionStrategyFactory executionStrategyFactory)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Storage.RelationalValueBufferFactoryDependencies",
+    "MemberId": "public .ctor()",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Query.Expressions.SelectExpressionDependencies",
+    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGeneratorFactory querySqlGeneratorFactory)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalValueBufferFactoryFactory",
+    "MemberId": "Microsoft.EntityFrameworkCore.Storage.IRelationalValueBufferFactory Create(System.Collections.Generic.IReadOnlyList<Microsoft.EntityFrameworkCore.Storage.TypeMaterializationInfo> types)",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalDatabaseCreator : Microsoft.EntityFrameworkCore.Storage.IDatabaseCreator",
+    "MemberId": "System.String GenerateCreateScript()",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Design.IAnnotationCodeGenerator",
+    "MemberId": "Microsoft.EntityFrameworkCore.Design.MethodCallCodeFragment GenerateFluentApi(Microsoft.EntityFrameworkCore.Metadata.IEntityType entityType, Microsoft.EntityFrameworkCore.Infrastructure.IAnnotation annotation)",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Design.IAnnotationCodeGenerator",
+    "MemberId": "Microsoft.EntityFrameworkCore.Design.MethodCallCodeFragment GenerateFluentApi(Microsoft.EntityFrameworkCore.Metadata.IForeignKey foreignKey, Microsoft.EntityFrameworkCore.Infrastructure.IAnnotation annotation)",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Design.IAnnotationCodeGenerator",
+    "MemberId": "Microsoft.EntityFrameworkCore.Design.MethodCallCodeFragment GenerateFluentApi(Microsoft.EntityFrameworkCore.Metadata.IIndex index, Microsoft.EntityFrameworkCore.Infrastructure.IAnnotation annotation)",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Design.IAnnotationCodeGenerator",
+    "MemberId": "Microsoft.EntityFrameworkCore.Design.MethodCallCodeFragment GenerateFluentApi(Microsoft.EntityFrameworkCore.Metadata.IKey key, Microsoft.EntityFrameworkCore.Infrastructure.IAnnotation annotation)",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Design.IAnnotationCodeGenerator",
+    "MemberId": "Microsoft.EntityFrameworkCore.Design.MethodCallCodeFragment GenerateFluentApi(Microsoft.EntityFrameworkCore.Metadata.IModel model, Microsoft.EntityFrameworkCore.Infrastructure.IAnnotation annotation)",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Design.IAnnotationCodeGenerator",
+    "MemberId": "Microsoft.EntityFrameworkCore.Design.MethodCallCodeFragment GenerateFluentApi(Microsoft.EntityFrameworkCore.Metadata.IProperty property, Microsoft.EntityFrameworkCore.Infrastructure.IAnnotation annotation)",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.SqlTranslatingExpressionVisitorDependencies",
+    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.IExpressionFragmentTranslator compositeExpressionFragmentTranslator, Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.ICompositeMethodCallTranslator methodCallTranslator, Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.IMemberTranslator memberTranslator, Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper relationalTypeMapper)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Query.Sql.QuerySqlGeneratorDependencies",
+    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalCommandBuilderFactory commandBuilderFactory, Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper sqlGenerationHelper, Microsoft.EntityFrameworkCore.Storage.IParameterNameGeneratorFactory parameterNameGeneratorFactory, Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper relationalTypeMapper)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Infrastructure.RelationalModelValidatorDependencies",
+    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Storage.IRelationalTypeMapper typeMapper)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.MigrationBuilder",
+    "MemberId": "public virtual Microsoft.EntityFrameworkCore.Migrations.Operations.Builders.AlterOperationBuilder<Microsoft.EntityFrameworkCore.Migrations.Operations.AlterColumnOperation> AlterColumn<T0>(System.String name, System.String table, System.String type = null, System.Nullable<System.Boolean> unicode = default(System.Nullable<System.Boolean>), System.Nullable<System.Int32> maxLength = default(System.Nullable<System.Int32>), System.Boolean rowVersion = False, System.String schema = null, System.Boolean nullable = False, System.Object defaultValue = null, System.String defaultValueSql = null, System.String computedColumnSql = null, System.Type oldClrType = null, System.String oldType = null, System.Nullable<System.Boolean> oldUnicode = default(System.Nullable<System.Boolean>), System.Nullable<System.Int32> oldMaxLength = default(System.Nullable<System.Int32>), System.Boolean oldRowVersion = False, System.Boolean oldNullable = False, System.Object oldDefaultValue = null, System.String oldDefaultValueSql = null, System.String oldComputedColumnSql = null)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.MigrationBuilder",
+    "MemberId": "public virtual Microsoft.EntityFrameworkCore.Migrations.Operations.Builders.OperationBuilder<Microsoft.EntityFrameworkCore.Migrations.Operations.AddColumnOperation> AddColumn<T0>(System.String name, System.String table, System.String type = null, System.Nullable<System.Boolean> unicode = default(System.Nullable<System.Boolean>), System.Nullable<System.Int32> maxLength = default(System.Nullable<System.Int32>), System.Boolean rowVersion = False, System.String schema = null, System.Boolean nullable = False, System.Object defaultValue = null, System.String defaultValueSql = null, System.String computedColumnSql = null)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.Operations.Builders.ColumnsBuilder",
+    "MemberId": "public virtual Microsoft.EntityFrameworkCore.Migrations.Operations.Builders.OperationBuilder<Microsoft.EntityFrameworkCore.Migrations.Operations.AddColumnOperation> Column<T0>(System.String type = null, System.Nullable<System.Boolean> unicode = default(System.Nullable<System.Boolean>), System.Nullable<System.Int32> maxLength = default(System.Nullable<System.Int32>), System.Boolean rowVersion = False, System.String name = null, System.Boolean nullable = False, System.Object defaultValue = null, System.String defaultValueSql = null, System.String computedColumnSql = null)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IRelationalPropertyAnnotations",
+    "MemberId": "System.Boolean get_IsFixedLength()",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
+    "MemberId": "System.Reflection.MethodInfo get_FastQueryMethod()",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.BoolTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
+    "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.ByteArrayTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
+    "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.ByteTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
+    "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.CharTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
+    "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.DateTimeOffsetTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
+    "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.DateTimeTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
+    "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.DecimalTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
+    "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.DoubleTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
+    "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.FloatTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
+    "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.GuidTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
+    "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.IntTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
+    "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.LongTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
+    "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.SByteTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
+    "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.ShortTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
+    "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.StringTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
+    "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.TimeSpanTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
+    "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.UIntTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
+    "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.ULongTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
+    "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.UShortTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
+    "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+    "MemberId": "System.String GenerateParameterNamePlaceholder(System.String name)",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+    "MemberId": "System.Void GenerateParameterNamePlaceholder(System.Text.StringBuilder builder, System.String name)",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.RelationalEntityQueryableExpressionVisitorDependencies",
+    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IModel model, Microsoft.EntityFrameworkCore.Query.Expressions.ISelectExpressionFactory selectExpressionFactory, Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal.IMaterializerFactory materializerFactory, Microsoft.EntityFrameworkCore.Query.Internal.IShaperCommandContextFactory shaperCommandContextFactory)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.RelationalCompositeMethodCallTranslatorDependencies",
+    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Diagnostics.IDiagnosticsLogger<Microsoft.EntityFrameworkCore.DbLoggerCategory+Query> logger)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IDbFunction",
+    "MemberId": "System.Boolean get_IsIQueryable()",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor",
+    "MemberId": "System.Linq.Expressions.Expression VisitCrossJoinLateralOuter(Microsoft.EntityFrameworkCore.Query.Expressions.CrossJoinLateralOuterExpression crossJoinLateralOuterExpression)",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor",
+    "MemberId": "System.Linq.Expressions.Expression VisitQueryableSqlFunctionExpression(Microsoft.EntityFrameworkCore.Query.Expressions.QuerableSqlFunctionExpression querableSqlFunctionExpression)",
+    "Kind": "Addition"
+  }
 ]

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerQueryCompilationContext.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerQueryCompilationContext.cs
@@ -35,5 +35,11 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override bool IsLateralJoinSupported => true;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override bool IsLateralJoinOuterSupported => true;
     }
 }

--- a/src/EFCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
+++ b/src/EFCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
@@ -77,6 +77,21 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Sql.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public override Expression VisitCrossJoinLateralOuter(CrossJoinLateralOuterExpression crossJoinLateralOuterExpression)
+        {
+            Check.NotNull(crossJoinLateralOuterExpression, nameof(crossJoinLateralOuterExpression));
+
+            Sql.Append("OUTER APPLY ");
+
+            Visit(crossJoinLateralOuterExpression.TableExpression);
+
+            return crossJoinLateralOuterExpression;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         protected override void GenerateLimitOffset(SelectExpression selectExpression)
         {
             if (selectExpression.Offset != null
@@ -125,6 +140,28 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Sql.Internal
             }
 
             return base.VisitSqlFunction(sqlFunctionExpression);
+        }
+
+        /// <summary>
+        ///     Visits a QuerableSqlFunctionExpression.
+        /// </summary>
+        /// <param name="querableSqlFunctionExpression"> The SQL function expression. </param>
+        /// <returns>
+        ///     An Expression.
+        /// </returns>
+        public override Expression VisitQueryableSqlFunctionExpression(QuerableSqlFunctionExpression querableSqlFunctionExpression)
+        {
+            Check.NotNull(querableSqlFunctionExpression, nameof(querableSqlFunctionExpression));
+
+            base.VisitQueryableSqlFunctionExpression(querableSqlFunctionExpression);
+
+            if (querableSqlFunctionExpression.Alias != null)
+            {
+                Sql.Append(" AS ")
+                        .Append(SqlGenerator.DelimitIdentifier(querableSqlFunctionExpression.Alias));
+            }
+
+            return querableSqlFunctionExpression;
         }
 
         /// <summary>

--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -24,6 +24,7 @@ using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Remotion.Linq.Parsing.ExpressionVisitors.Transformation;
 using Remotion.Linq.Parsing.ExpressionVisitors.TreeEvaluation;
 
 namespace Microsoft.EntityFrameworkCore.Infrastructure
@@ -146,6 +147,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(IResettableService), new ServiceCharacteristics(ServiceLifetime.Scoped, multipleRegistrations: true) },
                 { typeof(ISingletonOptions), new ServiceCharacteristics(ServiceLifetime.Singleton, multipleRegistrations: true) },
                 { typeof(IEvaluatableExpressionFilter), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+                { typeof(IExpressionTranformationProvider), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+                { typeof(IDbFunctionSourceFactory), new ServiceCharacteristics(ServiceLifetime.Singleton) },
                 { typeof(ITypeMappingSourcePlugin), new ServiceCharacteristics(ServiceLifetime.Singleton, multipleRegistrations: true) }
             };
 
@@ -279,6 +282,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<IResettableService, IDbContextTransactionManager>(p => p.GetService<IDbContextTransactionManager>());
             TryAdd<Func<IStateManager>>(p => p.GetService<IStateManager>);
             TryAdd<IEvaluatableExpressionFilter, EvaluatableExpressionFilter>();
+            TryAdd<IExpressionTranformationProvider>(p => ExpressionTransformerRegistry.CreateDefault());
             TryAdd<IValueConverterSelector, ValueConverterSelector>();
             TryAdd<IConstructorBindingFactory, ConstructorBindingFactory>();
             TryAdd<ILazyLoader, LazyLoader>();
@@ -288,6 +292,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<IParameterBindingFactory, LazyLoaderParameterBindingFactory>();
             TryAdd<IParameterBindingFactory, ContextParameterBindingFactory>();
             TryAdd<IParameterBindingFactory, EntityTypeParameterBindingFactory>();
+            TryAdd<IDbFunctionSourceFactory, DbFunctionSourceFactory>();
 
             ServiceCollectionMap
                 .TryAddSingleton<DiagnosticSource>(new DiagnosticListener(DbLoggerCategory.Name));

--- a/src/EFCore/Internal/DbFunctionSourceFactory.cs
+++ b/src/EFCore/Internal/DbFunctionSourceFactory.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Text;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class DbFunctionSourceFactory : IDbFunctionSourceFactory
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Expression GenerateDbFunctionSource(MethodCallExpression methodCall, IModel model)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/EFCore/Internal/IDbFunctionSourceFactory.cs
+++ b/src/EFCore/Internal/IDbFunctionSourceFactory.cs
@@ -1,0 +1,19 @@
+﻿using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public interface IDbFunctionSourceFactory
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        Expression GenerateDbFunctionSource([NotNull] MethodCallExpression methodCall, [NotNull] IModel model);
+    }
+}

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2674,6 +2674,13 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 property, serviceType, entityType);
 
         /// <summary>
+        ///     The expression body must be a MethodCallExpression
+        /// </summary>
+        public static string ExpressionBodyMustBeMethodCallExpression()
+            => string.Format(
+                GetString("ExpressionBodyMustBeMethodCallExpression"));
+
+        /// <summary>
         ///     Cannot use multiple DbContext instances within a single query execution. Ensure the query uses a single context instance.
         /// </summary>
         public static string ErrorInvalidQueryable

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1081,6 +1081,9 @@
   <data name="AmbiguousServiceProperty" xml:space="preserve">
     <value>The service property '{property}' of type '{serviceType}' cannot be added to the entity type '{entityType}' because there is another property of the same type. Ignore one of the properties using the NotMappedAttribute or 'EntityTypeBuilder.Ignore' in 'OnModelCreating'.</value>
   </data>
+  <data name="ExpressionBodyMustBeMethodCallExpression" xml:space="preserve">
+    <value>The expression body must be a MethodCallExpression.</value>
+  </data>
   <data name="ErrorInvalidQueryable" xml:space="preserve">
     <value>Cannot use multiple DbContext instances within a single query execution. Ensure the query uses a single context instance.</value>
   </data>

--- a/src/EFCore/Query/Internal/QueryModelGenerator.cs
+++ b/src/EFCore/Query/Internal/QueryModelGenerator.cs
@@ -23,6 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
     {
         private readonly INodeTypeProvider _nodeTypeProvider;
         private readonly IEvaluatableExpressionFilter _evaluatableExpressionFilter;
+        private readonly IExpressionTranformationProvider _expressionTranformationProvider;
         private readonly ICurrentDbContext _currentDbContext;
 
         /// <summary>
@@ -32,14 +33,17 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         public QueryModelGenerator(
             [NotNull] INodeTypeProviderFactory nodeTypeProviderFactory,
             [NotNull] IEvaluatableExpressionFilter evaluatableExpressionFilter,
+            [NotNull] IExpressionTranformationProvider expressionTranformationProvider,
             [NotNull] ICurrentDbContext currentDbContext)
         {
             Check.NotNull(nodeTypeProviderFactory, nameof(nodeTypeProviderFactory));
             Check.NotNull(evaluatableExpressionFilter, nameof(evaluatableExpressionFilter));
+            Check.NotNull(expressionTranformationProvider, nameof(expressionTranformationProvider));
             Check.NotNull(currentDbContext, nameof(currentDbContext));
 
             _nodeTypeProvider = nodeTypeProviderFactory.Create();
             _evaluatableExpressionFilter = evaluatableExpressionFilter;
+            _expressionTranformationProvider = expressionTranformationProvider;
             _currentDbContext = currentDbContext;
         }
 
@@ -81,7 +85,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         new IExpressionTreeProcessor[]
                         {
                             new PartialEvaluatingExpressionTreeProcessor(_evaluatableExpressionFilter),
-                            new TransformingExpressionTreeProcessor(ExpressionTransformerRegistry.CreateDefault())
+                            new TransformingExpressionTreeProcessor(_expressionTranformationProvider)
                         })));
     }
 }

--- a/test/EFCore.Relational.Tests/Metadata/DbFunctionMetadataTests.cs
+++ b/test/EFCore.Relational.Tests/Metadata/DbFunctionMetadataTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -161,6 +162,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         public static MethodInfo MethodAmi = typeof(TestMethods).GetRuntimeMethod(nameof(TestMethods.MethodA), new[] { typeof(string), typeof(int) });
         public static MethodInfo MethodBmi = typeof(TestMethods).GetRuntimeMethod(nameof(TestMethods.MethodB), new[] { typeof(string), typeof(int) });
         public static MethodInfo MethodHmi = typeof(TestMethods).GetTypeInfo().GetDeclaredMethod(nameof(TestMethods.MethodH));
+        public static MethodInfo MethodImi = typeof(TestMethods).GetTypeInfo().GetDeclaredMethod(nameof(TestMethods.MethodI));
 
         public class TestMethods
         {
@@ -192,6 +194,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             }
 
             public static int MethodH<T>(T a, string b)
+            {
+                throw new Exception();
+            }
+
+            public static IQueryable<TestMethods> MethodI()
             {
                 throw new Exception();
             }
@@ -475,6 +482,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             var expectedMessage = AbstractionsStrings.ArgumentIsEmpty("name");
 
             Assert.Equal(expectedMessage, Assert.Throws<ArgumentException>(() => modelBuilder.HasDbFunction(MethodAmi).HasName("")).Message);
+        }
+
+        [Fact]
+        public virtual void Queryable_method_must_be_static()
+        {
+            var modelBuilder = GetModelBuilder();
+
+            var expectedMessage = RelationalStrings.DbFunctionQueryableNotStatic("TestMethods.MethodI");
+
+            Assert.Equal(expectedMessage, Assert.Throws<ArgumentException>(() => modelBuilder.HasDbFunction(MethodImi)).Message);
         }
 
         private ModelBuilder GetModelBuilder()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/UdfDbFunctionSqlServerTests.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/UdfDbFunctionSqlServerTests.cs
@@ -1,12 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
-using Microsoft.EntityFrameworkCore.Diagnostics;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestUtilities;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -740,9 +736,427 @@ WHERE 3 = [dbo].[CustomerOrderCount](ABS([c].[Id]))");
 
         #endregion
 
-        public class SqlServer : UdfFixtureBase
+        #region BootStrap
+
+        [Fact]
+        public override void BootstrapScalarNoParams()
+        {
+            base.BootstrapScalarNoParams();
+
+            AssertSql(@"SELECT SCHEMA_NAME()");
+        }
+
+        [Fact]
+        public override async Task BootstrapScalarNoParamsAsync()
+        {
+            await base.BootstrapScalarNoParamsAsync();
+
+            AssertSql(@"SELECT SCHEMA_NAME()");
+        }
+
+        [Fact]
+        public override void BootstrapScalarParams()
+        {
+            base.BootstrapScalarParams();
+
+            AssertSql(@"@__a_0='1'
+@__b_1='2'
+
+SELECT [dbo].[AddValues](@__a_0, @__b_1)");
+        }
+
+        [Fact]
+        public override void BootstrapScalarFuncParams()
+        {
+            base.BootstrapScalarFuncParams();
+
+            AssertSql(@"@__b_1='2'
+
+SELECT [dbo].[AddValues]([dbo].[AddValues](1, 2), @__b_1)");
+        }
+
+        [Fact]
+        public override void BootstrapScalarFuncParamsWithVariable()
+        {
+            base.BootstrapScalarFuncParamsWithVariable();
+
+            AssertSql(@"@__x_1='5'
+@__b_2='2'
+
+SELECT [dbo].[AddValues]([dbo].[AddValues](@__x_1, 2), @__b_2)");
+        }
+
+        [Fact]
+        public override void BootstrapScalarFuncParamsConstant()
+        {
+            base.BootstrapScalarFuncParamsConstant();
+
+            AssertSql(@"@__b_0='2'
+
+SELECT [dbo].[AddValues](1, @__b_0)");
+        }
+        #endregion
+
+        #region Table Valued Tests
+
+        [Fact]
+        public override void TVF_Stand_Alone()
+        {
+            base.TVF_Stand_Alone();
+
+            AssertSql(@"SELECT [t].[AmountSold], [t].[ProductId]
+FROM [dbo].[GetTopTwoSellingProducts]() AS [t]
+ORDER BY [t].[ProductId]");
+        }
+
+        [Fact]
+        public override void TVF_Stand_Alone_With_Translation()
+        {
+            base.TVF_Stand_Alone_With_Translation();
+
+            AssertSql(@"SELECT [t].[AmountSold], [t].[ProductId]
+FROM [dbo].[GetTopTwoSellingProducts]() AS [t]
+ORDER BY [t].[ProductId]");
+        }
+
+        [Fact]
+        public override void TVF_Stand_Alone_Parameter()
+        {
+            base.TVF_Stand_Alone_Parameter();
+
+            AssertSql(@"@__customerId_0='1'
+
+SELECT [c].[Count], [c].[CustomerId], [c].[Year]
+FROM [dbo].[GetCustomerOrderCountByYear](@__customerId_0) AS [c]
+ORDER BY [c].[Count] DESC");
+        }
+
+        [Fact]
+        public override void TVF_Stand_Alone_Nested()
+        {
+            base.TVF_Stand_Alone_Nested();
+
+            AssertSql(@"SELECT [r].[Count], [r].[CustomerId], [r].[Year]
+FROM [dbo].[GetCustomerOrderCountByYear]([dbo].[AddValues](-2, 3)) AS [r]
+ORDER BY [r].[Count] DESC");
+        }
+
+        [Fact]
+        public override void TVF_CrossApply_Correlated_Select_Anonymous()
+        {
+            base.TVF_CrossApply_Correlated_Select_Anonymous();
+
+            AssertSql(@"SELECT [c].[Id], [c].[LastName], [r].[Year], [r].[Count]
+FROM [Customers] AS [c]
+CROSS APPLY [dbo].[GetCustomerOrderCountByYear]([c].[Id]) AS [r]
+ORDER BY [c].[Id], [r].[Year]");
+        }
+
+        [Fact]
+        public override void TVF_Select_Direct_In_Anonymous()
+        {
+            base.TVF_Select_Direct_In_Anonymous();
+
+            AssertSql(@"SELECT [c].[Id]
+FROM [Customers] AS [c]",
+
+                    @"SELECT [t].[AmountSold], [t].[ProductId]
+FROM [dbo].[GetTopTwoSellingProducts]() AS [t]");
+        }
+
+        [Fact]
+        public override void TVF_Select_Correlated_Direct_In_Anonymous()
+        {
+            base.TVF_Select_Correlated_Direct_In_Anonymous();
+
+            AssertSql(@"SELECT [c].[Id]
+FROM [Customers] AS [c]",
+
+                    @"@_outer_Id='1'
+
+SELECT [o].[Count], [o].[CustomerId], [o].[Year]
+FROM [dbo].[GetCustomerOrderCountByYear](@_outer_Id) AS [o]",
+
+                    @"@_outer_Id='2'
+
+SELECT [o].[Count], [o].[CustomerId], [o].[Year]
+FROM [dbo].[GetCustomerOrderCountByYear](@_outer_Id) AS [o]",
+
+                    @"@_outer_Id='3'
+
+SELECT [o].[Count], [o].[CustomerId], [o].[Year]
+FROM [dbo].[GetCustomerOrderCountByYear](@_outer_Id) AS [o]",
+
+                    @"@_outer_Id='4'
+
+SELECT [o].[Count], [o].[CustomerId], [o].[Year]
+FROM [dbo].[GetCustomerOrderCountByYear](@_outer_Id) AS [o]");
+        }
+
+        [Fact]
+        public override void TVF_Select_Correlated_Direct_With_Function_Query_Parameter_Correlated_In_Anonymous()
+        {
+            base.TVF_Select_Correlated_Direct_With_Function_Query_Parameter_Correlated_In_Anonymous();
+
+            AssertSql(@"SELECT [c].[Id]
+FROM [Customers] AS [c]
+WHERE [c].[Id] = 1",
+
+                    @"@_outer_Id='1'
+
+SELECT [o].[Count], [o].[CustomerId], [o].[Year]
+FROM [dbo].[GetCustomerOrderCountByYear]([dbo].[AddValues](@_outer_Id, 1)) AS [o]");
+        }
+
+        [Fact]
+        public override void TVF_Select_Correlated_Subquery_In_Anonymous()
+        {
+            base.TVF_Select_Correlated_Subquery_In_Anonymous();
+
+            AssertSql(@"SELECT [c].[Id]
+FROM [Customers] AS [c]",
+
+                @"@_outer_Id='1'
+
+SELECT [o].[Count], [o].[CustomerId], [o].[Year]
+FROM [dbo].[GetCustomerOrderCountByYear](@_outer_Id) AS [o]
+WHERE [o].[Year] = 2000",
+
+                @"@_outer_Id='2'
+
+SELECT [o].[Count], [o].[CustomerId], [o].[Year]
+FROM [dbo].[GetCustomerOrderCountByYear](@_outer_Id) AS [o]
+WHERE [o].[Year] = 2000",
+
+                @"@_outer_Id='3'
+
+SELECT [o].[Count], [o].[CustomerId], [o].[Year]
+FROM [dbo].[GetCustomerOrderCountByYear](@_outer_Id) AS [o]
+WHERE [o].[Year] = 2000",
+
+                @"@_outer_Id='4'
+
+SELECT [o].[Count], [o].[CustomerId], [o].[Year]
+FROM [dbo].[GetCustomerOrderCountByYear](@_outer_Id) AS [o]
+WHERE [o].[Year] = 2000");
+        }
+
+        [Fact]
+        public override void TVF_Select_Correlated_Subquery_In_Anonymous_Nested()
+        {
+            base.TVF_Select_Correlated_Subquery_In_Anonymous_Nested();
+
+            AssertSql(@"SELECT [c].[Id]
+FROM [Customers] AS [c]",
+
+                    @"SELECT [o].[Year]
+FROM [dbo].[GetCustomerOrderCountByYear](1) AS [o]
+WHERE [o].[Year] = 2000",
+
+                    @"@_outer_Year='2000' (Nullable = true)
+
+SELECT [o2].[Count], [o2].[CustomerId], [o2].[Year]
+FROM [dbo].[GetCustomerOrderCountByYear](2000) AS [o2]
+WHERE @_outer_Year = 2001");
+
+            Assert.Equal(13, Fixture.TestSqlLoggerFactory.SqlStatements.Count);
+        }
+
+        [Fact]
+        public override void TVF_Select_NonCorrelated_Subquery_In_Anonymous()
+        {
+            base.TVF_Select_NonCorrelated_Subquery_In_Anonymous();
+
+            AssertSql(@"SELECT [c].[Id]
+FROM [Customers] AS [c]",
+
+                    @"SELECT [p].[ProductId]
+FROM [dbo].[GetTopTwoSellingProducts]() AS [p]
+WHERE [p].[AmountSold] = 27");
+        }
+
+        [Fact]
+        public override void TVF_Select_NonCorrelated_Subquery_In_Anonymous_Parameter()
+        {
+            base.TVF_Select_NonCorrelated_Subquery_In_Anonymous_Parameter();
+
+            AssertSql(@"SELECT [c].[Id]
+FROM [Customers] AS [c]",
+
+                    @"@__amount_1='27'
+
+SELECT [p].[ProductId]
+FROM [dbo].[GetTopTwoSellingProducts]() AS [p]
+WHERE [p].[AmountSold] = @__amount_1");
+        }
+
+        [Fact]
+        public override void TVF_Correlated_Select_In_Anonymous()
+        {
+            base.TVF_Correlated_Select_In_Anonymous();
+
+            AssertSql(@"SELECT [c].[Id], [c].[LastName]
+FROM [Customers] AS [c]
+ORDER BY [c].[Id]",
+
+                @"@_outer_Id='1'
+
+SELECT [o].[Count], [o].[CustomerId], [o].[Year]
+FROM [dbo].[GetCustomerOrderCountByYear](@_outer_Id) AS [o]",
+
+                    @"@_outer_Id='2'
+
+SELECT [o].[Count], [o].[CustomerId], [o].[Year]
+FROM [dbo].[GetCustomerOrderCountByYear](@_outer_Id) AS [o]",
+
+                    @"@_outer_Id='3'
+
+SELECT [o].[Count], [o].[CustomerId], [o].[Year]
+FROM [dbo].[GetCustomerOrderCountByYear](@_outer_Id) AS [o]",
+
+                    @"@_outer_Id='4'
+
+SELECT [o].[Count], [o].[CustomerId], [o].[Year]
+FROM [dbo].[GetCustomerOrderCountByYear](@_outer_Id) AS [o]"
+);
+        }
+
+        [Fact]
+        public override void TVF_CrossApply_Correlated_Select_Result()
+        {
+            base.TVF_CrossApply_Correlated_Select_Result();
+
+            AssertSql(@"SELECT [r].[Count], [r].[CustomerId], [r].[Year]
+FROM [Customers] AS [c]
+CROSS APPLY [dbo].[GetCustomerOrderCountByYear]([c].[Id]) AS [r]
+ORDER BY [r].[Count] DESC, [r].[Year] DESC");
+        }
+
+        [Fact]
+        public override void TVF_CrossJoin_Not_Correlated()
+        {
+            base.TVF_CrossJoin_Not_Correlated();
+
+            AssertSql(@"SELECT [c].[Id], [c].[LastName], [r].[Year], [r].[Count]
+FROM [Customers] AS [c]
+CROSS JOIN [dbo].[GetCustomerOrderCountByYear](2) AS [r]
+WHERE [c].[Id] = 2
+ORDER BY [r].[Count]");
+        }
+
+        [Fact]
+        public override void TVF_CrossJoin_Parameter()
+        {
+            base.TVF_CrossJoin_Parameter();
+
+            AssertSql(@"@__custId_1='2'
+
+SELECT [c].[Id], [c].[LastName], [r].[Year], [r].[Count]
+FROM [Customers] AS [c]
+CROSS JOIN [dbo].[GetCustomerOrderCountByYear](@__custId_1) AS [r]
+WHERE [c].[Id] = @__custId_1
+ORDER BY [r].[Count]");
+        }
+
+        [Fact]
+        public override void TVF_Join()
+        {
+            base.TVF_Join();
+
+            AssertSql(@"SELECT [p].[Id], [p].[Name], [r].[AmountSold]
+FROM [Products] AS [p]
+INNER JOIN [dbo].[GetTopTwoSellingProducts]() AS [r] ON [p].[Id] = [r].[ProductId]
+ORDER BY [p].[Id]");
+        }
+
+        [Fact]
+        public override void TVF_LeftJoin_Select_Anonymous()
+        {
+            base.TVF_LeftJoin_Select_Anonymous();
+
+            AssertSql(@"SELECT [p].[Id], [p].[Name], [r].[AmountSold]
+FROM [Products] AS [p]
+LEFT JOIN [dbo].[GetTopTwoSellingProducts]() AS [r] ON [p].[Id] = [r].[ProductId]
+ORDER BY [p].[Id] DESC");
+        }
+
+        [Fact]
+        public override void TVF_LeftJoin_Select_Result()
+        {
+            base.TVF_LeftJoin_Select_Result();
+
+            AssertSql(@"SELECT [r].[AmountSold], [r].[ProductId]
+FROM [Products] AS [p]
+LEFT JOIN [dbo].[GetTopTwoSellingProducts]() AS [r] ON [p].[Id] = [r].[ProductId]
+ORDER BY [p].[Id] DESC");
+        }
+
+        [Fact]
+        public override void TVF_OuterApply_Correlated_Select_TVF()
+        {
+            base.TVF_OuterApply_Correlated_Select_TVF();
+
+            AssertSql(@"SELECT [g].[Count], [g].[CustomerId], [g].[Year]
+FROM [Customers] AS [c]
+OUTER APPLY [dbo].[GetCustomerOrderCountByYear]([c].[Id]) AS [g]
+ORDER BY [c].[Id], [g].[Year]");
+        }
+
+        [Fact]
+        public override void TVF_OuterApply_Correlated_Select_DbSet()
+        {
+            base.TVF_OuterApply_Correlated_Select_DbSet();
+
+            AssertSql(@"SELECT [c].[Id], [c].[FirstName], [c].[LastName]
+FROM [Customers] AS [c]
+OUTER APPLY [dbo].[GetCustomerOrderCountByYear]([c].[Id]) AS [g]
+ORDER BY [c].[Id], [g].[Year]");
+        }
+
+        [Fact]
+        public override void TVF_OuterApply_Correlated_Select_Anonymous()
+        {
+            base.TVF_OuterApply_Correlated_Select_Anonymous();
+
+            AssertSql(@"SELECT [c].[Id], [c].[LastName], [g].[Year], [g].[Count]
+FROM [Customers] AS [c]
+OUTER APPLY [dbo].[GetCustomerOrderCountByYear]([c].[Id]) AS [g]
+ORDER BY [c].[Id], [g].[Year]");
+        }
+
+        [Fact]
+        public override void TVF_Nested()
+        {
+            base.TVF_Nested();
+
+            AssertSql(@"@__custId_1='2'
+
+SELECT [c].[Id], [c].[LastName], [r].[Year], [r].[Count]
+FROM [Customers] AS [c]
+CROSS JOIN [dbo].[GetCustomerOrderCountByYear]([dbo].[AddValues](1, 1)) AS [r]
+WHERE [c].[Id] = @__custId_1
+ORDER BY [r].[Year]");
+        }
+
+        [Fact]
+        public override void TVF_Correlated_Nested_Func_Call()
+        {
+            base.TVF_Correlated_Nested_Func_Call();
+
+            AssertSql(@"@__custId_1='2'
+
+SELECT [c].[Id], [r].[Count], [r].[Year]
+FROM [Customers] AS [c]
+CROSS APPLY [dbo].[GetCustomerOrderCountByYear]([dbo].[AddValues]([c].[Id], 1)) AS [r]
+WHERE [c].[Id] = @__custId_1");
+        }
+
+        #endregion
+
+        public class SqlServer : BaseUdfFixture
         {
             protected override string StoreName { get; } = "UDFDbFunctionSqlServerTests";
+
             protected override ITestStoreFactory TestStoreFactory => SqlServerTestStoreFactory.Instance;
 
             protected override void Seed(DbContext context)
@@ -810,6 +1224,53 @@ WHERE 3 = [dbo].[CustomerOrderCount](ABS([c].[Id]))");
                                                     as
                                                     begin
                                                         return @customerName;
+                                                    end");
+
+                context.Database.ExecuteSqlCommand(
+                    @"create function [dbo].GetCustomerOrderCountByYear(@customerId int)
+                                                    returns @reports table
+                                                    (
+                                                        CustomerId int not null,
+	                                                    Count int not null,
+	                                                    Year int not null
+                                                    )
+                                                    as
+                                                    begin
+	
+	                                                    insert into @reports
+	                                                    select @customerId, count(id), year(orderDate)
+	                                                    from orders
+	                                                    where customerId = @customerId
+	                                                    group by customerId, year(orderDate)
+	                                                    order by year(orderDate)
+	
+	                                                    return 
+                                                    end");
+
+                context.Database.ExecuteSqlCommand(
+                    @"create function [dbo].GetTopTwoSellingProducts()
+                                                    returns @products table
+                                                    (
+	                                                    ProductId int not null,
+	                                                    AmountSold int
+                                                    )
+                                                    as
+                                                    begin
+	
+	                                                    insert into @products
+	                                                    select top 2 ProductID, sum(quantitySold) as totalSold
+	                                                    from orders
+	                                                    group by ProductID
+	                                                    order by totalSold desc
+	                                                    return 
+                                                    end");
+
+                context.Database.ExecuteSqlCommand(
+                    @"create function [dbo].[AddValues] (@a int, @b int)
+                                                    returns int
+                                                    as
+                                                    begin
+                                                        return @a + @b;
                                                     end");
 
                 context.SaveChanges();


### PR DESCRIPTION
This is still a wip.  I'm putting this out here in response to @divega inquiry on #4319

This adds support for the following items

* Bootstrapable Scalar Functions
* Bootstrapable TVFs
* Nestable DbFunction calls on both types of bootstrapped methods (pass a function as a parameter to the bootstrapped function)
* Full query support for TVFs via Cross Join
* TVF integration with Query Types. You can either directly materialize the QT from the TVF, or use it as part of a larger query.

I am still working on Outer Apply support. 

The code is not ready for a full review at this time.  There are a ton of nits and what not that need to be cleaned up still.

I am placing this PR here so the team can see the general approach I have taken and determine if there are any breaking changes which would preclude this from getting into 2.1

Feedback is welcome as always.  

