### PR TITLE
Query: Refine FreeText function for SqlServer

### DIFF
--- a/samples/OracleProvider/test/OracleProvider.FunctionalTests/Query/DbFunctionsOracleTest.cs
+++ b/samples/OracleProvider/test/OracleProvider.FunctionalTests/Query/DbFunctionsOracleTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
-        public override void String_Like_Literal()
+        public override void Like_literal()
         {
             using (var context = CreateContext())
             {

--- a/src/EFCore.Specification.Tests/Query/DbFunctionsTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/DbFunctionsTestBase.cs
@@ -18,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected TFixture Fixture { get; }
 
         [ConditionalFact]
-        public virtual void String_Like_Literal()
+        public virtual void Like_literal()
         {
             using (var context = CreateContext())
             {
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
-        public virtual void String_Like_Identity()
+        public virtual void Like_identity()
         {
             using (var context = CreateContext())
             {
@@ -40,7 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
-        public virtual void String_Like_Literal_With_Escape()
+        public virtual void Like_literal_with_escape()
         {
             using (var context = CreateContext())
             {

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -315,6 +315,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         public static string FreeTextFunctionOnClient
             => GetString("FreeTextFunctionOnClient");
 
+        /// <summary>
+        ///     The expression passed to the 'propertyReference' parameter of the 'FreeText' method is not a valid reference to a property. The expression should represent a reference to a full-text indexed property on the object referenced in the from clause: 'from e in context.Entities where EF.Functions.FreeText(e.SomeProperty, textToSearchFor) select e'
+        /// </summary>
+        public static string InvalidColumnNameForFreeText
+            => GetString("InvalidColumnNameForFreeText");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -222,4 +222,7 @@
   <data name="FreeTextFunctionOnClient" xml:space="preserve">
     <value>The 'FreeText' method is not supported because the query has switched to client-evaluation. Inspect the log to determine which query expressions are triggering client-evaluation.</value>
   </data>
+  <data name="InvalidColumnNameForFreeText" xml:space="preserve">
+    <value>The expression passed to the 'propertyReference' parameter of the 'FreeText' method is not a valid reference to a property. The expression should represent a reference to a full-text indexed property on the object referenced in the from clause: 'from e in context.Entities where EF.Functions.FreeText(e.SomeProperty, textToSearchFor) select e'</value>
+  </data>
 </root>

--- a/src/EFCore.SqlServer/SqlServerDbFunctionsExtensions.cs
+++ b/src/EFCore.SqlServer/SqlServerDbFunctionsExtensions.cs
@@ -23,15 +23,15 @@ namespace Microsoft.EntityFrameworkCore
         ///     This can happen if the query contains one or more expressions that could not be translated to the store.
         /// </remarks>
         /// <param name="_">DbFunctions instance</param>
-        /// <param name="propertyName">The property on which the search will be performed.</param>
+        /// <param name="propertyReference">The property on which the search will be performed.</param>
         /// <param name="freeText">The text that will be searched for in the property.</param>
         /// <param name="languageTerm">A Language ID from the sys.syslanguages table.</param>
         public static bool FreeText(
             [CanBeNull] this DbFunctions _,
-            [NotNull] string propertyName,
+            [NotNull] string propertyReference,
             [NotNull] string freeText,
             int languageTerm)
-            => FreeTextCore(propertyName, freeText, languageTerm);
+            => FreeTextCore(propertyReference, freeText, languageTerm);
 
         /// <summary>
         /// <para>
@@ -43,13 +43,13 @@ namespace Microsoft.EntityFrameworkCore
         ///     This can happen if the query contains one or more expressions that could not be translated to the store.
         /// </remarks>
         /// <param name="_">DbFunctions instance</param>
-        /// <param name="propertyName">The property on which the search will be performed.</param>
+        /// <param name="propertyReference">The property on which the search will be performed.</param>
         /// <param name="freeText">The text that will be searched for in the property.</param>
         public static bool FreeText(
             [CanBeNull] this DbFunctions _,
-            [NotNull] string propertyName,
+            [NotNull] string propertyReference,
             [NotNull] string freeText)
-            => FreeTextCore(propertyName, freeText, null);
+            => FreeTextCore(propertyReference, freeText, null);
 
         private static bool FreeTextCore(string propertyName, string freeText, int? languageTerm)
         {


### PR DESCRIPTION
Throw better exception when using non property as first arg.

Resolves #11481
