### PR TITLE
Handle value generation when value conversion is being used

### DIFF
--- a/src/EFCore.Relational/Storage/ValueConversion/RelationalConverterMappingHints.cs
+++ b/src/EFCore.Relational/Storage/ValueConversion/RelationalConverterMappingHints.cs
@@ -1,6 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
+
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
@@ -17,13 +22,15 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// <param name="scale"> The suggested scale of the mapped data type. </param>
         /// <param name="unicode"> Whether or not the mapped data type should support Unicode. </param>
         /// <param name="fixedLength"> Whether or not the mapped data type is fixed length. </param>
+        /// <param name="valueGeneratorFactory"> An optional factory for creating a specific <see cref="ValueGenerator"/>. </param>
         public RelationalConverterMappingHints(
             int? size = null,
             int? precision = null,
             int? scale = null,
             bool? unicode = null,
-            bool? fixedLength = null)
-        : base(size, precision, scale, unicode)
+            bool? fixedLength = null,
+            [CanBeNull] Func<IProperty, IEntityType, ValueGenerator> valueGeneratorFactory = null)
+        : base(size, precision, scale, unicode, valueGeneratorFactory)
         {
             IsFixedLength = fixedLength;
         }
@@ -42,7 +49,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
                     hints.Precision ?? Precision,
                     hints.Scale ?? Scale,
                     hints.IsUnicode ?? IsUnicode,
-                    (hints as RelationalConverterMappingHints)?.IsFixedLength ?? IsFixedLength);
+                    (hints as RelationalConverterMappingHints)?.IsFixedLength ?? IsFixedLength,
+                    hints.ValueGeneratorFactory ?? ValueGeneratorFactory);
 
         /// <summary>
         ///     Whether or not the mapped data type is fixed length.

--- a/src/EFCore.Sqlite.Core/Migrations/Internal/SqliteMigrationsAnnotationProvider.cs
+++ b/src/EFCore.Sqlite.Core/Migrations/Internal/SqliteMigrationsAnnotationProvider.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Sqlite.Metadata.Internal;
 
@@ -33,10 +34,15 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Migrations.Internal
         public override IEnumerable<IAnnotation> For(IProperty property)
         {
             if (property.ValueGenerated == ValueGenerated.OnAdd
-                && property.ClrType.UnwrapNullableType().IsInteger())
+                && property.ClrType.UnwrapNullableType().IsInteger()
+                && !HasConverter(property))
             {
                 yield return new Annotation(SqliteAnnotationNames.Autoincrement, true);
             }
         }
+
+        private static bool HasConverter(IProperty property)
+            => (property.FindMapping()?.Converter
+                ?? property.GetValueConverter()) != null;
     }
 }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -1391,6 +1391,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
             => GetString("HiLoBadBlockSize");
 
         /// <summary>
+        ///     Value generation is not supported for property '{entityType}.{property}' because it has a '{converter}' converter configured. Configure the property to not use value generation using 'ValueGenerated.Never' or 'DatabaseGeneratedOption.None' and specify explict values instead.
+        /// </summary>
+        public static string ValueGenWithConversion([CanBeNull] object entityType, [CanBeNull] object property, [CanBeNull] object converter)
+            => string.Format(
+                GetString("ValueGenWithConversion", nameof(entityType), nameof(property), nameof(converter)),
+                entityType, property, converter);
+
+        /// <summary>
         ///     The entity type related to '{entityType}' cannot be determined because the specified foreign key {foreignKey} references entity type '{principalEntityType}' that it is in the same hierarchy as the entity type that it is declared on '{dependentEntityType}'.
         /// </summary>
         public static string IntraHierarchicalAmbiguousTargetEntityType([CanBeNull] object entityType, [CanBeNull] object foreignKey, [CanBeNull] object principalEntityType, [CanBeNull] object dependentEntityType)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -614,6 +614,9 @@
   </data>
   <data name="HiLoBadBlockSize" xml:space="preserve">
     <value>The block size used for Hi-Lo value generation must be positive. When the Hi-Lo generator is backed by a SQL sequence this means that the sequence increment must be positive.</value>
+  </data>
+  <data name="ValueGenWithConversion" xml:space="preserve">
+    <value>Value generation is not supported for property '{entityType}.{property}' because it has a '{converter}' converter configured. Configure the property to not use value generation using 'ValueGenerated.Never' or 'DatabaseGeneratedOption.None' and specify explict values instead.</value>
   </data>
   <data name="IntraHierarchicalAmbiguousTargetEntityType" xml:space="preserve">
     <value>The entity type related to '{entityType}' cannot be determined because the specified foreign key {foreignKey} references entity type '{principalEntityType}' that it is in the same hierarchy as the entity type that it is declared on '{dependentEntityType}'.</value>

--- a/src/EFCore/Storage/ValueConversion/ConverterMappingHints.cs
+++ b/src/EFCore/Storage/ValueConversion/ConverterMappingHints.cs
@@ -1,7 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
 
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
@@ -18,16 +21,19 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// <param name="precision"> The suggested precision of the mapped data type. </param>
         /// <param name="scale"> The suggested scale of the mapped data type. </param>
         /// <param name="unicode"> Whether or not the mapped data type should support Unicode. </param>
+        /// <param name="valueGeneratorFactory"> An optional factory for creating a specific <see cref="ValueGenerator"/>. </param>
         public ConverterMappingHints(
             int? size = null,
             int? precision = null,
             int? scale = null,
-            bool? unicode = null)
+            bool? unicode = null,
+            [CanBeNull] Func<IProperty, IEntityType, ValueGenerator> valueGeneratorFactory = null)
         {
             Size = size;
             Precision = precision;
             Scale = scale;
             IsUnicode = unicode;
+            ValueGeneratorFactory = valueGeneratorFactory;
         }
 
         /// <summary>
@@ -43,7 +49,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
                     hints.Size ?? Size,
                     hints.Precision ?? Precision,
                     hints.Scale ?? Scale,
-                    hints.IsUnicode ?? IsUnicode);
+                    hints.IsUnicode ?? IsUnicode,
+                    hints.ValueGeneratorFactory ?? ValueGeneratorFactory);
 
         /// <summary>
         ///     The suggested size of the mapped data type.
@@ -64,5 +71,11 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         ///     Whether or not the mapped data type should support Unicode.
         /// </summary>
         public virtual bool? IsUnicode { get; }
+
+        /// <summary>
+        ///     An optional factory for creating a specific <see cref="ValueGenerator"/> to use for model
+        ///     values when this converter is being used.
+        /// </summary>
+        public virtual Func<IProperty, IEntityType, ValueGenerator> ValueGeneratorFactory { get; }
     }
 }

--- a/src/EFCore/Storage/ValueConversion/GuidToBytesConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/GuidToBytesConverter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
 
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
@@ -12,7 +13,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
     public class GuidToBytesConverter : ValueConverter<Guid, byte[]>
     {
         private static readonly ConverterMappingHints _defaultHints
-            = new ConverterMappingHints(size: 16);
+            = new ConverterMappingHints(
+                size: 16,
+                valueGeneratorFactory: (p, t) => new SequentialGuidValueGenerator());
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/Storage/ValueConversion/GuidToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/GuidToStringConverter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
 
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
@@ -13,7 +14,9 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
     public class GuidToStringConverter : ValueConverter<Guid, string>
     {
         private static readonly ConverterMappingHints _defaultHints
-            = new ConverterMappingHints(size: 36);
+            = new ConverterMappingHints(
+                size: 36,
+                valueGeneratorFactory: (p, t) => new SequentialGuidValueGenerator());
 
         /// <summary>
         ///     Creates a new instance of this converter.


### PR DESCRIPTION
Fixes #11010

Approach is:
* Throw by default if a converter is associated with a property that will use value generation
* However, a value generator to use can be specified:
  * On the property
  * On the type mapping
  * On a converter
* A client-side generator is added to the Guid converters so that Guid key scenarios still work
