### PR TITLE
Query: Clone inner SubQuery before flattening it out

### DIFF
--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -4244,5 +4244,19 @@ namespace Microsoft.EntityFrameworkCore.Query
                 // No verification. Query Compilation check.
             }
         }
+
+        [ConditionalFact]
+        public virtual void Let_subquery_with_multiple_occurences()
+        {
+            AssertQuery<Order>(
+                os => from o in os
+                      let details =
+                            from od in o.OrderDetails
+                            where od.Quantity < 10
+                            select od.Quantity
+                      where details.Any()
+                      select new { Count = details.Count() });
+        }
+
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -4497,6 +4497,23 @@ LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[Custom
 WHERE [o].[OrderID] < 10300");
         }
 
+        public override void Let_subquery_with_multiple_occurences()
+        {
+            base.Let_subquery_with_multiple_occurences();
+
+            AssertSql(
+                @"SELECT (
+    SELECT COUNT(*)
+    FROM [Order Details] AS [od0]
+    WHERE ([od0].[Quantity] < CAST(10 AS smallint)) AND ([o].[OrderID] = [od0].[OrderID])
+) AS [Count]
+FROM [Orders] AS [o]
+WHERE EXISTS (
+    SELECT 1
+    FROM [Order Details] AS [od]
+    WHERE ([od].[Quantity] < CAST(10 AS smallint)) AND ([o].[OrderID] = [od].[OrderID]))");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Issue: When using let keyword in linq, ReLinq would create 1 SubQueryExpression being used in multiple places.
When we are flattening it out, it would mutate the SubQueryExpression so the other references are corrupted now.
This throws Must be reducible node exception since during translation the qsre in the tree is not in the scope of that subquery model

Resolves #11425
