### PR TITLE
Sqlite: Translate DateTime.Millisecond

### DIFF
--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -701,5 +701,53 @@ namespace Microsoft.EntityFrameworkCore.Query
                 .Select(
                     o => o.OrderDetails.OrderBy(od => od.Product.ProductName).Take(1).FirstOrDefault()));
         }
+
+        [ConditionalFact]
+        public virtual void Select_datetime_year_component()
+        {
+            AssertQueryScalar<Order>(os => os.Select(o => o.OrderDate.Value.Year));
+        }
+
+        [ConditionalFact]
+        public virtual void Select_datetime_month_component()
+        {
+            AssertQueryScalar<Order>(os => os.Select(o => o.OrderDate.Value.Month));
+        }
+
+        [ConditionalFact]
+        public virtual void Select_datetime_day_of_year_component()
+        {
+            AssertQueryScalar<Order>(os => os.Select(o => o.OrderDate.Value.DayOfYear));
+        }
+
+        [ConditionalFact]
+        public virtual void Select_datetime_day_component()
+        {
+            AssertQueryScalar<Order>(os => os.Select(o => o.OrderDate.Value.Day));
+        }
+
+        [ConditionalFact]
+        public virtual void Select_datetime_hour_component()
+        {
+            AssertQueryScalar<Order>(os => os.Select(o => o.OrderDate.Value.Hour));
+        }
+
+        [ConditionalFact]
+        public virtual void Select_datetime_minute_component()
+        {
+            AssertQueryScalar<Order>(os => os.Select(o => o.OrderDate.Value.Minute));
+        }
+
+        [ConditionalFact]
+        public virtual void Select_datetime_second_component()
+        {
+            AssertQueryScalar<Order>(os => os.Select(o => o.OrderDate.Value.Second));
+        }
+
+        [ConditionalFact]
+        public virtual void Select_datetime_millisecond_component()
+        {
+            AssertQueryScalar<Order>(os => os.Select(o => o.OrderDate.Value.Millisecond));
+        }
     }
 }

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteDateTimeMemberTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteDateTimeMemberTranslator.cs
@@ -39,24 +39,21 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Inter
 
                 if (memberName == nameof(DateTime.Millisecond))
                 {
-                    var timeExpression = new SqlFunctionExpression(
-                        "strftime",
-                        memberExpression.Type,
-                        new[]
-                        {
-                            new SqlFragmentExpression("'%Y-%m-%d %H:%M:%f'"),
-                            memberExpression.Expression
-                        });
                     return new ExplicitCastExpression(
                         new SqlFunctionExpression(
                             "substr",
                             memberExpression.Type,
                             new Expression[]
                             {
-                                timeExpression,
-                                Expression.Subtract(
-                                    new SqlFunctionExpression("LENGTH", typeof(int), new[] { timeExpression }),
-                                    Expression.Constant(2))
+                                new SqlFunctionExpression(
+                                    "strftime",
+                                    memberExpression.Type,
+                                    new[]
+                                    {
+                                        new SqlFragmentExpression("'%f'"),
+                                        memberExpression.Expression
+                                    }),
+                                Expression.Constant(4),
                             }),
                         typeof(int));
                 }

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteDateTimeMemberTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteDateTimeMemberTranslator.cs
@@ -40,20 +40,19 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Inter
                 if (memberName == nameof(DateTime.Millisecond))
                 {
                     var factor = 1000;
-                    return new ExplicitCastExpression(
-                        Expression.Modulo(
-                            Expression.Multiply(
-                                new SqlFunctionExpression(
-                                    "strftime",
-                                    memberExpression.Type,
-                                    new[]
-                                    {
-                                        new SqlFragmentExpression("'%f'"),
-                                        memberExpression.Expression
-                                    }),
-                                Expression.Constant(factor)),
+
+                    return Expression.Modulo(
+                        Expression.Multiply(
+                            new SqlFunctionExpression(
+                                "strftime",
+                                memberExpression.Type,
+                                new[]
+                                {
+                                    new SqlFragmentExpression("'%f'"),
+                                    memberExpression.Expression
+                                }),
                             Expression.Constant(factor)),
-                        typeof(int));
+                        Expression.Constant(factor));
                 }
 
                 if (_datePartMapping.TryGetValue(memberName, out var datePart))

--- a/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteDateTimeMemberTranslator.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionTranslators/Internal/SqliteDateTimeMemberTranslator.cs
@@ -39,12 +39,10 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Inter
 
                 if (memberName == nameof(DateTime.Millisecond))
                 {
+                    var factor = 1000;
                     return new ExplicitCastExpression(
-                        new SqlFunctionExpression(
-                            "substr",
-                            memberExpression.Type,
-                            new Expression[]
-                            {
+                        Expression.Modulo(
+                            Expression.Multiply(
                                 new SqlFunctionExpression(
                                     "strftime",
                                     memberExpression.Type,
@@ -53,8 +51,8 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Inter
                                         new SqlFragmentExpression("'%f'"),
                                         memberExpression.Expression
                                     }),
-                                Expression.Constant(4),
-                            }),
+                                Expression.Constant(factor)),
+                            Expression.Constant(factor)),
                         typeof(int));
                 }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
@@ -773,5 +773,77 @@ FROM (
 ) AS [t]
 ORDER BY [t].[ProductName]");
         }
+
+        public override void Select_datetime_year_component()
+        {
+            base.Select_datetime_year_component();
+
+            AssertSql(
+                @"SELECT DATEPART(year, [o].[OrderDate])
+FROM [Orders] AS [o]");
+        }
+
+        public override void Select_datetime_month_component()
+        {
+            base.Select_datetime_month_component();
+
+            AssertSql(
+                @"SELECT DATEPART(month, [o].[OrderDate])
+FROM [Orders] AS [o]");
+        }
+
+        public override void Select_datetime_day_of_year_component()
+        {
+            base.Select_datetime_day_of_year_component();
+
+            AssertSql(
+                @"SELECT DATEPART(dayofyear, [o].[OrderDate])
+FROM [Orders] AS [o]");
+        }
+
+        public override void Select_datetime_day_component()
+        {
+            base.Select_datetime_day_component();
+
+            AssertSql(
+                @"SELECT DATEPART(day, [o].[OrderDate])
+FROM [Orders] AS [o]");
+        }
+
+        public override void Select_datetime_hour_component()
+        {
+            base.Select_datetime_hour_component();
+
+            AssertSql(
+                @"SELECT DATEPART(hour, [o].[OrderDate])
+FROM [Orders] AS [o]");
+        }
+
+        public override void Select_datetime_minute_component()
+        {
+            base.Select_datetime_minute_component();
+
+            AssertSql(
+                @"SELECT DATEPART(minute, [o].[OrderDate])
+FROM [Orders] AS [o]");
+        }
+
+        public override void Select_datetime_second_component()
+        {
+            base.Select_datetime_second_component();
+
+            AssertSql(
+                @"SELECT DATEPART(second, [o].[OrderDate])
+FROM [Orders] AS [o]");
+        }
+
+        public override void Select_datetime_millisecond_component()
+        {
+            base.Select_datetime_millisecond_component();
+
+            AssertSql(
+                @"SELECT DATEPART(millisecond, [o].[OrderDate])
+FROM [Orders] AS [o]");
+        }
     }
 }

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
@@ -163,7 +163,7 @@ WHERE CAST(strftime('%S', ""o"".""OrderDate"") AS INTEGER) = 44");
             AssertSql(
                 @"SELECT ""o"".""OrderID"", ""o"".""CustomerID"", ""o"".""EmployeeID"", ""o"".""OrderDate""
 FROM ""Orders"" AS ""o""
-WHERE CAST(substr(strftime('%Y-%m-%d %H:%M:%f', ""o"".""OrderDate""), LENGTH(strftime('%Y-%m-%d %H:%M:%f', ""o"".""OrderDate"")) - 2) AS INTEGER) = 88");
+WHERE CAST(substr(strftime('%f', ""o"".""OrderDate""), 4) AS INTEGER) = 88");
         }
 
         public override void String_StartsWith_Literal()

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
@@ -163,7 +163,7 @@ WHERE CAST(strftime('%S', ""o"".""OrderDate"") AS INTEGER) = 44");
             AssertSql(
                 @"SELECT ""o"".""OrderID"", ""o"".""CustomerID"", ""o"".""EmployeeID"", ""o"".""OrderDate""
 FROM ""Orders"" AS ""o""
-WHERE CAST((strftime('%f', ""o"".""OrderDate"") * 1000) % 1000 AS INTEGER) = 88");
+WHERE ((strftime('%f', ""o"".""OrderDate"") * 1000) % 1000) = 88");
         }
 
         public override void String_StartsWith_Literal()
@@ -598,6 +598,78 @@ WHERE trim(""c"".""ContactTitle"", 'Or') = 'wne'");
                 @"SELECT SUM(COALESCE(""p"".""UnitPrice"", '0.0'))
 FROM ""Products"" AS ""p""
 WHERE ""p"".""ProductID"" < 40");
+        }
+
+        public override void Select_datetime_year_component()
+        {
+            base.Select_datetime_year_component();
+
+            AssertSql(
+                @"SELECT CAST(strftime('%Y', ""o"".""OrderDate"") AS INTEGER)
+FROM ""Orders"" AS ""o""");
+        }
+
+        public override void Select_datetime_month_component()
+        {
+            base.Select_datetime_month_component();
+
+            AssertSql(
+                @"SELECT CAST(strftime('%m', ""o"".""OrderDate"") AS INTEGER)
+FROM ""Orders"" AS ""o""");
+        }
+
+        public override void Select_datetime_day_of_year_component()
+        {
+            base.Select_datetime_day_of_year_component();
+
+            AssertSql(
+                @"SELECT CAST(strftime('%j', ""o"".""OrderDate"") AS INTEGER)
+FROM ""Orders"" AS ""o""");
+        }
+
+        public override void Select_datetime_day_component()
+        {
+            base.Select_datetime_day_component();
+
+            AssertSql(
+                @"SELECT CAST(strftime('%d', ""o"".""OrderDate"") AS INTEGER)
+FROM ""Orders"" AS ""o""");
+        }
+
+        public override void Select_datetime_hour_component()
+        {
+            base.Select_datetime_hour_component();
+
+            AssertSql(
+                @"SELECT CAST(strftime('%H', ""o"".""OrderDate"") AS INTEGER)
+FROM ""Orders"" AS ""o""");
+        }
+
+        public override void Select_datetime_minute_component()
+        {
+            base.Select_datetime_minute_component();
+
+            AssertSql(
+                @"SELECT CAST(strftime('%M', ""o"".""OrderDate"") AS INTEGER)
+FROM ""Orders"" AS ""o""");
+        }
+
+        public override void Select_datetime_second_component()
+        {
+            base.Select_datetime_second_component();
+
+            AssertSql(
+                @"SELECT CAST(strftime('%S', ""o"".""OrderDate"") AS INTEGER)
+FROM ""Orders"" AS ""o""");
+        }
+
+        public override void Select_datetime_millisecond_component()
+        {
+            base.Select_datetime_millisecond_component();
+
+            AssertSql(
+                @"SELECT (strftime('%f', ""o"".""OrderDate"") * 1000) % 1000
+FROM ""Orders"" AS ""o""");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
@@ -162,7 +162,8 @@ WHERE CAST(strftime('%S', ""o"".""OrderDate"") AS INTEGER) = 44");
 
             AssertSql(
                 @"SELECT ""o"".""OrderID"", ""o"".""CustomerID"", ""o"".""EmployeeID"", ""o"".""OrderDate""
-FROM ""Orders"" AS ""o""");
+FROM ""Orders"" AS ""o""
+WHERE CAST(substr(strftime('%Y-%m-%d %H:%M:%f', ""o"".""OrderDate""), LENGTH(strftime('%Y-%m-%d %H:%M:%f', ""o"".""OrderDate"")) - 2) AS INTEGER) = 88");
         }
 
         public override void String_StartsWith_Literal()

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
@@ -163,7 +163,7 @@ WHERE CAST(strftime('%S', ""o"".""OrderDate"") AS INTEGER) = 44");
             AssertSql(
                 @"SELECT ""o"".""OrderID"", ""o"".""CustomerID"", ""o"".""EmployeeID"", ""o"".""OrderDate""
 FROM ""Orders"" AS ""o""
-WHERE CAST(substr(strftime('%f', ""o"".""OrderDate""), 4) AS INTEGER) = 88");
+WHERE CAST((strftime('%f', ""o"".""OrderDate"") * 1000) % 1000 AS INTEGER) = 88");
         }
 
         public override void String_StartsWith_Literal()


### PR DESCRIPTION
Fixes #10523.
- Get milliseconds by using substr and casting them to INTEGER