### PR TITLE
Increase test column size to accommodate base64 data

### DIFF
--- a/src/EFCore.Specification.Tests/ConvertToProviderTypesTestBase.cs
+++ b/src/EFCore.Specification.Tests/ConvertToProviderTypesTestBase.cs
@@ -154,7 +154,7 @@ namespace Microsoft.EntityFrameworkCore
                         b.Property(e => e.String3).HasConversion<byte[]>();
                         b.Property(e => e.String9000).HasConversion<byte[]>();
                         b.Property(e => e.ByteArray5).HasConversion<string>().HasMaxLength(8);
-                        b.Property(e => e.ByteArray9000).HasConversion<string>();
+                        b.Property(e => e.ByteArray9000).HasConversion<string>().HasMaxLength(LongStringLength * 2);
                     });
             }
         }

--- a/src/EFCore.Specification.Tests/CustomConvertersTestBase.cs
+++ b/src/EFCore.Specification.Tests/CustomConvertersTestBase.cs
@@ -409,8 +409,10 @@ namespace Microsoft.EntityFrameworkCore
                                     v => v.Reverse().Skip(2).ToArray()))
                             .HasMaxLength(7);
 
-                        b.Property(e => e.ByteArray9000).HasConversion(
-                            BytesToStringConverter.DefaultInfo.Create());
+                        b.Property(e => e.ByteArray9000)
+                            .HasConversion(
+                                BytesToStringConverter.DefaultInfo.Create())
+                            .HasMaxLength(LongStringLength * 2);
                     });
 
                 modelBuilder.Entity<StringListDataType>(b =>


### PR DESCRIPTION
While implementing some missing tests in Npgsql, `ConvertToProvider.Can_insert_and_read_with_max_length_set()`failed. After some investigation, it turns out that it's trying to insert the 9000-long `ByteArray9000` field into a database string column (converting with base64), but the database field is a `varchar(9000)` (BuiltInDataTypesFixtureBase sets MaxLength to LongStringLength). However, the base64 representation of the 9000 bytes ends up being more than 9000 characters, but the column is limited to 9000.

I'm guessing that on SQL Server the column's type is `varchar(max)`, so the limit doesn't actually get enforced. This PR doubles the character capacity of the column.