### PR TITLE
Query: Owned entity with non-nullable PK generates invalid SQL when s…

### DIFF
--- a/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
@@ -381,20 +381,29 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
 
             foreach (var expression in projectionsToAdd)
             {
-                var expressionToAdd = subquery.CreateUniqueProjection(expression);
-
-                if (expression is AliasExpression aliasExpression)
+                var expressionToAdd = expression;
+                // To de-dup same projections from table splitting case
+                var projectionIndex = subquery.FindProjectionIndex(expressionToAdd);
+                if (projectionIndex == -1)
                 {
-                    aliasExpressionMap.Add(aliasExpression, expressionToAdd);
-                }
+                    expressionToAdd = subquery.CreateUniqueProjection(expression);
+                    if (expression is AliasExpression aliasExpression)
+                    {
+                        aliasExpressionMap.Add(aliasExpression, expressionToAdd);
+                    }
 
-                if (IsProjectStar)
-                {
-                    subquery._starProjection.Add(expressionToAdd);
+                    if (IsProjectStar)
+                    {
+                        subquery._starProjection.Add(expressionToAdd);
+                    }
+                    else
+                    {
+                        subquery._projection.Add(expressionToAdd);
+                    }
                 }
                 else
                 {
-                    subquery._projection.Add(expressionToAdd);
+                    expressionToAdd = subquery.Projection[projectionIndex];
                 }
 
                 var outerProjection = expressionToAdd.LiftExpressionFromSubquery(subquery);
@@ -609,10 +618,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
                 }
             }
 
-            var projectionIndex
-                = _projection.FindIndex(
-                    e => ExpressionEqualityComparer.Instance.Equals(e, expression)
-                         || ExpressionEqualityComparer.Instance.Equals((e as AliasExpression)?.Expression, expression));
+            var projectionIndex = FindProjectionIndex(expression);
 
             if (projectionIndex != -1)
             {
@@ -649,6 +655,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             }
 
             return _projection.Count - 1;
+        }
+
+        private int FindProjectionIndex(Expression expression)
+        {
+            return _projection.FindIndex(
+                e => ExpressionEqualityComparer.Instance.Equals(e, expression)
+                    || ExpressionEqualityComparer.Instance.Equals((e as AliasExpression)?.Expression, expression));
         }
 
         /// <summary>
@@ -738,10 +751,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
 
         private Expression CreateUniqueProjection(Expression expression, string newAlias = null)
         {
-            var currentProjectionIndex
-                = _projection.FindIndex(
-                    e => ExpressionEqualityComparer.Instance.Equals(e, expression)
-                         || ExpressionEqualityComparer.Instance.Equals((e as AliasExpression)?.Expression, expression));
+            var currentProjectionIndex = FindProjectionIndex(expression);
 
             if (currentProjectionIndex != -1)
             {
@@ -830,10 +840,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
 
             var projectedExpressionToSearch = BindProperty(property, querySource);
 
-            return _projection
-                .FindIndex(
-                    e => ExpressionEqualityComparer.Instance.Equals(e, projectedExpressionToSearch)
-                         || ExpressionEqualityComparer.Instance.Equals((e as AliasExpression)?.Expression, projectedExpressionToSearch));
+            return FindProjectionIndex(projectedExpressionToSearch);
         }
 
         /// <summary>

--- a/src/EFCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
+++ b/src/EFCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
@@ -182,10 +182,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Sql.Internal
                 }
 
                 var subQuery = selectExpression.PushDownSubquery();
-
-                foreach (var projection in subQuery.Projection)
+                if (subQuery.Projection.Count > 0)
                 {
-                    selectExpression.AddToProjection(projection.LiftExpressionFromSubquery(subQuery));
+                    selectExpression.ExplodeStarProjection();
                 }
 
                 if (subQuery.OrderBy.Count == 0)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -3079,21 +3079,39 @@ ORDER BY [t].[Id]");
         {
             using (var context = new MyContext10168(Fixture.TestSqlLoggerFactory))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureClean();
+                context.Add(new Note
+                {
+                    Text = "Foo Bar",
+                    User = new User10168
+                    {
+                        Fullname = "Full1",
+                        Email = "abc@def.com"
+                    }
+                });
 
+                context.SaveChanges();
                 ClearLog();
+            }
 
-                var queryableObj = context.Note.Where(x => x.Text == "Foo Bar").AsQueryable();
+            using (var context = new MyContext10168(Fixture.TestSqlLoggerFactory))
+            {
+                var query = context.Note.Where(x => x.Text == "Foo Bar")
+                                .Skip(0)
+                                .Take(100)
+                                .ToList();
 
-                queryableObj.Skip(0).Take(100).ToList();
+                var result = Assert.Single(query);
+                Assert.NotNull(result.User);
+                Assert.Equal("Full1", result.User.Fullname);
 
                 AssertSql(
                     @"@__p_0='?' (DbType = Int32)
 @__p_1='?' (DbType = Int32)
 
-SELECT [t].[Id], [t].[Text], [t].[Id0], [t].[User_Email], [t].[User_Fullname]
+SELECT [t].[Id], [t].[Text], [t].[Id], [t].[User_Email], [t].[User_Fullname]
 FROM (
-    SELECT [x].[Id], [x].[Text], [x].[Id] AS [Id0], [x].[User_Email], [x].[User_Fullname], ROW_NUMBER() OVER(ORDER BY @@RowCount) AS [__RowNumber__]
+    SELECT [x].[Id], [x].[Text], [x].[User_Email], [x].[User_Fullname], ROW_NUMBER() OVER(ORDER BY @@RowCount) AS [__RowNumber__]
     FROM [Note] AS [x]
     WHERE [x].[Text] = N'Foo Bar'
 ) AS [t]
@@ -3137,6 +3155,7 @@ WHERE ([t].[__RowNumber__] > @__p_0) AND ([t].[__RowNumber__] <= (@__p_0 + @__p_
 
         public class User10168
         {
+            public Guid Id { get; set; }
             public string Fullname { get; set; }
             public string Email { get; set; }
         }


### PR DESCRIPTION
…ubquery

Issue: For owned Entity when PK is non-nullble (which is sharing column with owner PK), we conclude both the columns to be same. This stops creating proper aliases for subquery generating invalid SQL.
Fix: We de-dupe same columns inside subquery when pushing down. We cannot do the same on top level due to valuebuffer index bindings

