### PR TITLE
Allow to override a navigation property discovered by convention with a property on the principal side.

### DIFF
--- a/src/EFCore.Specification.Tests/CustomConvertersTestBase.cs
+++ b/src/EFCore.Specification.Tests/CustomConvertersTestBase.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Xunit;
 
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore
 {
     public abstract class CustomConvertersTestBase<TFixture> : BuiltInDataTypesTestBase<TFixture>

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -398,15 +398,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         if ((duplicateNavigation.IsDependentToPrincipal()
                             ? foreignKey.GetDependentToPrincipalConfigurationSource()
                             : foreignKey.GetPrincipalToDependentConfigurationSource())
-                            .Overrides(configurationSource)
-                            && configurationSource == ConfigurationSource.Explicit)
+                            .Overrides(configurationSource))
                         {
-                            throw new InvalidOperationException(CoreStrings.PropertyCalledOnNavigation(propertyName, Metadata.DisplayName()));
+                            if (configurationSource == ConfigurationSource.Explicit)
+                            {
+                                throw new InvalidOperationException(CoreStrings.PropertyCalledOnNavigation(propertyName, Metadata.DisplayName()));
+                            }
+
+                            return null;
                         }
 
                         if (foreignKey.GetConfigurationSource() == ConfigurationSource.Convention)
                         {
-                            RemoveForeignKey(foreignKey, ConfigurationSource.Convention);
+                            foreignKey.DeclaringEntityType.Builder.RemoveForeignKey(foreignKey, ConfigurationSource.Convention);
                         }
                         else
                         {

--- a/src/EFCore/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -1444,7 +1444,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return builder;
             }
 
-            if (!CanSetForeignKey(properties, dependentEntityType, configurationSource, out var resetIsRequired, out var resetPrincipalKey))
+            if (!CanSetForeignKey(
+                properties, dependentEntityType, configurationSource, out var resetIsRequired, out var resetPrincipalKey))
             {
                 return null;
             }

--- a/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
@@ -420,6 +420,22 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             }
 
             [Fact]
+            public virtual void Can_override_navigations_as_properties()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+                modelBuilder.Entity<Customer>();
+
+                var customer = model.FindEntityType(typeof(Customer));
+                Assert.NotNull(customer.FindNavigation(nameof(Customer.Orders)));
+
+                modelBuilder.Entity<Customer>().Property(c => c.Orders);
+
+                Assert.Null(customer.FindNavigation(nameof(Customer.Orders)));
+                Assert.NotNull(customer.FindProperty(nameof(Customer.Orders)));
+            }
+
+            [Fact]
             public virtual void Ignoring_a_navigation_property_removes_discovered_entity_types()
             {
                 var modelBuilder = CreateModelBuilder();


### PR DESCRIPTION
Fixes #11199
