### PR TITLE
Query: Anonymous object group by causes invalid SQL

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -683,8 +683,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
             {
                 var newExpression = Visit(memberExpression.Expression);
 
-                if (newExpression != null
-                    || memberExpression.Expression == null)
+                if (memberExpression.Expression == null
+                    || (newExpression != null
+                        && newExpression.Type == memberExpression.Expression.Type))
                 {
                     var newMemberExpression
                         = newExpression != memberExpression.Expression

--- a/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -240,8 +240,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     }
 
                     expression = (expression as ExplicitCastExpression)?.Operand ?? expression;
+                    expression = UnwrapAliasExpression(expression);
                     expression = new ExplicitCastExpression(expression, outputType);
-                    Expression averageExpression = new SqlFunctionExpression("AVG", outputType, new[] { expression });
+                    Expression averageExpression = new SqlFunctionExpression(
+                        "AVG",
+                        outputType,
+                        new[] { expression });
 
                     if (nonNullableInputType == typeof(float))
                     {
@@ -823,7 +827,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 if (!(expression.RemoveConvert() is SelectExpression))
                 {
-                    var minExpression = new SqlFunctionExpression("MIN", handlerContext.QueryModel.SelectClause.Selector.Type, new[] { expression });
+                    var minExpression = new SqlFunctionExpression(
+                        "MIN",
+                        handlerContext.QueryModel.SelectClause.Selector.Type,
+                        new[] { UnwrapAliasExpression(expression) });
 
                     handlerContext.SelectExpression.SetProjectionExpression(minExpression);
 
@@ -849,7 +856,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 if (!(expression.RemoveConvert() is SelectExpression))
                 {
-                    var maxExpression = new SqlFunctionExpression("MAX", handlerContext.QueryModel.SelectClause.Selector.Type, new[] { expression });
+                    var maxExpression = new SqlFunctionExpression(
+                        "MAX",
+                        handlerContext.QueryModel.SelectClause.Selector.Type,
+                        new[] { UnwrapAliasExpression(expression) });
 
                     handlerContext.SelectExpression.SetProjectionExpression(maxExpression);
 
@@ -935,7 +945,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     var inputType = handlerContext.QueryModel.SelectClause.Selector.Type;
 
                     expression = (expression as ExplicitCastExpression)?.Operand ?? expression;
-                    Expression sumExpression = new SqlFunctionExpression("SUM", inputType, new[] { expression });
+                    Expression sumExpression = new SqlFunctionExpression(
+                        "SUM", inputType, new[] { UnwrapAliasExpression(expression) });
                     if (inputType.UnwrapNullableType() == typeof(float))
                     {
                         sumExpression = new ExplicitCastExpression(sumExpression, inputType);
@@ -1000,6 +1011,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 selectExpression.ExplodeStarProjection();
             }
         }
+
+        private static Expression UnwrapAliasExpression(Expression expression)
+            => (expression as AliasExpression)?.Expression ?? expression;
 
         private static readonly MethodInfo _transformClientExpressionMethodInfo
             = typeof(RelationalResultOperatorHandler).GetTypeInfo()

--- a/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
@@ -1018,6 +1018,23 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 19);
         }
 
+        [ConditionalFact]
+        public virtual async Task Select_anonymous_GroupBy_Aggregate()
+        {
+            await AssertQuery<Order>(
+                os => os.Where(o => o.OrderID < 10300)
+                        .Select(o => new { A = o.CustomerID, B = o.OrderDate, C = o.OrderID })
+                        .GroupBy(e => e.A)
+                        .Select(
+                            g => new
+                            {
+                                Min = g.Min(o => o.B),
+                                Max = g.Max(o => o.B),
+                                Sum = g.Sum(o => o.C),
+                                Avg = g.Average(o => o.C)
+                            }));
+        }
+
         #endregion
 
         #region GroupByAggregateComposition

--- a/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -1021,6 +1021,23 @@ namespace Microsoft.EntityFrameworkCore.Query
                 entryCount: 19);
         }
 
+        [ConditionalFact]
+        public virtual void Select_anonymous_GroupBy_Aggregate()
+        {
+            AssertQuery<Order>(
+                os => os.Where(o => o.OrderID < 10300)
+                        .Select(o => new { A = o.CustomerID, B = o.OrderDate, C = o.OrderID })
+                        .GroupBy(e => e.A)
+                        .Select(
+                            g => new
+                            {
+                                Min = g.Min(o => o.B),
+                                Max = g.Max(o => o.B),
+                                Sum = g.Sum(o => o.C),
+                                Avg = g.Average(o => o.C)
+                            }));
+        }
+
         #endregion
 
         #region GroupByAggregateComposition

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -771,5 +771,14 @@ namespace Microsoft.EntityFrameworkCore.Query
             AssertQueryScalar<Customer, bool>(cs => cs.Select(c => c.CustomerID == "ALFKI" ? true : false));
         }
 #endif
+
+        [ConditionalFact]
+        public virtual void Anonymous_projection_AsNoTracking_Selector()
+        {
+            AssertQueryScalar<Order>(
+                os => os.Select(o => new { A = o.CustomerID, B = o.OrderDate })
+                    .AsNoTracking() // Just to cause a subquery
+                    .Select(e => e.B));
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
@@ -907,6 +907,17 @@ GROUP BY [od.Order].[CustomerID], [od.Product].[ProductName]");
             AssertSql(" ");
         }
 
+        public override void Select_anonymous_GroupBy_Aggregate()
+        {
+            base.Select_anonymous_GroupBy_Aggregate();
+
+            AssertSql(
+                @"SELECT MIN([o].[OrderDate]) AS [Min], MAX([o].[OrderDate]) AS [Max], SUM([o].[OrderID]) AS [Sum], AVG(CAST([o].[OrderID] AS float)) AS [Avg]
+FROM [Orders] AS [o]
+WHERE [o].[OrderID] < 10300
+GROUP BY [o].[CustomerID]");
+        }
+
         public override void GroupBy_OrderBy_key()
         {
             base.GroupBy_OrderBy_key();
@@ -1403,6 +1414,16 @@ ORDER BY [e].[Title]");
 FROM [Employees] AS [e]
 WHERE [e].[EmployeeID] = 1
 ORDER BY [e].[EmployeeID]");
+        }
+
+        public override void GroupBy_Select_First_GroupBy()
+        {
+            base.GroupBy_Select_First_GroupBy();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[City]");
         }
 
         public override void Select_GroupBy()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
@@ -887,5 +887,14 @@ END
 FROM [Customers] AS [c]");
         }
 #endif
+
+        public override void Anonymous_projection_AsNoTracking_Selector()
+        {
+            base.Anonymous_projection_AsNoTracking_Selector();
+
+            AssertSql(
+                @"SELECT [o].[CustomerID] AS [A], [o].[OrderDate] AS [B]
+FROM [Orders] AS [o]");
+        }
     }
 }


### PR DESCRIPTION
Issue: Due to anonymous object we aliased projections. When wrapping the expression insider aggregate function, this generates invalid sql.
The same could happen with aggregate operation without group by too. Due to relinq optimizations, unable to write such a test.

Resolves #11636

Also added fixed issue with doing multiple select with first being on anonymous type.

