### PR TITLE
[2.1] Metadata: Fix for calling OwnsOne on navigation which implements ICol…

### DIFF
--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericStringTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericStringTest.cs
@@ -17,6 +17,13 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 {
     public class ModelBuilderNonGenericStringTest : ModelBuilderNonGenericTest
     {
+        // TODO: See issue#11712
+        //public class NonGenericStringOwnedTypes : OwnedTypesTestBase
+        //{
+        //    protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+        //        => new NonGenericStringTestModelBuilder(testHelpers);
+        //}
+
         public class NonGenericStringOneToManyType : OneToManyTestBase
         {
             [Fact]

--- a/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -504,6 +505,15 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 modelBuilder.Entity<OtherCustomer>().OwnsOne(c => c.Details);
 
                 Assert.Equal(2, modelBuilder.Model.GetEntityTypes(typeof(CustomerDetails)).Count);
+            }
+
+            [Fact]
+            public virtual void OwnedType_can_derive_from_Collection()
+            {
+                var modelBuilder = CreateModelBuilder();
+                modelBuilder.Entity<PrincipalEntity>().OwnsOne(o => o.InverseNav);
+
+                Assert.Single(modelBuilder.Model.GetEntityTypes(typeof(List<DependentEntity>)));
             }
         }
     }


### PR DESCRIPTION
Metadata: Fix for calling OwnsOne on navigation which implements ICollection throws NullRef

Issue: Conventions create one-to-many relationship when navigation of sequence type is found.
Later when OwnsOne is called, we would try to reuse the same navigation's FK to convert it to ownership.
This works fine for reference navigation. For navigation implementing ICollection, we would have FK with different target type. Since we cannot do such conversion, we encounter exception in pipeline.

Fix is to remove FK if the target type is different from target type of FK.

This also uncovered another issue in query. If the owned entity has non-shadow PK, it will be used as FK too.
This does not work well with SelectExpression.PushDownSubquery() because we consider 2 column with same name as same in SQL tree and hence not alias it but still add it. Which generates invalid SQL.
As for fix in query, we would de-dup the inner projections in the subquery, since that does not cause issue with valuebuffer indexes in shapers. At outer level they would still be repeated.

Resolves #11688
