### PR TITLE
Query: rewrite predicate with constanList.Any(e =>e == someProperty) to Contains

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -909,7 +909,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
 
             if (subQueryModel.IsIdentityQuery()
                 && subQueryModel.ResultOperators.Count == 1
-                && subQueryModel.ResultOperators.First() is ContainsResultOperator)
+                && subQueryModel.ResultOperators[0] is ContainsResultOperator)
             {
                 var contains = (ContainsResultOperator)subQueryModel.ResultOperators.First();
                 var fromExpression = subQueryModel.MainFromClause.FromExpression;

--- a/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -3944,7 +3944,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 l1s => l1s.Where(l1 => l1.OneToOne_Optional_PK != null).Select(l1 => Math.Max(l1.OneToOne_Optional_PK.Level1_Required_Id, 7)));
         }
 
-        [ConditionalFact]
+        [ConditionalFact(Skip = "See PR #11433")]
         public virtual void Accessing_optional_property_inside_result_operator_subquery()
         {
             var names = new[] { "Name1", "Name2" };

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
@@ -1246,5 +1246,69 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             AssertSingleResult<Employee>(es => es.Sum(e => 1));
         }
+
+        [ConditionalFact]
+        public virtual void Where_subquery_any_equals_operator()
+        {
+            var ids = new List<string> { "ABCDE", "ALFKI", "ANATR" };
+            AssertQuery<Customer>(cs => cs.Where(c => ids.Any(li => li == c.CustomerID)),
+                entryCount: 2);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_subquery_any_equals()
+        {
+            var ids = new List<string> { "ABCDE", "ALFKI", "ANATR" };
+            AssertQuery<Customer>(cs => cs.Where(c => ids.Any(li => li.Equals(c.CustomerID))),
+                entryCount: 2);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_subquery_any_equals_static()
+        {
+            var ids = new List<string> { "ABCDE", "ALFKI", "ANATR" };
+            AssertQuery<Customer>(cs => cs.Where(c => ids.Any(li => Equals(li, c.CustomerID))),
+                entryCount: 2);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_subquery_where_any()
+        {
+            var ids = new List<string> { "ABCDE", "ALFKI", "ANATR" };
+            AssertQuery<Customer>(cs => cs.Where(c => c.City == "México D.F.").Where(c => ids.Any(li => li == c.CustomerID)),
+                entryCount: 1);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_subquery_all_not_equals_operator()
+        {
+            var ids = new List<string> { "ABCDE", "ALFKI", "ANATR" };
+            AssertQuery<Customer>(cs => cs.Where(c => ids.All(li => li != c.CustomerID)),
+                entryCount: 89);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_subquery_all_not_equals()
+        {
+            var ids = new List<string> { "ABCDE", "ALFKI", "ANATR" };
+            AssertQuery<Customer>(cs => cs.Where(c => ids.All(li => !li.Equals(c.CustomerID))),
+                entryCount: 89);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_subquery_all_not_equals_static()
+        {
+            var ids = new List<string> { "ABCDE", "ALFKI", "ANATR" };
+            AssertQuery<Customer>(cs => cs.Where(c => ids.All(li => !Equals(li, c.CustomerID))),
+                entryCount: 89);
+        }
+
+        [ConditionalFact]
+        public virtual void Where_subquery_where_all()
+        {
+            var ids = new List<string> { "ABCDE", "ALFKI", "ANATR" };
+            AssertQuery<Customer>(cs => cs.Where(c => c.City == "México D.F.").Where(c => ids.All(li => li != c.CustomerID)),
+                entryCount: 4);
+        }
     }
 }

--- a/src/EFCore/Query/ExpressionVisitors/Internal/AllAnyToContainsResultOperatorExpressionRewriter.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/AllAnyToContainsResultOperatorExpressionRewriter.cs
@@ -1,0 +1,166 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Clauses.ResultOperators;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class AllAnyToContainsResultOperatorExpressionRewriter : ExpressionVisitorBase
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override Expression VisitSubQuery(SubQueryExpression expression)
+        {
+            Check.NotNull(expression, nameof(expression));
+
+            var subQueryModel = expression.QueryModel;
+
+            var fromExpression = subQueryModel.MainFromClause.FromExpression;
+
+            if (fromExpression.NodeType == ExpressionType.Parameter
+                || fromExpression.NodeType == ExpressionType.Constant
+                || fromExpression.NodeType == ExpressionType.ListInit
+                || fromExpression.NodeType == ExpressionType.NewArrayInit)
+            {
+                if (subQueryModel.ResultOperators.Count == 1
+                    && subQueryModel.BodyClauses.Count == 0
+                    && subQueryModel.ResultOperators[0] is AllResultOperator all)
+                {
+                    if (TryMatchInequalityExpression(
+                        all.Predicate,
+                        out var left,
+                        out var right))
+                    {
+                        var containsItem = CompareReturnOpposite(subQueryModel.SelectClause.Selector, left, right);
+
+                        if (containsItem != null)
+                        {
+                            subQueryModel.ResultOperators.Clear();
+                            subQueryModel.ResultOperators.Add(new ContainsResultOperator(containsItem));
+
+                            return Expression.Not(
+                                new SubQueryExpression(subQueryModel));
+                        }
+                    }
+                }
+
+                if (subQueryModel.ResultOperators.Count == 1
+                    && subQueryModel.BodyClauses.Count == 1
+                    && subQueryModel.ResultOperators[0] is AnyResultOperator
+                    && subQueryModel.BodyClauses[0] is WhereClause whereClause)
+                {
+                    if (TryMatchEqualityExpression(
+                        whereClause.Predicate,
+                        out var left,
+                        out var right))
+                    {
+                        var containsItem = CompareReturnOpposite(subQueryModel.SelectClause.Selector, left, right);
+
+                        if (containsItem != null)
+                        {
+                            subQueryModel.BodyClauses.Clear();
+                            subQueryModel.ResultOperators.Clear();
+                            subQueryModel.ResultOperators.Add(new ContainsResultOperator(containsItem));
+
+                            return new SubQueryExpression(subQueryModel);
+                        }
+                    }
+                }
+            }
+
+            return expression;
+        }
+
+        private static Expression CompareReturnOpposite(Expression selector, Expression left, Expression right)
+            => ExpressionEqualityComparer.Instance.Equals(selector, left)
+                ? right
+                : ExpressionEqualityComparer.Instance.Equals(selector, right)
+                    ? left
+                    : null;
+
+        private static bool TryMatchEqualityExpression(Expression expression, out Expression left, out Expression right)
+        {
+            left = null;
+            right = null;
+
+            if (expression is BinaryExpression binaryExpression
+                && binaryExpression.NodeType == ExpressionType.Equal)
+            {
+                left = binaryExpression.Left;
+                right = binaryExpression.Right;
+
+                return true;
+            }
+
+            if (expression is MethodCallExpression methodCallExpression
+                && methodCallExpression.Method.Name == nameof(object.Equals))
+            {
+                return TryMatchEqualsMethodCallExpression(methodCallExpression, out left, out right);
+            }
+
+            return false;
+        }
+
+        private static bool TryMatchInequalityExpression(Expression expression, out Expression left, out Expression right)
+        {
+            left = null;
+            right = null;
+
+            if (expression is BinaryExpression binaryExpression
+                && binaryExpression.NodeType == ExpressionType.NotEqual)
+            {
+                left = binaryExpression.Left;
+                right = binaryExpression.Right;
+
+                return true;
+            }
+
+            if (expression is UnaryExpression unaryExpression
+                && unaryExpression.NodeType == ExpressionType.Not
+                && unaryExpression.Operand is MethodCallExpression methodCallExpression
+                && methodCallExpression.Method.Name == nameof(object.Equals))
+            {
+                return TryMatchEqualsMethodCallExpression(methodCallExpression, out left, out right);
+            }
+
+            return false;
+        }
+
+        private static bool TryMatchEqualsMethodCallExpression(MethodCallExpression methodCallExpression, out Expression left, out Expression right)
+        {
+            left = null;
+            right = null;
+
+            if (methodCallExpression.Arguments.Count == 1
+                && methodCallExpression.Object?.Type == methodCallExpression.Arguments[0].Type)
+            {
+                left = methodCallExpression.Object;
+                right = methodCallExpression.Arguments[0];
+
+                return true;
+            }
+
+            if (methodCallExpression.Arguments.Count == 2
+                && methodCallExpression.Arguments[0].Type == methodCallExpression.Arguments[1].Type)
+            {
+                left = methodCallExpression.Arguments[0];
+                right = methodCallExpression.Arguments[1];
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/EFCore/Query/Internal/QueryOptimizer.cs
+++ b/src/EFCore/Query/Internal/QueryOptimizer.cs
@@ -83,6 +83,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             queryModel.TransformExpressions(new ConditionalOptimizingExpressionVisitor().Visit);
             queryModel.TransformExpressions(new EntityEqualityRewritingExpressionVisitor(queryCompilationContext).Visit);
             queryModel.TransformExpressions(new SubQueryMemberPushDownExpressionVisitor(queryCompilationContext).Visit);
+            queryModel.TransformExpressions(new AllAnyToContainsResultOperatorExpressionRewriter().Visit);
         }
 
         /// <summary>

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
@@ -1046,5 +1046,85 @@ WHERE [o].[ProductID] = 42");
                 @"SELECT 1
 FROM [Employees] AS [e]");
         }
+
+        public override void Where_subquery_any_equals_operator()
+        {
+            base.Where_subquery_any_equals_operator();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN (N'ABCDE', N'ALFKI', N'ANATR')");
+        }
+
+        public override void Where_subquery_any_equals()
+        {
+            base.Where_subquery_any_equals();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN (N'ABCDE', N'ALFKI', N'ANATR')");
+        }
+
+        public override void Where_subquery_any_equals_static()
+        {
+            base.Where_subquery_any_equals_static();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IN (N'ABCDE', N'ALFKI', N'ANATR')");
+        }
+
+        public override void Where_subquery_where_any()
+        {
+            base.Where_subquery_where_any();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE ([c].[City] = N'México D.F.') AND [c].[CustomerID] IN (N'ABCDE', N'ALFKI', N'ANATR')");
+        }
+
+        public override void Where_subquery_all_not_equals_operator()
+        {
+            base.Where_subquery_all_not_equals_operator();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] NOT IN (N'ABCDE', N'ALFKI', N'ANATR')");
+        }
+
+        public override void Where_subquery_all_not_equals()
+        {
+            base.Where_subquery_all_not_equals();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] NOT IN (N'ABCDE', N'ALFKI', N'ANATR')");
+        }
+
+        public override void Where_subquery_all_not_equals_static()
+        {
+            base.Where_subquery_all_not_equals_static();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] NOT IN (N'ABCDE', N'ALFKI', N'ANATR')");
+        }
+
+        public override void Where_subquery_where_all()
+        {
+            base.Where_subquery_where_all();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE ([c].[City] = N'México D.F.') AND [c].[CustomerID] NOT IN (N'ABCDE', N'ALFKI', N'ANATR')");
+        }
     }
 }


### PR DESCRIPTION
Resolves #11389, works both for Equals and == operator.

Not sure what to do with inequality, @smitpatel did you mean, that
`list.Any(e => e != someProperty)` should be rewritten into `!list.Contains(someProperty)`?

I also added a few tests for simplest cases.