### PR TITLE
Stop using Property to cache type mappings

### DIFF
--- a/src/EFCore.Relational/Storage/Internal/FallbackRelationalTypeMappingSource.cs
+++ b/src/EFCore.Relational/Storage/Internal/FallbackRelationalTypeMappingSource.cs
@@ -3,6 +3,7 @@
 
 using System;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Storage.Internal
@@ -17,6 +18,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         private readonly IRelationalTypeMapper _relationalTypeMapper;
 #pragma warning restore 618
 
+        [ThreadStatic]
+        private static IProperty _property;
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
@@ -30,6 +34,19 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             : base(dependencies, relationalDependencies)
         {
             _relationalTypeMapper = typeMapper;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override CoreTypeMapping FindMappingWithConversion(
+            TypeMappingInfo mappingInfo,
+            IProperty property)
+        {
+            _property = property;
+
+            return base.FindMappingWithConversion(mappingInfo, property);
         }
 
         /// <summary>
@@ -67,8 +84,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         }
 
         private RelationalTypeMapping FindMappingForProperty(RelationalTypeMappingInfo mappingInfo)
-            => mappingInfo.Property != null
-                ? _relationalTypeMapper.FindMapping(mappingInfo.Property)
+            => _property != null
+                ? _relationalTypeMapper.FindMapping(_property)
                 : null;
 
         private RelationalTypeMapping FindMappingForClrType(RelationalTypeMappingInfo mappingInfo)

--- a/src/EFCore.Relational/Storage/RelationalTypeMappingSource.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMappingSource.cs
@@ -77,7 +77,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
         public override CoreTypeMapping FindMapping(IProperty property)
             => property.FindRelationalMapping()
-               ?? FindMappingWithConversion(new ConcreteRelationalTypeMappingInfo(property));
+               ?? FindMappingWithConversion(new ConcreteRelationalTypeMappingInfo(property), property);
 
         /// <summary>
         ///     <para>
@@ -95,7 +95,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="type"> The CLR type. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
         public override CoreTypeMapping FindMapping(Type type)
-            => FindMappingWithConversion(new ConcreteRelationalTypeMappingInfo(type));
+            => FindMappingWithConversion(new ConcreteRelationalTypeMappingInfo(type), null);
 
         /// <summary>
         ///     <para>
@@ -113,7 +113,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="member"> The field or property. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
         public override CoreTypeMapping FindMapping(MemberInfo member)
-            => FindMappingWithConversion(new ConcreteRelationalTypeMappingInfo(member));
+            => FindMappingWithConversion(new ConcreteRelationalTypeMappingInfo(member), null);
 
         /// <summary>
         ///     <para>
@@ -130,7 +130,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="storeTypeName"> The database type name. </param>
         /// <returns> The type mapping, or <c>null</c> if none was found. </returns>
         public virtual RelationalTypeMapping FindMapping(string storeTypeName)
-            => (RelationalTypeMapping)FindMappingWithConversion(new ConcreteRelationalTypeMappingInfo(storeTypeName));
+            => (RelationalTypeMapping)FindMappingWithConversion(new ConcreteRelationalTypeMappingInfo(storeTypeName), null);
 
         /// <summary>
         ///     <para>
@@ -164,7 +164,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             int? scale = null)
             => (RelationalTypeMapping)FindMappingWithConversion(
                 new ConcreteRelationalTypeMappingInfo(
-                    type, keyOrIndex, unicode, size, rowVersion, fixedLength, precision, scale));
+                    type, keyOrIndex, unicode, size, rowVersion, fixedLength, precision, scale), null);
 
         RelationalTypeMapping IRelationalTypeMappingSource.FindMapping(IProperty property)
             => (RelationalTypeMapping)FindMapping(property);

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
@@ -8,6 +8,7 @@ using System.Data;
 using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.SqlServer.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 
@@ -204,25 +205,27 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected override RelationalTypeMapping FindMapping(RelationalTypeMappingInfo mappingInfo)
+        protected override void ValidateMapping(CoreTypeMapping mapping, IProperty property)
         {
-            var mapping = FindRawMapping(mappingInfo)?.Clone(mappingInfo);
+            var relationalMapping = mapping as RelationalTypeMapping;
 
-            if (_disallowedMappings.Contains(mapping?.StoreType))
+            if (_disallowedMappings.Contains(relationalMapping?.StoreType))
             {
-                var propertyName = mappingInfo.Property?.Name
-                                   ?? mappingInfo.MemberInfo?.Name;
-
-                if (propertyName == null)
+                if (property== null)
                 {
-                    throw new ArgumentException(SqlServerStrings.UnqualifiedDataType(mapping.StoreType));
+                    throw new ArgumentException(SqlServerStrings.UnqualifiedDataType(relationalMapping.StoreType));
                 }
 
-                throw new ArgumentException(SqlServerStrings.UnqualifiedDataTypeOnProperty(mapping.StoreType, propertyName));
+                throw new ArgumentException(SqlServerStrings.UnqualifiedDataTypeOnProperty(relationalMapping.StoreType, property.Name));
             }
-
-            return mapping;
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override RelationalTypeMapping FindMapping(RelationalTypeMappingInfo mappingInfo)
+            => FindRawMapping(mappingInfo)?.Clone(mappingInfo);
 
         private RelationalTypeMapping FindRawMapping(RelationalTypeMappingInfo mappingInfo)
         {


### PR DESCRIPTION
Also, stop providers from using Property directly when determining a type mapping so that providers build type mappings with the same information that is used to cache them.

Fixes #11358