### PR TITLE
Fix #11033 - Issue when using EFCore with Automapper's ProjectTo and Unions

### DIFF
--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
@@ -19,6 +19,42 @@ namespace Microsoft.EntityFrameworkCore.Query
     public abstract partial class SimpleQueryTestBase<TFixture>
     {
         [ConditionalFact]
+        public virtual void Union_with_custom_projection()
+        {
+            AssertQuery<Customer>(
+                cs => cs.Where(c => c.CompanyName.StartsWith("A"))
+                    .Union(cs.Where(c => c.CompanyName.StartsWith("B")))
+                    .Select(
+                        c => new CustomerDeets
+                        {
+                            Id = c.CustomerID
+                        }));
+        }
+
+        public class CustomerDeets
+        {
+            public string Id { get; set; }
+
+            public override bool Equals(object obj)
+            {
+                if (obj is null)
+                {
+                    return false;
+                }
+
+                if (ReferenceEquals(this, obj))
+                {
+                    return true;
+                }
+
+                return obj.GetType() == GetType()
+                       && string.Equals(Id, ((CustomerDeets)obj).Id);
+            }
+
+            public override int GetHashCode() => Id != null ? Id.GetHashCode() : 0;
+        }
+
+        [ConditionalFact]
         public virtual void Select_All()
         {
             using (var context = CreateContext())

--- a/src/EFCore/Query/Internal/QueryOptimizer.cs
+++ b/src/EFCore/Query/Internal/QueryOptimizer.cs
@@ -184,15 +184,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 = !queryModel.BodyClauses.Any()
                   && subQueryModel.ResultOperators.All(
                       ro => ro is CastResultOperator
-                            || ro is ConcatResultOperator
                             || ro is DefaultIfEmptyResultOperator
                             || ro is ExceptResultOperator
-                            || ro is IntersectResultOperator
                             || ro is OfTypeResultOperator
                             || ro is ReverseResultOperator
                             || ro is SkipResultOperator
-                            || ro is TakeResultOperator
-                            || ro is UnionResultOperator);
+                            || ro is TakeResultOperator);
 
             // we can lift distinct however if the outer query has result operator that doesn't care about having correct element count
             var emptyQueryModelWithResultOperatorThatIgnoresElementCountAndDistinctInSubquery

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
@@ -2,13 +2,26 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.Internal;
-using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
     public partial class SimpleQuerySqlServerTest
     {
+        public override void Union_with_custom_projection()
+        {
+            base.Union_with_custom_projection();
+
+            AssertSql(
+                @"SELECT [c1].[CustomerID], [c1].[Address], [c1].[City], [c1].[CompanyName], [c1].[ContactName], [c1].[ContactTitle], [c1].[Country], [c1].[Fax], [c1].[Phone], [c1].[PostalCode], [c1].[Region]
+FROM [Customers] AS [c1]
+WHERE [c1].[CompanyName] LIKE N'A' + N'%' AND (LEFT([c1].[CompanyName], LEN(N'A')) = N'A')",
+                //
+                @"SELECT [c2].[CustomerID], [c2].[Address], [c2].[City], [c2].[CompanyName], [c2].[ContactName], [c2].[ContactTitle], [c2].[Country], [c2].[Fax], [c2].[Phone], [c2].[PostalCode], [c2].[Region]
+FROM [Customers] AS [c2]
+WHERE [c2].[CompanyName] LIKE N'B' + N'%' AND (LEFT([c2].[CompanyName], LEN(N'B')) = N'B')");
+        }
+
         public override void Select_All()
         {
             base.Select_All();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Linq;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;


### PR DESCRIPTION
- Fix over aggressive subquery elimination in QueryOptimizer.
