### PR TITLE
Fix 'MilitaryRank' default values

### DIFF
--- a/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/MilitaryRank.cs
+++ b/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/MilitaryRank.cs
@@ -8,13 +8,13 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
     [Flags]
     public enum MilitaryRank
     {
-        Private,
-        Corporal,
-        Sergeant,
-        Lieutenant,
-        Captain,
-        Major,
-        Colonel,
-        General
+        Private = 0,
+        Corporal = 1,
+        Sergeant = 2,
+        Lieutenant = 4,
+        Captain = 8,
+        Major = 16,
+        Colonel = 32,
+        General = 64
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -733,7 +733,7 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (([g].[Rank] & 1) = 1)",
                 //
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]
-WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (([g].[Rank] & 5) = 5)",
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (([g].[Rank] & 9) = 9",
                 //
                 @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
 FROM [Gears] AS [g]


### PR DESCRIPTION
Enumeration '**MilitaryRank**' was declared with '**Flags**' attribute but does not set any initializers to override default values.