### PR TITLE
Fix to #11622 - Query: Correlated subquery with complex ordering fails during compilation

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -1008,6 +1008,17 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         /// <summary>
+        /// Removes orderings for a given query model.
+        /// </summary>
+        /// <param name="queryModel">Query model to remove orderings on.</param>
+        protected override void RemoveOrderings(QueryModel queryModel)
+        {
+            base.RemoveOrderings(queryModel);
+
+            TryGetQuery(queryModel.MainFromClause)?.ClearOrderBy();
+        }
+
+        /// <summary>
         ///     Visit an order by clause.
         /// </summary>
         /// <param name="orderByClause"> The order by clause. </param>

--- a/src/EFCore.Specification.Tests/Query/AsyncGearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncGearsOfWarQueryTestBase.cs
@@ -1606,13 +1606,26 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
 
-        [ConditionalFact(Skip = "See issue#11622")]
+        [ConditionalFact]
         public virtual async Task Correlated_collection_with_complex_OrderBy()
         {
             await AssertQuery<Gear>(
-                os => os.OfType<Officer>()
-                        .OrderBy(o => o.Weapons.Count)
-                        .Select(o => o.Reports.Where(g => g.HasSoulPatch).ToList()));
+                gs => gs.OfType<Officer>()
+                    .OrderBy(o => o.Weapons.Count)
+                    .Select(o => o.Reports.Where(g => !g.HasSoulPatch).ToList()),
+                assertOrder: true,
+                elementAsserter: CollectionAsserter<Gear>(ee => ee.FullName, (ee, aa) => Assert.Equal(ee.FullName, aa.FullName)));
+        }
+
+        [ConditionalFact]
+        public virtual async Task Correlated_collection_with_very_complex_order_by()
+        {
+            await AssertQuery<Gear>(
+                gs => gs.OfType<Officer>()
+                    .OrderBy(o => o.Weapons.Where(w => w.IsAutomatic == gs.Where(g => g.Nickname == "Marcus").Select(g => g.HasSoulPatch).FirstOrDefault()).Count())
+                    .Select(o => o.Reports.Where(g => !g.HasSoulPatch).ToList()),
+                assertOrder: true,
+                elementAsserter: CollectionAsserter<Gear>(ee => ee.FullName, (ee, aa) => Assert.Equal(ee.FullName, aa.FullName)));
         }
 
         [ConditionalFact]

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -31,6 +31,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
         }
 
+        // Remember to add any new tests to Async version of this test class
+
         [ConditionalFact]
         public virtual void Entity_equality_empty()
         {
@@ -4783,13 +4785,26 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new List<IExpectedInclude> { new ExpectedInclude<Officer>(o => o.Reports, "Reports") });
         }
 
-        [ConditionalFact(Skip = "See issue#11622")]
+        [ConditionalFact]
         public virtual void Correlated_collection_with_complex_OrderBy()
         {
             AssertQuery<Gear>(
-                os => os.OfType<Officer>()
-                        .OrderBy(o => o.Weapons.Count)
-                        .Select(o => o.Reports.Where(g => g.HasSoulPatch).ToList()));
+                gs => gs.OfType<Officer>()
+                    .OrderBy(o => o.Weapons.Count)
+                    .Select(o => o.Reports.Where(g => !g.HasSoulPatch).ToList()),
+                assertOrder: true,
+                elementAsserter: CollectionAsserter<Gear>(ee => ee.FullName, (ee, aa) => Assert.Equal(ee.FullName, aa.FullName)));
+        }
+
+        [ConditionalFact]
+        public virtual void Correlated_collection_with_very_complex_order_by()
+        {
+            AssertQuery<Gear>(
+                gs => gs.OfType<Officer>()
+                    .OrderBy(o => o.Weapons.Where(w => w.IsAutomatic == gs.Where(g => g.Nickname == "Marcus").Select(g => g.HasSoulPatch).FirstOrDefault()).Count())
+                    .Select(o => o.Reports.Where(g => !g.HasSoulPatch).ToList()),
+                assertOrder: true,
+                elementAsserter: CollectionAsserter<Gear>(ee => ee.FullName, (ee, aa) => Assert.Equal(ee.FullName, aa.FullName)));
         }
 
         [ConditionalFact]

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -1210,14 +1210,9 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                 if (correlatedCollectionOptimizer.ParentOrderings.Count > 0)
                 {
-                    var existingOrderByClauses = queryModel.BodyClauses.OfType<OrderByClause>().ToList();
-                    foreach (var existingOrderByClause in existingOrderByClauses)
-                    {
-                        queryModel.BodyClauses.Remove(existingOrderByClause);
-                    }
+                    RemoveOrderings(queryModel);
 
                     var orderByClause = new OrderByClause();
-
                     foreach (var ordering in correlatedCollectionOptimizer.ParentOrderings)
                     {
                         orderByClause.Orderings.Add(ordering);
@@ -1227,6 +1222,19 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                     VisitOrderByClause(orderByClause, queryModel, queryModel.BodyClauses.IndexOf(orderByClause));
                 }
+            }
+        }
+
+        /// <summary>
+        /// Removes orderings for a given query model.
+        /// </summary>
+        /// <param name="queryModel">Query model to remove orderings on.</param>
+        protected virtual void RemoveOrderings(QueryModel queryModel)
+        {
+            var existingOrderByClauses = queryModel.BodyClauses.OfType<OrderByClause>().ToList();
+            foreach (var existingOrderByClause in existingOrderByClauses)
+            {
+                queryModel.BodyClauses.Remove(existingOrderByClause);
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AsyncGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AsyncGearsOfWarQuerySqlServerTest.cs
@@ -2205,7 +2205,7 @@ INNER JOIN (
         SELECT COUNT(*)
         FROM [Weapons] AS [w0]
         WHERE [o0].[FullName] = [w0].[OwnerFullName]
-    ) AS [c], [o0].[FullName]
+    ) AS [c]
     FROM [Gears] AS [o0]
     WHERE [o0].[Discriminator] = N'Officer'
 ) AS [t] ON ([o.Reports].[LeaderNickname] = [t].[Nickname]) AND ([o.Reports].[LeaderSquadId] = [t].[SquadId])
@@ -2236,7 +2236,7 @@ INNER JOIN (
         FROM [Weapons] AS [w0]
         WHERE [o0].[FullName] = [w0].[OwnerFullName]
         ORDER BY [w0].[Id]
-    ), 0) AS bit) AS [c], [o0].[FullName]
+    ), 0) AS bit) AS [c]
     FROM [Gears] AS [o0]
     WHERE [o0].[Discriminator] = N'Officer'
 ) AS [t] ON ([o.Reports].[LeaderNickname] = [t].[Nickname]) AND ([o.Reports].[LeaderSquadId] = [t].[SquadId])
@@ -2248,7 +2248,82 @@ ORDER BY [t].[c], [t].[Nickname], [t].[SquadId]");
         {
             await base.Correlated_collection_with_complex_OrderBy();
 
-            AssertSql(" ");
+            AssertSql(
+                @"SELECT [o].[Nickname], [o].[SquadId]
+FROM [Gears] AS [o]
+WHERE [o].[Discriminator] = N'Officer'
+ORDER BY (
+    SELECT COUNT(*)
+    FROM [Weapons] AS [w0]
+    WHERE [o].[FullName] = [w0].[OwnerFullName]
+), [o].[Nickname], [o].[SquadId]",
+                //
+                @"SELECT [o.Reports].[Nickname], [o.Reports].[SquadId], [o.Reports].[AssignedCityName], [o.Reports].[CityOrBirthName], [o.Reports].[Discriminator], [o.Reports].[FullName], [o.Reports].[HasSoulPatch], [o.Reports].[LeaderNickname], [o.Reports].[LeaderSquadId], [o.Reports].[Rank], [t].[c], [t].[Nickname], [t].[SquadId]
+FROM [Gears] AS [o.Reports]
+INNER JOIN (
+    SELECT (
+        SELECT COUNT(*)
+        FROM [Weapons] AS [w1]
+        WHERE [o0].[FullName] = [w1].[OwnerFullName]
+    ) AS [c], [o0].[Nickname], [o0].[SquadId]
+    FROM [Gears] AS [o0]
+    WHERE [o0].[Discriminator] = N'Officer'
+) AS [t] ON ([o.Reports].[LeaderNickname] = [t].[Nickname]) AND ([o.Reports].[LeaderSquadId] = [t].[SquadId])
+WHERE [o.Reports].[Discriminator] IN (N'Officer', N'Gear') AND ([o.Reports].[HasSoulPatch] = 0)
+ORDER BY [t].[c], [t].[Nickname], [t].[SquadId]");
+        }
+
+
+        public override async Task Correlated_collection_with_very_complex_order_by()
+        {
+            await base.Correlated_collection_with_very_complex_order_by();
+
+            AssertSql(
+                @"SELECT [o].[Nickname], [o].[SquadId]
+FROM [Gears] AS [o]
+WHERE [o].[Discriminator] = N'Officer'
+ORDER BY (
+    SELECT COUNT(*)
+    FROM [Weapons] AS [w0]
+    WHERE ([w0].[IsAutomatic] = CASE
+        WHEN CASE
+            WHEN COALESCE((
+                SELECT TOP(1) [g0].[HasSoulPatch]
+                FROM [Gears] AS [g0]
+                WHERE [g0].[Discriminator] IN (N'Officer', N'Gear') AND ([g0].[Nickname] = N'Marcus')
+            ), 0) = 1
+            THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+        END = 1
+        THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+    END) AND ([o].[FullName] = [w0].[OwnerFullName])
+), [o].[Nickname], [o].[SquadId]",
+                //
+                @"SELECT [o.Reports].[Nickname], [o.Reports].[SquadId], [o.Reports].[AssignedCityName], [o.Reports].[CityOrBirthName], [o.Reports].[Discriminator], [o.Reports].[FullName], [o.Reports].[HasSoulPatch], [o.Reports].[LeaderNickname], [o.Reports].[LeaderSquadId], [o.Reports].[Rank], [t].[c], [t].[Nickname], [t].[SquadId]
+FROM [Gears] AS [o.Reports]
+INNER JOIN (
+    SELECT (
+        SELECT COUNT(*)
+        FROM [Weapons] AS [w1]
+        WHERE ([w1].[IsAutomatic] = CASE
+            WHEN CASE
+                WHEN CASE
+                    WHEN COALESCE((
+                        SELECT TOP(1) [g1].[HasSoulPatch]
+                        FROM [Gears] AS [g1]
+                        WHERE [g1].[Discriminator] IN (N'Officer', N'Gear') AND ([g1].[Nickname] = N'Marcus')
+                    ), 0) = 1
+                    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+                END = 1
+                THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+            END = 1
+            THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+        END) AND ([o0].[FullName] = [w1].[OwnerFullName])
+    ) AS [c], [o0].[Nickname], [o0].[SquadId]
+    FROM [Gears] AS [o0]
+    WHERE [o0].[Discriminator] = N'Officer'
+) AS [t] ON ([o.Reports].[LeaderNickname] = [t].[Nickname]) AND ([o.Reports].[LeaderSquadId] = [t].[SquadId])
+WHERE [o.Reports].[Discriminator] IN (N'Officer', N'Gear') AND ([o.Reports].[HasSoulPatch] = 0)
+ORDER BY [t].[c], [t].[Nickname], [t].[SquadId]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -3310,7 +3310,7 @@ ORDER BY ABS([l2].[Level1_Required_Id]), [l2].[Name], [l2].[Id]",
                 @"SELECT [l2.OneToMany_Optional].[Id], [l2.OneToMany_Optional].[Level2_Optional_Id], [l2.OneToMany_Optional].[Level2_Required_Id], [l2.OneToMany_Optional].[Name], [l2.OneToMany_Optional].[OneToMany_Optional_InverseId], [l2.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l2.OneToMany_Optional].[OneToMany_Required_InverseId], [l2.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l2.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l2.OneToMany_Optional].[OneToOne_Optional_SelfId]
 FROM [LevelThree] AS [l2.OneToMany_Optional]
 INNER JOIN (
-    SELECT [l20].[Id], ABS([l20].[Level1_Required_Id]) AS [c], [l20].[Name], [l20].[Level1_Required_Id]
+    SELECT [l20].[Id], ABS([l20].[Level1_Required_Id]) AS [c], [l20].[Name]
     FROM [LevelTwo] AS [l20]
 ) AS [t] ON [l2.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
 ORDER BY [t].[c], [t].[Name], [t].[Id]");
@@ -3328,7 +3328,7 @@ ORDER BY ABS([l2].[Level1_Required_Id]) + 7, [l2].[Name], [l2].[Id]",
                 @"SELECT [l2.OneToMany_Optional].[Id], [l2.OneToMany_Optional].[Level2_Optional_Id], [l2.OneToMany_Optional].[Level2_Required_Id], [l2.OneToMany_Optional].[Name], [l2.OneToMany_Optional].[OneToMany_Optional_InverseId], [l2.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l2.OneToMany_Optional].[OneToMany_Required_InverseId], [l2.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l2.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l2.OneToMany_Optional].[OneToOne_Optional_SelfId]
 FROM [LevelThree] AS [l2.OneToMany_Optional]
 INNER JOIN (
-    SELECT [l20].[Id], ABS([l20].[Level1_Required_Id]) + 7 AS [c], [l20].[Name], [l20].[Level1_Required_Id]
+    SELECT [l20].[Id], ABS([l20].[Level1_Required_Id]) + 7 AS [c], [l20].[Name]
     FROM [LevelTwo] AS [l20]
 ) AS [t] ON [l2.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
 ORDER BY [t].[c], [t].[Name], [t].[Id]");
@@ -3346,7 +3346,7 @@ ORDER BY -[l2].[Level1_Required_Id], [l2].[Name], [l2].[Id]",
                 @"SELECT [l2.OneToMany_Optional].[Id], [l2.OneToMany_Optional].[Level2_Optional_Id], [l2.OneToMany_Optional].[Level2_Required_Id], [l2.OneToMany_Optional].[Name], [l2.OneToMany_Optional].[OneToMany_Optional_InverseId], [l2.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l2.OneToMany_Optional].[OneToMany_Required_InverseId], [l2.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l2.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l2.OneToMany_Optional].[OneToOne_Optional_SelfId]
 FROM [LevelThree] AS [l2.OneToMany_Optional]
 INNER JOIN (
-    SELECT [l20].[Id], -[l20].[Level1_Required_Id] AS [c], [l20].[Name], [l20].[Level1_Required_Id]
+    SELECT [l20].[Id], -[l20].[Level1_Required_Id] AS [c], [l20].[Name]
     FROM [LevelTwo] AS [l20]
 ) AS [t] ON [l2.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
 ORDER BY [t].[c], [t].[Name], [t].[Id]");

--- a/test/EFCore.SqlServer.FunctionalTests/Query/IncludeSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/IncludeSqlServerTest.cs
@@ -1384,18 +1384,18 @@ INNER JOIN (
     FROM [Orders] AS [c.Orders0]
     INNER JOIN (
         SELECT TOP(1) [c1].[CustomerID], (
-            SELECT TOP(1) [oo4].[OrderDate]
-            FROM [Orders] AS [oo4]
-            WHERE [c1].[CustomerID] = [oo4].[CustomerID]
-            ORDER BY [oo4].[OrderDate] DESC
-        ) AS [c]
-        FROM [Customers] AS [c1]
-        WHERE [c1].[CustomerID] LIKE N'W' + N'%' AND (LEFT([c1].[CustomerID], LEN(N'W')) = N'W')
-        ORDER BY (
             SELECT TOP(1) [oo3].[OrderDate]
             FROM [Orders] AS [oo3]
             WHERE [c1].[CustomerID] = [oo3].[CustomerID]
             ORDER BY [oo3].[OrderDate] DESC
+        ) AS [c]
+        FROM [Customers] AS [c1]
+        WHERE [c1].[CustomerID] LIKE N'W' + N'%' AND (LEFT([c1].[CustomerID], LEN(N'W')) = N'W')
+        ORDER BY (
+            SELECT TOP(1) [oo2].[OrderDate]
+            FROM [Orders] AS [oo2]
+            WHERE [c1].[CustomerID] = [oo2].[CustomerID]
+            ORDER BY [oo2].[OrderDate] DESC
         ) DESC, [c1].[CustomerID]
     ) AS [t0] ON [c.Orders0].[CustomerID] = [t0].[CustomerID]
 ) AS [t1] ON [c.Orders.OrderDetails].[OrderID] = [t1].[OrderID]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -2688,7 +2688,7 @@ INNER JOIN (
         END AS [c], CASE
             WHEN [b0].[CustomerDetailsId] IS NOT NULL
             THEN [b.CustomerDetails0].[Name] ELSE N''
-        END AS [c0], [b0].[AddressId], [b0].[CustomerDetailsId], [b.CustomerDetails0].[Name]
+        END AS [c0]
         FROM [Customers] AS [b0]
         LEFT JOIN [CustomerDetails9735] AS [b.CustomerDetails0] ON [b0].[CustomerDetailsId] = [b.CustomerDetails0].[Id]
         ORDER BY [c], [c0], [b0].[Id]


### PR DESCRIPTION
Problem was that when we were building QM for correlated subquery we relied on query model cloning when trying to remap order by elements, that need to be applied to the correlated collection query.
Relinq cloning is currently broken (https://www.re-motion.org/jira/projects/RMLNQ/issues/RMLNQ-111) if the cloned query contains two copies of the same query source. This is the case if the order by or predicate of the main query contains a subquery itself.

Fix is to not rely on AdjustExpressionAfterCloning to remap complex orderings - now we get them directly from the cloned QM. Only simple orderings, that are guaranteed to be key accesses are remapped.
Also fixed issue in RelationalProjectionExpressionVisitor, where we would visit a projection (which could be complex), add appropriate SQL fragment to SqlExpression, but we would not modify the returned expression, so that the same subquery would be visited later in the pipeline, which would cause unnecessary N+1 queries, or some unnecessary columns being fetched from the database.