### PR TITLE
Friday eve bugs burndown

### DIFF
--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -1942,6 +1942,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
                 return expression.IsComparisonOperation()
                        || expression.IsLogicalOperation()
+                       || expression.NodeType == ExpressionType.Not
                        || expression is ExistsExpression
                        || expression is InExpression
                        || expression is IsNullExpression

--- a/src/EFCore.Specification.Tests/Query/AsyncGearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncGearsOfWarQueryTestBase.cs
@@ -1357,5 +1357,20 @@ namespace Microsoft.EntityFrameworkCore.Query
                 gs => gs.Include(g => g.Squad).Concat(gs),
                 expectedIncludes);
         }
+
+        [ConditionalFact]
+        public virtual async Task Negated_bool_ternary_inside_anonymous_type_in_projection()
+        {
+            await AssertQuery<CogTag>(
+                cts => cts.Select(t => new { c = !(t.Gear.HasSoulPatch ? true : ((bool?)t.Gear.HasSoulPatch ?? true)) }),
+                cts => cts.Select(
+                    t => new
+                    {
+                        c = !(MaybeScalar<bool>(t.Gear, () => t.Gear.HasSoulPatch) ?? false
+                            ? true
+                            : (MaybeScalar<bool>(t.Gear, () => t.Gear.HasSoulPatch) ?? true))
+                    }),
+                elementSorter: e => e.c);
+        }
     }
 }

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -4350,6 +4350,21 @@ namespace Microsoft.EntityFrameworkCore.Query
                 expectedIncludes);
         }
 
+        [ConditionalFact]
+        public virtual void Negated_bool_ternary_inside_anonymous_type_in_projection()
+        {
+            AssertQuery<CogTag>(
+                cts => cts.Select(t => new { c = !(t.Gear.HasSoulPatch ? true : ((bool?)t.Gear.HasSoulPatch ?? true)) }),
+                cts => cts.Select(
+                    t => new
+                    {
+                        c = !(MaybeScalar<bool>(t.Gear, () => t.Gear.HasSoulPatch) ?? false
+                            ? true
+                            : (MaybeScalar<bool>(t.Gear, () => t.Gear.HasSoulPatch) ?? true))
+                    }),
+                elementSorter: e => e.c);
+        }
+
         // Remember to add any new tests to Async version of this test class
 
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -6111,6 +6111,26 @@ FROM [Gears] AS [g0]
 WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')");
         }
 
+        public override void Negated_bool_ternary_inside_anonymous_type_in_projection()
+        {
+            base.Negated_bool_ternary_inside_anonymous_type_in_projection();
+
+            AssertSql(
+                @"SELECT CASE
+    WHEN NOT (CASE
+        WHEN [t0].[HasSoulPatch] = 1
+        THEN CAST(1 AS BIT) ELSE COALESCE([t0].[HasSoulPatch], 1)
+    END = 1)
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END AS [c]
+FROM [Tags] AS [t]
+LEFT JOIN (
+    SELECT [t.Gear].*
+    FROM [Gears] AS [t.Gear]
+    WHERE [t.Gear].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Convert Not(...) on top level projection to conditional block in SQL

Issue: Our logic to identity search condition was missing Not nodetype. So when we encountered it on top level projection, we did not modify it assuming it is a value but that causes invalid SQL

Resolves #9944
