### PR TITLE
[For 2.1] Update no-tracking lazy-loading behavior

### DIFF
--- a/src/EFCore.Specification.Tests/LoadTestBase.cs
+++ b/src/EFCore.Specification.Tests/LoadTestBase.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -1232,7 +1233,10 @@ namespace Microsoft.EntityFrameworkCore
                 }
 
                 Assert.Equal(
-                    CoreStrings.CannotLoadDetached(nameof(Parent.Children), nameof(Parent)),
+                    CoreStrings.WarningAsErrorTemplate(
+                        CoreEventId.DetachedLazyLoadingWarning.ToString(),
+                        CoreStrings.LogDetachedLazyLoading.GenerateMessage(nameof(Parent.Children), "Parent"),
+                        "CoreEventId.DetachedLazyLoadingWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () => parent.Children).Message);
             }
@@ -1253,7 +1257,10 @@ namespace Microsoft.EntityFrameworkCore
                 }
 
                 Assert.Equal(
-                    CoreStrings.CannotLoadDetached(nameof(Child.Parent), nameof(Child)),
+                    CoreStrings.WarningAsErrorTemplate(
+                        CoreEventId.DetachedLazyLoadingWarning.ToString(),
+                        CoreStrings.LogDetachedLazyLoading.GenerateMessage(nameof(Child.Parent), "Child"),
+                        "CoreEventId.DetachedLazyLoadingWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () => child.Parent).Message);
             }
@@ -1274,7 +1281,10 @@ namespace Microsoft.EntityFrameworkCore
                 }
 
                 Assert.Equal(
-                    CoreStrings.CannotLoadDetached(nameof(Parent.Single), nameof(Parent)),
+                    CoreStrings.WarningAsErrorTemplate(
+                        CoreEventId.DetachedLazyLoadingWarning.ToString(),
+                        CoreStrings.LogDetachedLazyLoading.GenerateMessage(nameof(Parent.Single), "Parent"),
+                        "CoreEventId.DetachedLazyLoadingWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () => parent.Single).Message);
             }

--- a/src/EFCore/Diagnostics/CoreEventId.cs
+++ b/src/EFCore/Diagnostics/CoreEventId.cs
@@ -74,6 +74,7 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             LazyLoadOnDisposedContextWarning,
             NavigationLazyLoading,
             ContextDisposed,
+            DetachedLazyLoadingWarning,
 
             // Model events
             ShadowPropertyCreated = CoreBaseId + 600,
@@ -353,6 +354,19 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     </para>
         /// </summary>
         public static readonly EventId LazyLoadOnDisposedContextWarning = MakeInfraId(Id.LazyLoadOnDisposedContextWarning);
+
+        /// <summary>
+        ///     <para>
+        ///         An attempt was made to lazy-load a property from a detached/no-tracking entity.
+        ///     </para>
+        ///     <para>
+        ///         This event is in the <see cref="DbLoggerCategory.Infrastructure" /> category.
+        ///     </para>
+        ///     <para>
+        ///         This event uses the <see cref="LazyLoadingEventData" /> payload when used with a <see cref="DiagnosticSource" />.
+        ///     </para>
+        /// </summary>
+        public static readonly EventId DetachedLazyLoadingWarning = MakeInfraId(Id.DetachedLazyLoadingWarning);
 
         private static readonly string _modelPrefix = DbLoggerCategory.Model.Name + ".";
         private static EventId MakeModelId(Id id) => new EventId((int)id, _modelPrefix + id);

--- a/src/EFCore/Extensions/Internal/CoreLoggerExtensions.cs
+++ b/src/EFCore/Extensions/Internal/CoreLoggerExtensions.cs
@@ -741,6 +741,47 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public static void DetachedLazyLoadingWarning(
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Infrastructure> diagnostics,
+            [NotNull] DbContext context,
+            [NotNull] object entityType,
+            [NotNull] string navigationName)
+        {
+            var definition = CoreStrings.LogDetachedLazyLoading;
+
+            var warningBehavior = definition.GetLogBehavior(diagnostics);
+            if (warningBehavior != WarningBehavior.Ignore)
+            {
+                definition.Log(
+                    diagnostics,
+                    warningBehavior,
+                    navigationName, entityType.GetType().ShortDisplayName());
+            }
+
+            if (diagnostics.DiagnosticSource.IsEnabled(definition.EventId.Name))
+            {
+                diagnostics.DiagnosticSource.Write(
+                    definition.EventId.Name,
+                    new LazyLoadingEventData(
+                        definition,
+                        DetachedLazyLoadingWarning,
+                        context,
+                        entityType,
+                        navigationName));
+            }
+        }
+
+        private static string DetachedLazyLoadingWarning(EventDefinitionBase definition, EventData payload)
+        {
+            var d = (EventDefinition<string, string>)definition;
+            var p = (LazyLoadingEventData)payload;
+            return d.GenerateMessage(p.NavigationPropertyName, p.Entity.GetType().ShortDisplayName());
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public static void ShadowPropertyCreated(
             [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Model> diagnostics,
             [NotNull] IProperty property)

--- a/src/EFCore/Infrastructure/CoreOptionsExtension.cs
+++ b/src/EFCore/Infrastructure/CoreOptionsExtension.cs
@@ -40,7 +40,10 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         private string _logFragment;
 
         private WarningsConfiguration _warningsConfiguration
-            = new WarningsConfiguration().TryWithExplicit(CoreEventId.LazyLoadOnDisposedContextWarning, WarningBehavior.Throw);
+            = new WarningsConfiguration()
+                .TryWithExplicit(CoreEventId.LazyLoadOnDisposedContextWarning, WarningBehavior.Throw)
+                .TryWithExplicit(CoreEventId.DetachedLazyLoadingWarning, WarningBehavior.Throw);
+
         /// <summary>
         ///     Creates a new set of options with everything set to default values.
         /// </summary>

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2348,6 +2348,19 @@ namespace Microsoft.EntityFrameworkCore.Internal
                     _resourceManager.GetString("LogLazyLoadOnDisposedContext")));
 
         /// <summary>
+        ///     An attempt was made to lazy-load navigation property '{navigation}' on detached entity of type '{entityType}'. Lazy-loading is not supported for detached entities or entities that are loaded with 'AsNoTracking()'.
+        /// </summary>
+        public static readonly EventDefinition<string, string> LogDetachedLazyLoading
+            = new EventDefinition<string, string>(
+                CoreEventId.DetachedLazyLoadingWarning,
+                LogLevel.Warning,
+                "CoreEventId.DetachedLazyLoadingWarning",
+                LoggerMessage.Define<string, string>(
+                    LogLevel.Warning,
+                    CoreEventId.DetachedLazyLoadingWarning,
+                    _resourceManager.GetString("LogDetachedLazyLoading")));
+
+        /// <summary>
         ///     Cannot create a DbSet for '{typeName}' because it is a query type. Use the DbContext.Query method to create a DbQuery instead.
         /// </summary>
         public static string InvalidSetTypeQuery([CanBeNull] object typeName)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -971,6 +971,10 @@
     <value>An attempt was made to lazy-load navigation property '{navigation}' on entity type '{entityType}' after the associated DbContext was disposed.</value>
     <comment>Warning CoreEventId.LazyLoadOnDisposedContextWarning string string</comment>
   </data>
+  <data name="LogDetachedLazyLoading" xml:space="preserve">
+    <value>An attempt was made to lazy-load navigation property '{navigation}' on detached entity of type '{entityType}'. Lazy-loading is not supported for detached entities or entities that are loaded with 'AsNoTracking()'.</value>
+    <comment>Warning CoreEventId.DetachedLazyLoadingWarning string string</comment>
+  </data>
   <data name="InvalidSetTypeQuery" xml:space="preserve">
     <value>Cannot create a DbSet for '{typeName}' because it is a query type. Use the DbContext.Query method to create a DbQuery instead.</value>
   </data>


### PR DESCRIPTION
Issue #11664

* If the navigation is not null/not empty, then no-op rather than throw. This matches the behavior in EF6 when attempting to lazy-load after a no-tracking query.
* Change the error to a warning-as-error so it can be forced to a no-op if needed.
