### PR TITLE
Don't unwrap enums in MigrationsModelDiffer

### DIFF
--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -953,7 +953,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         {
             columnOperation.ClrType
                 = typeMapping.Converter?.ProviderClrType
-                  ?? typeMapping.ClrType.UnwrapNullableType().UnwrapEnumType();
+                  ?? typeMapping.ClrType.UnwrapNullableType();
 
             columnOperation.ColumnType = property.GetConfiguredColumnType();
             columnOperation.MaxLength = property.GetMaxLength();


### PR DESCRIPTION
As mentioned in #11324, [MigrationsModelDiffer unwraps enums to their underlying integral types](https://github.com/aspnet/EntityFrameworkCore/blob/13b4f7da77f6cad405f08d9b74d4d168ad382154/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs#L954). This causes migrations to be generated as `table.Column<int>(nullable: false)` instead of the actual type. The ModelSnapshot *does* contain the enum CLR type rather than int.

Strangely, this doesn't seem to affect the type of the column created in the database - running the migration with `Column<int>` does actually cause a PostgreSQL enum column to be created. I'm not sure exactly what's going on - I'm guessing that the model is consulted when running the migration, but I'm wondering if this won't interfere in other scenarios.

It seems right to me to remove this, but I may be missing something.

/cc @ajcvickers @bricelam