### PR TITLE
Is it flaky or flakey?

### DIFF
--- a/test/EFCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerDatabaseCreatorTest.cs
@@ -46,7 +46,6 @@ namespace Microsoft.EntityFrameworkCore
         {
             await Create_checks_for_existence_and_retries_until_it_passes(1832, async: false);
         }
-
         [Fact]
         public async Task Create_checks_for_existence_and_retries_if_cannot_open_file_until_it_passes()
         {
@@ -95,11 +94,12 @@ namespace Microsoft.EntityFrameworkCore
             var connection = (FakeSqlServerConnection)contextServices.GetRequiredService<ISqlServerConnection>();
 
             connection.ErrorNumber = errorNumber;
-            connection.FailureCount = 5;
+            connection.FailureCount = 2;
 
             var creator = (SqlServerDatabaseCreator)contextServices.GetRequiredService<IRelationalDatabaseCreator>();
 
             creator.RetryDelay = TimeSpan.FromMilliseconds(1);
+            creator.RetryTimeout = TimeSpan.FromMinutes(5);
 
             if (async)
             {
@@ -110,7 +110,7 @@ namespace Microsoft.EntityFrameworkCore
                 creator.Create();
             }
 
-            Assert.Equal(5, connection.OpenCount);
+            Assert.Equal(2, connection.OpenCount);
         }
 
         [Fact]
@@ -205,10 +205,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             public IndentedStringBuilder Instance { get; } = new IndentedStringBuilder();
 
-            public IRelationalParameterBuilder ParameterBuilder
-            {
-                get { throw new NotImplementedException(); }
-            }
+            public IRelationalParameterBuilder ParameterBuilder => throw new NotImplementedException();
 
             public IRelationalCommand Build() => new FakeRelationalCommand();
         }
@@ -219,10 +216,7 @@ namespace Microsoft.EntityFrameworkCore
 
             public IReadOnlyList<IRelationalParameter> Parameters { get; }
 
-            public IReadOnlyDictionary<string, object> ParameterValues
-            {
-                get { throw new NotImplementedException(); }
-            }
+            public IReadOnlyDictionary<string, object> ParameterValues => throw new NotImplementedException();
 
             public int ExecuteNonQuery(IRelationalConnection connection, IReadOnlyDictionary<string, object> parameterValues)
             {


### PR DESCRIPTION
Increase timeout for async database creation tests

Issue:
The test mimics exception for first 5 attempts and passes on 6th attempt. We retry at interval of 1ms. Total duration before timeout is 1 minute.
In case of async test, if the thread is not scheduled to run at least 6 time in 1 min timeout period, we would not be able to reach 6th attempt and hence throw exception.

Resolves #11443
