### PR TITLE
Query: Apply appropriate cast before converting to conditional block in projection

### DIFF
--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -1969,7 +1969,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
             private static Expression ConvertToValue(Expression expression)
                 => IsSearchCondition(expression)
                     ? Expression.Condition(
-                        expression,
+                        expression.Type == typeof(bool)
+                            ? expression
+                            : Expression.Convert(expression, typeof(bool)),
                         Expression.Constant(true, expression.Type),
                         Expression.Constant(false, expression.Type))
                     : expression;

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -1667,6 +1667,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void Optional_navigation_type_compensation_works_with_binary_and_expression()
+        {
+            AssertQueryScalar<CogTag>(
+                ts => ts.Select(t => t.Gear.HasSoulPatch && t.Note.Contains("Cole")),
+                ts => ts.Select(t => MaybeScalar<bool>(t.Gear, () => t.Gear.HasSoulPatch) == true && t.Note.Contains("Cole")));
+        }
+
+        [ConditionalFact]
         public virtual void Optional_navigation_type_compensation_works_with_projection()
         {
             AssertQueryScalar<CogTag>(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -2394,6 +2394,23 @@ LEFT JOIN (
 WHERE ([t0].[HasSoulPatch] = 1) OR (CHARINDEX(N'Cole', [t].[Note]) > 0)");
         }
 
+        public override void Optional_navigation_type_compensation_works_with_binary_and_expression()
+        {
+            base.Optional_navigation_type_compensation_works_with_binary_and_expression();
+
+            AssertSql(
+                @"SELECT CASE
+    WHEN ([t0].[HasSoulPatch] = 1) AND (CHARINDEX(N'Cole', [t].[Note]) > 0)
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END
+FROM [Tags] AS [t]
+LEFT JOIN (
+    SELECT [t.Gear].*
+    FROM [Gears] AS [t.Gear]
+    WHERE [t.Gear].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])");
+        }
+
         public override void Optional_navigation_type_compensation_works_with_projection()
         {
             base.Optional_navigation_type_compensation_works_with_projection();


### PR DESCRIPTION
ConditionalExpression requires test to be bool type. When an optional navigation is projected out with other conditions, it coerce everything to nullable bool. When trying to convert to conditional block it fails because test becomes of type nullable bool. The fix is to apply cast before creating ConditionalExpression

Resolves #9275
