### PR TITLE
Don't mark as modified the PK overlapping FK portion when using navigation entries.

### DIFF
--- a/src/EFCore/ChangeTracking/NavigationEntry.cs
+++ b/src/EFCore/ChangeTracking/NavigationEntry.cs
@@ -239,9 +239,14 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
         private void SetFkPropertiesModified(InternalEntityEntry internalEntityEntry, bool modified)
         {
+            var anyNonPk = Metadata.ForeignKey.Properties.Any(p => !p.IsPrimaryKey());
             foreach (var property in Metadata.ForeignKey.Properties)
             {
-                internalEntityEntry.SetPropertyModified(property, isModified: modified);
+                if (anyNonPk
+                    && !property.IsPrimaryKey())
+                {
+                    internalEntityEntry.SetPropertyModified(property, isModified: modified);
+                }
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/CompositeKeyEndToEndTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/CompositeKeyEndToEndTest.cs
@@ -9,6 +9,7 @@ using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore
 {
     public class CompositeKeyEndToEndTest : IDisposable


### PR DESCRIPTION
Fixes #10449
