### PR TITLE
SqlServer: Generate literal for datetime type correctly

### DIFF
--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerDateTimeTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerDateTimeTypeMapping.cs
@@ -16,7 +16,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
     /// </summary>
     public class SqlServerDateTimeTypeMapping : DateTimeTypeMapping
     {
+        private const string DateFormatConst = "{0:yyyy-MM-dd}";
         private const string DateTimeFormatConst = "{0:yyyy-MM-ddTHH:mm:ss.fffK}";
+        private const string DateTime2FormatConst = "{0:yyyy-MM-ddTHH:mm:ss.fffffffK}";
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -76,6 +78,11 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected override string SqlLiteralFormatString => "'" + DateTimeFormatConst + "'";
+        protected override string SqlLiteralFormatString
+            => StoreType == "date"
+                ? "'" + DateFormatConst + "'"
+                : (StoreType == "datetime"
+                    ? "'" + DateTimeFormatConst + "'"
+                    : "'" + DateTime2FormatConst + "'");
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -374,7 +374,7 @@ WHERE ([e1.OneToOne_Optional_FK].[Name] LIKE [e1.OneToOne_Optional_FK].[Name] + 
                 @"SELECT [e1].[Id], [e1].[Date], [e1].[Name], [e1].[OneToMany_Optional_Self_InverseId], [e1].[OneToMany_Required_Self_InverseId], [e1].[OneToOne_Optional_SelfId]
 FROM [LevelOne] AS [e1]
 LEFT JOIN [LevelTwo] AS [e1.OneToOne_Optional_FK] ON [e1].[Id] = [e1.OneToOne_Optional_FK].[Level1_Optional_Id]
-WHERE DATEADD(day, 10E0, [e1.OneToOne_Optional_FK].[Date]) > '2000-02-01T00:00:00.000'");
+WHERE DATEADD(day, 10E0, [e1.OneToOne_Optional_FK].[Date]) > '2000-02-01T00:00:00.0000000'");
         }
 
         public override void Optional_navigation_inside_nested_method_call_translated_to_join_keeps_original_nullability()
@@ -385,7 +385,7 @@ WHERE DATEADD(day, 10E0, [e1.OneToOne_Optional_FK].[Date]) > '2000-02-01T00:00:0
                 @"SELECT [e1].[Id], [e1].[Date], [e1].[Name], [e1].[OneToMany_Optional_Self_InverseId], [e1].[OneToMany_Required_Self_InverseId], [e1].[OneToOne_Optional_SelfId]
 FROM [LevelOne] AS [e1]
 LEFT JOIN [LevelTwo] AS [e1.OneToOne_Optional_FK] ON [e1].[Id] = [e1.OneToOne_Optional_FK].[Level1_Optional_Id]
-WHERE DATEADD(month, 2, DATEADD(day, 15E0, DATEADD(day, 10E0, [e1.OneToOne_Optional_FK].[Date]))) > '2002-02-01T00:00:00.000'");
+WHERE DATEADD(month, 2, DATEADD(day, 15E0, DATEADD(day, 10E0, [e1.OneToOne_Optional_FK].[Date]))) > '2002-02-01T00:00:00.0000000'");
         }
 
         public override void Optional_navigation_inside_nested_method_call_translated_to_join_keeps_original_nullability_also_for_arguments()
@@ -396,7 +396,7 @@ WHERE DATEADD(month, 2, DATEADD(day, 15E0, DATEADD(day, 10E0, [e1.OneToOne_Optio
                 @"SELECT [e1].[Id], [e1].[Date], [e1].[Name], [e1].[OneToMany_Optional_Self_InverseId], [e1].[OneToMany_Required_Self_InverseId], [e1].[OneToOne_Optional_SelfId]
 FROM [LevelOne] AS [e1]
 LEFT JOIN [LevelTwo] AS [e1.OneToOne_Optional_FK] ON [e1].[Id] = [e1.OneToOne_Optional_FK].[Level1_Optional_Id]
-WHERE DATEADD(day, [e1.OneToOne_Optional_FK].[Id], DATEADD(day, 15E0, [e1.OneToOne_Optional_FK].[Date])) > '2002-02-01T00:00:00.000'");
+WHERE DATEADD(day, [e1.OneToOne_Optional_FK].[Id], DATEADD(day, 15E0, [e1.OneToOne_Optional_FK].[Date])) > '2002-02-01T00:00:00.0000000'");
         }
 
         public override void Join_navigation_in_outer_selector_translated_to_extra_join()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQuerySqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NorthwindQuerySqlServerFixture.cs
@@ -27,9 +27,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                         b.Property(c => c.ReportsTo).HasColumnType("int");
                     });
 
-            modelBuilder.Entity<Order>()
-                .Property(o => o.EmployeeID)
-                .HasColumnType("int");
+            modelBuilder.Entity<Order>(
+                b =>
+                {
+                    b.Property(o => o.EmployeeID).HasColumnType("int");
+                    b.Property(o => o.OrderDate).HasColumnType("datetime");
+                });
 
             modelBuilder.Entity<OrderDetail>()
                 .Property(od => od.UnitPrice)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Functions.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Functions.cs
@@ -1286,7 +1286,7 @@ WHERE [c].[CustomerID] = N'ANATR'");
             base.Static_equals_nullable_datetime_compared_to_non_nullable();
 
             AssertSql(
-                @"@__arg_0='1996-07-04T00:00:00'
+                @"@__arg_0='1996-07-04T00:00:00' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
@@ -750,7 +750,7 @@ WHERE CONVERT(date, GETDATE()) = CONVERT(date, GETDATE())");
             base.Where_datetime_date_component();
 
             AssertSql(
-                @"@__myDatetime_0='1998-05-04T00:00:00'
+                @"@__myDatetime_0='1998-05-04T00:00:00' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -2568,7 +2568,7 @@ ORDER BY COALESCE([c].[Region], N'ZZ')");
             base.DateTime_parse_is_parameterized();
 
             AssertSql(
-                @"@__Parse_0='1998-01-01T12:00:00'
+                @"@__Parse_0='1998-01-01T12:00:00' (DbType = DateTime)
 
 SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]

--- a/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingTest.cs
+++ b/test/EFCore.SqlServer.Tests/Storage/SqlServerTypeMappingTest.cs
@@ -190,7 +190,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var value = new DateTime(2015, 3, 12, 13, 36, 37, 371);
             var literal = GetMapping(typeof(DateTime)).GenerateSqlLiteral(value);
 
-            Assert.Equal("'2015-03-12T13:36:37.371'", literal);
+            Assert.Equal("'2015-03-12T13:36:37.3710000'", literal);
         }
 
         public override void GenerateSqlLiteral_returns_DateTimeOffset_literal()


### PR DESCRIPTION
Resolves #11262
