### PR TITLE
Fix to #10294 - Query: FirstOrDefault on empty collection returning a value type tries to return null instead of default

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/SubqueryProjectingSingleValueOptimizingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/SubqueryProjectingSingleValueOptimizingExpressionVisitor.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Clauses.ResultOperators;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class SubqueryProjectingSingleValueOptimizingExpressionVisitor : ExpressionVisitorBase
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override Expression VisitSubQuery(SubQueryExpression subQueryExpression)
+        {
+            if (subQueryExpression.QueryModel.ResultOperators.LastOrDefault() is FirstResultOperator first
+                && first.ReturnDefaultWhenEmpty
+                && !subQueryExpression.Type.IsNullableType())
+            {
+                var result = Expression.Coalesce(
+                    Expression.Convert(subQueryExpression, subQueryExpression.Type.MakeNullable()),
+                    Expression.Constant(subQueryExpression.Type.GetDefaultValue()));
+
+                return result;
+            }
+
+            return base.VisitSubQuery(subQueryExpression);
+        }
+    }
+}

--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -1366,8 +1366,8 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             base.OptimizeQueryModel(queryModel, asyncQuery);
 
-            var typeIsExpressionTranslatingVisitor = new TypeIsExpressionTranslatingVisitor(QueryCompilationContext.Model);
-            queryModel.TransformExpressions(typeIsExpressionTranslatingVisitor.Visit);
+            queryModel.TransformExpressions(new TypeIsExpressionTranslatingVisitor(QueryCompilationContext.Model).Visit);
+            queryModel.TransformExpressions(new SubqueryProjectingSingleValueOptimizingExpressionVisitor().Visit);
         }
 
         /// <summary>

--- a/src/EFCore.Specification.Tests/Query/AsyncGearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncGearsOfWarQueryTestBase.cs
@@ -1532,5 +1532,19 @@ namespace Microsoft.EntityFrameworkCore.Query
                 }
             }
         }
+
+        [ConditionalFact]
+        public virtual async Task Project_one_value_type_from_empty_collection()
+        {
+            await AssertQuery<Squad>(
+                ss => ss.Where(s => s.Name == "Kilo").Select(s => new { s.Name, SquadId = s.Members.Where(m => m.HasSoulPatch).Select(m => m.SquadId).FirstOrDefault() }));
+        }
+
+        [ConditionalFact]
+        public virtual async Task Filter_on_subquery_projecting_one_value_type_from_empty_collection()
+        {
+            await AssertQuery<Squad>(
+                ss => ss.Where(s => s.Name == "Kilo").Where(s => s.Members.Where(m => m.HasSoulPatch).Select(m => m.SquadId).FirstOrDefault() != 0).Select(s => s.Name));
+        }
     }
 }

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -4618,6 +4618,20 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
+        [Fact]
+        public virtual void Project_one_value_type_from_empty_collection()
+        {
+            AssertQuery<Squad>(
+                ss => ss.Where(s => s.Name == "Kilo").Select(s => new { s.Name, SquadId = s.Members.Where(m => m.HasSoulPatch).Select(m => m.SquadId).FirstOrDefault() }));
+        }
+
+        [Fact]
+        public virtual void Filter_on_subquery_projecting_one_value_type_from_empty_collection()
+        {
+            AssertQuery<Squad>(
+                ss => ss.Where(s => s.Name == "Kilo").Where(s => s.Members.Where(m => m.HasSoulPatch).Select(m => m.SquadId).FirstOrDefault() != 0).Select(s => s.Name));
+        }
+
         // Remember to add any new tests to Async version of this test class
 
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -441,11 +441,11 @@ INNER JOIN [LevelOne] AS [e1] ON [e3.OneToOne_Required_FK_Inverse.OneToOne_Optio
             AssertSql(
                 @"SELECT [e2].[Id] AS [Id2], [e1].[Id] AS [Id1]
 FROM [LevelTwo] AS [e2]
-INNER JOIN [LevelOne] AS [e1] ON [e2].[Id] = (
+INNER JOIN [LevelOne] AS [e1] ON [e2].[Id] = COALESCE((
     SELECT TOP(1) [subQuery0].[Id]
     FROM [LevelTwo] AS [subQuery0]
     WHERE [subQuery0].[Level1_Optional_Id] = [e1].[Id]
-)");
+), 0)");
         }
 
         public override void Join_navigations_in_inner_selector_translated_to_multiple_subquery_without_collision()
@@ -455,11 +455,11 @@ INNER JOIN [LevelOne] AS [e1] ON [e2].[Id] = (
             AssertSql(
                 @"SELECT [e2].[Id] AS [Id2], [e1].[Id] AS [Id1], [e3].[Id] AS [Id3]
 FROM [LevelTwo] AS [e2]
-INNER JOIN [LevelOne] AS [e1] ON [e2].[Id] = (
+INNER JOIN [LevelOne] AS [e1] ON [e2].[Id] = COALESCE((
     SELECT TOP(1) [subQuery0].[Id]
     FROM [LevelTwo] AS [subQuery0]
     WHERE [subQuery0].[Level1_Optional_Id] = [e1].[Id]
-)
+), 0)
 INNER JOIN [LevelThree] AS [e3] ON [e2].[Id] = [e3].[Level2_Optional_Id]");
         }
 
@@ -2245,11 +2245,11 @@ INNER JOIN (
             AssertSql(
                 @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[OneToMany_Optional_Self_InverseId], [l1].[OneToMany_Required_Self_InverseId], [l1].[OneToOne_Optional_SelfId], [l2].[Id], [l2].[Date], [l2].[Level1_Optional_Id], [l2].[Level1_Required_Id], [l2].[Name], [l2].[OneToMany_Optional_InverseId], [l2].[OneToMany_Optional_Self_InverseId], [l2].[OneToMany_Required_InverseId], [l2].[OneToMany_Required_Self_InverseId], [l2].[OneToOne_Optional_PK_InverseId], [l2].[OneToOne_Optional_SelfId]
 FROM [LevelOne] AS [l1]
-INNER JOIN [LevelTwo] AS [l2] ON [l1].[Id] = (
+INNER JOIN [LevelTwo] AS [l2] ON [l1].[Id] = COALESCE((
     SELECT TOP(1) [l0].[Id]
     FROM [LevelTwo] AS [l0]
     ORDER BY [l0].[Id]
-)");
+), 0)");
         }
 
         public override void Contains_with_subquery_optional_navigation_and_constant_item()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryNavigationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryNavigationsSqlServerTest.cs
@@ -1184,12 +1184,12 @@ ORDER BY [o].[OrderID]");
             AssertSql(
                 @"@__p_0='3'
 
-SELECT TOP(@__p_0) [o].[OrderID], (
+SELECT TOP(@__p_0) [o].[OrderID], COALESCE((
     SELECT TOP(1) [od].[OrderID]
     FROM [Order Details] AS [od]
     WHERE [o].[OrderID] = [od].[OrderID]
     ORDER BY [od].[OrderID], [od].[ProductID]
-) AS [OrderDetail], [o.Customer].[City]
+), 0) AS [OrderDetail], [o.Customer].[City]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]
 ORDER BY [o].[OrderID]");

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
@@ -363,7 +363,7 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) =
             base.Select_nested_collection_multi_level4();
 
             AssertSql(
-                @"SELECT (
+                @"SELECT COALESCE((
     SELECT TOP(1) (
         SELECT COUNT(*)
         FROM [Order Details] AS [od]
@@ -371,7 +371,7 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) =
     )
     FROM [Orders] AS [o]
     WHERE ([o].[OrderID] < 10500) AND ([c].[CustomerID] = [o].[CustomerID])
-) AS [Order]
+), 0) AS [Order]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')");
         }
@@ -381,7 +381,7 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) =
             base.Select_nested_collection_multi_level5();
 
             AssertSql(
-                @"SELECT (
+                @"SELECT COALESCE((
     SELECT TOP(1) (
         SELECT TOP(1) [od].[ProductID]
         FROM [Order Details] AS [od]
@@ -393,7 +393,7 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) =
     )
     FROM [Orders] AS [o]
     WHERE ([o].[OrderID] < 10500) AND ([c].[CustomerID] = [o].[CustomerID])
-) AS [Order]
+), 0) AS [Order]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')");
         }
@@ -403,7 +403,7 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) =
             base.Select_nested_collection_multi_level6();
 
             AssertSql(
-                @"SELECT (
+                @"SELECT COALESCE((
     SELECT TOP(1) (
         SELECT TOP(1) [od].[ProductID]
         FROM [Order Details] AS [od]
@@ -411,7 +411,7 @@ WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) =
     )
     FROM [Orders] AS [o]
     WHERE ([o].[OrderID] < 10500) AND ([c].[CustomerID] = [o].[CustomerID])
-) AS [Order]
+), 0) AS [Order]
 FROM [Customers] AS [c]
 WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')");
         }
@@ -725,7 +725,7 @@ FROM [Customers] AS [c]");
             base.Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault();
 
             AssertSql(
-                @"SELECT (
+                @"SELECT COALESCE((
     SELECT TOP(1) [t].[OrderID]
     FROM (
         SELECT TOP(1) [od].[OrderID], [od.Product].[ProductName]
@@ -735,7 +735,7 @@ FROM [Customers] AS [c]");
         ORDER BY [od.Product].[ProductName]
     ) AS [t]
     ORDER BY [t].[ProductName]
-)
+), 0)
 FROM [Orders] AS [o]
 WHERE [o].[OrderID] < 10300");
         }


### PR DESCRIPTION
Sql naturally returns null for subqueries that contain no results.

Fix is to recognize the pattern and add COALESCE around it, and in case original term results in null return default value for that type instead.