### PR TITLE
Don't mark rowversion as modified if the token hasn't changed

### DIFF
--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
@@ -2,9 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
@@ -22,7 +25,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             = new SqlServerFloatTypeMapping("real");
 
         private readonly SqlServerByteArrayTypeMapping _rowversion
-            = new SqlServerByteArrayTypeMapping("rowversion", dbType: DbType.Binary, size: 8);
+            = new SqlServerByteArrayTypeMapping(
+                "rowversion",
+                null,
+                new ValueComparer<byte[]>(
+                    (v1, v2) => StructuralComparisons.StructuralEqualityComparer.Equals(v1, v2),
+                    v => v == null ? null : v.ToArray()),
+                dbType: DbType.Binary,
+                size: 8);
 
         private readonly IntTypeMapping _int
             = new IntTypeMapping("int", DbType.Int32);

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -688,7 +688,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             {
                 var currentValue = this[propertyBase];
                 var propertyIndex = property.GetIndex();
-                if (!Equals(currentValue, value)
+                if (!ValuesEqual(property, currentValue, value)
                     && !_stateData.IsPropertyFlagged(propertyIndex, PropertyFlag.Unknown))
                 {
                     SetPropertyModified(property);
@@ -804,7 +804,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 var propertyIndex = asProperty?.GetIndex();
 
                 var valuesEqual = asProperty != null
-                    ? Equals(currentValue, value)
+                    ? ValuesEqual(asProperty, value, currentValue)
                     : ReferenceEquals(currentValue, value);
 
                 if (!valuesEqual
@@ -865,6 +865,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 }
             }
         }
+
+        private static bool ValuesEqual(IProperty property, object value, object currentValue)
+            => (property.GetValueComparer()
+                ?? property.FindMapping()?.Comparer)
+               ?.CompareFunc(currentValue, value)
+               ?? Equals(currentValue, value);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/ChangeTracking/MemberEntry.cs
+++ b/src/EFCore/ChangeTracking/MemberEntry.cs
@@ -73,8 +73,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// </summary>
         public virtual object CurrentValue
         {
-            get { return InternalEntry[Metadata]; }
-            [param: CanBeNull] set { InternalEntry[Metadata] = value; }
+            get => InternalEntry[Metadata];
+            [param: CanBeNull] set => InternalEntry[Metadata] = value;
         }
 
         /// <summary>

--- a/src/EFCore/ChangeTracking/PropertyEntry`.cs
+++ b/src/EFCore/ChangeTracking/PropertyEntry`.cs
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         public new virtual TProperty CurrentValue
         {
             get => InternalEntry.GetCurrentValue<TProperty>(Metadata);
-            [param: CanBeNull] set { base.CurrentValue = value; }
+            [param: CanBeNull] set => base.CurrentValue = value;
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         public new virtual TProperty OriginalValue
         {
             get => InternalEntry.GetOriginalValue<TProperty>(Metadata);
-            [param: CanBeNull] set { base.OriginalValue = value; }
+            [param: CanBeNull] set => base.OriginalValue = value;
         }
     }
 }


### PR DESCRIPTION
Fixes #9856

The fix is to add a ValueComparer for this mapping so that it does deep comparison. Testing revealed a couple of bugs in ValueCompaer--they were not being used when explicitly setting CurrentValue or OriginalValue.

Providers: This is only done for SQL Server, since this is a SQL Server-specific mechanism, but it is possible other providers have similar issues.
