### PR TITLE
Fix lifetime of IRelationalCommandBuilderFactory in test

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/ExecutionStrategyTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ExecutionStrategyTest.cs
@@ -579,7 +579,7 @@ namespace Microsoft.EntityFrameworkCore
                 return base.AddServices(serviceCollection)
                     .AddSingleton<IRelationalTransactionFactory, TestRelationalTransactionFactory>()
                     .AddScoped<ISqlServerConnection, TestSqlServerConnection>()
-                    .AddScoped<IRelationalCommandBuilderFactory, TestRelationalCommandBuilderFactory>();
+                    .AddSingleton<IRelationalCommandBuilderFactory, TestRelationalCommandBuilderFactory>();
             }
 
             public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)


### PR DESCRIPTION
We fixed validation in DI and it found misconfigured service lifetime:
```
Cannot consume scoped service 'Microsoft.EntityFrameworkCore.Storage.IRelationalCommandBuilderFactory' from singleton 'Microsoft.EntityFrameworkCore.Query.Sql.QuerySqlGeneratorDependencies'.
```