### PR TITLE
Allow duplicate values for unique indexes.

### DIFF
--- a/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
+++ b/src/EFCore.Relational/Properties/RelationalStrings.Designer.cs
@@ -985,22 +985,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
                     _resourceManager.GetString("LogMigrationAttributeMissingWarning")));
 
         /// <summary>
-        ///     There are multiple entities of type '{entityType}' that had the same value for the unique index {index}. Configure the index as non-unique if duplicates should be allowed. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the values.
-        /// </summary>
-        public static string DuplicateUniqueIndexValuesRemoved([CanBeNull] object entityType, [CanBeNull] object index)
-            => string.Format(
-                GetString("DuplicateUniqueIndexValuesRemoved", nameof(entityType), nameof(index)),
-                entityType, index);
-
-        /// <summary>
-        ///     The entities of type '{entityType}' with key values {firstKeyValues} and {secondKeyValues} had the same value for the unique index {indexValue}. Configure the index as non-unique if duplicates should be allowed.
-        /// </summary>
-        public static string DuplicateUniqueIndexValuesRemovedSensitive([CanBeNull] object entityType, [CanBeNull] object firstKeyValues, [CanBeNull] object secondKeyValues, [CanBeNull] object indexValue)
-            => string.Format(
-                GetString("DuplicateUniqueIndexValuesRemovedSensitive", nameof(entityType), nameof(firstKeyValues), nameof(secondKeyValues), nameof(indexValue)),
-                entityType, firstKeyValues, secondKeyValues, indexValue);
-
-        /// <summary>
         ///     A SQL parameter or literal was generated for the type '{type}' using the ValueConverter '{valueConverter}'. Review the generated SQL for correctness and consider evaluating the target expression in-memory instead.
         /// </summary>
         public static readonly EventDefinition<object, object> LogValueConversionSqlLiteralWarning

--- a/src/EFCore.Relational/Properties/RelationalStrings.resx
+++ b/src/EFCore.Relational/Properties/RelationalStrings.resx
@@ -473,14 +473,8 @@
     <value>A MigrationAttribute isn't specified on the '{class}' class.</value>
     <comment>Warning RelationalEventId.MigrationAttributeMissingWarning string</comment>
   </data>
-  <data name="DuplicateUniqueIndexValuesRemoved" xml:space="preserve">
-    <value>There are multiple entities of type '{entityType}' that had the same value for the unique index {index}. Configure the index as non-unique if duplicates should be allowed. Consider using 'DbContextOptionsBuilder.EnableSensitiveDataLogging' to see the values.</value>
-  </data>
-  <data name="DuplicateUniqueIndexValuesRemovedSensitive" xml:space="preserve">
-    <value>The entities of type '{entityType}' with key values {firstKeyValues} and {secondKeyValues} had the same value for the unique index {indexValue}. Configure the index as non-unique if duplicates should be allowed.</value>
-  </data>
-  <data name="LogValueConversionSqlLiteralWarning" xml:space="preserve"> 
-    <value>A SQL parameter or literal was generated for the type '{type}' using the ValueConverter '{valueConverter}'. Review the generated SQL for correctness and consider evaluating the target expression in-memory instead.</value> 
-    <comment>Warning RelationalEventId.ValueConversionSqlLiteralWarning object object</comment> 
+  <data name="LogValueConversionSqlLiteralWarning" xml:space="preserve">
+    <value>A SQL parameter or literal was generated for the type '{type}' using the ValueConverter '{valueConverter}'. Review the generated SQL for correctness and consider evaluating the target expression in-memory instead.</value>
+    <comment>Warning RelationalEventId.ValueConversionSqlLiteralWarning object object</comment>
   </data>
 </root>

--- a/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
+++ b/src/EFCore.Relational/Update/Internal/CommandBatchPreparer.cs
@@ -693,8 +693,8 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                         }
 
                         var valueFactory = index.GetNullableValueFactory<object[]>();
-                        if (valueFactory.TryCreateFromOriginalValues((InternalEntityEntry)entry,
-                            out var indexValue))
+                        if (valueFactory.TryCreateFromOriginalValues(
+                            (InternalEntityEntry)entry, out var indexValue))
                         {
                             predecessorsMap = predecessorsMap ??
                                               new Dictionary<IIndex, Dictionary<object[], ModificationCommand>>();
@@ -704,28 +704,10 @@ namespace Microsoft.EntityFrameworkCore.Update.Internal
                                     new Dictionary<object[], ModificationCommand>(valueFactory.EqualityComparer);
                                 predecessorsMap.Add(index, predecessorCommands);
                             }
-                            if (predecessorCommands.TryGetValue(indexValue, out var duplicateCommand))
+                            if (!predecessorCommands.ContainsKey(indexValue))
                             {
-                                if (_sensitiveLoggingEnabled)
-                                {
-                                    var duplicateEntry = duplicateCommand.Entries
-                                        .First(e => index.DeclaringEntityType.IsAssignableFrom(e.EntityType));
-                                    throw new InvalidOperationException(
-                                        RelationalStrings.DuplicateUniqueIndexValuesRemovedSensitive(
-                                            entry.EntityType.DisplayName(),
-                                            entry.BuildOriginalValuesString(
-                                                entry.EntityType.FindPrimaryKey().Properties),
-                                            duplicateEntry.BuildOriginalValuesString(
-                                                duplicateEntry.EntityType.FindPrimaryKey().Properties),
-                                            entry.BuildOriginalValuesString(index.Properties)));
-                                }
-
-                                throw new InvalidOperationException(
-                                    RelationalStrings.DuplicateUniqueIndexValuesRemoved(
-                                        entry.EntityType.DisplayName(),
-                                        Property.Format(index.Properties)));
+                                predecessorCommands.Add(indexValue, command);
                             }
-                            predecessorCommands.Add(indexValue, command);
                         }
                     }
                 }


### PR DESCRIPTION
Only the first command will be used to determine batch dependencies. This will work fine unless there are other unique index or foreign key dependencies between the involved commands.

Fixes #11505 
