### PR TITLE
Query: Client eval when aggregating over unmapped property in groupBy…

### DIFF
--- a/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
@@ -1049,16 +1049,19 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalFact(Skip = "Issue#11251")]
-        public virtual async Task GroupBy_OrderBy_count_Select_sum_over_unmapped_property()
+        [ConditionalFact]
+        public virtual async Task GroupBy_Select_sum_over_unmapped_property()
         {
-            await AssertQuery<Order>(
-                os =>
-                    os.GroupBy(o => o.CustomerID)
-                        .OrderBy(o => o.Count())
-                        .ThenBy(o => o.Key)
-                        .Select(g => new { g.Key, Sum = g.Sum(o => o.Freight) }),
-                assertOrder: true);
+            using (var context = CreateContext())
+            {
+                var query = await context.Orders
+                        .GroupBy(o => o.CustomerID)
+                        .Select(g => new { g.Key, Sum = g.Sum(o => o.Freight) })
+                        .ToListAsync();
+
+                // Do not do deep assertion of result. We don't have data for unmapped property in EF model
+                Assert.Equal(89, query.Count);
+            }
         }
 
         [ConditionalFact]

--- a/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -1052,16 +1052,19 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true);
         }
 
-        [ConditionalFact(Skip = "Issue#11251")]
-        public virtual void GroupBy_OrderBy_count_Select_sum_over_unmapped_property()
+        [ConditionalFact]
+        public virtual void GroupBy_Select_sum_over_unmapped_property()
         {
-            AssertQuery<Order>(
-                os =>
-                    os.GroupBy(o => o.CustomerID)
-                        .OrderBy(o => o.Count())
-                        .ThenBy(o => o.Key)
-                        .Select(g => new { g.Key, Sum = g.Sum(o => o.Freight) }),
-                assertOrder: true);
+            using (var context = CreateContext())
+            {
+                var query = context.Orders
+                        .GroupBy(o => o.CustomerID)
+                        .Select(g => new { g.Key, Sum = g.Sum(o => o.Freight) })
+                        .ToList();
+
+                // Do not do deep assertion of result. We don't have data for unmapped property in EF model
+                Assert.Equal(89, query.Count);
+            }
         }
 
         [ConditionalFact]

--- a/src/EFCore/Query/ExpressionVisitors/Internal/RequiresMaterializationExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/RequiresMaterializationExpressionVisitor.cs
@@ -287,7 +287,20 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 && _queryModelStack.Count == 1
                 && !_queryModelStack.Peek().BodyClauses.OfType<IQuerySource>().Any())
             {
-                return true;
+                var groupResultOperator
+                    = (GroupResultOperator)
+                        ((SubQueryExpression)
+                            ((FromClauseBase)queryModel.MainFromClause.FromExpression.TryGetReferencedQuerySource())
+                        .FromExpression)
+                        .QueryModel.ResultOperators.Last();
+
+                if (MemberAccessBindingExpressionVisitor.GetPropertyPath(
+                    queryModel.SelectClause.Selector, _queryModelVisitor.QueryCompilationContext, out var qsre).Count > 0
+                    || groupResultOperator.ElementSelector is MemberInitExpression
+                    || groupResultOperator.ElementSelector is NewExpression)
+                {
+                    return true;
+                }
             }
 
             return false;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
@@ -940,11 +940,14 @@ GROUP BY [o].[CustomerID]
 ORDER BY COUNT(*), [Key]");
         }
 
-        public override void GroupBy_OrderBy_count_Select_sum_over_unmapped_property()
+        public override void GroupBy_Select_sum_over_unmapped_property()
         {
-            base.GroupBy_OrderBy_count_Select_sum_over_unmapped_property();
+            base.GroupBy_Select_sum_over_unmapped_property();
 
-            AssertSql(" ");
+            AssertSql(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+ORDER BY [o].[CustomerID]");
         }
 
         public override void GroupBy_filter_key()


### PR DESCRIPTION
… when element selector is not composite
We still be aggressive in translation when element selector is NewExpression/MemberInitExpression

Part of #11251 
