### PR TITLE
Fix to #11459 - Query: incorrect data returned for queries projecting a single constant from a subquery

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -1106,7 +1106,8 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                     _canBindPropertyToOuterParameter = canBindPropertyToOuterParameter;
 
-                    if (sqlOrderingExpression == null)
+                    if (sqlOrderingExpression == null
+                        || sqlOrderingExpression.Type == typeof(Expression[]))
                     {
                         break;
                     }

--- a/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -2493,7 +2493,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                      join l1i in l1s
                          on l2i.Level1_Required_Id equals l1i.Id
                      orderby l2i.Id
-                     select new { Navigation = l2i.OneToOne_Required_FK_Inverse, Contant = 7 }).First().Navigation.Name);
+                     select new { Navigation = l2i.OneToOne_Required_FK_Inverse, Constant = 7 }).First().Navigation.Name);
         }
 
         [ConditionalFact]

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -764,6 +764,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             AssertQueryScalar<Customer, short>(cs => cs.Select(c => c.CustomerID == "ALFKI" ? (short)1 : (short)2));
         }
+
+        [ConditionalFact]
+        public virtual void Select_bool_constant()
+        {
+            AssertQueryScalar<Customer, bool>(cs => cs.Select(c => c.CustomerID == "ALFKI" ? true : false));
+        }
 #endif
     }
 }

--- a/src/EFCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
+++ b/src/EFCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
@@ -146,8 +146,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Sql.Internal
         }
 
         private static Expression ExplicitCastToBool(Expression expression)
-            => (expression as BinaryExpression)?.NodeType == ExpressionType.Coalesce
-            && expression.Type.UnwrapNullableType() == typeof(bool)
+            => ((expression as BinaryExpression)?.NodeType == ExpressionType.Coalesce || expression.NodeType == ExpressionType.Constant)
+                && expression.Type.UnwrapNullableType() == typeof(bool)
                 ? new ExplicitCastExpression(expression, expression.Type)
                 : expression;
 

--- a/src/EFCore/Query/ExpressionVisitors/Internal/CorrelatedCollectionOptimizingVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/CorrelatedCollectionOptimizingVisitor.cs
@@ -76,6 +76,14 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public static bool IsCorrelatedCollectionMethod(MethodCallExpression methodCallExpression)
+            => methodCallExpression.Method.MethodIsClosedFormOf(_correlateSubqueryMethodInfo)
+               || methodCallExpression.Method.MethodIsClosedFormOf(_correlateSubqueryAsyncMethodInfo);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
         {
             if (methodCallExpression.Method.MethodIsClosedFormOf(_toListMethodInfo)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AsyncGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AsyncGearsOfWarQuerySqlServerTest.cs
@@ -979,7 +979,7 @@ FROM [Gears] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[Nickname] <> N'Marcus')
 ORDER BY [g].[Nickname], [g].[SquadId], [g].[FullName]",
                 //
-                @"SELECT [t].[Nickname], [t].[SquadId], [t].[FullName], [g.Weapons].[OwnerFullName]
+                @"SELECT [t].[Nickname], [t].[SquadId], [t].[FullName], N'BFG', [g.Weapons].[OwnerFullName]
 FROM [Weapons] AS [g.Weapons]
 INNER JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[FullName]
@@ -1039,11 +1039,11 @@ ORDER BY [t].[Id]");
             await base.Correlated_collections_nested();
 
             AssertSql(
-                  @"SELECT [s].[Id]
+                @"SELECT [s].[Id]
 FROM [Squads] AS [s]
 ORDER BY [s].[Id]",
-                  //
-                  @"SELECT [t].[Id], [m.Mission].[Id], [s.Missions].[SquadId]
+                //
+                @"SELECT [t].[Id], [s.Missions].[SquadId], [m.Mission].[Id]
 FROM [SquadMissions] AS [s.Missions]
 INNER JOIN [Missions] AS [m.Mission] ON [s.Missions].[MissionId] = [m.Mission].[Id]
 INNER JOIN (
@@ -1052,8 +1052,8 @@ INNER JOIN (
 ) AS [t] ON [s.Missions].[SquadId] = [t].[Id]
 WHERE [s.Missions].[MissionId] < 42
 ORDER BY [t].[Id], [s.Missions].[SquadId], [s.Missions].[MissionId], [m.Mission].[Id]",
-                  //
-                  @"SELECT [m.Mission.ParticipatingSquads].[SquadId], [m.Mission.ParticipatingSquads].[MissionId], [t1].[Id], [t1].[SquadId], [t1].[MissionId], [t1].[Id0]
+                //
+                @"SELECT [m.Mission.ParticipatingSquads].[SquadId], [m.Mission.ParticipatingSquads].[MissionId], [t1].[Id], [t1].[SquadId], [t1].[MissionId], [t1].[Id0]
 FROM [SquadMissions] AS [m.Mission.ParticipatingSquads]
 INNER JOIN (
     SELECT [t0].[Id], [s.Missions0].[SquadId], [s.Missions0].[MissionId], [m.Mission0].[Id] AS [Id0]
@@ -1320,7 +1320,7 @@ ORDER BY [t0].[FullName], [t0].[Nickname], [t0].[SquadId], [o.Reports].[FullName
             await base.Correlated_collections_multiple_nested_complex_collections();
 
             AssertSql(
-                  @"SELECT [o].[FullName] AS [FullName0], [o].[Nickname], [o].[SquadId], [t].[FullName]
+                @"SELECT [o].[FullName], [o].[Nickname], [o].[SquadId], [t].[FullName]
 FROM [Gears] AS [o]
 LEFT JOIN [Tags] AS [o.Tag] ON ([o].[Nickname] = [o.Tag].[GearNickName]) AND ([o].[SquadId] = [o.Tag].[GearSquadId])
 LEFT JOIN (
@@ -1333,8 +1333,8 @@ WHERE ([o].[Discriminator] = N'Officer') AND EXISTS (
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (([o].[Nickname] = [g].[LeaderNickname]) AND ([o].[SquadId] = [g].[LeaderSquadId])))
 ORDER BY [o].[HasSoulPatch] DESC, [o.Tag].[Note], [o].[Nickname], [o].[SquadId], [t].[FullName]",
-                  //
-                  @"SELECT [t1].[HasSoulPatch], [t1].[Note], [t1].[Nickname], [t1].[SquadId], [o.Reports].[FullName], [o.Reports].[LeaderNickname], [o.Reports].[LeaderSquadId]
+                //
+                @"SELECT [t1].[HasSoulPatch], [t1].[Note], [t1].[Nickname], [t1].[SquadId], [o.Reports].[FullName], [o.Reports].[LeaderNickname], [o.Reports].[LeaderSquadId]
 FROM [Gears] AS [o.Reports]
 INNER JOIN (
     SELECT [o0].[HasSoulPatch], [o.Tag0].[Note], [o0].[Nickname], [o0].[SquadId]
@@ -1352,8 +1352,8 @@ INNER JOIN (
 ) AS [t1] ON ([o.Reports].[LeaderNickname] = [t1].[Nickname]) AND ([o.Reports].[LeaderSquadId] = [t1].[SquadId])
 WHERE [o.Reports].[Discriminator] IN (N'Officer', N'Gear') AND ([o.Reports].[FullName] <> N'Foo')
 ORDER BY [t1].[HasSoulPatch] DESC, [t1].[Note], [t1].[Nickname], [t1].[SquadId], [o.Reports].[Rank], [o.Reports].[Nickname], [o.Reports].[SquadId], [o.Reports].[FullName]",
-                  //
-                  @"SELECT [t5].[HasSoulPatch], [t5].[Note], [t5].[Nickname], [t5].[SquadId], [t5].[Rank], [t5].[Nickname0], [t5].[SquadId0], [t5].[FullName], [o.Reports.Weapons].[Id] AS [Id0], [t2].[FullName], [w.Owner.Squad].[Id], [o.Reports.Weapons].[OwnerFullName]
+                //
+                @"SELECT [t5].[HasSoulPatch], [t5].[Note], [t5].[Nickname], [t5].[SquadId], [t5].[Rank], [t5].[Nickname0], [t5].[SquadId0], [t5].[FullName], [o.Reports.Weapons].[Id], [o.Reports.Weapons].[OwnerFullName], [t2].[FullName], [w.Owner.Squad].[Id]
 FROM [Weapons] AS [o.Reports.Weapons]
 LEFT JOIN (
     SELECT [w.Owner].*
@@ -1382,8 +1382,8 @@ INNER JOIN (
 ) AS [t5] ON [o.Reports.Weapons].[OwnerFullName] = [t5].[FullName]
 WHERE ([o.Reports.Weapons].[Name] <> N'Bar') OR [o.Reports.Weapons].[Name] IS NULL
 ORDER BY [t5].[HasSoulPatch] DESC, [t5].[Note], [t5].[Nickname], [t5].[SquadId], [t5].[Rank], [t5].[Nickname0], [t5].[SquadId0], [t5].[FullName], [o.Reports.Weapons].[IsAutomatic], [o.Reports.Weapons].[Id], [t2].[FullName], [w.Owner.Squad].[Id]",
-                  //
-                  @"SELECT [t10].[HasSoulPatch], [t10].[Note], [t10].[Nickname], [t10].[SquadId], [t10].[Rank], [t10].[Nickname0], [t10].[SquadId0], [t10].[FullName], [t10].[IsAutomatic], [t10].[Id], [t10].[FullName0], [w.Owner.Weapons].[Name], [w.Owner.Weapons].[IsAutomatic] AS [IsAutomatic0], [w.Owner.Weapons].[OwnerFullName]
+                //
+                @"SELECT [t10].[HasSoulPatch], [t10].[Note], [t10].[Nickname], [t10].[SquadId], [t10].[Rank], [t10].[Nickname0], [t10].[SquadId0], [t10].[FullName], [t10].[IsAutomatic], [t10].[Id], [t10].[FullName0], [w.Owner.Weapons].[Name], [w.Owner.Weapons].[IsAutomatic] AS [IsAutomatic0], [w.Owner.Weapons].[OwnerFullName]
 FROM [Weapons] AS [w.Owner.Weapons]
 INNER JOIN (
     SELECT [t9].[HasSoulPatch], [t9].[Note], [t9].[Nickname], [t9].[SquadId], [t9].[Rank], [t9].[Nickname0], [t9].[SquadId0], [t9].[FullName], [o.Reports.Weapons0].[IsAutomatic], [o.Reports.Weapons0].[Id], [t6].[FullName] AS [FullName0]
@@ -1416,8 +1416,8 @@ INNER JOIN (
     WHERE ([o.Reports.Weapons0].[Name] <> N'Bar') OR [o.Reports.Weapons0].[Name] IS NULL
 ) AS [t10] ON [w.Owner.Weapons].[OwnerFullName] = [t10].[FullName0]
 ORDER BY [t10].[HasSoulPatch] DESC, [t10].[Note], [t10].[Nickname], [t10].[SquadId], [t10].[Rank], [t10].[Nickname0], [t10].[SquadId0], [t10].[FullName], [t10].[IsAutomatic], [t10].[Id], [t10].[FullName0]",
-                  //
-                  @"SELECT [t15].[HasSoulPatch], [t15].[Note], [t15].[Nickname], [t15].[SquadId], [t15].[Rank], [t15].[Nickname0], [t15].[SquadId0], [t15].[FullName], [t15].[IsAutomatic], [t15].[Id], [t15].[Id0], [w.Owner.Squad.Members].[Nickname] AS [Nickname1], [w.Owner.Squad.Members].[HasSoulPatch] AS [HasSoulPatch0], [w.Owner.Squad.Members].[SquadId]
+                //
+                @"SELECT [t15].[HasSoulPatch], [t15].[Note], [t15].[Nickname], [t15].[SquadId], [t15].[Rank], [t15].[Nickname0], [t15].[SquadId0], [t15].[FullName], [t15].[IsAutomatic], [t15].[Id], [t15].[Id0], [w.Owner.Squad.Members].[Nickname] AS [Nickname1], [w.Owner.Squad.Members].[HasSoulPatch] AS [HasSoulPatch0], [w.Owner.Squad.Members].[SquadId]
 FROM [Gears] AS [w.Owner.Squad.Members]
 INNER JOIN (
     SELECT [t14].[HasSoulPatch], [t14].[Note], [t14].[Nickname], [t14].[SquadId], [t14].[Rank], [t14].[Nickname0], [t14].[SquadId0], [t14].[FullName], [o.Reports.Weapons1].[IsAutomatic], [o.Reports.Weapons1].[Id], [w.Owner.Squad1].[Id] AS [Id0]
@@ -1451,8 +1451,8 @@ INNER JOIN (
 ) AS [t15] ON [w.Owner.Squad.Members].[SquadId] = [t15].[Id0]
 WHERE [w.Owner.Squad.Members].[Discriminator] IN (N'Officer', N'Gear')
 ORDER BY [t15].[HasSoulPatch] DESC, [t15].[Note], [t15].[Nickname], [t15].[SquadId], [t15].[Rank], [t15].[Nickname0], [t15].[SquadId0], [t15].[FullName], [t15].[IsAutomatic], [t15].[Id], [t15].[Id0], [Nickname1]",
-                  //
-                  @"SELECT [o.Tag.Gear.Weapons].[Id], [o.Tag.Gear.Weapons].[AmmunitionType], [o.Tag.Gear.Weapons].[IsAutomatic], [o.Tag.Gear.Weapons].[Name], [o.Tag.Gear.Weapons].[OwnerFullName], [o.Tag.Gear.Weapons].[SynergyWithId], [t18].[HasSoulPatch], [t18].[Note], [t18].[Nickname], [t18].[SquadId], [t18].[FullName]
+                //
+                @"SELECT [o.Tag.Gear.Weapons].[Id], [o.Tag.Gear.Weapons].[AmmunitionType], [o.Tag.Gear.Weapons].[IsAutomatic], [o.Tag.Gear.Weapons].[Name], [o.Tag.Gear.Weapons].[OwnerFullName], [o.Tag.Gear.Weapons].[SynergyWithId], [t18].[HasSoulPatch], [t18].[Note], [t18].[Nickname], [t18].[SquadId], [t18].[FullName]
 FROM [Weapons] AS [o.Tag.Gear.Weapons]
 LEFT JOIN (
     SELECT [www.Owner].*
@@ -1880,7 +1880,7 @@ LEFT JOIN (
 LEFT JOIN [Squads] AS [g.Squad] ON [t0].[SquadId] = [g.Squad].[Id]
 ORDER BY [t].[Note], [t0].[Nickname] DESC, [t0].[SquadId], [g.Squad].[Id]",
                 //
-                @"SELECT [t3].[Note], [t3].[Nickname], [t3].[SquadId], [t3].[Id], [g.Squad.Members].[Nickname] AS [Nickname0], [g.Squad.Members].[FullName], [g.Squad.Members].[SquadId]
+                @"SELECT [t3].[Note], [t3].[Nickname], [t3].[SquadId], [t3].[Id], [g.Squad.Members].[Nickname] AS [Nickname0], [g.Squad.Members].[SquadId], [g.Squad.Members].[FullName]
 FROM [Gears] AS [g.Squad.Members]
 INNER JOIN (
     SELECT [t1].[Note], [t2].[Nickname], [t2].[SquadId], [g.Squad0].[Id]
@@ -1931,7 +1931,7 @@ LEFT JOIN (
 LEFT JOIN [Squads] AS [w.Owner.Squad] ON [t].[SquadId] = [w.Owner.Squad].[Id]
 ORDER BY [w].[Name], [w].[Id], [w.Owner.Squad].[Id]",
                 //
-                @"SELECT [t1].[Name], [t1].[Id], [t1].[Id0], [w.Owner.Squad.Members].[FullName], [w.Owner.Squad.Members].[Rank], [w.Owner.Squad.Members].[SquadId]
+                @"SELECT [t1].[Name], [t1].[Id], [t1].[Id0], [w.Owner.Squad.Members].[Rank], [w.Owner.Squad.Members].[SquadId], [w.Owner.Squad.Members].[FullName]
 FROM [Gears] AS [w.Owner.Squad.Members]
 INNER JOIN (
     SELECT [w0].[Name], [w0].[Id], [w.Owner.Squad0].[Id] AS [Id0]
@@ -1977,7 +1977,7 @@ FROM [Gears] AS [r]
 WHERE [r].[Discriminator] IN (N'Officer', N'Gear')
 ORDER BY [r].[Nickname], [r].[SquadId], [r].[FullName]",
                 //
-                @"SELECT [t0].[Nickname], [t0].[SquadId], [t0].[FullName], [r.Weapons].[Id] AS [Id0], [w.Owner.Squad].[Id], [r.Weapons].[OwnerFullName]
+                @"SELECT [t0].[Nickname], [t0].[SquadId], [t0].[FullName], [r.Weapons].[Id], [r.Weapons].[OwnerFullName], [w.Owner.Squad].[Id]
 FROM [Weapons] AS [r.Weapons]
 LEFT JOIN (
     SELECT [w.Owner].*
@@ -2033,7 +2033,7 @@ INNER JOIN (
 WHERE [o.Reports].[Discriminator] IN (N'Officer', N'Gear')
 ORDER BY [t].[Nickname], [t].[SquadId], [o.Reports].[Nickname], [o.Reports].[SquadId], [o.Reports].[FullName]",
                 //
-                @"SELECT [t2].[Nickname], [t2].[SquadId], [t2].[Nickname0], [t2].[SquadId0], [t2].[FullName], [o.Reports.Weapons].[Id] AS [Id0], [w.Owner.Squad].[Id], [o.Reports.Weapons].[OwnerFullName]
+                @"SELECT [t2].[Nickname], [t2].[SquadId], [t2].[Nickname0], [t2].[SquadId0], [t2].[FullName], [o.Reports.Weapons].[Id], [o.Reports.Weapons].[OwnerFullName], [w.Owner.Squad].[Id]
 FROM [Weapons] AS [o.Reports.Weapons]
 LEFT JOIN (
     SELECT [w.Owner].*

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -2319,7 +2319,7 @@ ORDER BY [l2i0].[Id]");
 FROM [LevelTwo] AS [l2o]
 WHERE [l2o].[Id] = 7",
                 //
-                @"SELECT TOP(1) [l2i.OneToOne_Required_FK_Inverse].[Id], [l2i.OneToOne_Required_FK_Inverse].[Date], [l2i.OneToOne_Required_FK_Inverse].[Name], [l2i.OneToOne_Required_FK_Inverse].[OneToMany_Optional_Self_InverseId], [l2i.OneToOne_Required_FK_Inverse].[OneToMany_Required_Self_InverseId], [l2i.OneToOne_Required_FK_Inverse].[OneToOne_Optional_SelfId]
+                @"SELECT TOP(1) [l2i.OneToOne_Required_FK_Inverse].[Id], [l2i.OneToOne_Required_FK_Inverse].[Date], [l2i.OneToOne_Required_FK_Inverse].[Name], [l2i.OneToOne_Required_FK_Inverse].[OneToMany_Optional_Self_InverseId], [l2i.OneToOne_Required_FK_Inverse].[OneToMany_Required_Self_InverseId], [l2i.OneToOne_Required_FK_Inverse].[OneToOne_Optional_SelfId], 7 AS [Constant]
 FROM [LevelTwo] AS [l2i]
 INNER JOIN [LevelOne] AS [l2i.OneToOne_Required_FK_Inverse] ON [l2i].[Level1_Required_Id] = [l2i.OneToOne_Required_FK_Inverse].[Id]
 INNER JOIN [LevelOne] AS [l1i] ON [l2i].[Level1_Required_Id] = [l1i].[Id]
@@ -3129,7 +3129,7 @@ ORDER BY [t].[Id], [t].[Id0]");
             base.Project_collection_navigation_nested_anonymous();
 
             AssertSql(
-                @"SELECT [l1].[Id] AS [Id0], [l1.OneToOne_Optional_FK].[Id]
+                @"SELECT [l1].[Id], [l1.OneToOne_Optional_FK].[Id]
 FROM [LevelOne] AS [l1]
 LEFT JOIN [LevelTwo] AS [l1.OneToOne_Optional_FK] ON [l1].[Id] = [l1.OneToOne_Optional_FK].[Level1_Optional_Id]
 ORDER BY [l1].[Id], [l1.OneToOne_Optional_FK].[Id]",
@@ -3206,21 +3206,21 @@ ORDER BY [t].[Id]");
 FROM [LevelOne] AS [l]
 ORDER BY [l].[Id]",
                 //
-                @"SELECT [l.OneToMany_Optional0].[Id], [l.OneToMany_Optional0].[Date], [l.OneToMany_Optional0].[Level1_Optional_Id], [l.OneToMany_Optional0].[Level1_Required_Id], [l.OneToMany_Optional0].[Name], [l.OneToMany_Optional0].[OneToMany_Optional_InverseId], [l.OneToMany_Optional0].[OneToMany_Optional_Self_InverseId], [l.OneToMany_Optional0].[OneToMany_Required_InverseId], [l.OneToMany_Optional0].[OneToMany_Required_Self_InverseId], [l.OneToMany_Optional0].[OneToOne_Optional_PK_InverseId], [l.OneToMany_Optional0].[OneToOne_Optional_SelfId]
-FROM [LevelTwo] AS [l.OneToMany_Optional0]
-INNER JOIN (
-    SELECT [l1].[Id]
-    FROM [LevelOne] AS [l1]
-) AS [t0] ON [l.OneToMany_Optional0].[OneToMany_Optional_InverseId] = [t0].[Id]
-ORDER BY [t0].[Id]",
-                //
-                @"SELECT [l.OneToMany_Optional].[Id], [l.OneToMany_Optional].[Date], [l.OneToMany_Optional].[Level1_Optional_Id], [l.OneToMany_Optional].[Level1_Required_Id], [l.OneToMany_Optional].[Name], [l.OneToMany_Optional].[OneToMany_Optional_InverseId], [l.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l.OneToMany_Optional].[OneToMany_Required_InverseId], [l.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l.OneToMany_Optional].[OneToOne_Optional_SelfId], [t].[Id]
+                @"SELECT [l.OneToMany_Optional].[Id], [l.OneToMany_Optional].[Date], [l.OneToMany_Optional].[Level1_Optional_Id], [l.OneToMany_Optional].[Level1_Required_Id], [l.OneToMany_Optional].[Name], [l.OneToMany_Optional].[OneToMany_Optional_InverseId], [l.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l.OneToMany_Optional].[OneToMany_Required_InverseId], [l.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l.OneToMany_Optional].[OneToOne_Optional_SelfId]
 FROM [LevelTwo] AS [l.OneToMany_Optional]
 INNER JOIN (
     SELECT [l0].[Id]
     FROM [LevelOne] AS [l0]
 ) AS [t] ON [l.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
-ORDER BY [t].[Id]");
+ORDER BY [t].[Id]",
+                //
+                @"SELECT [l.OneToMany_Optional0].[Id], [l.OneToMany_Optional0].[Date], [l.OneToMany_Optional0].[Level1_Optional_Id], [l.OneToMany_Optional0].[Level1_Required_Id], [l.OneToMany_Optional0].[Name], [l.OneToMany_Optional0].[OneToMany_Optional_InverseId], [l.OneToMany_Optional0].[OneToMany_Optional_Self_InverseId], [l.OneToMany_Optional0].[OneToMany_Required_InverseId], [l.OneToMany_Optional0].[OneToMany_Required_Self_InverseId], [l.OneToMany_Optional0].[OneToOne_Optional_PK_InverseId], [l.OneToMany_Optional0].[OneToOne_Optional_SelfId], [t0].[Id]
+FROM [LevelTwo] AS [l.OneToMany_Optional0]
+INNER JOIN (
+    SELECT [l1].[Id]
+    FROM [LevelOne] AS [l1]
+) AS [t0] ON [l.OneToMany_Optional0].[OneToMany_Optional_InverseId] = [t0].[Id]
+ORDER BY [t0].[Id]");
         }
 
         public override void Project_navigation_and_collection()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -3920,7 +3920,7 @@ WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'Locust
             base.Project_collection_navigation_with_inheritance1();
 
             AssertSql(
-                @"SELECT [h].[Id] AS [Id0], [t0].[Id]
+                @"SELECT [h].[Id], [t0].[Id]
 FROM [Factions] AS [h]
 LEFT JOIN (
     SELECT [h.Commander].*
@@ -4646,7 +4646,28 @@ FROM [Gears] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[Nickname] <> N'Marcus')
 ORDER BY [g].[Nickname], [g].[SquadId], [g].[FullName]",
                 //
-                @"SELECT [t].[Nickname], [t].[SquadId], [t].[FullName], [g.Weapons].[OwnerFullName]
+                @"SELECT [t].[Nickname], [t].[SquadId], [t].[FullName], N'BFG', [g.Weapons].[OwnerFullName]
+FROM [Weapons] AS [g.Weapons]
+INNER JOIN (
+    SELECT [g0].[Nickname], [g0].[SquadId], [g0].[FullName]
+    FROM [Gears] AS [g0]
+    WHERE [g0].[Discriminator] IN (N'Officer', N'Gear') AND ([g0].[Nickname] <> N'Marcus')
+) AS [t] ON [g.Weapons].[OwnerFullName] = [t].[FullName]
+WHERE ([g.Weapons].[IsAutomatic] = 1) OR (([g.Weapons].[Name] <> N'foo') OR [g.Weapons].[Name] IS NULL)
+ORDER BY [t].[Nickname], [t].[SquadId], [t].[FullName]");
+        }
+
+        public override void Correlated_collections_basic_projecting_constant_bool()
+        {
+            base.Correlated_collections_basic_projecting_constant_bool();
+
+            AssertSql(
+                @"SELECT [g].[FullName]
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[Nickname] <> N'Marcus')
+ORDER BY [g].[Nickname], [g].[SquadId], [g].[FullName]",
+                //
+                @"SELECT [t].[Nickname], [t].[SquadId], [t].[FullName], CAST(1 AS bit), [g.Weapons].[OwnerFullName]
 FROM [Weapons] AS [g.Weapons]
 INNER JOIN (
     SELECT [g0].[Nickname], [g0].[SquadId], [g0].[FullName]
@@ -4710,7 +4731,7 @@ ORDER BY [t].[Id]");
 FROM [Squads] AS [s]
 ORDER BY [s].[Id]",
                 //
-                @"SELECT [t].[Id], [m.Mission].[Id], [s.Missions].[SquadId]
+                @"SELECT [t].[Id], [s.Missions].[SquadId], [m.Mission].[Id]
 FROM [SquadMissions] AS [s.Missions]
 INNER JOIN [Missions] AS [m.Mission] ON [s.Missions].[MissionId] = [m.Mission].[Id]
 INNER JOIN (
@@ -4987,7 +5008,7 @@ ORDER BY [t0].[FullName], [t0].[Nickname], [t0].[SquadId], [o.Reports].[FullName
             base.Correlated_collections_multiple_nested_complex_collections();
 
             AssertSql(
-                @"SELECT [o].[FullName] AS [FullName0], [o].[Nickname], [o].[SquadId], [t].[FullName]
+                @"SELECT [o].[FullName], [o].[Nickname], [o].[SquadId], [t].[FullName]
 FROM [Gears] AS [o]
 LEFT JOIN [Tags] AS [o.Tag] ON ([o].[Nickname] = [o.Tag].[GearNickName]) AND ([o].[SquadId] = [o.Tag].[GearSquadId])
 LEFT JOIN (
@@ -5020,7 +5041,7 @@ INNER JOIN (
 WHERE [o.Reports].[Discriminator] IN (N'Officer', N'Gear') AND ([o.Reports].[FullName] <> N'Foo')
 ORDER BY [t1].[HasSoulPatch] DESC, [t1].[Note], [t1].[Nickname], [t1].[SquadId], [o.Reports].[Rank], [o.Reports].[Nickname], [o.Reports].[SquadId], [o.Reports].[FullName]",
                 //
-                @"SELECT [t5].[HasSoulPatch], [t5].[Note], [t5].[Nickname], [t5].[SquadId], [t5].[Rank], [t5].[Nickname0], [t5].[SquadId0], [t5].[FullName], [o.Reports.Weapons].[Id] AS [Id0], [t2].[FullName], [w.Owner.Squad].[Id], [o.Reports.Weapons].[OwnerFullName]
+                @"SELECT [t5].[HasSoulPatch], [t5].[Note], [t5].[Nickname], [t5].[SquadId], [t5].[Rank], [t5].[Nickname0], [t5].[SquadId0], [t5].[FullName], [o.Reports.Weapons].[Id], [o.Reports.Weapons].[OwnerFullName], [t2].[FullName], [w.Owner.Squad].[Id]
 FROM [Weapons] AS [o.Reports.Weapons]
 LEFT JOIN (
     SELECT [w.Owner].*
@@ -5547,7 +5568,7 @@ LEFT JOIN (
 LEFT JOIN [Squads] AS [g.Squad] ON [t0].[SquadId] = [g.Squad].[Id]
 ORDER BY [t].[Note], [t0].[Nickname] DESC, [t0].[SquadId], [g.Squad].[Id]",
                 //
-                @"SELECT [t3].[Note], [t3].[Nickname], [t3].[SquadId], [t3].[Id], [g.Squad.Members].[Nickname] AS [Nickname0], [g.Squad.Members].[FullName], [g.Squad.Members].[SquadId]
+                @"SELECT [t3].[Note], [t3].[Nickname], [t3].[SquadId], [t3].[Id], [g.Squad.Members].[Nickname] AS [Nickname0], [g.Squad.Members].[SquadId], [g.Squad.Members].[FullName]
 FROM [Gears] AS [g.Squad.Members]
 INNER JOIN (
     SELECT [t1].[Note], [t2].[Nickname], [t2].[SquadId], [g.Squad0].[Id]
@@ -5598,7 +5619,7 @@ LEFT JOIN (
 LEFT JOIN [Squads] AS [w.Owner.Squad] ON [t].[SquadId] = [w.Owner.Squad].[Id]
 ORDER BY [w].[Name], [w].[Id], [w.Owner.Squad].[Id]",
                 //
-                @"SELECT [t1].[Name], [t1].[Id], [t1].[Id0], [w.Owner.Squad.Members].[FullName], [w.Owner.Squad.Members].[Rank], [w.Owner.Squad.Members].[SquadId]
+                @"SELECT [t1].[Name], [t1].[Id], [t1].[Id0], [w.Owner.Squad.Members].[Rank], [w.Owner.Squad.Members].[SquadId], [w.Owner.Squad.Members].[FullName]
 FROM [Gears] AS [w.Owner.Squad.Members]
 INNER JOIN (
     SELECT [w0].[Name], [w0].[Id], [w.Owner.Squad0].[Id] AS [Id0]
@@ -5644,7 +5665,7 @@ FROM [Gears] AS [r]
 WHERE [r].[Discriminator] IN (N'Officer', N'Gear')
 ORDER BY [r].[Nickname], [r].[SquadId], [r].[FullName]",
                 //
-                @"SELECT [t0].[Nickname], [t0].[SquadId], [t0].[FullName], [r.Weapons].[Id] AS [Id0], [w.Owner.Squad].[Id], [r.Weapons].[OwnerFullName]
+                @"SELECT [t0].[Nickname], [t0].[SquadId], [t0].[FullName], [r.Weapons].[Id], [r.Weapons].[OwnerFullName], [w.Owner.Squad].[Id]
 FROM [Weapons] AS [r.Weapons]
 LEFT JOIN (
     SELECT [w.Owner].*
@@ -5700,7 +5721,7 @@ INNER JOIN (
 WHERE [o.Reports].[Discriminator] IN (N'Officer', N'Gear')
 ORDER BY [t].[Nickname], [t].[SquadId], [o.Reports].[Nickname], [o.Reports].[SquadId], [o.Reports].[FullName]",
                 //
-                @"SELECT [t2].[Nickname], [t2].[SquadId], [t2].[Nickname0], [t2].[SquadId0], [t2].[FullName], [o.Reports.Weapons].[Id] AS [Id0], [w.Owner.Squad].[Id], [o.Reports.Weapons].[OwnerFullName]
+                @"SELECT [t2].[Nickname], [t2].[SquadId], [t2].[Nickname0], [t2].[SquadId0], [t2].[FullName], [o.Reports.Weapons].[Id], [o.Reports.Weapons].[OwnerFullName], [w.Owner.Squad].[Id]
 FROM [Weapons] AS [o.Reports.Weapons]
 LEFT JOIN (
     SELECT [w.Owner].*
@@ -6513,6 +6534,165 @@ WHERE ([s].[Name] = N'Kilo') AND (COALESCE((
     FROM [Gears] AS [m]
     WHERE ([m].[Discriminator] IN (N'Officer', N'Gear') AND ([m].[HasSoulPatch] = 1)) AND ([s].[Id] = [m].[SquadId])
 ), 0) <> 0)");
+        }
+
+        public override void Select_subquery_projecting_single_constant_int()
+        {
+            base.Select_subquery_projecting_single_constant_int();
+
+            AssertSql(
+                @"SELECT [s].[Name], COALESCE((
+    SELECT TOP(1) 42
+    FROM [Gears] AS [g]
+    WHERE ([g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 1)) AND ([s].[Id] = [g].[SquadId])
+), 0) AS [Gear]
+FROM [Squads] AS [s]");
+        }
+
+        public override void Select_subquery_projecting_single_constant_string()
+        {
+            base.Select_subquery_projecting_single_constant_string();
+
+            AssertSql(
+                @"SELECT [s].[Name], (
+    SELECT TOP(1) N'Foo'
+    FROM [Gears] AS [g]
+    WHERE ([g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 1)) AND ([s].[Id] = [g].[SquadId])
+) AS [Gear]
+FROM [Squads] AS [s]");
+        }
+
+        public override void Select_subquery_projecting_single_constant_bool()
+        {
+            base.Select_subquery_projecting_single_constant_bool();
+
+            AssertSql(
+                @"SELECT [s].[Name], CAST(COALESCE((
+    SELECT TOP(1) CAST(1 AS bit)
+    FROM [Gears] AS [g]
+    WHERE ([g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 1)) AND ([s].[Id] = [g].[SquadId])
+), 0) AS bit) AS [Gear]
+FROM [Squads] AS [s]");
+        }
+
+        public override void Select_subquery_projecting_single_constant_inside_anonymous()
+        {
+            base.Select_subquery_projecting_single_constant_inside_anonymous();
+
+            AssertSql(
+                @"SELECT [s].[Name], [s].[Id]
+FROM [Squads] AS [s]",
+                //
+                @"@_outer_Id='1'
+
+SELECT TOP(1) 1
+FROM [Gears] AS [g]
+WHERE ([g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 1)) AND (@_outer_Id = [g].[SquadId])",
+                //
+                @"@_outer_Id='2'
+
+SELECT TOP(1) 1
+FROM [Gears] AS [g]
+WHERE ([g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 1)) AND (@_outer_Id = [g].[SquadId])");
+        }
+
+        public override void Select_subquery_projecting_multiple_constants_inside_anonymous()
+        {
+            base.Select_subquery_projecting_multiple_constants_inside_anonymous();
+
+            AssertSql(
+                @"SELECT [s].[Name], [s].[Id]
+FROM [Squads] AS [s]",
+                //
+                @"@_outer_Id='1'
+
+SELECT TOP(1) 1
+FROM [Gears] AS [g]
+WHERE ([g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 1)) AND (@_outer_Id = [g].[SquadId])",
+                //
+                @"@_outer_Id='2'
+
+SELECT TOP(1) 1
+FROM [Gears] AS [g]
+WHERE ([g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 1)) AND (@_outer_Id = [g].[SquadId])");
+        }
+
+        public override void Include_with_order_by_constant()
+        {
+            base.Include_with_order_by_constant();
+
+            AssertSql(
+                @"SELECT [s].[Id], [s].[InternalNumber], [s].[Name]
+FROM [Squads] AS [s]
+ORDER BY (SELECT 1), [s].[Id]",
+                //
+                @"SELECT [s.Members].[Nickname], [s.Members].[SquadId], [s.Members].[AssignedCityName], [s.Members].[CityOrBirthName], [s.Members].[Discriminator], [s.Members].[FullName], [s.Members].[HasSoulPatch], [s.Members].[LeaderNickname], [s.Members].[LeaderSquadId], [s.Members].[Rank]
+FROM [Gears] AS [s.Members]
+INNER JOIN (
+    SELECT [s0].[Id], 42 AS [c]
+    FROM [Squads] AS [s0]
+) AS [t] ON [s.Members].[SquadId] = [t].[Id]
+WHERE [s.Members].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [t].[c], [t].[Id]");
+        }
+
+        public override void Include_groupby_constant()
+        {
+            base.Include_groupby_constant();
+
+            AssertSql(
+                @"SELECT [s].[Id], [s].[InternalNumber], [s].[Name]
+FROM [Squads] AS [s]
+ORDER BY (SELECT 1), [s].[Id]",
+                //
+                @"SELECT [s.Members].[Nickname], [s.Members].[SquadId], [s.Members].[AssignedCityName], [s.Members].[CityOrBirthName], [s.Members].[Discriminator], [s.Members].[FullName], [s.Members].[HasSoulPatch], [s.Members].[LeaderNickname], [s.Members].[LeaderSquadId], [s.Members].[Rank]
+FROM [Gears] AS [s.Members]
+INNER JOIN (
+    SELECT [s0].[Id], 1 AS [c]
+    FROM [Squads] AS [s0]
+) AS [t] ON [s.Members].[SquadId] = [t].[Id]
+WHERE [s.Members].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [t].[c], [t].[Id]");
+        }
+
+        public override void Correlated_collection_order_by_constant()
+        {
+            base.Correlated_collection_order_by_constant();
+
+            AssertSql(
+                @"SELECT [s].[Nickname], [s].[FullName]
+FROM [Gears] AS [s]
+WHERE [s].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY (SELECT 1) DESC, [s].[Nickname], [s].[SquadId], [s].[FullName]",
+                //
+                @"SELECT [t].[c], [t].[Nickname], [t].[SquadId], [t].[FullName], [s.Weapons].[Name], [s.Weapons].[OwnerFullName]
+FROM [Weapons] AS [s.Weapons]
+INNER JOIN (
+    SELECT 1 AS [c], [s0].[Nickname], [s0].[SquadId], [s0].[FullName]
+    FROM [Gears] AS [s0]
+    WHERE [s0].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON [s.Weapons].[OwnerFullName] = [t].[FullName]
+ORDER BY [t].[c] DESC, [t].[Nickname], [t].[SquadId], [t].[FullName]");
+        }
+
+        public override void GroupBy_composite_key_with_Include()
+        {
+            base.GroupBy_composite_key_with_Include();
+
+            AssertSql(
+                @"SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOrBirthName], [o].[Discriminator], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank]
+FROM [Gears] AS [o]
+WHERE [o].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [o].[Rank], (SELECT 1), [o].[Nickname], [o].[FullName]",
+                //
+                @"SELECT [o.Weapons].[Id], [o.Weapons].[AmmunitionType], [o.Weapons].[IsAutomatic], [o.Weapons].[Name], [o.Weapons].[OwnerFullName], [o.Weapons].[SynergyWithId]
+FROM [Weapons] AS [o.Weapons]
+INNER JOIN (
+    SELECT [o0].[FullName], [o0].[Rank], 1 AS [c], [o0].[Nickname]
+    FROM [Gears] AS [o0]
+    WHERE [o0].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t] ON [o.Weapons].[OwnerFullName] = [t].[FullName]
+ORDER BY [t].[Rank], [t].[c], [t].[Nickname], [t].[FullName]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
@@ -874,6 +874,18 @@ FROM [Customers] AS [c]");
 END
 FROM [Customers] AS [c]");
         }
+
+        public override void Select_bool_constant()
+        {
+            base.Select_bool_constant();
+
+            AssertSql(
+                @"SELECT CASE
+    WHEN [c].[CustomerID] = N'ALFKI'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END
+FROM [Customers] AS [c]");
+        }
 #endif
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -2263,7 +2263,7 @@ FROM [Customers] AS [c2]");
             base.Select_DTO_distinct_translated_to_server();
 
             AssertSql(
-                @"SELECT DISTINCT 1
+                @"SELECT 1
 FROM [Orders] AS [o]
 WHERE [o].[OrderID] < 10300");
         }


### PR DESCRIPTION
Also fixes related issues:
#10946 - ArgumentOutOfRangeException when ordering by a constant in collection include
#11525 - Query: order by anonymous object is silently ignored

Problem was that when a constant was part of the projection, we were never incorporating it into the SQL, but rather materialize it on the client. This is incorrect in case of subquery, since other queries could depend on that constant projection.
Example is include collection with order by a constant - as part of include rewrite we generate a subquery whose projection consists of all the orderings from the outer query, and the collection query is ordered by the elements in the projection. Since before constants were not translated into sql, the resulting query was incorrect, trying to order by element that didnt exist.

Fix is to incorporate projected constants into SQL in case of a subquery. Constant projections of outermost queries are still materialized on the client to avoid transferring large amounts of data over from the database.

Also improved experience for queries ordered by an anonymous object. Before, in some cases those were ignored, in some cases they were producing incorrect queries. Now, we will issue a warning explaining to use OrderBy + ThenBy instead, as well as make it work consistently for all scenarios.