### PR TITLE
Query: Fix for Having clause missing in Grouping Subquery

### DIFF
--- a/src/EFCore.Relational/Query/Expressions/ColumnExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/ColumnExpression.cs
@@ -98,7 +98,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         ///     children, and if any of them change, should return a new copy of
         ///     itself with the modified children.
         /// </remarks>
-        protected override Expression VisitChildren(ExpressionVisitor visitor) => this;
+        protected override Expression VisitChildren(ExpressionVisitor visitor)
+        {
+            var newTable = (TableExpressionBase)visitor.Visit(Table);
+
+            return newTable != Table
+                ? new ColumnExpression(Name, _property, newTable)
+                : this;
+        }
 
         /// <summary>
         ///     Tests if this object is considered equal to another.

--- a/src/EFCore.Relational/Query/Expressions/JoinExpressionBase.cs
+++ b/src/EFCore.Relational/Query/Expressions/JoinExpressionBase.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
     /// </summary>
     public abstract class JoinExpressionBase : TableExpressionBase
     {
-        private readonly TableExpressionBase _tableExpression;
+        private TableExpressionBase _tableExpression;
 
         /// <summary>
         ///     Specialized constructor for use only by derived class.
@@ -46,7 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         /// </remarks>
         protected override Expression VisitChildren(ExpressionVisitor visitor)
         {
-            visitor.Visit(_tableExpression);
+            _tableExpression = (TableExpressionBase)visitor.Visit(_tableExpression);
 
             return this;
         }

--- a/src/EFCore.Relational/Query/Expressions/PredicateJoinExpressionBase.cs
+++ b/src/EFCore.Relational/Query/Expressions/PredicateJoinExpressionBase.cs
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         /// </value>
         public virtual Expression Predicate
         {
-            get { return _predicate; }
+            get => _predicate;
             [param: NotNull]
             set
             {
@@ -56,8 +56,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         /// </remarks>
         protected override Expression VisitChildren(ExpressionVisitor visitor)
         {
-            visitor.Visit(TableExpression);
-            visitor.Visit(_predicate);
+            base.VisitChildren(visitor);
+
+            _predicate = visitor.Visit(_predicate);
 
             return this;
         }

--- a/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -14,6 +14,7 @@ using Microsoft.EntityFrameworkCore.Extensions.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -497,6 +498,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                             key = new[] { sql };
                             break;
 
+                        case NullConditionalExpression nullConditionalExpression:
+                            sql = sqlTranslatingExpressionVisitor.Visit(nullConditionalExpression);
+                            selectExpression.SetProjectionForMemberInfo(groupByKeyMemberInfo, sql);
+                            key = new[] { sql };
+                            break;
 
                         case NewExpression newExpression:
                             key = VisitAndSaveMapping(

--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -270,11 +270,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
                 _relationalCommandBuilder.Append("GROUP BY ");
                 GenerateList(selectExpression.GroupBy);
+            }
 
-                if (selectExpression.Having != null)
-                {
-                    GenerateHaving(selectExpression.Having);
-                }
+            if (selectExpression.Having != null)
+            {
+                GenerateHaving(selectExpression.Having);
             }
 
             if (selectExpression.OrderBy.Count > 0)
@@ -1993,7 +1993,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
                 // All current Extension expressions have value type children
                 _isSearchCondition = false;
-                var newExpression = base.VisitExtension(extensionExpression);
+
+                // We skip selectExpression here because it will be processed by outer visitor when generating SQL
+                var newExpression = extensionExpression is SelectExpression
+                    ? extensionExpression
+                    : base.VisitExtension(extensionExpression);
 
                 _isSearchCondition = parentIsSearchCondition;
 

--- a/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -360,6 +360,38 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void Simple_owned_level1_level2_GroupBy_Count()
+        {
+            AssertQueryScalar<Level1>(
+                l1s => l1s.GroupBy(
+                            l1 => l1.OneToOne_Required_PK.OneToOne_Required_PK.Name)
+                        .Select(g => g.Count()),
+                l1s => l1s.GroupBy(
+                            l1 => Maybe(l1.OneToOne_Required_PK,
+                                () => Maybe(l1.OneToOne_Required_PK.OneToOne_Required_PK,
+                                    () => l1.OneToOne_Required_PK.OneToOne_Required_PK.Name)))
+                        .Select(g => g.Count()));
+        }
+
+        [ConditionalFact]
+        public virtual void Simple_owned_level1_level2_GroupBy_Having_Count()
+        {
+            AssertQueryScalar<Level1>(
+                l1s => l1s.GroupBy(
+                            l1 => l1.OneToOne_Required_PK.OneToOne_Required_PK.Name,
+                            l1 => new { Id = ((int?)l1.OneToOne_Required_PK.Id ?? 0) })
+                        .Where(g => g.Min(l1 => l1.Id) > 0)
+                        .Select(g => g.Count()),
+                l1s => l1s.GroupBy(
+                            l1 => Maybe(l1.OneToOne_Required_PK,
+                                () => Maybe(l1.OneToOne_Required_PK.OneToOne_Required_PK,
+                                    () => l1.OneToOne_Required_PK.OneToOne_Required_PK.Name)),
+                            l1 => new { Id = (MaybeScalar<int>(l1.OneToOne_Required_PK, () => l1.OneToOne_Required_PK.Id) ?? 0) })
+                        .Where(g => g.Min(l1 => l1.Id) > 0)
+                        .Select(g => g.Count()));
+        }
+
+        [ConditionalFact]
         public virtual void Simple_owned_level1_level2_level3()
         {
             AssertQuery<Level1>(
@@ -3842,7 +3874,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             AssertIncludeQuery<InheritanceBase1>(
                 i1s => i1s.Include("ReferenceDifferentType"),
                 expectedIncludes);
-       }
+        }
 
         [ConditionalFact]
         public virtual void String_include_multiple_derived_navigation_with_same_name_and_different_type_nested_also_includes_partially_matching_navigation_chains()

--- a/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -627,7 +627,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void GroupBy_Constant_with_element_selector_Select_Sum_Min_Key_Max_Avg()
         {
             AssertQuery<Order>(
-                os => os.GroupBy(o => 2, o=> o.OrderID).Select(
+                os => os.GroupBy(o => 2, o => o.OrderID).Select(
                     g =>
                         new
                         {
@@ -1078,6 +1078,30 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void GroupBy_aggregate_Contains()
+        {
+            AssertQuery<Order>(
+                os => os.Where(
+                    o => os.GroupBy(e => e.CustomerID)
+                        .Where(g => g.Count() > 30)
+                        .Select(g => g.Key)
+                        .Contains(o.CustomerID)),
+                entryCount: 31);
+        }
+
+        [ConditionalFact]
+        public virtual void GroupBy_aggregate_Pushdown()
+        {
+            AssertQuery<Order>(
+                os => os.GroupBy(e => e.CustomerID)
+                        .Where(g => g.Count() > 10)
+                        .Select(g => g.Key)
+                        .OrderBy(t => t)
+                        .Take(20)
+                        .Skip(4));
+        }
+
+        [ConditionalFact]
         public virtual void GroupBy_Select_sum_over_unmapped_property()
         {
             using (var context = CreateContext())
@@ -1136,6 +1160,35 @@ namespace Microsoft.EntityFrameworkCore.Query
                     join o in os on a.LastOrderID equals o.OrderID
                     select new { c, o },
                 entryCount: 126);
+        }
+
+        [ConditionalFact]
+        public virtual void GroupBy_Aggregate_Join_inverse()
+        {
+            AssertQuery<Order, Customer>(
+                (os, cs) =>
+                    from c in cs
+                    join a in os.GroupBy(o => o.CustomerID)
+                                .Where(g => g.Count() > 5)
+                                .Select(g => new { CustomerID = g.Key, LastOrderID = g.Max(o => o.OrderID) })
+                        on c.CustomerID equals a.CustomerID
+                    join o in os on a.LastOrderID equals o.OrderID
+                    select new { c, o },
+                entryCount: 126);
+        }
+
+        [ConditionalFact]
+        public virtual void GroupBy_Aggregate_Join_inverse2()
+        {
+            AssertQuery<Order, Customer>(
+                (os, cs) =>
+                    from c in cs
+                    join a in os.GroupBy(o => o.CustomerID)
+                                .Where(g => g.Count() > 5)
+                                .Select(g => new { CustomerID = g.Key, LastOrderID = g.Max(o => o.OrderID) })
+                        on c.CustomerID equals a.CustomerID
+                    select new { c, a.LastOrderID },
+                entryCount: 63);
         }
 
         [ConditionalFact]
@@ -1485,7 +1538,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             AssertQuery<Order>(
                 os =>
-                // TODO: See issue#11215
+                    // TODO: See issue#11215
                     os.GroupBy(o => o.CustomerID).Distinct().Select(g => g.Key));
         }
 

--- a/src/EFCore/Query/ExpressionVisitors/Internal/RequiresMaterializationExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/RequiresMaterializationExpressionVisitor.cs
@@ -247,8 +247,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                         .FromExpression)
                         .QueryModel.ResultOperators.Last();
 
-                if (MemberAccessBindingExpressionVisitor.GetPropertyPath(
-                    queryModel.SelectClause.Selector, _queryModelVisitor.QueryCompilationContext, out var qsre).Count > 0
+                var properties = MemberAccessBindingExpressionVisitor.GetPropertyPath(
+                    queryModel.SelectClause.Selector, _queryModelVisitor.QueryCompilationContext, out var qsre);
+
+                if (qsre != null
                     || groupResultOperator.ElementSelector is MemberInitExpression
                     || groupResultOperator.ElementSelector is NewExpression)
                 {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -1141,7 +1141,7 @@ FROM [LevelThree] AS [e3]
 INNER JOIN [LevelOne] AS [e1] ON [e3].[Id] = (
     SELECT TOP(1) [subQuery30].[Id]
     FROM [LevelTwo] AS [subQuery20]
-    LEFT JOIN [LevelThree] AS [subQuery30] ON [subQuery20].[Id] = [subQuery30].[Level2_Optional_Id]
+    LEFT JOIN [LevelThree] AS [subQuery30] ON ([subQuery20].[Id] = [subQuery30].[Level2_Optional_Id]) OR ([subQuery20].[Id] IS NULL AND [subQuery30].[Level2_Optional_Id] IS NULL)
     ORDER BY [subQuery30].[Id]
 )");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsWeakQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsWeakQuerySqlServerTest.cs
@@ -7,14 +7,11 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public class ComplexNavigationsWeakQuerySqlServerTest : ComplexNavigationsWeakQueryTestBase<ComplexNavigationsWeakQuerySqlServerFixture>
     {
-        private readonly ITestOutputHelper _testOutputHelper;
-
         public ComplexNavigationsWeakQuerySqlServerTest(
             ComplexNavigationsWeakQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
             Fixture.TestSqlLoggerFactory.Clear();
-            _testOutputHelper = testOutputHelper;
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
@@ -43,6 +40,27 @@ FROM [Level1] AS [l]");
             AssertSql(
                 @"SELECT [l1].[Id], [l1].[Date], [l1].[Name], [l1].[Id], [l1].[OneToOne_Required_PK_Date], [l1].[Level1_Optional_Id], [l1].[Level1_Required_Id], [l1].[Level2_Name], [l1].[OneToOne_Optional_PK_InverseId], [l1].[Id], [l1].[Level2_Optional_Id], [l1].[Level2_Required_Id], [l1].[Level3_Name], [l1].[Level3_OneToOne_Optional_PK_InverseId]
 FROM [Level1] AS [l1]");
+        }
+
+        public override void Simple_owned_level1_level2_GroupBy_Count()
+        {
+            base.Simple_owned_level1_level2_GroupBy_Count();
+
+            AssertSql(
+                @"SELECT COUNT(*)
+FROM [Level1] AS [l1]
+GROUP BY [l1].[Level3_Name]");
+        }
+
+        public override void Simple_owned_level1_level2_GroupBy_Having_Count()
+        {
+            base.Simple_owned_level1_level2_GroupBy_Having_Count();
+
+            AssertSql(
+                @"SELECT COUNT(*)
+FROM [Level1] AS [l1]
+GROUP BY [l1].[Level3_Name]
+HAVING MIN(COALESCE([l1].[Id], 0)) > 0");
         }
 
         public override void Simple_owned_level1_level2_level3()


### PR DESCRIPTION
Issue: We missed Having clause because it wasn't being copied while cloning SelectExpression
Fix:
We added processing of Having & GroupBy both in following places now to be consistent with other SelectExpression metadata
- Clone
- PushDownSubquery
- Clear
- JoinElimination for tablesplitting
- VisitChildren

Further, added NullConditionalExpression for translation of grouping key which can arise from GroupJoin-DefaultIfEmpty pattern. This improved some of the query translation

Resolves #11646
