### PR TITLE
[TINY] Fix to #11007 - ArgumentNullException with Concat

### DIFF
--- a/src/EFCore.Specification.Tests/Query/AsyncGearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncGearsOfWarQueryTestBase.cs
@@ -1343,5 +1343,19 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true,
                 elementAsserter: (e, a) => CollectionAsserter<string>(elementSorter: ee => ee)(e.Collection, a.Collection));
         }
+
+        [ConditionalFact]
+        public virtual async Task Include_with_concat()
+        {
+            var expectedIncludes = new List<IExpectedInclude>
+            {
+                new ExpectedInclude<Gear>(g => g.Squad, "Squad"),
+                new ExpectedInclude<Officer>(o => o.Squad, "Squad")
+            };
+
+            await AssertIncludeQuery<Gear>(
+                gs => gs.Include(g => g.Squad).Concat(gs),
+                expectedIncludes);
+        }
     }
 }

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -4336,6 +4336,20 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: (e, a) => CollectionAsserter<string>(elementSorter: ee => ee)(e.Collection, a.Collection));
         }
 
+        [ConditionalFact]
+        public virtual void Include_with_concat()
+        {
+            var expectedIncludes = new List<IExpectedInclude>
+            {
+                new ExpectedInclude<Gear>(g => g.Squad, "Squad"),
+                new ExpectedInclude<Officer>(o => o.Squad, "Squad")
+            };
+
+            AssertIncludeQuery<Gear>(
+                gs => gs.Include(g => g.Squad).Concat(gs),
+                expectedIncludes);
+        }
+
         // Remember to add any new tests to Async version of this test class
 
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();

--- a/src/EFCore/Query/ExpressionVisitors/Internal/RequiresMaterializationExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/RequiresMaterializationExpressionVisitor.cs
@@ -250,12 +250,14 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             if (referencedQuerySource != null)
             {
                 var parentQuerySource = parentQueryModel.SelectClause.Selector.TryGetReferencedQuerySource();
-                var resultSetOperators = GetSetResultOperatorSourceExpressions(parentQueryModel.ResultOperators);
-
-                if (resultSetOperators.Any(r => r.Equals(expression))
-                    && _querySourceReferences[parentQuerySource] > 0)
+                if (parentQuerySource != null)
                 {
-                    PromoteQuerySource(referencedQuerySource);
+                    var resultSetOperators = GetSetResultOperatorSourceExpressions(parentQueryModel.ResultOperators);
+                    if (resultSetOperators.Any(r => r.Equals(expression))
+                        && _querySourceReferences[parentQuerySource] > 0)
+                    {
+                        PromoteQuerySource(referencedQuerySource);
+                    }
                 }
             }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AsyncGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AsyncGearsOfWarQuerySqlServerTest.cs
@@ -2169,6 +2169,21 @@ LEFT JOIN (
 ) AS [t0] ON @_outer_FullName1 = [t0].[FullName]");
         }
 
+        public override async Task Include_with_concat()
+        {
+            await base.Include_with_concat();
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.Squad].[Id], [g.Squad].[InternalNumber], [g.Squad].[Name]
+FROM [Gears] AS [g]
+INNER JOIN [Squads] AS [g.Squad] ON [g].[SquadId] = [g.Squad].[Id]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')",
+                //
+                @"SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
+FROM [Gears] AS [g0]
+WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -6096,6 +6096,21 @@ LEFT JOIN (
 ) AS [t0] ON @_outer_FullName1 = [t0].[FullName]");
         }
 
+        public override void Include_with_concat()
+        {
+            base.Include_with_concat();
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.Squad].[Id], [g.Squad].[InternalNumber], [g.Squad].[Name]
+FROM [Gears] AS [g]
+INNER JOIN [Squads] AS [g.Squad] ON [g].[SquadId] = [g.Squad].[Id]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')",
+                //
+                @"SELECT [g0].[Nickname], [g0].[SquadId], [g0].[AssignedCityName], [g0].[CityOrBirthName], [g0].[Discriminator], [g0].[FullName], [g0].[HasSoulPatch], [g0].[LeaderNickname], [g0].[LeaderSquadId], [g0].[Rank]
+FROM [Gears] AS [g0]
+WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Problem was that in RequiresMaterializationExpressionVisitor tried to access a dictionary based on querySource that could in some cases be null. Fix is to check that the value we are about to use as key is not null.