### PR TITLE
Query: Improvements to Relational GroupBy translation for composition

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/ResultTransformingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/ResultTransformingExpressionVisitor.cs
@@ -25,11 +25,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public ResultTransformingExpressionVisitor(
-            [NotNull] IQuerySource outerQuerySource,
             [NotNull] RelationalQueryCompilationContext relationalQueryCompilationContext,
             bool throwOnNullResult)
         {
-            Check.NotNull(outerQuerySource, nameof(outerQuerySource));
             Check.NotNull(relationalQueryCompilationContext, nameof(relationalQueryCompilationContext));
 
             _relationalQueryCompilationContext = relationalQueryCompilationContext;

--- a/src/EFCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
@@ -6,11 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Extensions.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
-using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -30,8 +28,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         private readonly ISqlTranslatingExpressionVisitorFactory _sqlTranslatingExpressionVisitorFactory;
         private readonly IEntityMaterializerSource _entityMaterializerSource;
         private readonly IQuerySource _querySource;
-        private readonly SelectExpression _selectExpression;
-        private bool _topLevelProjection;
+        private readonly SelectExpression _groupAggregateTargetSelectExpression;
+        private readonly SelectExpression _targetSelectExpression;
+        private bool _isGroupAggregate;
 
         private readonly Dictionary<Expression, Expression> _sourceExpressionProjectionMapping
             = new Dictionary<Expression, Expression>();
@@ -54,8 +53,18 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
             _sqlTranslatingExpressionVisitorFactory = dependencies.SqlTranslatingExpressionVisitorFactory;
             _entityMaterializerSource = dependencies.EntityMaterializerSource;
             _querySource = querySource;
-            _topLevelProjection = true;
-            _selectExpression = QueryModelVisitor.TryGetQuery(querySource);
+            _targetSelectExpression = QueryModelVisitor.TryGetQuery(querySource);
+
+            if (_targetSelectExpression != null)
+            {
+                _groupAggregateTargetSelectExpression = _targetSelectExpression.Clone();
+
+                _isGroupAggregate = _querySource.ItemType.IsGrouping() && _targetSelectExpression.GroupBy.Count > 0;
+                if (_isGroupAggregate)
+                {
+                    _targetSelectExpression.ClearProjection();
+                }
+            }
         }
 
         private new RelationalQueryModelVisitor QueryModelVisitor
@@ -72,7 +81,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         {
             var newMemberInitExpression = base.VisitMemberInit(memberInitExpression);
 
-            if (_selectExpression != null)
+            if (_targetSelectExpression != null)
             {
                 foreach (var sourceBinding in memberInitExpression.Bindings)
                 {
@@ -84,7 +93,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                         {
                             var memberInfo = memberAssignment.Member;
 
-                            _selectExpression.SetProjectionForMemberInfo(
+                            _targetSelectExpression.SetProjectionForMemberInfo(
                                 memberInfo,
                                 sqlExpression);
                         }
@@ -122,7 +131,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
 
             var newNewExpression = base.VisitNew(newExpression);
 
-            if (_selectExpression != null)
+            if (_targetSelectExpression != null)
             {
                 for (var i = 0; i < newExpression.Arguments.Count; i++)
                 {
@@ -134,7 +143,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
 
                         if (memberInfo != null)
                         {
-                            _selectExpression.SetProjectionForMemberInfo(
+                            _targetSelectExpression.SetProjectionForMemberInfo(
                                 memberInfo,
                                 sqlExpression);
                         }
@@ -154,25 +163,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         /// </returns>
         public override Expression Visit(Expression expression)
         {
-            if (_topLevelProjection
-                && (QueryModelVisitor.Expression as MethodCallExpression)?.Method.MethodIsClosedFormOf(
-                    QueryModelVisitor.QueryCompilationContext.QueryMethodProvider.GroupByMethod) == true)
-            {
-                var translation = new GroupByAggregateTranslatingExpressionVisitor(this)
-
-                    .Translate(expression);
-
-                if (translation != null)
-                {
-                    QueryModelVisitor.RequiresStreamingGroupResultOperator = false;
-
-                    return translation;
-                }
-            }
-
-            _topLevelProjection = false;
-
-            if (expression == null || _selectExpression == null)
+            if (expression == null || _targetSelectExpression == null)
             {
                 return expression;
             }
@@ -190,10 +181,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                     return VisitMemberInit(memberInitExpression);
 
                 case QuerySourceReferenceExpression qsre:
-                    if (_selectExpression.HandlesQuerySource(qsre.ReferencedQuerySource))
+                    if (_targetSelectExpression.HandlesQuerySource(qsre.ReferencedQuerySource))
                     {
-                        _selectExpression.ProjectStarTable
-                            = _selectExpression.GetTableForQuerySource(qsre.ReferencedQuerySource);
+                        _targetSelectExpression.ProjectStarTable
+                            = _targetSelectExpression.GetTableForQuerySource(qsre.ReferencedQuerySource);
                     }
 
                     return qsre;
@@ -202,340 +193,125 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 case MethodCallExpression methodCallExpression when IncludeCompiler.IsIncludeMethod(methodCallExpression):
                     return methodCallExpression;
 
-                default:
-                    var sqlExpression
-                        = _sqlTranslatingExpressionVisitorFactory
-                            .Create(QueryModelVisitor, _selectExpression, inProjection: true)
-                            .Visit(expression);
+                // Group By key translation to cover composite key cases
+                case MemberExpression memberExpression
+                when memberExpression.Expression.TryGetReferencedQuerySource() == _querySource
+                    && _querySource.ItemType.IsGrouping()
+                    && memberExpression.Member.Name == nameof(IGrouping<int, int>.Key):
 
-                    if (sqlExpression == null)
+                    var groupResultOperator
+                        = (GroupResultOperator)((SubQueryExpression)((FromClauseBase)_querySource).FromExpression)
+                            .QueryModel.ResultOperators.Last();
+
+                    if (groupResultOperator.KeySelector is NewExpression)
                     {
-                        QueryModelVisitor.RequiresClientProjection = true;
-
-                        return base.Visit(expression);
-                    }
-                    else if (sqlExpression is ConstantExpression)
-                    {
-                        return base.Visit(expression);
-                    }
-                    else
-                    {
-                        if (sqlExpression is NullableExpression nullableExpression)
-                        {
-                            sqlExpression = nullableExpression.Operand;
-                        }
-
-                        if (sqlExpression is ColumnExpression)
-                        {
-                            var index = _selectExpression.AddToProjection(sqlExpression);
-
-                            _sourceExpressionProjectionMapping[expression] = _selectExpression.Projection[index];
-
-                            return expression;
-                        }
-
-                        var targetExpression
-                            = QueryModelVisitor.QueryCompilationContext.QuerySourceMapping
-                                .GetExpression(_querySource);
-
-                        if (targetExpression.Type == typeof(ValueBuffer))
-                        {
-                            var index = _selectExpression.AddToProjection(sqlExpression);
-
-                            _sourceExpressionProjectionMapping[expression] = _selectExpression.Projection[index];
-
-                            var readValueExpression
-                                = _entityMaterializerSource
-                                    .CreateReadValueExpression(
-                                        targetExpression,
-                                        expression.Type.MakeNullable(),
-                                        index,
-                                        sqlExpression.FindProperty(expression.Type));
-
-                            var outputDataInfo
-                                = (expression as SubQueryExpression)?.QueryModel
-                                .GetOutputDataInfo();
-
-                            if (outputDataInfo is StreamedScalarValueInfo)
-                            {
-                                // Compensate for possible nulls
-                                readValueExpression
-                                    = Expression.Coalesce(
-                                        readValueExpression,
-                                        Expression.Default(expression.Type));
-                            }
-
-                            return Expression.Convert(readValueExpression, expression.Type);
-                        }
-
-                        return expression;
-                    }
-            }
-        }
-
-        #region GroupByHelper
-
-        private class GroupByAggregateTranslatingExpressionVisitor : RelinqExpressionVisitor
-        {
-            private readonly RelationalProjectionExpressionVisitor _projectionExpressionVisitor;
-            private readonly RelationalQueryModelVisitor _queryModelVisitor;
-            private readonly IQuerySource _groupQuerySource;
-            private readonly ISqlTranslatingExpressionVisitorFactory _sqlTranslatingExpressionVisitorFactory;
-            private readonly IEntityMaterializerSource _entityMaterializerSource;
-            private readonly SelectExpression _selectExpression;
-            private readonly Dictionary<Expression, Expression> _sqlMapping = new Dictionary<Expression, Expression>();
-            private bool _translateToSql;
-            private Expression _keySelector;
-            private const string KeyName = nameof(IGrouping<object, object>.Key);
-
-            private static readonly List<Type> _aggregateResultOperators = new List<Type>
-            {
-                typeof(AverageResultOperator),
-                typeof(CountResultOperator),
-                typeof(LongCountResultOperator),
-                typeof(MaxResultOperator),
-                typeof(MinResultOperator),
-                typeof(SumResultOperator)
-            };
-
-            public GroupByAggregateTranslatingExpressionVisitor(RelationalProjectionExpressionVisitor projectionExpressionVisitor)
-            {
-                _projectionExpressionVisitor = projectionExpressionVisitor;
-                _queryModelVisitor = projectionExpressionVisitor.QueryModelVisitor;
-                _groupQuerySource = projectionExpressionVisitor._querySource;
-                _sqlTranslatingExpressionVisitorFactory = projectionExpressionVisitor._sqlTranslatingExpressionVisitorFactory;
-                _entityMaterializerSource = projectionExpressionVisitor._entityMaterializerSource;
-                _selectExpression = _queryModelVisitor.TryGetQuery(_groupQuerySource);
-            }
-
-            public Expression Translate(Expression expression)
-            {
-                if (!CanTranslate(expression))
-                {
-                    return null;
-                }
-
-                _translateToSql = true;
-
-                Visit(expression);
-
-                _selectExpression.ClearProjection();
-                UpdateGroupQuerySourceParameter(typeof(ValueBuffer));
-
-                _translateToSql = false;
-
-                return Visit(expression);
-            }
-
-            protected override Expression VisitMember(MemberExpression memberExpression)
-            {
-                if (!_translateToSql)
-                {
-                    // For composite Key case, projection member info will be already populated
-                    var sqlExpression = _selectExpression.GetProjectionForMemberInfo(memberExpression.Member);
-                    if (sqlExpression != null)
-                    {
-                        return BindSqlToValueBuffer(sqlExpression, memberExpression.Type);
-                    }
-
-                    if (memberExpression.Member.Name == KeyName
-                        && memberExpression.Expression.TryGetReferencedQuerySource() == _groupQuerySource)
-                    {
+                        // If the key is composite then we need to visit actual keySelector to construct the type.
+                        // Since we are mapping translating actual KeySelector now, we need to re-map QuerySources
                         var querySourceFinder = new QuerySourceFindingExpressionVisitor();
-                        querySourceFinder.Visit(_keySelector);
-
-                        var currentParameter = _queryModelVisitor.CurrentParameter;
+                        querySourceFinder.Visit(groupResultOperator.KeySelector);
 
                         foreach (var querySource in querySourceFinder.QuerySources)
                         {
-                            _queryModelVisitor.QueryCompilationContext.AddOrUpdateMapping(
+                            QueryModelVisitor.QueryCompilationContext.AddOrUpdateMapping(
                                 querySource,
-                                currentParameter);
+                                QueryModelVisitor.CurrentParameter);
                         }
 
-                        sqlExpression = _projectionExpressionVisitor.Visit(_keySelector);
-                        _sqlMapping[memberExpression] = sqlExpression;
-                        return sqlExpression;
+                        _isGroupAggregate = false;
+                        var translatedKey = Visit(groupResultOperator.KeySelector);
+                        _isGroupAggregate = true;
+
+                        return translatedKey;
                     }
-                }
-
-                return base.VisitMember(memberExpression);
+                    break;
             }
 
-            protected override Expression VisitSubQuery(SubQueryExpression subQueryExpression)
+            // Fallback
+            var sqlExpression
+                        = _sqlTranslatingExpressionVisitorFactory
+                            .Create(
+                                QueryModelVisitor,
+                                _isGroupAggregate ? _groupAggregateTargetSelectExpression : _targetSelectExpression,
+                                inProjection: true)
+                            .Visit(expression);
+
+            if (sqlExpression == null)
             {
-                if (_translateToSql)
+                QueryModelVisitor.RequiresClientProjection = true;
+
+                return base.Visit(expression);
+            }
+            else if (sqlExpression is ConstantExpression)
+            {
+                return base.Visit(expression);
+            }
+            else
+            {
+                if (sqlExpression is NullableExpression nullableExpression)
                 {
-                    var sqlExpression = _sqlTranslatingExpressionVisitorFactory.Create(
-                            _queryModelVisitor,
-                            _selectExpression,
-                            inProjection: true)
-                        .Visit(subQueryExpression);
-                    _sqlMapping[subQueryExpression] = sqlExpression;
-
-                    return subQueryExpression;
+                    sqlExpression = nullableExpression.Operand;
                 }
 
-                return BindSqlToValueBuffer(_sqlMapping[subQueryExpression], subQueryExpression.Type);
-            }
+                // We bind with ValueBuffer in GroupByAggregate case straight away
+                // Since the expression can be some translation from [g].[Key] which won't bind with MemberAccessBindingEV
+                if (!_isGroupAggregate
+                    && sqlExpression is ColumnExpression)
+                {
+                    var index = _targetSelectExpression.AddToProjection(sqlExpression);
 
-            private Expression BindSqlToValueBuffer(Expression sqlExpression, Type expressionType)
-            {
+                    _sourceExpressionProjectionMapping[expression] = _targetSelectExpression.Projection[index];
+
+                    return expression;
+                }
+
                 var targetExpression
-                    = _queryModelVisitor.QueryCompilationContext.QuerySourceMapping
-                        .GetExpression(_groupQuerySource);
+                    = QueryModelVisitor.QueryCompilationContext.QuerySourceMapping
+                        .GetExpression(_querySource);
 
                 if (targetExpression.Type == typeof(ValueBuffer))
                 {
-                    var index = _selectExpression.AddToProjection(sqlExpression);
+                    var index = _targetSelectExpression.AddToProjection(sqlExpression);
+
+                    _sourceExpressionProjectionMapping[expression] = _targetSelectExpression.Projection[index];
 
                     var readValueExpression
                         = _entityMaterializerSource
                             .CreateReadValueExpression(
                                 targetExpression,
-                                expressionType,
+                                expression.Type.MakeNullable(),
                                 index,
-                                sqlExpression.FindProperty(expressionType));
+                                sqlExpression.FindProperty(expression.Type));
 
-                    return Expression.Convert(readValueExpression, expressionType);
-                }
+                    var outputDataInfo
+                        = (expression as SubQueryExpression)?.QueryModel
+                        .GetOutputDataInfo();
 
-                return null;
-            }
-
-            private bool CanTranslate(Expression expression)
-            {
-                // Check for Query shape
-                if (IsAggregateGroupBySelector(expression))
-                {
-                    var groupByResultOperator =
-                        (GroupResultOperator)((SubQueryExpression)((MainFromClause)_groupQuerySource).FromExpression)
-                        .QueryModel.ResultOperators
-                        .Last();
-
-                    _keySelector = groupByResultOperator.KeySelector;
-                    var elementSelector = groupByResultOperator.ElementSelector;
-
-                    if (!(elementSelector is QuerySourceReferenceExpression)
-                        && _sqlTranslatingExpressionVisitorFactory.Create(
-                                _queryModelVisitor,
-                                _selectExpression)
-                            .Visit(groupByResultOperator.ElementSelector) == null)
+                    if (outputDataInfo is StreamedScalarValueInfo)
                     {
-                        return false;
+                        // Compensate for possible nulls
+                        readValueExpression
+                            = Expression.Coalesce(
+                                readValueExpression,
+                                Expression.Default(expression.Type));
                     }
 
-                    _selectExpression.ClearOrderBy();
-                    _selectExpression.ClearProjection();
-
-                    UpdateGroupQuerySourceParameter(typeof(ValueBuffer));
-
-                    _projectionExpressionVisitor.Visit(_keySelector);
-                    var columns = _selectExpression.Projection.ToArray();
-                    _selectExpression.ClearProjection();
-
-                    if (!(elementSelector is QuerySourceReferenceExpression))
-                    {
-                        _projectionExpressionVisitor.Visit(groupByResultOperator.ElementSelector);
-                    }
-
-                    if (_selectExpression.Projection.Count > 1)
-                    {
-                        _selectExpression.ClearProjection();
-                    }
-
-                    _selectExpression.AddToGroupBy(columns);
-
-                    var shapedQuery =
-                        (MethodCallExpression)((MethodCallExpression)_queryModelVisitor.Expression).Arguments[0];
-
-                    var valueBufferShaper = new ValueBufferShaper(_groupQuerySource);
-
-                    var groupShapedQuery = Expression.Call(
-                        _queryModelVisitor.QueryCompilationContext
-                            .QueryMethodProvider
-                            .ShapedQueryMethod
-                            .MakeGenericMethod(valueBufferShaper.Type),
-                        shapedQuery.Arguments[0],
-                        shapedQuery.Arguments[1],
-                        Expression.Constant(valueBufferShaper));
-
-                    _queryModelVisitor.Expression = groupShapedQuery;
-
-                    UpdateGroupQuerySourceParameter(groupShapedQuery.Type);
-
-                    return true;
+                    return Expression.Convert(readValueExpression, expression.Type);
                 }
 
-                return false;
-            }
-
-            private class QuerySourceFindingExpressionVisitor : RelinqExpressionVisitor
-            {
-                public ICollection<IQuerySource> QuerySources { get; } = new HashSet<IQuerySource>();
-
-                protected override Expression VisitQuerySourceReference(QuerySourceReferenceExpression querySourceReferenceExpression)
-                {
-                    QuerySources.Add(querySourceReferenceExpression.TryGetReferencedQuerySource());
-
-                    return base.VisitQuerySourceReference(querySourceReferenceExpression);
-                }
-            }
-
-            private void UpdateGroupQuerySourceParameter(Type parameterType)
-            {
-                var currentParameter = Expression.Parameter(
-                    parameterType,
-                    _groupQuerySource.ItemName);
-
-                _queryModelVisitor.CurrentParameter = currentParameter;
-                _queryModelVisitor.QueryCompilationContext.QuerySourceMapping.ReplaceMapping(
-                    _groupQuerySource,
-                    currentParameter);
-            }
-
-            private bool IsAggregateGroupBySelector(Expression expression)
-            {
-                if (expression is NewExpression newExpression)
-                {
-                    return newExpression.Arguments.All(e => IsAggregateSubQueryExpression(e) || IsKeySelector(e));
-                }
-
-                return IsAggregateSubQueryExpression(expression);
-            }
-
-            private bool IsAggregateSubQueryExpression(Expression expression)
-            {
-                if (expression is SubQueryExpression subQuery
-                    && subQuery.QueryModel.BodyClauses.Count == 0
-                    && subQuery.QueryModel.MainFromClause.FromExpression.TryGetReferencedQuerySource() == _groupQuerySource
-                    && subQuery.QueryModel.ResultOperators.Count == 1
-                    && !(subQuery.QueryModel.SelectClause.Selector is ConstantExpression)
-                    && _aggregateResultOperators.Contains(subQuery.QueryModel.ResultOperators.Single().GetType()))
-                {
-                    return true;
-                }
-
-                return false;
-            }
-
-            private bool IsKeySelector(Expression expression)
-            {
-                while (expression is MemberExpression memberExpression)
-                {
-                    if (memberExpression.Member.Name == KeyName
-                        && memberExpression.Expression.TryGetReferencedQuerySource() == _groupQuerySource)
-                    {
-                        return true;
-                    }
-
-                    expression = memberExpression.Expression;
-                }
-
-                return false;
+                return expression;
             }
         }
 
-        #endregion
+        private class QuerySourceFindingExpressionVisitor : RelinqExpressionVisitor
+        {
+            public ICollection<IQuerySource> QuerySources { get; } = new HashSet<IQuerySource>();
+
+            protected override Expression VisitQuerySourceReference(QuerySourceReferenceExpression querySourceReferenceExpression)
+            {
+                QuerySources.Add(querySourceReferenceExpression.TryGetReferencedQuerySource());
+
+                return base.VisitQuerySourceReference(querySourceReferenceExpression);
+            }
+        }
     }
 }

--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -253,6 +253,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
                 _relationalCommandBuilder.Append("GROUP BY ");
                 GenerateList(selectExpression.GroupBy);
+
+                if (selectExpression.Having != null)
+                {
+                    GenerateHaving(selectExpression.Having);
+                }
             }
 
             if (selectExpression.OrderBy.Count > 0)
@@ -519,6 +524,20 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
             _relationalCommandBuilder.AppendLine()
                 .Append("WHERE ");
+
+            Visit(optimizedPredicate);
+        }
+
+        /// <summary>
+        ///     Visit the predicate in SQL HAVING clause
+        /// </summary>
+        /// <param name="predicate"> The having predicate expression. </param>
+        protected virtual void GenerateHaving([NotNull] Expression predicate)
+        {
+            var optimizedPredicate = ApplyOptimizations(predicate, searchCondition: true);
+
+            _relationalCommandBuilder.AppendLine()
+                .Append("HAVING ");
 
             Visit(optimizedPredicate);
         }

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
@@ -1240,5 +1240,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(91, query.Count);
             }
         }
+
+        [ConditionalFact]
+        public virtual void Project_constant_Sum()
+        {
+            AssertSingleResult<Employee>(es => es.Sum(e => 1));
+        }
     }
 }

--- a/src/EFCore.Specification.Tests/TestModels/Northwind/NorthwindData.Objects.cs
+++ b/src/EFCore.Specification.Tests/TestModels/Northwind/NorthwindData.Objects.cs
@@ -1798,7 +1798,7 @@ Winchester Way",
                 new Product
                 {
                     ProductID = 22,
-                    ProductName = "Gustaf's Kn„ckebr”d",
+                    ProductName = "Gustaf's Knäckebröd",
                     SupplierID = 9,
                     CategoryID = 5,
                     QuantityPerUnit = "24 - 500 g pkgs.",
@@ -1811,7 +1811,7 @@ Winchester Way",
                 new Product
                 {
                     ProductID = 23,
-                    ProductName = "Tunnbr”d",
+                    ProductName = "Tunnbröd",
                     SupplierID = 9,
                     CategoryID = 5,
                     QuantityPerUnit = "12 - 250 g pkgs.",
@@ -1824,7 +1824,7 @@ Winchester Way",
                 new Product
                 {
                     ProductID = 24,
-                    ProductName = "Guaran  Fant stica",
+                    ProductName = "Guaraná Fantástica",
                     SupplierID = 10,
                     CategoryID = 1,
                     QuantityPerUnit = "12 - 355 ml cans",
@@ -1837,7 +1837,7 @@ Winchester Way",
                 new Product
                 {
                     ProductID = 25,
-                    ProductName = "NuNuCa Nuá-Nougat-Creme",
+                    ProductName = "NuNuCa Nuß-Nougat-Creme",
                     SupplierID = 11,
                     CategoryID = 3,
                     QuantityPerUnit = "20 - 450 g glasses",
@@ -1850,7 +1850,7 @@ Winchester Way",
                 new Product
                 {
                     ProductID = 26,
-                    ProductName = "Gumb„r Gummib„rchen",
+                    ProductName = "Gumbär Gummibärchen",
                     SupplierID = 11,
                     CategoryID = 3,
                     QuantityPerUnit = "100 - 250 g bags",
@@ -1876,7 +1876,7 @@ Winchester Way",
                 new Product
                 {
                     ProductID = 28,
-                    ProductName = "R”ssle Sauerkraut",
+                    ProductName = "Rössle Sauerkraut",
                     SupplierID = 12,
                     CategoryID = 7,
                     QuantityPerUnit = "25 - 825 g cans",
@@ -1889,7 +1889,7 @@ Winchester Way",
                 new Product
                 {
                     ProductID = 29,
-                    ProductName = "Thringer Rostbratwurst",
+                    ProductName = "Thüringer Rostbratwurst",
                     SupplierID = 12,
                     CategoryID = 6,
                     QuantityPerUnit = "50 bags x 30 sausgs.",
@@ -2006,7 +2006,7 @@ Winchester Way",
                 new Product
                 {
                     ProductID = 38,
-                    ProductName = "C“te de Blaye",
+                    ProductName = "Côte de Blaye",
                     SupplierID = 18,
                     CategoryID = 1,
                     QuantityPerUnit = "12 - 75 cl bottles",
@@ -2214,7 +2214,7 @@ Winchester Way",
                 new Product
                 {
                     ProductID = 54,
-                    ProductName = "TourtiŠre",
+                    ProductName = "Tourtière",
                     SupplierID = 25,
                     CategoryID = 6,
                     QuantityPerUnit = "16 pies",
@@ -2227,7 +2227,7 @@ Winchester Way",
                 new Product
                 {
                     ProductID = 55,
-                    ProductName = "Pƒt‚ chinois",
+                    ProductName = "Pâté chinois",
                     SupplierID = 25,
                     CategoryID = 6,
                     QuantityPerUnit = "24 boxes x 2 pies",
@@ -2305,7 +2305,7 @@ Winchester Way",
                 new Product
                 {
                     ProductID = 61,
-                    ProductName = "Sirop d'‚rable",
+                    ProductName = "Sirop d'érable",
                     SupplierID = 29,
                     CategoryID = 2,
                     QuantityPerUnit = "24 - 500 ml bottles",
@@ -2344,7 +2344,7 @@ Winchester Way",
                 new Product
                 {
                     ProductID = 64,
-                    ProductName = "Wimmers gute Semmelkn”del",
+                    ProductName = "Wimmers gute Semmelknödel",
                     SupplierID = 12,
                     CategoryID = 5,
                     QuantityPerUnit = "20 bags x 4 pieces",
@@ -2461,7 +2461,7 @@ Winchester Way",
                 new Product
                 {
                     ProductID = 73,
-                    ProductName = "R”d Kaviar",
+                    ProductName = "Röd Kaviar",
                     SupplierID = 17,
                     CategoryID = 8,
                     QuantityPerUnit = "24 - 150 g jars",
@@ -2487,7 +2487,7 @@ Winchester Way",
                 new Product
                 {
                     ProductID = 75,
-                    ProductName = "Rh”nbr„u Klosterbier",
+                    ProductName = "Rhönbräu Klosterbier",
                     SupplierID = 12,
                     CategoryID = 1,
                     QuantityPerUnit = "24 - 0.5 l bottles",
@@ -2500,7 +2500,7 @@ Winchester Way",
                 new Product
                 {
                     ProductID = 76,
-                    ProductName = "Lakkalik””ri",
+                    ProductName = "Lakkalikööri",
                     SupplierID = 23,
                     CategoryID = 1,
                     QuantityPerUnit = "500 ml",
@@ -2513,7 +2513,7 @@ Winchester Way",
                 new Product
                 {
                     ProductID = 77,
-                    ProductName = "Original Frankfurter grne Soáe",
+                    ProductName = "Original Frankfurter grüne Soße",
                     SupplierID = 12,
                     CategoryID = 2,
                     QuantityPerUnit = "12 boxes",

--- a/src/EFCore.SqlServer/Query/ExpressionVisitors/Internal/SqlServerSqlTranslatingExpressionVisitorFactory.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionVisitors/Internal/SqlServerSqlTranslatingExpressionVisitorFactory.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Diagnostics;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
@@ -27,14 +28,13 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        [DebuggerStepThrough]
         public override SqlTranslatingExpressionVisitor Create(
             RelationalQueryModelVisitor queryModelVisitor,
             SelectExpression targetSelectExpression = null,
             Expression topLevelPredicate = null,
             bool inProjection = false)
-        {
-            return new SqlServerSqlTranslatingExpressionVisitor(
+            => new SqlServerSqlTranslatingExpressionVisitor(
                 Dependencies, queryModelVisitor, targetSelectExpression, topLevelPredicate, inProjection);
-        }
     }
 }

--- a/src/EFCore.Sqlite.Core/Query/ExpressionVisitors/Internal/SqliteSqlTranslatingExpressionVisitorFactory.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionVisitors/Internal/SqliteSqlTranslatingExpressionVisitorFactory.cs
@@ -32,9 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             SelectExpression targetSelectExpression = null,
             Expression topLevelPredicate = null,
             bool inProjection = false)
-        {
-            return new SqliteSqlTranslatingExpressionVisitor(
+            => new SqliteSqlTranslatingExpressionVisitor(
                 Dependencies, queryModelVisitor, targetSelectExpression, topLevelPredicate, inProjection);
-        }
     }
 }

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -1396,7 +1396,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     targetExpression,
                     _queryCompilationContext.QuerySourceMapping.GetExpression(querySource));
 
-            _queryCompilationContext.QuerySourceMapping.ReplaceMapping(querySource, memberAccessExpression);
+            _queryCompilationContext.AddOrUpdateMapping(querySource, memberAccessExpression);
         }
 
         private static Expression ShiftMemberAccess(Expression targetExpression, Expression currentExpression)

--- a/src/EFCore/Query/ExpressionVisitors/Internal/CorrelatedCollectionOptimizingVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/CorrelatedCollectionOptimizingVisitor.cs
@@ -146,7 +146,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             bool forceListResult)
         {
             var querySourceReferenceFindingExpressionTreeVisitor
-                = new QuerySourceReferenceFindingExpressionTreeVisitor();
+                = new QuerySourceReferenceFindingExpressionVisitor();
 
             var originalCorrelationPredicate = collectionQueryModel.BodyClauses.OfType<WhereClause>()
                 .Single(c => c.Predicate is NullSafeEqualExpression);
@@ -156,7 +156,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             querySourceReferenceFindingExpressionTreeVisitor.Visit(keyEquality.Left);
             var parentQuerySourceReferenceExpression = querySourceReferenceFindingExpressionTreeVisitor.QuerySourceReferenceExpression;
 
-            querySourceReferenceFindingExpressionTreeVisitor = new QuerySourceReferenceFindingExpressionTreeVisitor();
+            querySourceReferenceFindingExpressionTreeVisitor = new QuerySourceReferenceFindingExpressionVisitor();
             querySourceReferenceFindingExpressionTreeVisitor.Visit(keyEquality.Right);
 
             var currentKey = BuildKeyAccess(navigation.ForeignKey.Properties, querySourceReferenceFindingExpressionTreeVisitor.QuerySourceReferenceExpression);

--- a/src/EFCore/Query/ExpressionVisitors/Internal/QuerySourceReferenceFindingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/QuerySourceReferenceFindingExpressionVisitor.cs
@@ -11,7 +11,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class QuerySourceReferenceFindingExpressionTreeVisitor : RelinqExpressionVisitor
+    public class QuerySourceReferenceFindingExpressionVisitor : RelinqExpressionVisitor
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Query/Internal/IncludeCompiler.CollectionQueryModelRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.CollectionQueryModelRewritingExpressionVisitor.cs
@@ -86,7 +86,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             private void Rewrite(QueryModel collectionQueryModel, INavigation navigation)
             {
                 var querySourceReferenceFindingExpressionTreeVisitor
-                    = new QuerySourceReferenceFindingExpressionTreeVisitor();
+                    = new QuerySourceReferenceFindingExpressionVisitor();
 
                 var whereClause = collectionQueryModel.BodyClauses
                     .OfType<WhereClause>()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -24,6 +25,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 @"SELECT AVG(CAST([o].[OrderID] AS float))
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
+
+            // Validating that we don't generate warning when translating GroupBy. See Issue#11157
+            Assert.DoesNotContain("The LINQ expression 'GroupBy([o].CustomerID, [o])' could not be translated and will be evaluated locally.", Fixture.TestSqlLoggerFactory.Log);
         }
 
         public override void GroupBy_Property_Select_Count()
@@ -81,7 +85,7 @@ GROUP BY [o].[CustomerID]");
             base.GroupBy_Property_Select_Sum_Min_Max_Avg();
 
             AssertSql(
-                @"SELECT SUM([o].[OrderID]), MIN([o].[OrderID]), MAX([o].[OrderID]), AVG(CAST([o].[OrderID] AS float))
+                @"SELECT SUM([o].[OrderID]) AS [Sum], MIN([o].[OrderID]) AS [Min], MAX([o].[OrderID]) AS [Max], AVG(CAST([o].[OrderID] AS float)) AS [Avg]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
         }
@@ -91,7 +95,7 @@ GROUP BY [o].[CustomerID]");
             base.GroupBy_Property_Select_Key_Average();
 
             AssertSql(
-                @"SELECT [o].[CustomerID], AVG(CAST([o].[OrderID] AS float))
+                @"SELECT [o].[CustomerID] AS [Key], AVG(CAST([o].[OrderID] AS float)) AS [Average]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
         }
@@ -101,7 +105,7 @@ GROUP BY [o].[CustomerID]");
             base.GroupBy_Property_Select_Key_Count();
 
             AssertSql(
-                @"SELECT [o].[CustomerID], COUNT(*)
+                @"SELECT [o].[CustomerID] AS [Key], COUNT(*) AS [Count]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
         }
@@ -111,7 +115,7 @@ GROUP BY [o].[CustomerID]");
             base.GroupBy_Property_Select_Key_LongCount();
 
             AssertSql(
-                @"SELECT [o].[CustomerID], COUNT_BIG(*)
+                @"SELECT [o].[CustomerID] AS [Key], COUNT_BIG(*) AS [LongCount]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
         }
@@ -121,7 +125,7 @@ GROUP BY [o].[CustomerID]");
             base.GroupBy_Property_Select_Key_Max();
 
             AssertSql(
-                @"SELECT [o].[CustomerID], MAX([o].[OrderID])
+                @"SELECT [o].[CustomerID] AS [Key], MAX([o].[OrderID]) AS [Max]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
         }
@@ -131,7 +135,7 @@ GROUP BY [o].[CustomerID]");
             base.GroupBy_Property_Select_Key_Min();
 
             AssertSql(
-                @"SELECT [o].[CustomerID], MIN([o].[OrderID])
+                @"SELECT [o].[CustomerID] AS [Key], MIN([o].[OrderID]) AS [Min]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
         }
@@ -141,7 +145,7 @@ GROUP BY [o].[CustomerID]");
             base.GroupBy_Property_Select_Key_Sum();
 
             AssertSql(
-                @"SELECT [o].[CustomerID], SUM([o].[OrderID])
+                @"SELECT [o].[CustomerID] AS [Key], SUM([o].[OrderID]) AS [Sum]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
         }
@@ -151,7 +155,7 @@ GROUP BY [o].[CustomerID]");
             base.GroupBy_Property_Select_Key_Sum_Min_Max_Avg();
 
             AssertSql(
-                @"SELECT [o].[CustomerID], SUM([o].[OrderID]), MIN([o].[OrderID]), MAX([o].[OrderID]), AVG(CAST([o].[OrderID] AS float))
+                @"SELECT [o].[CustomerID] AS [Key], SUM([o].[OrderID]) AS [Sum], MIN([o].[OrderID]) AS [Min], MAX([o].[OrderID]) AS [Max], AVG(CAST([o].[OrderID] AS float)) AS [Avg]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
         }
@@ -161,7 +165,7 @@ GROUP BY [o].[CustomerID]");
             base.GroupBy_Property_Select_Sum_Min_Key_Max_Avg();
 
             AssertSql(
-                @"SELECT SUM([o].[OrderID]), MIN([o].[OrderID]), [o].[CustomerID], MAX([o].[OrderID]), AVG(CAST([o].[OrderID] AS float))
+                @"SELECT SUM([o].[OrderID]) AS [Sum], MIN([o].[OrderID]) AS [Min], [o].[CustomerID] AS [Key], MAX([o].[OrderID]) AS [Max], AVG(CAST([o].[OrderID] AS float)) AS [Avg]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
         }
@@ -231,7 +235,17 @@ GROUP BY [o].[CustomerID]");
             base.GroupBy_anonymous_Select_Sum_Min_Max_Avg();
 
             AssertSql(
-                @"SELECT SUM([o].[OrderID]), MIN([o].[OrderID]), MAX([o].[OrderID]), AVG(CAST([o].[OrderID] AS float))
+                @"SELECT SUM([o].[OrderID]) AS [Sum], MIN([o].[OrderID]) AS [Min], MAX([o].[OrderID]) AS [Max], AVG(CAST([o].[OrderID] AS float)) AS [Avg]
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]");
+        }
+
+        public override void GroupBy_anonymous_with_alias_Select_Key_Sum()
+        {
+            base.GroupBy_anonymous_with_alias_Select_Key_Sum();
+
+            AssertSql(
+                @"SELECT [o].[CustomerID] AS [Key], SUM([o].[OrderID]) AS [Sum]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
         }
@@ -301,7 +315,7 @@ GROUP BY [o].[CustomerID], [o].[EmployeeID]");
             base.GroupBy_Composite_Select_Sum_Min_Max_Avg();
 
             AssertSql(
-                @"SELECT SUM([o].[OrderID]), MIN([o].[OrderID]), MAX([o].[OrderID]), AVG(CAST([o].[OrderID] AS float))
+                @"SELECT SUM([o].[OrderID]) AS [Sum], MIN([o].[OrderID]) AS [Min], MAX([o].[OrderID]) AS [Max], AVG(CAST([o].[OrderID] AS float)) AS [Avg]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID], [o].[EmployeeID]");
         }
@@ -311,7 +325,7 @@ GROUP BY [o].[CustomerID], [o].[EmployeeID]");
             base.GroupBy_Composite_Select_Key_Average();
 
             AssertSql(
-                @"SELECT [o].[CustomerID], [o].[EmployeeID], AVG(CAST([o].[OrderID] AS float))
+                @"SELECT [o].[CustomerID], [o].[EmployeeID], AVG(CAST([o].[OrderID] AS float)) AS [Average]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID], [o].[EmployeeID]");
         }
@@ -321,7 +335,7 @@ GROUP BY [o].[CustomerID], [o].[EmployeeID]");
             base.GroupBy_Composite_Select_Key_Count();
 
             AssertSql(
-                @"SELECT [o].[CustomerID], [o].[EmployeeID], COUNT(*)
+                @"SELECT [o].[CustomerID], [o].[EmployeeID], COUNT(*) AS [Count]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID], [o].[EmployeeID]");
         }
@@ -331,7 +345,7 @@ GROUP BY [o].[CustomerID], [o].[EmployeeID]");
             base.GroupBy_Composite_Select_Key_LongCount();
 
             AssertSql(
-                @"SELECT [o].[CustomerID], [o].[EmployeeID], COUNT_BIG(*)
+                @"SELECT [o].[CustomerID], [o].[EmployeeID], COUNT_BIG(*) AS [LongCount]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID], [o].[EmployeeID]");
         }
@@ -341,7 +355,7 @@ GROUP BY [o].[CustomerID], [o].[EmployeeID]");
             base.GroupBy_Composite_Select_Key_Max();
 
             AssertSql(
-                @"SELECT [o].[CustomerID], [o].[EmployeeID], MAX([o].[OrderID])
+                @"SELECT [o].[CustomerID], [o].[EmployeeID], MAX([o].[OrderID]) AS [Max]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID], [o].[EmployeeID]");
         }
@@ -351,7 +365,7 @@ GROUP BY [o].[CustomerID], [o].[EmployeeID]");
             base.GroupBy_Composite_Select_Key_Min();
 
             AssertSql(
-                @"SELECT [o].[CustomerID], [o].[EmployeeID], MIN([o].[OrderID])
+                @"SELECT [o].[CustomerID], [o].[EmployeeID], MIN([o].[OrderID]) AS [Min]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID], [o].[EmployeeID]");
         }
@@ -361,7 +375,7 @@ GROUP BY [o].[CustomerID], [o].[EmployeeID]");
             base.GroupBy_Composite_Select_Key_Sum();
 
             AssertSql(
-                @"SELECT [o].[CustomerID], [o].[EmployeeID], SUM([o].[OrderID])
+                @"SELECT [o].[CustomerID], [o].[EmployeeID], SUM([o].[OrderID]) AS [Sum]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID], [o].[EmployeeID]");
         }
@@ -371,7 +385,7 @@ GROUP BY [o].[CustomerID], [o].[EmployeeID]");
             base.GroupBy_Composite_Select_Key_Sum_Min_Max_Avg();
 
             AssertSql(
-                @"SELECT [o].[CustomerID], [o].[EmployeeID], SUM([o].[OrderID]), MIN([o].[OrderID]), MAX([o].[OrderID]), AVG(CAST([o].[OrderID] AS float))
+                @"SELECT [o].[CustomerID], [o].[EmployeeID], SUM([o].[OrderID]) AS [Sum], MIN([o].[OrderID]) AS [Min], MAX([o].[OrderID]) AS [Max], AVG(CAST([o].[OrderID] AS float)) AS [Avg]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID], [o].[EmployeeID]");
         }
@@ -381,7 +395,7 @@ GROUP BY [o].[CustomerID], [o].[EmployeeID]");
             base.GroupBy_Composite_Select_Sum_Min_Key_Max_Avg();
 
             AssertSql(
-                @"SELECT SUM([o].[OrderID]), MIN([o].[OrderID]), [o].[CustomerID], [o].[EmployeeID], MAX([o].[OrderID]), AVG(CAST([o].[OrderID] AS float))
+                @"SELECT SUM([o].[OrderID]) AS [Sum], MIN([o].[OrderID]) AS [Min], [o].[CustomerID], [o].[EmployeeID], MAX([o].[OrderID]) AS [Max], AVG(CAST([o].[OrderID] AS float)) AS [Avg]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID], [o].[EmployeeID]");
         }
@@ -391,7 +405,36 @@ GROUP BY [o].[CustomerID], [o].[EmployeeID]");
             base.GroupBy_Composite_Select_Sum_Min_Key_flattened_Max_Avg();
 
             AssertSql(
-                @"SELECT SUM([o].[OrderID]), MIN([o].[OrderID]), [o].[CustomerID], [o].[EmployeeID], MAX([o].[OrderID]), AVG(CAST([o].[OrderID] AS float))
+                @"SELECT SUM([o].[OrderID]) AS [Sum], MIN([o].[OrderID]) AS [Min], [o].[CustomerID], [o].[EmployeeID], MAX([o].[OrderID]) AS [Max], AVG(CAST([o].[OrderID] AS float)) AS [Avg]
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID], [o].[EmployeeID]");
+        }
+
+        public override void GroupBy_Dto_as_key_Select_Sum()
+        {
+            base.GroupBy_Dto_as_key_Select_Sum();
+
+            AssertSql(
+                @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Orders] AS [o0]");
+        }
+
+        public override void GroupBy_Dto_as_element_selector_Select_Sum()
+        {
+            base.GroupBy_Dto_as_element_selector_Select_Sum();
+
+            AssertSql(
+                @"SELECT [o].[CustomerID], [o].[EmployeeID]
+FROM [Orders] AS [o]
+ORDER BY [o].[CustomerID]");
+        }
+
+        public override void GroupBy_Composite_Select_Dto_Sum_Min_Key_flattened_Max_Avg()
+        {
+            base.GroupBy_Composite_Select_Dto_Sum_Min_Key_flattened_Max_Avg();
+
+            AssertSql(
+                @"SELECT SUM([o].[OrderID]) AS [Sum], MIN([o].[OrderID]) AS [Min], [o].[CustomerID], [o].[EmployeeID], MAX([o].[OrderID]) AS [Max], AVG(CAST([o].[OrderID] AS float)) AS [Avg]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID], [o].[EmployeeID]");
         }
@@ -401,9 +444,79 @@ GROUP BY [o].[CustomerID], [o].[EmployeeID]");
             base.GroupBy_Composite_Select_Sum_Min_part_Key_flattened_Max_Avg();
 
             AssertSql(
-                @"SELECT SUM([o].[OrderID]), MIN([o].[OrderID]), [o].[CustomerID], MAX([o].[OrderID]), AVG(CAST([o].[OrderID] AS float))
+                @"SELECT SUM([o].[OrderID]) AS [Sum], MIN([o].[OrderID]) AS [Min], [o].[CustomerID], MAX([o].[OrderID]) AS [Max], AVG(CAST([o].[OrderID] AS float)) AS [Avg]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID], [o].[EmployeeID]");
+        }
+
+        public override void GroupBy_Constant_Select_Sum_Min_Key_Max_Avg()
+        {
+            base.GroupBy_Constant_Select_Sum_Min_Key_Max_Avg();
+
+            AssertSql(
+                @"SELECT SUM([t].[OrderID]) AS [Sum], MIN([t].[OrderID]) AS [Min], [t].[Key], MAX([t].[OrderID]) AS [Max], AVG(CAST([t].[OrderID] AS float)) AS [Avg]
+FROM (
+    SELECT [o].*, 2 AS [Key]
+    FROM [Orders] AS [o]
+) AS [t]
+GROUP BY [t].[Key]");
+        }
+
+        public override void GroupBy_after_predicate_Constant_Select_Sum_Min_Key_Max_Avg()
+        {
+            base.GroupBy_after_predicate_Constant_Select_Sum_Min_Key_Max_Avg();
+
+            AssertSql(
+                @"SELECT SUM([t].[OrderID]) AS [Sum], MIN([t].[OrderID]) AS [Min], [t].[Key] AS [Random], MAX([t].[OrderID]) AS [Max], AVG(CAST([t].[OrderID] AS float)) AS [Avg]
+FROM (
+    SELECT [o].*, 2 AS [Key]
+    FROM [Orders] AS [o]
+    WHERE [o].[OrderID] > 10500
+) AS [t]
+GROUP BY [t].[Key]");
+        }
+
+        public override void GroupBy_Constant_with_element_selector_Select_Sum_Min_Key_Max_Avg()
+        {
+            base.GroupBy_Constant_with_element_selector_Select_Sum_Min_Key_Max_Avg();
+
+            AssertSql(
+                @"SELECT SUM([t].[OrderID]) AS [Sum], [t].[Key]
+FROM (
+    SELECT [o].[OrderID], 2 AS [Key]
+    FROM [Orders] AS [o]
+) AS [t]
+GROUP BY [t].[Key]");
+        }
+
+        public override void GroupBy_param_Select_Sum_Min_Key_Max_Avg()
+        {
+            base.GroupBy_param_Select_Sum_Min_Key_Max_Avg();
+
+            AssertSql(
+                @"@__a_0='2'
+
+SELECT SUM([t].[OrderID]) AS [Sum], MIN([t].[OrderID]) AS [Min], [t].[Key], MAX([t].[OrderID]) AS [Max], AVG(CAST([t].[OrderID] AS float)) AS [Avg]
+FROM (
+    SELECT [o].*, @__a_0 AS [Key]
+    FROM [Orders] AS [o]
+) AS [t]
+GROUP BY [t].[Key]");
+        }
+
+        public override void GroupBy_param_with_element_selector_Select_Sum_Min_Key_Max_Avg()
+        {
+            base.GroupBy_param_with_element_selector_Select_Sum_Min_Key_Max_Avg();
+
+            AssertSql(
+                @"@__a_0='2'
+
+SELECT SUM([t].[OrderID]) AS [Sum], [t].[Key]
+FROM (
+    SELECT [o].[OrderID], @__a_0 AS [Key]
+    FROM [Orders] AS [o]
+) AS [t]
+GROUP BY [t].[Key]");
         }
 
         public override void GroupBy_Property_scalar_element_selector_Average()
@@ -471,7 +584,7 @@ GROUP BY [o].[CustomerID]");
             base.GroupBy_Property_scalar_element_selector_Sum_Min_Max_Avg();
 
             AssertSql(
-                @"SELECT SUM([o].[OrderID]), MIN([o].[OrderID]), MAX([o].[OrderID]), AVG(CAST([o].[OrderID] AS float))
+                @"SELECT SUM([o].[OrderID]) AS [Sum], MIN([o].[OrderID]) AS [Min], MAX([o].[OrderID]) AS [Max], AVG(CAST([o].[OrderID] AS float)) AS [Avg]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
         }
@@ -541,17 +654,7 @@ GROUP BY [o].[CustomerID]");
             base.GroupBy_Property_anonymous_element_selector_Sum_Min_Max_Avg();
 
             AssertSql(
-                @"SELECT SUM([o].[OrderID]), MIN([o].[EmployeeID]), MAX([o].[EmployeeID]), AVG(CAST([o].[OrderID] AS float))
-FROM [Orders] AS [o]
-GROUP BY [o].[CustomerID]");
-        }
-
-        public override void GroupBy_with_result_selector()
-        {
-            base.GroupBy_with_result_selector();
-
-            AssertSql(
-                @"SELECT SUM([o].[OrderID]), MIN([o].[OrderID]), MAX([o].[OrderID]), AVG(CAST([o].[OrderID] AS float))
+                @"SELECT SUM([o].[OrderID]) AS [Sum], MIN([o].[EmployeeID]) AS [Min], MAX([o].[EmployeeID]) AS [Max], AVG(CAST([o].[OrderID] AS float)) AS [Avg]
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
         }
@@ -575,7 +678,7 @@ GROUP BY [o].[CustomerID]");
 
 SELECT AVG(CAST([t].[OrderID] AS float))
 FROM (
-    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT [o].*
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
     OFFSET @__p_0 ROWS
@@ -592,7 +695,7 @@ GROUP BY [t].[CustomerID]");
 
 SELECT MIN([t].[OrderID])
 FROM (
-    SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT TOP(@__p_0) [o].*
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
 ) AS [t]
@@ -609,7 +712,7 @@ GROUP BY [t].[CustomerID]");
 
 SELECT MAX([t].[OrderID])
 FROM (
-    SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT [o].*
     FROM [Orders] AS [o]
     ORDER BY [o].[OrderID]
     OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
@@ -622,9 +725,9 @@ GROUP BY [t].[CustomerID]");
             base.Distinct_GroupBy_Aggregate();
 
             AssertSql(
-                @"SELECT [t].[CustomerID], COUNT(*)
+                @"SELECT [t].[CustomerID] AS [Key], COUNT(*) AS [c]
 FROM (
-    SELECT DISTINCT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT DISTINCT [o].*
     FROM [Orders] AS [o]
 ) AS [t]
 GROUP BY [t].[CustomerID]");
@@ -635,7 +738,7 @@ GROUP BY [t].[CustomerID]");
             base.Anonymous_projection_Distinct_GroupBy_Aggregate();
 
             AssertSql(
-                @"SELECT [t].[EmployeeID], COUNT(*)
+                @"SELECT [t].[EmployeeID] AS [Key], COUNT(*) AS [c]
 FROM (
     SELECT DISTINCT [o].[OrderID], [o].[EmployeeID]
     FROM [Orders] AS [o]
@@ -648,7 +751,7 @@ GROUP BY [t].[EmployeeID]");
             base.SelectMany_GroupBy_Aggregate();
 
             AssertSql(
-                @"SELECT [c.Orders].[EmployeeID], COUNT(*)
+                @"SELECT [c.Orders].[EmployeeID] AS [Key], COUNT(*) AS [c]
 FROM [Customers] AS [c]
 INNER JOIN [Orders] AS [c.Orders] ON [c].[CustomerID] = [c.Orders].[CustomerID]
 GROUP BY [c.Orders].[EmployeeID]");
@@ -659,10 +762,21 @@ GROUP BY [c.Orders].[EmployeeID]");
             base.Join_GroupBy_Aggregate();
 
             AssertSql(
-                @"SELECT [c].[CustomerID], AVG(CAST([o].[OrderID] AS float))
+                @"SELECT [c].[CustomerID] AS [Key], AVG(CAST([o].[OrderID] AS float)) AS [Count]
 FROM [Orders] AS [o]
 INNER JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 GROUP BY [c].[CustomerID]");
+        }
+
+        public override void GroupBy_required_navigation_member_Aggregate()
+        {
+            base.GroupBy_required_navigation_member_Aggregate();
+
+            AssertSql(
+                @"SELECT [od.Order].[CustomerID] AS [CustomerId], COUNT(*) AS [Count]
+FROM [Order Details] AS [od]
+INNER JOIN [Orders] AS [od.Order] ON [od].[OrderID] = [od.Order].[OrderID]
+GROUP BY [od.Order].[CustomerID]");
         }
 
         public override void Join_complex_GroupBy_Aggregate()
@@ -674,7 +788,7 @@ GROUP BY [c].[CustomerID]");
 @__p_1='10'
 @__p_2='50'
 
-SELECT [t0].[CustomerID], AVG(CAST([t].[OrderID] AS float))
+SELECT [t0].[CustomerID] AS [Key], AVG(CAST([t].[OrderID] AS float)) AS [Count]
 FROM (
     SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
@@ -696,7 +810,7 @@ GROUP BY [t0].[CustomerID]");
             base.GroupJoin_GroupBy_Aggregate();
 
             AssertSql(
-                @"SELECT [o].[CustomerID], AVG(CAST([o].[OrderID] AS float))
+                @"SELECT [o].[CustomerID] AS [Key], AVG(CAST([o].[OrderID] AS float)) AS [Count]
 FROM [Customers] AS [c]
 INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 GROUP BY [o].[CustomerID]");
@@ -707,7 +821,7 @@ GROUP BY [o].[CustomerID]");
             base.GroupJoin_GroupBy_Aggregate_2();
 
             AssertSql(
-                @"SELECT [c].[CustomerID], MAX([c].[City])
+                @"SELECT [c].[CustomerID] AS [Key], MAX([c].[City]) AS [Count]
 FROM [Customers] AS [c]
 INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 GROUP BY [c].[CustomerID]");
@@ -718,10 +832,21 @@ GROUP BY [c].[CustomerID]");
             base.GroupJoin_GroupBy_Aggregate_3();
 
             AssertSql(
-                @"SELECT [o].[CustomerID], AVG(CAST([o].[OrderID] AS float))
+                @"SELECT [o].[CustomerID] AS [Key], AVG(CAST([o].[OrderID] AS float)) AS [Count]
 FROM [Orders] AS [o]
 INNER JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 GROUP BY [o].[CustomerID]");
+        }
+
+        public override void GroupBy_optional_navigation_member_Aggregate()
+        {
+            base.GroupBy_optional_navigation_member_Aggregate();
+
+            AssertSql(
+                @"SELECT [o.Customer].[Country]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
+ORDER BY [o.Customer].[Country]");
         }
 
         public override void GroupJoin_complex_GroupBy_Aggregate()
@@ -733,7 +858,7 @@ GROUP BY [o].[CustomerID]");
 @__p_1='50'
 @__p_2='100'
 
-SELECT [t0].[CustomerID], AVG(CAST([t0].[OrderID] AS float))
+SELECT [t0].[CustomerID] AS [Key], AVG(CAST([t0].[OrderID] AS float)) AS [Count]
 FROM (
     SELECT [c].*
     FROM [Customers] AS [c]
@@ -756,11 +881,23 @@ GROUP BY [t0].[CustomerID]");
             base.Self_join_GroupBy_Aggregate();
 
             AssertSql(
-                @"SELECT [o].[CustomerID], AVG(CAST([o2].[OrderID] AS float))
+                @"SELECT [o].[CustomerID] AS [Key], AVG(CAST([o2].[OrderID] AS float)) AS [Count]
 FROM [Orders] AS [o]
 INNER JOIN [Orders] AS [o2] ON [o].[OrderID] = [o2].[OrderID]
 WHERE [o].[OrderID] < 10400
 GROUP BY [o].[CustomerID]");
+        }
+
+        public override void GroupBy_multi_navigation_members_Aggregate()
+        {
+            base.GroupBy_multi_navigation_members_Aggregate();
+
+            AssertSql(
+                @"SELECT [od.Order].[CustomerID], [od.Product].[ProductName], COUNT(*) AS [Count]
+FROM [Order Details] AS [od]
+INNER JOIN [Products] AS [od.Product] ON [od].[ProductID] = [od.Product].[ProductID]
+INNER JOIN [Orders] AS [od.Order] ON [od].[OrderID] = [od.Order].[OrderID]
+GROUP BY [od.Order].[CustomerID], [od.Product].[ProductName]");
         }
 
         public override void Union_simple_groupby()
@@ -768,6 +905,97 @@ GROUP BY [o].[CustomerID]");
             base.Union_simple_groupby();
 
             AssertSql(" ");
+        }
+
+        public override void GroupBy_OrderBy_key()
+        {
+            base.GroupBy_OrderBy_key();
+
+            AssertSql(
+                @"SELECT [o].[CustomerID] AS [Key], COUNT(*) AS [c]
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]
+ORDER BY [Key]");
+        }
+
+        public override void GroupBy_OrderBy_count()
+        {
+            base.GroupBy_OrderBy_count();
+
+            AssertSql(
+                @"SELECT [o].[CustomerID] AS [Key], COUNT(*) AS [Count]
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]
+ORDER BY [Count], [Key]");
+        }
+
+        public override void GroupBy_OrderBy_count_Select_sum()
+        {
+            base.GroupBy_OrderBy_count_Select_sum();
+
+            AssertSql(
+                @"SELECT [o].[CustomerID] AS [Key], SUM([o].[OrderID]) AS [Sum]
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]
+ORDER BY COUNT(*), [Key]");
+        }
+
+        public override void GroupBy_OrderBy_count_Select_sum_over_unmapped_property()
+        {
+            base.GroupBy_OrderBy_count_Select_sum_over_unmapped_property();
+
+            AssertSql(" ");
+        }
+
+        public override void GroupBy_filter_key()
+        {
+            base.GroupBy_filter_key();
+
+            AssertSql(
+                @"SELECT [o].[CustomerID] AS [Key], COUNT(*) AS [c]
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]
+HAVING [o].[CustomerID] = N'ALFKI'");
+        }
+
+        public override void GroupBy_filter_count()
+        {
+            base.GroupBy_filter_count();
+
+            AssertSql(
+                @"SELECT [o].[CustomerID] AS [Key], COUNT(*) AS [Count]
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]
+HAVING COUNT(*) > 4");
+        }
+
+        public override void GroupBy_filter_count_OrderBy_count_Select_sum()
+        {
+            base.GroupBy_filter_count_OrderBy_count_Select_sum();
+
+            AssertSql(
+                @"SELECT [o].[CustomerID] AS [Key], COUNT(*) AS [Count], SUM([o].[OrderID]) AS [Sum]
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]
+HAVING COUNT(*) > 4
+ORDER BY [Count], [Key]");
+        }
+
+        public override void GroupBy_Aggregate_Join()
+        {
+            base.GroupBy_Aggregate_Join();
+
+            AssertSql(" ");
+        }
+
+        public override void GroupBy_with_result_selector()
+        {
+            base.GroupBy_with_result_selector();
+
+            AssertSql(
+                @"SELECT SUM([o].[OrderID]) AS [Sum], MIN([o].[OrderID]) AS [Min], MAX([o].[OrderID]) AS [Max], AVG(CAST([o].[OrderID] AS float)) AS [Avg]
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]");
         }
 
         public override void GroupBy_Sum_constant()
@@ -785,12 +1013,13 @@ ORDER BY [o].[CustomerID]");
             base.Distinct_GroupBy_OrderBy_key();
 
             AssertSql(
-                @"SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+                @"SELECT [t].[CustomerID] AS [Key], COUNT(*) AS [c]
 FROM (
-    SELECT DISTINCT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+    SELECT DISTINCT [o].*
     FROM [Orders] AS [o]
 ) AS [t]
-ORDER BY [t].[CustomerID]");
+GROUP BY [t].[CustomerID]
+ORDER BY [Key]");
         }
 
         public override void Select_nested_collection_with_groupby()
@@ -812,28 +1041,28 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) =
                 //
                 @"@_outer_CustomerID='ALFKI' (Size = 5)
 
-SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
+SELECT [o1].[OrderID]
 FROM [Orders] AS [o1]
 WHERE @_outer_CustomerID = [o1].[CustomerID]
 ORDER BY [o1].[OrderID]",
                 //
                 @"@_outer_CustomerID='ANATR' (Size = 5)
 
-SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
+SELECT [o1].[OrderID]
 FROM [Orders] AS [o1]
 WHERE @_outer_CustomerID = [o1].[CustomerID]
 ORDER BY [o1].[OrderID]",
                 //
                 @"@_outer_CustomerID='ANTON' (Size = 5)
 
-SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
+SELECT [o1].[OrderID]
 FROM [Orders] AS [o1]
 WHERE @_outer_CustomerID = [o1].[CustomerID]
 ORDER BY [o1].[OrderID]",
                 //
                 @"@_outer_CustomerID='AROUT' (Size = 5)
 
-SELECT [o1].[OrderID], [o1].[CustomerID], [o1].[EmployeeID], [o1].[OrderDate]
+SELECT [o1].[OrderID]
 FROM [Orders] AS [o1]
 WHERE @_outer_CustomerID = [o1].[CustomerID]
 ORDER BY [o1].[OrderID]");
@@ -944,7 +1173,7 @@ ORDER BY [o].[CustomerID]");
             base.GroupBy_with_element_selector();
 
             AssertSql(
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+                @"SELECT [o].[CustomerID], [o].[OrderID]
 FROM [Orders] AS [o]
 ORDER BY [o].[CustomerID]");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
@@ -1037,5 +1037,14 @@ WHERE [o].[ProductID] = 42");
                 CoreStrings.LogFirstWithoutOrderByAndFilter.GenerateMessage(
                     @"(from char <generated>_1 in [c].CustomerID select [<generated>_1]).FirstOrDefault()"), Fixture.TestSqlLoggerFactory.Log);
         }
+
+        public override void Project_constant_Sum()
+        {
+            base.Project_constant_Sum();
+
+            AssertSql(
+                @"SELECT 1
+FROM [Employees] AS [e]");
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
@@ -183,6 +183,15 @@ END AS [IsAvailable]
 FROM [Products] AS [p]");
         }
 
+        public override void Select_constant_int()
+        {
+            base.Select_constant_int();
+
+            AssertSql(
+                @"SELECT 1
+FROM [Customers] AS [c]");
+        }
+
         public override void Select_constant_null_string()
         {
             base.Select_constant_null_string();


### PR DESCRIPTION
Query: Improvements to Relational GroupBy translation for composition

- Add support for translating OrderBy after GroupBy operator
- Add support for `HAVING` clause in SQL which would be generated when translating predicate after GroupByAggregate Resolves #10870
- Make sure client eval warning is not issued when translating GroupByAggregate Resolves #11157
- GroupBy Aggregate works when element/result selector is DTO instead of anonymous type Resolves #11176 (KeySelector has to be client evaluated)
- Make sure that SQL added to GROUP BY clause is not aliased Resolves #11218
- Translate GroupBy Constant/Parameter with aggregates Resolves #9969

Part of #10012 
Part of #2341 
