### PR TITLE
Query: TaskLiftingExpressionVisitor should never give null Cancellati…

### DIFF
--- a/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
@@ -1554,6 +1554,18 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .Select(g => EF.Property<string>(g.First(), "Title")));
         }
 
+        [ConditionalFact]
+        public virtual async Task GroupBy_Select_First_GroupBy()
+        {
+            await AssertQuery<Customer>(
+                cs =>
+                    cs.GroupBy(c => c.City)
+                      .Select(g => g.OrderBy(c => c.CustomerID).First())
+                      .GroupBy(c => c.ContactName),
+                elementSorter: GroupingSorter<string, object>(),
+                elementAsserter: GroupingAsserter<string, dynamic>(d => d.CustomerID));
+        }
+
         #endregion
 
         #region GroupByEntityType

--- a/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -1559,6 +1559,20 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .Select(g => EF.Property<string>(g.First(), "Title")));
         }
 
+
+
+        [ConditionalFact]
+        public virtual void GroupBy_Select_First_GroupBy()
+        {
+            AssertQuery<Customer>(
+                cs =>
+                    cs.GroupBy(c => c.City)
+                      .Select(g => g.OrderBy(c => c.CustomerID).First())
+                      .GroupBy(c => c.ContactName),
+                elementSorter: GroupingSorter<string, object>(),
+                elementAsserter: GroupingAsserter<string, dynamic>(d => d.CustomerID));
+        }
+
         #endregion
 
         #region GroupByEntityType

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -1321,8 +1321,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             Expression.Lambda(
                                 asyncSelector,
                                 CurrentParameter,
-                                taskLiftingExpressionVisitor.CancellationTokenParameter
-                                ?? Expression.Parameter(typeof(CancellationToken), name: "ct")));
+                                taskLiftingExpressionVisitor.CancellationTokenParameter));
             }
         }
 

--- a/src/EFCore/Query/ExpressionVisitors/Internal/TaskLiftingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/TaskLiftingExpressionVisitor.cs
@@ -21,6 +21,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
     {
         private static readonly ParameterExpression _resultsParameter
             = Expression.Parameter(typeof(object[]), name: "results");
+        private static readonly ParameterExpression _dummyCancellationToken
+            = Expression.Parameter(typeof(CancellationToken), name: "ct");
 
         private readonly List<Expression> _taskExpressions = new List<Expression>();
 
@@ -45,6 +47,11 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                         _executeAsync.MakeGenericMethod(expression.Type),
                         Expression.NewArrayInit(typeof(Func<Task<object>>), _taskExpressions),
                         Expression.Lambda(newExpression, _resultsParameter));
+
+                if (CancellationTokenParameter == null)
+                {
+                    CancellationTokenParameter = _dummyCancellationToken;
+                }
             }
 
             return newExpression;


### PR DESCRIPTION
…onTokenParameter

Issue: We had an ET generated which used `queryContext.CancellationToken` as CT parameter. We use that property to pass CT from user code to our execution pipeline.
We cannot use that in LambdaExpression since it is not ParameterExpression.
Fix is to use a dummy CT for Lambda since actual CT will be injected from queryContext automatically.


Resolves #11561
