### PR TITLE
Migrations: Preserve MaxIdentifierLength in snapshot

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -63,7 +63,6 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     GenerateFluentApiForAnnotation(ref annotations, RelationalAnnotationNames.DefaultSchema, nameof(RelationalModelBuilderExtensions.HasDefaultSchema), stringBuilder);
 
                     IgnoreAnnotationTypes(annotations, RelationalAnnotationNames.DbFunction);
-                    IgnoreAnnotationTypes(annotations, RelationalAnnotationNames.MaxIdentifierLength);
                     IgnoreAnnotationTypes(annotations, CoreAnnotationNames.OwnedTypesAnnotation);
 
                     GenerateAnnotations(annotations, stringBuilder);


### PR DESCRIPTION
Fixes #11473