### PR TITLE
Further improve model building performance

### DIFF
--- a/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleTypeMappingSource.cs
+++ b/samples/OracleProvider/src/OracleProvider/Storage/Internal/OracleTypeMappingSource.cs
@@ -164,7 +164,7 @@ namespace Microsoft.EntityFrameworkCore.Oracle.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected override RelationalTypeMapping FindMapping(RelationalTypeMappingInfo mappingInfo)
+        protected override RelationalTypeMapping FindMapping(in RelationalTypeMappingInfo mappingInfo)
         {
             var mapping = FindRawMapping(mappingInfo)?.Clone(mappingInfo);
 

--- a/src/EFCore.Relational/Storage/Internal/FallbackRelationalTypeMappingSource.cs
+++ b/src/EFCore.Relational/Storage/Internal/FallbackRelationalTypeMappingSource.cs
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected override RelationalTypeMapping FindMappingWithConversion(
-            RelationalTypeMappingInfo mappingInfo,
+            in RelationalTypeMappingInfo mappingInfo,
             IProperty property)
         {
             _property = property;
@@ -53,7 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected override RelationalTypeMapping FindMapping(RelationalTypeMappingInfo mappingInfo)
+        protected override RelationalTypeMapping FindMapping(in RelationalTypeMappingInfo mappingInfo)
         {
             Check.NotNull(mappingInfo, nameof(mappingInfo));
 
@@ -83,12 +83,12 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             return mapping;
         }
 
-        private RelationalTypeMapping FindMappingForProperty(RelationalTypeMappingInfo mappingInfo)
+        private RelationalTypeMapping FindMappingForProperty(in RelationalTypeMappingInfo mappingInfo)
             => _property != null
                 ? _relationalTypeMapper.FindMapping(_property)
                 : null;
 
-        private RelationalTypeMapping FindMappingForClrType(RelationalTypeMappingInfo mappingInfo)
+        private RelationalTypeMapping FindMappingForClrType(in RelationalTypeMappingInfo mappingInfo)
         {
             if (mappingInfo.ClrType == null
                 || (mappingInfo.StoreTypeName != null
@@ -118,7 +118,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             return _relationalTypeMapper.FindMapping(mappingInfo.ClrType);
         }
 
-        private RelationalTypeMapping FindMappingForStoreTypeName(RelationalTypeMappingInfo mappingInfo)
+        private RelationalTypeMapping FindMappingForStoreTypeName(in RelationalTypeMappingInfo mappingInfo)
         {
             if (mappingInfo.StoreTypeName != null)
             {
@@ -130,7 +130,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             return null;
         }
 
-        private static RelationalTypeMapping FilterByClrType(RelationalTypeMapping mapping, RelationalTypeMappingInfo mappingInfo)
+        private static RelationalTypeMapping FilterByClrType(RelationalTypeMapping mapping, in RelationalTypeMappingInfo mappingInfo)
             => mapping != null
                && (mappingInfo.ClrType == null
                    || mappingInfo.ClrType == mapping.ClrType)

--- a/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
@@ -295,7 +295,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="mappingInfo"> The mapping info containing the facets to use. </param>
         /// <returns> The cloned mapping, or the original mapping if no clone was needed. </returns>
-        public virtual RelationalTypeMapping Clone(RelationalTypeMappingInfo mappingInfo)
+        public virtual RelationalTypeMapping Clone(in RelationalTypeMappingInfo mappingInfo)
         {
             Check.NotNull(mappingInfo, nameof(mappingInfo));
 

--- a/src/EFCore.Relational/Storage/RelationalTypeMappingInfo.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMappingInfo.cs
@@ -17,7 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
     ///     Describes metadata needed to decide on a relational type mapping for
     ///     a property, type, or provider-specific relational type name.
     /// </summary>
-    public readonly struct RelationalTypeMappingInfo
+    public readonly struct RelationalTypeMappingInfo : IEquatable<RelationalTypeMappingInfo>
     {
         private readonly TypeMappingInfo _coreTypeMappingInfo;
         private readonly int? _parsedSize;
@@ -88,11 +88,12 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             _coreTypeMappingInfo = new TypeMappingInfo(member);
 
-            var attribute = member.GetCustomAttributes<ColumnAttribute>(true)?.FirstOrDefault();
-            if (attribute != null)
+            if (Attribute.IsDefined(member, typeof(ColumnAttribute), inherit: true))
             {
+                var attribute = member.GetCustomAttributes<ColumnAttribute>(inherit: true).First();
                 StoreTypeName = attribute.TypeName;
-                StoreTypeNameBase = ParseStoreTypeName(attribute.TypeName, out _parsedSize, out _parsedPrecision, out _parsedScale, out _isMax);
+                StoreTypeNameBase = ParseStoreTypeName(
+                    attribute.TypeName, out _parsedSize, out _parsedPrecision, out _parsedScale, out _isMax);
             }
             else
             {
@@ -113,8 +114,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="source"> The source info. </param>
         /// <param name="converter"> The converter to apply. </param>
         public RelationalTypeMappingInfo(
-            RelationalTypeMappingInfo source,
-            ValueConverterInfo converter)
+            in RelationalTypeMappingInfo source,
+            in ValueConverterInfo converter)
         {
             _coreTypeMappingInfo = new TypeMappingInfo(
                 source._coreTypeMappingInfo,
@@ -277,7 +278,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="converterInfo"> The converter to apply. </param>
         /// <returns> The new mapping info. </returns>
-        public RelationalTypeMappingInfo WithConverter(ValueConverterInfo converterInfo)
+        public RelationalTypeMappingInfo WithConverter(in ValueConverterInfo converterInfo)
             => new RelationalTypeMappingInfo(this, converterInfo);
 
         /// <summary>

--- a/src/EFCore.SqlServer/Metadata/SqlServerPropertyAnnotations.cs
+++ b/src/EFCore.SqlServer/Metadata/SqlServerPropertyAnnotations.cs
@@ -7,7 +7,6 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal;
-using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Metadata

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
@@ -224,7 +224,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected override RelationalTypeMapping FindMapping(RelationalTypeMappingInfo mappingInfo)
+        protected override RelationalTypeMapping FindMapping(in RelationalTypeMappingInfo mappingInfo)
             => FindRawMapping(mappingInfo)?.Clone(mappingInfo);
 
         private RelationalTypeMapping FindRawMapping(RelationalTypeMappingInfo mappingInfo)

--- a/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTypeMappingSource.cs
+++ b/src/EFCore.Sqlite.Core/Storage/Internal/SqliteTypeMappingSource.cs
@@ -64,7 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected override RelationalTypeMapping FindMapping(RelationalTypeMappingInfo mappingInfo)
+        protected override RelationalTypeMapping FindMapping(in RelationalTypeMappingInfo mappingInfo)
         {
             var clrType = mappingInfo.ClrType;
             if (clrType != null

--- a/src/EFCore/Extensions/MutableModelExtensions.cs
+++ b/src/EFCore/Extensions/MutableModelExtensions.cs
@@ -70,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(model, nameof(model));
             Check.NotNull(type, nameof(type));
 
-            return model.RemoveEntityType(type.DisplayName());
+            return model.AsModel().RemoveEntityType(type);
         }
 
         /// <summary>

--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -511,12 +511,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             foreach (var entityType in model.GetEntityTypes().Where(et => !et.IsQueryType))
             {
                 var key = entityType.FindPrimaryKey();
-                if (!identityMaps.TryGetValue(key, out var identityMap))
-                {
-                    identityMap = key.GetIdentityMapFactory()(sensitiveDataLogged);
-                    identityMaps[key] = identityMap;
-                }
-
+                IIdentityMap identityMap = null;
                 foreach (var seedDatum in entityType.GetData())
                 {
                     foreach (var property in entityType.GetProperties())
@@ -575,6 +570,15 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                                 navigation.Name,
                                 navigation.GetTargetType().DisplayName(),
                                 Property.Format(navigation.ForeignKey.Properties)));
+                        }
+                    }
+
+                    if (identityMap == null)
+                    {
+                        if (!identityMaps.TryGetValue(key, out identityMap))
+                        {
+                            identityMap = key.GetIdentityMapFactory()(sensitiveDataLogged);
+                            identityMaps[key] = identityMap;
                         }
                     }
 

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
@@ -226,7 +226,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             [NotNull] Type ownedType,
             [NotNull] string navigationName)
             => OwnsOneBuilder(
-                new TypeIdentity(Check.NotNull(ownedType, nameof(ownedType))),
+                new TypeIdentity(Check.NotNull(ownedType, nameof(ownedType)), (Model)Metadata.Model),
                 Check.NotEmpty(navigationName, nameof(navigationName)));
 
         /// <summary>
@@ -278,7 +278,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
 
             using (Builder.Metadata.Model.ConventionDispatcher.StartBatch())
             {
-                buildAction.Invoke(OwnsOneBuilder(new TypeIdentity(ownedType), navigationName));
+                buildAction.Invoke(OwnsOneBuilder(new TypeIdentity(ownedType, (Model)Metadata.Model), navigationName));
                 return this;
             }
         }
@@ -311,7 +311,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             }
         }
 
-        private ReferenceOwnershipBuilder OwnsOneBuilder(TypeIdentity ownedType, string navigationName)
+        private ReferenceOwnershipBuilder OwnsOneBuilder(in TypeIdentity ownedType, string navigationName)
         {
             InternalRelationshipBuilder relationship;
             using (Builder.Metadata.Model.ConventionDispatcher.StartBatch())

--- a/src/EFCore/Metadata/Builders/ReferenceOwnershipBuilder.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceOwnershipBuilder.cs
@@ -279,7 +279,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             [NotNull] Type ownedType,
             [NotNull] string navigationName)
             => OwnsOneBuilder(
-                new TypeIdentity(Check.NotNull(ownedType, nameof(ownedType))),
+                new TypeIdentity(Check.NotNull(ownedType, nameof(ownedType)), (Model)OwnedEntityType.Model),
                 Check.NotEmpty(navigationName, nameof(navigationName)));
 
         /// <summary>
@@ -339,7 +339,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
 
             using (DeclaringEntityType.Model.ConventionDispatcher.StartBatch())
             {
-                buildAction.Invoke(OwnsOneBuilder(new TypeIdentity(ownedType), navigationName));
+                buildAction.Invoke(OwnsOneBuilder(new TypeIdentity(ownedType, (Model)OwnedEntityType.Model), navigationName));
                 return this;
             }
         }
@@ -380,7 +380,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             }
         }
 
-        private ReferenceOwnershipBuilder OwnsOneBuilder(TypeIdentity ownedType, string navigationName)
+        private ReferenceOwnershipBuilder OwnsOneBuilder(in TypeIdentity ownedType, string navigationName)
         {
             InternalRelationshipBuilder relationship;
             using (RelatedEntityType.Model.ConventionDispatcher.StartBatch())

--- a/src/EFCore/Metadata/Conventions/Internal/CacheCleanupConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/CacheCleanupConvention.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class CacheCleanupConvention : IModelBuiltConvention
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual InternalModelBuilder Apply(InternalModelBuilder modelBuilder)
+        {
+            foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
+            {
+                entityType.ClearCaches();
+            }
+
+            return modelBuilder;
+        }
+    }
+}

--- a/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
@@ -160,6 +160,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             conventionSet.ModelBuiltConventions.Add(new RelationshipValidationConvention());
             conventionSet.ModelBuiltConventions.Add(foreignKeyPropertyDiscoveryConvention);
             conventionSet.ModelBuiltConventions.Add(servicePropertyDiscoveryConvention);
+            conventionSet.ModelBuiltConventions.Add(new CacheCleanupConvention());
 
             conventionSet.NavigationAddedConventions.Add(backingFieldConvention);
             conventionSet.NavigationAddedConventions.Add(new RequiredNavigationAttributeConvention(Dependencies.Logger));

--- a/src/EFCore/Metadata/Conventions/Internal/EntityTypeAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/EntityTypeAttributeConvention.cs
@@ -24,7 +24,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
 
-            var attributes = entityTypeBuilder.Metadata.ClrType?.GetTypeInfo().GetCustomAttributes<TAttribute>(true);
+            var type = entityTypeBuilder.Metadata.ClrType;
+            if (type == null
+                || !Attribute.IsDefined(type, typeof(TAttribute), inherit: true))
+            {
+                return entityTypeBuilder;
+            }
+
+            var attributes = type.GetTypeInfo().GetCustomAttributes<TAttribute>(true);
             if (attributes != null)
             {
                 foreach (var attribute in attributes)

--- a/src/EFCore/Metadata/Conventions/Internal/KeyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/KeyAttributeConvention.cs
@@ -36,7 +36,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             var entityTypeBuilder = entityType.Builder;
             var currentKey = entityTypeBuilder.Metadata.FindPrimaryKey();
-            var properties = new List<string> { propertyBuilder.Metadata.Name };
+            var properties = new List<string>
+            {
+                propertyBuilder.Metadata.Name
+            };
 
             if (currentKey != null
                 && entityType.GetPrimaryKeyConfigurationSource() == ConfigurationSource.DataAnnotation)
@@ -81,8 +84,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                     foreach (var declaredProperty in entityType.GetDeclaredProperties())
                     {
                         var memberInfo = declaredProperty.GetIdentifyingMemberInfo();
-                        var attributes = memberInfo?.GetCustomAttributes<KeyAttribute>(true);
-                        if (attributes?.Any() == true)
+
+                        if (memberInfo != null
+                            && Attribute.IsDefined(memberInfo, typeof(KeyAttribute), inherit: true))
                         {
                             throw new InvalidOperationException(
                                 CoreStrings.KeyAttributeOnDerivedEntity(entityType.DisplayName(), declaredProperty.Name));

--- a/src/EFCore/Metadata/Conventions/Internal/NavigationAttributeEntityTypeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/NavigationAttributeEntityTypeConvention.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -53,23 +54,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 return entityTypeBuilder;
             }
 
-            foreach (var navigationPropertyInfo in entityType.ClrType.GetRuntimeProperties().OrderBy(p => p.Name))
+            foreach (var navigationPropertyInfo in entityType.GetRuntimeProperties().Values.OrderBy(p => p.Name))
             {
-                var targetClrType = FindCandidateNavigationPropertyType(navigationPropertyInfo);
+                var targetClrType = FindCandidateNavigationWithAttributePropertyType(navigationPropertyInfo);
                 if (targetClrType == null)
                 {
                     continue;
                 }
 
-                var attributes = navigationPropertyInfo.GetCustomAttributes<TAttribute>(true);
-                if (attributes != null)
+                var attributes = navigationPropertyInfo.GetCustomAttributes<TAttribute>(inherit: true);
+                foreach (var attribute in attributes)
                 {
-                    foreach (var attribute in attributes)
+                    if (Apply(entityTypeBuilder, navigationPropertyInfo, targetClrType, attribute) == null)
                     {
-                        if (Apply(entityTypeBuilder, navigationPropertyInfo, targetClrType, attribute) == null)
-                        {
-                            return null;
-                        }
+                        return null;
                     }
                 }
             }
@@ -90,21 +88,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             foreach (var navigationPropertyInfo in type.GetRuntimeProperties().OrderBy(p => p.Name))
             {
-                var targetClrType = FindCandidateNavigationPropertyType(navigationPropertyInfo);
+                var targetClrType = FindCandidateNavigationWithAttributePropertyType(navigationPropertyInfo);
                 if (targetClrType == null)
                 {
                     continue;
                 }
 
                 var attributes = navigationPropertyInfo.GetCustomAttributes<TAttribute>(true);
-                if (attributes != null)
+                foreach (var attribute in attributes)
                 {
-                    foreach (var attribute in attributes)
+                    if (!Apply(modelBuilder, type, navigationPropertyInfo, targetClrType, attribute))
                     {
-                        if (!Apply(modelBuilder, type, navigationPropertyInfo, targetClrType, attribute))
-                        {
-                            return false;
-                        }
+                        return false;
                     }
                 }
             }
@@ -116,24 +111,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual InternalRelationshipBuilder Apply(InternalRelationshipBuilder relationshipBuilder, Navigation navigation)
+        public virtual InternalRelationshipBuilder Apply(
+            InternalRelationshipBuilder relationshipBuilder, Navigation navigation)
         {
             var navigationPropertyInfo = navigation.GetIdentifyingMemberInfo();
-            if (navigationPropertyInfo == null)
+            if (navigationPropertyInfo == null
+                || !Attribute.IsDefined(navigationPropertyInfo, typeof(TAttribute), inherit: true))
             {
                 return relationshipBuilder;
             }
 
             var attributes = navigationPropertyInfo.GetCustomAttributes<TAttribute>(true);
-            if (attributes != null)
+            foreach (var attribute in attributes)
             {
-                foreach (var attribute in attributes)
+                relationshipBuilder = Apply(relationshipBuilder, navigation, attribute);
+                if (relationshipBuilder == null)
                 {
-                    relationshipBuilder = Apply(relationshipBuilder, navigation, attribute);
-                    if (relationshipBuilder == null)
-                    {
-                        return null;
-                    }
+                    return null;
                 }
             }
 
@@ -146,29 +140,26 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         /// </summary>
         public virtual bool Apply(InternalEntityTypeBuilder entityTypeBuilder, EntityType oldBaseType)
         {
-            var clrType = entityTypeBuilder.Metadata.ClrType;
-            if (clrType == null)
+            var entityType = entityTypeBuilder.Metadata;
+            if (!entityType.HasClrType())
             {
                 return true;
             }
 
-            foreach (var navigationPropertyInfo in clrType.GetRuntimeProperties().OrderBy(p => p.Name))
+            foreach (var navigationPropertyInfo in entityType.GetRuntimeProperties().Values.OrderBy(p => p.Name))
             {
-                var targetClrType = FindCandidateNavigationPropertyType(navigationPropertyInfo);
+                var targetClrType = FindCandidateNavigationWithAttributePropertyType(navigationPropertyInfo);
                 if (targetClrType == null)
                 {
                     continue;
                 }
 
                 var attributes = navigationPropertyInfo.GetCustomAttributes<TAttribute>(true);
-                if (attributes != null)
+                foreach (var attribute in attributes)
                 {
-                    foreach (var attribute in attributes)
+                    if (!Apply(entityTypeBuilder, oldBaseType, navigationPropertyInfo, targetClrType, attribute))
                     {
-                        if (!Apply(entityTypeBuilder, oldBaseType, navigationPropertyInfo, targetClrType, attribute))
-                        {
-                            return false;
-                        }
+                        return false;
                     }
                 }
             }
@@ -183,27 +174,24 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         public virtual bool Apply(InternalEntityTypeBuilder entityTypeBuilder, string ignoredMemberName)
         {
             var navigationPropertyInfo =
-                entityTypeBuilder.Metadata.ClrType.GetRuntimeProperties().FirstOrDefault(p => p.Name == ignoredMemberName);
+                entityTypeBuilder.Metadata.GetRuntimeProperties()?.Find(ignoredMemberName);
             if (navigationPropertyInfo == null)
             {
                 return true;
             }
 
-            var targetClrType = FindCandidateNavigationPropertyType(navigationPropertyInfo);
+            var targetClrType = FindCandidateNavigationWithAttributePropertyType(navigationPropertyInfo);
             if (targetClrType == null)
             {
                 return true;
             }
 
             var attributes = navigationPropertyInfo.GetCustomAttributes<TAttribute>(true);
-            if (attributes != null)
+            foreach (var attribute in attributes)
             {
-                foreach (var attribute in attributes)
+                if (!ApplyIgnored(entityTypeBuilder, navigationPropertyInfo, targetClrType, attribute))
                 {
-                    if (!ApplyIgnored(entityTypeBuilder, navigationPropertyInfo, targetClrType, attribute))
-                    {
-                        return false;
-                    }
+                    return false;
                 }
             }
             return true;
@@ -214,10 +202,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual Type FindCandidateNavigationPropertyType([NotNull] PropertyInfo propertyInfo)
-        {
-            Check.NotNull(propertyInfo, nameof(propertyInfo));
+            => propertyInfo.FindCandidateNavigationPropertyType(_typeMappingSource, _parameterBindingFactories);
 
-            return propertyInfo.FindCandidateNavigationPropertyType(_typeMappingSource, _parameterBindingFactories);
+        private Type FindCandidateNavigationWithAttributePropertyType([NotNull] PropertyInfo propertyInfo)
+        {
+            var targetClrType = propertyInfo.FindCandidateNavigationPropertyType(_typeMappingSource, _parameterBindingFactories);
+            if (targetClrType == null
+                || !Attribute.IsDefined(propertyInfo, typeof(TAttribute), inherit: true))
+            {
+                return null;
+            }
+            return targetClrType;
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Conventions/Internal/NavigationAttributeNavigationConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/NavigationAttributeNavigationConvention.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -22,24 +23,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual InternalRelationshipBuilder Apply(InternalRelationshipBuilder relationshipBuilder, Navigation navigation)
+        public virtual InternalRelationshipBuilder Apply(InternalRelationshipBuilder relationshipBuilder,
+            Navigation navigation)
         {
             Check.NotNull(relationshipBuilder, nameof(relationshipBuilder));
             Check.NotNull(navigation, nameof(navigation));
 
             var attributes = GetAttributes<TAttribute>(navigation.DeclaringEntityType, navigation.Name);
-
-            if (attributes != null)
+            foreach (var attribute in attributes)
             {
-                foreach (var attribute in attributes)
+                relationshipBuilder = Apply(relationshipBuilder, navigation, attribute);
+                if (relationshipBuilder == null)
                 {
-                    relationshipBuilder = Apply(relationshipBuilder, navigation, attribute);
-                    if (relationshipBuilder == null)
-                    {
-                        break;
-                    }
+                    break;
                 }
             }
+
             return relationshipBuilder;
         }
 
@@ -47,20 +46,33 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public abstract InternalRelationshipBuilder Apply([NotNull] InternalRelationshipBuilder relationshipBuilder, [NotNull] Navigation navigation, [NotNull] TAttribute attribute);
+        public abstract InternalRelationshipBuilder Apply([NotNull] InternalRelationshipBuilder relationshipBuilder,
+            [NotNull] Navigation navigation, [NotNull] TAttribute attribute);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected static IEnumerable<TCustomAttribute> GetAttributes<TCustomAttribute>([NotNull] EntityType entityType, [NotNull] string propertyName)
+        protected static IEnumerable<TCustomAttribute> GetAttributes<TCustomAttribute>(
+            [NotNull] EntityType entityType, [NotNull] string propertyName)
             where TCustomAttribute : Attribute
         {
             Check.NotNull(entityType, nameof(entityType));
             Check.NotNull(propertyName, nameof(propertyName));
 
-            return entityType.ClrType?.GetRuntimeProperties().FirstOrDefault(p => p.Name == propertyName)
-                ?.GetCustomAttributes<TCustomAttribute>(true);
+            if (!entityType.HasClrType())
+            {
+                return Enumerable.Empty<TCustomAttribute>();
+            }
+
+            var property = entityType.GetRuntimeProperties().Find(propertyName);
+            if (property != null
+                && Attribute.IsDefined(property, typeof(TCustomAttribute), inherit: true))
+            {
+                return property.GetCustomAttributes<TCustomAttribute>(true);
+            }
+
+            return Enumerable.Empty<TCustomAttribute>();
         }
     }
 }

--- a/src/EFCore/Metadata/Conventions/Internal/NotMappedMemberAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/NotMappedMemberAttributeConvention.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Reflection;
@@ -23,18 +24,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         {
             Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
 
-            var clrType = entityTypeBuilder.Metadata.ClrType;
-            if (clrType == null)
+            var entityType = entityTypeBuilder.Metadata;
+            if (!entityType.HasClrType())
             {
                 return entityTypeBuilder;
             }
 
-            var members = clrType.GetRuntimeProperties().Cast<MemberInfo>().Concat(clrType.GetRuntimeFields());
+            var members = entityType.GetRuntimeProperties().Values.Cast<MemberInfo>()
+                .Concat(entityType.GetRuntimeFields().Values);
 
             foreach (var member in members)
             {
-                var attributes = member.GetCustomAttributes<NotMappedAttribute>(inherit: true);
-                if (attributes.Any())
+                if (Attribute.IsDefined(member, typeof(NotMappedAttribute), inherit: true))
                 {
                     entityTypeBuilder.Ignore(member.Name, ConfigurationSource.DataAnnotation);
                 }

--- a/src/EFCore/Metadata/Conventions/Internal/PropertyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/PropertyAttributeConvention.cs
@@ -25,7 +25,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             Check.NotNull(propertyBuilder, nameof(propertyBuilder));
 
             var memberInfo = propertyBuilder.Metadata.GetIdentifyingMemberInfo();
-            var attributes = memberInfo?.GetCustomAttributes<TAttribute>(true);
+            if (memberInfo == null)
+            {
+                return propertyBuilder;
+            }
+
+            if (!Attribute.IsDefined(memberInfo, typeof(TAttribute), inherit: true))
+            {
+                return propertyBuilder;
+            }
+
+            var attributes = memberInfo.GetCustomAttributes<TAttribute>(inherit: true);
             if (attributes != null)
             {
                 foreach (var attribute in attributes)

--- a/src/EFCore/Metadata/Conventions/Internal/PropertyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/PropertyDiscoveryConvention.cs
@@ -40,9 +40,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             if (entityType.HasClrType())
             {
-                var candidates = entityType.ClrType.GetRuntimeProperties();
-
-                foreach (var propertyInfo in candidates)
+                foreach (var propertyInfo in entityType.GetRuntimeProperties().Values)
                 {
                     if (IsCandidatePrimitiveProperty(propertyInfo))
                     {

--- a/src/EFCore/Metadata/Conventions/Internal/PropertyMappingValidationConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/PropertyMappingValidationConvention.cs
@@ -43,8 +43,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         /// </summary>
         public virtual InternalModelBuilder Apply(InternalModelBuilder modelBuilder)
         {
-            Check.NotNull(modelBuilder, nameof(modelBuilder));
-
             foreach (var entityType in modelBuilder.Metadata.GetEntityTypes())
             {
                 var unmappedProperty = entityType.GetProperties().FirstOrDefault(p =>
@@ -58,72 +56,79 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                             entityType.DisplayName(), unmappedProperty.Name, unmappedProperty.ClrType.ShortDisplayName()));
                 }
 
-                if (entityType.HasClrType())
+                if (!entityType.HasClrType())
                 {
-                    var clrProperties = new HashSet<string>();
+                    continue;
+                }
 
-                    clrProperties.UnionWith(
-                        entityType.ClrType.GetRuntimeProperties()
-                            .Where(pi => pi.IsCandidateProperty())
-                            .Select(pi => pi.Name));
+                var clrProperties = new HashSet<string>();
 
-                    clrProperties.ExceptWith(entityType.GetProperties().Select(p => p.Name));
-                    clrProperties.ExceptWith(entityType.GetNavigations().Select(p => p.Name));
-                    clrProperties.ExceptWith(entityType.GetServiceProperties().Select(p => p.Name));
-                    clrProperties.RemoveWhere(p => entityType.Builder.IsIgnored(p, ConfigurationSource.Convention));
+                clrProperties.UnionWith(
+                    entityType.GetRuntimeProperties().Values
+                        .Where(pi => pi.IsCandidateProperty())
+                        .Select(pi => pi.Name));
 
-                    if (clrProperties.Count > 0)
+                clrProperties.ExceptWith(entityType.GetProperties().Select(p => p.Name));
+                clrProperties.ExceptWith(entityType.GetNavigations().Select(p => p.Name));
+                clrProperties.ExceptWith(entityType.GetServiceProperties().Select(p => p.Name));
+                clrProperties.RemoveWhere(p => entityType.Builder.IsIgnored(p, ConfigurationSource.Convention));
+
+                if (clrProperties.Count <= 0)
+                {
+                    continue;
+                }
+
+                foreach (var clrProperty in clrProperties)
+                {
+                    var actualProperty = entityType.GetRuntimeProperties()[clrProperty];
+                    var propertyType = actualProperty.PropertyType;
+                    var targetSequenceType = propertyType.TryGetSequenceType();
+
+                    if (modelBuilder.IsIgnored(modelBuilder.Metadata.GetDisplayName(propertyType),
+                        ConfigurationSource.Convention)
+                        || (targetSequenceType != null
+                            && modelBuilder.IsIgnored(modelBuilder.Metadata.GetDisplayName(targetSequenceType),
+                                ConfigurationSource.Convention)))
                     {
-                        foreach (var clrProperty in clrProperties)
+                        continue;
+                    }
+
+                    var targetType = FindCandidateNavigationPropertyType(actualProperty);
+
+                    var isTargetWeakOrOwned
+                        = targetType != null
+                          && (modelBuilder.Metadata.HasEntityTypeWithDefiningNavigation(targetType)
+                              || modelBuilder.Metadata.ShouldBeOwnedType(targetType));
+
+                    if (targetType != null
+                        && targetType.IsValidEntityType()
+                        && (isTargetWeakOrOwned
+                            || modelBuilder.Metadata.FindEntityType(targetType) != null
+                            || targetType.GetRuntimeProperties().Any(p => p.IsCandidateProperty())))
+                    {
+                        if ((!isTargetWeakOrOwned
+                             || !targetType.GetTypeInfo().Equals(entityType.ClrType.GetTypeInfo()))
+                            && entityType.GetDerivedTypes().All(
+                                dt => dt.FindDeclaredNavigation(actualProperty.Name) == null)
+                            && !entityType.IsInDefinitionPath(targetType))
                         {
-                            var actualProperty = entityType.ClrType.GetRuntimeProperties().First(p => p.Name == clrProperty);
-                            var propertyType = actualProperty.PropertyType;
-                            var targetSequenceType = propertyType.TryGetSequenceType();
-
-                            if (modelBuilder.IsIgnored(propertyType.DisplayName(), ConfigurationSource.Convention)
-                                || (targetSequenceType != null
-                                && modelBuilder.IsIgnored(targetSequenceType.DisplayName(), ConfigurationSource.Convention)))
-                            {
-                                continue;
-                            }
-
-                            var targetType = FindCandidateNavigationPropertyType(actualProperty);
-
-                            var isTargetWeakOrOwned
-                                = targetType != null
-                                  && (modelBuilder.Metadata.HasEntityTypeWithDefiningNavigation(targetType)
-                                      || modelBuilder.Metadata.ShouldBeOwnedType(targetType));
-
-                            if (targetType != null
-                                && targetType.IsValidEntityType()
-                                && (isTargetWeakOrOwned
-                                    || modelBuilder.Metadata.FindEntityType(targetType) != null
-                                    || targetType.GetRuntimeProperties().Any(p => p.IsCandidateProperty())))
-                            {
-                                if ((!isTargetWeakOrOwned
-                                     || !targetType.GetTypeInfo().Equals(entityType.ClrType.GetTypeInfo()))
-                                    && entityType.GetDerivedTypes().All(dt => dt.FindDeclaredNavigation(actualProperty.Name) == null)
-                                    && !entityType.IsInDefinitionPath(targetType))
-                                {
-                                    throw new InvalidOperationException(
-                                        CoreStrings.NavigationNotAdded(
-                                            entityType.DisplayName(), actualProperty.Name, propertyType.ShortDisplayName()));
-                                }
-                            }
-                            else if (targetSequenceType == null && propertyType.GetTypeInfo().IsInterface
-                                     || targetSequenceType != null && targetSequenceType.GetTypeInfo().IsInterface)
-                            {
-                                throw new InvalidOperationException(
-                                    CoreStrings.InterfacePropertyNotAdded(
-                                        entityType.DisplayName(), actualProperty.Name, propertyType.ShortDisplayName()));
-                            }
-                            else
-                            {
-                                throw new InvalidOperationException(
-                                    CoreStrings.PropertyNotAdded(
-                                        entityType.DisplayName(), actualProperty.Name, propertyType.ShortDisplayName()));
-                            }
+                            throw new InvalidOperationException(
+                                CoreStrings.NavigationNotAdded(
+                                    entityType.DisplayName(), actualProperty.Name, propertyType.ShortDisplayName()));
                         }
+                    }
+                    else if (targetSequenceType == null && propertyType.GetTypeInfo().IsInterface
+                             || targetSequenceType != null && targetSequenceType.GetTypeInfo().IsInterface)
+                    {
+                        throw new InvalidOperationException(
+                            CoreStrings.InterfacePropertyNotAdded(
+                                entityType.DisplayName(), actualProperty.Name, propertyType.ShortDisplayName()));
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException(
+                            CoreStrings.PropertyNotAdded(
+                                entityType.DisplayName(), actualProperty.Name, propertyType.ShortDisplayName()));
                     }
                 }
             }
@@ -137,8 +142,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         /// </summary>
         public virtual bool IsMappedPrimitiveProperty([NotNull] IProperty property)
         {
-            Check.NotNull(property, nameof(property));
-
             return _typeMappingSource.FindMapping(property) != null;
         }
 
@@ -148,8 +151,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         /// </summary>
         public virtual Type FindCandidateNavigationPropertyType([NotNull] PropertyInfo propertyInfo)
         {
-            Check.NotNull(propertyInfo, nameof(propertyInfo));
-
             return propertyInfo.FindCandidateNavigationPropertyType(_typeMappingSource, _parameterBindingFactories);
         }
     }

--- a/src/EFCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
@@ -353,7 +353,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var entityType = entityTypeBuilder.Metadata;
             var existingNavigation = entityType.FindNavigation(navigationProperty.Name);
             if (existingNavigation != null
-                && !CanMergeWith(existingNavigation, inversePropertyInfo.Name, targetEntityTypeBuilder))
+                && !CanMergeWith(existingNavigation, inversePropertyInfo, targetEntityTypeBuilder))
             {
                 return false;
             }
@@ -362,7 +362,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             if (existingInverse != null)
             {
                 if (existingInverse.DeclaringEntityType != targetEntityTypeBuilder.Metadata
-                    || !CanMergeWith(existingInverse, navigationProperty.Name, entityTypeBuilder))
+                    || !CanMergeWith(existingInverse, navigationProperty, entityTypeBuilder))
                 {
                     return false;
                 }
@@ -379,12 +379,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         }
 
         private static bool CanMergeWith(
-            Navigation existingNavigation, string inverseName, InternalEntityTypeBuilder inverseEntityTypeBuilder)
+            Navigation existingNavigation, PropertyInfo inverse, InternalEntityTypeBuilder inverseEntityTypeBuilder)
         {
             var fk = existingNavigation.ForeignKey;
             return (fk.IsSelfReferencing()
                     || fk.ResolveOtherEntityType(existingNavigation.DeclaringEntityType) == inverseEntityTypeBuilder.Metadata)
-                   && fk.Builder.CanSetNavigation(inverseName, !existingNavigation.IsDependentToPrincipal(), ConfigurationSource.Convention);
+                   && fk.Builder.CanSetNavigation(inverse, !existingNavigation.IsDependentToPrincipal(), ConfigurationSource.Convention);
         }
 
         private static IReadOnlyList<RelationshipCandidate> RemoveInheritedInverseNavigations(
@@ -824,7 +824,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             var dictionaryBuilder = ImmutableSortedDictionary.CreateBuilder<PropertyInfo, Type>(MemberInfoNameComparer.Instance);
             if (entityType.HasClrType())
             {
-                foreach (var propertyInfo in entityType.ClrType.GetRuntimeProperties().OrderBy(p => p.Name))
+                foreach (var propertyInfo in entityType.GetRuntimeProperties().Values.OrderBy(p => p.Name))
                 {
                     var targetType = FindCandidateNavigationPropertyType(propertyInfo);
                     if (targetType != null)

--- a/src/EFCore/Metadata/Conventions/Internal/ServicePropertyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ServicePropertyDiscoveryConvention.cs
@@ -57,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 return entityTypeBuilder;
             }
 
-            var candidates = entityType.ClrType.GetRuntimeProperties();
+            var candidates = entityType.GetRuntimeProperties().Values;
 
             foreach (var propertyInfo in candidates)
             {
@@ -129,8 +129,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 return true;
             }
 
-            var member = (MemberInfo)entityType.ClrType.GetRuntimeProperties().FirstOrDefault(p => p.Name == ignoredMemberName)
-                         ?? entityType.ClrType.GetFieldInfo(ignoredMemberName);
+            var member = (MemberInfo)entityType.GetRuntimeProperties().Find(ignoredMemberName)
+                         ?? entityType.GetRuntimeFields().Find(ignoredMemberName);
             var type = member.GetMemberType();
             if (duplicateMap.TryGetValue(type, out var duplicateServiceProperties)
                 && duplicateServiceProperties.Remove(member))

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -11,6 +11,7 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -373,6 +374,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override string ToString() => this.ToDebugString();
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override void ClearCaches()
+        {
+            base.ClearCaches();
+
+            RemoveAnnotation(RelationshipDiscoveryConvention.AmbiguousNavigationsAnnotationName);
+            RemoveAnnotation(RelationshipDiscoveryConvention.NavigationCandidatesAnnotationName);
+            RemoveAnnotation(InversePropertyAttributeConvention.InverseNavigationsAnnotationName);
+        }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
@@ -48,10 +48,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual InternalEntityTypeBuilder Entity(
             [NotNull] Type type, ConfigurationSource configurationSource, bool throwOnQuery = false)
-            => Entity(new TypeIdentity(type), configurationSource, throwOnQuery);
+            => Entity(new TypeIdentity(type, Metadata), configurationSource, throwOnQuery);
 
         private InternalEntityTypeBuilder Entity(
-            TypeIdentity type, ConfigurationSource configurationSource, bool throwOnQuery)
+            in TypeIdentity type, ConfigurationSource configurationSource, bool throwOnQuery)
         {
             if (IsIgnored(type, configurationSource))
             {
@@ -187,10 +187,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [NotNull] string definingNavigationName,
             [NotNull] EntityType definingEntityType,
             ConfigurationSource configurationSource)
-            => Entity(new TypeIdentity(type), definingNavigationName, definingEntityType, configurationSource);
+            => Entity(new TypeIdentity(type, Metadata), definingNavigationName, definingEntityType, configurationSource);
 
         private InternalEntityTypeBuilder Entity(
-            TypeIdentity type,
+            in TypeIdentity type,
             string definingNavigationName,
             EntityType definingEntityType,
             ConfigurationSource configurationSource)
@@ -266,9 +266,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual bool Owned(
             [NotNull] Type type, ConfigurationSource configurationSource)
-            => Owned(new TypeIdentity(type), configurationSource);
+            => Owned(new TypeIdentity(type, Metadata), configurationSource);
 
-        private bool Owned(TypeIdentity type, ConfigurationSource configurationSource)
+        private bool Owned(in TypeIdentity type, ConfigurationSource configurationSource)
         {
             if (IsIgnored(type, configurationSource))
             {
@@ -320,7 +320,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual bool IsIgnored([NotNull] Type type, ConfigurationSource configurationSource)
-            => IsIgnored(new TypeIdentity(type), configurationSource);
+            => IsIgnored(new TypeIdentity(type, Metadata), configurationSource);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -329,7 +329,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual bool IsIgnored([NotNull] string name, ConfigurationSource configurationSource)
             => IsIgnored(new TypeIdentity(name), configurationSource);
 
-        private bool IsIgnored(TypeIdentity type, ConfigurationSource configurationSource)
+        private bool IsIgnored(in TypeIdentity type, ConfigurationSource configurationSource)
         {
             if (configurationSource == ConfigurationSource.Explicit)
             {
@@ -346,7 +346,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual bool Ignore([NotNull] Type type, ConfigurationSource configurationSource)
-            => Ignore(new TypeIdentity(type), configurationSource);
+            => Ignore(new TypeIdentity(type, Metadata), configurationSource);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -355,7 +355,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public virtual bool Ignore([NotNull] string name, ConfigurationSource configurationSource)
             => Ignore(new TypeIdentity(name), configurationSource);
 
-        private bool Ignore(TypeIdentity type, ConfigurationSource configurationSource)
+        private bool Ignore(in TypeIdentity type, ConfigurationSource configurationSource)
         {
             var name = type.Name;
             var ignoredConfigurationSource = Metadata.FindIgnoredTypeConfigurationSource(name);

--- a/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalPropertyBuilder.cs
@@ -148,7 +148,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (fieldName != null)
             {
                 var fieldInfo = PropertyBase.GetFieldInfo(
-                    fieldName, Metadata.DeclaringType.ClrType, Metadata.Name,
+                    fieldName, Metadata.DeclaringType, Metadata.Name,
                     shouldThrow: configurationSource == ConfigurationSource.Explicit);
                 Metadata.SetFieldInfo(fieldInfo, configurationSource);
                 return true;

--- a/src/EFCore/Metadata/Internal/InternalServicePropertyBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalServicePropertyBuilder.cs
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (fieldName != null)
             {
                 var fieldInfo = PropertyBase.GetFieldInfo(
-                    fieldName, Metadata.DeclaringType.ClrType, Metadata.Name,
+                    fieldName, Metadata.DeclaringType, Metadata.Name,
                     shouldThrow: configurationSource == ConfigurationSource.Explicit);
                 Metadata.SetFieldInfo(fieldInfo, configurationSource);
                 return true;

--- a/src/EFCore/Metadata/Internal/ModelExtensions.cs
+++ b/src/EFCore/Metadata/Internal/ModelExtensions.cs
@@ -58,7 +58,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             while (clrType != null)
             {
-                if (ownedTypes.Contains(clrType.DisplayName()))
+                var name = (model as Model)?.GetDisplayName(clrType) ?? clrType.DisplayName();
+                if (ownedTypes.Contains(name))
                 {
                     return true;
                 }
@@ -89,7 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static void MarkAsOwnedType([NotNull] this Model model, [NotNull] Type clrType)
-            => model.MarkAsOwnedType(clrType.DisplayName());
+            => model.MarkAsOwnedType(model.GetDisplayName(clrType));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -114,7 +115,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             while (clrType != null)
             {
-                ownedTypes.Remove(clrType.DisplayName());
+                ownedTypes.Remove(model.GetDisplayName(clrType));
 
                 clrType = clrType.BaseType;
             }

--- a/src/EFCore/Metadata/Internal/Navigation.cs
+++ b/src/EFCore/Metadata/Internal/Navigation.cs
@@ -75,7 +75,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public new virtual EntityType DeclaringType => DeclaringEntityType;
+        public override TypeBase DeclaringType
+        {
+            [DebuggerStepThrough] get => DeclaringEntityType;
+        }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -217,8 +220,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         IMutableForeignKey IMutableNavigation.ForeignKey => ForeignKey;
         IEntityType INavigation.DeclaringEntityType => DeclaringEntityType;
         IMutableEntityType IMutableNavigation.DeclaringEntityType => DeclaringEntityType;
-        ITypeBase IPropertyBase.DeclaringType => DeclaringType;
-        IMutableTypeBase IMutablePropertyBase.DeclaringType => DeclaringType;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/Internal/Property.cs
+++ b/src/EFCore/Metadata/Internal/Property.cs
@@ -75,7 +75,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public new virtual EntityType DeclaringType
+        public override TypeBase DeclaringType
         {
             [DebuggerStepThrough] get => DeclaringEntityType;
         }
@@ -465,9 +465,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                + "}";
 
         IEntityType IProperty.DeclaringEntityType => DeclaringEntityType;
-        ITypeBase IPropertyBase.DeclaringType => DeclaringType;
         IMutableEntityType IMutableProperty.DeclaringEntityType => DeclaringEntityType;
-        IMutableTypeBase IMutablePropertyBase.DeclaringType => DeclaringType;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -478,14 +476,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Check.NotNull(properties, nameof(properties));
             Check.NotNull(entityType, nameof(entityType));
 
-            return properties.All(
-                property =>
-                    property.IsShadowProperty
-                    || (entityType.HasClrType()
-                        && ((property.PropertyInfo != null
-                             && entityType.ClrType.GetRuntimeProperties().FirstOrDefault(p => p.Name == property.Name) != null)
-                            || (property.FieldInfo != null
-                                && entityType.ClrType.GetFieldInfo(property.Name) != null))));
+            return properties.All(property =>
+                property.IsShadowProperty
+                || (entityType.HasClrType()
+                    && ((property.PropertyInfo != null
+                         && entityType.GetRuntimeProperties().ContainsKey(property.Name))
+                        || (property.FieldInfo != null
+                            && entityType.GetRuntimeFields().ContainsKey(property.Name)))));
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Internal/ServiceProperty.cs
+++ b/src/EFCore/Metadata/Internal/ServiceProperty.cs
@@ -51,7 +51,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public new virtual EntityType DeclaringType => DeclaringEntityType;
+        public override TypeBase DeclaringType
+        {
+            [DebuggerStepThrough] get => DeclaringEntityType;
+        }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -136,7 +139,5 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         IEntityType IServiceProperty.DeclaringEntityType => DeclaringEntityType;
         IMutableEntityType IMutableServiceProperty.DeclaringEntityType => DeclaringEntityType;
-        ITypeBase IPropertyBase.DeclaringType => DeclaringType;
-        IMutableTypeBase IMutablePropertyBase.DeclaringType => DeclaringType;
     }
 }

--- a/src/EFCore/Metadata/Internal/TypeIdentity.cs
+++ b/src/EFCore/Metadata/Internal/TypeIdentity.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Diagnostics;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 {
@@ -15,16 +14,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     [DebuggerDisplay("{DebuggerDisplay(),nq}")]
     public readonly struct TypeIdentity
     {
-        private readonly object _nameOrType;
-
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         [DebuggerStepThrough]
         public TypeIdentity([NotNull] string name)
-            : this((object)name)
         {
+            Name = name;
+            Type = null;
         }
 
         /// <summary>
@@ -32,34 +30,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         [DebuggerStepThrough]
-        public TypeIdentity([NotNull] Type type)
-            : this((object)type)
+        public TypeIdentity([NotNull] Type type, [NotNull] Model model)
         {
-        }
-
-        [DebuggerStepThrough]
-        private TypeIdentity(object nameOrType)
-        {
-            _nameOrType = nameOrType;
+            Name = model.GetDisplayName(type);
+            Type = type;
         }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public string Name
-        {
-            [DebuggerStepThrough] get { return Type?.DisplayName() ?? (string)_nameOrType; }
-        }
+        public string Name { [DebuggerStepThrough] get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public Type Type
-        {
-            [DebuggerStepThrough] get { return _nameOrType as Type; }
-        }
+        public Type Type { [DebuggerStepThrough] get; }
 
         private string DebuggerDisplay() => Name;
     }

--- a/src/EFCore/Storage/Internal/FallbackTypeMappingSource.cs
+++ b/src/EFCore/Storage/Internal/FallbackTypeMappingSource.cs
@@ -42,7 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected override CoreTypeMapping FindMapping(TypeMappingInfo mappingInfo)
+        protected override CoreTypeMapping FindMapping(in TypeMappingInfo mappingInfo)
         {
             Check.NotNull(mappingInfo, nameof(mappingInfo));
 

--- a/src/EFCore/Storage/TypeMappingInfo.cs
+++ b/src/EFCore/Storage/TypeMappingInfo.cs
@@ -15,7 +15,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
     /// <summary>
     ///     Describes metadata needed to decide on a type mapping for a property or type.
     /// </summary>
-    public readonly struct TypeMappingInfo
+    public readonly struct TypeMappingInfo : IEquatable<TypeMappingInfo>
     {
         private readonly Type _providerClrType;
         private readonly ValueConverter _customConverter;
@@ -153,7 +153,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="converterInfo"> The converter to apply. </param>
         /// <returns> The new mapping info. </returns>
-        public TypeMappingInfo WithConverter(ValueConverterInfo converterInfo)
+        public TypeMappingInfo WithConverter(in ValueConverterInfo converterInfo)
             => new TypeMappingInfo(this, converterInfo);
 
         /// <summary>

--- a/src/EFCore/Storage/TypeMappingSourceBase.cs
+++ b/src/EFCore/Storage/TypeMappingSourceBase.cs
@@ -7,12 +7,14 @@ using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
 
+#pragma warning disable 1574
+#pragma warning disable CS0419 // Ambiguous reference in cref attribute
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>
     ///     <para>
     ///         The base class for non-relational type mapping starting with version 2.1. Non-relational providers
-    ///         should derive from this class and override <see cref="FindMapping(TypeMappingInfo)" />
+    ///         should derive from this class and override <see cref="TypeMappingSourceBase.FindMapping" />
     ///     </para>
     ///     <para>
     ///         This type is typically used by database providers (and other extensions). It is generally
@@ -49,7 +51,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="mappingInfo"> The mapping info to use to create the mapping. </param>
         /// <returns> The type mapping, or <c>null</c> if none could be found. </returns>
-        protected abstract CoreTypeMapping FindMapping(TypeMappingInfo mappingInfo);
+        protected abstract CoreTypeMapping FindMapping(in TypeMappingInfo mappingInfo);
 
         /// <summary>
         ///     Called after a mapping has been found so that it can be validated for the given property.

--- a/src/EFCore/Storage/ValueConversion/IValueConverterSelector.cs
+++ b/src/EFCore/Storage/ValueConversion/IValueConverterSelector.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// <param name="providerClrType"> The store type to target, or null for any. </param>
         /// <returns> The converters available. </returns>
         IEnumerable<ValueConverterInfo> Select(
-            [NotNull] Type modelClrType, 
+            [NotNull] Type modelClrType,
             [CanBeNull] Type providerClrType = null);
     }
 }

--- a/src/Shared/PropertyInfoExtensions.cs
+++ b/src/Shared/PropertyInfoExtensions.cs
@@ -18,11 +18,10 @@ namespace System.Reflection
 
         public static bool IsCandidateProperty(this PropertyInfo propertyInfo, bool needsWrite = true, bool publicOnly = true)
             => !propertyInfo.IsStatic()
-               && propertyInfo.GetIndexParameters().Length == 0
                && propertyInfo.CanRead
                && (!needsWrite || propertyInfo.FindSetterProperty() != null)
-               && propertyInfo.GetMethod != null && (!publicOnly || propertyInfo.GetMethod.IsPublic);
-
+               && propertyInfo.GetMethod != null && (!publicOnly || propertyInfo.GetMethod.IsPublic)
+               && propertyInfo.GetIndexParameters().Length == 0;
 
         public static Type FindCandidateNavigationPropertyType(
             this PropertyInfo propertyInfo,

--- a/test/EFCore.Relational.Tests/TestUtilities/TestRelationalTypeMappingSource.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/TestRelationalTypeMappingSource.cs
@@ -154,7 +154,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
         }
 
-        protected override RelationalTypeMapping FindMapping(RelationalTypeMappingInfo mappingInfo)
+        protected override RelationalTypeMapping FindMapping(in RelationalTypeMappingInfo mappingInfo)
         {
             var clrType = mappingInfo.ClrType;
             var storeTypeName = mappingInfo.StoreTypeName;

--- a/test/EFCore.SqlServer.FunctionalTests/EverythingIsBytesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/EverythingIsBytesSqlServerTest.cs
@@ -222,7 +222,7 @@ UnicodeDataTypes.StringUnicode ---> [nullable varbinary] [MaxLength = -1]
                     };
             }
 
-            protected override RelationalTypeMapping FindMapping(RelationalTypeMappingInfo mappingInfo)
+            protected override RelationalTypeMapping FindMapping(in RelationalTypeMappingInfo mappingInfo)
                 => FindRawMapping(mappingInfo)?.Clone(mappingInfo);
 
             private RelationalTypeMapping FindRawMapping(RelationalTypeMappingInfo mappingInfo)

--- a/test/EFCore.SqlServer.FunctionalTests/EverythingIsStringsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/EverythingIsStringsSqlServerTest.cs
@@ -243,7 +243,7 @@ UnicodeDataTypes.StringUnicode ---> [nullable nvarchar] [MaxLength = -1]
                     };
             }
 
-            protected override RelationalTypeMapping FindMapping(RelationalTypeMappingInfo mappingInfo)
+            protected override RelationalTypeMapping FindMapping(in RelationalTypeMappingInfo mappingInfo)
                 => FindRawMapping(mappingInfo)?.Clone(mappingInfo);
 
             private RelationalTypeMapping FindRawMapping(RelationalTypeMappingInfo mappingInfo)

--- a/test/EFCore.Tests/Metadata/Conventions/Internal/NavigationAttributeConventionTest.cs
+++ b/test/EFCore.Tests/Metadata/Conventions/Internal/NavigationAttributeConventionTest.cs
@@ -16,8 +16,8 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
-// ReSharper disable MemberHidesStaticFromOuterClass
 
+// ReSharper disable MemberHidesStaticFromOuterClass
 // ReSharper disable InconsistentNaming
 // ReSharper disable ClassNeverInstantiated.Local
 // ReSharper disable UnusedMember.Local


### PR DESCRIPTION
Cache property and field infos
Memoize DisplayName() for Type
Call Attribute.IsDefined before GetCustomAttributes()
Use in parameters for TypeMappingInfo and RelationalTypeMappingInfo
Implement IEquatable<T> on TypeMappingInfo and RelationalTypeMappingInfo

Fixes #9347
