### PR TITLE
[Preview2] Generate array literals in CSharpUtilies

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpUtilities.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpUtilities.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
@@ -11,6 +12,7 @@ using System.Text.RegularExpressions;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Utilities;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 {
@@ -146,11 +148,14 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual string GenerateLiteral(byte[] value)
+        public virtual string GenerateLiteral(Array value)
         {
             Check.NotNull(value, nameof(value));
 
-            return "new byte[] {" + string.Join(", ", value) + "}";
+            var elementType = value.GetType().GetElementType();
+            Debug.Assert(elementType != null);
+
+            return $"new {elementType.ShortDisplayName()}[] {{ {string.Join(", ", value.Cast<object>().Select(e => GenerateLiteral((dynamic)e)))} }}";
         }
 
         /// <summary>

--- a/src/EFCore.Design/Scaffolding/Internal/ICSharpUtilities.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/ICSharpUtilities.cs
@@ -54,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        string GenerateLiteral([NotNull] byte[] value);
+        string GenerateLiteral([NotNull] Array value);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpUtilitiesTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpUtilitiesTest.cs
@@ -47,6 +47,16 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
         }
 
         [Fact]
+        public void Generate_MethodCallCodeFragment_works_with_arrays()
+        {
+            var method = new MethodCallCodeFragment("Test", new byte[] { 1, 2 }, new[] { 3, 4 }, new[] { "foo", "bar" });
+
+            var result = new CSharpUtilities().Generate(method);
+
+            Assert.Equal(".Test(new byte[] { 1, 2 }, new int[] { 3, 4 }, new string[] { \"foo\", \"bar\" })", result);
+        }
+
+        [Fact]
         public void Generate_MethodCallCodeFragment_works_when_niladic()
         {
             var method = new MethodCallCodeFragment("Test");


### PR DESCRIPTION
Scaffolding database enums involves generating fluent API calls which accept an array (the label list for the enum), this is currently unsupported.