### PR TITLE
[2.1 RC] Query: Fix for GroupBy with Where Aggregate produces incorrect SQL

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -840,9 +840,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                         || !subSelectExpression.IsCorrelated()
                         || !(querySource is AdditionalFromClause)))
                 {
+                    var groupByNotRequiringPushdown = subSelectExpression.GroupBy.Count > 0
+                        && subQueryModel.ResultOperators.LastOrDefault() is GroupResultOperator;
+
                     if (!subSelectExpression.IsIdentityQuery()
-                        // If the query has GroupBy then we don't need to pushdown since we can compose further.
-                        && subSelectExpression.GroupBy.Count == 0)
+                        && !groupByNotRequiringPushdown)
                     {
                         subSelectExpression.PushDownSubquery().QuerySource = querySource;
                     }


### PR DESCRIPTION
Issue: Due to the shape of QM we incorrectly identified the query for Group By SQL translation.
Which is not the case hence we generate a SQL which produces incorrect result
Fix: During result operator processing, we more carefully identify if we are selecting from a grouping source.
Also relax criterea that group by aggregate should be only 1 level deep. This also allows us to translate group by aggregate when it is inside join

Resolves #11695
