### PR TITLE
Use the correct model builder for seed data in model snapshot

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -198,7 +198,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                         GenerateRelationships(builderName, entityType, stringBuilder);
                     }
 
-                    GenerateData(entityType.GetProperties(), entityType.GetData(providerValues: true), stringBuilder);
+                    GenerateData(builderName, entityType.GetProperties(), entityType.GetData(providerValues: true), stringBuilder);
                 }
 
                 stringBuilder
@@ -1084,10 +1084,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         /// <summary>
         ///     Generates code for data seeding.
         /// </summary>
+        /// <param name="builderName"> The name of the builder variable. </param>
         /// <param name="properties"> The properties to generate. </param>
         /// <param name="data"> The data to be seeded. </param>
         /// <param name="stringBuilder"> The builder code is added to. </param>
         protected virtual void GenerateData(
+            [NotNull] string builderName,
             [NotNull] IEnumerable<IProperty> properties,
             [NotNull] IEnumerable<IDictionary<string, object>> data,
             [NotNull] IndentedStringBuilder stringBuilder)
@@ -1106,7 +1108,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
 
             stringBuilder
                 .AppendLine()
-                .AppendLine($"b.{nameof(EntityTypeBuilder.HasData)}(");
+                .Append(builderName)
+                .Append(".")
+                .Append(nameof(EntityTypeBuilder.HasData))
+                .AppendLine("(");
 
             using (stringBuilder.Indent())
             {

--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -495,7 +495,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     t.Name,
                     StringComparison.OrdinalIgnoreCase),
                 (s, t, c) => string.Equals(s.GetRootType().Name, t.GetRootType().Name, StringComparison.OrdinalIgnoreCase),
-                (s, t, c) => s.EntityTypes.Any(se => t.EntityTypes.Any(te => string.Equals(se.Name, te.Name, StringComparison.OrdinalIgnoreCase))));
+                (s, t, c) => s.EntityTypes.Any(se => t.EntityTypes.Any(te =>
+                    string.Equals(se.Name, te.Name, StringComparison.OrdinalIgnoreCase))));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -1488,12 +1489,20 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
                     foreach (var keyProperty in targetKey.Properties)
                     {
                         var sourceProperty = diffContext.FindSource(keyProperty);
-                        if (sourceProperty?.ClrType != keyProperty.ClrType)
+                        if (sourceProperty == null)
                         {
                             break;
                         }
 
-                        keyPropertiesMap.Add(sourceProperty);
+                        var keySourceProperty = sourceEntityType.GetProperties().FirstOrDefault(p =>
+                            p.ClrType == keyProperty.ClrType
+                            && p.Relational().ColumnName == sourceProperty.Relational().ColumnName);
+                        if (keySourceProperty == null)
+                        {
+                            break;
+                        }
+
+                        keyPropertiesMap.Add(keySourceProperty);
                     }
 
                     if (keyPropertiesMap.Count == targetKey.Properties.Count)

--- a/src/EFCore/Metadata/Conventions/Internal/NavigationAttributeEntityTypeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/NavigationAttributeEntityTypeConvention.cs
@@ -196,7 +196,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual Type FindCandidateNavigationPropertyType([NotNull] PropertyInfo propertyInfo)
+        protected virtual Type FindCandidateNavigationPropertyType([NotNull] PropertyInfo propertyInfo)
             => _memberClassifier.FindCandidateNavigationPropertyType(propertyInfo);
 
         private Type FindCandidateNavigationWithAttributePropertyType([NotNull] PropertyInfo propertyInfo)

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -615,7 +615,13 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                                         eb.HasIndex(e => e.Id);
 
                                         eb.OwnsOne(e => e.EntityWithStringProperty);
-                                    });
+
+                                        eb.HasData(new EntityWithTwoProperties
+                                        {
+                                            AlternateId = 1
+                                        });
+                                    })
+                            .HasData(new EntityWithOneProperty{Id = 1});
                     },
                 GetHeading() + @"
 builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
@@ -627,6 +633,10 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
         b.HasKey(""Id"");
 
         b.ToTable(""EntityWithOneProperty"");
+
+        b.HasData(
+            new { Id = 1 }
+        );
     });
 
 builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
@@ -663,6 +673,10 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                             .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", ""Id"")
                             .OnDelete(DeleteBehavior.Cascade);
                     });
+
+                b1.HasData(
+                    new { AlternateId = 1, Id = 0 }
+                );
             });
     });
 ",

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -6738,6 +6738,39 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         }
 
         [Fact]
+        public void SeedData_type_with_ownership_no_changes()
+        {
+            Execute(
+                common =>
+                {
+                    common.Ignore<Customer>();
+                    common.Entity<Order>(
+                        x =>
+                        {
+                            x.Property<int>("_secretId");
+                            x.HasData(new Order(42)
+                            {
+                                Id = 1
+                            });
+                            x.OwnsOne(y => y.Billing).HasData(new
+                            {
+                                OrderId = 1,
+                                AddressLine1 = "billing"
+                            });
+                            x.OwnsOne(y => y.Shipping).HasData(new
+                            {
+                                OrderId = 1,
+                                AddressLine2 = "shipping"
+                            });
+                        });
+                },
+                _ => { },
+                _ => { },
+                Assert.Empty,
+                Assert.Empty);
+        }
+
+        [Fact]
         public void Move_properties_to_owned_type()
         {
             Execute(


### PR DESCRIPTION
Match the correct source property for a given type when diffing seed data

Fixes #11607
