### PR TITLE
Add internal builder for service properties.

### DIFF
--- a/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder.cs
@@ -219,9 +219,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                     && referenceName != null
                     && ReferenceName == referenceName)
                 {
-                    throw new InvalidOperationException(
-                        CoreStrings.DuplicateNavigation(
-                            referenceName, RelatedEntityType.DisplayName(), RelatedEntityType.DisplayName()));
+                    throw new InvalidOperationException(CoreStrings.ConflictingPropertyOrNavigation(
+                        referenceName, RelatedEntityType.DisplayName(), RelatedEntityType.DisplayName()));
                 }
 
                 var pointsToPrincipal = !foreignKey.IsSelfReferencing()

--- a/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
@@ -90,6 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             conventionSet.EntityTypeMemberIgnoredConventions.Add(inversePropertyAttributeConvention);
             conventionSet.EntityTypeMemberIgnoredConventions.Add(relationshipDiscoveryConvention);
             conventionSet.EntityTypeMemberIgnoredConventions.Add(foreignKeyPropertyDiscoveryConvention);
+            conventionSet.EntityTypeMemberIgnoredConventions.Add(servicePropertyDiscoveryConvention);
 
             var keyAttributeConvention = new KeyAttributeConvention();
             var backingFieldConvention = new BackingFieldConvention();
@@ -158,6 +159,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             conventionSet.ModelBuiltConventions.Add(new RelationshipValidationConvention());
             conventionSet.ModelBuiltConventions.Add(foreignKeyPropertyDiscoveryConvention);
+            conventionSet.ModelBuiltConventions.Add(servicePropertyDiscoveryConvention);
 
             conventionSet.NavigationAddedConventions.Add(backingFieldConvention);
             conventionSet.NavigationAddedConventions.Add(new RequiredNavigationAttributeConvention(Dependencies.Logger));

--- a/src/EFCore/Metadata/Internal/InternalServicePropertyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalServicePropertyBuilder.cs
@@ -1,0 +1,100 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Diagnostics;
+using System.Reflection;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    [DebuggerDisplay("{Metadata,nq}")]
+    public class InternalServicePropertyBuilder : InternalMetadataItemBuilder<ServiceProperty>
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public InternalServicePropertyBuilder([NotNull] ServiceProperty property, [NotNull] InternalModelBuilder modelBuilder)
+            : base(property, modelBuilder)
+        {
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual bool HasField([CanBeNull] string fieldName, ConfigurationSource configurationSource)
+        {
+            if (Metadata.FieldInfo?.Name == fieldName)
+            {
+                Metadata.SetField(fieldName, configurationSource);
+                return true;
+            }
+
+            if (!configurationSource.Overrides(Metadata.GetFieldInfoConfigurationSource()))
+            {
+                return false;
+            }
+
+            if (fieldName != null)
+            {
+                var fieldInfo = PropertyBase.GetFieldInfo(
+                    fieldName, Metadata.DeclaringType.ClrType, Metadata.Name,
+                    shouldThrow: configurationSource == ConfigurationSource.Explicit);
+                Metadata.SetFieldInfo(fieldInfo, configurationSource);
+                return true;
+            }
+
+            Metadata.SetField(fieldName, configurationSource);
+            return true;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual bool HasFieldInfo([CanBeNull] FieldInfo fieldInfo, ConfigurationSource configurationSource)
+        {
+            if ((configurationSource.Overrides(Metadata.GetFieldInfoConfigurationSource())
+                 && (fieldInfo == null
+                     || PropertyBase.IsCompatible(
+                         fieldInfo, Metadata.ClrType, Metadata.DeclaringType.ClrType, Metadata.Name,
+                         shouldThrow: configurationSource == ConfigurationSource.Explicit)))
+                || Equals(Metadata.FieldInfo, fieldInfo))
+            {
+                Metadata.SetFieldInfo(fieldInfo, configurationSource);
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual bool UsePropertyAccessMode(PropertyAccessMode propertyAccessMode, ConfigurationSource configurationSource)
+            => HasAnnotation(CoreAnnotationNames.PropertyAccessModeAnnotation, propertyAccessMode, configurationSource);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual bool SetParameterBinding(
+            [NotNull] ServiceParameterBinding parameterBinding, ConfigurationSource configurationSource)
+        {
+            if (configurationSource.Overrides(Metadata.GetParameterBindingConfigurationSource())
+                || (Metadata.ParameterBinding == parameterBinding))
+            {
+                Metadata.SetParameterBinding(parameterBinding, configurationSource);
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/EFCore/Metadata/Internal/PropertyBase.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBase.cs
@@ -78,7 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual FieldInfo FieldInfo
         {
             [DebuggerStepThrough] get => _fieldInfo;
-            [DebuggerStepThrough] [param: CanBeNull] set { SetFieldInfo(value, ConfigurationSource.Explicit); }
+            [DebuggerStepThrough] [param: CanBeNull] set => SetFieldInfo(value, ConfigurationSource.Explicit);
         }
 
         /// <summary>
@@ -110,7 +110,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public static FieldInfo GetFieldInfo([NotNull] string fieldName, [NotNull] Type type, [CanBeNull] string propertyName, bool shouldThrow)
+        public static FieldInfo GetFieldInfo(
+            [NotNull] string fieldName, [NotNull] Type type, [CanBeNull] string propertyName, bool shouldThrow)
         {
             Debug.Assert(propertyName != null || !shouldThrow);
 

--- a/src/EFCore/Metadata/Internal/ServiceProperty.cs
+++ b/src/EFCore/Metadata/Internal/ServiceProperty.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Diagnostics;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -14,6 +15,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     /// </summary>
     public class ServiceProperty : PropertyBase, IMutableServiceProperty
     {
+        private ServiceParameterBinding _parameterBinding;
+
+        private ConfigurationSource _configurationSource;
+        private ConfigurationSource? _parameterBindingConfigurationSource;
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
@@ -22,13 +28,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [NotNull] string name,
             [CanBeNull] PropertyInfo propertyInfo,
             [CanBeNull] FieldInfo fieldInfo,
-            [NotNull] EntityType declaringEntityType)
+            [NotNull] EntityType declaringEntityType,
+            ConfigurationSource configurationSource)
             : base(name, propertyInfo, fieldInfo)
         {
             Check.NotNull(declaringEntityType, nameof(declaringEntityType));
 
             DeclaringEntityType = declaringEntityType;
             ClrType = propertyInfo?.PropertyType ?? fieldInfo?.FieldType;
+            _configurationSource = configurationSource;
+
+            Builder = new InternalServicePropertyBuilder(this, declaringEntityType.Model.Builder);
         }
 
         /// <summary>
@@ -59,7 +69,57 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual ServiceParameterBinding ParameterBinding { get; [param: NotNull] set; }
+        public virtual InternalServicePropertyBuilder Builder
+        {
+            [DebuggerStepThrough] get; [DebuggerStepThrough] [param: CanBeNull] set;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual ConfigurationSource GetConfigurationSource() => _configurationSource;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void UpdateConfigurationSource(ConfigurationSource configurationSource)
+            => _configurationSource = _configurationSource.Max(configurationSource);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual ServiceParameterBinding ParameterBinding
+        {
+            get => _parameterBinding;
+            [param: NotNull] set => SetParameterBinding(value, ConfigurationSource.Explicit);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void SetParameterBinding(ServiceParameterBinding parameterBinding, ConfigurationSource configurationSource)
+        {
+            if (_parameterBinding != parameterBinding)
+            {
+                _parameterBinding = parameterBinding;
+
+                PropertyMetadataChanged();
+            }
+            UpdateParameterBindingConfigurationSource(configurationSource);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual ConfigurationSource? GetParameterBindingConfigurationSource() => _parameterBindingConfigurationSource;
+
+        private void UpdateParameterBindingConfigurationSource(ConfigurationSource configurationSource)
+            => _parameterBindingConfigurationSource = configurationSource.Max(_parameterBindingConfigurationSource);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -845,14 +845,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
             => GetString("PropertyMethodInvoked");
 
         /// <summary>
-        ///     The property '{property}' cannot be added to the entity type '{entityType}' because a property with the same name already exists on entity type '{duplicateEntityType}'.
-        /// </summary>
-        public static string DuplicateProperty([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object duplicateEntityType)
-            => string.Format(
-                GetString("DuplicateProperty", nameof(property), nameof(entityType), nameof(duplicateEntityType)),
-                property, entityType, duplicateEntityType);
-
-        /// <summary>
         ///     The property '{property}' cannot be added to type '{entityType}' because the type of the corresponding CLR property or field '{clrType}' does not match the specified type '{propertyType}'.
         /// </summary>
         public static string PropertyWrongClrType([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object clrType, [CanBeNull] object propertyType)
@@ -883,22 +875,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
             => string.Format(
                 GetString("KeyInUse", nameof(key), nameof(entityType), nameof(dependentType)),
                 key, entityType, dependentType);
-
-        /// <summary>
-        ///     The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because a navigation property with the same name already exists on entity type '{duplicateEntityType}'.
-        /// </summary>
-        public static string DuplicateNavigation([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object duplicateEntityType)
-            => string.Format(
-                GetString("DuplicateNavigation", nameof(navigation), nameof(entityType), nameof(duplicateEntityType)),
-                navigation, entityType, duplicateEntityType);
-
-        /// <summary>
-        ///     The service property '{property}' cannot be added to the entity type '{entityType}' because a service property with the same name already exists on entity type '{duplicateEntityType}'.
-        /// </summary>
-        public static string DuplicateServiceProperty([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object duplicateEntityType)
-            => string.Format(
-                GetString("DuplicateServiceProperty", nameof(property), nameof(entityType), nameof(duplicateEntityType)),
-                property, entityType, duplicateEntityType);
 
         /// <summary>
         ///     The service property '{property}' of type '{serviceType}' cannot be added to the entity type '{entityType}' because service property '{duplicateName}' of the same type already exists on entity type '{duplicateEntityType}'.
@@ -1509,28 +1485,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 navigation, entityType, referencedNavigation, referencedEntityType);
 
         /// <summary>
-        ///     The property '{property}' cannot be added to the entity type '{entityType}' because a navigation property with the same name already exists on entity type '{duplicateEntityType}'.
+        ///     The property or navigation '{member}' cannot be added to the entity type '{entityType}' because a property or navigation with the same name already exists on entity type '{conflictingEntityType}'.
         /// </summary>
-        public static string ConflictingNavigation([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object duplicateEntityType)
+        public static string ConflictingPropertyOrNavigation([CanBeNull] object member, [CanBeNull] object entityType, [CanBeNull] object conflictingEntityType)
             => string.Format(
-                GetString("ConflictingNavigation", nameof(property), nameof(entityType), nameof(duplicateEntityType)),
-                property, entityType, duplicateEntityType);
-
-        /// <summary>
-        ///     The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because a property with the same name already exists on entity type '{duplicateEntityType}'.
-        /// </summary>
-        public static string ConflictingProperty([CanBeNull] object navigation, [CanBeNull] object entityType, [CanBeNull] object duplicateEntityType)
-            => string.Format(
-                GetString("ConflictingProperty", nameof(navigation), nameof(entityType), nameof(duplicateEntityType)),
-                navigation, entityType, duplicateEntityType);
-
-        /// <summary>
-        ///     The property or navigation '{property}' cannot be added to the entity type '{entityType}' because a service property with the same name already exists on entity type '{duplicateEntityType}'.
-        /// </summary>
-        public static string ConflictingServiceProperty([CanBeNull] object property, [CanBeNull] object entityType, [CanBeNull] object duplicateEntityType)
-            => string.Format(
-                GetString("ConflictingServiceProperty", nameof(property), nameof(entityType), nameof(duplicateEntityType)),
-                property, entityType, duplicateEntityType);
+                GetString("ConflictingPropertyOrNavigation", nameof(member), nameof(entityType), nameof(conflictingEntityType)),
+                member, entityType, conflictingEntityType);
 
         /// <summary>
         ///     The specified entity type '{entityType}' is invalid. It should be either the dependent entity type '{dependentType}' or the principal entity type '{principalType}'.
@@ -2651,6 +2611,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
             => string.Format(
                 GetString("IdentifyingRelationshipCycle", nameof(entityType)),
                 entityType);
+
+        /// <summary>
+        ///     The service property '{property}' of type '{serviceType}' cannot be added to the entity type '{entityType}' because there is another property of the same type. Ignore one of the properties using the NotMappedAttribute or 'EntityTypeBuilder.Ignore' in 'OnModelCreating'.
+        /// </summary>
+        public static string AmbiguousServiceProperty([CanBeNull] object property, [CanBeNull] object serviceType, [CanBeNull] object entityType)
+            => string.Format(
+                GetString("AmbiguousServiceProperty", nameof(property), nameof(serviceType), nameof(entityType)),
+                property, serviceType, entityType);
 
         private static string GetString(string name, params string[] formatterNames)
         {

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -407,9 +407,6 @@
   <data name="PropertyMethodInvoked" xml:space="preserve">
     <value>The EF.Property&lt;T&gt; method may only be used within LINQ queries.</value>
   </data>
-  <data name="DuplicateProperty" xml:space="preserve">
-    <value>The property '{property}' cannot be added to the entity type '{entityType}' because a property with the same name already exists on entity type '{duplicateEntityType}'.</value>
-  </data>
   <data name="PropertyWrongClrType" xml:space="preserve">
     <value>The property '{property}' cannot be added to type '{entityType}' because the type of the corresponding CLR property or field '{clrType}' does not match the specified type '{propertyType}'.</value>
   </data>
@@ -421,12 +418,6 @@
   </data>
   <data name="KeyInUse" xml:space="preserve">
     <value>Cannot remove key {key} from entity type '{entityType}' because it is referenced by a foreign key in entity type '{dependentType}'. All foreign keys must be removed or redefined before the referenced key can be removed.</value>
-  </data>
-  <data name="DuplicateNavigation" xml:space="preserve">
-    <value>The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because a navigation property with the same name already exists on entity type '{duplicateEntityType}'.</value>
-  </data>
-  <data name="DuplicateServiceProperty" xml:space="preserve">
-    <value>The service property '{property}' cannot be added to the entity type '{entityType}' because a service property with the same name already exists on entity type '{duplicateEntityType}'.</value>
   </data>
   <data name="DuplicateServicePropertyType" xml:space="preserve">
     <value>The service property '{property}' of type '{serviceType}' cannot be added to the entity type '{entityType}' because service property '{duplicateName}' of the same type already exists on entity type '{duplicateEntityType}'.</value>
@@ -660,14 +651,8 @@
   <data name="InvalidRelationshipUsingDataAnnotations" xml:space="preserve">
     <value>Invalid relationship has been specified using InversePropertyAttribute and ForeignKeyAttribute. The navigation '{navigation}' in entity type '{entityType}' and the navigation '{referencedNavigation}' in entity type '{referencedEntityType}' are related by InversePropertyAttribute but the ForeignKeyAttribute specified for both navigations have different values.</value>
   </data>
-  <data name="ConflictingNavigation" xml:space="preserve">
-    <value>The property '{property}' cannot be added to the entity type '{entityType}' because a navigation property with the same name already exists on entity type '{duplicateEntityType}'.</value>
-  </data>
-  <data name="ConflictingProperty" xml:space="preserve">
-    <value>The navigation property '{navigation}' cannot be added to the entity type '{entityType}' because a property with the same name already exists on entity type '{duplicateEntityType}'.</value>
-  </data>
-  <data name="ConflictingServiceProperty" xml:space="preserve">
-    <value>The property or navigation '{property}' cannot be added to the entity type '{entityType}' because a service property with the same name already exists on entity type '{duplicateEntityType}'.</value>
+  <data name="ConflictingPropertyOrNavigation" xml:space="preserve">
+    <value>The property or navigation '{member}' cannot be added to the entity type '{entityType}' because a property or navigation with the same name already exists on entity type '{conflictingEntityType}'.</value>
   </data>
   <data name="EntityTypeNotInRelationshipStrict" xml:space="preserve">
     <value>The specified entity type '{entityType}' is invalid. It should be either the dependent entity type '{dependentType}' or the principal entity type '{principalType}'.</value>
@@ -1073,5 +1058,8 @@
   </data>
   <data name="IdentifyingRelationshipCycle" xml:space="preserve">
     <value>The entity type '{entityType}' is part of a relationship cycle involving its primary key.</value>
+  </data>
+  <data name="AmbiguousServiceProperty" xml:space="preserve">
+    <value>The service property '{property}' of type '{serviceType}' cannot be added to the entity type '{entityType}' because there is another property of the same type. Ignore one of the properties using the NotMappedAttribute or 'EntityTypeBuilder.Ignore' in 'OnModelCreating'.</value>
   </data>
 </root>

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/ConstructorBindingConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/ConstructorBindingConventionTest.cs
@@ -10,6 +10,14 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
+// ReSharper disable UnassignedGetOnlyAutoProperty
+// ReSharper disable UnusedAutoPropertyAccessor.Local
+// ReSharper disable UnusedMember.Local
+// ReSharper disable UnusedParameter.Local
+// ReSharper disable ClassNeverInstantiated.Local
+// ReSharper disable MemberCanBePrivate.Local
+// ReSharper disable MemberHidesStaticFromOuterClass
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 {
     public class ConstructorBindingConventionTest
@@ -740,10 +748,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         private abstract class Blog
         {
 #pragma warning disable 649
+#pragma warning disable IDE1006 // Naming Styles
             public string _content;
 
-            // ReSharper disable once InconsistentNaming
             public int m_follows;
+#pragma warning restore IDE1006 // Naming Styles
 #pragma warning restore 649
 
             public int Id { get; set; }

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/ServicePropertyDiscoveryConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/ServicePropertyDiscoveryConventionTest.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit;
+
+// ReSharper disable MemberCanBePrivate.Local
+// ReSharper disable UnusedAutoPropertyAccessor.Local
+// ReSharper disable ClassNeverInstantiated.Local
+// ReSharper disable InconsistentNaming
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
+{
+    public class ServicePropertyDiscoveryConventionTest
+    {
+        [Fact]
+        public void Finds_one_service_property()
+        {
+            var entityType = ApplyConvention<BlogOneService>();
+
+            var serviceProperty = entityType.FindServiceProperty(nameof(BlogOneService.Loader));
+            var binding = serviceProperty.ParameterBinding;
+
+            Assert.Equal(typeof(ILazyLoader), binding.ParameterType);
+            Assert.Equal(typeof(ILazyLoader), binding.ServiceType);
+        }
+
+        [Fact]
+        public void Does_not_find_service_property_configured_as_property()
+        {
+            var entityType = new Model().AddEntityType(typeof(BlogOneService));
+            entityType.Builder.Property(nameof(BlogOneService.Loader), typeof(ILazyLoader), ConfigurationSource.Explicit)
+                .HasConversion(typeof(string), ConfigurationSource.Explicit);
+
+            ApplyConvention(entityType);
+
+            Assert.NotNull(entityType.FindProperty(nameof(BlogOneService.Loader)));
+            Assert.Null(entityType.FindServiceProperty(nameof(BlogOneService.Loader)));
+        }
+
+        [Fact]
+        public void Does_not_find_service_property_configured_as_navigation()
+        {
+            var model = new Model();
+            var entityType = model.AddEntityType(typeof(BlogOneService));
+            entityType.Builder.Navigation(
+                model.AddEntityType(typeof(LazyLoader)).Builder, nameof(BlogOneService.Loader), ConfigurationSource.Explicit);
+
+            ApplyConvention(entityType);
+
+            Assert.NotNull(entityType.FindNavigation(nameof(BlogOneService.Loader)));
+            Assert.Null(entityType.FindServiceProperty(nameof(BlogOneService.Loader)));
+        }
+
+        [Fact]
+        public void Does_not_find_duplicate_service_properties()
+        {
+            var convention = TestServiceFactory.Instance.Create<ServicePropertyDiscoveryConvention>();
+            var entityType = new Model().AddEntityType(typeof(BlogDuplicateService));
+
+            convention.Apply(entityType.Builder);
+
+            Assert.Empty(entityType.GetServiceProperties());
+
+            Assert.Equal(
+                CoreStrings.AmbiguousServiceProperty(nameof(BlogDuplicateService.ContextTwo), nameof(DbContext), nameof(BlogDuplicateService)),
+                Assert.Throws<InvalidOperationException>(() =>
+                    TestServiceFactory.Instance.Create<ServicePropertyDiscoveryConvention>().Apply(entityType.Model.Builder)).Message);
+        }
+
+        [Fact]
+        public void Finds_service_property_duplicate_ignored()
+        {
+            var convention = TestServiceFactory.Instance.Create<ServicePropertyDiscoveryConvention>();
+            var entityType = new Model().AddEntityType(typeof(BlogDuplicateService));
+
+            convention.Apply(entityType.Builder);
+
+            Assert.Empty(entityType.GetServiceProperties());
+
+            entityType.Builder.Ignore(nameof(BlogDuplicateService.ContextTwo), ConfigurationSource.Convention);
+
+            convention.Apply(entityType.Builder, nameof(BlogDuplicateService.ContextTwo));
+
+            Assert.NotNull(entityType.FindServiceProperty(nameof(BlogDuplicateService.ContextOne)));
+
+            convention.Apply(entityType.Model.Builder);
+        }
+
+        private static EntityType ApplyConvention<TEntity>()
+            => ApplyConvention(new Model().AddEntityType(typeof(TEntity)));
+
+        private static EntityType ApplyConvention(EntityType entityType)
+        {
+            entityType.AddProperty(nameof(Blog.Id), typeof(int));
+
+            TestServiceFactory.Instance.Create<ServicePropertyDiscoveryConvention>().Apply(entityType.Builder);
+
+            return entityType;
+        }
+
+        private class BlogOneService : Blog
+        {
+            public ILazyLoader Loader { get; set; }
+        }
+
+        private class BlogDuplicateService : Blog
+        {
+            public DbContext ContextOne { get; set; }
+            public DbContext ContextTwo { get; set; }
+        }
+
+        private abstract class Blog
+        {
+            public int Id { get; set; }
+        }
+    }
+}

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeBaseTypeTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeBaseTypeTest.cs
@@ -1,0 +1,1165 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Internal;
+using Xunit;
+
+// ReSharper disable InconsistentNaming
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    public partial class EntityTypeTest
+    {
+        [Fact]
+        public void Circular_inheritance_should_throw()
+        {
+            var model = new Model();
+
+            //    A
+            //   / \
+            //  B   C
+            //       \
+            //        D
+
+            var a = model.AddEntityType(typeof(A).Name);
+            var b = model.AddEntityType(typeof(B).Name);
+            var c = model.AddEntityType(typeof(C).Name);
+            var d = model.AddEntityType(typeof(D).Name);
+
+            b.HasBaseType(a);
+            c.HasBaseType(a);
+            d.HasBaseType(c);
+
+            Assert.Equal(
+                CoreStrings.CircularInheritance(a.DisplayName(), a.DisplayName()),
+                Assert.Throws<InvalidOperationException>(() => { a.HasBaseType(a); }).Message);
+
+            Assert.Equal(
+                CoreStrings.CircularInheritance(a.DisplayName(), b.DisplayName()),
+                Assert.Throws<InvalidOperationException>(() => { a.HasBaseType(b); }).Message);
+
+            Assert.Equal(
+                CoreStrings.CircularInheritance(a.DisplayName(), d.DisplayName()),
+                Assert.Throws<InvalidOperationException>(() => { a.HasBaseType(d); }).Message);
+        }
+
+        [Fact]
+        public void Setting_CLR_base_for_shadow_entity_type_should_throw()
+        {
+            var model = new Model();
+
+            var a = model.AddEntityType(typeof(A));
+            var b = model.AddEntityType(typeof(B).Name);
+
+            Assert.Equal(
+                CoreStrings.NonShadowBaseType(typeof(B).Name, typeof(A).Name),
+                Assert.Throws<InvalidOperationException>(() => { b.HasBaseType(a); }).Message);
+        }
+
+        [Fact]
+        public void Setting_shadow_base_for_CLR_entity_type_should_throw()
+        {
+            var model = new Model();
+
+            var a = model.AddEntityType(typeof(A).Name);
+            var b = model.AddEntityType(typeof(B));
+
+            Assert.Equal(
+                CoreStrings.NonClrBaseType(typeof(B).Name, typeof(A).Name),
+                Assert.Throws<InvalidOperationException>(() => { b.HasBaseType(a); }).Message);
+        }
+
+        [Fact]
+        public void Setting_not_assignable_base_should_throw()
+        {
+            var model = new Model();
+
+            var a = model.AddEntityType(typeof(A));
+            var b = model.AddEntityType(typeof(B));
+
+            Assert.Equal(
+                CoreStrings.NotAssignableClrBaseType(typeof(A).Name, typeof(B).Name, typeof(A).Name, typeof(B).Name),
+                Assert.Throws<InvalidOperationException>(() => { a.HasBaseType(b); }).Message);
+        }
+
+        [Fact]
+        public void Properties_on_base_type_should_be_inherited()
+        {
+            var model = new Model();
+
+            //    A
+            //   / \
+            //  B   C
+
+            var a = model.AddEntityType(typeof(A));
+            a.AddProperty(A.GProperty);
+            a.AddProperty(A.EProperty);
+
+            var b = model.AddEntityType(typeof(B));
+            b.AddProperty(B.HProperty);
+            b.AddProperty(B.FProperty);
+
+            var c = model.AddEntityType(typeof(C));
+            c.AddProperty(C.HProperty);
+            c.AddProperty("I", typeof(string));
+
+            Assert.Equal(new[] { "E", "G" }, a.GetProperties().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { "F", "H" }, b.GetProperties().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { "H", "I" }, c.GetProperties().Select(p => p.Name).ToArray());
+
+            b.HasBaseType(a);
+            c.HasBaseType(a);
+
+            Assert.Equal(new[] { "E", "G" }, a.GetProperties().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { "E", "G", "F", "H" }, b.GetProperties().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { "E", "G", "H", "I" }, c.GetProperties().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { 0, 1, 2, 3 }, b.GetProperties().Select(p => p.GetIndex()));
+            Assert.Equal(new[] { 0, 1, 2, 3 }, c.GetProperties().Select(p => p.GetIndex()));
+            Assert.Same(b.FindProperty("E"), a.FindProperty("E"));
+        }
+
+        [Fact]
+        public void Properties_added_to_base_type_should_be_inherited()
+        {
+            var model = new Model();
+
+            //    A
+            //   / \
+            //  B   C
+
+            var a = model.AddEntityType(typeof(A));
+            var b = model.AddEntityType(typeof(B));
+            var c = model.AddEntityType(typeof(C));
+
+            b.HasBaseType(a);
+            c.HasBaseType(a);
+
+            a.AddProperty(A.GProperty);
+            a.AddProperty(A.EProperty);
+
+            b.AddProperty(B.HProperty);
+            b.AddProperty(B.FProperty);
+
+            c.AddProperty(C.HProperty);
+            c.AddProperty("I", typeof(string));
+
+            Assert.Equal(new[] { "E", "G" }, a.GetProperties().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { "E", "G", "F", "H" }, b.GetProperties().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { "E", "G", "H", "I" }, c.GetProperties().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { 0, 1, 2, 3 }, b.GetProperties().Select(p => p.GetIndex()));
+            Assert.Equal(new[] { 0, 1, 2, 3 }, c.GetProperties().Select(p => p.GetIndex()));
+        }
+
+        [Fact]
+        public void Properties_should_be_updated_when_base_type_changes()
+        {
+            var model = new Model();
+
+            var c = model.AddEntityType(typeof(C));
+            c.AddProperty(C.HProperty);
+            c.AddProperty(C.FProperty);
+
+            var d = model.AddEntityType(typeof(D));
+            d.AddProperty(A.EProperty);
+            d.AddProperty(A.GProperty);
+            d.HasBaseType(c);
+
+            Assert.Equal(new[] { "F", "H" }, c.GetProperties().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { "F", "H", "E", "G" }, d.GetProperties().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { 0, 1 }, c.GetProperties().Select(p => p.GetIndex()));
+            Assert.Equal(new[] { 0, 1, 2, 3 }, d.GetProperties().Select(p => p.GetIndex()));
+
+            d.HasBaseType(null);
+
+            Assert.Equal(new[] { "F", "H" }, c.GetProperties().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { "E", "G" }, d.GetProperties().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { 0, 1 }, c.GetProperties().Select(p => p.GetIndex()));
+            Assert.Equal(new[] { 0, 1 }, d.GetProperties().Select(p => p.GetIndex()));
+
+            var a = model.AddEntityType(typeof(A));
+            a.AddProperty(A.EProperty);
+            a.AddProperty(A.GProperty);
+
+            c.HasBaseType(a);
+
+            Assert.Equal(new[] { "E", "G" }, a.GetProperties().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { "E", "G", "F", "H" }, c.GetProperties().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { "E", "G" }, d.GetProperties().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { 0, 1 }, a.GetProperties().Select(p => p.GetIndex()));
+            Assert.Equal(new[] { 0, 1, 2, 3 }, c.GetProperties().Select(p => p.GetIndex()));
+            Assert.Equal(new[] { 0, 1 }, d.GetProperties().Select(p => p.GetIndex()));
+        }
+
+        [Fact]
+        public void Adding_property_throws_when_parent_type_has_property_with_same_name()
+        {
+            var model = new Model();
+
+            var a = model.AddEntityType(typeof(A));
+            a.AddProperty(A.GProperty);
+
+            var b = model.AddEntityType(typeof(B));
+            b.HasBaseType(a);
+
+            Assert.Equal(
+                CoreStrings.ConflictingPropertyOrNavigation("G", typeof(B).Name, typeof(A).Name),
+                Assert.Throws<InvalidOperationException>(() => b.AddProperty("G")).Message);
+        }
+
+        [Fact]
+        public void Adding_property_throws_when_grandparent_type_has_property_with_same_name()
+        {
+            var model = new Model();
+
+            var a = model.AddEntityType(typeof(A));
+            a.AddProperty(A.GProperty);
+
+            var c = model.AddEntityType(typeof(C));
+            c.HasBaseType(a);
+
+            var d = model.AddEntityType(typeof(D));
+            d.HasBaseType(c);
+
+            Assert.Equal(
+                CoreStrings.ConflictingPropertyOrNavigation("G", typeof(D).Name, typeof(A).Name),
+                Assert.Throws<InvalidOperationException>(() => d.AddProperty("G")).Message);
+        }
+
+        [Fact]
+        public void Adding_property_throws_when_child_type_has_property_with_same_name()
+        {
+            var model = new Model();
+
+            var a = model.AddEntityType(typeof(A));
+
+            var b = model.AddEntityType(typeof(B));
+            b.HasBaseType(a);
+
+            b.AddProperty(A.GProperty);
+
+            Assert.Equal(
+                CoreStrings.ConflictingPropertyOrNavigation("G", typeof(A).Name, typeof(B).Name),
+                Assert.Throws<InvalidOperationException>(() => a.AddProperty(A.GProperty)).Message);
+        }
+
+        [Fact]
+        public void Adding_property_throws_when_grandchild_type_has_property_with_same_name()
+        {
+            var model = new Model();
+
+            var a = model.AddEntityType(typeof(A));
+
+            var c = model.AddEntityType(typeof(C));
+            c.HasBaseType(a);
+
+            var d = model.AddEntityType(typeof(D));
+            d.HasBaseType(c);
+
+            d.AddProperty(A.GProperty);
+
+            Assert.Equal(
+                CoreStrings.ConflictingPropertyOrNavigation("G", typeof(A).Name, typeof(D).Name),
+                Assert.Throws<InvalidOperationException>(() => a.AddProperty(A.GProperty)).Message);
+        }
+
+        [Fact]
+        public void Setting_base_type_throws_when_parent_contains_duplicate_property()
+        {
+            var model = new Model();
+
+            var a = model.AddEntityType(typeof(A));
+            a.AddProperty(A.GProperty);
+
+            var b = model.AddEntityType(typeof(B));
+            b.AddProperty(A.GProperty);
+
+            Assert.Equal(
+                CoreStrings.DuplicatePropertiesOnBase(typeof(B).Name, typeof(A).Name, typeof(B).Name, "G", typeof(A).Name, "G"),
+                Assert.Throws<InvalidOperationException>(() => { b.HasBaseType(a); }).Message);
+        }
+
+        [Fact]
+        public void Setting_base_type_throws_when_grandparent_contains_duplicate_property()
+        {
+            var model = new Model();
+
+            var a = model.AddEntityType(typeof(A));
+            a.AddProperty(A.EProperty);
+            a.AddProperty(A.GProperty);
+
+            var c = model.AddEntityType(typeof(C));
+            c.HasBaseType(a);
+
+            var d = model.AddEntityType(typeof(D));
+            d.AddProperty(A.EProperty);
+            d.AddProperty(A.GProperty);
+
+            Assert.Equal(
+                CoreStrings.DuplicatePropertiesOnBase(typeof(D).Name, typeof(C).Name, typeof(D).Name, "E", typeof(A).Name, "E"),
+                Assert.Throws<InvalidOperationException>(() => { d.HasBaseType(c); }).Message);
+        }
+
+        [Fact]
+        public void Setting_base_type_throws_when_grandchild_contain_duplicate_property()
+        {
+            var model = new Model();
+
+            var a = model.AddEntityType(typeof(A));
+            a.AddProperty(A.EProperty);
+            a.AddProperty(A.GProperty);
+
+            var c = model.AddEntityType(typeof(C));
+
+            var d = model.AddEntityType(typeof(D));
+            d.AddProperty(A.EProperty);
+            d.AddProperty(A.GProperty);
+            d.HasBaseType(c);
+
+            Assert.Equal(
+                CoreStrings.DuplicatePropertiesOnBase(typeof(C).Name, typeof(A).Name, typeof(D).Name, "E", typeof(A).Name, "E"),
+                Assert.Throws<InvalidOperationException>(() => { c.HasBaseType(a); }).Message);
+        }
+
+        [Fact]
+        public void Keys_on_base_type_should_be_inherited()
+        {
+            var model = new Model();
+
+            var a = model.AddEntityType(typeof(A));
+            var g = a.AddProperty(A.GProperty);
+            g.IsNullable = false;
+            var e = a.AddProperty(A.EProperty);
+            e.IsNullable = false;
+            var pk = a.SetPrimaryKey(g);
+            a.AddKey(e);
+
+            var b = model.AddEntityType(typeof(B));
+            b.AddProperty(B.FProperty);
+
+            Assert.Equal(
+                new[] { new[] { "E" }, new[] { "G" } },
+                a.GetKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+            Assert.Equal(
+                Array.Empty<string[]>(),
+                b.GetKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+            Assert.Equal(new[] { "G", "E" }, a.GetProperties().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { "F" }, b.GetProperties().Select(p => p.Name).ToArray());
+
+            b.HasBaseType(a);
+
+            Assert.Equal(
+                new[] { new[] { "E" }, new[] { "G" } },
+                a.GetKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+            Assert.Equal(
+                new[] { new[] { "E" }, new[] { "G" } },
+                b.GetKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+            Assert.Equal(new[] { "G", "E" }, a.GetProperties().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { "G", "E", "F" }, b.GetProperties().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { 0, 1, 2 }, b.GetProperties().Select(p => p.GetIndex()));
+            Assert.Same(pk, b.FindPrimaryKey(new[] { b.FindProperty("G") }));
+            Assert.Same(b.FindKey(b.FindProperty("G")), a.FindKey(a.FindProperty("G")));
+        }
+
+        [Fact]
+        public void Keys_added_to_base_type_should_be_inherited()
+        {
+            var model = new Model();
+
+            var a = model.AddEntityType(typeof(A));
+            a.AddProperty(A.GProperty).IsNullable = false;
+            a.AddProperty(A.EProperty).IsNullable = false;
+
+            var b = model.AddEntityType(typeof(B));
+            b.AddProperty(B.FProperty);
+
+            b.HasBaseType(a);
+
+            a.SetPrimaryKey(a.FindProperty("G"));
+            a.AddKey(a.FindProperty("E"));
+
+            Assert.Equal(
+                new[] { new[] { "E" }, new[] { "G" } },
+                a.GetKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+            Assert.Equal(
+                new[] { new[] { "E" }, new[] { "G" } },
+                b.GetKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+            Assert.Equal(new[] { "G", "E" }, a.GetProperties().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { "G", "E", "F" }, b.GetProperties().Select(p => p.Name).ToArray());
+        }
+
+        [Fact]
+        public void Keys_should_be_updated_when_base_type_changes()
+        {
+            var model = new Model();
+
+            var a = model.AddEntityType(typeof(A));
+            var g = a.AddProperty(A.GProperty);
+            g.IsNullable = false;
+            a.SetPrimaryKey(g);
+            var e = a.AddProperty(A.EProperty);
+            e.IsNullable = false;
+            a.AddKey(e);
+
+            var b = model.AddEntityType(typeof(B));
+            b.AddProperty(B.FProperty);
+            b.HasBaseType(a);
+
+            b.HasBaseType(null);
+
+            Assert.Equal(
+                new[] { new[] { "E" }, new[] { "G" } },
+                a.GetKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+            Assert.Equal(
+                Array.Empty<string[]>(),
+                b.GetKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+            Assert.Equal(new[] { "G", "E" }, a.GetProperties().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { "F" }, b.GetProperties().Select(p => p.Name).ToArray());
+        }
+
+        [Fact]
+        public void Adding_keys_throws_when_there_is_a_parent_type()
+        {
+            var model = new Model();
+
+            var a = model.AddEntityType(typeof(A));
+            var b = model.AddEntityType(typeof(B));
+            b.HasBaseType(a);
+
+            Assert.Equal(
+                CoreStrings.DerivedEntityTypeKey(typeof(B).Name, typeof(A).Name),
+                Assert.Throws<InvalidOperationException>(() => b.SetPrimaryKey(b.AddProperty("G"))).Message);
+            Assert.Equal(
+                CoreStrings.DerivedEntityTypeKey(typeof(B).Name, typeof(A).Name),
+                Assert.Throws<InvalidOperationException>(() => b.AddKey(b.AddProperty("E"))).Message);
+        }
+
+        [Fact]
+        public void Setting_base_type_throws_when_child_contains_key()
+        {
+            var model = new Model();
+
+            var a = model.AddEntityType(typeof(A));
+            var b = model.AddEntityType(typeof(B));
+            var h = b.AddProperty(B.HProperty);
+            h.IsNullable = false;
+            var key = b.AddKey(h);
+
+            Assert.Equal(
+                CoreStrings.DerivedEntityCannotHaveKeys(typeof(B).Name),
+                Assert.Throws<InvalidOperationException>(() => { b.HasBaseType(a); }).Message);
+
+            b.RemoveKey(key.Properties);
+            var f = b.AddProperty(B.FProperty);
+            f.IsNullable = false;
+            b.SetPrimaryKey(f);
+
+            Assert.Equal(
+                CoreStrings.DerivedEntityCannotHaveKeys(typeof(B).Name),
+                Assert.Throws<InvalidOperationException>(() => { b.HasBaseType(a); }).Message);
+        }
+
+        [Fact]
+        public void Setting_base_type_throws_when_mixing_views_and_entities()
+        {
+            var model = new Model();
+
+            var a = model.AddEntityType(typeof(A));
+            var b = model.AddQueryType(typeof(B));
+
+            Assert.Equal(
+                CoreStrings.ErrorMixedQueryEntityTypeInheritance(typeof(A).Name, typeof(B).Name),
+                Assert.Throws<InvalidOperationException>(() => { b.HasBaseType(a); }).Message);
+
+            Assert.Equal(
+                CoreStrings.ErrorMixedQueryEntityTypeInheritance(typeof(B).Name, typeof(A).Name),
+                Assert.Throws<InvalidOperationException>(() => { a.HasBaseType(b); }).Message);
+        }
+
+        [Fact]
+        public void Navigations_on_base_type_should_be_inherited()
+        {
+            var model = new Model();
+
+            var customerType = model.AddEntityType(typeof(Customer));
+            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
+
+            var orderType = model.AddEntityType(typeof(SpecialOrder));
+            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+            var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
+
+            customerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
+
+            var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
+
+            Assert.Equal(new[] { "Orders" }, customerType.GetNavigations().Select(p => p.Name).ToArray());
+            Assert.Equal(Array.Empty<string>(), specialCustomerType.GetNavigations().Select(p => p.Name).ToArray());
+
+            specialCustomerType.HasBaseType(customerType);
+
+            Assert.Equal(new[] { "Orders" }, customerType.GetNavigations().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { "Orders" }, specialCustomerType.GetNavigations().Select(p => p.Name).ToArray());
+
+            var derivedForeignKeyProperty = orderType.GetOrAddProperty(Order.IdProperty);
+            var specialCustomerForeignKey = orderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, specialCustomerType);
+            specialCustomerForeignKey.HasPrincipalToDependent(SpecialCustomer.DerivedOrdersProperty);
+            Assert.Equal(new[] { "Orders" }, customerType.GetNavigations().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { "Orders", "DerivedOrders" }, specialCustomerType.GetNavigations().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { "Orders", "DerivedOrders" }, ((IEntityType)specialCustomerType).GetNavigations().Select(p => p.Name).ToArray());
+            Assert.Same(customerType.FindNavigation("Orders"), specialCustomerType.FindNavigation("Orders"));
+        }
+
+        [Fact]
+        public void Navigations_added_to_base_type_should_be_inherited()
+        {
+            var model = new Model();
+
+            var customerType = model.AddEntityType(typeof(Customer));
+            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
+
+            var orderType = model.AddEntityType(typeof(SpecialOrder));
+            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+            var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
+
+            var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
+            specialCustomerType.HasBaseType(customerType);
+
+            customerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
+
+            Assert.Equal(new[] { "Orders" }, customerType.GetNavigations().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { "Orders" }, specialCustomerType.GetNavigations().Select(p => p.Name).ToArray());
+
+            var derivedForeignKeyProperty = orderType.GetOrAddProperty(Order.IdProperty);
+            var specialCustomerForeignKey = orderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, specialCustomerType);
+            specialCustomerForeignKey.HasPrincipalToDependent(SpecialCustomer.DerivedOrdersProperty);
+
+            Assert.Equal(new[] { "Orders" }, customerType.GetNavigations().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { "Orders", "DerivedOrders" }, specialCustomerType.GetNavigations().Select(p => p.Name).ToArray());
+        }
+
+        [Fact]
+        public void Navigations_should_be_updated_when_base_type_changes()
+        {
+            var model = new Model();
+
+            var customerType = model.AddEntityType(typeof(Customer));
+            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
+
+            var orderType = model.AddEntityType(typeof(SpecialOrder));
+            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+            var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
+
+            customerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
+
+            var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
+            specialCustomerType.HasBaseType(customerType);
+
+            var derivedForeignKeyProperty = orderType.GetOrAddProperty(Order.IdProperty);
+            var specialCustomerForeignKey = orderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, specialCustomerType);
+            specialCustomerForeignKey.HasPrincipalToDependent(SpecialCustomer.DerivedOrdersProperty);
+
+            specialCustomerType.HasBaseType(null);
+
+            Assert.Equal(new[] { nameof(Customer.Orders) }, customerType.GetNavigations().Select(p => p.Name).ToArray());
+            Assert.Equal(new[] { nameof(SpecialCustomer.DerivedOrders) }, specialCustomerType.GetNavigations().Select(p => p.Name).ToArray());
+        }
+
+        [Fact]
+        public void Adding_navigation_throws_when_parent_type_has_navigation_with_same_name()
+        {
+            var model = new Model();
+
+            var customerType = model.AddEntityType(typeof(Customer));
+            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
+
+            var orderType = model.AddEntityType(typeof(SpecialOrder));
+            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+            var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
+            customerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
+
+            var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
+            specialCustomerType.HasBaseType(customerType);
+
+            var derivedForeignKeyProperty = orderType.GetOrAddProperty(Order.IdProperty);
+            var specialCustomerForeignKey = orderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, specialCustomerType);
+
+            Assert.Equal(
+                CoreStrings.NavigationForWrongForeignKey(nameof(Customer.Orders), typeof(Customer).Name, "{'Id'}", "{'CustomerId'}"),
+                Assert.Throws<InvalidOperationException>(
+                    () =>
+                        specialCustomerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty)).Message);
+        }
+
+        [Fact]
+        public void Adding_navigation_throws_when_grandparent_type_has_navigation_with_same_name()
+        {
+            var model = new Model();
+
+            var customerType = model.AddEntityType(typeof(Customer));
+            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
+
+            var orderType = model.AddEntityType(typeof(SpecialOrder));
+            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+            var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
+            customerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
+
+            var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
+            specialCustomerType.HasBaseType(customerType);
+
+            var verySpecialCustomerType = model.AddEntityType(typeof(VerySpecialCustomer));
+            verySpecialCustomerType.HasBaseType(specialCustomerType);
+
+            var derivedForeignKeyProperty = orderType.GetOrAddProperty(Order.IdProperty);
+            var specialCustomerForeignKey = orderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, verySpecialCustomerType);
+
+            Assert.Equal(
+                CoreStrings.NavigationForWrongForeignKey("Orders", typeof(Customer).Name, "{'Id'}", "{'CustomerId'}"),
+                Assert.Throws<InvalidOperationException>(
+                    () =>
+                        specialCustomerForeignKey.HasPrincipalToDependent("Orders")).Message);
+
+            Assert.Equal("Orders", ((IEntityType)verySpecialCustomerType).GetNavigations().Single().Name);
+        }
+
+        [Fact]
+        public void Adding_navigation_throws_when_child_type_has_navigation_with_same_name()
+        {
+            var model = new Model();
+
+            var customerType = model.AddEntityType(typeof(Customer));
+            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
+
+            var orderType = model.AddEntityType(typeof(SpecialOrder));
+            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+            var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
+
+            var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
+            specialCustomerType.HasBaseType(customerType);
+
+            var derivedForeignKeyProperty = orderType.GetOrAddProperty(Order.IdProperty);
+            var specialCustomerForeignKey = orderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, specialCustomerType);
+            specialCustomerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
+
+            Assert.Equal(
+                CoreStrings.NavigationForWrongForeignKey("Orders", typeof(SpecialCustomer).Name, "{'CustomerId'}", "{'Id'}"),
+                Assert.Throws<InvalidOperationException>(
+                    () =>
+                        customerForeignKey.HasPrincipalToDependent("Orders")).Message);
+        }
+
+        [Fact]
+        public void Adding_navigation_throws_when_grandchild_type_has_navigation_with_same_name()
+        {
+            var model = new Model();
+
+            var customerType = model.AddEntityType(typeof(Customer));
+            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
+
+            var orderType = model.AddEntityType(typeof(SpecialOrder));
+            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+            var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
+
+            var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
+            specialCustomerType.HasBaseType(customerType);
+
+            var verySpecialCustomerType = model.AddEntityType(typeof(VerySpecialCustomer));
+            verySpecialCustomerType.HasBaseType(specialCustomerType);
+
+            var derivedForeignKeyProperty = orderType.GetOrAddProperty(Order.IdProperty);
+            var specialCustomerForeignKey = orderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, verySpecialCustomerType);
+            specialCustomerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
+
+            Assert.Equal(
+                CoreStrings.NavigationForWrongForeignKey(nameof(Customer.Orders), typeof(VerySpecialCustomer).Name, "{'CustomerId'}", "{'Id'}"),
+                Assert.Throws<InvalidOperationException>(
+                    () =>
+                        customerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty)).Message);
+
+            Assert.Equal(nameof(Customer.Orders), ((IEntityType)verySpecialCustomerType).GetNavigations().Single().Name);
+        }
+
+        [Fact]
+        public void Setting_base_type_throws_when_parent_contains_duplicate_navigation()
+        {
+            var model = new Model();
+
+            var customerType = model.AddEntityType(typeof(Customer));
+            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
+
+            var orderType = model.AddEntityType(typeof(Order));
+            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+            var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
+            customerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
+
+            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
+
+            var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
+
+            var derivedForeignKeyProperty = specialOrderType.GetOrAddProperty(Order.IdProperty);
+            var property = specialCustomerType.AddProperty("AltId", typeof(int));
+            var specialCustomerKey = specialCustomerType.GetOrAddKey(property);
+            var specialCustomerForeignKey = specialOrderType.GetOrAddForeignKey(derivedForeignKeyProperty, specialCustomerKey, specialCustomerType);
+            specialCustomerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
+
+            Assert.Equal(
+                CoreStrings.DuplicateNavigationsOnBase(typeof(SpecialOrder).Name, typeof(Order).Name, "Customer"),
+                Assert.Throws<InvalidOperationException>(() => { specialOrderType.HasBaseType(orderType); }).Message);
+        }
+
+        [Fact]
+        public void Setting_base_type_throws_when_grandparent_contains_duplicate_navigation()
+        {
+            var model = new Model();
+
+            var customerType = model.AddEntityType(typeof(Customer));
+            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
+
+            var orderType = model.AddEntityType(typeof(Order));
+            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+            var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
+            customerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
+
+            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
+
+            var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
+
+            var verySpecialOrderType = model.AddEntityType(typeof(VerySpecialOrder));
+            var derivedForeignKeyProperty = verySpecialOrderType.GetOrAddProperty(Order.IdProperty);
+            var property = specialCustomerType.AddProperty("AltId", typeof(int));
+            var specialCustomerKey = specialCustomerType.GetOrAddKey(property);
+            var specialCustomerForeignKey = verySpecialOrderType.GetOrAddForeignKey(derivedForeignKeyProperty, specialCustomerKey, specialCustomerType);
+            specialCustomerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
+            verySpecialOrderType.HasBaseType(specialOrderType);
+
+            Assert.Equal(
+                CoreStrings.DuplicateNavigationsOnBase(typeof(SpecialOrder).Name, typeof(Order).Name, nameof(Order.Customer)),
+                Assert.Throws<InvalidOperationException>(() => { specialOrderType.HasBaseType(orderType); }).Message);
+        }
+
+        [Fact]
+        public void Setting_base_type_throws_when_grandchild_contain_duplicate_navigation()
+        {
+            var model = new Model();
+
+            var customerType = model.AddEntityType(typeof(Customer));
+            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
+
+            var orderType = model.AddEntityType(typeof(Order));
+            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+            var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
+            customerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
+
+            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
+            specialOrderType.HasBaseType(orderType);
+
+            var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
+
+            var verySpecialOrderType = model.AddEntityType(typeof(VerySpecialOrder));
+            var derivedForeignKeyProperty = verySpecialOrderType.GetOrAddProperty(Order.IdProperty);
+            var property = specialCustomerType.AddProperty("AltId", typeof(int));
+            var specialCustomerKey = specialCustomerType.GetOrAddKey(property);
+            var specialCustomerForeignKey = verySpecialOrderType.GetOrAddForeignKey(derivedForeignKeyProperty, specialCustomerKey, specialCustomerType);
+            specialCustomerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
+
+            Assert.Equal(
+                CoreStrings.DuplicateNavigationsOnBase(typeof(VerySpecialOrder).Name, typeof(SpecialOrder).Name, "Customer"),
+                Assert.Throws<InvalidOperationException>(() => { verySpecialOrderType.HasBaseType(specialOrderType); }).Message);
+        }
+
+        [Fact]
+        public void ForeignKeys_on_base_type_should_be_inherited()
+        {
+            var model = new Model();
+
+            var customerType = model.AddEntityType(typeof(SpecialCustomer));
+            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
+
+            var orderType = model.AddEntityType(typeof(Order));
+            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+            var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
+
+            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
+            var derivedForeignKeyProperty = specialOrderType.GetOrAddProperty(Order.IdProperty);
+            specialOrderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, customerType);
+
+            Assert.Equal(
+                new[] { new[] { Order.CustomerIdProperty.Name } },
+                orderType.GetForeignKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+            Assert.Equal(
+                new[] { new[] { Order.IdProperty.Name } },
+                specialOrderType.GetForeignKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+
+            specialOrderType.HasBaseType(orderType);
+
+            Assert.Equal(
+                new[] { new[] { Order.CustomerIdProperty.Name } },
+                orderType.GetForeignKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+            Assert.Equal(
+                new[] { new[] { Order.CustomerIdProperty.Name }, new[] { Order.IdProperty.Name } },
+                specialOrderType.GetForeignKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+            Assert.Same(customerForeignKey, specialOrderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType));
+        }
+
+        [Fact]
+        public void ForeignKeys_added_to_base_type_should_be_inherited()
+        {
+            var model = new Model();
+
+            var customerType = model.AddEntityType(typeof(SpecialCustomer));
+            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
+
+            var orderType = model.AddEntityType(typeof(Order));
+            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+
+            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
+
+            specialOrderType.HasBaseType(orderType);
+            orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
+
+            Assert.Equal(
+                new[] { new[] { Order.CustomerIdProperty.Name } },
+                orderType.GetForeignKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+            Assert.Equal(
+                new[] { new[] { Order.CustomerIdProperty.Name } },
+                specialOrderType.GetForeignKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+
+            var derivedForeignKeyProperty = specialOrderType.GetOrAddProperty(Order.IdProperty);
+            specialOrderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, customerType);
+
+            Assert.Equal(
+                new[] { new[] { Order.CustomerIdProperty.Name } },
+                orderType.GetForeignKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+            Assert.Equal(
+                new[] { new[] { Order.CustomerIdProperty.Name }, new[] { Order.IdProperty.Name } },
+                specialOrderType.GetForeignKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+        }
+
+        [Fact]
+        public void ForeignKeys_should_be_updated_when_base_type_changes()
+        {
+            var model = new Model();
+
+            var customerType = model.AddEntityType(typeof(SpecialCustomer));
+            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
+
+            var orderType = model.AddEntityType(typeof(Order));
+
+            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
+            specialOrderType.HasBaseType(orderType);
+            var derivedForeignKeyProperty = specialOrderType.GetOrAddProperty(Order.IdProperty);
+            specialOrderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, customerType);
+
+            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+            orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
+
+            specialOrderType.HasBaseType(null);
+
+            Assert.Equal(
+                new[] { new[] { Order.CustomerIdProperty.Name } },
+                orderType.GetForeignKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+            Assert.Equal(
+                new[] { new[] { Order.IdProperty.Name } },
+                specialOrderType.GetForeignKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+        }
+
+        [Fact]
+        public void Adding_foreignKey_throws_when_parent_type_has_foreignKey_on_same_properties()
+        {
+            var model = new Model();
+
+            var customerType = model.AddEntityType(typeof(Customer));
+            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
+
+            var orderType = model.AddEntityType(typeof(Order));
+            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+            orderType.AddForeignKey(foreignKeyProperty, customerKey, customerType);
+
+            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
+            specialOrderType.HasBaseType(orderType);
+
+            Assert.Equal(
+                CoreStrings.DuplicateForeignKey(
+                    Property.Format(new[] { foreignKeyProperty }),
+                    typeof(SpecialOrder).Name,
+                    typeof(Order).Name,
+                    Property.Format(customerKey.Properties),
+                    typeof(Customer).Name),
+                Assert.Throws<InvalidOperationException>(
+                    () => specialOrderType.AddForeignKey(foreignKeyProperty, customerKey, customerType)).Message);
+        }
+
+        [Fact]
+        public void Adding_foreignKey_throws_when_grandparent_type_has_foreignKey_on_same_properties()
+        {
+            var model = new Model();
+
+            var customerType = model.AddEntityType(typeof(Customer));
+            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
+
+            var orderType = model.AddEntityType(typeof(Order));
+            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+            orderType.AddForeignKey(foreignKeyProperty, customerKey, customerType);
+
+            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
+            specialOrderType.HasBaseType(orderType);
+
+            var verySpecialOrderType = model.AddEntityType(typeof(VerySpecialOrder));
+            verySpecialOrderType.HasBaseType(specialOrderType);
+
+            Assert.Equal(
+                CoreStrings.DuplicateForeignKey(
+                    Property.Format(new[] { foreignKeyProperty }),
+                    typeof(VerySpecialOrder).Name,
+                    typeof(Order).Name,
+                    Property.Format(customerKey.Properties),
+                    typeof(Customer).Name),
+                Assert.Throws<InvalidOperationException>(
+                    () => verySpecialOrderType.AddForeignKey(foreignKeyProperty, customerKey, customerType)).Message);
+        }
+
+        [Fact]
+        public void Adding_foreignKey_throws_when_child_type_has_foreignKey_on_same_properties()
+        {
+            var model = new Model();
+
+            var customerType = model.AddEntityType(typeof(Customer));
+            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
+
+            var orderType = model.AddEntityType(typeof(Order));
+            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+
+            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
+            specialOrderType.HasBaseType(orderType);
+            specialOrderType.AddForeignKey(foreignKeyProperty, customerKey, customerType);
+
+            Assert.Equal(
+                CoreStrings.DuplicateForeignKey(
+                    Property.Format(new[] { foreignKeyProperty }),
+                    typeof(Order).Name,
+                    typeof(SpecialOrder).Name,
+                    Property.Format(customerKey.Properties),
+                    typeof(Customer).Name),
+                Assert.Throws<InvalidOperationException>(
+                    () => orderType.AddForeignKey(foreignKeyProperty, customerKey, customerType)).Message);
+        }
+
+        [Fact]
+        public void Adding_foreignKey_throws_when_grandchild_type_has_foreignKey_on_same_properties()
+        {
+            var model = new Model();
+
+            var customerType = model.AddEntityType(typeof(Customer));
+            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
+
+            var orderType = model.AddEntityType(typeof(Order));
+            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+
+            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
+            specialOrderType.HasBaseType(orderType);
+
+            var verySpecialOrderType = model.AddEntityType(typeof(VerySpecialOrder));
+            verySpecialOrderType.HasBaseType(specialOrderType);
+            verySpecialOrderType.AddForeignKey(foreignKeyProperty, customerKey, customerType);
+
+            Assert.Equal(
+                CoreStrings.DuplicateForeignKey(
+                    Property.Format(new[] { foreignKeyProperty }),
+                    typeof(Order).Name,
+                    typeof(VerySpecialOrder).Name,
+                    Property.Format(customerKey.Properties),
+                    typeof(Customer).Name),
+                Assert.Throws<InvalidOperationException>(
+                    () => orderType.AddForeignKey(foreignKeyProperty, customerKey, customerType)).Message);
+        }
+
+        [Fact]
+        public void Index_on_base_type_should_be_inherited()
+        {
+            var model = new Model();
+
+            var orderType = model.AddEntityType(typeof(Order));
+            var indexProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+            var index = orderType.GetOrAddIndex(indexProperty);
+
+            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
+            var derivedIndexProperty = specialOrderType.GetOrAddProperty(Order.IdProperty);
+            specialOrderType.GetOrAddIndex(derivedIndexProperty);
+
+            Assert.Equal(
+                new[] { new[] { Order.CustomerIdProperty.Name } },
+                orderType.GetIndexes().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+            Assert.Equal(
+                new[] { new[] { Order.IdProperty.Name } },
+                specialOrderType.GetIndexes().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+
+            specialOrderType.HasBaseType(orderType);
+
+            Assert.Equal(
+                new[] { new[] { Order.CustomerIdProperty.Name } },
+                orderType.GetIndexes().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+            Assert.Equal(
+                new[] { new[] { Order.CustomerIdProperty.Name }, new[] { Order.IdProperty.Name } },
+                specialOrderType.GetIndexes().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+            Assert.Same(index, specialOrderType.GetOrAddIndex(indexProperty));
+        }
+
+        [Fact]
+        public void Index_added_to_base_type_should_be_inherited()
+        {
+            var model = new Model();
+
+            var orderType = model.AddEntityType(typeof(Order));
+            var indexProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+
+            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
+
+            specialOrderType.HasBaseType(orderType);
+            orderType.GetOrAddIndex(indexProperty);
+
+            Assert.Equal(
+                new[] { new[] { Order.CustomerIdProperty.Name } },
+                orderType.GetIndexes().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+            Assert.Equal(
+                new[] { new[] { Order.CustomerIdProperty.Name } },
+                specialOrderType.GetIndexes().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+
+            var derivedIndexProperty = specialOrderType.GetOrAddProperty(Order.IdProperty);
+            specialOrderType.GetOrAddIndex(derivedIndexProperty);
+
+            Assert.Equal(
+                new[] { new[] { Order.CustomerIdProperty.Name } },
+                orderType.GetIndexes().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+            Assert.Equal(
+                new[] { new[] { Order.CustomerIdProperty.Name }, new[] { Order.IdProperty.Name } },
+                specialOrderType.GetIndexes().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+        }
+
+        [Fact]
+        public void Indexes_should_be_updated_when_base_type_changes()
+        {
+            var model = new Model();
+
+            var orderType = model.AddEntityType(typeof(Order));
+
+            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
+            specialOrderType.HasBaseType(orderType);
+            var derivedIndexProperty = specialOrderType.GetOrAddProperty(Order.IdProperty);
+            specialOrderType.GetOrAddIndex(derivedIndexProperty);
+
+            var indexProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+            orderType.GetOrAddIndex(indexProperty);
+
+            specialOrderType.HasBaseType(null);
+
+            Assert.Equal(
+                new[] { new[] { Order.CustomerIdProperty.Name } },
+                orderType.GetIndexes().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+            Assert.Equal(
+                new[] { new[] { Order.IdProperty.Name } },
+                specialOrderType.GetIndexes().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
+        }
+
+        [Fact]
+        public void Adding_an_index_throws_if_properties_were_removed()
+        {
+            var model = new Model();
+            var entityType = model.AddEntityType(typeof(Customer));
+            var idProperty = entityType.GetOrAddProperty(Customer.IdProperty);
+            entityType.RemoveProperty(idProperty.Name);
+
+            Assert.Equal(
+                CoreStrings.IndexPropertiesWrongEntity("{'" + Customer.IdProperty.Name + "'}", typeof(Customer).Name),
+                Assert.Throws<InvalidOperationException>(() => entityType.AddIndex(new[] { idProperty })).Message);
+        }
+
+        [Fact]
+        public void Adding_an_index_throws_if_duplicate_properties()
+        {
+            var model = new Model();
+            var entityType = model.AddEntityType(typeof(Customer));
+            var idProperty = entityType.GetOrAddProperty(Customer.IdProperty);
+
+            Assert.Equal(
+                CoreStrings.DuplicatePropertyInList("{'" + Customer.IdProperty.Name + "', '" + Customer.IdProperty.Name + "'}", Customer.IdProperty.Name),
+                Assert.Throws<InvalidOperationException>(() => entityType.AddIndex(new[] { idProperty, idProperty })).Message);
+        }
+
+        [Fact]
+        public void Adding_an_index_throws_when_parent_type_has_index_on_same_properties()
+        {
+            var model = new Model();
+
+            var orderType = model.AddEntityType(typeof(Order));
+            var indexProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+            orderType.AddIndex(indexProperty);
+
+            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
+            specialOrderType.HasBaseType(orderType);
+
+            Assert.Equal(
+                CoreStrings.DuplicateIndex(Property.Format(new[] { indexProperty }), typeof(SpecialOrder).Name, typeof(Order).Name),
+                Assert.Throws<InvalidOperationException>(
+                    () => specialOrderType.AddIndex(indexProperty)).Message);
+        }
+
+        [Fact]
+        public void Adding_an_index_throws_when_grandparent_type_has_index_on_same_properties()
+        {
+            var model = new Model();
+
+            var orderType = model.AddEntityType(typeof(Order));
+            var indexProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+            orderType.AddIndex(indexProperty);
+
+            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
+            specialOrderType.HasBaseType(orderType);
+
+            var verySpecialOrderType = model.AddEntityType(typeof(VerySpecialOrder));
+            verySpecialOrderType.HasBaseType(specialOrderType);
+
+            Assert.Equal(
+                CoreStrings.DuplicateIndex(Property.Format(new[] { indexProperty }), typeof(VerySpecialOrder).Name, typeof(Order).Name),
+                Assert.Throws<InvalidOperationException>(
+                    () => verySpecialOrderType.AddIndex(indexProperty)).Message);
+        }
+
+        [Fact]
+        public void Adding_an_index_throws_when_child_type_has_index_on_same_properties()
+        {
+            var model = new Model();
+
+            var orderType = model.AddEntityType(typeof(Order));
+            var indexProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+
+            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
+            specialOrderType.HasBaseType(orderType);
+            specialOrderType.AddIndex(indexProperty);
+
+            Assert.Equal(
+                CoreStrings.DuplicateIndex(Property.Format(new[] { indexProperty }), typeof(Order).Name, typeof(SpecialOrder).Name),
+                Assert.Throws<InvalidOperationException>(
+                    () => orderType.AddIndex(indexProperty)).Message);
+        }
+
+        [Fact]
+        public void Adding_an_index_throws_when_grandchild_type_has_index_on_same_properties()
+        {
+            var model = new Model();
+
+            var orderType = model.AddEntityType(typeof(Order));
+            var indexProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
+
+            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
+            specialOrderType.HasBaseType(orderType);
+
+            var verySpecialOrderType = model.AddEntityType(typeof(VerySpecialOrder));
+            verySpecialOrderType.HasBaseType(specialOrderType);
+            verySpecialOrderType.AddIndex(indexProperty);
+
+            Assert.Equal(
+                CoreStrings.DuplicateIndex(Property.Format(new[] { indexProperty }), typeof(Order).Name, typeof(VerySpecialOrder).Name),
+                Assert.Throws<InvalidOperationException>(
+                    () => orderType.AddIndex(indexProperty)).Message);
+        }
+    }
+}

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -12,12 +13,17 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
+// ReSharper disable CollectionNeverUpdated.Local
+// ReSharper disable UnusedAutoPropertyAccessor.Local
+// ReSharper disable MemberCanBePrivate.Local
+// ReSharper disable MemberHidesStaticFromOuterClass
+// ReSharper disable UnassignedGetOnlyAutoProperty
 // ReSharper disable InconsistentNaming
 // ReSharper disable UnusedMember.Local
 // ReSharper disable ImplicitlyCapturedClosure
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
-    public class EntityTypeTest
+    public partial class EntityTypeTest
     {
         private readonly Model _model = BuildModel();
 
@@ -108,1179 +114,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             public IServiceProperty FindServiceProperty(string name) => throw new NotImplementedException();
             public IEnumerable<IServiceProperty> GetServiceProperties() => throw new NotImplementedException();
             public IEnumerable<IDictionary<string, object>> GetSeedData() => throw new NotImplementedException();
-        }
-
-        [Fact]
-        public void Circular_inheritance_should_throw()
-        {
-            var model = new Model();
-
-            //    A
-            //   / \
-            //  B   C
-            //       \
-            //        D
-
-            var a = model.AddEntityType(typeof(A).Name);
-            var b = model.AddEntityType(typeof(B).Name);
-            var c = model.AddEntityType(typeof(C).Name);
-            var d = model.AddEntityType(typeof(D).Name);
-
-            b.HasBaseType(a);
-            c.HasBaseType(a);
-            d.HasBaseType(c);
-
-            Assert.Equal(
-                CoreStrings.CircularInheritance(a.DisplayName(), a.DisplayName()),
-                Assert.Throws<InvalidOperationException>(() => { a.HasBaseType(a); }).Message);
-
-            Assert.Equal(
-                CoreStrings.CircularInheritance(a.DisplayName(), b.DisplayName()),
-                Assert.Throws<InvalidOperationException>(() => { a.HasBaseType(b); }).Message);
-
-            Assert.Equal(
-                CoreStrings.CircularInheritance(a.DisplayName(), d.DisplayName()),
-                Assert.Throws<InvalidOperationException>(() => { a.HasBaseType(d); }).Message);
-        }
-
-        [Fact]
-        public void Setting_CLR_base_for_shadow_entity_type_should_throw()
-        {
-            var model = new Model();
-
-            var a = model.AddEntityType(typeof(A));
-            var b = model.AddEntityType(typeof(B).Name);
-
-            Assert.Equal(
-                CoreStrings.NonShadowBaseType(typeof(B).Name, typeof(A).Name),
-                Assert.Throws<InvalidOperationException>(() => { b.HasBaseType(a); }).Message);
-        }
-
-        [Fact]
-        public void Setting_shadow_base_for_CLR_entity_type_should_throw()
-        {
-            var model = new Model();
-
-            var a = model.AddEntityType(typeof(A).Name);
-            var b = model.AddEntityType(typeof(B));
-
-            Assert.Equal(
-                CoreStrings.NonClrBaseType(typeof(B).Name, typeof(A).Name),
-                Assert.Throws<InvalidOperationException>(() => { b.HasBaseType(a); }).Message);
-        }
-
-        [Fact]
-        public void Setting_not_assignable_base_should_throw()
-        {
-            var model = new Model();
-
-            var a = model.AddEntityType(typeof(A));
-            var b = model.AddEntityType(typeof(B));
-
-            Assert.Equal(
-                CoreStrings.NotAssignableClrBaseType(typeof(A).Name, typeof(B).Name, typeof(A).Name, typeof(B).Name),
-                Assert.Throws<InvalidOperationException>(() => { a.HasBaseType(b); }).Message);
-        }
-
-        [Fact]
-        public void Properties_on_base_type_should_be_inherited()
-        {
-            var model = new Model();
-
-            //    A
-            //   / \
-            //  B   C
-
-            var a = model.AddEntityType(typeof(A));
-            a.AddProperty(A.GProperty);
-            a.AddProperty(A.EProperty);
-
-            var b = model.AddEntityType(typeof(B));
-            b.AddProperty(B.HProperty);
-            b.AddProperty(B.FProperty);
-
-            var c = model.AddEntityType(typeof(C));
-            c.AddProperty(C.HProperty);
-            c.AddProperty("I", typeof(string));
-
-            Assert.Equal(new[] { "E", "G" }, a.GetProperties().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { "F", "H" }, b.GetProperties().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { "H", "I" }, c.GetProperties().Select(p => p.Name).ToArray());
-
-            b.HasBaseType(a);
-            c.HasBaseType(a);
-
-            Assert.Equal(new[] { "E", "G" }, a.GetProperties().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { "E", "G", "F", "H" }, b.GetProperties().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { "E", "G", "H", "I" }, c.GetProperties().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { 0, 1, 2, 3 }, b.GetProperties().Select(p => p.GetIndex()));
-            Assert.Equal(new[] { 0, 1, 2, 3 }, c.GetProperties().Select(p => p.GetIndex()));
-            Assert.Same(b.FindProperty("E"), a.FindProperty("E"));
-        }
-
-        [Fact]
-        public void Properties_added_to_base_type_should_be_inherited()
-        {
-            var model = new Model();
-
-            //    A
-            //   / \
-            //  B   C
-
-            var a = model.AddEntityType(typeof(A));
-            var b = model.AddEntityType(typeof(B));
-            var c = model.AddEntityType(typeof(C));
-
-            b.HasBaseType(a);
-            c.HasBaseType(a);
-
-            a.AddProperty(A.GProperty);
-            a.AddProperty(A.EProperty);
-
-            b.AddProperty(B.HProperty);
-            b.AddProperty(B.FProperty);
-
-            c.AddProperty(C.HProperty);
-            c.AddProperty("I", typeof(string));
-
-            Assert.Equal(new[] { "E", "G" }, a.GetProperties().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { "E", "G", "F", "H" }, b.GetProperties().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { "E", "G", "H", "I" }, c.GetProperties().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { 0, 1, 2, 3 }, b.GetProperties().Select(p => p.GetIndex()));
-            Assert.Equal(new[] { 0, 1, 2, 3 }, c.GetProperties().Select(p => p.GetIndex()));
-        }
-
-        [Fact]
-        public void Properties_should_be_updated_when_base_type_changes()
-        {
-            var model = new Model();
-
-            var c = model.AddEntityType(typeof(C));
-            c.AddProperty(C.HProperty);
-            c.AddProperty(C.FProperty);
-
-            var d = model.AddEntityType(typeof(D));
-            d.AddProperty(A.EProperty);
-            d.AddProperty(A.GProperty);
-            d.HasBaseType(c);
-
-            Assert.Equal(new[] { "F", "H" }, c.GetProperties().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { "F", "H", "E", "G" }, d.GetProperties().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { 0, 1 }, c.GetProperties().Select(p => p.GetIndex()));
-            Assert.Equal(new[] { 0, 1, 2, 3 }, d.GetProperties().Select(p => p.GetIndex()));
-
-            d.HasBaseType(null);
-
-            Assert.Equal(new[] { "F", "H" }, c.GetProperties().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { "E", "G" }, d.GetProperties().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { 0, 1 }, c.GetProperties().Select(p => p.GetIndex()));
-            Assert.Equal(new[] { 0, 1 }, d.GetProperties().Select(p => p.GetIndex()));
-
-            var a = model.AddEntityType(typeof(A));
-            a.AddProperty(A.EProperty);
-            a.AddProperty(A.GProperty);
-
-            c.HasBaseType(a);
-
-            Assert.Equal(new[] { "E", "G" }, a.GetProperties().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { "E", "G", "F", "H" }, c.GetProperties().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { "E", "G" }, d.GetProperties().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { 0, 1 }, a.GetProperties().Select(p => p.GetIndex()));
-            Assert.Equal(new[] { 0, 1, 2, 3 }, c.GetProperties().Select(p => p.GetIndex()));
-            Assert.Equal(new[] { 0, 1 }, d.GetProperties().Select(p => p.GetIndex()));
-        }
-
-        [Fact]
-        public void Adding_property_throws_when_parent_type_has_property_with_same_name()
-        {
-            var model = new Model();
-
-            var a = model.AddEntityType(typeof(A));
-            a.AddProperty(A.GProperty);
-
-            var b = model.AddEntityType(typeof(B));
-            b.HasBaseType(a);
-
-            Assert.Equal(
-                CoreStrings.DuplicateProperty("G", typeof(B).Name, typeof(A).Name),
-                Assert.Throws<InvalidOperationException>(() => b.AddProperty("G")).Message);
-        }
-
-        [Fact]
-        public void Adding_property_throws_when_grandparent_type_has_property_with_same_name()
-        {
-            var model = new Model();
-
-            var a = model.AddEntityType(typeof(A));
-            a.AddProperty(A.GProperty);
-
-            var c = model.AddEntityType(typeof(C));
-            c.HasBaseType(a);
-
-            var d = model.AddEntityType(typeof(D));
-            d.HasBaseType(c);
-
-            Assert.Equal(
-                CoreStrings.DuplicateProperty("G", typeof(D).Name, typeof(A).Name),
-                Assert.Throws<InvalidOperationException>(() => d.AddProperty("G")).Message);
-        }
-
-        [Fact]
-        public void Adding_property_throws_when_child_type_has_property_with_same_name()
-        {
-            var model = new Model();
-
-            var a = model.AddEntityType(typeof(A));
-
-            var b = model.AddEntityType(typeof(B));
-            b.HasBaseType(a);
-
-            b.AddProperty(A.GProperty);
-
-            Assert.Equal(
-                CoreStrings.DuplicateProperty("G", typeof(A).Name, typeof(B).Name),
-                Assert.Throws<InvalidOperationException>(() => a.AddProperty(A.GProperty)).Message);
-        }
-
-        [Fact]
-        public void Adding_property_throws_when_grandchild_type_has_property_with_same_name()
-        {
-            var model = new Model();
-
-            var a = model.AddEntityType(typeof(A));
-
-            var c = model.AddEntityType(typeof(C));
-            c.HasBaseType(a);
-
-            var d = model.AddEntityType(typeof(D));
-            d.HasBaseType(c);
-
-            d.AddProperty(A.GProperty);
-
-            Assert.Equal(
-                CoreStrings.DuplicateProperty("G", typeof(A).Name, typeof(D).Name),
-                Assert.Throws<InvalidOperationException>(() => a.AddProperty(A.GProperty)).Message);
-        }
-
-        [Fact]
-        public void Setting_base_type_throws_when_parent_contains_duplicate_property()
-        {
-            var model = new Model();
-
-            var a = model.AddEntityType(typeof(A));
-            a.AddProperty(A.GProperty);
-
-            var b = model.AddEntityType(typeof(B));
-            b.AddProperty(A.GProperty);
-
-            Assert.Equal(
-                CoreStrings.DuplicatePropertiesOnBase(typeof(B).Name, typeof(A).Name, typeof(B).Name, "G", typeof(A).Name, "G"),
-                Assert.Throws<InvalidOperationException>(() => { b.HasBaseType(a); }).Message);
-        }
-
-        [Fact]
-        public void Setting_base_type_throws_when_grandparent_contains_duplicate_property()
-        {
-            var model = new Model();
-
-            var a = model.AddEntityType(typeof(A));
-            a.AddProperty(A.EProperty);
-            a.AddProperty(A.GProperty);
-
-            var c = model.AddEntityType(typeof(C));
-            c.HasBaseType(a);
-
-            var d = model.AddEntityType(typeof(D));
-            d.AddProperty(A.EProperty);
-            d.AddProperty(A.GProperty);
-
-            Assert.Equal(
-                CoreStrings.DuplicatePropertiesOnBase(typeof(D).Name, typeof(C).Name, typeof(D).Name, "E", typeof(A).Name, "E"),
-                Assert.Throws<InvalidOperationException>(() => { d.HasBaseType(c); }).Message);
-        }
-
-        [Fact]
-        public void Setting_base_type_throws_when_grandchild_contain_duplicate_property()
-        {
-            var model = new Model();
-
-            var a = model.AddEntityType(typeof(A));
-            a.AddProperty(A.EProperty);
-            a.AddProperty(A.GProperty);
-
-            var c = model.AddEntityType(typeof(C));
-
-            var d = model.AddEntityType(typeof(D));
-            d.AddProperty(A.EProperty);
-            d.AddProperty(A.GProperty);
-            d.HasBaseType(c);
-
-            Assert.Equal(
-                CoreStrings.DuplicatePropertiesOnBase(typeof(C).Name, typeof(A).Name, typeof(D).Name, "E", typeof(A).Name, "E"),
-                Assert.Throws<InvalidOperationException>(() => { c.HasBaseType(a); }).Message);
-        }
-
-        [Fact]
-        public void Keys_on_base_type_should_be_inherited()
-        {
-            var model = new Model();
-
-            var a = model.AddEntityType(typeof(A));
-            var g = a.AddProperty(A.GProperty);
-            g.IsNullable = false;
-            var e = a.AddProperty(A.EProperty);
-            e.IsNullable = false;
-            var pk = a.SetPrimaryKey(g);
-            a.AddKey(e);
-
-            var b = model.AddEntityType(typeof(B));
-            b.AddProperty(B.FProperty);
-
-            Assert.Equal(
-                new[] { new[] { "E" }, new[] { "G" } },
-                a.GetKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-            Assert.Equal(
-                Array.Empty<string[]>(),
-                b.GetKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-            Assert.Equal(new[] { "G", "E" }, a.GetProperties().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { "F" }, b.GetProperties().Select(p => p.Name).ToArray());
-
-            b.HasBaseType(a);
-
-            Assert.Equal(
-                new[] { new[] { "E" }, new[] { "G" } },
-                a.GetKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-            Assert.Equal(
-                new[] { new[] { "E" }, new[] { "G" } },
-                b.GetKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-            Assert.Equal(new[] { "G", "E" }, a.GetProperties().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { "G", "E", "F" }, b.GetProperties().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { 0, 1, 2 }, b.GetProperties().Select(p => p.GetIndex()));
-            Assert.Same(pk, b.FindPrimaryKey(new[] { b.FindProperty("G") }));
-            Assert.Same(b.FindKey(b.FindProperty("G")), a.FindKey(a.FindProperty("G")));
-        }
-
-        [Fact]
-        public void Keys_added_to_base_type_should_be_inherited()
-        {
-            var model = new Model();
-
-            var a = model.AddEntityType(typeof(A));
-            a.AddProperty(A.GProperty).IsNullable = false;
-            a.AddProperty(A.EProperty).IsNullable = false;
-
-            var b = model.AddEntityType(typeof(B));
-            b.AddProperty(B.FProperty);
-
-            b.HasBaseType(a);
-
-            a.SetPrimaryKey(a.FindProperty("G"));
-            a.AddKey(a.FindProperty("E"));
-
-            Assert.Equal(
-                new[] { new[] { "E" }, new[] { "G" } },
-                a.GetKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-            Assert.Equal(
-                new[] { new[] { "E" }, new[] { "G" } },
-                b.GetKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-            Assert.Equal(new[] { "G", "E" }, a.GetProperties().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { "G", "E", "F" }, b.GetProperties().Select(p => p.Name).ToArray());
-        }
-
-        [Fact]
-        public void Keys_should_be_updated_when_base_type_changes()
-        {
-            var model = new Model();
-
-            var a = model.AddEntityType(typeof(A));
-            var g = a.AddProperty(A.GProperty);
-            g.IsNullable = false;
-            a.SetPrimaryKey(g);
-            var e = a.AddProperty(A.EProperty);
-            e.IsNullable = false;
-            a.AddKey(e);
-
-            var b = model.AddEntityType(typeof(B));
-            b.AddProperty(B.FProperty);
-            b.HasBaseType(a);
-
-            b.HasBaseType(null);
-
-            Assert.Equal(
-                new[] { new[] { "E" }, new[] { "G" } },
-                a.GetKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-            Assert.Equal(
-                Array.Empty<string[]>(),
-                b.GetKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-            Assert.Equal(new[] { "G", "E" }, a.GetProperties().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { "F" }, b.GetProperties().Select(p => p.Name).ToArray());
-        }
-
-        [Fact]
-        public void Adding_keys_throws_when_there_is_a_parent_type()
-        {
-            var model = new Model();
-
-            var a = model.AddEntityType(typeof(A));
-            var b = model.AddEntityType(typeof(B));
-            b.HasBaseType(a);
-
-            Assert.Equal(
-                CoreStrings.DerivedEntityTypeKey(typeof(B).Name, typeof(A).Name),
-                Assert.Throws<InvalidOperationException>(() => b.SetPrimaryKey(b.AddProperty("G"))).Message);
-            Assert.Equal(
-                CoreStrings.DerivedEntityTypeKey(typeof(B).Name, typeof(A).Name),
-                Assert.Throws<InvalidOperationException>(() => b.AddKey(b.AddProperty("E"))).Message);
-        }
-
-        [Fact]
-        public void Setting_base_type_throws_when_child_contains_key()
-        {
-            var model = new Model();
-
-            var a = model.AddEntityType(typeof(A));
-            var b = model.AddEntityType(typeof(B));
-            var h = b.AddProperty(B.HProperty);
-            h.IsNullable = false;
-            var key = b.AddKey(h);
-
-            Assert.Equal(
-                CoreStrings.DerivedEntityCannotHaveKeys(typeof(B).Name),
-                Assert.Throws<InvalidOperationException>(() => { b.HasBaseType(a); }).Message);
-
-            b.RemoveKey(key.Properties);
-            var f = b.AddProperty(B.FProperty);
-            f.IsNullable = false;
-            b.SetPrimaryKey(f);
-
-            Assert.Equal(
-                CoreStrings.DerivedEntityCannotHaveKeys(typeof(B).Name),
-                Assert.Throws<InvalidOperationException>(() => { b.HasBaseType(a); }).Message);
-        }
-
-        [Fact]
-        public void Setting_base_type_throws_when_mixing_views_and_entities()
-        {
-            var model = new Model();
-
-            var a = model.AddEntityType(typeof(A));
-            var b = model.AddQueryType(typeof(B));
-
-            Assert.Equal(
-                CoreStrings.ErrorMixedQueryEntityTypeInheritance(typeof(A).Name, typeof(B).Name),
-                Assert.Throws<InvalidOperationException>(() => { b.HasBaseType(a); }).Message);
-
-            Assert.Equal(
-                CoreStrings.ErrorMixedQueryEntityTypeInheritance(typeof(B).Name, typeof(A).Name),
-                Assert.Throws<InvalidOperationException>(() => { a.HasBaseType(b); }).Message);
-        }
-
-        [Fact]
-        public void Navigations_on_base_type_should_be_inherited()
-        {
-            var model = new Model();
-
-            var customerType = model.AddEntityType(typeof(Customer));
-            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
-
-            var orderType = model.AddEntityType(typeof(SpecialOrder));
-            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-            var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
-
-            customerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
-
-            var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
-
-            Assert.Equal(new[] { "Orders" }, customerType.GetNavigations().Select(p => p.Name).ToArray());
-            Assert.Equal(Array.Empty<string>(), specialCustomerType.GetNavigations().Select(p => p.Name).ToArray());
-
-            specialCustomerType.HasBaseType(customerType);
-
-            Assert.Equal(new[] { "Orders" }, customerType.GetNavigations().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { "Orders" }, specialCustomerType.GetNavigations().Select(p => p.Name).ToArray());
-
-            var derivedForeignKeyProperty = orderType.GetOrAddProperty(Order.IdProperty);
-            var specialCustomerForeignKey = orderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, specialCustomerType);
-            specialCustomerForeignKey.HasPrincipalToDependent(SpecialCustomer.DerivedOrdersProperty);
-            Assert.Equal(new[] { "Orders" }, customerType.GetNavigations().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { "Orders", "DerivedOrders" }, specialCustomerType.GetNavigations().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { "Orders", "DerivedOrders" }, ((IEntityType)specialCustomerType).GetNavigations().Select(p => p.Name).ToArray());
-            Assert.Same(customerType.FindNavigation("Orders"), specialCustomerType.FindNavigation("Orders"));
-        }
-
-        [Fact]
-        public void Navigations_added_to_base_type_should_be_inherited()
-        {
-            var model = new Model();
-
-            var customerType = model.AddEntityType(typeof(Customer));
-            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
-
-            var orderType = model.AddEntityType(typeof(SpecialOrder));
-            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-            var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
-
-            var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
-            specialCustomerType.HasBaseType(customerType);
-
-            customerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
-
-            Assert.Equal(new[] { "Orders" }, customerType.GetNavigations().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { "Orders" }, specialCustomerType.GetNavigations().Select(p => p.Name).ToArray());
-
-            var derivedForeignKeyProperty = orderType.GetOrAddProperty(Order.IdProperty);
-            var specialCustomerForeignKey = orderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, specialCustomerType);
-            specialCustomerForeignKey.HasPrincipalToDependent(SpecialCustomer.DerivedOrdersProperty);
-
-            Assert.Equal(new[] { "Orders" }, customerType.GetNavigations().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { "Orders", "DerivedOrders" }, specialCustomerType.GetNavigations().Select(p => p.Name).ToArray());
-        }
-
-        [Fact]
-        public void Navigations_should_be_updated_when_base_type_changes()
-        {
-            var model = new Model();
-
-            var customerType = model.AddEntityType(typeof(Customer));
-            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
-
-            var orderType = model.AddEntityType(typeof(SpecialOrder));
-            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-            var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
-
-            customerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
-
-            var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
-            specialCustomerType.HasBaseType(customerType);
-
-            var derivedForeignKeyProperty = orderType.GetOrAddProperty(Order.IdProperty);
-            var specialCustomerForeignKey = orderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, specialCustomerType);
-            specialCustomerForeignKey.HasPrincipalToDependent(SpecialCustomer.DerivedOrdersProperty);
-
-            specialCustomerType.HasBaseType(null);
-
-            Assert.Equal(new[] { nameof(Customer.Orders) }, customerType.GetNavigations().Select(p => p.Name).ToArray());
-            Assert.Equal(new[] { nameof(SpecialCustomer.DerivedOrders) }, specialCustomerType.GetNavigations().Select(p => p.Name).ToArray());
-        }
-
-        [Fact]
-        public void Adding_navigation_throws_when_parent_type_has_navigation_with_same_name()
-        {
-            var model = new Model();
-
-            var customerType = model.AddEntityType(typeof(Customer));
-            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
-
-            var orderType = model.AddEntityType(typeof(SpecialOrder));
-            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-            var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
-            customerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
-
-            var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
-            specialCustomerType.HasBaseType(customerType);
-
-            var derivedForeignKeyProperty = orderType.GetOrAddProperty(Order.IdProperty);
-            var specialCustomerForeignKey = orderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, specialCustomerType);
-
-            Assert.Equal(
-                CoreStrings.NavigationForWrongForeignKey(nameof(Customer.Orders), typeof(Customer).Name, "{'Id'}", "{'CustomerId'}"),
-                Assert.Throws<InvalidOperationException>(
-                    () =>
-                        specialCustomerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty)).Message);
-        }
-
-        [Fact]
-        public void Adding_navigation_throws_when_grandparent_type_has_navigation_with_same_name()
-        {
-            var model = new Model();
-
-            var customerType = model.AddEntityType(typeof(Customer));
-            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
-
-            var orderType = model.AddEntityType(typeof(SpecialOrder));
-            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-            var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
-            customerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
-
-            var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
-            specialCustomerType.HasBaseType(customerType);
-
-            var verySpecialCustomerType = model.AddEntityType(typeof(VerySpecialCustomer));
-            verySpecialCustomerType.HasBaseType(specialCustomerType);
-
-            var derivedForeignKeyProperty = orderType.GetOrAddProperty(Order.IdProperty);
-            var specialCustomerForeignKey = orderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, verySpecialCustomerType);
-
-            Assert.Equal(
-                CoreStrings.NavigationForWrongForeignKey("Orders", typeof(Customer).Name, "{'Id'}", "{'CustomerId'}"),
-                Assert.Throws<InvalidOperationException>(
-                    () =>
-                        specialCustomerForeignKey.HasPrincipalToDependent("Orders")).Message);
-
-            Assert.Equal("Orders", ((IEntityType)verySpecialCustomerType).GetNavigations().Single().Name);
-        }
-
-        [Fact]
-        public void Adding_navigation_throws_when_child_type_has_navigation_with_same_name()
-        {
-            var model = new Model();
-
-            var customerType = model.AddEntityType(typeof(Customer));
-            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
-
-            var orderType = model.AddEntityType(typeof(SpecialOrder));
-            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-            var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
-
-            var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
-            specialCustomerType.HasBaseType(customerType);
-
-            var derivedForeignKeyProperty = orderType.GetOrAddProperty(Order.IdProperty);
-            var specialCustomerForeignKey = orderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, specialCustomerType);
-            specialCustomerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
-
-            Assert.Equal(
-                CoreStrings.NavigationForWrongForeignKey("Orders", typeof(SpecialCustomer).Name, "{'CustomerId'}", "{'Id'}"),
-                Assert.Throws<InvalidOperationException>(
-                    () =>
-                        customerForeignKey.HasPrincipalToDependent("Orders")).Message);
-        }
-
-        [Fact]
-        public void Adding_navigation_throws_when_grandchild_type_has_navigation_with_same_name()
-        {
-            var model = new Model();
-
-            var customerType = model.AddEntityType(typeof(Customer));
-            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
-
-            var orderType = model.AddEntityType(typeof(SpecialOrder));
-            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-            var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
-
-            var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
-            specialCustomerType.HasBaseType(customerType);
-
-            var verySpecialCustomerType = model.AddEntityType(typeof(VerySpecialCustomer));
-            verySpecialCustomerType.HasBaseType(specialCustomerType);
-
-            var derivedForeignKeyProperty = orderType.GetOrAddProperty(Order.IdProperty);
-            var specialCustomerForeignKey = orderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, verySpecialCustomerType);
-            specialCustomerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty);
-
-            Assert.Equal(
-                CoreStrings.NavigationForWrongForeignKey(nameof(Customer.Orders), typeof(VerySpecialCustomer).Name, "{'CustomerId'}", "{'Id'}"),
-                Assert.Throws<InvalidOperationException>(
-                    () =>
-                        customerForeignKey.HasPrincipalToDependent(Customer.OrdersProperty)).Message);
-
-            Assert.Equal(nameof(Customer.Orders), ((IEntityType)verySpecialCustomerType).GetNavigations().Single().Name);
-        }
-
-        [Fact]
-        public void Setting_base_type_throws_when_parent_contains_duplicate_navigation()
-        {
-            var model = new Model();
-
-            var customerType = model.AddEntityType(typeof(Customer));
-            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
-
-            var orderType = model.AddEntityType(typeof(Order));
-            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-            var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
-            customerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
-
-            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
-
-            var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
-
-            var derivedForeignKeyProperty = specialOrderType.GetOrAddProperty(Order.IdProperty);
-            var property = specialCustomerType.AddProperty("AltId", typeof(int));
-            var specialCustomerKey = specialCustomerType.GetOrAddKey(property);
-            var specialCustomerForeignKey = specialOrderType.GetOrAddForeignKey(derivedForeignKeyProperty, specialCustomerKey, specialCustomerType);
-            specialCustomerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
-
-            Assert.Equal(
-                CoreStrings.DuplicateNavigationsOnBase(typeof(SpecialOrder).Name, typeof(Order).Name, "Customer"),
-                Assert.Throws<InvalidOperationException>(() => { specialOrderType.HasBaseType(orderType); }).Message);
-        }
-
-        [Fact]
-        public void Setting_base_type_throws_when_grandparent_contains_duplicate_navigation()
-        {
-            var model = new Model();
-
-            var customerType = model.AddEntityType(typeof(Customer));
-            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
-
-            var orderType = model.AddEntityType(typeof(Order));
-            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-            var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
-            customerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
-
-            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
-
-            var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
-
-            var verySpecialOrderType = model.AddEntityType(typeof(VerySpecialOrder));
-            var derivedForeignKeyProperty = verySpecialOrderType.GetOrAddProperty(Order.IdProperty);
-            var property = specialCustomerType.AddProperty("AltId", typeof(int));
-            var specialCustomerKey = specialCustomerType.GetOrAddKey(property);
-            var specialCustomerForeignKey = verySpecialOrderType.GetOrAddForeignKey(derivedForeignKeyProperty, specialCustomerKey, specialCustomerType);
-            specialCustomerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
-            verySpecialOrderType.HasBaseType(specialOrderType);
-
-            Assert.Equal(
-                CoreStrings.DuplicateNavigationsOnBase(typeof(SpecialOrder).Name, typeof(Order).Name, nameof(Order.Customer)),
-                Assert.Throws<InvalidOperationException>(() => { specialOrderType.HasBaseType(orderType); }).Message);
-        }
-
-        [Fact]
-        public void Setting_base_type_throws_when_grandchild_contain_duplicate_navigation()
-        {
-            var model = new Model();
-
-            var customerType = model.AddEntityType(typeof(Customer));
-            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
-
-            var orderType = model.AddEntityType(typeof(Order));
-            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-            var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
-            customerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
-
-            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
-            specialOrderType.HasBaseType(orderType);
-
-            var specialCustomerType = model.AddEntityType(typeof(SpecialCustomer));
-
-            var verySpecialOrderType = model.AddEntityType(typeof(VerySpecialOrder));
-            var derivedForeignKeyProperty = verySpecialOrderType.GetOrAddProperty(Order.IdProperty);
-            var property = specialCustomerType.AddProperty("AltId", typeof(int));
-            var specialCustomerKey = specialCustomerType.GetOrAddKey(property);
-            var specialCustomerForeignKey = verySpecialOrderType.GetOrAddForeignKey(derivedForeignKeyProperty, specialCustomerKey, specialCustomerType);
-            specialCustomerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
-
-            Assert.Equal(
-                CoreStrings.DuplicateNavigationsOnBase(typeof(VerySpecialOrder).Name, typeof(SpecialOrder).Name, "Customer"),
-                Assert.Throws<InvalidOperationException>(() => { verySpecialOrderType.HasBaseType(specialOrderType); }).Message);
-        }
-
-        [Fact]
-        public void ForeignKeys_on_base_type_should_be_inherited()
-        {
-            var model = new Model();
-
-            var customerType = model.AddEntityType(typeof(SpecialCustomer));
-            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
-
-            var orderType = model.AddEntityType(typeof(Order));
-            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-            var customerForeignKey = orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
-
-            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
-            var derivedForeignKeyProperty = specialOrderType.GetOrAddProperty(Order.IdProperty);
-            specialOrderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, customerType);
-
-            Assert.Equal(
-                new[] { new[] { Order.CustomerIdProperty.Name } },
-                orderType.GetForeignKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-            Assert.Equal(
-                new[] { new[] { Order.IdProperty.Name } },
-                specialOrderType.GetForeignKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-
-            specialOrderType.HasBaseType(orderType);
-
-            Assert.Equal(
-                new[] { new[] { Order.CustomerIdProperty.Name } },
-                orderType.GetForeignKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-            Assert.Equal(
-                new[] { new[] { Order.CustomerIdProperty.Name }, new[] { Order.IdProperty.Name } },
-                specialOrderType.GetForeignKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-            Assert.Same(customerForeignKey, specialOrderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType));
-        }
-
-        [Fact]
-        public void ForeignKeys_added_to_base_type_should_be_inherited()
-        {
-            var model = new Model();
-
-            var customerType = model.AddEntityType(typeof(SpecialCustomer));
-            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
-
-            var orderType = model.AddEntityType(typeof(Order));
-            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-
-            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
-
-            specialOrderType.HasBaseType(orderType);
-            orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
-
-            Assert.Equal(
-                new[] { new[] { Order.CustomerIdProperty.Name } },
-                orderType.GetForeignKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-            Assert.Equal(
-                new[] { new[] { Order.CustomerIdProperty.Name } },
-                specialOrderType.GetForeignKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-
-            var derivedForeignKeyProperty = specialOrderType.GetOrAddProperty(Order.IdProperty);
-            specialOrderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, customerType);
-
-            Assert.Equal(
-                new[] { new[] { Order.CustomerIdProperty.Name } },
-                orderType.GetForeignKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-            Assert.Equal(
-                new[] { new[] { Order.CustomerIdProperty.Name }, new[] { Order.IdProperty.Name } },
-                specialOrderType.GetForeignKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-        }
-
-        [Fact]
-        public void ForeignKeys_should_be_updated_when_base_type_changes()
-        {
-            var model = new Model();
-
-            var customerType = model.AddEntityType(typeof(SpecialCustomer));
-            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
-
-            var orderType = model.AddEntityType(typeof(Order));
-
-            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
-            specialOrderType.HasBaseType(orderType);
-            var derivedForeignKeyProperty = specialOrderType.GetOrAddProperty(Order.IdProperty);
-            specialOrderType.GetOrAddForeignKey(derivedForeignKeyProperty, customerKey, customerType);
-
-            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-            orderType.GetOrAddForeignKey(foreignKeyProperty, customerKey, customerType);
-
-            specialOrderType.HasBaseType(null);
-
-            Assert.Equal(
-                new[] { new[] { Order.CustomerIdProperty.Name } },
-                orderType.GetForeignKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-            Assert.Equal(
-                new[] { new[] { Order.IdProperty.Name } },
-                specialOrderType.GetForeignKeys().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-        }
-
-        [Fact]
-        public void Adding_foreignKey_throws_when_parent_type_has_foreignKey_on_same_properties()
-        {
-            var model = new Model();
-
-            var customerType = model.AddEntityType(typeof(Customer));
-            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
-
-            var orderType = model.AddEntityType(typeof(Order));
-            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-            orderType.AddForeignKey(foreignKeyProperty, customerKey, customerType);
-
-            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
-            specialOrderType.HasBaseType(orderType);
-
-            Assert.Equal(
-                CoreStrings.DuplicateForeignKey(
-                    Property.Format(new[] { foreignKeyProperty }),
-                    typeof(SpecialOrder).Name,
-                    typeof(Order).Name,
-                    Property.Format(customerKey.Properties),
-                    typeof(Customer).Name),
-                Assert.Throws<InvalidOperationException>(
-                    () =>
-                        specialOrderType.AddForeignKey(foreignKeyProperty, customerKey, customerType)).Message);
-        }
-
-        [Fact]
-        public void Adding_foreignKey_throws_when_grandparent_type_has_foreignKey_on_same_properties()
-        {
-            var model = new Model();
-
-            var customerType = model.AddEntityType(typeof(Customer));
-            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
-
-            var orderType = model.AddEntityType(typeof(Order));
-            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-            orderType.AddForeignKey(foreignKeyProperty, customerKey, customerType);
-
-            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
-            specialOrderType.HasBaseType(orderType);
-
-            var verySpecialOrderType = model.AddEntityType(typeof(VerySpecialOrder));
-            verySpecialOrderType.HasBaseType(specialOrderType);
-
-            Assert.Equal(
-                CoreStrings.DuplicateForeignKey(
-                    Property.Format(new[] { foreignKeyProperty }),
-                    typeof(VerySpecialOrder).Name,
-                    typeof(Order).Name,
-                    Property.Format(customerKey.Properties),
-                    typeof(Customer).Name),
-                Assert.Throws<InvalidOperationException>(
-                    () =>
-                        verySpecialOrderType.AddForeignKey(foreignKeyProperty, customerKey, customerType)).Message);
-        }
-
-        [Fact]
-        public void Adding_foreignKey_throws_when_child_type_has_foreignKey_on_same_properties()
-        {
-            var model = new Model();
-
-            var customerType = model.AddEntityType(typeof(Customer));
-            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
-
-            var orderType = model.AddEntityType(typeof(Order));
-            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-
-            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
-            specialOrderType.HasBaseType(orderType);
-            specialOrderType.AddForeignKey(foreignKeyProperty, customerKey, customerType);
-
-            Assert.Equal(
-                CoreStrings.DuplicateForeignKey(
-                    Property.Format(new[] { foreignKeyProperty }),
-                    typeof(Order).Name,
-                    typeof(SpecialOrder).Name,
-                    Property.Format(customerKey.Properties),
-                    typeof(Customer).Name),
-                Assert.Throws<InvalidOperationException>(
-                    () =>
-                        orderType.AddForeignKey(foreignKeyProperty, customerKey, customerType)).Message);
-        }
-
-        [Fact]
-        public void Adding_foreignKey_throws_when_grandchild_type_has_foreignKey_on_same_properties()
-        {
-            var model = new Model();
-
-            var customerType = model.AddEntityType(typeof(Customer));
-            var customerKey = customerType.GetOrAddKey(customerType.GetOrAddProperty(Customer.IdProperty));
-
-            var orderType = model.AddEntityType(typeof(Order));
-            var foreignKeyProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-
-            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
-            specialOrderType.HasBaseType(orderType);
-
-            var verySpecialOrderType = model.AddEntityType(typeof(VerySpecialOrder));
-            verySpecialOrderType.HasBaseType(specialOrderType);
-            verySpecialOrderType.AddForeignKey(foreignKeyProperty, customerKey, customerType);
-
-            Assert.Equal(
-                CoreStrings.DuplicateForeignKey(
-                    Property.Format(new[] { foreignKeyProperty }),
-                    typeof(Order).Name,
-                    typeof(VerySpecialOrder).Name,
-                    Property.Format(customerKey.Properties),
-                    typeof(Customer).Name),
-                Assert.Throws<InvalidOperationException>(
-                    () =>
-                        orderType.AddForeignKey(foreignKeyProperty, customerKey, customerType)).Message);
-        }
-
-        [Fact]
-        public void Index_on_base_type_should_be_inherited()
-        {
-            var model = new Model();
-
-            var orderType = model.AddEntityType(typeof(Order));
-            var indexProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-            var index = orderType.GetOrAddIndex(indexProperty);
-
-            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
-            var derivedIndexProperty = specialOrderType.GetOrAddProperty(Order.IdProperty);
-            specialOrderType.GetOrAddIndex(derivedIndexProperty);
-
-            Assert.Equal(
-                new[] { new[] { Order.CustomerIdProperty.Name } },
-                orderType.GetIndexes().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-            Assert.Equal(
-                new[] { new[] { Order.IdProperty.Name } },
-                specialOrderType.GetIndexes().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-
-            specialOrderType.HasBaseType(orderType);
-
-            Assert.Equal(
-                new[] { new[] { Order.CustomerIdProperty.Name } },
-                orderType.GetIndexes().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-            Assert.Equal(
-                new[] { new[] { Order.CustomerIdProperty.Name }, new[] { Order.IdProperty.Name } },
-                specialOrderType.GetIndexes().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-            Assert.Same(index, specialOrderType.GetOrAddIndex(indexProperty));
-        }
-
-        [Fact]
-        public void Index_added_to_base_type_should_be_inherited()
-        {
-            var model = new Model();
-
-            var orderType = model.AddEntityType(typeof(Order));
-            var indexProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-
-            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
-
-            specialOrderType.HasBaseType(orderType);
-            orderType.GetOrAddIndex(indexProperty);
-
-            Assert.Equal(
-                new[] { new[] { Order.CustomerIdProperty.Name } },
-                orderType.GetIndexes().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-            Assert.Equal(
-                new[] { new[] { Order.CustomerIdProperty.Name } },
-                specialOrderType.GetIndexes().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-
-            var derivedIndexProperty = specialOrderType.GetOrAddProperty(Order.IdProperty);
-            specialOrderType.GetOrAddIndex(derivedIndexProperty);
-
-            Assert.Equal(
-                new[] { new[] { Order.CustomerIdProperty.Name } },
-                orderType.GetIndexes().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-            Assert.Equal(
-                new[] { new[] { Order.CustomerIdProperty.Name }, new[] { Order.IdProperty.Name } },
-                specialOrderType.GetIndexes().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-        }
-
-        [Fact]
-        public void Indexes_should_be_updated_when_base_type_changes()
-        {
-            var model = new Model();
-
-            var orderType = model.AddEntityType(typeof(Order));
-
-            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
-            specialOrderType.HasBaseType(orderType);
-            var derivedIndexProperty = specialOrderType.GetOrAddProperty(Order.IdProperty);
-            specialOrderType.GetOrAddIndex(derivedIndexProperty);
-
-            var indexProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-            orderType.GetOrAddIndex(indexProperty);
-
-            specialOrderType.HasBaseType(null);
-
-            Assert.Equal(
-                new[] { new[] { Order.CustomerIdProperty.Name } },
-                orderType.GetIndexes().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-            Assert.Equal(
-                new[] { new[] { Order.IdProperty.Name } },
-                specialOrderType.GetIndexes().Select(fk => fk.Properties.Select(p => p.Name).ToArray()).ToArray());
-        }
-
-        [Fact]
-        public void Adding_an_index_throws_if_properties_were_removed()
-        {
-            var model = new Model();
-            var entityType = model.AddEntityType(typeof(Customer));
-            var idProperty = entityType.GetOrAddProperty(Customer.IdProperty);
-            entityType.RemoveProperty(idProperty.Name);
-
-            Assert.Equal(
-                CoreStrings.IndexPropertiesWrongEntity("{'" + Customer.IdProperty.Name + "'}", typeof(Customer).Name),
-                Assert.Throws<InvalidOperationException>(() => entityType.AddIndex(new[] { idProperty })).Message);
-        }
-
-        [Fact]
-        public void Adding_an_index_throws_if_duplicate_properties()
-        {
-            var model = new Model();
-            var entityType = model.AddEntityType(typeof(Customer));
-            var idProperty = entityType.GetOrAddProperty(Customer.IdProperty);
-
-            Assert.Equal(
-                CoreStrings.DuplicatePropertyInList("{'" + Customer.IdProperty.Name + "', '" + Customer.IdProperty.Name + "'}", Customer.IdProperty.Name),
-                Assert.Throws<InvalidOperationException>(() => entityType.AddIndex(new[] { idProperty, idProperty })).Message);
-        }
-
-        [Fact]
-        public void Adding_an_index_throws_when_parent_type_has_index_on_same_properties()
-        {
-            var model = new Model();
-
-            var orderType = model.AddEntityType(typeof(Order));
-            var indexProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-            orderType.AddIndex(indexProperty);
-
-            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
-            specialOrderType.HasBaseType(orderType);
-
-            Assert.Equal(
-                CoreStrings.DuplicateIndex(Property.Format(new[] { indexProperty }), typeof(SpecialOrder).Name, typeof(Order).Name),
-                Assert.Throws<InvalidOperationException>(
-                    () =>
-                        specialOrderType.AddIndex(indexProperty)).Message);
-        }
-
-        [Fact]
-        public void Adding_an_index_throws_when_grandparent_type_has_index_on_same_properties()
-        {
-            var model = new Model();
-
-            var orderType = model.AddEntityType(typeof(Order));
-            var indexProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-            orderType.AddIndex(indexProperty);
-
-            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
-            specialOrderType.HasBaseType(orderType);
-
-            var verySpecialOrderType = model.AddEntityType(typeof(VerySpecialOrder));
-            verySpecialOrderType.HasBaseType(specialOrderType);
-
-            Assert.Equal(
-                CoreStrings.DuplicateIndex(Property.Format(new[] { indexProperty }), typeof(VerySpecialOrder).Name, typeof(Order).Name),
-                Assert.Throws<InvalidOperationException>(
-                    () =>
-                        verySpecialOrderType.AddIndex(indexProperty)).Message);
-        }
-
-        [Fact]
-        public void Adding_an_index_throws_when_child_type_has_index_on_same_properties()
-        {
-            var model = new Model();
-
-            var orderType = model.AddEntityType(typeof(Order));
-            var indexProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-
-            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
-            specialOrderType.HasBaseType(orderType);
-            specialOrderType.AddIndex(indexProperty);
-
-            Assert.Equal(
-                CoreStrings.DuplicateIndex(Property.Format(new[] { indexProperty }), typeof(Order).Name, typeof(SpecialOrder).Name),
-                Assert.Throws<InvalidOperationException>(
-                    () =>
-                        orderType.AddIndex(indexProperty)).Message);
-        }
-
-        [Fact]
-        public void Adding_an_index_throws_when_grandchild_type_has_index_on_same_properties()
-        {
-            var model = new Model();
-
-            var orderType = model.AddEntityType(typeof(Order));
-            var indexProperty = orderType.GetOrAddProperty(Order.CustomerIdProperty);
-
-            var specialOrderType = model.AddEntityType(typeof(SpecialOrder));
-            specialOrderType.HasBaseType(orderType);
-
-            var verySpecialOrderType = model.AddEntityType(typeof(VerySpecialOrder));
-            verySpecialOrderType.HasBaseType(specialOrderType);
-            verySpecialOrderType.AddIndex(indexProperty);
-
-            Assert.Equal(
-                CoreStrings.DuplicateIndex(Property.Format(new[] { indexProperty }), typeof(Order).Name, typeof(VerySpecialOrder).Name),
-                Assert.Throws<InvalidOperationException>(
-                    () =>
-                        orderType.AddIndex(indexProperty)).Message);
-        }
-
-        [Fact]
-        public void Can_create_entity_type()
-        {
-            var entityType = new Model().AddEntityType(typeof(Customer), ConfigurationSource.Convention);
-
-            Assert.Equal(typeof(Customer).FullName, entityType.Name);
-            Assert.Same(typeof(Customer), entityType.ClrType);
-            Assert.Equal(ConfigurationSource.Convention, entityType.GetConfigurationSource());
-
-            entityType.UpdateConfigurationSource(ConfigurationSource.DataAnnotation);
-
-            Assert.Equal(ConfigurationSource.DataAnnotation, entityType.GetConfigurationSource());
         }
 
         [Fact]
@@ -2194,7 +1027,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             orderType.AddProperty("Customer");
 
             Assert.Equal(
-                CoreStrings.ConflictingProperty("Customer", typeof(Order).Name, typeof(Order).Name),
+                CoreStrings.ConflictingPropertyOrNavigation("Customer", typeof(Order).Name, typeof(Order).Name),
                 Assert.Throws<InvalidOperationException>(
                     () => customerForeignKey.HasDependentToPrincipal("Customer")).Message);
         }
@@ -2213,7 +1046,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             orderType.AddServiceProperty(Order.CustomerProperty);
 
             Assert.Equal(
-                CoreStrings.ConflictingServiceProperty(nameof(Order.Customer), nameof(Order), nameof(Order)),
+                CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Customer), nameof(Order), nameof(Order)),
                 Assert.Throws<InvalidOperationException>(
                     () => customerForeignKey.HasDependentToPrincipal(nameof(Order.Customer))).Message);
         }
@@ -2397,7 +1230,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             fk.HasPrincipalToDependent(SelfRef.SelfRef1Property);
             Assert.Equal(
-                CoreStrings.DuplicateNavigation(nameof(SelfRef.SelfRef1), typeof(SelfRef).Name, typeof(SelfRef).Name),
+                CoreStrings.ConflictingPropertyOrNavigation(nameof(SelfRef.SelfRef1), typeof(SelfRef).Name, typeof(SelfRef).Name),
                 Assert.Throws<InvalidOperationException>(() => fk.HasDependentToPrincipal(SelfRef.SelfRef1Property)).Message);
         }
 
@@ -2619,7 +1452,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             public DateTime Date
             {
                 get => DateTime.Parse(_date);
-                set => _date = value.ToString();
+                set => _date = value.ToString(CultureInfo.InvariantCulture);
             }
         }
 
@@ -2832,7 +1665,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             entityType.AddProperty(Customer.IdProperty);
 
             Assert.Equal(
-                CoreStrings.DuplicateProperty("Id", typeof(Customer).Name, typeof(Customer).Name),
+                CoreStrings.ConflictingPropertyOrNavigation("Id", typeof(Customer).Name, typeof(Customer).Name),
                 Assert.Throws<InvalidOperationException>(() => entityType.AddProperty("Id")).Message);
         }
 
@@ -2850,7 +1683,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             customerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
 
             Assert.Equal(
-                CoreStrings.ConflictingNavigation("Customer", typeof(Order).Name, typeof(Order).Name),
+                CoreStrings.ConflictingPropertyOrNavigation("Customer", typeof(Order).Name, typeof(Order).Name),
                 Assert.Throws<InvalidOperationException>(() => orderType.AddProperty("Customer")).Message);
         }
 
@@ -2868,10 +1701,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             customerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
 
             Assert.Equal(
-                CoreStrings.ConflictingNavigation(nameof(Order.Customer), nameof(Order), nameof(Order)),
+                CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Customer), nameof(Order), nameof(Order)),
                 Assert.Throws<InvalidOperationException>(() => orderType.AddServiceProperty(Order.CustomerProperty)).Message);
         }
-        
+
         [Fact]
         public void Adding_a_new_service_property_with_a_name_that_conflicts_with_a_property_throws()
         {
@@ -2880,10 +1713,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             entityType.AddProperty(Customer.OrdersProperty);
 
             Assert.Equal(
-                CoreStrings.ConflictingProperty(nameof(Customer.Orders), nameof(Customer), nameof(Customer)),
+                CoreStrings.ConflictingPropertyOrNavigation(nameof(Customer.Orders), nameof(Customer), nameof(Customer)),
                 Assert.Throws<InvalidOperationException>(() => entityType.AddServiceProperty(Customer.OrdersProperty)).Message);
         }
-        
+
         [Fact]
         public void Adding_a_new_service_property_with_a_name_that_conflicts_with_a_navigation_throws()
         {
@@ -2898,10 +1731,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             customerForeignKey.HasDependentToPrincipal(Order.CustomerProperty);
 
             Assert.Equal(
-                CoreStrings.ConflictingNavigation(nameof(Order.Customer), nameof(Order), nameof(Order)),
+                CoreStrings.ConflictingPropertyOrNavigation(nameof(Order.Customer), nameof(Order), nameof(Order)),
                 Assert.Throws<InvalidOperationException>(() => orderType.AddServiceProperty(Order.CustomerProperty)).Message);
         }
-        
+
         [Fact]
         public void Adding_a_new_service_property_with_a_name_that_already_exists_throws()
         {
@@ -2910,10 +1743,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             entityType.AddServiceProperty(Customer.OrdersProperty);
 
             Assert.Equal(
-                CoreStrings.DuplicateServiceProperty(nameof(Customer.Orders), nameof(Customer), nameof(Customer)),
+                CoreStrings.ConflictingPropertyOrNavigation(nameof(Customer.Orders), nameof(Customer), nameof(Customer)),
                 Assert.Throws<InvalidOperationException>(() => entityType.AddServiceProperty(Customer.OrdersProperty)).Message);
         }
-        
+
         [Fact]
         public void Adding_a_new_service_property_with_a_type_that_already_exists_throws()
         {
@@ -3420,7 +2253,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         [Fact]
         public void Change_tracking_can_be_set_to_snapshot_or_changed_only_for_changed_only_entities()
         {
-            var model = new Model { ChangeTrackingStrategy = ChangeTrackingStrategy.ChangingAndChangedNotifications };
+            var model = new Model
+            {
+                ChangeTrackingStrategy = ChangeTrackingStrategy.ChangingAndChangedNotifications
+            };
             var entityType = model.AddEntityType(typeof(ChangedOnlyEntity));
 
             Assert.Equal(ChangeTrackingStrategy.ChangingAndChangedNotifications, entityType.ChangeTrackingStrategy);
@@ -3445,7 +2281,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         [Fact]
         public void Change_tracking_can_be_set_to_snapshot_only_for_non_notifying_entities()
         {
-            var model = new Model { ChangeTrackingStrategy = ChangeTrackingStrategy.ChangingAndChangedNotifications };
+            var model = new Model
+            {
+                ChangeTrackingStrategy = ChangeTrackingStrategy.ChangingAndChangedNotifications
+            };
             var entityType = model.AddEntityType(typeof(Customer));
 
             Assert.Equal(ChangeTrackingStrategy.ChangingAndChangedNotifications, entityType.ChangeTrackingStrategy);

--- a/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
@@ -2644,7 +2644,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var modelBuilder = CreateModelBuilder();
 
                 Assert.Equal(
-                    CoreStrings.DuplicateNavigation("SelfRef1", typeof(SelfRef).Name, typeof(SelfRef).Name),
+                    CoreStrings.ConflictingPropertyOrNavigation("SelfRef1", typeof(SelfRef).Name, typeof(SelfRef).Name),
                     Assert.Throws<InvalidOperationException>(
                         () =>
                             modelBuilder.Entity<SelfRef>().HasOne(e => e.SelfRef1).WithOne(e => e.SelfRef1)).Message);


### PR DESCRIPTION
Make Ignore, conventions, properties and navigations treat service properties consistently.
Break up EntityTypeTest

Fixes #11351
