### PR TITLE
Don't discover collection of string as navigation

### DIFF
--- a/src/EFCore.Specification.Tests/DataAnnotationTestBase.cs
+++ b/src/EFCore.Specification.Tests/DataAnnotationTestBase.cs
@@ -2089,10 +2089,16 @@ namespace Microsoft.EntityFrameworkCore
             modelBuilder.Entity<Book>();
             modelBuilder.Entity<One>();
 
+            Validate(modelBuilder);
+
             Assert.True(model.FindEntityType(typeof(Book)).FindNavigation(nameof(Book.AdditionalDetails)).ForeignKey.IsOwnership);
             var one = model.FindEntityType(typeof(One));
-            Assert.True(one.FindNavigation(nameof(One.Details)).ForeignKey.IsOwnership);
-            Assert.True(one.FindNavigation(nameof(One.AdditionalDetails)).ForeignKey.IsOwnership);
+            var ownership1 = one.FindNavigation(nameof(One.Details)).ForeignKey;
+            Assert.True(ownership1.IsOwnership);
+            Assert.NotNull(ownership1.DeclaringEntityType.FindProperty(nameof(Details.Name)));
+            var ownership2 = one.FindNavigation(nameof(One.AdditionalDetails)).ForeignKey;
+            Assert.True(ownership2.IsOwnership);
+            Assert.NotNull(ownership2.DeclaringEntityType.FindProperty(nameof(Details.Name)));
         }
 
         public abstract class DataAnnotationFixtureBase : SharedStoreFixtureBase<DbContext>

--- a/src/EFCore/Metadata/Conventions/Internal/BaseTypeDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/BaseTypeDiscoveryConvention.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var baseEntityType = FindClosestBaseType(entityType);
             if (baseEntityType == null
-                || baseEntityType.FindOwnership() != null)
+                || baseEntityType.DefiningNavigationName != null)
             {
                 return entityTypeBuilder;
             }

--- a/src/EFCore/Metadata/Conventions/Internal/OwnedEntityTypeAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/OwnedEntityTypeAttributeConvention.cs
@@ -16,11 +16,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override InternalEntityTypeBuilder Apply(InternalEntityTypeBuilder entityTypeBuilder, OwnedAttribute attribute)
-            => (entityTypeBuilder.Metadata.HasClrType()
-                ? entityTypeBuilder.ModelBuilder.Owned(entityTypeBuilder.Metadata.ClrType, ConfigurationSource.DataAnnotation)
-                : entityTypeBuilder.ModelBuilder.Owned(entityTypeBuilder.Metadata.Name, ConfigurationSource.DataAnnotation))
-               && !entityTypeBuilder.Metadata.HasDefiningNavigation()
-                ? null
-                : entityTypeBuilder;
+        {
+            if (entityTypeBuilder.Metadata.HasClrType())
+            {
+                entityTypeBuilder.ModelBuilder.Owned(entityTypeBuilder.Metadata.ClrType, ConfigurationSource.DataAnnotation);
+            }
+            else
+            {
+                entityTypeBuilder.ModelBuilder.Owned(entityTypeBuilder.Metadata.Name, ConfigurationSource.DataAnnotation);
+            }
+            return entityTypeBuilder.Metadata.Builder;
+        }
     }
 }

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -983,7 +983,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual IEnumerable<ForeignKey> GetDerivedForeignKeysInclusive()
-            => GetDeclaredForeignKeys().Concat(GetDerivedTypes().SelectMany(et => et.GetDeclaredForeignKeys()));
+            => GetDeclaredForeignKeys().Concat(GetDerivedForeignKeys());
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -1156,8 +1156,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public virtual IEnumerable<ForeignKey> GetDerivedReferencingForeignKeys()
+            => GetDerivedTypes().SelectMany(et => et.GetDeclaredReferencingForeignKeys());
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual IEnumerable<ForeignKey> GetDerivedReferencingForeignKeysInclusive()
-            => GetDeclaredReferencingForeignKeys().Concat(GetDerivedTypes().SelectMany(et => et.GetDeclaredReferencingForeignKeys()));
+            => GetDeclaredReferencingForeignKeys().Concat(GetDerivedReferencingForeignKeys());
 
         private SortedSet<ForeignKey> DeclaredReferencingForeignKeys { get; set; }
 

--- a/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -255,7 +255,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public static bool IsInOwnershipPath([NotNull] this EntityType entityType, [NotNull] EntityType entityTypeToOwn)
+        public static bool IsInOwnershipPath([NotNull] this EntityType entityType, [NotNull] EntityType targetType)
         {
             var owner = entityType;
             while (true)
@@ -267,7 +267,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
 
                 owner = ownOwnership.PrincipalEntityType;
-                if (owner == entityTypeToOwn)
+                if (owner == targetType)
                 {
                     return true;
                 }

--- a/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
@@ -267,8 +267,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [NotNull] Type type, ConfigurationSource configurationSource)
             => Owned(new TypeIdentity(type), configurationSource);
 
-        private bool Owned(
-            TypeIdentity type, ConfigurationSource configurationSource)
+        private bool Owned(TypeIdentity type, ConfigurationSource configurationSource)
         {
             if (IsIgnored(type, configurationSource))
             {
@@ -292,12 +291,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     throw new InvalidOperationException(CoreStrings.ClashingNonOwnedEntityType(entityType.DisplayName()));
                 }
 
-                var potentialOwnerships = entityType.GetForeignKeys().Where(fk => fk.PrincipalToDependent != null).ToList();
-                foreach (var foreignKey in potentialOwnerships)
-                {
-                    foreignKey.PrincipalEntityType.FindNavigation(foreignKey.PrincipalToDependent.Name).ForeignKey.Builder
-                        .IsOwnership(true, configurationSource);
-                }
+                var ownership = entityType.GetForeignKeys().FirstOrDefault(fk =>
+                    fk.PrincipalToDependent != null
+                    && !fk.PrincipalEntityType.IsInOwnershipPath(entityType)
+                    && !fk.PrincipalEntityType.IsInDefinitionPath(clrType));
+                ownership?.Builder.IsOwnership(true, configurationSource);
             }
 
             if (clrType == null)

--- a/src/Shared/PropertyInfoExtensions.cs
+++ b/src/Shared/PropertyInfoExtensions.cs
@@ -39,7 +39,7 @@ namespace System.Reflection
             targetType = targetSequenceType ?? targetType;
             targetType = targetType.UnwrapNullableType();
 
-            if (typeMappingSource.FindMapping(propertyInfo) != null
+            if (typeMappingSource.FindMapping(targetType) != null
                 || targetType.GetTypeInfo().IsInterface
                 || targetType.GetTypeInfo().IsValueType
                 || targetType == typeof(object)

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -6692,12 +6692,18 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         public void Rename_property_on_owned_type_and_add_similar_to_owner()
         {
             Execute(
-                source => source.Entity<Order>().OwnsOne(o => o.Billing).Property<int>("OldZip"),
+                source => source.Entity<Order>(
+                    x =>
+                    {
+                        x.OwnsOne(o => o.Billing).Property<int>("OldZip");
+                        x.Ignore(o => o.Shipping);
+                    }),
                 target => target.Entity<Order>(
                     x =>
                     {
                         x.Property<int>("NotZip");
                         x.OwnsOne(o => o.Billing).Property<int>("NewZip");
+                        x.Ignore(o => o.Shipping);
                     }),
                 operations =>
                 {
@@ -6723,12 +6729,14 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     {
                         x.Property<DateTime>("OldDate");
                         x.OwnsOne(o => o.Billing);
+                        x.Ignore(o => o.Shipping);
                     }),
                 target => target.Entity<Order>(
                     x =>
                     {
                         x.Property<DateTime>("NewDate");
                         x.OwnsOne(o => o.Billing).Property<DateTime>("AnotherDate");
+                        x.Ignore(o => o.Shipping);
                     }),
                 operations =>
                 {

--- a/test/EFCore.Tests/ModelBuilding/InheritanceTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/InheritanceTestBase.cs
@@ -151,6 +151,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var dependentEntityBuilder = modelBuilder.Entity<Order>();
                 var derivedDependentEntityBuilder = modelBuilder.Entity<SpecialOrder>();
                 derivedDependentEntityBuilder.Ignore(nameof(SpecialOrder.SpecialCustomer));
+                derivedDependentEntityBuilder.Ignore(nameof(SpecialOrder.ShippingAddress));
 
                 Assert.Same(principalEntityBuilder.Metadata, derivedPrincipalEntityBuilder.Metadata.BaseType);
                 Assert.Same(dependentEntityBuilder.Metadata, derivedDependentEntityBuilder.Metadata.BaseType);
@@ -196,6 +197,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var derivedDependentEntityBuilder = modelBuilder.Entity<SpecialOrder>();
                 derivedDependentEntityBuilder.Ignore(nameof(SpecialOrder.BackOrder));
                 derivedDependentEntityBuilder.Ignore(nameof(SpecialOrder.SpecialCustomer));
+                derivedDependentEntityBuilder.Ignore(nameof(SpecialOrder.ShippingAddress));
                 var otherDerivedDependentEntityBuilder = modelBuilder.Entity<BackOrder>();
                 otherDerivedDependentEntityBuilder.Ignore(nameof(BackOrder.SpecialOrder));
 
@@ -244,6 +246,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var derivedDependentEntityBuilder = modelBuilder.Entity<SpecialOrder>();
                 derivedDependentEntityBuilder.Ignore(nameof(SpecialOrder.BackOrder));
                 derivedDependentEntityBuilder.Ignore(nameof(SpecialOrder.SpecialCustomer));
+                derivedDependentEntityBuilder.Ignore(nameof(SpecialOrder.ShippingAddress));
                 var otherDerivedDependentEntityBuilder = modelBuilder.Entity<BackOrder>();
                 otherDerivedDependentEntityBuilder.Ignore(nameof(BackOrder.SpecialOrder));
 
@@ -276,6 +279,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 dependentEntityBuilder.Ignore(nameof(Order.Customer));
                 var derivedDependentEntityBuilder = modelBuilder.Entity<SpecialOrder>();
                 derivedDependentEntityBuilder.Ignore(nameof(SpecialOrder.BackOrder));
+                derivedDependentEntityBuilder.Ignore(nameof(SpecialOrder.ShippingAddress));
                 var otherDerivedPrincipalEntityBuilder = modelBuilder.Entity<OtherCustomer>();
 
                 derivedPrincipalEntityBuilder
@@ -305,6 +309,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var derivedDependentEntityBuilder = modelBuilder.Entity<SpecialOrder>();
                 derivedDependentEntityBuilder.Ignore(nameof(SpecialOrder.BackOrder));
                 derivedDependentEntityBuilder.Ignore(nameof(SpecialOrder.SpecialCustomer));
+                derivedDependentEntityBuilder.Ignore(nameof(SpecialOrder.ShippingAddress));
 
                 principalEntityBuilder
                     .HasOne(e => (SpecialOrder)e.Order)
@@ -358,6 +363,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var derivedDependentEntityBuilder = modelBuilder.Entity<SpecialOrder>();
                 derivedDependentEntityBuilder.Ignore(nameof(SpecialOrder.BackOrder));
                 derivedDependentEntityBuilder.Ignore(nameof(SpecialOrder.SpecialCustomer));
+                derivedDependentEntityBuilder.Ignore(nameof(SpecialOrder.ShippingAddress));
                 var otherDerivedDependentEntityBuilder = modelBuilder.Entity<BackOrder>();
                 otherDerivedDependentEntityBuilder.Ignore(nameof(BackOrder.SpecialOrder));
 
@@ -391,6 +397,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 dependentEntityBuilder.Ignore(e => e.Customer);
                 var derivedDependentEntityBuilder = modelBuilder.Entity<SpecialOrder>();
                 derivedDependentEntityBuilder.Ignore(e => e.SpecialCustomerId);
+                derivedDependentEntityBuilder.Ignore(e => e.ShippingAddress);
 
                 dependentEntityBuilder
                     .HasOne<SpecialCustomer>()
@@ -418,6 +425,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var dependentEntityBuilder = modelBuilder.Entity<Order>();
                 dependentEntityBuilder.Ignore(nameof(Order.Customer));
                 var derivedDependentEntityBuilder = modelBuilder.Entity<SpecialOrder>();
+                derivedDependentEntityBuilder.Ignore(nameof(SpecialOrder.ShippingAddress));
                 dependentEntityBuilder.Property<int?>("SpecialCustomerId");
 
                 derivedPrincipalEntityBuilder
@@ -446,7 +454,6 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<BackOrder>();
                 modelBuilder.Ignore<SpecialCustomer>();
-                modelBuilder.Ignore<SpecialOrder>();
 
                 var principalEntityBuilder = modelBuilder.Entity<Customer>();
                 var derivedPrincipalEntityBuilder = modelBuilder.Entity<OtherCustomer>();
@@ -517,7 +524,6 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 modelBuilder.Ignore<OrderDetails>();
                 modelBuilder.Ignore<BackOrder>();
                 modelBuilder.Ignore<SpecialCustomer>();
-                modelBuilder.Ignore<SpecialOrder>();
 
                 modelBuilder.Entity<Customer>();
                 var derivedPrincipalEntityBuilder = modelBuilder.Entity<OtherCustomer>();

--- a/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
@@ -1004,6 +1005,24 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
             private abstract class BadCustomValueGenerator2 : CustomValueGenerator
             {
+            }
+
+            [Fact]
+            public virtual void Throws_for_collection_of_string()
+            {
+                var modelBuilder = CreateModelBuilder();
+
+                modelBuilder.Entity<StringCollectionEntity>();
+
+                Assert.Equal(
+                    CoreStrings.PropertyNotAdded(
+                        nameof(StringCollectionEntity), nameof(StringCollectionEntity.Property), "ICollection<string>"),
+                    Assert.Throws<InvalidOperationException>(() => modelBuilder.Validate()).Message);
+            }
+
+            protected class StringCollectionEntity
+            {
+                public ICollection<string> Property { get; set; }
             }
 
             [Fact]

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -132,6 +132,13 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public OrderDetails Details { get; set; }
         }
 
+        [Owned]
+        public class StreetAddress
+        {
+            public string Street { get; set; }
+            public string City { get; set; }
+        }
+
         [NotMapped]
         protected class SpecialOrder : Order
         {
@@ -139,6 +146,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public SpecialCustomer SpecialCustomer { get; set; }
             public BackOrder BackOrder { get; set; }
             public OrderCombination SpecialOrderCombination { get; set; }
+            public StreetAddress ShippingAddress { get; set; }
         }
 
         protected class BackOrder : Order


### PR DESCRIPTION
Handle OwnedAttribute correctly
Convert types to owned in a more robust way

Fixes #11074
Fixes #11152
