### PR TITLE
Fix #11485 - Query: Entity equality rewrite on owned entities

### DIFF
--- a/src/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/OwnedQueryTestBase.cs
@@ -15,6 +15,51 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected TFixture Fixture { get; }
 
         [Fact]
+        public virtual void Query_with_owned_entity_equality_operator()
+        {
+            using (var context = CreateContext())
+            {
+                var query
+                    = (from a in context.Set<LeafA>()
+                       from b in context.Set<LeafB>()
+                       where a.LeafAAddress == b.LeafBAddress
+                       select a).ToList();
+
+                Assert.Equal(0, query.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Query_with_owned_entity_equality_method()
+        {
+            using (var context = CreateContext())
+            {
+                var query
+                    = (from a in context.Set<LeafA>()
+                       from b in context.Set<LeafB>()
+                       where a.LeafAAddress.Equals(b.LeafBAddress)
+                       select a).ToList();
+
+                Assert.Equal(0, query.Count);
+            }
+        }
+
+        [Fact]
+        public virtual void Query_with_owned_entity_equality_object_method()
+        {
+            using (var context = CreateContext())
+            {
+                var query
+                    = (from a in context.Set<LeafA>()
+                       from b in context.Set<LeafB>()
+                       where Equals(a.LeafAAddress, b.LeafBAddress)
+                       select a).ToList();
+
+                Assert.Equal(0, query.Count);
+            }
+        }
+        
+        [Fact]
         public virtual void Query_for_base_type_loads_all_owned_navs()
         {
             using (var context = CreateContext())

--- a/src/EFCore/Query/ExpressionVisitors/Internal/EntityEqualityRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/EntityEqualityRewritingExpressionVisitor.cs
@@ -177,7 +177,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
             var keyProperties = entityType.FindPrimaryKey().Properties;
             var nullCount = keyProperties.Count;
-            Expression keyAccessExpression = null;
+
+            Expression keyAccessExpression;
 
             // Skipping composite key with subquery since it requires to copy subquery
             // which would cause same subquery to be visited twice
@@ -222,7 +223,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         private Expression RewriteEntityEquality(ExpressionType nodeType, Expression left, Expression right)
         {
             var leftProperties = MemberAccessBindingExpressionVisitor
-                    .GetPropertyPath(left, _queryCompilationContext, out var leftQsre);
+                .GetPropertyPath(left, _queryCompilationContext, out var leftQsre);
+
             var rightProperties = MemberAccessBindingExpressionVisitor
                 .GetPropertyPath(right, _queryCompilationContext, out var rightQsre);
 
@@ -243,10 +245,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                         CreateNavigationCaller(leftQsre, leftProperties),
                         CreateNavigationCaller(rightQsre, rightProperties)));
                 }
-                else
-                {
-                    return Expression.Constant(false);
-                }
+
+                return Expression.Constant(false);
             }
 
             var entityType = _model.FindEntityType(left.Type)
@@ -278,7 +278,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         }
 
         private IEntityType GetEntityType(
-            List<IPropertyBase> properties, QuerySourceReferenceExpression querySourceReferenceExpression)
+            IReadOnlyList<IPropertyBase> properties, QuerySourceReferenceExpression querySourceReferenceExpression)
         {
             if (properties.Count > 0)
             {

--- a/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
@@ -315,7 +315,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             var leftJoin = leftNavigationJoin?.JoinClause ?? leftNavigationJoin?.GroupJoinClause?.JoinClause;
             var rightJoin = rightNavigationJoin?.JoinClause ?? rightNavigationJoin?.GroupJoinClause?.JoinClause;
 
-            if (leftNavigationJoin != null)
+            if (leftNavigationJoin != null
+                && !leftNavigationJoin.Navigation.GetTargetType().IsOwned())
             {
                 if (newRight.IsNullConstantExpression())
                 {
@@ -338,7 +339,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 }
             }
 
-            if (rightNavigationJoin != null)
+            if (rightNavigationJoin != null
+                && !rightNavigationJoin.Navigation.GetTargetType().IsOwned())
             {
                 if (newLeft.IsNullConstantExpression())
                 {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/OwnedQuerySqlServerTest.cs
@@ -14,6 +14,52 @@ namespace Microsoft.EntityFrameworkCore.Query
             //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
+        public override void Query_with_owned_entity_equality_operator()
+        {
+            base.Query_with_owned_entity_equality_operator();
+
+            AssertSql(
+                @"SELECT [a].[Id], [a].[Discriminator], [t].[Id], [t0].[Id], [t0].[BranchAddress_Country_Name], [t1].[Id], [t2].[Id], [t2].[PersonAddress_Country_Name], [t3].[Id], [t4].[Id], [t4].[LeafAAddress_Country_Name], [t5].[Id]
+FROM [OwnedPerson] AS [a]
+LEFT JOIN (
+    SELECT [a.BranchAddress].*
+    FROM [OwnedPerson] AS [a.BranchAddress]
+    WHERE [a.BranchAddress].[Discriminator] IN (N'LeafA', N'Branch')
+) AS [t] ON [a].[Id] = [t].[Id]
+LEFT JOIN (
+    SELECT [a.BranchAddress.Country].*
+    FROM [OwnedPerson] AS [a.BranchAddress.Country]
+    WHERE [a.BranchAddress.Country].[Discriminator] IN (N'LeafA', N'Branch')
+) AS [t0] ON [t].[Id] = [t0].[Id]
+LEFT JOIN (
+    SELECT [a.PersonAddress].*
+    FROM [OwnedPerson] AS [a.PersonAddress]
+    WHERE [a.PersonAddress].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
+) AS [t1] ON [a].[Id] = [t1].[Id]
+LEFT JOIN (
+    SELECT [a.PersonAddress.Country].*
+    FROM [OwnedPerson] AS [a.PersonAddress.Country]
+    WHERE [a.PersonAddress.Country].[Discriminator] IN (N'LeafB', N'LeafA', N'Branch', N'OwnedPerson')
+) AS [t2] ON [t1].[Id] = [t2].[Id]
+LEFT JOIN (
+    SELECT [a.LeafAAddress].*
+    FROM [OwnedPerson] AS [a.LeafAAddress]
+    WHERE [a.LeafAAddress].[Discriminator] = N'LeafA'
+) AS [t3] ON [a].[Id] = [t3].[Id]
+LEFT JOIN (
+    SELECT [a.LeafAAddress.Country].*
+    FROM [OwnedPerson] AS [a.LeafAAddress.Country]
+    WHERE [a.LeafAAddress.Country].[Discriminator] = N'LeafA'
+) AS [t4] ON [t3].[Id] = [t4].[Id]
+CROSS JOIN [OwnedPerson] AS [b]
+LEFT JOIN (
+    SELECT [b.LeafBAddress].*
+    FROM [OwnedPerson] AS [b.LeafBAddress]
+    WHERE [b.LeafBAddress].[Discriminator] = N'LeafB'
+) AS [t5] ON [b].[Id] = [t5].[Id]
+WHERE [a].[Discriminator] = N'LeafA'");
+        }
+
         public override void Query_for_base_type_loads_all_owned_navs()
         {
             base.Query_for_base_type_loads_all_owned_navs();


### PR DESCRIPTION
- Fixed issue, forced client-eval for equality of owned navs.

