### PR TITLE
[2.1] Metadata: Bring in symmetry for reference counting for FKs defined on…

### DIFF
--- a/src/EFCore/Metadata/Builders/QueryTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/QueryTypeBuilder.cs
@@ -187,18 +187,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         }
 
         /// <summary>
-        ///     Configures an index on the specified properties. If there is an existing index on the given
-        ///     set of properties, then the existing index will be returned for configuration.
-        /// </summary>
-        /// <param name="propertyNames"> The names of the properties that make up the index. </param>
-        /// <returns> An object that can be used to configure the index. </returns>
-        public virtual IndexBuilder HasIndex([NotNull] params string[] propertyNames)
-        {
-            return new IndexBuilder(Builder.HasIndex(Check.NotEmpty(propertyNames, nameof(propertyNames)),
-                ConfigurationSource.Explicit));
-        }
-
-        /// <summary>
         ///     <para>
         ///         Configures a relationship where this query type has a reference that points
         ///         to a single instance of the other type in the relationship.

--- a/src/EFCore/Metadata/Builders/QueryTypeBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/QueryTypeBuilder`.cs
@@ -112,27 +112,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             (QueryTypeBuilder<TQuery>)base.HasQueryFilter(filter);
 
         /// <summary>
-        ///     Configures an index on the specified properties. If there is an existing index on the given
-        ///     set of properties, then the existing index will be returned for configuration.
-        /// </summary>
-        /// <param name="indexExpression">
-        ///     <para>
-        ///         A lambda expression representing the property(s) to be included in the index
-        ///         (<c>blog => blog.Url</c>).
-        ///     </para>
-        ///     <para>
-        ///         If the index is made up of multiple properties then specify an anonymous type including the
-        ///         properties (<c>post => new { post.Title, post.BlogId }</c>).
-        ///     </para>
-        /// </param>
-        /// <returns> An object that can be used to configure the index. </returns>
-        public virtual IndexBuilder HasIndex([NotNull] Expression<Func<TQuery, object>> indexExpression) =>
-            new IndexBuilder(
-                Builder.HasIndex(
-                    Check.NotNull(indexExpression, nameof(indexExpression)).GetPropertyAccessList(),
-                    ConfigurationSource.Explicit));
-
-        /// <summary>
         ///     Configures a query used to provide data for a query type.
         /// </summary>
         /// <param name="query"> The query that will provider the underlying data for the query type. </param>

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -1128,8 +1128,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
 
-            foreignKey.PrincipalKey.ReferencingForeignKeys.Remove(foreignKey);
-            foreignKey.PrincipalEntityType.DeclaredReferencingForeignKeys.Remove(foreignKey);
+            if (!IsQueryType)
+            {
+                foreignKey.PrincipalKey.ReferencingForeignKeys.Remove(foreignKey);
+                foreignKey.PrincipalEntityType.DeclaredReferencingForeignKeys.Remove(foreignKey);
+            }
 
             PropertyMetadataChanged();
 

--- a/test/EFCore.Tests/ModelBuilding/IQueryTypeConfigurationTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/IQueryTypeConfigurationTest.cs
@@ -70,6 +70,54 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Equal(1000, entityType.FindProperty(nameof(Customer.Name)).GetMaxLength());
             }
 
+            [Fact]
+            public void Can_use_shadow_property_for_fk_on_queryType()
+            {
+                var builder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+
+                builder.Entity<Value>();
+                builder.Query<QueryResult>().HasOne(x => x.Value).WithMany().HasForeignKey("DataValueId");
+
+                var fk = Assert.Single(builder.Model.FindEntityType(typeof(QueryResult)).GetForeignKeys());
+                Assert.Equal("DataValueId", fk.Properties[0].Name);
+            }
+
+            [Fact]
+            public void Can_use_clr_property_for_fk_on_queryType()
+            {
+                var builder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+
+                builder.Entity<Value>();
+                builder.Query<QueryResult>().HasOne(x => x.Value).WithMany().HasForeignKey(e => e.ValueFk);
+
+                var fk = Assert.Single(builder.Model.FindEntityType(typeof(QueryResult)).GetForeignKeys());
+                Assert.Equal("ValueFk", fk.Properties[0].Name);
+            }
+
+            [Fact]
+            public void Can_use_different_clr_property_for_fk_on_queryType()
+            {
+                var builder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+
+                builder.Entity<Value>();
+                builder.Query<QueryCoreResult>().HasOne(x => x.Value).WithMany().HasForeignKey(e => e.ValueFk);
+
+                var fk = Assert.Single(builder.Model.FindEntityType(typeof(QueryCoreResult)).GetForeignKeys());
+                Assert.Equal("ValueFk", fk.Properties[0].Name);
+            }
+
+            [Fact]
+            public void Can_use_alternate_key()
+            {
+                var builder = InMemoryTestHelpers.Instance.CreateConventionBuilder();
+
+                builder.Entity<Value>();
+                builder.Query<QueryResult>().HasOne(x => x.Value).WithMany().HasPrincipalKey(e => e.AlternateId);
+
+                var fk = Assert.Single(builder.Model.FindEntityType(typeof(QueryResult)).GetForeignKeys());
+                Assert.Equal("AlternateId", fk.PrincipalKey.Properties[0].Name);
+            }
+
             private class CustomerConfiguration : IQueryTypeConfiguration<Customer>
             {
                 public void Configure(QueryTypeBuilder<Customer> builder)

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -133,7 +133,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         }
 
         [Owned]
-        public class StreetAddress
+        protected class StreetAddress
         {
             public string Street { get; set; }
             public string City { get; set; }
@@ -548,12 +548,12 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         {
         }
 
-        public class StringIdBase
+        protected class StringIdBase
         {
             public string Id { get; set; }
         }
 
-        public class StringIdDerived : StringIdBase
+        protected class StringIdDerived : StringIdBase
         {
         }
 
@@ -572,6 +572,25 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         {
             public int Id { get; set; }
             public IList<Friendship> Friendships { get; set; }
+        }
+
+        protected class QueryResult
+        {
+            public int ValueFk { get; set; }
+            public Value Value { get; set; }
+        }
+
+        protected class Value
+        {
+            public int Id { get; set; }
+            public int AlternateId { get; set; }
+        }
+
+        protected class QueryCoreResult
+        {
+            public int ValueFk { get; set; }
+            public int ValueId { get; set; }
+            public Value Value { get; set; }
         }
     }
 }


### PR DESCRIPTION
… QueryType

Issue: When adding an FK on query type we don't add it to `ReferenceingFKs` collections on principal end.
But when we modify any facet of FK which requires rebuilding FK, we still try to remove FK from those collections which are not initialized hence throws NullRef.
Fix: Only do fixup on such collection when FK is not on QueryType

Also remove HasIndex API from QueryTypeBuilder

Resolves #11720

