### PR TITLE
Design: Allow unspecified project language

### DIFF
--- a/src/EFCore.Design/Design/Internal/DatabaseOperations.cs
+++ b/src/EFCore.Design/Design/Internal/DatabaseOperations.cs
@@ -33,14 +33,13 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             [NotNull] Assembly startupAssembly,
             [NotNull] string projectDir,
             [NotNull] string rootNamespace,
-            [NotNull] string language,
+            [CanBeNull] string language,
             [NotNull] string[] args)
         {
             Check.NotNull(reporter, nameof(reporter));
             Check.NotNull(startupAssembly, nameof(startupAssembly));
             Check.NotNull(projectDir, nameof(projectDir));
             Check.NotNull(rootNamespace, nameof(rootNamespace));
-            Check.NotNull(language, nameof(language));
             Check.NotNull(args, nameof(args));
 
             _reporter = reporter;

--- a/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
+++ b/src/EFCore.Design/Design/Internal/MigrationsOperations.cs
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             [NotNull] Assembly startupAssembly,
             [NotNull] string projectDir,
             [NotNull] string rootNamespace,
-            [NotNull] string language,
+            [CanBeNull] string language,
             [NotNull] string[] args)
         {
             Check.NotNull(reporter, nameof(reporter));
@@ -49,7 +49,6 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             Check.NotNull(startupAssembly, nameof(startupAssembly));
             Check.NotNull(projectDir, nameof(projectDir));
             Check.NotNull(rootNamespace, nameof(rootNamespace));
-            Check.NotNull(language, nameof(language));
             Check.NotNull(args, nameof(args));
 
             _reporter = reporter;

--- a/src/EFCore.Design/Scaffolding/IReverseEngineerScaffolder.cs
+++ b/src/EFCore.Design/Scaffolding/IReverseEngineerScaffolder.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
             [NotNull] IEnumerable<string> tables,
             [NotNull] IEnumerable<string> schemas,
             [NotNull] string @namespace,
-            [NotNull] string language,
+            [CanBeNull] string language,
             [CanBeNull] string contextDir,
             [CanBeNull] string contextName,
             [NotNull] ModelReverseEngineerOptions modelOptions,

--- a/src/EFCore.Design/Scaffolding/Internal/ReverseEngineerScaffolder.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/ReverseEngineerScaffolder.cs
@@ -76,7 +76,6 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             Check.NotNull(tables, nameof(tables));
             Check.NotNull(schemas, nameof(schemas));
             Check.NotEmpty(@namespace, nameof(@namespace));
-            Check.NotNull(language, nameof(language));
             Check.NotNull(modelOptions, nameof(modelOptions));
             Check.NotNull(codeOptions, nameof(codeOptions));
 


### PR DESCRIPTION
This can happen when using an older tool with a newer runtime.

Fixes #11075