### PR TITLE
🔥 One liner bug fix - Challenge accepted 🔥 

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -642,7 +642,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 var selectExpression
                     = _queryModelVisitor.TryGetQuery(querySourceReferenceExpression.ReferencedQuerySource);
 
-                if (selectExpression != null)
+                if (selectExpression != null
+                    && (_targetSelectExpression == null || _targetSelectExpression == selectExpression))
                 {
                     var projectionIndex
                         = (int)((ConstantExpression)methodCallExpression.Arguments.Single()).Value;

--- a/src/EFCore.Specification.Tests/Query/AsyncGearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncGearsOfWarQueryTestBase.cs
@@ -1584,5 +1584,35 @@ namespace Microsoft.EntityFrameworkCore.Query
                     CollectionAsserter<string>()(e.Weapons, a.Weapons);
                 });
         }
+
+        [ConditionalFact]
+        public virtual async Task Include_collection_with_complex_OrderBy()
+        {
+            await AssertIncludeQuery<Gear>(
+                os => os.OfType<Officer>()
+                        .Include(o => o.Reports)
+                        .OrderBy(o => o.Weapons.Count),
+                new List<IExpectedInclude> { new ExpectedInclude<Officer>(o => o.Reports, "Reports") });
+        }
+
+        [ConditionalFact]
+        public virtual async Task Include_collection_with_complex_OrderBy2()
+        {
+            await AssertIncludeQuery<Gear>(
+                os => os.OfType<Officer>()
+                        .Include(o => o.Reports)
+                        .OrderBy(o => o.Weapons.OrderBy(w => w.Id).FirstOrDefault().IsAutomatic),
+                new List<IExpectedInclude> { new ExpectedInclude<Officer>(o => o.Reports, "Reports") });
+        }
+
+
+        [ConditionalFact(Skip = "See issue#11622")]
+        public virtual async Task Correlated_collection_with_complex_OrderBy()
+        {
+            await AssertQuery<Gear>(
+                os => os.OfType<Officer>()
+                        .OrderBy(o => o.Weapons.Count)
+                        .Select(o => o.Reports.Where(g => g.HasSoulPatch).ToList()));
+        }
     }
 }

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -4763,6 +4763,35 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
+        [ConditionalFact]
+        public virtual void Include_collection_OrderBy_aggregate()
+        {
+            AssertIncludeQuery<Gear>(
+                os => os.OfType<Officer>()
+                        .Include(o => o.Reports)
+                        .OrderBy(o => o.Weapons.Count),
+                new List<IExpectedInclude> { new ExpectedInclude<Officer>(o => o.Reports, "Reports") });
+        }
+
+        [ConditionalFact]
+        public virtual void Include_collection_with_complex_OrderBy2()
+        {
+            AssertIncludeQuery<Gear>(
+                os => os.OfType<Officer>()
+                        .Include(o => o.Reports)
+                        .OrderBy(o => o.Weapons.OrderBy(w => w.Id).FirstOrDefault().IsAutomatic),
+                new List<IExpectedInclude> { new ExpectedInclude<Officer>(o => o.Reports, "Reports") });
+        }
+
+        [ConditionalFact(Skip = "See issue#11622")]
+        public virtual void Correlated_collection_with_complex_OrderBy()
+        {
+            AssertQuery<Gear>(
+                os => os.OfType<Officer>()
+                        .OrderBy(o => o.Weapons.Count)
+                        .Select(o => o.Reports.Where(g => g.HasSoulPatch).ToList()));
+        }
+
         // Remember to add any new tests to Async version of this test class
 
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -6739,6 +6739,73 @@ INNER JOIN (
 ORDER BY [t].[Rank], [t].[c], [t].[Nickname], [t].[FullName]");
         }
 
+        public override void Include_collection_OrderBy_aggregate()
+        {
+            base.Include_collection_OrderBy_aggregate();
+
+            AssertSql(
+                @"SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOrBirthName], [o].[Discriminator], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank]
+FROM [Gears] AS [o]
+WHERE [o].[Discriminator] = N'Officer'
+ORDER BY (
+    SELECT COUNT(*)
+    FROM [Weapons] AS [w]
+    WHERE [o].[FullName] = [w].[OwnerFullName]
+), [o].[Nickname], [o].[SquadId]",
+                //
+                @"SELECT [o.Reports].[Nickname], [o.Reports].[SquadId], [o.Reports].[AssignedCityName], [o.Reports].[CityOrBirthName], [o.Reports].[Discriminator], [o.Reports].[FullName], [o.Reports].[HasSoulPatch], [o.Reports].[LeaderNickname], [o.Reports].[LeaderSquadId], [o.Reports].[Rank]
+FROM [Gears] AS [o.Reports]
+INNER JOIN (
+    SELECT [o0].[Nickname], [o0].[SquadId], (
+        SELECT COUNT(*)
+        FROM [Weapons] AS [w0]
+        WHERE [o0].[FullName] = [w0].[OwnerFullName]
+    ) AS [c], [o0].[FullName]
+    FROM [Gears] AS [o0]
+    WHERE [o0].[Discriminator] = N'Officer'
+) AS [t] ON ([o.Reports].[LeaderNickname] = [t].[Nickname]) AND ([o.Reports].[LeaderSquadId] = [t].[SquadId])
+WHERE [o.Reports].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [t].[c], [t].[Nickname], [t].[SquadId]");
+        }
+
+        public override void Include_collection_with_complex_OrderBy2()
+        {
+            base.Include_collection_with_complex_OrderBy2();
+
+            AssertSql(
+                @"SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOrBirthName], [o].[Discriminator], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank]
+FROM [Gears] AS [o]
+WHERE [o].[Discriminator] = N'Officer'
+ORDER BY COALESCE((
+    SELECT TOP(1) [w].[IsAutomatic]
+    FROM [Weapons] AS [w]
+    WHERE [o].[FullName] = [w].[OwnerFullName]
+    ORDER BY [w].[Id]
+), 0), [o].[Nickname], [o].[SquadId]",
+                //
+                @"SELECT [o.Reports].[Nickname], [o.Reports].[SquadId], [o.Reports].[AssignedCityName], [o.Reports].[CityOrBirthName], [o.Reports].[Discriminator], [o.Reports].[FullName], [o.Reports].[HasSoulPatch], [o.Reports].[LeaderNickname], [o.Reports].[LeaderSquadId], [o.Reports].[Rank]
+FROM [Gears] AS [o.Reports]
+INNER JOIN (
+    SELECT [o0].[Nickname], [o0].[SquadId], CAST(COALESCE((
+        SELECT TOP(1) [w0].[IsAutomatic]
+        FROM [Weapons] AS [w0]
+        WHERE [o0].[FullName] = [w0].[OwnerFullName]
+        ORDER BY [w0].[Id]
+    ), 0) AS bit) AS [c], [o0].[FullName]
+    FROM [Gears] AS [o0]
+    WHERE [o0].[Discriminator] = N'Officer'
+) AS [t] ON ([o.Reports].[LeaderNickname] = [t].[Nickname]) AND ([o.Reports].[LeaderSquadId] = [t].[SquadId])
+WHERE [o.Reports].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [t].[c], [t].[Nickname], [t].[SquadId]");
+        }
+
+        public override void Correlated_collection_with_complex_OrderBy()
+        {
+            base.Correlated_collection_with_complex_OrderBy();
+
+            AssertSql(" ");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Query: Async Collection Include produces invalid subquery with complex OrderBy

Issue: Current pipeline fails at lifting inner subquery in collection querymodel for async case. This causes client side join.
The OrderBy clause were dependent on inner subquery projection (through AnonymousObject). And while translating them we did not consider that select expression could be different.
Hence we added ordering to wrong select expression generating invalid SQL.

Resolves #10430
Resolves #11037
