### PR TITLE
Fix #11635 - Query: Collection Include with scalar subquery order by …

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -1201,7 +1201,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             base.VisitSelectClause(selectClause, queryModel);
 
             if (Expression is MethodCallExpression methodCallExpression
-                && methodCallExpression.Method.MethodIsClosedFormOf(LinqOperatorProvider.Select))
+                && (methodCallExpression.Method.MethodIsClosedFormOf(LinqOperatorProvider.Select)
+                || methodCallExpression.Method.MethodIsClosedFormOf(SelectAsyncMethod)
+                    && selectClause.Selector.Type == typeof(AnonymousObject)))
             {
                 var shapedQuery = methodCallExpression.Arguments[0] as MethodCallExpression;
 
@@ -1227,7 +1229,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                             materializer
                                 = Expression.Lambda(
-                                    Expression.Default(materializer.Body.Type),
+                                    Expression.Default(typeof(AnonymousObject)),
                                     materializer.Parameters);
                         }
 

--- a/src/EFCore.Specification.Tests/Query/IncludeAsyncTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/IncludeAsyncTestBase.cs
@@ -38,6 +38,24 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual async Task Include_collection_order_by_subquery()
+        {
+            using (var context = CreateContext())
+            {
+                var customer
+                    = await context.Set<Customer>()
+                            .Include(c => c.Orders)
+                            .Where(c => c.CustomerID == "ALFKI")
+                            .OrderBy(c => c.Orders.OrderBy(o => o.EmployeeID).Select(o => o.OrderDate).FirstOrDefault())
+                            .FirstOrDefaultAsync();
+
+                Assert.NotNull(customer);
+                Assert.NotNull(customer.Orders);
+                Assert.Equal(6, customer.Orders.Count);
+            }
+        }
+
+        [ConditionalFact]
         public virtual async Task Include_closes_reader()
         {
             using (var context = CreateContext())

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -1315,7 +1315,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             _expression,
                             Expression.Lambda(selector, CurrentParameter))
                         : Expression.Call(
-                            _selectAsync
+                            SelectAsyncMethod
                                 .MakeGenericMethod(CurrentParameter.Type, selector.Type),
                             _expression,
                             Expression.Lambda(
@@ -1325,7 +1325,10 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
-        private static readonly MethodInfo _selectAsync
+        /// <summary>
+        ///     The _SelectAsync method info.
+        /// </summary>
+        protected static MethodInfo SelectAsyncMethod { get; }
             = typeof(EntityQueryModelVisitor)
                 .GetTypeInfo()
                 .GetDeclaredMethod(nameof(_SelectAsync));

--- a/src/EFCore/Query/Internal/CompiledQueryCache.cs
+++ b/src/EFCore/Query/Internal/CompiledQueryCache.cs
@@ -54,12 +54,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private Func<QueryContext, TFunc> GetOrAddQueryCore<TFunc>(
             object cacheKey, Func<Func<QueryContext, TFunc>> compiler)
         {
-            Func<QueryContext, TFunc> compiledQuery;
-
             retry:
-            if (!_memoryCache.TryGetValue(cacheKey, out compiledQuery))
+            if (!_memoryCache.TryGetValue(cacheKey, out Func<QueryContext, TFunc> compiledQuery))
             {
-                if (!_querySyncObjects.TryAdd(cacheKey, null))
+                if (!_querySyncObjects.TryAdd(cacheKey, value: null))
                 {
                     goto retry;
                 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AsyncGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AsyncGearsOfWarQuerySqlServerTest.cs
@@ -2188,7 +2188,6 @@ WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')");
         {
             await base.Include_collection_with_complex_OrderBy();
 
-            // Collection Include query should be lifted
             AssertSql(
                 @"SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOrBirthName], [o].[Discriminator], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank]
 FROM [Gears] AS [o]
@@ -2201,10 +2200,7 @@ ORDER BY (
                 //
                 @"SELECT [o.Reports].[Nickname], [o.Reports].[SquadId], [o.Reports].[AssignedCityName], [o.Reports].[CityOrBirthName], [o.Reports].[Discriminator], [o.Reports].[FullName], [o.Reports].[HasSoulPatch], [o.Reports].[LeaderNickname], [o.Reports].[LeaderSquadId], [o.Reports].[Rank]
 FROM [Gears] AS [o.Reports]
-WHERE [o.Reports].[Discriminator] IN (N'Officer', N'Gear')",
-                //
-                @"SELECT [t].[Nickname], [t].[SquadId], [t].[c], [t].[FullName]
-FROM (
+INNER JOIN (
     SELECT [o0].[Nickname], [o0].[SquadId], (
         SELECT COUNT(*)
         FROM [Weapons] AS [w0]
@@ -2212,26 +2208,15 @@ FROM (
     ) AS [c], [o0].[FullName]
     FROM [Gears] AS [o0]
     WHERE [o0].[Discriminator] = N'Officer'
-) AS [t]",
-                //
-                @"@_outer_FullName='Damon Baird' (Size = 450)
-
-SELECT COUNT(*)
-FROM [Weapons] AS [w1]
-WHERE @_outer_FullName = [w1].[OwnerFullName]",
-                //
-                @"@_outer_FullName='Marcus Fenix' (Size = 450)
-
-SELECT COUNT(*)
-FROM [Weapons] AS [w1]
-WHERE @_outer_FullName = [w1].[OwnerFullName]");
+) AS [t] ON ([o.Reports].[LeaderNickname] = [t].[Nickname]) AND ([o.Reports].[LeaderSquadId] = [t].[SquadId])
+WHERE [o.Reports].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [t].[c], [t].[Nickname], [t].[SquadId]");
         }
 
         public override async Task Include_collection_with_complex_OrderBy2()
         {
             await base.Include_collection_with_complex_OrderBy2();
 
-            // Collection Include query should be lifted
             AssertSql(
                 @"SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOrBirthName], [o].[Discriminator], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank]
 FROM [Gears] AS [o]
@@ -2245,10 +2230,7 @@ ORDER BY COALESCE((
                 //
                 @"SELECT [o.Reports].[Nickname], [o.Reports].[SquadId], [o.Reports].[AssignedCityName], [o.Reports].[CityOrBirthName], [o.Reports].[Discriminator], [o.Reports].[FullName], [o.Reports].[HasSoulPatch], [o.Reports].[LeaderNickname], [o.Reports].[LeaderSquadId], [o.Reports].[Rank]
 FROM [Gears] AS [o.Reports]
-WHERE [o.Reports].[Discriminator] IN (N'Officer', N'Gear')",
-                //
-                @"SELECT [t].[Nickname], [t].[SquadId], [t].[c], [t].[FullName]
-FROM (
+INNER JOIN (
     SELECT [o0].[Nickname], [o0].[SquadId], CAST(COALESCE((
         SELECT TOP(1) [w0].[IsAutomatic]
         FROM [Weapons] AS [w0]
@@ -2257,21 +2239,9 @@ FROM (
     ), 0) AS bit) AS [c], [o0].[FullName]
     FROM [Gears] AS [o0]
     WHERE [o0].[Discriminator] = N'Officer'
-) AS [t]",
-                //
-                @"@_outer_FullName='Damon Baird' (Size = 450)
-
-SELECT TOP(1) [w1].[IsAutomatic]
-FROM [Weapons] AS [w1]
-WHERE @_outer_FullName = [w1].[OwnerFullName]
-ORDER BY [w1].[Id]",
-                //
-                @"@_outer_FullName='Marcus Fenix' (Size = 450)
-
-SELECT TOP(1) [w1].[IsAutomatic]
-FROM [Weapons] AS [w1]
-WHERE @_outer_FullName = [w1].[OwnerFullName]
-ORDER BY [w1].[Id]");
+) AS [t] ON ([o.Reports].[LeaderNickname] = [t].[Nickname]) AND ([o.Reports].[LeaderSquadId] = [t].[SquadId])
+WHERE [o.Reports].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [t].[c], [t].[Nickname], [t].[SquadId]");
         }
 
         public override async Task Correlated_collection_with_complex_OrderBy()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AsyncIncludeSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AsyncIncludeSqlServerTest.cs
@@ -12,7 +12,74 @@ namespace Microsoft.EntityFrameworkCore.Query
         public AsyncIncludeSqlServerTest(IncludeSqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
+            fixture.TestSqlLoggerFactory.Clear();
             //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        }
+
+        public override async Task Include_collection_order_by_subquery()
+        {
+            await base.Include_collection_order_by_subquery();
+
+            AssertSql(
+                @"SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] = N'ALFKI'
+ORDER BY (
+    SELECT TOP(1) [o].[OrderDate]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+    ORDER BY [o].[EmployeeID]
+), [c].[CustomerID]",
+                //
+                @"SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
+FROM [Orders] AS [c.Orders]
+INNER JOIN (
+    SELECT TOP(1) [c0].[CustomerID], (
+        SELECT TOP(1) [o1].[OrderDate]
+        FROM [Orders] AS [o1]
+        WHERE [c0].[CustomerID] = [o1].[CustomerID]
+        ORDER BY [o1].[EmployeeID]
+    ) AS [c]
+    FROM [Customers] AS [c0]
+    WHERE [c0].[CustomerID] = N'ALFKI'
+    ORDER BY (
+        SELECT TOP(1) [o0].[OrderDate]
+        FROM [Orders] AS [o0]
+        WHERE [c0].[CustomerID] = [o0].[CustomerID]
+        ORDER BY [o0].[EmployeeID]
+    ), [c0].[CustomerID]
+) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
+ORDER BY [t].[c], [t].[CustomerID]");
+        }
+
+        public override async Task Include_collection_then_include_collection()
+        {
+            await base.Include_collection_then_include_collection();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]",
+                //
+                @"SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
+FROM [Orders] AS [c.Orders]
+INNER JOIN (
+    SELECT [c0].[CustomerID]
+    FROM [Customers] AS [c0]
+) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
+ORDER BY [t].[CustomerID], [c.Orders].[OrderID]",
+                //
+                @"SELECT [c.Orders.OrderDetails].[OrderID], [c.Orders.OrderDetails].[ProductID], [c.Orders.OrderDetails].[Discount], [c.Orders.OrderDetails].[Quantity], [c.Orders.OrderDetails].[UnitPrice]
+FROM [Order Details] AS [c.Orders.OrderDetails]
+INNER JOIN (
+    SELECT DISTINCT [c.Orders0].[OrderID], [t0].[CustomerID]
+    FROM [Orders] AS [c.Orders0]
+    INNER JOIN (
+        SELECT [c1].[CustomerID]
+        FROM [Customers] AS [c1]
+    ) AS [t0] ON [c.Orders0].[CustomerID] = [t0].[CustomerID]
+) AS [t1] ON [c.Orders.OrderDetails].[OrderID] = [t1].[OrderID]
+ORDER BY [t1].[CustomerID], [t1].[OrderID]");
         }
 
         [SqlServerCondition(SqlServerCondition.SupportsOffset)] // Test does not pass on SqlServer 2008. TODO: See issue#7160
@@ -20,5 +87,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return base.Include_duplicate_reference();
         }
+
+        private void AssertSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
     }
 }


### PR DESCRIPTION
…causes client join for async

- Add _SelectAsync to pattern match when performing TypedProjectionShaper optimization.