### PR TITLE
Fix to #11690 - Handling of casts to nullable type differs between 2.1.0-preview2 and 2.0.0

### DIFF
--- a/src/EFCore.Specification.Tests/Query/AsyncGearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncGearsOfWarQueryTestBase.cs
@@ -1605,6 +1605,15 @@ namespace Microsoft.EntityFrameworkCore.Query
                 new List<IExpectedInclude> { new ExpectedInclude<Officer>(o => o.Reports, "Reports") });
         }
 
+        [ConditionalFact]
+        public virtual async Task Include_collection_with_complex_OrderBy3()
+        {
+            await AssertIncludeQuery<Gear>(
+                os => os.OfType<Officer>()
+                        .Include(o => o.Reports)
+                        .OrderBy(o => o.Weapons.OrderBy(w => w.Id).Select(w => w.IsAutomatic).FirstOrDefault()),
+                new List<IExpectedInclude> { new ExpectedInclude<Officer>(o => o.Reports, "Reports") });
+        }
 
         [ConditionalFact]
         public virtual async Task Correlated_collection_with_complex_OrderBy()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AsyncGearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AsyncGearsOfWarQuerySqlServerTest.cs
@@ -2221,6 +2221,37 @@ ORDER BY [t].[c], [t].[Nickname], [t].[SquadId]");
                 @"SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOrBirthName], [o].[Discriminator], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank]
 FROM [Gears] AS [o]
 WHERE [o].[Discriminator] = N'Officer'
+ORDER BY (
+    SELECT TOP(1) [w].[IsAutomatic]
+    FROM [Weapons] AS [w]
+    WHERE [o].[FullName] = [w].[OwnerFullName]
+    ORDER BY [w].[Id]
+), [o].[Nickname], [o].[SquadId]",
+                //
+                @"SELECT [o.Reports].[Nickname], [o.Reports].[SquadId], [o.Reports].[AssignedCityName], [o.Reports].[CityOrBirthName], [o.Reports].[Discriminator], [o.Reports].[FullName], [o.Reports].[HasSoulPatch], [o.Reports].[LeaderNickname], [o.Reports].[LeaderSquadId], [o.Reports].[Rank]
+FROM [Gears] AS [o.Reports]
+INNER JOIN (
+    SELECT [o0].[Nickname], [o0].[SquadId], (
+        SELECT TOP(1) [w0].[IsAutomatic]
+        FROM [Weapons] AS [w0]
+        WHERE [o0].[FullName] = [w0].[OwnerFullName]
+        ORDER BY [w0].[Id]
+    ) AS [c]
+    FROM [Gears] AS [o0]
+    WHERE [o0].[Discriminator] = N'Officer'
+) AS [t] ON ([o.Reports].[LeaderNickname] = [t].[Nickname]) AND ([o.Reports].[LeaderSquadId] = [t].[SquadId])
+WHERE [o.Reports].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [t].[c], [t].[Nickname], [t].[SquadId]");
+        }
+
+        public override async Task Include_collection_with_complex_OrderBy3()
+        {
+            await base.Include_collection_with_complex_OrderBy3();
+
+            AssertSql(
+                @"SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOrBirthName], [o].[Discriminator], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank]
+FROM [Gears] AS [o]
+WHERE [o].[Discriminator] = N'Officer'
 ORDER BY COALESCE((
     SELECT TOP(1) [w].[IsAutomatic]
     FROM [Weapons] AS [w]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/WarningsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/WarningsSqlServerTest.cs
@@ -51,7 +51,7 @@ WHERE [x].[OrderID] = 10248",
 
             Assert.Contains(
                 CoreStrings.LogFirstWithoutOrderByAndFilter.GenerateMessage(
-                    "(from Order <generated>_1 in [c].Orders select [<generated>_1].OrderID).FirstOrDefault()"), Fixture.TestSqlLoggerFactory.Log);
+                    "(from Order <generated>_1 in [c].Orders select (Nullable<int>)[<generated>_1].OrderID).FirstOrDefaul..."), Fixture.TestSqlLoggerFactory.Log);
         }
 
         public override void FirstOrDefault_without_orderby_but_with_filter_doesnt_issue_warning()


### PR DESCRIPTION
Problem was that we changed behavior of queries like:

customers.Select(c => (int?)c.Orders.Where(o => false).FirstOrDefault().Id)

In 2.0 this query would return collection of nulls, but in preview2 it would return collection of 0s. We made this change to address the following (very similar) scenario:

customers.Select(c => c.Orders.Where(o => false).Select(o => o.Id).FirstOrDefault())

which should have been returning 0s, but was returning nulls instead.

Fix is to add convert to nullable type whenever we perform member pushdown of a non-nullable property on a query containing FirstOrDefault/SingleOrDefault/LastOrDefault.
However, if the query doesn't require pushdown and *-OrDefault operator is applied on list of non-nullable scalars, rather than list of entities, we keep the query as is.