### PR TITLE
[TINY] Fix to #10060 - Test: OrderBy OptionalNav.Property fails for InMemory

### DIFF
--- a/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -3926,7 +3926,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             AssertIncludeQuery<Level1>(
                 l1s => l1s
                     .Include(l1 => l1.OneToOne_Optional_FK.OneToMany_Optional)
-                    .OrderBy(l1 => l1.OneToOne_Optional_FK.Id),
+                    .OrderBy(l1 => (int?)l1.OneToOne_Optional_FK.Id),
                 l1s => l1s
                     .Include(l1 => l1.OneToOne_Optional_FK.OneToMany_Optional)
                     .OrderBy(l1 => MaybeScalar<int>(l1.OneToOne_Optional_FK, () => l1.OneToOne_Optional_FK.Id)),

--- a/test/EFCore.InMemory.FunctionalTests/Query/ComplexNavigationsQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/ComplexNavigationsQueryInMemoryTest.cs
@@ -25,11 +25,5 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             base.Multi_include_with_groupby_in_subquery();
         }
-
-        [ConditionalFact(Skip = "Issue #10060")]
-        public override void Include_reference_collection_order_by_reference_navigation()
-        {
-            base.Include_reference_collection_order_by_reference_navigation();
-        }
     }
 }


### PR DESCRIPTION
Adding cast to int? so that it doesn't throw for in memory. If we wanted to compensate for the case we would have to rewrite the OrderBy to accept int?