### PR TITLE
[2.1] Fix #11689 - DbContext service parameter throws when FastQuery …

### DIFF
--- a/src/EFCore.Relational/Query/QueryMethodProvider.cs
+++ b/src/EFCore.Relational/Query/QueryMethodProvider.cs
@@ -36,7 +36,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         private static IEnumerable<TEntity> _FastQuery<TEntity>(
             RelationalQueryContext relationalQueryContext,
             ShaperCommandContext shaperCommandContext,
-            Func<DbDataReader, TEntity> materializer,
+            Func<DbDataReader, DbContext, TEntity> materializer,
             Type contextType,
             IDiagnosticsLogger<DbLoggerCategory.Query> logger)
         {
@@ -89,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
                             if (hasNext)
                             {
-                                yield return materializer(dbDataReader);
+                                yield return materializer(dbDataReader, relationalQueryContext.Context);
                             }
                             else
                             {

--- a/src/EFCore.Specification.Tests/Query/AsNoTrackingTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsNoTrackingTestBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
@@ -145,6 +146,34 @@ namespace Microsoft.EntityFrameworkCore.Query
                         .ToList();
 
                 Assert.Equal(6, employees.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Query_fast_path_when_ctor_binding()
+        {
+            using (var context = CreateContext())
+            {
+                var employees
+                    = context.Set<Customer>()
+                        .AsNoTracking()
+                        .ToList();
+
+                Assert.Equal(91, employees.Count);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual async Task Query_fast_path_when_ctor_binding_async()
+        {
+            using (var context = CreateContext())
+            {
+                var employees
+                    = await context.Set<Customer>()
+                        .AsNoTracking()
+                        .ToListAsync();
+
+                Assert.Equal(91, employees.Count);
             }
         }
 

--- a/src/EFCore.Specification.Tests/TestModels/Northwind/Customer.cs
+++ b/src/EFCore.Specification.Tests/TestModels/Northwind/Customer.cs
@@ -3,11 +3,24 @@
 
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+// ReSharper disable UnusedParameter.Local
 
 namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
 {
     public class Customer
     {
+        public Customer()
+        {
+        }
+
+        // Custom ctor binding
+        public Customer(DbContext context, ILazyLoader lazyLoader, string customerID)
+        {
+            CustomerID = customerID;
+        }
+
         public string CustomerID { get; set; }
         public string CompanyName { get; set; }
         public string ContactName { get; set; }
@@ -21,6 +34,8 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
         public string Fax { get; set; }
 
         public virtual List<Order> Orders { get; set; }
+
+        public NorthwindContext Context { get; set; } 
 
         [NotMapped]
         public bool IsLondon => City == "London";

--- a/src/EFCore/Metadata/Internal/ContextParameterBinding.cs
+++ b/src/EFCore/Metadata/Internal/ContextParameterBinding.cs
@@ -33,10 +33,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Expression materializationExpression,
             Expression entityTypeExpression,
             Expression entityExpression)
-            => Expression.TypeAs(
-                Expression.Call(
+        {
+            var propertyExpression
+                = Expression.Property(
                     materializationExpression,
-                    MaterializationContext.GetContextMethod),
-                ServiceType);
+                    MaterializationContext.ContextProperty);
+
+            return ServiceType != typeof(DbContext)
+                ? (Expression)Expression.TypeAs(propertyExpression, ServiceType)
+                : propertyExpression;
+        }
     }
 }

--- a/src/EFCore/Metadata/Internal/DefaultServiceParameterBinding.cs
+++ b/src/EFCore/Metadata/Internal/DefaultServiceParameterBinding.cs
@@ -43,9 +43,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             => Expression.Call(
                 _getServiceMethod.MakeGenericMethod(ServiceType),
                 Expression.Convert(
-                    Expression.Call(
+                    Expression.Property(
                         materializationExpression,
-                        MaterializationContext.GetContextMethod),
+                        MaterializationContext.ContextProperty),
                     typeof(IInfrastructure<IServiceProvider>)));
     }
 }

--- a/src/EFCore/Storage/MaterializationContext.cs
+++ b/src/EFCore/Storage/MaterializationContext.cs
@@ -22,8 +22,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
         internal static readonly MethodInfo GetValueBufferMethod
             = typeof(MaterializationContext).GetProperty(nameof(ValueBuffer)).GetMethod;
 
-        internal static readonly MethodInfo GetContextMethod
-            = typeof(MaterializationContext).GetProperty(nameof(Context)).GetMethod;
+        internal static readonly PropertyInfo ContextProperty
+            = typeof(MaterializationContext).GetProperty(nameof(Context));
 
         internal static readonly ConstructorInfo ObsoleteConstructor
             = typeof(MaterializationContext).GetConstructor(new[] { typeof(ValueBuffer) });

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AsNoTrackingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AsNoTrackingSqlServerTest.cs
@@ -2,14 +2,18 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
 {
     public class AsNoTrackingSqlServerTest : AsNoTrackingTestBase<NorthwindQuerySqlServerFixture<NoopModelCustomizer>>
     {
-        public AsNoTrackingSqlServerTest(NorthwindQuerySqlServerFixture<NoopModelCustomizer> fixture)
+        public AsNoTrackingSqlServerTest(
+            NorthwindQuerySqlServerFixture<NoopModelCustomizer> fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
+            Fixture.TestSqlLoggerFactory.Clear();
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
     }
 }


### PR DESCRIPTION
…is chosen

- When performing the fast query rewrite, transform materializationContext.Context access to a parameter on the materialization lambda.

