### PR TITLE
SqlServer: Translate DateTimeOffset.Now

### DIFF
--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
@@ -779,6 +779,20 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void Where_datetimeoffset_now_component()
+        {
+            AssertQuery<Order>(
+                oc => oc.Where(o => o.OrderDate == DateTimeOffset.Now));
+        }
+
+        [ConditionalFact]
+        public virtual void Where_datetimeoffset_utcnow_component()
+        {
+            AssertQuery<Order>(
+                oc => oc.Where(o => o.OrderDate == DateTimeOffset.UtcNow));
+        }
+
+        [ConditionalFact]
         public virtual void Where_simple_reversed()
         {
             AssertQuery<Customer>(

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerDateTimeMemberTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerDateTimeMemberTranslator.cs
@@ -56,7 +56,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
                             new SqlFunctionExpression("GETDATE", memberExpression.Type);
 
                     case nameof(DateTime.UtcNow):
-                        var getUtcDate = new SqlFunctionExpression("GETUTCDATE", memberExpression.Type);
+                        var getUtcDate = declaringType == typeof(DateTimeOffset) ?
+                            new SqlFunctionExpression("SYSUTCDATETIME", memberExpression.Type) :
+                            new SqlFunctionExpression("GETUTCDATE", memberExpression.Type);
                         return declaringType == typeof(DateTimeOffset)
                             ? (Expression)new ExplicitCastExpression(getUtcDate, typeof(DateTimeOffset))
                             : getUtcDate;

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerDateTimeMemberTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerDateTimeMemberTranslator.cs
@@ -56,12 +56,11 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
                             new SqlFunctionExpression("GETDATE", memberExpression.Type);
 
                     case nameof(DateTime.UtcNow):
-                        var getUtcDate = declaringType == typeof(DateTimeOffset) ?
-                            new SqlFunctionExpression("SYSUTCDATETIME", memberExpression.Type) :
+                        return declaringType == typeof(DateTimeOffset) ?
+                            (Expression)new ExplicitCastExpression(
+                                new SqlFunctionExpression("SYSUTCDATETIME", memberExpression.Type),
+                                typeof(DateTimeOffset)) :
                             new SqlFunctionExpression("GETUTCDATE", memberExpression.Type);
-                        return declaringType == typeof(DateTimeOffset)
-                            ? (Expression)new ExplicitCastExpression(getUtcDate, typeof(DateTimeOffset))
-                            : getUtcDate;
 
                     case nameof(DateTime.Date):
                         return new SqlFunctionExpression(

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerDateTimeMemberTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerDateTimeMemberTranslator.cs
@@ -51,10 +51,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
                 switch (memberName)
                 {
                     case nameof(DateTime.Now):
-                        var getDate = new SqlFunctionExpression("GETDATE", memberExpression.Type);
-                        return declaringType == typeof(DateTimeOffset)
-                            ? (Expression)new ExplicitCastExpression(getDate, typeof(DateTimeOffset))
-                            : getDate;
+                        return declaringType == typeof(DateTimeOffset) ?
+                            new SqlFunctionExpression("SYSDATETIMEOFFSET", memberExpression.Type) :
+                            new SqlFunctionExpression("GETDATE", memberExpression.Type);
 
                     case nameof(DateTime.UtcNow):
                         var getUtcDate = new SqlFunctionExpression("GETUTCDATE", memberExpression.Type);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -2909,7 +2909,7 @@ WHERE [m].[Timeline] <> SYSDATETIMEOFFSET()");
             AssertSql(
                 @"SELECT [m].[Id], [m].[CodeName], [m].[Timeline]
 FROM [Missions] AS [m]
-WHERE [m].[Timeline] <> CAST(GETUTCDATE() AS datetimeoffset)");
+WHERE [m].[Timeline] <> CAST(SYSUTCDATETIME() AS datetimeoffset)");
         }
 #endif
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -2899,7 +2899,7 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
             AssertSql(
                 @"SELECT [m].[Id], [m].[CodeName], [m].[Timeline]
 FROM [Missions] AS [m]
-WHERE [m].[Timeline] <> CAST(GETDATE() AS datetimeoffset)");
+WHERE [m].[Timeline] <> SYSDATETIMEOFFSET()");
         }
 
         public override void Where_datetimeoffset_utcnow()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/RowNumberPagingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/RowNumberPagingTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public void Dispose()
         {
             //Assert for all tests that OFFSET or FETCH is never used
-            Assert.All(Fixture.TestSqlLoggerFactory.SqlStatements, t => Assert.DoesNotContain("OFFSET", t));
+            Assert.All(Fixture.TestSqlLoggerFactory.SqlStatements, t => Assert.DoesNotMatch("\\W+OFFSET", t));
             Assert.All(Fixture.TestSqlLoggerFactory.SqlStatements, t => Assert.DoesNotContain("FETCH", t));
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
@@ -851,6 +851,22 @@ WHERE DATEPART(second, [o].[OrderDate]) = 44");
 FROM [Orders] AS [o]
 WHERE DATEPART(millisecond, [o].[OrderDate]) = 88");
         }
+
+        public override void Where_datetimeoffset_now_component()
+        {
+            base.Where_datetimeoffset_now_component();
+            AssertSql(@"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderDate] = SYSDATETIMEOFFSET()");
+        }
+
+        public override void Where_datetimeoffset_utcnow_component()
+        {
+            base.Where_datetimeoffset_utcnow_component();
+            AssertSql(@"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE [o].[OrderDate] = CAST(GETUTCDATE() AS datetimeoffset)");
+        }
 #endif
 
         public override void Where_simple_reversed()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
@@ -865,7 +865,7 @@ WHERE [o].[OrderDate] = SYSDATETIMEOFFSET()");
             base.Where_datetimeoffset_utcnow_component();
             AssertSql(@"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE [o].[OrderDate] = CAST(GETUTCDATE() AS datetimeoffset)");
+WHERE [o].[OrderDate] = CAST(SYSUTCDATETIME() AS datetimeoffset)");
         }
 #endif
 


### PR DESCRIPTION
Fixes #11594.
* Implemented translation and test of `DateTimeOffset.Now` to `SYSDATETIMEOFFSET`
* Added unit test for `DateTimeOffset.UtcNow`