### PR TITLE
Tools: Make the migration script path relative to the current directory

### DIFF
--- a/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
+++ b/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
@@ -842,7 +842,8 @@ function EF($project, $startupProject, $params, [switch] $skipBuild)
         '--assembly', $targetPath,
         '--startup-assembly', $startupTargetPath,
         '--project-dir', $projectDir,
-        '--language', $language
+        '--language', $language,
+        '--working-dir', $PWD.Path
 
     if (IsWeb $startupProject)
     {

--- a/src/dotnet-ef/Properties/Resources.Designer.cs
+++ b/src/dotnet-ef/Properties/Resources.Designer.cs
@@ -384,6 +384,12 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
         public static string ContextDirDescription
             => GetString("ContextDirDescription");
 
+        /// <summary>
+        ///     The working directory of the tool invoking this command.
+        /// </summary>
+        public static string WorkingDirDescription
+            => GetString("WorkingDirDescription");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/dotnet-ef/Properties/Resources.resx
+++ b/src/dotnet-ef/Properties/Resources.resx
@@ -294,4 +294,7 @@
   <data name="ContextDirDescription" xml:space="preserve">
     <value>The directory to put DbContext file in. Paths are relative to the project directory.</value>
   </data>
+  <data name="WorkingDirDescription" xml:space="preserve">
+    <value>The working directory of the tool invoking this command.</value>
+  </data>
 </root>

--- a/src/dotnet-ef/RootCommand.cs
+++ b/src/dotnet-ef/RootCommand.cs
@@ -171,6 +171,8 @@ namespace Microsoft.EntityFrameworkCore.Tools
             args.Add(project.ProjectDir);
             args.Add("--language");
             args.Add(project.Language);
+            args.Add("--working-dir");
+            args.Add(Directory.GetCurrentDirectory());
 
             if (Reporter.IsVerbose)
             {

--- a/src/ef/Commands/MigrationsScriptCommand.cs
+++ b/src/ef/Commands/MigrationsScriptCommand.cs
@@ -24,14 +24,20 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
             }
             else
             {
-                var directory = Path.GetDirectoryName(_output.Value());
+                var output = _output.Value();
+                if (WorkingDir.HasValue())
+                {
+                    output = Path.Combine(WorkingDir.Value(), output);
+                }
+
+                var directory = Path.GetDirectoryName(output);
                 if (!string.IsNullOrEmpty(directory))
                 {
                     Directory.CreateDirectory(directory);
                 }
 
                 Reporter.WriteVerbose(Resources.WritingFile(_output.Value()));
-                File.WriteAllText(_output.Value(), sql, Encoding.UTF8);
+                File.WriteAllText(output, sql, Encoding.UTF8);
             }
 
             return base.Execute();

--- a/src/ef/Commands/ProjectCommandBase.cs
+++ b/src/ef/Commands/ProjectCommandBase.cs
@@ -17,6 +17,8 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
         private CommandOption _rootNamespace;
         private CommandOption _language;
 
+        protected CommandOption WorkingDir { get; private set; }
+
         public override void Configure(CommandLineApplication command)
         {
             _assembly = command.Option("-a|--assembly <PATH>", Resources.AssemblyDescription);
@@ -25,6 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Tools.Commands
             _projectDir = command.Option("--project-dir <PATH>", Resources.ProjectDirDescription);
             _rootNamespace = command.Option("--root-namespace <NAMESPACE>", Resources.RootNamespaceDescription);
             _language = command.Option("--language <LANGUAGE>", Resources.LanguageDescription);
+            WorkingDir = command.Option("--working-dir <PATH>", Resources.WorkingDirDescription);
 
             base.Configure(command);
         }

--- a/src/ef/Properties/Resources.Designer.cs
+++ b/src/ef/Properties/Resources.Designer.cs
@@ -442,6 +442,12 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
         public static string ContextDirDescription
             => GetString("ContextDirDescription");
 
+        /// <summary>
+        ///     The working directory of the tool invoking this command.
+        /// </summary>
+        public static string WorkingDirDescription
+            => GetString("WorkingDirDescription");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/ef/Properties/Resources.resx
+++ b/src/ef/Properties/Resources.resx
@@ -312,4 +312,7 @@
   <data name="ContextDirDescription" xml:space="preserve">
     <value>The directory to put DbContext file in. Paths are relative to the project directory.</value>
   </data>
+  <data name="WorkingDirDescription" xml:space="preserve">
+    <value>The working directory of the tool invoking this command.</value>
+  </data>
 </root>


### PR DESCRIPTION
This passes the working directory of `dotnet ef` and the PMC commands to `ef.exe` so we can use it to resolve some relative paths (currently just `--output` on `ef migrations script`)

Fixes #10036