### PR TITLE
Fix #11101 - The value can not be NULL. Parameter name: entityType

### DIFF
--- a/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
@@ -29,13 +29,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         internal string DebugView => ToString();
 #endif
 
-        private readonly RelationalQueryCompilationContext _queryCompilationContext;
         private readonly List<Expression> _projection = new List<Expression>();
         private readonly List<TableExpressionBase> _tables = new List<TableExpressionBase>();
         private readonly List<Ordering> _orderBy = new List<Ordering>();
         private readonly Dictionary<MemberInfo, Expression> _memberInfoProjectionMapping = new Dictionary<MemberInfo, Expression>();
         private readonly List<Expression> _starProjection = new List<Expression>();
         private readonly List<Expression> _groupBy = new List<Expression>();
+
+        // NB: Currently unsafe to access this outside of compiler. #11601
+        private RelationalQueryCompilationContext _queryCompilationContext;
 
         private Expression _limit;
         private Expression _offset;
@@ -78,6 +80,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             // When assigning alias to select expression make it unique
             // ReSharper disable once VirtualMemberCallInConstructor
             Alias = queryCompilationContext.CreateUniqueTableAlias(alias);
+        }
+
+        internal void DetachContext()
+        {
+            // TODO: Remove dependency on QCC. #11601
+            _queryCompilationContext = null;
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -303,6 +303,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
             _valueConverterWarningsEnabled = oldValueConverterWarningsEnabled;
 
+            selectExpression.DetachContext();
+
             return selectExpression;
         }
 

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -53,6 +53,63 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void Multiple_context_instances()
+        {
+            using (var context1 = CreateContext())
+            {
+                using (var context2 = CreateContext())
+                {
+                    Assert.Equal(
+                        CoreStrings.ErrorInvalidQueryable,
+                        Assert.Throws<InvalidOperationException>(
+                            () =>
+                                (from c in context1.Customers
+                                 from o in context2.Set<Order>()
+                                 select c).First()).Message);
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Multiple_context_instances_set()
+        {
+            using (var context1 = CreateContext())
+            {
+                using (var context2 = CreateContext())
+                {
+                    var set = context2.Orders;
+
+                    Assert.Equal(
+                        CoreStrings.ErrorInvalidQueryable,
+                        Assert.Throws<InvalidOperationException>(
+                            () => (from c in context1.Customers
+                                   from o in set
+                                   select c).First()).Message);
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Multiple_context_instances_parameter()
+        {
+            using (var context1 = CreateContext())
+            {
+                using (var context2 = CreateContext())
+                {
+                    Customer Query(NorthwindContext c2) =>
+                        (from c in context1.Customers
+                         from o in c2.Orders
+                         select c).First();
+
+                    Assert.Equal(
+                        CoreStrings.ErrorInvalidQueryable,
+                        Assert.Throws<InvalidOperationException>(
+                            () => Query(context2)).Message);
+                }
+            }
+        }
+
+        [ConditionalFact]
         public virtual void Query_when_evaluatable_queryable_method_call_with_repository()
         {
             using (var context = CreateContext())

--- a/src/EFCore/Extensions/Internal/DbContextDependenciesExtensions.cs
+++ b/src/EFCore/Extensions/Internal/DbContextDependenciesExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 
 // ReSharper disable once CheckNamespace
@@ -20,6 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This should only be called from <see cref="InternalDbSet{TEntity}"/> as it is created
         ///     before the context is initialized
         /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static IDbContextDependencies GetDependencies([NotNull] this IDbContextDependencies context)
             => context;
 
@@ -27,6 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static IDbContextDependencies GetDependencies([NotNull] this ICurrentDbContext context)
             => context.Context;
     }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2644,6 +2644,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 GetString("AmbiguousServiceProperty", nameof(property), nameof(serviceType), nameof(entityType)),
                 property, serviceType, entityType);
 
+        /// <summary>
+        ///     Cannot use multiple DbContext instances within a single query execution. Ensure the query uses a single context instance.
+        /// </summary>
+        public static string ErrorInvalidQueryable
+            => GetString("ErrorInvalidQueryable");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1071,4 +1071,7 @@
   <data name="AmbiguousServiceProperty" xml:space="preserve">
     <value>The service property '{property}' of type '{serviceType}' cannot be added to the entity type '{entityType}' because there is another property of the same type. Ignore one of the properties using the NotMappedAttribute or 'EntityTypeBuilder.Ignore' in 'OnModelCreating'.</value>
   </data>
+  <data name="ErrorInvalidQueryable" xml:space="preserve">
+    <value>Cannot use multiple DbContext instances within a single query execution. Ensure the query uses a single context instance.</value>
+  </data>
 </root>

--- a/src/EFCore/Query/ExpressionVisitors/Internal/ModelExpressionApplyingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/ModelExpressionApplyingExpressionVisitor.cs
@@ -114,7 +114,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                                         _queryCompilationContext.Logger,
                                         query.Body,
                                         _parameters,
-                                        _queryCompilationContext.ContextType,
                                         parameterize: false,
                                         generateContextAccessors: true);
 
@@ -133,7 +132,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                                     _queryCompilationContext.Logger,
                                     entityType.QueryFilter,
                                     _parameters,
-                                    _queryCompilationContext.ContextType,
                                     parameterize: false,
                                     generateContextAccessors: true);
 

--- a/src/EFCore/Query/Internal/IQueryModelGenerator.cs
+++ b/src/EFCore/Query/Internal/IQueryModelGenerator.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -29,7 +28,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger,
             [NotNull] Expression query,
             [NotNull] IParameterValues parameterValues,
-            [NotNull] Type contextType,
             bool parameterize = true,
             bool generateContextAccessors = false);
     }

--- a/src/EFCore/Query/Internal/QueryCompiler.cs
+++ b/src/EFCore/Query/Internal/QueryCompiler.cs
@@ -82,7 +82,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             var queryContext = _queryContextFactory.Create();
 
-            query = _queryModelGenerator.ExtractParameters(_logger, query, queryContext, _contextType);
+            query = _queryModelGenerator.ExtractParameters(_logger, query, queryContext);
 
             var compiledQuery
                 = _compiledQueryCache
@@ -102,7 +102,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             Check.NotNull(query, nameof(query));
 
             query = _queryModelGenerator.ExtractParameters(
-                _logger, query, _queryContextFactory.Create(), _contextType,  parameterize: false);
+                _logger, query, _queryContextFactory.Create(),  parameterize: false);
 
             return CompileQueryCore<TResult>(query, _queryModelGenerator, _database, _logger, _contextType);
         }
@@ -164,7 +164,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             var queryContext = _queryContextFactory.Create();
 
-            query = _queryModelGenerator.ExtractParameters(_logger, query, queryContext, _contextType);
+            query = _queryModelGenerator.ExtractParameters(_logger, query, queryContext);
 
             return CompileAsyncQuery<TResult>(query)(queryContext);
         }
@@ -179,7 +179,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             Check.NotNull(query, nameof(query));
 
             query = _queryModelGenerator.ExtractParameters(
-                _logger, query, _queryContextFactory.Create(), _contextType, parameterize: false);
+                _logger, query, _queryContextFactory.Create(), parameterize: false);
 
             return CompileAsyncQueryCore<TResult>(query, _queryModelGenerator, _database);
         }
@@ -193,7 +193,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             Check.NotNull(query, nameof(query));
 
             query = _queryModelGenerator.ExtractParameters(
-                _logger, query, _queryContextFactory.Create(), _contextType, parameterize: false);
+                _logger, query, _queryContextFactory.Create(), parameterize: false);
 
             var compiledQuery = CompileAsyncQueryCore<TResult>(query, _queryModelGenerator, _database);
 
@@ -217,7 +217,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             queryContext.CancellationToken = cancellationToken;
 
-            query = _queryModelGenerator.ExtractParameters(_logger, query, queryContext, _contextType);
+            query = _queryModelGenerator.ExtractParameters(_logger, query, queryContext);
 
             var compiledQuery = CompileAsyncQuery<TResult>(query);
 

--- a/src/EFCore/Query/Internal/QueryModelGenerator.cs
+++ b/src/EFCore/Query/Internal/QueryModelGenerator.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Remotion.Linq;
@@ -23,6 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
     {
         private readonly INodeTypeProvider _nodeTypeProvider;
         private readonly IEvaluatableExpressionFilter _evaluatableExpressionFilter;
+        private readonly ICurrentDbContext _currentDbContext;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -30,13 +32,16 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         /// </summary>
         public QueryModelGenerator(
             [NotNull] INodeTypeProviderFactory nodeTypeProviderFactory,
-            [NotNull] IEvaluatableExpressionFilter evaluatableExpressionFilter)
+            [NotNull] IEvaluatableExpressionFilter evaluatableExpressionFilter,
+            [NotNull] ICurrentDbContext currentDbContext)
         {
             Check.NotNull(nodeTypeProviderFactory, nameof(nodeTypeProviderFactory));
             Check.NotNull(evaluatableExpressionFilter, nameof(evaluatableExpressionFilter));
+            Check.NotNull(currentDbContext, nameof(currentDbContext));
 
             _nodeTypeProvider = nodeTypeProviderFactory.Create();
             _evaluatableExpressionFilter = evaluatableExpressionFilter;
+            _currentDbContext = currentDbContext;
         }
 
         /// <summary>
@@ -47,7 +52,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             IDiagnosticsLogger<DbLoggerCategory.Query> logger,
             Expression query,
             IParameterValues parameterValues,
-            Type contextType,
             bool parameterize = true,
             bool generateContextAccessors = false)
         {
@@ -56,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     _evaluatableExpressionFilter,
                     parameterValues,
                     logger,
-                    contextType,
+                    _currentDbContext.Context,
                     parameterize,
                     generateContextAccessors);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;


### PR DESCRIPTION
- Validate that a query only uses a single EF IQueryProvider instance.


