### PR TITLE
CLI Tools: Error when targeting netcoreapp1.x

### DIFF
--- a/src/dotnet-ef/Properties/Resources.Designer.cs
+++ b/src/dotnet-ef/Properties/Resources.Designer.cs
@@ -235,6 +235,14 @@ namespace Microsoft.EntityFrameworkCore.Tools.Properties
             => GetString("MultipleStartupProjects");
 
         /// <summary>
+        ///     Startup project '{startupProject}' targets framework '.NETCoreApp' version '{targetFrameworkVersion}'. This version of the Entity Framework Core .NET Command-line Tools only supports version 2.0 or higher. For information on using older versions of the tools, see https://go.microsoft.com/fwlink/?linkid=871254
+        /// </summary>
+        public static string NETCoreApp1StartupProject([CanBeNull] object startupProject, [CanBeNull] object targetFrameworkVersion)
+            => string.Format(
+                GetString("NETCoreApp1StartupProject", nameof(startupProject), nameof(targetFrameworkVersion)),
+                startupProject, targetFrameworkVersion);
+
+        /// <summary>
         ///     Startup project '{startupProject}' targets framework '.NETStandard'. There is no runtime associated with this framework, and projects targeting it cannot be executed directly. To use the Entity Framework Core .NET Command-line Tools with this project, add an executable project targeting .NET Core or .NET Framework that references this project, and set it as the startup project using --startup-project; or, update this project to cross-target .NET Core or .NET Framework.
         /// </summary>
         public static string NETStandardStartupProject([CanBeNull] object startupProject)

--- a/src/dotnet-ef/Properties/Resources.resx
+++ b/src/dotnet-ef/Properties/Resources.resx
@@ -225,6 +225,9 @@
   <data name="MultipleStartupProjects" xml:space="preserve">
     <value>More than one project was found in the current working directory. Use the --startup-project option.</value>
   </data>
+  <data name="NETCoreApp1StartupProject" xml:space="preserve">
+    <value>Startup project '{startupProject}' targets framework '.NETCoreApp' version '{targetFrameworkVersion}'. This version of the Entity Framework Core .NET Command-line Tools only supports version 2.0 or higher. For information on using older versions of the tools, see https://go.microsoft.com/fwlink/?linkid=871254</value>
+  </data>
   <data name="NETStandardStartupProject" xml:space="preserve">
     <value>Startup project '{startupProject}' targets framework '.NETStandard'. There is no runtime associated with this framework, and projects targeting it cannot be executed directly. To use the Entity Framework Core .NET Command-line Tools with this project, add an executable project targeting .NET Core or .NET Framework that references this project, and set it as the startup project using --startup-project; or, update this project to cross-target .NET Core or .NET Framework.</value>
   </data>

--- a/src/dotnet-ef/RootCommand.cs
+++ b/src/dotnet-ef/RootCommand.cs
@@ -119,6 +119,12 @@ namespace Microsoft.EntityFrameworkCore.Tools
             }
             else if (targetFramework.Identifier == ".NETCoreApp")
             {
+                if (targetFramework.Version < new Version(2, 0))
+                {
+                    throw new CommandException(
+                        Resources.NETCoreApp1StartupProject(startupProject.ProjectName, targetFramework.Version));
+                }
+
                 executable = "dotnet";
                 args.Add("exec");
                 args.Add("--depsfile");


### PR DESCRIPTION
Note, you'll still get errors when using EF Core 1.x on .NET Core 2. And there are still ways to get crashes with the PMC Tools. But hopefully this covers most cases.

Fixes #9984