### PR TITLE
Fix to #11687 - Query with projection cast on correlated collections throws on 2.1.0-preview2

### DIFF
--- a/src/EFCore.Specification.Tests/Query/AsyncGearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncGearsOfWarQueryTestBase.cs
@@ -1644,5 +1644,44 @@ namespace Microsoft.EntityFrameworkCore.Query
             await AssertQuery<Gear>(
                 gs => gs.OfType<Officer>().Cast<Officer>());
         }
+
+        [ConditionalFact]
+        public virtual async Task Cast_subquery_to_base_type_using_typed_ToList()
+        {
+            await AssertQuery<City>(
+                cs => cs.Where(c => c.Name == "Ephyra").Select(c => c.StationedGears.Select(g => new Officer
+                {
+                    CityOrBirthName = g.CityOrBirthName,
+                    FullName = g.FullName,
+                    HasSoulPatch = g.HasSoulPatch,
+                    LeaderNickname = g.LeaderNickname,
+                    LeaderSquadId = g.LeaderSquadId,
+                    Nickname = g.Nickname,
+                    Rank = g.Rank,
+                    SquadId = g.SquadId
+                }).ToList<Gear>()),
+                assertOrder: true,
+                elementAsserter: CollectionAsserter<Gear>(e => e.Nickname, (e, a) => Assert.Equal(e.Nickname, a.Nickname)));
+        }
+
+
+        [ConditionalFact]
+        public virtual async Task Cast_ordered_subquery_to_base_type_using_typed_ToArray()
+        {
+            await AssertQuery<City>(
+                cs => cs.Where(c => c.Name == "Ephyra").Select(c => c.StationedGears.OrderByDescending(g => g.Nickname).Select(g => new Officer
+                {
+                    CityOrBirthName = g.CityOrBirthName,
+                    FullName = g.FullName,
+                    HasSoulPatch = g.HasSoulPatch,
+                    LeaderNickname = g.LeaderNickname,
+                    LeaderSquadId = g.LeaderSquadId,
+                    Nickname = g.Nickname,
+                    Rank = g.Rank,
+                    SquadId = g.SquadId
+                }).ToArray<Gear>()),
+                assertOrder: true,
+                elementAsserter: CollectionAsserter<Gear>(e => e.Nickname, (e, a) => Assert.Equal(e.Nickname, a.Nickname)));
+        }
     }
 }

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -4823,6 +4823,45 @@ namespace Microsoft.EntityFrameworkCore.Query
             AssertQuery<Gear>(
                 gs => gs.OfType<Officer>().Cast<Officer>());
         }
+
+        [ConditionalFact]
+        public virtual void Cast_subquery_to_base_type_using_typed_ToList()
+        {
+            AssertQuery<City>(
+                cs => cs.Where(c => c.Name == "Ephyra").Select(c => c.StationedGears.Select(g => new Officer
+                {
+                    CityOrBirthName = g.CityOrBirthName,
+                    FullName = g.FullName,
+                    HasSoulPatch = g.HasSoulPatch,
+                    LeaderNickname = g.LeaderNickname,
+                    LeaderSquadId = g.LeaderSquadId,
+                    Nickname = g.Nickname,
+                    Rank = g.Rank,
+                    SquadId = g.SquadId
+                }).ToList<Gear>()),
+                assertOrder: true,
+                elementAsserter: CollectionAsserter<Gear>(e => e.Nickname, (e, a) => Assert.Equal(e.Nickname, a.Nickname)));
+        }
+
+        [ConditionalFact]
+        public virtual void Cast_ordered_subquery_to_base_type_using_typed_ToArray()
+        {
+            AssertQuery<City>(
+                cs => cs.Where(c => c.Name == "Ephyra").Select(c => c.StationedGears.OrderByDescending(g => g.Nickname).Select(g => new Officer
+                {
+                    CityOrBirthName = g.CityOrBirthName,
+                    FullName = g.FullName,
+                    HasSoulPatch = g.HasSoulPatch,
+                    LeaderNickname = g.LeaderNickname,
+                    LeaderSquadId = g.LeaderSquadId,
+                    Nickname = g.Nickname,
+                    Rank = g.Rank,
+                    SquadId = g.SquadId
+                }).ToArray<Gear>()),
+                assertOrder: true,
+                elementAsserter: CollectionAsserter<Gear>(e => e.Nickname, (e, a) => Assert.Equal(e.Nickname, a.Nickname)));
+        }
+
         // Remember to add any new tests to Async version of this test class
 
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();

--- a/src/EFCore/Query/ExpressionVisitors/Internal/TypedToListToArrayRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/TypedToListToArrayRewritingExpressionVisitor.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Extensions.Internal;
+using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Clauses.ResultOperators;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class TypedToListToArrayRewritingExpressionVisitor : ExpressionVisitorBase
+    {
+        private static readonly MethodInfo _toListMethodInfo
+            = typeof(Enumerable).GetTypeInfo().GetDeclaredMethod(nameof(Enumerable.ToList));
+
+        private static readonly MethodInfo _toArrayMethodInfo
+            = typeof(Enumerable).GetTypeInfo().GetDeclaredMethod(nameof(Enumerable.ToArray));
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+        {
+            if ((methodCallExpression.Method.MethodIsClosedFormOf(_toListMethodInfo) || methodCallExpression.Method.MethodIsClosedFormOf(_toArrayMethodInfo))
+                && methodCallExpression.Arguments[0] is SubQueryExpression subQuery
+                && subQuery.Type.TryGetSequenceType() != methodCallExpression.Type.TryGetSequenceType())
+            {
+                var sequenceType = methodCallExpression.Type.GetSequenceType();
+                subQuery.QueryModel.ResultOperators.Add(new CastResultOperator(sequenceType));
+                subQuery.QueryModel.ResultTypeOverride = typeof(IEnumerable<>).MakeGenericType(sequenceType);
+
+                var newSubQueryExpression = new SubQueryExpression(subQuery.QueryModel);
+
+                return methodCallExpression.Update(methodCallExpression.Object, new[] { newSubQueryExpression });
+            }
+
+            return base.VisitMethodCall(methodCallExpression);
+        }
+    }
+}

--- a/src/EFCore/Query/Internal/QueryOptimizer.cs
+++ b/src/EFCore/Query/Internal/QueryOptimizer.cs
@@ -85,6 +85,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             queryModel.TransformExpressions(new SubQueryMemberPushDownExpressionVisitor(queryCompilationContext).Visit);
             queryModel.TransformExpressions(new ExistsToAnyRewritingExpressionVisitor().Visit);
             queryModel.TransformExpressions(new AllAnyToContainsRewritingExpressionVisitor().Visit);
+            queryModel.TransformExpressions(new TypedToListToArrayRewritingExpressionVisitor().Visit);
         }
 
         /// <summary>

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AsyncGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AsyncGearsOfWarQuerySqlServerTest.cs
@@ -2273,7 +2273,6 @@ WHERE [o.Reports].[Discriminator] IN (N'Officer', N'Gear') AND ([o.Reports].[Has
 ORDER BY [t].[c], [t].[Nickname], [t].[SquadId]");
         }
 
-
         public override async Task Correlated_collection_with_very_complex_order_by()
         {
             await base.Correlated_collection_with_very_complex_order_by();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -6890,6 +6890,39 @@ FROM [Gears] AS [g]
 WHERE [g].[Discriminator] = N'Officer'");
         }
 
+        public override void Cast_subquery_to_base_type_using_typed_ToList()
+        {
+            base.Cast_subquery_to_base_type_using_typed_ToList();
+
+            AssertSql(
+                @"SELECT [c].[Name]
+FROM [Cities] AS [c]
+WHERE [c].[Name] = N'Ephyra'",
+                //
+                @"@_outer_Name='Ephyra' (Size = 450)
+
+SELECT [g].[CityOrBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId]
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (@_outer_Name = [g].[AssignedCityName])");
+        }
+
+        public override void Cast_ordered_subquery_to_base_type_using_typed_ToArray()
+        {
+            base.Cast_ordered_subquery_to_base_type_using_typed_ToArray();
+
+            AssertSql(
+                @"SELECT [c].[Name]
+FROM [Cities] AS [c]
+WHERE [c].[Name] = N'Ephyra'",
+                //
+                @"@_outer_Name='Ephyra' (Size = 450)
+
+SELECT [g].[CityOrBirthName], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Nickname], [g].[Rank], [g].[SquadId]
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (@_outer_Name = [g].[AssignedCityName])
+ORDER BY [g].[Nickname] DESC");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Problem was that we were not recognizing a pattern where ToList<T> was used to cast a subquery returning collection of derived entities into their base types. We were trying to use correlated collection optimization pattern here but the logic was not accounting for the discrepancy in types.

Fix is to recognize the pattern and inject Cast<T>() into the subquery, which prevents correlated collection optimization from kicking in.

Impact: medium - this is a regression introduced in 2.1 preview2, but the scenario is fairly obscure.

Risk: medium - scenario is fairly obscure and the fix is localized, but the risk is increased because change affects query.