### PR TITLE
Migrator.cs refactored -  "PopulateMigrations" method made protected

### DIFF
--- a/src/EFCore.Relational/Migrations/Internal/Migrator.cs
+++ b/src/EFCore.Relational/Migrations/Internal/Migrator.cs
@@ -173,7 +173,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             }
         }
 
-        private void PopulateMigrations(
+        protected void PopulateMigrations(
             IEnumerable<string> appliedMigrationEntries,
             string targetMigration,
             out IReadOnlyList<Migration> migrationsToApply,


### PR DESCRIPTION
Summary of the changes:
- Made "PopulateMigrations" method protected in Migrator.cs (PopulateMigrations method is used in public virtual GenerateScript method, so it can be useful in descendants).