### PR TITLE
[TINY] Fix to #11219 - select new {} in a selectmany fails

### DIFF
--- a/src/EFCore.Specification.Tests/Query/ComplexNavigationsOwnedQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/ComplexNavigationsOwnedQueryTestBase.cs
@@ -423,6 +423,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
         }
 
+        public override void SelectMany_subquery_with_custom_projection()
+        {
+        }
+
         #endregion
     }
 }

--- a/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -3993,5 +3993,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                        select lOuter,
                 new List<IExpectedInclude> { new ExpectedInclude<Level3>(l3 => l3.OneToMany_Optional, "OneToMany_Optional") });
         }
+
+        [ConditionalFact]
+        public virtual void SelectMany_subquery_with_custom_projection()
+        {
+            AssertQuery<Level1>(
+                l1s => l1s.OrderBy(l1 => l1.Id).SelectMany(l1 => l1.OneToMany_Optional.Select(l2 => new { l2.Name })).Take(1));
+        }
     }
 }

--- a/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
@@ -695,17 +695,22 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 {
                     if (additionalFromClauseBeingProcessed.FromExpression is SubQueryExpression fromSubqueryExpression)
                     {
-                        return RewriteSelectManyInsideSubqueryIntoJoins(
-                            fromSubqueryExpression,
+                        if (fromSubqueryExpression.QueryModel.SelectClause.Selector is QuerySourceReferenceExpression)
+                        {
+                            return RewriteSelectManyInsideSubqueryIntoJoins(
+                                fromSubqueryExpression,
+                                outerQuerySourceReferenceExpression,
+                                navigations,
+                                additionalFromClauseBeingProcessed);
+                        }
+                    }
+                    else
+                    {
+                        return RewriteSelectManyNavigationsIntoJoins(
                             outerQuerySourceReferenceExpression,
                             navigations,
                             additionalFromClauseBeingProcessed);
                     }
-
-                    return RewriteSelectManyNavigationsIntoJoins(
-                        outerQuerySourceReferenceExpression,
-                        navigations,
-                        additionalFromClauseBeingProcessed);
                 }
 
                 if (navigations.Count == 1

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -3678,6 +3678,23 @@ ORDER BY [l1.OneToMany_Required.OneToOne_Optional_FK4].[Id]",
 FROM [LevelFour] AS [l1.OneToMany_Required.OneToOne_Optional_FK.OneToMany_Optional0]");
         }
 
+        public override void SelectMany_subquery_with_custom_projection()
+        {
+            base.SelectMany_subquery_with_custom_projection();
+
+            AssertSql(
+                @"@__p_0='1'
+
+SELECT TOP(@__p_0) [t].[Name]
+FROM [LevelOne] AS [l1]
+CROSS APPLY (
+    SELECT [l2].[Name]
+    FROM [LevelTwo] AS [l2]
+    WHERE [l1].[Id] = [l2].[OneToMany_Optional_InverseId]
+) AS [t]
+ORDER BY [l1].[Id]");
+        }
+
         private void AssertSql(params string[] expected)
         {
             Fixture.TestSqlLoggerFactory.AssertBaseline(expected);


### PR DESCRIPTION
Problem was that we were trying to convert SelectMany on a subquery with a non-qsre projection into join. We should only do that for subqueries with qsre selectors, because otherwise type of generated join qsre would not match the original type.