### PR TITLE
Updates to ValueComparers

### DIFF
--- a/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleByteArrayTypeMapping.cs
+++ b/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleByteArrayTypeMapping.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = System.Data.DbType.Binary,
             int? size = null)
-            : this(storeType, null, null, dbType, size)
+            : this(storeType, null, null, null, dbType, size)
         {
         }
 
@@ -28,10 +28,11 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             [CanBeNull] DbType? dbType = System.Data.DbType.Binary,
             int? size = null,
             bool fixedLength = false)
-            : base(storeType, converter, comparer, dbType, size, fixedLength)
+            : base(storeType, converter, comparer, keyComparer, dbType, size, fixedLength)
         {
             _maxSpecificSize = CalculateSize(size);
         }
@@ -40,10 +41,10 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             => size.HasValue && size < 8000 ? size.Value : 8000;
 
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new OracleByteArrayTypeMapping(storeType, Converter, Comparer, DbType, size, IsFixedLength);
+            => new OracleByteArrayTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType, size, IsFixedLength);
 
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new OracleByteArrayTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType, Size, IsFixedLength);
+            => new OracleByteArrayTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType, Size, IsFixedLength);
 
         protected override void ConfigureParameter(DbParameter parameter)
         {

--- a/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleDateTimeOffsetTypeMapping.cs
+++ b/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleDateTimeOffsetTypeMapping.cs
@@ -30,9 +30,10 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public OracleDateTimeOffsetTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
-            [CanBeNull] ValueComparer comparer = null)
+            [CanBeNull] ValueComparer comparer = null,
+            [CanBeNull] ValueComparer keyComparer = null)
 
-            : base(storeType, converter, comparer)
+            : base(storeType, converter, comparer, keyComparer)
         {
         }
 

--- a/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleDateTimeTypeMapping.cs
+++ b/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleDateTimeTypeMapping.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public OracleDateTimeTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -23,16 +23,17 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, converter, comparer, dbType)
+            : base(storeType, converter, comparer, keyComparer, dbType)
         {
         }
 
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new OracleDateTimeTypeMapping(storeType, Converter, Comparer, DbType);
+            => new OracleDateTimeTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new OracleDateTimeTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new OracleDateTimeTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
 
         protected override string SqlLiteralFormatString => DateTimeFormatConst;
     }

--- a/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleDoubleTypeMapping.cs
+++ b/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleDoubleTypeMapping.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public OracleDoubleTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -21,16 +21,17 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, converter, comparer, dbType)
+            : base(storeType, converter, comparer, keyComparer, dbType)
         {
         }
 
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new OracleDoubleTypeMapping(storeType, Converter, Comparer, DbType);
+            => new OracleDoubleTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new OracleDoubleTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new OracleDoubleTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
 
         protected override string GenerateNonNullSqlLiteral(object value)
         {

--- a/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleFloatTypeMapping.cs
+++ b/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleFloatTypeMapping.cs
@@ -13,7 +13,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public OracleFloatTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -21,16 +21,17 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, converter, comparer, dbType)
+            : base(storeType, converter, comparer, keyComparer, dbType)
         {
         }
 
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new OracleFloatTypeMapping(storeType, Converter, Comparer, DbType);
+            => new OracleFloatTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new OracleFloatTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new OracleFloatTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
 
         protected override string GenerateNonNullSqlLiteral(object value)
         {

--- a/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleStringTypeMapping.cs
+++ b/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleStringTypeMapping.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             bool unicode = false,
             int? size = null,
             bool fixedLength = false)
-            : this(storeType, null, null, dbType, unicode, size, fixedLength)
+            : this(storeType, null, null, null, dbType, unicode, size, fixedLength)
         {
         }
 
@@ -28,11 +28,12 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             [CanBeNull] DbType? dbType,
             bool unicode = false,
             int? size = null,
             bool fixedLength = false)
-            : base(storeType, converter, comparer, dbType, unicode, size, fixedLength)
+            : base(storeType, converter, comparer, keyComparer, dbType, unicode, size, fixedLength)
         {
             _maxSpecificSize = CalculateSize(unicode, size);
         }
@@ -47,10 +48,10 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                     : 4000;
 
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new OracleStringTypeMapping(storeType, Converter, Comparer, DbType, IsUnicode, size, IsFixedLength);
+            => new OracleStringTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType, IsUnicode, size, IsFixedLength);
 
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new OracleStringTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType, IsUnicode, Size, IsFixedLength);
+            => new OracleStringTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType, IsUnicode, Size, IsFixedLength);
 
         protected override void ConfigureParameter(DbParameter parameter)
         {

--- a/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleTimeSpanTypeMapping.cs
+++ b/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleTimeSpanTypeMapping.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
     public class OracleTimeSpanTypeMapping : TimeSpanTypeMapping
     {
         public OracleTimeSpanTypeMapping([NotNull] string storeType, [CanBeNull] DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -20,16 +20,17 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             [CanBeNull] DbType? dbType = null)
-            : base(storeType, converter, comparer, dbType)
+            : base(storeType, converter, comparer, keyComparer, dbType)
         {
         }
 
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new OracleTimeSpanTypeMapping(storeType, Converter, Comparer, DbType);
+            => new OracleTimeSpanTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new OracleTimeSpanTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new OracleTimeSpanTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
 
         protected override string GenerateNonNullSqlLiteral(object value)
         {

--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -518,7 +518,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 CoreAnnotationNames.ValueGeneratorFactoryAnnotation,
                 CoreAnnotationNames.PropertyAccessModeAnnotation,
                 CoreAnnotationNames.TypeMapping,
-                CoreAnnotationNames.ValueComparer);
+                CoreAnnotationNames.ValueComparer,
+                CoreAnnotationNames.KeyValueComparer);
 
             GenerateAnnotations(annotations, stringBuilder);
         }

--- a/src/EFCore.InMemory/Extensions/InMemoryServiceCollectionExtensions.cs
+++ b/src/EFCore.InMemory/Extensions/InMemoryServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
@@ -66,6 +67,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAdd<IEntityQueryModelVisitorFactory, InMemoryQueryModelVisitorFactory>()
                 .TryAdd<IEntityQueryableExpressionVisitorFactory, InMemoryEntityQueryableExpressionVisitorFactory>()
                 .TryAdd<IEvaluatableExpressionFilter, EvaluatableExpressionFilter>()
+                .TryAdd<IConventionSetBuilder, InMemoryConventionSetBuilder>()
                 .TryAdd<ISingletonOptions, IInMemorySingletonOptions>(p => p.GetService<IInMemorySingletonOptions>())
                 .TryAddProviderSpecificServices(
                     b => b

--- a/src/EFCore.InMemory/Metadata/Conventions/Internal/InMemoryConventionSetBuilder.cs
+++ b/src/EFCore.InMemory/Metadata/Conventions/Internal/InMemoryConventionSetBuilder.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class InMemoryConventionSetBuilder : IConventionSetBuilder
+    {
+        private readonly ITypeMappingSource _typeMappingSource;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public InMemoryConventionSetBuilder(
+            [NotNull] ITypeMappingSource typeMappingSource)
+        {
+            _typeMappingSource = typeMappingSource;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual ConventionSet AddConventions(ConventionSet conventionSet)
+        {
+            conventionSet.ModelBuiltConventions.Add(new InMemoryMappingConvention(_typeMappingSource));
+
+            return conventionSet;
+        }
+    }
+}

--- a/src/EFCore.InMemory/Metadata/Conventions/Internal/InMemoryTypeMappingConvention.cs
+++ b/src/EFCore.InMemory/Metadata/Conventions/Internal/InMemoryTypeMappingConvention.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class InMemoryMappingConvention : IModelBuiltConvention
+    {
+        private readonly ITypeMappingSource _typeMappingSource;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public InMemoryMappingConvention(
+            [NotNull] ITypeMappingSource typeMappingSource)
+        {
+            _typeMappingSource = typeMappingSource;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual InternalModelBuilder Apply(InternalModelBuilder modelBuilder)
+        {
+            foreach (var property in modelBuilder.Metadata.GetEntityTypes().SelectMany(e => e.GetDeclaredProperties()))
+            {
+                property.Builder.HasAnnotation(
+                    CoreAnnotationNames.TypeMapping,
+                    _typeMappingSource.FindMapping(property),
+                    ConfigurationSource.Convention);
+            }
+
+            return modelBuilder;
+        }
+    }
+}

--- a/src/EFCore.Relational/Storage/BoolTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/BoolTypeMapping.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public BoolTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -37,13 +37,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
         /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
+        /// <param name="keyComparer"> Supports custom comparisons between keys--e.g. PK to FK comparison. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public BoolTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, typeof(bool), converter, comparer, dbType)
+            : base(storeType, typeof(bool), converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -54,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new BoolTypeMapping(storeType, Converter, Comparer, DbType);
+            => new BoolTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -63,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new BoolTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new BoolTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     Generates the SQL representation of a literal value.

--- a/src/EFCore.Relational/Storage/ByteArrayTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/ByteArrayTypeMapping.cs
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             [NotNull] string storeType,
             DbType? dbType,
             int? size)
-            : this(storeType, null, null, dbType, size)
+            : this(storeType, null, null, null, dbType, size)
         {
         }
 
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             DbType? dbType = null,
             int? size = null,
             bool fixedLength = false)
-            : this(storeType, null, null, dbType, size, fixedLength)
+            : this(storeType, null, null, null, dbType, size, fixedLength)
         {
         }
 
@@ -58,6 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
         /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
+        /// <param name="keyComparer"> Supports custom comparisons between keys--e.g. PK to FK comparison. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <param name="fixedLength"> A value indicating whether the type is constrained to fixed-length data. </param>
@@ -65,10 +66,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null,
             int? size = null,
             bool fixedLength = false)
-            : base(storeType, typeof(byte[]), converter, comparer, dbType, size: size, fixedLength: fixedLength)
+            : base(storeType, typeof(byte[]), converter, comparer, keyComparer, dbType, size: size, fixedLength: fixedLength)
         {
         }
 
@@ -79,7 +81,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new ByteArrayTypeMapping(storeType, Converter, Comparer, DbType, size, IsFixedLength);
+            => new ByteArrayTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType, size, IsFixedLength);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -88,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new ByteArrayTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType, Size, IsFixedLength);
+            => new ByteArrayTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType, Size, IsFixedLength);
 
         /// <summary>
         ///     Generates the SQL representation of a literal value.

--- a/src/EFCore.Relational/Storage/ByteTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/ByteTypeMapping.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public ByteTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -37,13 +37,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
         /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
+        /// <param name="keyComparer"> Supports custom comparisons between keys--e.g. PK to FK comparison. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public ByteTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, typeof(byte), converter, comparer, dbType)
+            : base(storeType, typeof(byte), converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -54,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new ByteTypeMapping(storeType, Converter, Comparer, DbType);
+            => new ByteTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -63,6 +65,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new ByteTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new ByteTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
     }
 }

--- a/src/EFCore.Relational/Storage/CharTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/CharTypeMapping.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public CharTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -37,13 +37,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
         /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
+        /// <param name="keyComparer"> Supports custom comparisons between keys--e.g. PK to FK comparison. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public CharTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, typeof(char), converter, comparer, dbType)
+            : base(storeType, typeof(char), converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -54,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new CharTypeMapping(storeType, Converter, Comparer, DbType);
+            => new CharTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -63,7 +65,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new CharTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new CharTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     Gets the string format to be used to generate SQL literals of this type.

--- a/src/EFCore.Relational/Storage/DateTimeOffsetTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/DateTimeOffsetTypeMapping.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public DateTimeOffsetTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -40,13 +40,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts types to and from the store whenever this mapping is used. </param>
         /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
+        /// <param name="keyComparer"> Supports custom comparisons between keys--e.g. PK to FK comparison. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public DateTimeOffsetTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, typeof(DateTimeOffset), converter, comparer, dbType)
+            : base(storeType, typeof(DateTimeOffset), converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -57,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new DateTimeOffsetTypeMapping(storeType, Converter, Comparer, DbType);
+            => new DateTimeOffsetTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -66,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new DateTimeOffsetTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new DateTimeOffsetTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     Gets the string format to be used to generate SQL literals of this type.

--- a/src/EFCore.Relational/Storage/DateTimeTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/DateTimeTypeMapping.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public DateTimeTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -40,13 +40,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
         /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
+        /// <param name="keyComparer"> Supports custom comparisons between keys--e.g. PK to FK comparison. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public DateTimeTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, typeof(DateTime), converter, comparer, dbType)
+            : base(storeType, typeof(DateTime), converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -57,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new DateTimeTypeMapping(storeType, Converter, Comparer, DbType);
+            => new DateTimeTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -66,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new DateTimeTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new DateTimeTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     Gets the string format to be used to generate SQL literals of this type.

--- a/src/EFCore.Relational/Storage/DecimalTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/DecimalTypeMapping.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public DecimalTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -39,13 +39,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
         /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
+        /// <param name="keyComparer"> Supports custom comparisons between keys--e.g. PK to FK comparison. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public DecimalTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, typeof(decimal), converter, comparer, dbType)
+            : base(storeType, typeof(decimal), converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -56,7 +58,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new DecimalTypeMapping(storeType, Converter, Comparer, DbType);
+            => new DecimalTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -65,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new DecimalTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new DecimalTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     Gets the string format to be used to generate SQL literals of this type.

--- a/src/EFCore.Relational/Storage/DoubleTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/DoubleTypeMapping.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public DoubleTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -38,13 +38,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
         /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
+        /// <param name="keyComparer"> Supports custom comparisons between keys--e.g. PK to FK comparison. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public DoubleTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, typeof(double), converter, comparer, dbType)
+            : base(storeType, typeof(double), converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -55,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new DoubleTypeMapping(storeType, Converter, Comparer, DbType);
+            => new DoubleTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -64,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new DoubleTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new DoubleTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     Generates the SQL representation of a literal value.

--- a/src/EFCore.Relational/Storage/FloatTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/FloatTypeMapping.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public FloatTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -38,13 +38,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
         /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
+        /// <param name="keyComparer"> Supports custom comparisons between keys--e.g. PK to FK comparison. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public FloatTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, typeof(float), converter, comparer, dbType)
+            : base(storeType, typeof(float), converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -55,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new FloatTypeMapping(storeType, Converter, Comparer, DbType);
+            => new FloatTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -64,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new FloatTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new FloatTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     Generates the SQL representation of a literal value.

--- a/src/EFCore.Relational/Storage/GuidTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/GuidTypeMapping.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public GuidTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -38,13 +38,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts types to and from the store whenever this mapping is used. </param>
         /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
+        /// <param name="keyComparer"> Supports custom comparisons between keys--e.g. PK to FK comparison. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public GuidTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, typeof(Guid), converter, comparer, dbType)
+            : base(storeType, typeof(Guid), converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -55,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new GuidTypeMapping(storeType, Converter, Comparer, DbType);
+            => new GuidTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -64,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new GuidTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new GuidTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     Gets the string format to be used to generate SQL literals of this type.

--- a/src/EFCore.Relational/Storage/IntTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/IntTypeMapping.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public IntTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -37,13 +37,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
         /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
+        /// <param name="keyComparer"> Supports custom comparisons between keys--e.g. PK to FK comparison. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public IntTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, typeof(int), converter, comparer, dbType)
+            : base(storeType, typeof(int), converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -54,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new IntTypeMapping(storeType, Converter, Comparer, DbType);
+            => new IntTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -63,6 +65,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new IntTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new IntTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
     }
 }

--- a/src/EFCore.Relational/Storage/LongTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/LongTypeMapping.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public LongTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -37,13 +37,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
         /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
+        /// <param name="keyComparer"> Supports custom comparisons between keys--e.g. PK to FK comparison. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public LongTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, typeof(long), converter, comparer, dbType)
+            : base(storeType, typeof(long), converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -54,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new LongTypeMapping(storeType, Converter, Comparer, DbType);
+            => new LongTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -63,6 +65,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new LongTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new LongTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
     }
 }

--- a/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
@@ -79,7 +79,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             DbType? dbType = null,
             bool unicode = false,
             int? size = null)
-            : this(storeType, clrType, null, null, dbType, unicode, size)
+            : this(storeType, clrType, null, null, null, dbType, unicode, size)
         {
         }
 
@@ -90,6 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="clrType"> The .NET type. </param>
         /// <param name="converter"> Converts types to and from the store whenever this mapping is used. </param>
         /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
+        /// <param name="keyComparer"> Supports custom comparisons between keys--e.g. PK to FK comparison. </param>
         /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
         /// <param name="unicode"> A value indicating whether the type should handle Unicode data or not. </param>
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
@@ -99,11 +100,12 @@ namespace Microsoft.EntityFrameworkCore.Storage
             [NotNull] Type clrType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null,
             bool unicode = false,
             int? size = null,
             bool fixedLength = false)
-            : base(clrType, converter, comparer)
+            : base(clrType, converter, comparer, keyComparer)
         {
             Check.NotEmpty(storeType, nameof(storeType));
 

--- a/src/EFCore.Relational/Storage/SByteTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/SByteTypeMapping.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public SByteTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -37,13 +37,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts types to and from the store whenever this mapping is used. </param>
         /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
+        /// <param name="keyComparer"> Supports custom comparisons between keys--e.g. PK to FK comparison. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public SByteTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, typeof(sbyte), converter, comparer, dbType)
+            : base(storeType, typeof(sbyte), converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -54,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SByteTypeMapping(storeType, Converter, Comparer, DbType);
+            => new SByteTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -63,6 +65,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SByteTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new SByteTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
     }
 }

--- a/src/EFCore.Relational/Storage/ShortTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/ShortTypeMapping.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public ShortTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -37,13 +37,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
         /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
+        /// <param name="keyComparer"> Supports custom comparisons between keys--e.g. PK to FK comparison. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public ShortTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, typeof(short), converter, comparer, dbType)
+            : base(storeType, typeof(short), converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -54,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new ShortTypeMapping(storeType, Converter, Comparer, DbType);
+            => new ShortTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -63,6 +65,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new ShortTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new ShortTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
     }
 }

--- a/src/EFCore.Relational/Storage/StringTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/StringTypeMapping.cs
@@ -32,7 +32,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             DbType? dbType,
             bool unicode,
             int? size)
-            : this(storeType, null, null, dbType, unicode, size)
+            : this(storeType, null, null, null, dbType, unicode, size)
         {
         }
 
@@ -50,7 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             bool unicode = false,
             int? size = null,
             bool fixedLength = false)
-            : this(storeType, null, null, dbType, unicode, size, fixedLength)
+            : this(storeType, null, null, null, dbType, unicode, size, fixedLength)
         {
         }
 
@@ -60,6 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
         /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
+        /// <param name="keyComparer"> Supports custom comparisons between keys--e.g. PK to FK comparison. </param>
         /// <param name="dbType"> The <see cref="System.Data.DbType" /> to be used. </param>
         /// <param name="unicode"> A value indicating whether the type should handle Unicode data or not. </param>
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
@@ -68,11 +69,12 @@ namespace Microsoft.EntityFrameworkCore.Storage
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null,
             bool unicode = false,
             int? size = null,
             bool fixedLength = false)
-            : base(storeType, typeof(string), converter, comparer, dbType, unicode, size, fixedLength)
+            : base(storeType, typeof(string), converter, comparer, keyComparer, dbType, unicode, size, fixedLength)
         {
         }
 
@@ -83,7 +85,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new StringTypeMapping(storeType, Converter, Comparer, DbType, IsUnicode, size, IsFixedLength);
+            => new StringTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType, IsUnicode, size, IsFixedLength);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -92,7 +94,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new StringTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType, IsUnicode, Size, IsFixedLength);
+            => new StringTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType, IsUnicode, Size, IsFixedLength);
 
         /// <summary>
         ///     Generates the escaped SQL representation of a literal value.

--- a/src/EFCore.Relational/Storage/TimeSpanTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/TimeSpanTypeMapping.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public TimeSpanTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -38,13 +38,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts values to and from the store whenever this mapping is used. </param>
         /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
+        /// <param name="keyComparer"> Supports custom comparisons between keys--e.g. PK to FK comparison. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public TimeSpanTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, typeof(TimeSpan), converter, comparer, dbType)
+            : base(storeType, typeof(TimeSpan), converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -55,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new TimeSpanTypeMapping(storeType, Converter, Comparer, DbType);
+            => new TimeSpanTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -64,7 +66,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new TimeSpanTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new TimeSpanTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     Gets the string format to be used to generate SQL literals of this type.

--- a/src/EFCore.Relational/Storage/UIntTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/UIntTypeMapping.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public UIntTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -37,13 +37,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts types to and from the store whenever this mapping is used. </param>
         /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
+        /// <param name="keyComparer"> Supports custom comparisons between keys--e.g. PK to FK comparison. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public UIntTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, typeof(uint), converter, comparer, dbType)
+            : base(storeType, typeof(uint), converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -54,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new UIntTypeMapping(storeType, Converter, Comparer, DbType);
+            => new UIntTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -63,6 +65,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new UIntTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new UIntTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
     }
 }

--- a/src/EFCore.Relational/Storage/ULongTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/ULongTypeMapping.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public ULongTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -37,13 +37,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts types to and from the store whenever this mapping is used. </param>
         /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
+        /// <param name="keyComparer"> Supports custom comparisons between keys--e.g. PK to FK comparison. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public ULongTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, typeof(ulong), converter, comparer, dbType)
+            : base(storeType, typeof(ulong), converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -54,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new ULongTypeMapping(storeType, Converter, Comparer, DbType);
+            => new ULongTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -63,6 +65,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new ULongTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new ULongTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
     }
 }

--- a/src/EFCore.Relational/Storage/UShortTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/UShortTypeMapping.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public UShortTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -37,13 +37,15 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="storeType"> The name of the database type. </param>
         /// <param name="converter"> Converts types to and from the store whenever this mapping is used. </param>
         /// <param name="comparer"> Supports custom value snapshotting and comparisons. </param>
+        /// <param name="keyComparer"> Supports custom comparisons between keys--e.g. PK to FK comparison. </param>
         /// <param name="dbType"> The <see cref="DbType" /> to be used. </param>
         public UShortTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, typeof(ushort), converter, comparer, dbType)
+            : base(storeType, typeof(ushort), converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -54,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="size"> The size of data the property is configured to store, or null if no size is configured. </param>
         /// <returns> The newly created mapping. </returns>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new UShortTypeMapping(storeType, Converter, Comparer, DbType);
+            => new UShortTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///    Returns a new copy of this type mapping with the given <see cref="ValueConverter"/>
@@ -63,6 +65,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new UShortTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new UShortTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
     }
 }

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerByteArrayTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerByteArrayTypeMapping.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             DbType? dbType = System.Data.DbType.Binary,
             int? size = null,
             bool fixedLength = false)
-            : this(storeType, null, null, dbType, size, fixedLength)
+            : this(storeType, null, null, null, dbType, size, fixedLength)
         {
         }
 
@@ -39,10 +39,11 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = System.Data.DbType.Binary,
             int? size = null,
             bool fixedLength = false)
-            : base(storeType, converter, comparer, dbType, size, fixedLength)
+            : base(storeType, converter, comparer, keyComparer, dbType, size, fixedLength)
         {
         }
 
@@ -54,14 +55,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqlServerByteArrayTypeMapping(storeType, Converter, Comparer, DbType, size, IsFixedLength);
+            => new SqlServerByteArrayTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType, size, IsFixedLength);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqlServerByteArrayTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType, Size, IsFixedLength);
+            => new SqlServerByteArrayTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType, Size, IsFixedLength);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerDateTimeOffsetTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerDateTimeOffsetTypeMapping.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqlServerDateTimeOffsetTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = System.Data.DbType.DateTimeOffset)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -35,8 +35,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = System.Data.DbType.DateTimeOffset)
-            : base(storeType, converter, comparer, dbType)
+            : base(storeType, converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -45,14 +46,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqlServerDateTimeOffsetTypeMapping(storeType, Converter, Comparer, DbType);
+            => new SqlServerDateTimeOffsetTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqlServerDateTimeOffsetTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new SqlServerDateTimeOffsetTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerDateTimeTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerDateTimeTypeMapping.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqlServerDateTimeTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -37,8 +37,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, converter, comparer, dbType)
+            : base(storeType, converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -62,14 +63,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqlServerDateTimeTypeMapping(storeType, Converter, Comparer, DbType);
+            => new SqlServerDateTimeTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqlServerDateTimeTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new SqlServerDateTimeTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerDoubleTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerDoubleTypeMapping.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqlServerDoubleTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -33,8 +33,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, converter, comparer, dbType)
+            : base(storeType, converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -43,14 +44,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqlServerDoubleTypeMapping(storeType, Converter, Comparer, DbType);
+            => new SqlServerDoubleTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqlServerDoubleTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new SqlServerDoubleTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerFloatTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerFloatTypeMapping.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqlServerFloatTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -33,8 +33,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, converter, comparer, dbType)
+            : base(storeType, converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -43,14 +44,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqlServerFloatTypeMapping(storeType, Converter, Comparer, DbType);
+            => new SqlServerFloatTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqlServerFloatTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new SqlServerFloatTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerSqlVariantTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerSqlVariantTypeMapping.cs
@@ -20,8 +20,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqlServerSqlVariantTypeMapping(
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter = null,
-            [CanBeNull] ValueComparer comparer = null)
-            : base(storeType, typeof(object), converter, comparer)
+            [CanBeNull] ValueComparer comparer = null,
+            [CanBeNull] ValueComparer keyComparer = null)
+            : base(storeType, typeof(object), converter, comparer, keyComparer)
         {
         }
 
@@ -30,13 +31,13 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqlServerSqlVariantTypeMapping(storeType, Converter, Comparer);
+            => new SqlServerSqlVariantTypeMapping(storeType, Converter, Comparer, KeyComparer);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqlServerSqlVariantTypeMapping(StoreType, ComposeConverter(converter), Comparer);
+            => new SqlServerSqlVariantTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer);
     }
 }

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerStringTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerStringTypeMapping.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             bool unicode = false,
             int? size = null,
             bool fixedLength = false)
-            : this(storeType, null, null, dbType, unicode, size, fixedLength)
+            : this(storeType, null, null, null, dbType, unicode, size, fixedLength)
         {
         }
 
@@ -40,11 +40,12 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType,
             bool unicode = false,
             int? size = null,
             bool fixedLength = false)
-            : base(storeType, converter, comparer, dbType, unicode, size, fixedLength)
+            : base(storeType, converter, comparer, keyComparer, dbType, unicode, size, fixedLength)
         {
             _maxSpecificSize = CalculateSize(unicode, size);
         }
@@ -63,14 +64,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqlServerStringTypeMapping(storeType, Converter, Comparer, DbType, IsUnicode, size, IsFixedLength);
+            => new SqlServerStringTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType, IsUnicode, size, IsFixedLength);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqlServerStringTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType, IsUnicode, Size, IsFixedLength);
+            => new SqlServerStringTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType, IsUnicode, Size, IsFixedLength);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTimeSpanTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTimeSpanTypeMapping.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public SqlServerTimeSpanTypeMapping([NotNull] string storeType, DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -33,8 +33,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, converter, comparer, dbType)
+            : base(storeType, converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -43,14 +44,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqlServerTimeSpanTypeMapping(storeType, Converter, Comparer, DbType);
+            => new SqlServerTimeSpanTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqlServerTimeSpanTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new SqlServerTimeSpanTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
@@ -30,7 +30,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                 null,
                 new ValueComparer<byte[]>(
                     (v1, v2) => StructuralComparisons.StructuralEqualityComparer.Equals(v1, v2),
+                    v => StructuralComparisons.StructuralEqualityComparer.GetHashCode(v),
                     v => v == null ? null : v.ToArray()),
+                null,
                 dbType: DbType.Binary,
                 size: 8);
 

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerUdtTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerUdtTypeMapping.cs
@@ -30,11 +30,12 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [CanBeNull] string udtTypeName = null,
             [CanBeNull] ValueConverter converter = null,
             [CanBeNull] ValueComparer comparer = null,
+            [CanBeNull] ValueComparer keyComparer = null,
             DbType? dbType = null,
             bool unicode = false,
             int? size = null,
             bool fixedLength = false)
-            : base(storeType, clrType, converter, comparer, dbType, unicode, size, fixedLength)
+            : base(storeType, clrType, converter, comparer, keyComparer, dbType, unicode, size, fixedLength)
         {
             UdtTypeName = udtTypeName ?? storeType;
         }
@@ -50,14 +51,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqlServerUdtTypeMapping(storeType, ClrType, UdtTypeName, Converter, Comparer, DbType, IsUnicode, size, IsFixedLength);
+            => new SqlServerUdtTypeMapping(storeType, ClrType, UdtTypeName, Converter, Comparer, KeyComparer, DbType, IsUnicode, size, IsFixedLength);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqlServerUdtTypeMapping(StoreType, ClrType, UdtTypeName, ComposeConverter(converter), Comparer, DbType, IsUnicode, Size, IsFixedLength);
+            => new SqlServerUdtTypeMapping(StoreType, ClrType, UdtTypeName, ComposeConverter(converter), Comparer, KeyComparer, DbType, IsUnicode, Size, IsFixedLength);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteCharTypeMapping.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteCharTypeMapping.cs
@@ -32,8 +32,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, converter, comparer, dbType)
+            : base(storeType, converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -42,14 +43,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqliteCharTypeMapping(storeType, Converter, Comparer, DbType);
+            => new SqliteCharTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqliteCharTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new SqliteCharTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDateTimeOffsetTypeMapping.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDateTimeOffsetTypeMapping.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqliteDateTimeOffsetTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -35,8 +35,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, converter, comparer, dbType)
+            : base(storeType, converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -45,14 +46,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqliteDateTimeOffsetTypeMapping(storeType, Converter, Comparer, DbType);
+            => new SqliteDateTimeOffsetTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqliteDateTimeOffsetTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new SqliteDateTimeOffsetTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDateTimeTypeMapping.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDateTimeTypeMapping.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqliteDateTimeTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -35,8 +35,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, converter, comparer, dbType)
+            : base(storeType, converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -45,14 +46,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqliteDateTimeTypeMapping(storeType, Converter, Comparer, DbType);
+            => new SqliteDateTimeTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqliteDateTimeTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new SqliteDateTimeTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDecimalTypeMapping.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDecimalTypeMapping.cs
@@ -31,8 +31,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, converter, comparer, dbType)
+            : base(storeType, converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -41,14 +42,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqliteDecimalTypeMapping(storeType, Converter, Comparer, DbType);
+            => new SqliteDecimalTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqliteDecimalTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new SqliteDecimalTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteGuidTypeMapping.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteGuidTypeMapping.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         public SqliteGuidTypeMapping(
             [NotNull] string storeType,
             DbType? dbType = null)
-            : this(storeType, null, null, dbType)
+            : this(storeType, null, null, null, dbType)
         {
         }
 
@@ -34,8 +34,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, converter, comparer, dbType)
+            : base(storeType, converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -44,14 +45,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqliteGuidTypeMapping(storeType, Converter, Comparer, DbType);
+            => new SqliteGuidTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqliteGuidTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new SqliteGuidTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteULongTypeMapping.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteULongTypeMapping.cs
@@ -31,8 +31,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             [NotNull] string storeType,
             [CanBeNull] ValueConverter converter,
             [CanBeNull] ValueComparer comparer,
+            [CanBeNull] ValueComparer keyComparer,
             DbType? dbType = null)
-            : base(storeType, converter, comparer, dbType)
+            : base(storeType, converter, comparer, keyComparer, dbType)
         {
         }
 
@@ -41,14 +42,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override RelationalTypeMapping Clone(string storeType, int? size)
-            => new SqliteULongTypeMapping(storeType, Converter, Comparer, DbType);
+            => new SqliteULongTypeMapping(storeType, Converter, Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override CoreTypeMapping Clone(ValueConverter converter)
-            => new SqliteULongTypeMapping(StoreType, ComposeConverter(converter), Comparer, DbType);
+            => new SqliteULongTypeMapping(StoreType, ComposeConverter(converter), Comparer, KeyComparer, DbType);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
+++ b/src/EFCore/ChangeTracking/Internal/ChangeDetector.cs
@@ -161,7 +161,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     }
                     else
                     {
-                        if (!comparer.CompareFunc(current, original))
+                        if (!comparer.Equals(current, original))
                         {
                             LogChangeDetected(entry, property, original, current);
                             entry.SetPropertyModified(property);
@@ -203,9 +203,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 var snapshotValue = entry.GetRelationshipSnapshotValue(property);
                 var currentValue = entry[property];
 
+                var comparer = property.GetKeyValueComparer()
+                    ?? property.FindMapping()?.KeyComparer;
+
                 // Note that mutation of a byte[] key is not supported or detected, but two different instances
                 // of byte[] with the same content must be detected as equal.
-                if (!StructuralComparisons.StructuralEqualityComparer.Equals(currentValue, snapshotValue))
+                if (!(comparer?.Equals(currentValue, snapshotValue)
+                      ?? StructuralComparisons.StructuralEqualityComparer.Equals(currentValue, snapshotValue)))
                 {
                     var keys = property.GetContainingKeys().ToList();
                     var foreignKeys = property.GetContainingForeignKeys()

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -869,7 +869,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         private static bool ValuesEqual(IProperty property, object value, object currentValue)
             => (property.GetValueComparer()
                 ?? property.FindMapping()?.Comparer)
-               ?.CompareFunc(currentValue, value)
+               ?.Equals(currentValue, value)
                ?? Equals(currentValue, value);
 
         /// <summary>

--- a/src/EFCore/ChangeTracking/Internal/ValueComparerExtensions.cs
+++ b/src/EFCore/ChangeTracking/Internal/ValueComparerExtensions.cs
@@ -1,0 +1,63 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public static class ValueComparerExtensions
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static ValueComparer ToNonNullNullableComparer([NotNull] this ValueComparer comparer)
+        {
+            var type = comparer.EqualsExpression.Parameters[0].Type;
+            var nullableType = type.MakeNullable();
+
+            var newEqualsParam1 = Expression.Parameter(nullableType, "v1");
+            var newEqualsParam2 = Expression.Parameter(nullableType, "v2");
+            var newHashCodeParam = Expression.Parameter(nullableType, "v");
+            var newSnapshotParam = Expression.Parameter(nullableType, "v");
+
+            return (ValueComparer)Activator.CreateInstance(
+                typeof(NonNullNullableValueComparer<>).MakeGenericType(nullableType),
+                Expression.Lambda(
+                    comparer.ExtractEqualsBody(
+                        Expression.Convert(newEqualsParam1, type),
+                        Expression.Convert(newEqualsParam2, type)),
+                    newEqualsParam1, newEqualsParam2),
+                Expression.Lambda(
+                    comparer.ExtractHashCodeBody(
+                        Expression.Convert(newHashCodeParam, type)),
+                    newHashCodeParam),
+                Expression.Lambda(
+                    Expression.Convert(
+                        comparer.ExtractSnapshotBody(
+                            Expression.Convert(newSnapshotParam, type)),
+                        nullableType),
+                    newSnapshotParam));
+        }
+
+        private class NonNullNullableValueComparer<T> : ValueComparer<T>
+        {
+            public NonNullNullableValueComparer(
+                LambdaExpression equalsExpression,
+                LambdaExpression hashCodeExpression,
+                LambdaExpression snapshotExpression)
+                : base(
+                    (Expression<Func<T, T, bool>>)equalsExpression,
+                    (Expression<Func<T, int>>)hashCodeExpression,
+                    (Expression<Func<T, T>>)snapshotExpression)
+            {
+            }
+        }
+    }
+}

--- a/src/EFCore/ChangeTracking/ValueComparer.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer.cs
@@ -2,8 +2,13 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
+using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Remotion.Linq.Parsing.ExpressionVisitors;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking
 {
@@ -23,23 +28,47 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     /// </summary>
     public abstract class ValueComparer
     {
+        internal static readonly MethodInfo EqualityComparerHashCodeMethod
+            = typeof(IEqualityComparer).GetTypeInfo()
+                .GetDeclaredMethod(nameof(IEqualityComparer.GetHashCode));
+
+        internal static readonly MethodInfo EqualityComparerEqualsMethod
+            = typeof(IEqualityComparer).GetTypeInfo()
+                .GetDeclaredMethod(nameof(IEqualityComparer.Equals));
+
+        internal static readonly MethodInfo ObjectEqualsMethod = typeof(object).GetTypeInfo().DeclaredMethods.Single(
+            m => m.IsStatic
+                 && m.ReturnType == typeof(bool)
+                 && nameof(object.Equals).Equals(m.Name, StringComparison.Ordinal)
+                 && m.IsPublic
+                 && m.GetParameters().Length == 2
+                 && m.GetParameters()[0].ParameterType == typeof(object)
+                 && m.GetParameters()[1].ParameterType == typeof(object));
+
+        internal static readonly MethodInfo ObjectGetHashCodeMethod = typeof(object).GetTypeInfo().DeclaredMethods.Single(
+            m => m.ReturnType == typeof(int)
+                 && nameof(GetHashCode).Equals(m.Name, StringComparison.Ordinal)
+                 && m.IsPublic
+                 && m.GetParameters().Length == 0);
+
         /// <summary>
         ///     Creates a new <see cref="ValueComparer" /> with the given comparison and
         ///     snapshotting expressions.
         /// </summary>
-        /// <param name="compareFunc"> The compare expression compiled into a untyped delegate. </param>
-        /// <param name="snapshotFunc"> The snapshot expression compiled into a untyped delegate. </param>
-        /// <param name="compareExpression"> The comparison expression. </param>
+        /// <param name="equalsExpression"> The comparison expression. </param>
+        /// <param name="hashCodeExpression"> The associated hash code generator. </param>
         /// <param name="snapshotExpression"> The snapshot expression. </param>
         protected ValueComparer(
-            [NotNull] Func<object, object, bool> compareFunc,
-            [NotNull] Func<object, object> snapshotFunc,
-            [NotNull] LambdaExpression compareExpression,
+            [NotNull] LambdaExpression equalsExpression,
+            [NotNull] LambdaExpression hashCodeExpression,
             [NotNull] LambdaExpression snapshotExpression)
         {
-            CompareFunc = compareFunc;
-            SnapshotFunc = snapshotFunc;
-            CompareExpression = compareExpression;
+            Check.NotNull(equalsExpression, nameof(equalsExpression));
+            Check.NotNull(hashCodeExpression, nameof(hashCodeExpression));
+            Check.NotNull(snapshotExpression, nameof(snapshotExpression));
+
+            EqualsExpression = equalsExpression;
+            HashCodeExpression = hashCodeExpression;
             SnapshotExpression = snapshotExpression;
         }
 
@@ -51,7 +80,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// <summary>
         ///     The comparison expression compiled into an untyped delegate.
         /// </summary>
-        public virtual Func<object, object, bool> CompareFunc { get; }
+        public new abstract Func<object, object, bool> Equals { get; }
+
+        /// <summary>
+        ///     The hash code expression compiled into an untyped delegate.
+        /// </summary>
+        public abstract Func<object, int> HashCode { get; }
 
         /// <summary>
         ///     <para>
@@ -64,12 +98,17 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///         reference.
         ///     </para>
         /// </summary>
-        public virtual Func<object, object> SnapshotFunc { get; }
+        public abstract Func<object, object> Snapshot { get; }
 
         /// <summary>
         ///     The comparison expression.
         /// </summary>
-        public virtual LambdaExpression CompareExpression { get; }
+        public virtual LambdaExpression EqualsExpression { get; }
+
+        /// <summary>
+        ///     The hash code expression.
+        /// </summary>
+        public virtual LambdaExpression HashCodeExpression { get; }
 
         /// <summary>
         ///     <para>
@@ -83,5 +122,62 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///     </para>
         /// </summary>
         public virtual LambdaExpression SnapshotExpression { get; }
+
+        /// <summary>
+        ///     Takes <see cref="EqualsExpression" /> and replaces the two parameters with the given expressions,
+        ///     returning the transformed body.
+        /// </summary>
+        /// <param name="leftExpression"> The new left expression. </param>
+        /// <param name="rightExpression"> The new right expression. </param>
+        /// <returns> The body of the lambda with left and right parameters replaced.</returns>
+        public virtual Expression ExtractEqualsBody(
+            [NotNull] Expression leftExpression,
+            [NotNull] Expression rightExpression)
+        {
+            Check.NotNull(leftExpression, nameof(leftExpression));
+            Check.NotNull(rightExpression, nameof(rightExpression));
+
+            return ReplacingExpressionVisitor.Replace(
+                EqualsExpression.Parameters[1],
+                rightExpression,
+                ReplacingExpressionVisitor.Replace(
+                    EqualsExpression.Parameters[0],
+                    leftExpression,
+                    EqualsExpression.Body));
+        }
+
+        /// <summary>
+        ///     Takes the <see cref="HashCodeExpression"/> and replaces the parameter with the given expression, 
+        ///     returning the transformed body.
+        /// </summary>
+        /// <param name="expression"> The new expression. </param>
+        /// <returns> The body of the lambda with the parameter replaced.</returns>
+        public virtual Expression ExtractHashCodeBody(
+            [NotNull] Expression expression)
+        {
+            Check.NotNull(expression, nameof(expression));
+
+            return ReplacingExpressionVisitor.Replace(
+                HashCodeExpression.Parameters[0],
+                expression,
+                HashCodeExpression.Body);
+        }
+
+        /// <summary>
+        ///     Takes the <see cref="SnapshotExpression"/> and replaces the parameter with the given expression, 
+        ///     returning the transformed body.
+        /// </summary>
+        /// <param name="expression"> The new expression. </param>
+        /// <returns> The body of the lambda with the parameter replaced.</returns>
+        public virtual Expression ExtractSnapshotBody(
+            [NotNull] Expression expression)
+        {
+            Check.NotNull(expression, nameof(expression));
+
+            return ReplacingExpressionVisitor.Replace(
+                SnapshotExpression.Parameters[0],
+                expression,
+                SnapshotExpression.Body);
+        }
     }
 }

--- a/src/EFCore/ChangeTracking/ValueComparer`.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer`.cs
@@ -2,8 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
+using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.ChangeTracking
 {
@@ -24,14 +28,35 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     /// <typeparam name="T"> The type. </typeparam>
     public class ValueComparer<T> : ValueComparer
     {
+        private Func<object, object, bool> _equals;
+        private Func<object, int> _hashCode;
+        private Func<object, object> _snapshotFunc;
+
+        /// <summary>
+        ///     Creates a new <see cref="ValueComparer{T}" /> with a default comparison
+        ///     expression and a shallow copy for the snapshot.
+        /// </summary>
+        /// <param name="favorStructuralComparisons">
+        ///     If <c>true</c>, then EF will use <see cref="IStructuralEquatable" /> if the type
+        ///     implements it. This is usually used when byte arrays act as keys.
+        /// </param>
+        public ValueComparer(bool favorStructuralComparisons)
+            : this(
+                CreateDefaultEqualsExpression(favorStructuralComparisons),
+                CreateDefaultHashCodeExpression(favorStructuralComparisons))
+        {
+        }
+
         /// <summary>
         ///     Creates a new <see cref="ValueComparer{T}" /> with the given comparison expression.
         ///     A shallow copy will be used for the snapshot.
         /// </summary>
-        /// <param name="compareExpression"> The comparison expression. </param>
+        /// <param name="equalsExpression"> The comparison expression. </param>
+        /// <param name="hashCodeExpression"> The associated hash code generator. </param>
         public ValueComparer(
-            [NotNull] Expression<Func<T, T, bool>> compareExpression)
-            : this(compareExpression, v => v)
+            [NotNull] Expression<Func<T, T, bool>> equalsExpression,
+            [NotNull] Expression<Func<T, int>> hashCodeExpression)
+            : this(equalsExpression, hashCodeExpression, v => v)
         {
         }
 
@@ -47,18 +72,169 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         ///         reference.
         ///     </para>
         /// </summary>
-        /// <param name="compareExpression"> The comparison expression. </param>
+        /// <param name="equalsExpression"> The comparison expression. </param>
+        /// <param name="hashCodeExpression"> The associated hash code generator. </param>
         /// <param name="snapshotExpression"> The snapshot expression. </param>
         public ValueComparer(
-            [NotNull] Expression<Func<T, T, bool>> compareExpression,
+            [NotNull] Expression<Func<T, T, bool>> equalsExpression,
+            [NotNull] Expression<Func<T, int>> hashCodeExpression,
             [NotNull] Expression<Func<T, T>> snapshotExpression)
-            : base(
-                Compile(compareExpression),
-                Compile(snapshotExpression),
-                compareExpression,
-                snapshotExpression)
+            : base(equalsExpression, hashCodeExpression, snapshotExpression)
         {
         }
+
+        private static Expression<Func<T, T, bool>> CreateDefaultEqualsExpression(bool favorStructuralComparisons)
+        {
+            var type = typeof(T);
+            var param1 = Expression.Parameter(type, "v1");
+            var param2 = Expression.Parameter(type, "v2");
+
+            if (favorStructuralComparisons
+                && typeof(IStructuralEquatable).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()))
+            {
+                return Expression.Lambda<Func<T, T, bool>>(
+                    Expression.Call(
+                        Expression.Constant(StructuralComparisons.StructuralEqualityComparer, typeof(IEqualityComparer)),
+                        EqualityComparerEqualsMethod,
+                        Expression.Convert(param1, typeof(object)),
+                        Expression.Convert(param2, typeof(object))
+                    ),
+                    param1, param2);
+            }
+
+            var unwrappedType = type.UnwrapNullableType();
+            if (unwrappedType.IsInteger()
+                || unwrappedType == typeof(string)
+                || unwrappedType == typeof(Guid)
+                || unwrappedType == typeof(bool)
+                || unwrappedType == typeof(decimal)
+                || unwrappedType == typeof(double)
+                || unwrappedType == typeof(float)
+                || unwrappedType == typeof(object)
+            )
+            {
+                return Expression.Lambda<Func<T, T, bool>>(
+                    Expression.Equal(param1, param2),
+                    param1, param2);
+            }
+
+            var typedEquals = type.GetRuntimeMethods().FirstOrDefault(
+                m => m.ReturnType == typeof(bool)
+                     && !m.IsStatic
+                     && nameof(object.Equals).Equals(m.Name, StringComparison.Ordinal)
+                     && m.GetParameters().Length == 1
+                     && m.GetParameters()[0].ParameterType == typeof(T));
+
+            while (typedEquals == null
+                   && type != null)
+            {
+                var declaredMethods = type.GetTypeInfo().DeclaredMethods;
+                typedEquals = declaredMethods.FirstOrDefault(
+                    m => m.IsStatic
+                         && m.ReturnType == typeof(bool)
+                         && "op_Equality".Equals(m.Name, StringComparison.Ordinal)
+                         && m.GetParameters().Length == 2
+                         && m.GetParameters()[0].ParameterType == typeof(T)
+                         && m.GetParameters()[1].ParameterType == typeof(T));
+
+                type = type.BaseType;
+            }
+
+            return Expression.Lambda<Func<T, T, bool>>(
+                typedEquals == null
+                    ? Expression.Call(
+                        ObjectEqualsMethod,
+                        Expression.Convert(param1, typeof(object)),
+                        Expression.Convert(param2, typeof(object)))
+                    : typedEquals.IsStatic
+                        ? Expression.Call(typedEquals, param1, param2)
+                        : Expression.Call(param1, typedEquals, param2),
+                param1, param2);
+        }
+
+        private static Expression<Func<T, int>> CreateDefaultHashCodeExpression(bool favorStructuralComparisons)
+        {
+            var type = typeof(T);
+            var unwrappedType = type.UnwrapNullableType();
+            var param = Expression.Parameter(type, "v");
+
+            if (favorStructuralComparisons
+                && typeof(IStructuralEquatable).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()))
+            {
+                return Expression.Lambda<Func<T, int>>(
+                    Expression.Call(
+                        Expression.Constant(StructuralComparisons.StructuralEqualityComparer, typeof(IEqualityComparer)),
+                        EqualityComparerHashCodeMethod,
+                        Expression.Convert(param, typeof(object))
+                    ),
+                    param);
+            }
+
+            var expression
+                = type == typeof(int)
+                    ? param
+                    : unwrappedType == typeof(int)
+                      || unwrappedType == typeof(short)
+                      || unwrappedType == typeof(byte)
+                      || unwrappedType == typeof(uint)
+                      || unwrappedType == typeof(ushort)
+                      || unwrappedType == typeof(sbyte)
+                      || unwrappedType == typeof(char)
+                        ? (Expression)Expression.Convert(param, typeof(int))
+                        : Expression.Call(
+                            Expression.Convert(param, typeof(object)), ObjectGetHashCodeMethod);
+
+            return Expression.Lambda<Func<T, int>>(expression, param);
+        }
+
+        /// <summary>
+        ///     The comparison expression compiled into an untyped delegate.
+        /// </summary>
+        public override Func<object, object, bool> Equals
+            => NonCapturingLazyInitializer.EnsureInitialized(
+                ref _equals, this, c => HandleNulls(c.EqualsExpression));
+
+        /// <summary>
+        ///     The hash code expression compiled into an untyped delegate.
+        /// </summary>
+        public override Func<object, int> HashCode
+            => NonCapturingLazyInitializer.EnsureInitialized(
+                ref _hashCode, this, c => HandleNulls(c.HashCodeExpression));
+
+        private static Func<object, object, bool> HandleNulls(Expression<Func<T, T, bool>> expression)
+        {
+            var compiled = expression.Compile();
+
+            return (v1, v2) =>
+            {
+                var v1Null = v1 == null;
+                var v2Null = v2 == null;
+
+                return v1Null || v2Null ? v1Null && v2Null : compiled((T)v1, (T)v2);
+            };
+        }
+
+        private static Func<object, int> HandleNulls(Expression<Func<T, int>> expression)
+        {
+            var compiled = expression.Compile();
+
+            return v => v == null ? 0 : compiled((T)v);
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         The snapshot expression compiled into an untyped delegate.
+        ///     </para>
+        ///     <para>
+        ///         Snapshotting is the process of creating a copy of the value into a snapshot so it can
+        ///         later be compared to determine if it has changed. For some types, such as collections,
+        ///         this needs to be a deep copy of the collection rather than just a shallow copy of the
+        ///         reference.
+        ///     </para>
+        /// </summary>
+        public override Func<object, object> Snapshot
+            => NonCapturingLazyInitializer.EnsureInitialized(
+                ref _snapshotFunc, this, c => Compile(c.SnapshotExpression));
 
         /// <summary>
         ///     The type.
@@ -68,8 +244,14 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// <summary>
         ///     The comparison expression.
         /// </summary>
-        public new virtual Expression<Func<T, T, bool>> CompareExpression
-            => (Expression<Func<T, T, bool>>)base.CompareExpression;
+        public new virtual Expression<Func<T, T, bool>> EqualsExpression
+            => (Expression<Func<T, T, bool>>)base.EqualsExpression;
+
+        /// <summary>
+        ///     The hash code expression.
+        /// </summary>
+        public new virtual Expression<Func<T, int>> HashCodeExpression
+            => (Expression<Func<T, int>>)base.HashCodeExpression;
 
         /// <summary>
         ///     <para>
@@ -84,13 +266,6 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// </summary>
         public new virtual Expression<Func<T, T>> SnapshotExpression
             => (Expression<Func<T, T>>)base.SnapshotExpression;
-
-        private static Func<object, object, bool> Compile(Expression<Func<T, T, bool>> compareExpression)
-        {
-            var compiled = compareExpression.Compile();
-
-            return (l, r) => compiled((T)l, (T)r);
-        }
 
         private static Func<object, object> Compile(Expression<Func<T, T>> snapshotExpression)
         {

--- a/src/EFCore/Extensions/MutablePropertyExtensions.cs
+++ b/src/EFCore/Extensions/MutablePropertyExtensions.cs
@@ -144,17 +144,35 @@ namespace Microsoft.EntityFrameworkCore
         /// <param name="comparer"> The comparer, or <c>null</c> to remove any previously set comparer. </param>
         public static void SetValueComparer([NotNull] this IMutableProperty property, [CanBeNull] ValueComparer comparer)
         {
+            CheckComparerType(property, comparer);
+
+            property[CoreAnnotationNames.ValueComparer] = comparer;
+        }
+
+        /// <summary>
+        ///     Sets the custom <see cref="ValueComparer"/> for this property when performing key comparisons..
+        /// </summary>
+        /// <param name="property"> The property. </param>
+        /// <param name="comparer"> The comparer, or <c>null</c> to remove any previously set comparer. </param>
+        public static void SetKeyValueComparer([NotNull] this IMutableProperty property, [CanBeNull] ValueComparer comparer)
+        {
+            CheckComparerType(property, comparer);
+
+            property[CoreAnnotationNames.KeyValueComparer] = comparer;
+        }
+
+        private static void CheckComparerType(IMutableProperty property, ValueComparer comparer)
+        {
             if (comparer != null
                 && comparer.Type != property.ClrType)
             {
-                throw new ArgumentException(CoreStrings.ComparerPropertyMismatch(
-                    comparer.Type.ShortDisplayName(),
-                    property.DeclaringEntityType.DisplayName(),
-                    property.Name,
-                    property.ClrType.ShortDisplayName()));
+                throw new ArgumentException(
+                    CoreStrings.ComparerPropertyMismatch(
+                        comparer.Type.ShortDisplayName(),
+                        property.DeclaringEntityType.DisplayName(),
+                        property.Name,
+                        property.ClrType.ShortDisplayName()));
             }
-
-            property[CoreAnnotationNames.ValueComparer] = comparer;
         }
     }
 }

--- a/src/EFCore/Extensions/PropertyExtensions.cs
+++ b/src/EFCore/Extensions/PropertyExtensions.cs
@@ -168,5 +168,13 @@ namespace Microsoft.EntityFrameworkCore
         /// <returns> The comparer, or <c>null</c> if none has been set. </returns>
         public static ValueComparer GetValueComparer([NotNull] this IProperty property)
             => (ValueComparer)Check.NotNull(property, nameof(property))[CoreAnnotationNames.ValueComparer];
+
+        /// <summary>
+        ///     Gets the <see cref="ValueComparer"/> for this property, or null if none is set.
+        /// </summary>
+        /// <param name="property"> The property. </param>
+        /// <returns> The comparer, or <c>null</c> if none has been set. </returns>
+        public static ValueComparer GetKeyValueComparer([NotNull] this IProperty property)
+            => (ValueComparer)Check.NotNull(property, nameof(property))[CoreAnnotationNames.KeyValueComparer];
     }
 }

--- a/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
+++ b/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
@@ -79,6 +79,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public const string KeyValueComparer = "KeyValueComparer";
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public const string ProviderClrType = "ProviderClrType";
     }
 }

--- a/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTreeNode.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTreeNode.cs
@@ -258,7 +258,24 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                                 Expression equalityExpression;
 
-                                if (typeof(IStructuralEquatable).GetTypeInfo()
+                                var comparer
+                                    = pk.GetKeyValueComparer()
+                                      ?? pk.FindMapping()?.KeyComparer;
+
+                                if (comparer != null)
+                                {
+                                    if (comparer.Type != pkMemberAccess.Type
+                                        && comparer.Type == pkMemberAccess.Type.UnwrapNullableType())
+                                    {
+                                        comparer = comparer.ToNonNullNullableComparer();
+                                    }
+
+                                    equalityExpression
+                                        = comparer.ExtractEqualsBody(
+                                            pkMemberAccess,
+                                            fkMemberAccess);
+                                }
+                                else if (typeof(IStructuralEquatable).GetTypeInfo()
                                     .IsAssignableFrom(pkMemberAccess.Type.GetTypeInfo()))
                                 {
                                     equalityExpression

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -50,6 +50,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 CoreAnnotationNames.TypeMapping,
                 CoreAnnotationNames.ValueConverter,
                 CoreAnnotationNames.ValueComparer,
+                CoreAnnotationNames.KeyValueComparer,
                 CoreAnnotationNames.ProviderClrType,
                 RelationalAnnotationNames.ColumnName,
                 RelationalAnnotationNames.ColumnType,
@@ -485,6 +486,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Design;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace MyNamespace

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -6012,6 +6012,46 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         }
 
         [Fact]
+        public void SeedData_nonkey_refactoring_value_conversion_with_structural_provider_type()
+        {
+            Execute(
+                common => common.Entity(
+                    "EntityWithOneProperty",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                    }),
+                source => source.Entity(
+                    "EntityWithOneProperty",
+                    x =>
+                    {
+                        x.Property<int>("Value1")
+                            .IsRequired()
+                            .HasConversion(e => new int[] { e }, e => e[0]);
+                        x.SeedData(new
+                        {
+                            Id = 42,
+                            Value1 = 32
+                        });
+                    }),
+                target => target.Entity(
+                    "EntityWithOneProperty",
+                    x =>
+                    {
+                        x.Property<string>("Value1")
+                            .IsRequired()
+                            .HasConversion(e => new int[] { int.Parse(e) }, e => e[0].ToString());
+                        x.SeedData(new
+                        {
+                            Id = 42,
+                            Value1 = "32"
+                        });
+                    }),
+                Assert.Empty,
+                Assert.Empty);
+        }
+
+        [Fact]
         public void SeedData_key_refactoring_value_conversion()
         {
             Execute(

--- a/test/EFCore.Relational.Tests/Storage/RelationalTypeMappingTest.cs
+++ b/test/EFCore.Relational.Tests/Storage/RelationalTypeMappingTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         protected class FakeValueComparer : ValueComparer<object>
         {
             public FakeValueComparer()
-                : base((_, __) => true, _ => _)
+                : base(false)
             {
             }
 
@@ -61,6 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 "<original>",
                 new FakeValueConverter(),
                 new FakeValueComparer(),
+                new FakeValueComparer(),
                 DbType.VarNumeric);
 
             var clone = mapping.Clone("<clone>", null);
@@ -73,6 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.NotNull(mapping.Converter);
             Assert.Same(mapping.Converter, clone.Converter);
             Assert.Same(mapping.Comparer, clone.Comparer);
+            Assert.Same(mapping.KeyComparer, clone.KeyComparer);
             Assert.Same(typeof(object), clone.ClrType);
 
             var newConverter = new FakeValueConverter();
@@ -85,6 +87,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.Null(clone.Size);
             Assert.NotSame(mapping.Converter, clone.Converter);
             Assert.Same(mapping.Comparer, clone.Comparer);
+            Assert.Same(mapping.KeyComparer, clone.KeyComparer);
             Assert.Same(typeof(object), clone.ClrType);
         }
 
@@ -96,6 +99,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 mappingType,
                 "<original>",
                 new FakeValueConverter(),
+                new FakeValueComparer(),
                 new FakeValueComparer(),
                 DbType.VarNumeric,
                 33,
@@ -113,6 +117,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.NotNull(mapping.Converter);
             Assert.Same(mapping.Converter, clone.Converter);
             Assert.Same(mapping.Comparer, clone.Comparer);
+            Assert.Same(mapping.KeyComparer, clone.KeyComparer);
             Assert.Same(typeof(object), clone.ClrType);
             Assert.True(mapping.IsFixedLength);
             Assert.True(clone.IsFixedLength);
@@ -129,6 +134,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.Equal(33, clone.Size);
             Assert.NotSame(mapping.Converter, clone.Converter);
             Assert.Same(mapping.Comparer, clone.Comparer);
+            Assert.Same(mapping.KeyComparer, clone.KeyComparer);
             Assert.Same(typeof(object), clone.ClrType);
             Assert.True(mapping.IsFixedLength);
             Assert.True(clone.IsFixedLength);
@@ -142,6 +148,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 mappingType,
                 "<original>",
                 new FakeValueConverter(),
+                new FakeValueComparer(),
                 new FakeValueComparer(),
                 DbType.VarNumeric,
                 false,
@@ -162,6 +169,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.NotNull(mapping.Converter);
             Assert.Same(mapping.Converter, clone.Converter);
             Assert.Same(mapping.Comparer, clone.Comparer);
+            Assert.Same(mapping.KeyComparer, clone.KeyComparer);
             Assert.Same(typeof(object), clone.ClrType);
             Assert.True(mapping.IsFixedLength);
             Assert.True(clone.IsFixedLength);
@@ -180,6 +188,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.False(clone.IsUnicode);
             Assert.NotSame(mapping.Converter, clone.Converter);
             Assert.Same(mapping.Comparer, clone.Comparer);
+            Assert.Same(mapping.KeyComparer, clone.KeyComparer);
             Assert.Same(typeof(object), clone.ClrType);
             Assert.True(mapping.IsFixedLength);
             Assert.True(clone.IsFixedLength);

--- a/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingTest.cs
+++ b/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingTest.cs
@@ -122,6 +122,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 "udtType",
                 new FakeValueConverter(),
                 new FakeValueComparer(),
+                new FakeValueComparer(),
                 DbType.VarNumeric,
                 false,
                 33,
@@ -143,6 +144,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.NotNull(mapping.Converter);
             Assert.Same(mapping.Converter, clone.Converter);
             Assert.Same(mapping.Comparer, clone.Comparer);
+            Assert.Same(mapping.KeyComparer, clone.KeyComparer);
             Assert.Same(typeof(object), clone.ClrType);
             Assert.True(mapping.IsFixedLength);
             Assert.True(clone.IsFixedLength);
@@ -163,6 +165,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Assert.False(clone.IsUnicode);
             Assert.NotSame(mapping.Converter, clone.Converter);
             Assert.Same(mapping.Comparer, clone.Comparer);
+            Assert.Same(mapping.KeyComparer, clone.KeyComparer);
             Assert.Same(typeof(object), clone.ClrType);
             Assert.True(mapping.IsFixedLength);
             Assert.True(clone.IsFixedLength);

--- a/test/EFCore.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/ChangeDetectorTest.cs
@@ -248,6 +248,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             {
                 var intArrayComparer = new ValueComparer<int[]>(
                     (l, r) => (l == null || r == null) ? (l == r) : l.SequenceEqual(r),
+                    v => v == null ? 0 : v.Aggregate(0, (t, e) => (t * 397) ^ e),
                     v => v == null ? null : v.ToArray());
 
                 var intArrayConverter = new ValueConverter<int[], string>(

--- a/test/EFCore.Tests/Storage/ValueComparerTest.cs
+++ b/test/EFCore.Tests/Storage/ValueComparerTest.cs
@@ -1,0 +1,621 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    public class ValueComparerTest
+    {
+        [Theory]
+        [InlineData(typeof(byte), (byte)1, (byte)2, 1)]
+        [InlineData(typeof(ushort), (ushort)1, (ushort)2, 1)]
+        [InlineData(typeof(uint), (uint)1, (uint)2, 1)]
+        [InlineData(typeof(ulong), (ulong)1, (ulong)2, null)]
+        [InlineData(typeof(sbyte), (sbyte)1, (sbyte)2, 1)]
+        [InlineData(typeof(short), (short)1, (short)2, 1)]
+        [InlineData(typeof(int), 1, 2, 1)]
+        [InlineData(typeof(long), (long)1, (long)2, null)]
+        [InlineData(typeof(char), 'A', 'B', (int)'A')]
+        [InlineData(typeof(string), "A", "B", null)]
+        [InlineData(typeof(bool), true, false, null)]
+        [InlineData(typeof(object), 1, "B", null)]
+        [InlineData(typeof(float), (float)1, (float)2, null)]
+        [InlineData(typeof(double), (double)1, (double)2, null)]
+        [InlineData(typeof(JustAnEnum), JustAnEnum.A, JustAnEnum.B, null)]
+        public ValueComparer Default_comparer_works_for_normal_types(Type type, object value1, object value2, int? hashCode)
+        {
+            return CompareTest(type, value1, value2, hashCode);
+        }
+
+        private static ValueComparer CompareTest(Type type, object value1, object value2, int? hashCode = null)
+            => CompareTest(type, value1, value2, hashCode, false);
+
+        private static ValueComparer CompareTest(Type type, object value1, object value2, int? hashCode, bool toNullable)
+        {
+            var comparer = (ValueComparer)Activator.CreateInstance(typeof(ValueComparer<>).MakeGenericType(type), new object[] { false });
+            if (toNullable)
+            {
+                comparer = comparer.ToNonNullNullableComparer();
+            }
+            
+            Assert.True(comparer.Equals(value1, value1));
+            Assert.True(comparer.Equals(value2, value2));
+            Assert.False(comparer.Equals(value1, value2));
+            Assert.False(comparer.Equals(value2, value1));
+            Assert.False(comparer.Equals(value1, null));
+            Assert.False(comparer.Equals(null, value2));
+            Assert.True(comparer.Equals(null, null));
+
+            Assert.Equal(0, comparer.HashCode(null));
+            Assert.Equal(hashCode ?? value1.GetHashCode(), comparer.HashCode(value1));
+
+            var keyComparer = (ValueComparer)Activator.CreateInstance(typeof(ValueComparer<>).MakeGenericType(type), new object[] { true });
+            if (toNullable)
+            {
+                keyComparer = keyComparer.ToNonNullNullableComparer();
+            }
+
+            Assert.True(keyComparer.Equals(value1, value1));
+            Assert.True(keyComparer.Equals(value2, value2));
+            Assert.False(keyComparer.Equals(value1, value2));
+            Assert.False(keyComparer.Equals(value2, value1));
+            Assert.False(keyComparer.Equals(value1, null));
+            Assert.False(keyComparer.Equals(null, value2));
+            Assert.True(keyComparer.Equals(null, null));
+
+            Assert.Equal(0, keyComparer.HashCode(null));
+            Assert.Equal(hashCode ?? value1.GetHashCode(), keyComparer.HashCode(value1));
+
+            return comparer;
+        }
+
+        private enum JustAnEnum : ushort
+        {
+            A,
+            B
+        }
+
+        [Fact]
+        public void Default_comparer_works_for_decimals()
+        {
+            CompareTest(typeof(decimal), (decimal)1, (decimal)2);
+        }
+
+        [Fact]
+        public void Default_comparer_works_for_structs()
+        {
+            CompareTest(
+                typeof(JustAStruct),
+                new JustAStruct
+                {
+                    A = 1,
+                    B = "B1"
+                },
+                new JustAStruct
+                {
+                    A = 1,
+                    B = "B2"
+                });
+
+            CompareTest(
+                typeof(JustAStruct),
+                new JustAStruct
+                {
+                    A = 1,
+                    B = "B"
+                },
+                new JustAStruct
+                {
+                    A = 2,
+                    B = "B"
+                });
+        }
+
+        private struct JustAStruct
+        {
+            public int A { get; set; }
+            public string B { get; set; }
+        }
+
+        [Fact]
+        public void Default_comparer_works_for_structs_with_equality()
+        {
+            CompareTest(
+                typeof(JustAStructWithEquality),
+                new JustAStructWithEquality
+                {
+                    A = 1,
+                    B = "B"
+                },
+                new JustAStructWithEquality
+                {
+                    A = 2,
+                    B = "B"
+                });
+        }
+
+        private struct JustAStructWithEquality
+        {
+            public int A { get; set; }
+            public string B { get; set; }
+
+            private bool Equals(JustAStructWithEquality other) => A == other.A;
+
+            public override bool Equals(object obj)
+                => obj is JustAStructWithEquality o && Equals(o);
+
+            public override int GetHashCode() => A;
+        }
+
+        [Fact]
+        public void Default_comparer_works_for_structs_with_equality_operators()
+        {
+            CompareTest(
+                typeof(JustAStructWithEqualityOperators),
+                new JustAStructWithEqualityOperators
+                {
+                    A = 1,
+                    B = "B"
+                },
+                new JustAStructWithEqualityOperators
+                {
+                    A = 2,
+                    B = "B"
+                });
+        }
+
+#pragma warning disable 660,661
+        private struct JustAStructWithEqualityOperators
+#pragma warning restore 660,661
+        {
+            public int A { get; set; }
+            public string B { get; set; }
+
+            public static bool operator ==(JustAStructWithEqualityOperators left, JustAStructWithEqualityOperators right)
+                => left.A == right.A
+                   && left.B == right.B;
+
+            public static bool operator !=(JustAStructWithEqualityOperators left, JustAStructWithEqualityOperators right)
+                => !(left == right);
+        }
+
+        [Fact]
+        public void Default_comparer_works_for_classes()
+        {
+            CompareTest(
+                typeof(JustAClass), // Reference equality
+                new JustAClass
+                {
+                    A = 1
+                },
+                new JustAClass
+                {
+                    A = 1
+                });
+        }
+
+        private class JustAClass
+        {
+            public int A { get; set; }
+        }
+
+        [Fact]
+        public void Default_comparer_works_for_classes_with_equality_members()
+        {
+            var comparer = CompareTest(
+                typeof(JustAClassWithEquality),
+                new JustAClassWithEquality
+                {
+                    A = 1
+                },
+                new JustAClassWithEquality
+                {
+                    A = 2
+                });
+
+            Assert.True(
+                comparer.Equals(
+                    new JustAClassWithEquality
+                    {
+                        A = 1
+                    },
+                    new JustAClassWithEquality
+                    {
+                        A = 1
+                    }));
+        }
+
+        private sealed class JustAClassWithEquality
+        {
+            public int A { get; set; }
+
+            private bool Equals(JustAClassWithEquality other) => A == other.A;
+
+            public override bool Equals(object obj)
+                => !(obj is null)
+                   && (ReferenceEquals(this, obj)
+                       || obj is JustAClassWithEquality o
+                       && Equals(o));
+
+            public override int GetHashCode() => A;
+        }
+
+        [Fact]
+        public void Default_comparer_works_for_classes_with_equality_operators()
+        {
+            var comparer = CompareTest(
+                typeof(JustAClassWithEqualityOperators),
+                new JustAClassWithEqualityOperators
+                {
+                    A = 1
+                },
+                new JustAClassWithEqualityOperators
+                {
+                    A = 2
+                });
+
+            Assert.True(
+                comparer.Equals(
+                    new JustAClassWithEqualityOperators
+                    {
+                        A = 1
+                    },
+                    new JustAClassWithEqualityOperators
+                    {
+                        A = 1
+                    }));
+        }
+
+#pragma warning disable 660,661
+        private sealed class JustAClassWithEqualityOperators
+#pragma warning restore 660,661
+        {
+            public int A { get; set; }
+
+            private static bool InternalEquals(JustAClassWithEqualityOperators left, JustAClassWithEqualityOperators right)
+                => left is null
+                   || right is null
+                    ? left is null && right is null
+                    : left.A == right.A;
+
+            public static bool operator ==(JustAClassWithEqualityOperators left, JustAClassWithEqualityOperators right)
+                => InternalEquals(left, right);
+
+            public static bool operator !=(JustAClassWithEqualityOperators left, JustAClassWithEqualityOperators right)
+                => !InternalEquals(left, right);
+        }
+
+        public void GenericCompareTest<T>(T value1, T value2, int? hashCode = null)
+        {
+            var comparer = new ValueComparer<T>(false);
+            var equals = comparer.EqualsExpression.Compile();
+            var getHashCode = comparer.HashCodeExpression.Compile();
+
+            Assert.True(equals(value1, value1));
+            Assert.True(equals(value2, value2));
+            Assert.False(equals(value1, value2));
+            Assert.False(equals(value2, value1));
+
+            var keyComparer = new ValueComparer<T>(true);
+            var keyEquals = keyComparer.EqualsExpression.Compile();
+            var getKeyHashCode = keyComparer.HashCodeExpression.Compile();
+
+            Assert.True(keyEquals(value1, value1));
+            Assert.True(keyEquals(value2, value2));
+            Assert.False(keyEquals(value1, value2));
+            Assert.False(keyEquals(value2, value1));
+
+            Assert.Equal(hashCode ?? value1.GetHashCode(), getHashCode(value1));
+
+            Assert.Equal(hashCode ?? value1.GetHashCode(), getKeyHashCode(value1));
+        }
+
+        [Fact]
+        public void Default_raw_comparer_works_for_non_null_normal_types()
+        {
+            GenericCompareTest<byte>(1, 2, 1);
+            GenericCompareTest<ushort>(1, 2, 1);
+            GenericCompareTest<uint>(1, 2, 1);
+            GenericCompareTest<ulong>(1, 2);
+            GenericCompareTest<sbyte>(1, 2, 1);
+            GenericCompareTest<short>(1, 2, 1);
+            GenericCompareTest(1, 2, 1);
+            GenericCompareTest<long>(1, 2);
+            GenericCompareTest<float>(1, 2);
+            GenericCompareTest<double>(1, 2);
+            GenericCompareTest<decimal>(1, 2);
+            GenericCompareTest('A', 'B', (int)'A');
+            GenericCompareTest("A", "B");
+            GenericCompareTest<object>(1, "A");
+            GenericCompareTest(JustAnEnum.A, JustAnEnum.B);
+            GenericCompareTest(new JustAClass { A = 1 }, new JustAClass { A = 2 });
+            GenericCompareTest(new JustAClassWithEquality { A = 1 }, new JustAClassWithEquality { A = 2 });
+            GenericCompareTest(new JustAClassWithEqualityOperators { A = 1 }, new JustAClassWithEqualityOperators { A = 2 });
+            GenericCompareTest(new JustAStruct { A = 1 }, new JustAStruct { A = 2 });
+            GenericCompareTest(new JustAStructWithEquality { A = 1 }, new JustAStructWithEquality { A = 2 });
+            GenericCompareTest(new JustAStructWithEqualityOperators { A = 1 }, new JustAStructWithEqualityOperators { A = 2 });
+        }
+
+        [Fact]
+        public void Default_comparer_works_for_normal_types_mixing_nullables()
+        {
+            CompareTest(typeof(byte), (byte)1, (byte?)2, 1);
+            CompareTest(typeof(ushort), (ushort?)1, (ushort?)2, 1);
+            CompareTest(typeof(uint), (uint?)1, (uint)2, 1);
+            CompareTest(typeof(ulong), (ulong)1, (ulong?)2);
+            CompareTest(typeof(sbyte), (sbyte?)1, (sbyte)2, 1);
+            CompareTest(typeof(short), (short)1, (short?)2, 1);
+            CompareTest(typeof(int), (int?)1, 2, 1);
+            CompareTest(typeof(long), (long)1, (long?)2);
+            CompareTest(typeof(float), (float?)1, (float)2);
+            CompareTest(typeof(double), (double)1, (double?)2);
+            CompareTest(typeof(decimal), (decimal?)1, (decimal)2);
+            CompareTest(typeof(char), (char)1, (char?)2, 1);
+            CompareTest(typeof(JustAnEnum), JustAnEnum.A, (JustAnEnum?)JustAnEnum.B);
+
+            CompareTest(
+                typeof(JustAStruct),
+                (JustAStruct?)new JustAStruct { A = 1 },
+                new JustAStruct { A = 2 });
+
+            CompareTest(
+                typeof(JustAStructWithEquality),
+                (JustAStructWithEquality?)new JustAStructWithEquality { A = 1 },
+                new JustAStructWithEquality { A = 2 });
+
+            CompareTest(
+                typeof(JustAStructWithEqualityOperators),
+                (JustAStructWithEqualityOperators?)new JustAStructWithEqualityOperators { A = 1 },
+                new JustAStructWithEqualityOperators { A = 2 });
+        }
+
+        [Fact]
+        public void Default_comparer_works_for_normal_nullable_types_mixing_nullables()
+        {
+            CompareTest(typeof(byte?), (byte)1, (byte?)2, 1);
+            CompareTest(typeof(ushort?), (ushort?)1, (ushort?)2, 1);
+            CompareTest(typeof(uint?), (uint?)1, (uint)2, 1);
+            CompareTest(typeof(ulong?), (ulong)1, (ulong?)2);
+            CompareTest(typeof(sbyte?), (sbyte?)1, (sbyte)2, 1);
+            CompareTest(typeof(short?), (short)1, (short?)2, 1);
+            CompareTest(typeof(int?), (int?)1, 2, 1);
+            CompareTest(typeof(long?), (long)1, (long?)2);
+            CompareTest(typeof(float?), (float?)1, (float)2);
+            CompareTest(typeof(double?), (double)1, (double?)2);
+            CompareTest(typeof(decimal?), (decimal?)1, (decimal)2);
+            CompareTest(typeof(char?), (char)1, (char?)2, 1);
+            CompareTest(typeof(JustAnEnum?), JustAnEnum.A, (JustAnEnum?)JustAnEnum.B);
+
+            CompareTest(
+                typeof(JustAStruct?),
+                (JustAStruct?)new JustAStruct { A = 1 },
+                new JustAStruct { A = 2 });
+
+            CompareTest(
+                typeof(JustAStructWithEquality?),
+                (JustAStructWithEquality?)new JustAStructWithEquality { A = 1 },
+                new JustAStructWithEquality { A = 2 });
+
+            CompareTest(
+                typeof(JustAStructWithEqualityOperators?),
+                (JustAStructWithEqualityOperators?)new JustAStructWithEqualityOperators { A = 1 },
+                new JustAStructWithEqualityOperators { A = 2 });
+        }
+
+        [Fact]
+        public void Can_clone_to_nullable()
+        {
+            CompareTest(typeof(byte), (byte)1, (byte?)2, 1, true);
+            CompareTest(typeof(ushort), (ushort?)1, (ushort?)2, 1, true);
+            CompareTest(typeof(uint), (uint?)1, (uint)2, 1, true);
+            CompareTest(typeof(ulong), (ulong)1, (ulong?)2, null, true);
+            CompareTest(typeof(sbyte), (sbyte?)1, (sbyte)2, 1, true);
+            CompareTest(typeof(short), (short)1, (short?)2, 1, true);
+            CompareTest(typeof(int), (int?)1, 2, 1, true);
+            CompareTest(typeof(long), (long)1, (long?)2, null, true);
+            CompareTest(typeof(float), (float?)1, (float)2, null, true);
+            CompareTest(typeof(double), (double)1, (double?)2, null, true);
+            CompareTest(typeof(decimal), (decimal?)1, (decimal)2, null, true);
+            CompareTest(typeof(char), (char)1, (char?)2, 1, true);
+            CompareTest(typeof(JustAnEnum), JustAnEnum.A, (JustAnEnum?)JustAnEnum.B, null, true);
+
+            CompareTest(
+                typeof(JustAStruct),
+                (JustAStruct?)new JustAStruct { A = 1 },
+                new JustAStruct { A = 2 },
+                null,
+                true);
+
+            CompareTest(
+                typeof(JustAStructWithEquality),
+                (JustAStructWithEquality?)new JustAStructWithEquality { A = 1 },
+                new JustAStructWithEquality { A = 2 },
+                null,
+                true);
+
+            CompareTest(
+                typeof(JustAStructWithEqualityOperators),
+                (JustAStructWithEqualityOperators?)new JustAStructWithEqualityOperators { A = 1 },
+                new JustAStructWithEqualityOperators { A = 2 },
+                null,
+                true);
+        }
+
+        [Fact]
+        public void Structural_objects_get_deep_key_comperer_by_default()
+        {
+            var comparer = new ValueComparer<byte[]>(false);
+            var keyComparer = new ValueComparer<byte[]>(true);
+
+            var equals = comparer.EqualsExpression.Compile();
+            var keyEquals = keyComparer.EqualsExpression.Compile();
+            var getHashCode = comparer.HashCodeExpression.Compile();
+            var getKeyHashCode = keyComparer.HashCodeExpression.Compile();
+
+            var value1a = new byte[] { 1, 2 };
+            var value1b = new byte[] { 1, 2 };
+            var value2 = new byte[] { 2, 1 };
+
+            Assert.True(equals(value1a, value1a));
+            Assert.False(equals(value1a, value1b));
+            Assert.False(equals(value1a, value2));
+
+            Assert.True(keyEquals(value1a, value1a));
+            Assert.True(keyEquals(value1a, value1b));
+            Assert.False(keyEquals(value1a, value2));
+
+            Assert.Equal(value1a.GetHashCode(), getHashCode(value1a));
+            Assert.NotEqual(value1a.GetHashCode(), getKeyHashCode(value1a));
+        }
+
+        private class Binary
+        {
+            public Binary(byte value0, byte value1)
+            {
+                Value0 = value0;
+                Value1 = value1;
+            }
+
+            public byte Value0 { get; }
+            public byte Value1 { get; }
+        }
+
+        [Fact]
+        public void Can_define_different_custom_equals_for_key_and_non_key()
+        {
+            var comparer = new ValueComparer<Binary>(
+                (v1, v2) => v1.Equals(v2),
+                v => v.GetHashCode());
+
+            var keyComparer = new ValueComparer<Binary>(
+                (v1, v2) => v1.Value0 == v2.Value0 && v1.Value1 == v2.Value1,
+                v => v.Value0 << 8 | v.Value1);
+
+            var equals = comparer.EqualsExpression.Compile();
+            var keyEquals = keyComparer.EqualsExpression.Compile();
+            var getHashCode = comparer.HashCodeExpression.Compile();
+            var getKeyHashCode = keyComparer.HashCodeExpression.Compile();
+
+            var value1a = new Binary(1, 2);
+            var value1b = new Binary(1, 2);
+            var value2 = new Binary(2, 1);
+
+            Assert.True(equals(value1a, value1a));
+            Assert.False(equals(value1a, value1b));
+            Assert.False(equals(value1a, value2));
+
+            Assert.True(keyEquals(value1a, value1a));
+            Assert.True(keyEquals(value1a, value1b));
+            Assert.False(keyEquals(value1a, value2));
+
+            Assert.Equal(value1a.GetHashCode(), getHashCode(value1a));
+            Assert.Equal(258, getKeyHashCode(value1a));
+        }
+
+        private class DeepBinary
+        {
+            public DeepBinary(byte[] value0, byte[] value1)
+            {
+                Value0 = value0;
+                Value1 = value1;
+            }
+
+            public byte[] Value0 { get; }
+            public byte[] Value1 { get; }
+        }
+
+        private static readonly MethodInfo _getValue0Method
+            = typeof(DeepBinary).GetProperty(nameof(DeepBinary.Value0)).GetMethod;
+
+        private static readonly MethodInfo _getValue1Method
+            = typeof(DeepBinary).GetProperty(nameof(DeepBinary.Value1)).GetMethod;
+
+        [Fact]
+        public void Can_create_new_comparer_composing_existing_comparers()
+        {
+            var bytesComparer = new ValueComparer<byte[]>(false);
+            var bytesKeyComparer = new ValueComparer<byte[]>(true);
+
+            var comparer = new ValueComparer<DeepBinary>(
+                (Expression<Func<DeepBinary, DeepBinary, bool>>)CreateAndExpression(bytesComparer),
+                (Expression<Func<DeepBinary, int>>)CreateHashCodeExpression(bytesComparer));
+
+            var keyComparer = new ValueComparer<DeepBinary>(
+                (Expression<Func<DeepBinary, DeepBinary, bool>>)CreateAndExpression(bytesKeyComparer),
+                (Expression<Func<DeepBinary, int>>)CreateHashCodeExpression(bytesKeyComparer));
+
+            var equals = comparer.EqualsExpression.Compile();
+            var keyEquals = keyComparer.EqualsExpression.Compile();
+            var getHashCode = comparer.HashCodeExpression.Compile();
+            var getKeyHashCode = keyComparer.HashCodeExpression.Compile();
+
+            var array1a = new byte[] { 1, 2 };
+            var array1b = new byte[] { 1, 2 };
+            var array2 = new byte[] { 2, 1 };
+
+            var value1a = new DeepBinary(array1a, array2);
+            var value1b = new DeepBinary(array1a, array2);
+            var value1c = new DeepBinary(array1b, array2);
+            var value2 = new DeepBinary(array2, array1a);
+
+            Assert.True(equals(value1a, value1a));
+            Assert.True(equals(value1a, value1b)); // Underlying array instances the same
+            Assert.False(equals(value1a, value1c)); // Underlying array instances different
+            Assert.False(keyEquals(value1a, value2)); // Underlying array instances different values
+
+            Assert.True(keyEquals(value1a, value1a));
+            Assert.True(keyEquals(value1a, value1b)); // Underlying array instances the same
+            Assert.True(keyEquals(value1a, value1c)); // Underlying array instances same values
+            Assert.False(keyEquals(value1a, value2)); // Underlying array instances different values
+
+            Assert.Equal(getHashCode(value1b), getHashCode(value1a));
+            Assert.Equal(getKeyHashCode(value1b), getKeyHashCode(value1a));
+
+            Assert.NotEqual(getHashCode(value1c), getHashCode(value1a));
+            Assert.Equal(getKeyHashCode(value1c), getKeyHashCode(value1a));
+
+            Assert.NotEqual(getHashCode(value2), getHashCode(value1a));
+            Assert.NotEqual(getKeyHashCode(value2), getKeyHashCode(value1a));
+        }
+
+        private static LambdaExpression CreateAndExpression(ValueComparer comparer)
+        {
+            var param1 = Expression.Parameter(typeof(DeepBinary), "v1");
+            var param2 = Expression.Parameter(typeof(DeepBinary), "v2");
+
+            var firstEquals = comparer.ExtractEqualsBody(
+                Expression.Call(param1, _getValue0Method),
+                Expression.Call(param2, _getValue0Method));
+
+            var secondEquals = comparer.ExtractEqualsBody(
+                Expression.Call(param1, _getValue1Method),
+                Expression.Call(param2, _getValue1Method));
+
+            return Expression.Lambda(
+                Expression.AndAlso(firstEquals, secondEquals),
+                param1, param2);
+        }
+
+        private static LambdaExpression CreateHashCodeExpression(ValueComparer comparer)
+        {
+            var param = Expression.Parameter(typeof(DeepBinary), "v");
+
+            var firstHashCode = comparer.ExtractHashCodeBody(Expression.Call(param, _getValue0Method));
+            var secondHashCode = comparer.ExtractHashCodeBody(Expression.Call(param, _getValue1Method));
+
+            return Expression.Lambda(
+                Expression.ExclusiveOr(
+                    Expression.Multiply(
+                        firstHashCode,
+                        Expression.Constant(397, typeof(int))),
+                    secondHashCode),
+                param);
+        }
+    }
+}

--- a/test/EFCore.Tests/Storage/ValueConverterTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConverterTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Internal;


### PR DESCRIPTION
Fixes #11072

Main changes:
* Every type mapping now has a ValueComparer to allow general composition with the "null" case
* ValueComparers now also support generation of associated hash code
* ValueComparers allow for different comparisons when being used as a key (e.g. PK == FK check) than is used for DetectChanges/mutation
* Added some tests and helpers around composition of the expression trees