### PR TITLE
Sqlite: Change namespace for provider Internal code

### DIFF
--- a/src/EFCore.Sqlite.Core/Design/Internal/SqliteDesignTimeServices.cs
+++ b/src/EFCore.Sqlite.Core/Design/Internal/SqliteDesignTimeServices.cs
@@ -1,13 +1,14 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Scaffolding;
-using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
-using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Microsoft.EntityFrameworkCore.Design.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Design.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/EFCore.Sqlite.Core.csproj
+++ b/src/EFCore.Sqlite.Core/EFCore.Sqlite.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Microsoft.EntityFrameworkCore.Sqlite</AssemblyName>
     <PackageId>Microsoft.EntityFrameworkCore.Sqlite.Core</PackageId>
-    <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
+    <RootNamespace>Microsoft.EntityFrameworkCore.Sqlite</RootNamespace>
     <Description>SQLite database provider for Entity Framework Core.</Description>
     <TargetFramework>netstandard2.0</TargetFramework>
     <MinClientVersion>3.6</MinClientVersion>
@@ -46,7 +46,7 @@
 
   <ItemGroup>
     <EmbeddedResource Update="Properties\SqliteStrings.resx">
-      <CustomToolNamespace>Microsoft.EntityFrameworkCore.Internal</CustomToolNamespace>
+      <CustomToolNamespace>Microsoft.EntityFrameworkCore.Sqlite.Internal</CustomToolNamespace>
     </EmbeddedResource>
   </ItemGroup>
 

--- a/src/EFCore.Sqlite.Core/Infrastructure/Internal/SqliteOptionsExtension.cs
+++ b/src/EFCore.Sqlite.Core/Infrastructure/Internal/SqliteOptionsExtension.cs
@@ -3,10 +3,11 @@
 
 using System.Text;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace Microsoft.EntityFrameworkCore.Infrastructure.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Infrastructure.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Infrastructure/SqliteDbContextOptionsBuilder.cs
+++ b/src/EFCore.Sqlite.Core/Infrastructure/SqliteDbContextOptionsBuilder.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Infrastructure.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Infrastructure
 {

--- a/src/EFCore.Sqlite.Core/Infrastructure/SqliteServiceCollectionExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Infrastructure/SqliteServiceCollectionExtensions.cs
@@ -3,20 +3,21 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
-using Microsoft.EntityFrameworkCore.Migrations.Internal;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
-using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
-using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
 using Microsoft.EntityFrameworkCore.Query.Sql;
-using Microsoft.EntityFrameworkCore.Query.Sql.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Migrations.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionVisitors.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Query.Sql.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Update.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
-using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.EntityFrameworkCore.Update.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;

--- a/src/EFCore.Sqlite.Core/Internal/SqliteLoggerExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Internal/SqliteLoggerExtensions.cs
@@ -5,6 +5,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Internal
 {

--- a/src/EFCore.Sqlite.Core/Metadata/Internal/SqliteAnnotationNames.cs
+++ b/src/EFCore.Sqlite.Core/Metadata/Internal/SqliteAnnotationNames.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Metadata.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Metadata/Internal/SqliteInternalMetadataBuilderExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Metadata/Internal/SqliteInternalMetadataBuilderExtensions.cs
@@ -2,8 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 
-namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Metadata.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Migrations/Internal/SqliteHistoryRepository.cs
+++ b/src/EFCore.Sqlite.Core/Migrations/Internal/SqliteHistoryRepository.cs
@@ -3,10 +3,11 @@
 
 using System;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 
-namespace Microsoft.EntityFrameworkCore.Migrations.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Migrations.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Migrations/Internal/SqliteMigrationsAnnotationProvider.cs
+++ b/src/EFCore.Sqlite.Core/Migrations/Internal/SqliteMigrationsAnnotationProvider.cs
@@ -6,9 +6,10 @@ using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Sqlite.Metadata.Internal;
 
-namespace Microsoft.EntityFrameworkCore.Migrations.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Migrations.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Migrations/SqliteMigrationsSqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Migrations/SqliteMigrationsSqlGenerator.cs
@@ -10,6 +10,8 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Migrations

--- a/src/EFCore.Sqlite.Core/Properties/AssemblyInfo.cs
+++ b/src/EFCore.Sqlite.Core/Properties/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 using Microsoft.EntityFrameworkCore.Design;
 
-[assembly: DesignTimeProviderServices("Microsoft.EntityFrameworkCore.Design.Internal.SqliteDesignTimeServices")]
+[assembly: DesignTimeProviderServices("Microsoft.EntityFrameworkCore.Sqlite.Design.Internal.SqliteDesignTimeServices")]

--- a/src/EFCore.Sqlite.Core/Properties/SqliteStrings.Designer.cs
+++ b/src/EFCore.Sqlite.Core/Properties/SqliteStrings.Designer.cs
@@ -7,7 +7,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Logging;
 
-namespace Microsoft.EntityFrameworkCore.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Internal
 {
     /// <summary>
     ///		This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteCompositeMemberTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteCompositeMemberTranslator.cs
@@ -3,8 +3,9 @@
 
 using System.Collections.Generic;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
-namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteCompositeMethodCallTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteCompositeMethodCallTranslator.cs
@@ -2,8 +2,9 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
-namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteContainsOptimizedTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteContainsOptimizedTranslator.cs
@@ -4,8 +4,9 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
-namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteDateAddTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteDateAddTranslator.cs
@@ -6,8 +6,9 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
-namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteDateTimeMemberTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteDateTimeMemberTranslator.cs
@@ -5,8 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
-namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteEndsWithOptimizedTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteEndsWithOptimizedTranslator.cs
@@ -4,8 +4,9 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
-namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteMathTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteMathTranslator.cs
@@ -6,8 +6,9 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
-namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStartsWithOptimizedTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStartsWithOptimizedTranslator.cs
@@ -4,8 +4,9 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
-namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringIndexOfTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringIndexOfTranslator.cs
@@ -4,8 +4,9 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
-namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringIsNullOrWhiteSpaceTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringIsNullOrWhiteSpaceTranslator.cs
@@ -4,8 +4,9 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
-namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringLengthTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringLengthTranslator.cs
@@ -3,8 +3,9 @@
 
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
-namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringReplaceTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringReplaceTranslator.cs
@@ -5,8 +5,9 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
-namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringSubstringTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringSubstringTranslator.cs
@@ -4,8 +4,9 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
-namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringToLowerTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringToLowerTranslator.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringToUpperTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringToUpperTranslator.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringTrimEndTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringTrimEndTranslator.cs
@@ -6,8 +6,9 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
-namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringTrimStartTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringTrimStartTranslator.cs
@@ -6,8 +6,9 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
-namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringTrimTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteStringTrimTranslator.cs
@@ -6,8 +6,9 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 
-namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Query/ExpressionVisitors/Internal/SqliteSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionVisitors/Internal/SqliteSqlTranslatingExpressionVisitor.cs
@@ -1,15 +1,16 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Collections.Generic;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
+using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
-using Microsoft.EntityFrameworkCore.Storage.Internal;
 
-namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionVisitors.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Query/ExpressionVisitors/Internal/SqliteSqlTranslatingExpressionVisitorFactory.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionVisitors/Internal/SqliteSqlTranslatingExpressionVisitorFactory.cs
@@ -3,9 +3,11 @@
 
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
 
-namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionVisitors.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Query/Sql/Internal/SqliteQuerySqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Query/Sql/Internal/SqliteQuerySqlGenerator.cs
@@ -4,10 +4,11 @@
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.Sql;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
-namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Sql.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Query/Sql/Internal/SqliteQuerySqlGeneratorFactory.cs
+++ b/src/EFCore.Sqlite.Core/Query/Sql/Internal/SqliteQuerySqlGeneratorFactory.cs
@@ -3,9 +3,10 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.Sql;
 using Microsoft.EntityFrameworkCore.Utilities;
 
-namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Sql.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Scaffolding/Internal/SqliteCodeGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Scaffolding/Internal/SqliteCodeGenerator.cs
@@ -3,8 +3,9 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Scaffolding;
 
-namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Scaffolding/Internal/SqliteDatabaseModelFactory.cs
+++ b/src/EFCore.Sqlite.Core/Scaffolding/Internal/SqliteDatabaseModelFactory.cs
@@ -14,11 +14,12 @@ using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Scaffolding;
 using Microsoft.EntityFrameworkCore.Scaffolding.Metadata;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
-namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/SqliteDatabaseFacadeExtensions.cs
+++ b/src/EFCore.Sqlite.Core/SqliteDatabaseFacadeExtensions.cs
@@ -5,7 +5,7 @@ using System;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Infrastructure.Internal;
 
 namespace Microsoft.EntityFrameworkCore
 {

--- a/src/EFCore.Sqlite.Core/SqliteDbContextOptionsBuilderExtensions.cs
+++ b/src/EFCore.Sqlite.Core/SqliteDbContextOptionsBuilderExtensions.cs
@@ -6,7 +6,7 @@ using System.Data.Common;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore

--- a/src/EFCore.Sqlite.Core/Storage/Internal/ISqliteRelationalConnection.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/ISqliteRelationalConnection.cs
@@ -1,7 +1,9 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-namespace Microsoft.EntityFrameworkCore.Storage.Internal
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteCharTypeMapping.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteCharTypeMapping.cs
@@ -5,9 +5,10 @@ using System;
 using System.Data;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-namespace Microsoft.EntityFrameworkCore.Storage.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDatabaseCreator.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDatabaseCreator.cs
@@ -4,8 +4,9 @@
 using System.IO;
 using JetBrains.Annotations;
 using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore.Storage;
 
-namespace Microsoft.EntityFrameworkCore.Storage.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDateTimeOffsetTypeMapping.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDateTimeOffsetTypeMapping.cs
@@ -4,9 +4,10 @@
 using System.Data;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-namespace Microsoft.EntityFrameworkCore.Storage.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDateTimeTypeMapping.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDateTimeTypeMapping.cs
@@ -4,9 +4,10 @@
 using System.Data;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-namespace Microsoft.EntityFrameworkCore.Storage.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDecimalTypeMapping.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteDecimalTypeMapping.cs
@@ -4,9 +4,10 @@
 using System.Data;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-namespace Microsoft.EntityFrameworkCore.Storage.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteGuidTypeMapping.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteGuidTypeMapping.cs
@@ -5,9 +5,10 @@ using System;
 using System.Data;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-namespace Microsoft.EntityFrameworkCore.Storage.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteRelationalConnection.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteRelationalConnection.cs
@@ -7,10 +7,11 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
-namespace Microsoft.EntityFrameworkCore.Storage.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteSqlGenerationHelper.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteSqlGenerationHelper.cs
@@ -3,8 +3,9 @@
 
 using System.Text;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Storage;
 
-namespace Microsoft.EntityFrameworkCore.Storage.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTypeMappingSource.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTypeMappingSource.cs
@@ -5,8 +5,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Storage;
 
-namespace Microsoft.EntityFrameworkCore.Storage.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteULongTypeMapping.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteULongTypeMapping.cs
@@ -4,9 +4,10 @@
 using System.Data;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
-namespace Microsoft.EntityFrameworkCore.Storage.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Update/Internal/SqliteModificationCommandBatchFactory.cs
+++ b/src/EFCore.Sqlite.Core/Update/Internal/SqliteModificationCommandBatchFactory.cs
@@ -3,9 +3,10 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.EntityFrameworkCore.Utilities;
 
-namespace Microsoft.EntityFrameworkCore.Update.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Update.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/Update/Internal/SqliteUpdateSqlGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Update/Internal/SqliteUpdateSqlGenerator.cs
@@ -4,10 +4,11 @@
 using System;
 using System.Text;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
+using Microsoft.EntityFrameworkCore.Update;
 using Microsoft.EntityFrameworkCore.Utilities;
 
-namespace Microsoft.EntityFrameworkCore.Update.Internal
+namespace Microsoft.EntityFrameworkCore.Sqlite.Update.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Sqlite.Core/breakingchanges.netcore.json
+++ b/src/EFCore.Sqlite.Core/breakingchanges.netcore.json
@@ -1,0 +1,6 @@
+﻿[
+  {
+    "TypeId": "public class Microsoft.EntityFrameworkCore.Infrastructure.SqliteDbContextOptionsBuilder : Microsoft.EntityFrameworkCore.Infrastructure.RelationalDbContextOptionsBuilder<Microsoft.EntityFrameworkCore.Infrastructure.SqliteDbContextOptionsBuilder, Microsoft.EntityFrameworkCore.Infrastructure.Internal.SqliteOptionsExtension>",
+    "Kind": "Removal"
+  }
+]

--- a/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/DataAnnotationSqliteTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;

--- a/test/EFCore.Sqlite.FunctionalTests/LoggingSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/LoggingSqliteTest.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Infrastructure.Internal;
 using Xunit;
 
 // ReSharper disable InconsistentNaming

--- a/test/EFCore.Sqlite.FunctionalTests/Scaffolding/SqliteDatabaseModelFactoryTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Scaffolding/SqliteDatabaseModelFactoryTest.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
@@ -17,6 +16,8 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
+using Microsoft.EntityFrameworkCore.Sqlite.Design.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Scaffolding

--- a/test/EFCore.Sqlite.FunctionalTests/SqliteMigrationSqlGeneratorTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/SqliteMigrationSqlGeneratorTest.cs
@@ -6,6 +6,8 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 

--- a/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SqliteDatabaseCleaner.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/TestUtilities/SqliteDatabaseCleaner.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics;
-using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Scaffolding;
@@ -12,6 +11,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Microsoft.EntityFrameworkCore.Sqlite.Design.Internal;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities
 {

--- a/test/EFCore.Sqlite.Tests/ApiConsistencyTest.cs
+++ b/test/EFCore.Sqlite.Tests/ApiConsistencyTest.cs
@@ -5,7 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore

--- a/test/EFCore.Sqlite.Tests/Design/SqliteDesignTimeProviderServicesTest.cs
+++ b/test/EFCore.Sqlite.Tests/Design/SqliteDesignTimeProviderServicesTest.cs
@@ -3,8 +3,8 @@
 
 using System;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore.Design.Internal;
-using Microsoft.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Design.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Design
 {

--- a/test/EFCore.Sqlite.Tests/Metadata/Internal/SqliteInternalMetadataBuilderExtensionsTest.cs
+++ b/test/EFCore.Sqlite.Tests/Metadata/Internal/SqliteInternalMetadataBuilderExtensionsTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using Microsoft.EntityFrameworkCore.Sqlite.Metadata.Internal;
 using Xunit;
 
 // ReSharper disable InconsistentNaming

--- a/test/EFCore.Sqlite.Tests/Migrations/SqliteHistoryRepositoryTest.cs
+++ b/test/EFCore.Sqlite.Tests/Migrations/SqliteHistoryRepositoryTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;

--- a/test/EFCore.Sqlite.Tests/Migrations/SqliteMigrationAnnotationProviderTest.cs
+++ b/test/EFCore.Sqlite.Tests/Migrations/SqliteMigrationAnnotationProviderTest.cs
@@ -1,11 +1,9 @@
-﻿﻿// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
-using Microsoft.EntityFrameworkCore.Metadata.Internal;
-using Microsoft.EntityFrameworkCore.Migrations.Internal;
-using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Sqlite.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Migrations.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 

--- a/test/EFCore.Sqlite.Tests/Scaffolding/SqliteCodeGeneratorTest.cs
+++ b/test/EFCore.Sqlite.Tests/Scaffolding/SqliteCodeGeneratorTest.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.EntityFrameworkCore.Scaffolding.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Scaffolding

--- a/test/EFCore.Sqlite.Tests/SqliteDbContextOptionsBuilderExtensionsTest.cs
+++ b/test/EFCore.Sqlite.Tests/SqliteDbContextOptionsBuilderExtensionsTest.cs
@@ -3,7 +3,7 @@
 
 using System.Linq;
 using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore.Infrastructure.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Infrastructure.Internal;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore

--- a/test/EFCore.Sqlite.Tests/SqliteModelValidatorTest.cs
+++ b/test/EFCore.Sqlite.Tests/SqliteModelValidatorTest.cs
@@ -5,9 +5,9 @@ using System.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
-using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -102,7 +102,7 @@ namespace Microsoft.EntityFrameworkCore
                         new DiagnosticListener("Fake"))),
                 new RelationalModelValidatorDependencies(
 #pragma warning disable 618
-                    new ObsoleteRelationalTypeMapper(), 
+                    new ObsoleteRelationalTypeMapper(),
 #pragma warning restore 618
                     TestServiceFactory.Instance.Create<SqliteTypeMappingSource>()));
 

--- a/test/EFCore.Sqlite.Tests/Storage/SqliteSqlGenerationHelperTest.cs
+++ b/test/EFCore.Sqlite.Tests/Storage/SqliteSqlGenerationHelperTest.cs
@@ -1,7 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.EntityFrameworkCore.Storage.Internal;
+
+using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Storage
 {

--- a/test/EFCore.Sqlite.Tests/Storage/SqliteTypeMappingTest.cs
+++ b/test/EFCore.Sqlite.Tests/Storage/SqliteTypeMappingTest.cs
@@ -5,7 +5,7 @@ using System;
 using System.Data;
 using System.Data.Common;
 using Microsoft.Data.Sqlite;
-using Microsoft.EntityFrameworkCore.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 

--- a/test/EFCore.Sqlite.Tests/Update/SqliteUpdateSqlGeneratorTest.cs
+++ b/test/EFCore.Sqlite.Tests/Update/SqliteUpdateSqlGeneratorTest.cs
@@ -3,10 +3,11 @@
 
 using System;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Update.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
-using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
-using Microsoft.EntityFrameworkCore.Update.Internal;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Update


### PR DESCRIPTION
new namespace would be rooted at Microsoft.EntityFrameworkCore.Sqlite

Part of #11132

