### PR TITLE
[TINY] Fix to #11267 - Query: empty AnonymousObject.GetHashCode throws

### DIFF
--- a/src/EFCore/Query/Internal/AnonymousObject.cs
+++ b/src/EFCore/Query/Internal/AnonymousObject.cs
@@ -98,10 +98,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         {
             unchecked
             {
-                return _values.Aggregate(
-                    0,
-                    (current, argument)
-                        => current + ((current * 397) ^ (argument?.GetHashCode() ?? 0)));
+                return _values != null
+                    ? _values.Aggregate(
+                        0,
+                        (current, argument)
+                            => current + ((current * 397) ^ (argument?.GetHashCode() ?? 0)))
+                    : 0;
             }
         }
 

--- a/src/EFCore/Query/Internal/MaterializedAnonymousObject.cs
+++ b/src/EFCore/Query/Internal/MaterializedAnonymousObject.cs
@@ -104,10 +104,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         {
             unchecked
             {
-                return _values.Aggregate(
-                    0,
-                    (current, argument)
-                        => current + ((current * 397) ^ (argument?.GetHashCode() ?? 0)));
+                return _values != null
+                    ? _values.Aggregate(
+                        0,
+                        (current, argument)
+                            => current + ((current * 397) ^ (argument?.GetHashCode() ?? 0)))
+                    : 0;
             }
         }
 


### PR DESCRIPTION
Adding safeguards for empty AnonymousObject and MaterializedAnonymousObject.