### PR TITLE
Ensure AUTO_CLOSE is OFF before creating memory-optimized tables

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/MigrationsTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/MigrationsTestBase.cs
@@ -49,7 +49,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public void Can_apply_one_migration()
         {
             using (var db = Fixture.CreateContext())
@@ -118,7 +118,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Can_generate_no_migration_script()
         {
             using (var db = Fixture.CreateEmptyContext())
@@ -129,7 +129,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Can_generate_migration_from_initial_database_to_initial()
         {
             using (var db = Fixture.CreateContext())
@@ -140,7 +140,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Can_generate_up_scripts()
         {
             using (var db = Fixture.CreateContext())
@@ -151,7 +151,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Can_generate_one_up_script()
         {
             using (var db = Fixture.CreateContext())
@@ -162,7 +162,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Can_generate_up_script_using_names()
         {
             using (var db = Fixture.CreateContext())
@@ -173,7 +173,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Can_generate_idempotent_up_scripts()
         {
             using (var db = Fixture.CreateContext())
@@ -184,7 +184,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Can_generate_down_scripts()
         {
             using (var db = Fixture.CreateContext())
@@ -198,7 +198,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Can_generate_one_down_script()
         {
             using (var db = Fixture.CreateContext())
@@ -212,7 +212,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Can_generate_down_script_using_names()
         {
             using (var db = Fixture.CreateContext())
@@ -226,7 +226,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Can_generate_idempotent_down_scripts()
         {
             using (var db = Fixture.CreateContext())
@@ -241,7 +241,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        [Fact]
+        [ConditionalFact]
         public virtual void Can_get_active_provider()
         {
             using (var db = Fixture.CreateContext())
@@ -259,7 +259,7 @@ namespace Microsoft.EntityFrameworkCore
         ///     Creating databases and executing DDL is slow. This oddly-structured test allows us to get the most ammount of
         ///     coverage using the least ammount of database operations.
         /// </remarks>
-        [Fact]
+        [ConditionalFact]
         public virtual async Task Can_execute_operations()
         {
             using (var db = Fixture.CreateContext())

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -853,6 +853,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 {
                     builder
                         .AppendLine("BEGIN")
+                        .AppendLine("ALTER DATABASE CURRENT SET AUTO_CLOSE OFF;")
                         .AppendLine("DECLARE @db_name NVARCHAR(MAX) = DB_NAME();")
                         .AppendLine("DECLARE @fg_name NVARCHAR(MAX);")
                         .AppendLine("SELECT TOP(1) @fg_name = [name] FROM [sys].[filegroups] WHERE [type] = N'FX';")

--- a/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/MigrationsSqlServerTest.cs
@@ -14,6 +14,7 @@ using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 #endif
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Xunit;
 
 // ReSharper disable InconsistentNaming
@@ -443,7 +444,7 @@ CreatedTable
             return builder.ToString();
         }
 
-        [Fact]
+        [ConditionalFact]
         public async Task Empty_Migration_Creates_Database()
         {
             using (var context = new BloggingContext(Fixture.TestStore.AddProviderOptions(new DbContextOptionsBuilder()).Options))

--- a/test/EFCore.SqlServer.FunctionalTests/Query/DbFunctionsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/DbFunctionsSqlServerTest.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Query
 {
     public class DbFunctionsSqlServerTest : DbFunctionsTestBase<NorthwindQuerySqlServerFixture<NoopModelCustomizer>>

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerDatabaseCreatorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerDatabaseCreatorTest.cs
@@ -8,8 +8,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+#if Test20
 using Microsoft.EntityFrameworkCore.Internal;
-#if !Test20
+#else
 using Microsoft.EntityFrameworkCore.SqlServer.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 #endif
@@ -699,6 +700,7 @@ namespace Microsoft.EntityFrameworkCore
         }
     }
 
+    [SqlServerCondition(SqlServerCondition.IsNotSqlAzure)]
     public class SqlServerDatabaseCreatorTest
     {
 

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestEnvironment.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestEnvironment.cs
@@ -29,8 +29,11 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 
         public static string DefaultConnection => Config["DefaultConnection"] ?? DefaultConnectionString;
 
-        public static bool IsSqlAzure
-            => new SqlConnectionStringBuilder(DefaultConnection).DataSource.Contains("database.windows.net");
+        private static bool? _isSqlAzure;
+
+        public static bool IsSqlAzure =>
+            (bool)(_isSqlAzure
+                   ?? (_isSqlAzure = new SqlConnectionStringBuilder(DefaultConnection).DataSource.Contains("database.windows.net")));
 
         public static bool IsTeamCity => Environment.GetEnvironmentVariable("TEAMCITY_VERSION") != null;
 

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestSqlServerRetryingExecutionStrategy.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/TestSqlServerRetryingExecutionStrategy.cs
@@ -9,6 +9,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 {
     public class TestSqlServerRetryingExecutionStrategy : SqlServerRetryingExecutionStrategy
     {
+        private const bool ErrorNumberDebugMode = false;
+
         private static readonly int[] _additionalErrorNumbers =
         {
             -1, // Physical connection is not usable
@@ -46,13 +48,15 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 return true;
             }
 
-            if (exception is SqlException sqlException)
+            if (ErrorNumberDebugMode
+                && exception is SqlException sqlException)
             {
                 var message = "Didn't retry on";
                 foreach (SqlError err in sqlException.Errors)
                 {
                     message += " " + err.Number;
                 }
+                message += Environment.NewLine;
                 throw new InvalidOperationException(message + exception, exception);
             }
 


### PR DESCRIPTION
Properly ignore some tests on SQL Azure