### PR TITLE
[2.1] Use passed-in IEntityType when entity is weak.

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -292,6 +292,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             var newEntry = _internalEntityEntryFactory.Create(
                 this,
                 baseEntityType.ClrType == clrType
+                || baseEntityType.HasDefiningNavigation()
                     ? baseEntityType
                     : _model.FindRuntimeEntityType(clrType),
                 entity, valueBuffer);


### PR DESCRIPTION
Because it cannot be looked up, and it cannot have inheritance.

Fixes #11676 