### PR TITLE
Fix to #10122 - No value provided for required parameter '_outer_Id'

### DIFF
--- a/src/EFCore.Specification.Tests/Query/AsyncGearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncGearsOfWarQueryTestBase.cs
@@ -1291,5 +1291,57 @@ namespace Microsoft.EntityFrameworkCore.Query
                         })(e.OuterCollection, a.OuterCollection);
                 });
         }
+
+        [ConditionalFact]
+        public virtual async Task Outer_parameter_in_join_key()
+        {
+            await AssertQuery<Gear, CogTag>(
+                (gs, ts) =>
+                    from o in gs.OfType<Officer>()
+                    orderby o.Nickname
+                    select new
+                    {
+                        Collection = (from t in ts
+                                      join g in gs on o.FullName equals g.FullName
+                                      select t.Note).ToList()
+                    },
+                assertOrder: true,
+                elementAsserter: (e, a) => CollectionAsserter<string>(elementSorter: ee => ee)(e.Collection, a.Collection));
+        }
+
+        [ConditionalFact]
+        public virtual async Task Outer_parameter_in_group_join_key()
+        {
+            await AssertQuery<Gear, CogTag>(
+                (gs, ts) =>
+                    from o in gs.OfType<Officer>()
+                    orderby o.Nickname
+                    select new
+                    {
+                        Collection = (from t in ts
+                                      join g in gs on o.FullName equals g.FullName into grouping
+                                      select t.Note).ToList()
+                    },
+                assertOrder: true,
+                elementAsserter: (e, a) => CollectionAsserter<string>(elementSorter: ee => ee)(e.Collection, a.Collection));
+        }
+
+        [ConditionalFact]
+        public virtual async Task Outer_parameter_in_group_join_with_DefaultIfEmpty()
+        {
+            await AssertQuery<Gear, CogTag>(
+                (gs, ts) =>
+                    from o in gs.OfType<Officer>()
+                    orderby o.Nickname
+                    select new
+                    {
+                        Collection = (from t in ts
+                                      join g in gs on o.FullName equals g.FullName into grouping
+                                      from g in grouping.DefaultIfEmpty()
+                                      select t.Note).ToList()
+                    },
+                assertOrder: true,
+                elementAsserter: (e, a) => CollectionAsserter<string>(elementSorter: ee => ee)(e.Collection, a.Collection));
+        }
     }
 }

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -4267,6 +4267,75 @@ namespace Microsoft.EntityFrameworkCore.Query
                 lls => lls.Where(ll => ll is LocustCommander ? ((LocustCommander)ll).HighCommand.IsOperational : false));
         }
 
+        [ConditionalFact]
+        public virtual void Outer_parameter_in_join_key()
+        {
+            AssertQuery<Gear, CogTag>(
+                (gs, ts) =>
+                    from o in gs.OfType<Officer>()
+                    orderby o.Nickname
+                    select new
+                    {
+                        Collection = (from t in ts
+                                      join g in gs on o.FullName equals g.FullName
+                                      select t.Note).ToList()
+                    },
+                assertOrder: true,
+                elementAsserter: (e, a) => CollectionAsserter<string>(elementSorter: ee => ee)(e.Collection, a.Collection));
+        }
+
+        [ConditionalFact]
+        public virtual void Outer_parameter_in_join_key_inner_and_outer()
+        {
+            AssertQuery<Gear, CogTag>(
+                (gs, ts) =>
+                    from o in gs.OfType<Officer>()
+                    orderby o.Nickname
+                    select new
+                    {
+                        Collection = (from t in ts
+                                      join g in gs on o.FullName equals o.Nickname
+                                      select t.Note).ToList()
+                    },
+                assertOrder: true,
+                elementAsserter: (e, a) => CollectionAsserter<string>(elementSorter: ee => ee)(e.Collection, a.Collection));
+        }
+
+        [ConditionalFact]
+        public virtual void Outer_parameter_in_group_join_key()
+        {
+            AssertQuery<Gear, CogTag>(
+                (gs, ts) =>
+                    from o in gs.OfType<Officer>()
+                    orderby o.Nickname
+                    select new
+                    {
+                        Collection = (from t in ts
+                                      join g in gs on o.FullName equals g.FullName into grouping
+                                      select t.Note).ToList()
+                    },
+                assertOrder: true,
+                elementAsserter: (e, a) => CollectionAsserter<string>(elementSorter: ee => ee)(e.Collection, a.Collection));
+        }
+
+        [ConditionalFact]
+        public virtual void Outer_parameter_in_group_join_with_DefaultIfEmpty()
+        {
+            AssertQuery<Gear, CogTag>(
+                (gs, ts) =>
+                    from o in gs.OfType<Officer>()
+                    orderby o.Nickname
+                    select new
+                    {
+                        Collection = (from t in ts
+                                      join g in gs on o.FullName equals g.FullName into grouping
+                                      from g in grouping.DefaultIfEmpty()
+                                      select t.Note).ToList()
+                    },
+                assertOrder: true,
+                elementAsserter: (e, a) => CollectionAsserter<string>(elementSorter: ee => ee)(e.Collection, a.Collection));
+        }
+
         // Remember to add any new tests to Async version of this test class
 
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AsyncGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AsyncGearsOfWarQuerySqlServerTest.cs
@@ -2079,6 +2079,96 @@ WHERE [w.Owner.Squad.Members].[Discriminator] IN (N'Officer', N'Gear')
 ORDER BY [t6].[Nickname], [t6].[SquadId], [t6].[Nickname0], [t6].[SquadId0], [t6].[FullName], [t6].[Id], [t6].[Id0], [Nickname1]");
         }
 
+        public override async Task Outer_parameter_in_join_key()
+        {
+            await base.Outer_parameter_in_join_key();
+
+            AssertSql(
+                @"SELECT [o].[FullName]
+FROM [Gears] AS [o]
+WHERE [o].[Discriminator] = N'Officer'
+ORDER BY [o].[Nickname]",
+                //
+                @"@_outer_FullName='Damon Baird' (Size = 450)
+
+SELECT [t].[Note]
+FROM [Tags] AS [t]
+INNER JOIN [Gears] AS [g] ON @_outer_FullName = [g].[FullName]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')",
+                //
+                @"@_outer_FullName='Marcus Fenix' (Size = 450)
+
+SELECT [t].[Note]
+FROM [Tags] AS [t]
+INNER JOIN [Gears] AS [g] ON @_outer_FullName = [g].[FullName]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
+        }
+
+        public override async Task Outer_parameter_in_group_join_key()
+        {
+            await base.Outer_parameter_in_group_join_key();
+
+            AssertSql(
+                @"SELECT [o].[FullName]
+FROM [Gears] AS [o]
+WHERE [o].[Discriminator] = N'Officer'
+ORDER BY [o].[Nickname]",
+                //
+                @"@_outer_FullName1='Damon Baird' (Size = 450)
+
+SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[Note], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank]
+FROM [Tags] AS [t]
+LEFT JOIN (
+    SELECT [g].*
+    FROM [Gears] AS [g]
+    WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t0] ON @_outer_FullName1 = [t0].[FullName]
+ORDER BY (SELECT 1)",
+                //
+                @"@_outer_FullName1='Marcus Fenix' (Size = 450)
+
+SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[Note], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank]
+FROM [Tags] AS [t]
+LEFT JOIN (
+    SELECT [g].*
+    FROM [Gears] AS [g]
+    WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t0] ON @_outer_FullName1 = [t0].[FullName]
+ORDER BY (SELECT 1)");
+        }
+
+
+        public override async Task Outer_parameter_in_group_join_with_DefaultIfEmpty()
+        {
+            await base.Outer_parameter_in_group_join_with_DefaultIfEmpty();
+
+            AssertSql(
+                @"SELECT [o].[FullName]
+FROM [Gears] AS [o]
+WHERE [o].[Discriminator] = N'Officer'
+ORDER BY [o].[Nickname]",
+                //
+                @"@_outer_FullName1='Damon Baird' (Size = 450)
+
+SELECT [t].[Note]
+FROM [Tags] AS [t]
+LEFT JOIN (
+    SELECT [g].*
+    FROM [Gears] AS [g]
+    WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t0] ON @_outer_FullName1 = [t0].[FullName]",
+                //
+                @"@_outer_FullName1='Marcus Fenix' (Size = 450)
+
+SELECT [t].[Note]
+FROM [Tags] AS [t]
+LEFT JOIN (
+    SELECT [g].*
+    FROM [Gears] AS [g]
+    WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t0] ON @_outer_FullName1 = [t0].[FullName]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -5980,6 +5980,122 @@ LEFT JOIN [LocustHighCommands] AS [ll.HighCommand] ON ([ll].[Discriminator] = N'
 WHERE [ll].[Discriminator] IN (N'LocustCommander', N'LocustLeader') AND ([ll.HighCommand].[IsOperational] = 1)");
         }
 
+        public override void Outer_parameter_in_join_key()
+        {
+            base.Outer_parameter_in_join_key();
+
+            AssertSql(
+                @"SELECT [o].[FullName]
+FROM [Gears] AS [o]
+WHERE [o].[Discriminator] = N'Officer'
+ORDER BY [o].[Nickname]",
+                //
+                @"@_outer_FullName='Damon Baird' (Size = 450)
+
+SELECT [t].[Note]
+FROM [Tags] AS [t]
+INNER JOIN [Gears] AS [g] ON @_outer_FullName = [g].[FullName]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')",
+                //
+                @"@_outer_FullName='Marcus Fenix' (Size = 450)
+
+SELECT [t].[Note]
+FROM [Tags] AS [t]
+INNER JOIN [Gears] AS [g] ON @_outer_FullName = [g].[FullName]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
+        }
+
+        public override void Outer_parameter_in_join_key_inner_and_outer()
+        {
+            base.Outer_parameter_in_join_key_inner_and_outer();
+
+            AssertSql(
+                @"SELECT [o].[FullName], [o].[Nickname]
+FROM [Gears] AS [o]
+WHERE [o].[Discriminator] = N'Officer'
+ORDER BY [o].[Nickname]",
+                //
+                @"@_outer_FullName='Damon Baird' (Size = 4000)
+@_outer_Nickname='Baird' (Size = 4000)
+
+SELECT [t].[Note]
+FROM [Tags] AS [t]
+INNER JOIN [Gears] AS [g] ON @_outer_FullName = @_outer_Nickname
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')",
+                //
+                @"@_outer_FullName='Marcus Fenix' (Size = 4000)
+@_outer_Nickname='Marcus' (Size = 4000)
+
+SELECT [t].[Note]
+FROM [Tags] AS [t]
+INNER JOIN [Gears] AS [g] ON @_outer_FullName = @_outer_Nickname
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
+        }
+
+        public override void Outer_parameter_in_group_join_key()
+        {
+            base.Outer_parameter_in_group_join_key();
+
+            AssertSql(
+                @"SELECT [o].[FullName]
+FROM [Gears] AS [o]
+WHERE [o].[Discriminator] = N'Officer'
+ORDER BY [o].[Nickname]",
+                //
+                @"@_outer_FullName1='Damon Baird' (Size = 450)
+
+SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[Note], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank]
+FROM [Tags] AS [t]
+LEFT JOIN (
+    SELECT [g].*
+    FROM [Gears] AS [g]
+    WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t0] ON @_outer_FullName1 = [t0].[FullName]
+ORDER BY (SELECT 1)",
+                //
+                @"@_outer_FullName1='Marcus Fenix' (Size = 450)
+
+SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[Note], [t0].[Nickname], [t0].[SquadId], [t0].[AssignedCityName], [t0].[CityOrBirthName], [t0].[Discriminator], [t0].[FullName], [t0].[HasSoulPatch], [t0].[LeaderNickname], [t0].[LeaderSquadId], [t0].[Rank]
+FROM [Tags] AS [t]
+LEFT JOIN (
+    SELECT [g].*
+    FROM [Gears] AS [g]
+    WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t0] ON @_outer_FullName1 = [t0].[FullName]
+ORDER BY (SELECT 1)");
+        }
+
+        public override void Outer_parameter_in_group_join_with_DefaultIfEmpty()
+        {
+            base.Outer_parameter_in_group_join_with_DefaultIfEmpty();
+
+            AssertSql(
+                @"SELECT [o].[FullName]
+FROM [Gears] AS [o]
+WHERE [o].[Discriminator] = N'Officer'
+ORDER BY [o].[Nickname]",
+                //
+                @"@_outer_FullName1='Damon Baird' (Size = 450)
+
+SELECT [t].[Note]
+FROM [Tags] AS [t]
+LEFT JOIN (
+    SELECT [g].*
+    FROM [Gears] AS [g]
+    WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t0] ON @_outer_FullName1 = [t0].[FullName]",
+                //
+                @"@_outer_FullName1='Marcus Fenix' (Size = 450)
+
+SELECT [t].[Note]
+FROM [Tags] AS [t]
+LEFT JOIN (
+    SELECT [g].*
+    FROM [Gears] AS [g]
+    WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t0] ON @_outer_FullName1 = [t0].[FullName]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Problem was that when processing Join/GroupJoin/SelectMany, we replace the existing Expression with a new methodcall expression representing updated Join/GroupJoin/SelectMany. However, if the clause that's being processed required outer parameter injection (e.g. as part of the Join/GroupJoin key), that information would be lost.

Fix is to only replace/update the correct fragment of the Expression, rather than its entirety. We also need to add compensation for GroupJoinDefaultIfEmpty processing, which was not able to handle case where InjectParameters was wrapping the GroupJoin method.