### PR TITLE
Query: Client eval when doing joins after GroupByAggregate

### DIFF
--- a/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
@@ -1093,7 +1093,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .Select(g => new { g.Key, Count = g.Count(), Sum = g.Sum(o => o.OrderID) }));
         }
 
-        [ConditionalFact(Skip = "Issue#10012")]
+        [ConditionalFact]
         public virtual async Task GroupBy_Aggregate_Join()
         {
             await AssertQuery<Order, Customer>(
@@ -1103,7 +1103,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                                 .Select(g => new { CustomerID = g.Key, LastOrderID = g.Max(o => o.OrderID) })
                     join c in cs on a.CustomerID equals c.CustomerID
                     join o in os on a.LastOrderID equals o.OrderID
-                    select new { c, o });
+                    select new { c, o },
+                entryCount: 126);
         }
 
         [ConditionalFact]

--- a/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -1096,7 +1096,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .Select(g => new { g.Key, Count = g.Count(), Sum = g.Sum(o => o.OrderID) }));
         }
 
-        [ConditionalFact(Skip = "Issue#10012")]
+        [ConditionalFact]
         public virtual void GroupBy_Aggregate_Join()
         {
             AssertQuery<Order, Customer>(
@@ -1106,7 +1106,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                                 .Select(g => new { CustomerID = g.Key, LastOrderID = g.Max(o => o.OrderID) })
                     join c in cs on a.CustomerID equals c.CustomerID
                     join o in os on a.LastOrderID equals o.OrderID
-                    select new { c, o });
+                    select new { c, o },
+                entryCount: 126);
         }
 
         [ConditionalFact]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
@@ -985,7 +985,16 @@ ORDER BY [Count], [Key]");
         {
             base.GroupBy_Aggregate_Join();
 
-            AssertSql(" ");
+            AssertContainsSql(
+                @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Orders] AS [o0]",
+                //
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]",
+                //
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+ORDER BY [o].[CustomerID]");
         }
 
         public override void GroupBy_with_result_selector()
@@ -1436,6 +1445,9 @@ INNER JOIN (
 
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+        private void AssertContainsSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected, assertOrder: false);
 
         protected override void ClearLog()
             => Fixture.TestSqlLoggerFactory.Clear();


### PR DESCRIPTION
Part of #10012

