### PR TITLE
QueryBuffer is required when derived types of querying types are having shadow props

### DIFF
--- a/src/EFCore.Relational/Query/Internal/QueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/QueryingEnumerable.cs
@@ -77,7 +77,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     {
                         _executionStrategy = _relationalQueryContext.ExecutionStrategyFactory.Create();
                     }
-                    
+
                     return _executionStrategy.Execute(_executionStrategy.RetriesOnFailure, _bufferlessMoveNext, null);
                 }
 

--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -367,7 +367,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     if (entityType != null
                         && !entityType.IsQueryType
                         && (_referencedEntityTypes > 0
-                            || entityType.ShadowPropertyCount() > 0))
+                            || entityType.GetDerivedTypesInclusive().Any(et => et.ShadowPropertyCount() > 0)))
                     {
                         _requiresBuffering = true;
 


### PR DESCRIPTION
Resolves #11104
