### PR TITLE
Don't uniquify foreign key names set by convention…

### DIFF
--- a/src/EFCore.Abstractions/EFCore.Abstractions.csproj
+++ b/src/EFCore.Abstractions/EFCore.Abstractions.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <None Update="Properties\AbstractionsStrings.Designer.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
+      <CustomToolNamespace>Microsoft.EntityFrameworkCore.Internal</CustomToolNamespace>
       <LastGenOutput>AbstractionsStrings.Designer.cs</LastGenOutput>
     </None>
   </ItemGroup>

--- a/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
+++ b/src/EFCore.Relational/Infrastructure/RelationalModelValidator.cs
@@ -386,91 +386,14 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
 
             foreach (var foreignKey in mappedTypes.SelectMany(et => et.GetDeclaredForeignKeys()))
             {
-                var foreignKeyAnnotations = foreignKey.Relational();
-                var foreignKeyName = foreignKeyAnnotations.Name;
-
+                var foreignKeyName = foreignKey.Relational().Name;
                 if (!foreignKeyMappings.TryGetValue(foreignKeyName, out var duplicateForeignKey))
                 {
                     foreignKeyMappings[foreignKeyName] = foreignKey;
                     continue;
                 }
 
-                var principalAnnotations = foreignKey.PrincipalEntityType.Relational();
-                var principalTable = Format(principalAnnotations.Schema, principalAnnotations.TableName);
-                var duplicateAnnotations = duplicateForeignKey.PrincipalEntityType.Relational();
-                var duplicatePrincipalTable = Format(duplicateAnnotations.Schema, duplicateAnnotations.TableName);
-                if (!string.Equals(principalTable, duplicatePrincipalTable, StringComparison.OrdinalIgnoreCase))
-                {
-                    throw new InvalidOperationException(
-                        RelationalStrings.DuplicateForeignKeyPrincipalTableMismatch(
-                            Property.Format(foreignKey.Properties),
-                            foreignKey.DeclaringEntityType.DisplayName(),
-                            Property.Format(duplicateForeignKey.Properties),
-                            duplicateForeignKey.DeclaringEntityType.DisplayName(),
-                            tableName,
-                            foreignKeyName,
-                            principalTable,
-                            duplicatePrincipalTable));
-                }
-
-                if (!foreignKey.Properties.Select(p => p.Relational().ColumnName)
-                    .SequenceEqual(duplicateForeignKey.Properties.Select(p => p.Relational().ColumnName)))
-                {
-                    throw new InvalidOperationException(
-                        RelationalStrings.DuplicateForeignKeyColumnMismatch(
-                            Property.Format(foreignKey.Properties),
-                            foreignKey.DeclaringEntityType.DisplayName(),
-                            Property.Format(duplicateForeignKey.Properties),
-                            duplicateForeignKey.DeclaringEntityType.DisplayName(),
-                            tableName,
-                            foreignKeyName,
-                            foreignKey.Properties.FormatColumns(),
-                            duplicateForeignKey.Properties.FormatColumns()));
-                }
-
-                if (!foreignKey.PrincipalKey.Properties
-                    .Select(p => p.Relational().ColumnName)
-                    .SequenceEqual(
-                        duplicateForeignKey.PrincipalKey.Properties
-                            .Select(p => p.Relational().ColumnName)))
-                {
-                    throw new InvalidOperationException(
-                        RelationalStrings.DuplicateForeignKeyPrincipalColumnMismatch(
-                            Property.Format(foreignKey.Properties),
-                            foreignKey.DeclaringEntityType.DisplayName(),
-                            Property.Format(duplicateForeignKey.Properties),
-                            duplicateForeignKey.DeclaringEntityType.DisplayName(),
-                            tableName,
-                            foreignKeyName,
-                            foreignKey.PrincipalKey.Properties.FormatColumns(),
-                            duplicateForeignKey.PrincipalKey.Properties.FormatColumns()));
-                }
-
-                if (foreignKey.IsUnique != duplicateForeignKey.IsUnique)
-                {
-                    throw new InvalidOperationException(
-                        RelationalStrings.DuplicateForeignKeyUniquenessMismatch(
-                            Property.Format(foreignKey.Properties),
-                            foreignKey.DeclaringEntityType.DisplayName(),
-                            Property.Format(duplicateForeignKey.Properties),
-                            duplicateForeignKey.DeclaringEntityType.DisplayName(),
-                            tableName,
-                            foreignKeyName));
-                }
-
-                if (foreignKey.DeleteBehavior != duplicateForeignKey.DeleteBehavior)
-                {
-                    throw new InvalidOperationException(
-                        RelationalStrings.DuplicateForeignKeyDeleteBehaviorMismatch(
-                            Property.Format(foreignKey.Properties),
-                            foreignKey.DeclaringEntityType.DisplayName(),
-                            Property.Format(duplicateForeignKey.Properties),
-                            duplicateForeignKey.DeclaringEntityType.DisplayName(),
-                            tableName,
-                            foreignKeyName,
-                            foreignKey.DeleteBehavior,
-                            duplicateForeignKey.DeleteBehavior));
-                }
+                foreignKey.AreCompatible(duplicateForeignKey, shouldThrow: true);
             }
         }
 
@@ -486,39 +409,13 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             foreach (var index in mappedTypes.SelectMany(et => et.GetDeclaredIndexes()))
             {
                 var indexName = index.Relational().Name;
-
                 if (!indexMappings.TryGetValue(indexName, out var duplicateIndex))
                 {
                     indexMappings[indexName] = index;
                     continue;
                 }
 
-                if (!index.Properties.Select(p => p.Relational().ColumnName)
-                    .SequenceEqual(duplicateIndex.Properties.Select(p => p.Relational().ColumnName)))
-                {
-                    throw new InvalidOperationException(
-                        RelationalStrings.DuplicateIndexColumnMismatch(
-                            Property.Format(index.Properties),
-                            index.DeclaringEntityType.DisplayName(),
-                            Property.Format(duplicateIndex.Properties),
-                            duplicateIndex.DeclaringEntityType.DisplayName(),
-                            tableName,
-                            indexName,
-                            index.Properties.FormatColumns(),
-                            duplicateIndex.Properties.FormatColumns()));
-                }
-
-                if (index.IsUnique != duplicateIndex.IsUnique)
-                {
-                    throw new InvalidOperationException(
-                        RelationalStrings.DuplicateIndexUniquenessMismatch(
-                            Property.Format(index.Properties),
-                            index.DeclaringEntityType.DisplayName(),
-                            Property.Format(duplicateIndex.Properties),
-                            duplicateIndex.DeclaringEntityType.DisplayName(),
-                            tableName,
-                            indexName));
-                }
+                index.AreCompatible(duplicateIndex, shouldThrow: true);
             }
         }
 

--- a/src/EFCore.Relational/Metadata/Internal/ForeignKeyExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/ForeignKeyExtensions.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public static class ForeignKeyExtensions
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static bool AreCompatible([NotNull] this IForeignKey foreignKey, [NotNull] IForeignKey duplicateForeignKey, bool shouldThrow)
+        {
+            var principalAnnotations = foreignKey.PrincipalEntityType.Relational();
+            var duplicatePrincipalAnnotations = duplicateForeignKey.PrincipalEntityType.Relational();
+            if (!string.Equals(principalAnnotations.Schema, duplicatePrincipalAnnotations.Schema, StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(principalAnnotations.TableName, duplicatePrincipalAnnotations.TableName, StringComparison.OrdinalIgnoreCase))
+            {
+                if (shouldThrow)
+                {
+                    throw new InvalidOperationException(
+                        RelationalStrings.DuplicateForeignKeyPrincipalTableMismatch(
+                            Property.Format(foreignKey.Properties),
+                            foreignKey.DeclaringEntityType.DisplayName(),
+                            Property.Format(duplicateForeignKey.Properties),
+                            duplicateForeignKey.DeclaringEntityType.DisplayName(),
+                            Format(foreignKey.DeclaringEntityType.Relational()),
+                            foreignKey.Relational().Name,
+                            Format(principalAnnotations),
+                            Format(duplicatePrincipalAnnotations)));
+                }
+
+                return false;
+            }
+
+            if (!foreignKey.Properties.Select(p => p.Relational().ColumnName)
+                .SequenceEqual(duplicateForeignKey.Properties.Select(p => p.Relational().ColumnName)))
+            {
+                if (shouldThrow)
+                {
+                    throw new InvalidOperationException(
+                        RelationalStrings.DuplicateForeignKeyColumnMismatch(
+                            Property.Format(foreignKey.Properties),
+                            foreignKey.DeclaringEntityType.DisplayName(),
+                            Property.Format(duplicateForeignKey.Properties),
+                            duplicateForeignKey.DeclaringEntityType.DisplayName(),
+                            Format(foreignKey.DeclaringEntityType.Relational()),
+                            foreignKey.Relational().Name,
+                            foreignKey.Properties.FormatColumns(),
+                            duplicateForeignKey.Properties.FormatColumns()));
+                }
+
+                return false;
+            }
+
+            if (!foreignKey.PrincipalKey.Properties
+                .Select(p => p.Relational().ColumnName)
+                .SequenceEqual(duplicateForeignKey.PrincipalKey.Properties
+                    .Select(p => p.Relational().ColumnName)))
+            {
+                if (shouldThrow)
+                {
+                    throw new InvalidOperationException(
+                        RelationalStrings.DuplicateForeignKeyPrincipalColumnMismatch(
+                            Property.Format(foreignKey.Properties),
+                            foreignKey.DeclaringEntityType.DisplayName(),
+                            Property.Format(duplicateForeignKey.Properties),
+                            duplicateForeignKey.DeclaringEntityType.DisplayName(),
+                            Format(foreignKey.DeclaringEntityType.Relational()),
+                            foreignKey.Relational().Name,
+                            foreignKey.PrincipalKey.Properties.FormatColumns(),
+                            duplicateForeignKey.PrincipalKey.Properties.FormatColumns()));
+                }
+
+                return false;
+            }
+
+            if (foreignKey.IsUnique != duplicateForeignKey.IsUnique)
+            {
+                if (shouldThrow)
+                {
+                    throw new InvalidOperationException(
+                        RelationalStrings.DuplicateForeignKeyUniquenessMismatch(
+                            Property.Format(foreignKey.Properties),
+                            foreignKey.DeclaringEntityType.DisplayName(),
+                            Property.Format(duplicateForeignKey.Properties),
+                            duplicateForeignKey.DeclaringEntityType.DisplayName(),
+                            Format(foreignKey.DeclaringEntityType.Relational()),
+                            foreignKey.Relational().Name));
+                }
+
+                return false;
+            }
+
+            if (foreignKey.DeleteBehavior != duplicateForeignKey.DeleteBehavior)
+            {
+                if (shouldThrow)
+                {
+                    throw new InvalidOperationException(
+                        RelationalStrings.DuplicateForeignKeyDeleteBehaviorMismatch(
+                            Property.Format(foreignKey.Properties),
+                            foreignKey.DeclaringEntityType.DisplayName(),
+                            Property.Format(duplicateForeignKey.Properties),
+                            duplicateForeignKey.DeclaringEntityType.DisplayName(),
+                            Format(foreignKey.DeclaringEntityType.Relational()),
+                            foreignKey.Relational().Name,
+                            foreignKey.DeleteBehavior,
+                            duplicateForeignKey.DeleteBehavior));
+                }
+
+                return false;
+            }
+
+            return true;
+        }
+
+        private static string Format(IRelationalEntityTypeAnnotations annotations)
+            => (string.IsNullOrEmpty(annotations.Schema) ? "" : annotations.Schema + ".") + annotations.TableName;
+    }
+}

--- a/src/EFCore.Relational/Metadata/Internal/IndexExtensions.cs
+++ b/src/EFCore.Relational/Metadata/Internal/IndexExtensions.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public static class IndexExtensions
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static bool AreCompatible([NotNull] this IIndex index, [NotNull] IIndex duplicateIndex, bool shouldThrow)
+        {
+            if (!index.Properties.Select(p => p.Relational().ColumnName)
+                .SequenceEqual(duplicateIndex.Properties.Select(p => p.Relational().ColumnName)))
+            {
+                if (shouldThrow)
+                {
+                    throw new InvalidOperationException(
+                        RelationalStrings.DuplicateIndexColumnMismatch(
+                            Property.Format(index.Properties),
+                            index.DeclaringEntityType.DisplayName(),
+                            Property.Format(duplicateIndex.Properties),
+                            duplicateIndex.DeclaringEntityType.DisplayName(),
+                            Format(index.DeclaringEntityType.Relational()),
+                            index.Relational().Name,
+                            index.Properties.FormatColumns(),
+                            duplicateIndex.Properties.FormatColumns()));
+                }
+
+                return false;
+            }
+
+            if (index.IsUnique != duplicateIndex.IsUnique)
+            {
+                if (shouldThrow)
+                {
+                    throw new InvalidOperationException(
+                        RelationalStrings.DuplicateIndexUniquenessMismatch(
+                            Property.Format(index.Properties),
+                            index.DeclaringEntityType.DisplayName(),
+                            Property.Format(duplicateIndex.Properties),
+                            duplicateIndex.DeclaringEntityType.DisplayName(),
+                            Format(index.DeclaringEntityType.Relational()),
+                            index.Relational().Name));
+                }
+
+                return false;
+            }
+
+            return true;
+        }
+
+        private static string Format(IRelationalEntityTypeAnnotations annotations)
+            => (string.IsNullOrEmpty(annotations.Schema) ? "" : annotations.Schema + ".") + annotations.TableName;
+    }
+}

--- a/src/Shared/MemberInfoExtensions.cs
+++ b/src/Shared/MemberInfoExtensions.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
-using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace System.Reflection
 {
@@ -13,16 +12,23 @@ namespace System.Reflection
 
         public static bool IsSameAs(this MemberInfo propertyInfo, MemberInfo otherPropertyInfo)
         {
-            Check.NotNull(propertyInfo, nameof(propertyInfo));
-            Check.NotNull(otherPropertyInfo, nameof(otherPropertyInfo));
+            if (propertyInfo == null)
+            {
+                return otherPropertyInfo == null;
+            }
+
+            if (otherPropertyInfo == null)
+            {
+                return false;
+            }
 
             return Equals(propertyInfo, otherPropertyInfo)
-                   || propertyInfo.Name == otherPropertyInfo.Name
-                   && (propertyInfo.DeclaringType == otherPropertyInfo.DeclaringType
-                       || propertyInfo.DeclaringType.GetTypeInfo().IsSubclassOf(otherPropertyInfo.DeclaringType)
-                       || otherPropertyInfo.DeclaringType.GetTypeInfo().IsSubclassOf(propertyInfo.DeclaringType)
-                       || propertyInfo.DeclaringType.GetTypeInfo().ImplementedInterfaces.Contains(otherPropertyInfo.DeclaringType)
-                       || otherPropertyInfo.DeclaringType.GetTypeInfo().ImplementedInterfaces.Contains(propertyInfo.DeclaringType));
+                   || (propertyInfo.Name == otherPropertyInfo.Name
+                       && (propertyInfo.DeclaringType == otherPropertyInfo.DeclaringType
+                           || propertyInfo.DeclaringType.GetTypeInfo().IsSubclassOf(otherPropertyInfo.DeclaringType)
+                           || otherPropertyInfo.DeclaringType.GetTypeInfo().IsSubclassOf(propertyInfo.DeclaringType)
+                           || propertyInfo.DeclaringType.GetTypeInfo().ImplementedInterfaces.Contains(otherPropertyInfo.DeclaringType)
+                           || otherPropertyInfo.DeclaringType.GetTypeInfo().ImplementedInterfaces.Contains(propertyInfo.DeclaringType)));
         }
     }
 }

--- a/test/EFCore.Sqlite.Tests/SqliteModelValidatorTest.cs
+++ b/test/EFCore.Sqlite.Tests/SqliteModelValidatorTest.cs
@@ -70,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore
         public void Detects_schemas()
         {
             var modelBuilder = CreateConventionalModelBuilder();
-            modelBuilder.Entity<Animal>().ToTable("Animals", "pet");
+            modelBuilder.Entity<Animal>().ToTable("Animals", "pet").Ignore(a => a.FavoritePerson);
 
             VerifyWarning(SqliteStrings.LogSchemaConfigured.GenerateMessage("Animal", "pet"), modelBuilder.Model);
         }


### PR DESCRIPTION
… if the navigations used for both are the same CLR properties

Don't uniqufy index name set by convention if added for foreign keys that have the same name

Fixes #11094
