### PR TITLE
[2.1] Query: Avoid applying entity equality rewrite to subquery coming from let

### DIFF
--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -4258,5 +4258,32 @@ namespace Microsoft.EntityFrameworkCore.Query
                       select new { Count = details.Count() });
         }
 
+        [ConditionalFact]
+        public virtual void Let_entity_equality_to_null()
+        {
+            AssertQuery<Customer>(
+                cs => from c in cs.Where(c => c.CustomerID.StartsWith("A"))
+                      let o = c.Orders.OrderBy(e => e.OrderDate).FirstOrDefault()
+                      where o != null
+                      select new
+                      {
+                          c.CustomerID,
+                          o.OrderDate
+                      });
+        }
+
+        [ConditionalFact]
+        public virtual void Let_entity_equality_to_other_entity()
+        {
+            AssertQuery<Customer>(
+                cs => from c in cs.Where(c => c.CustomerID.StartsWith("A"))
+                      let o = c.Orders.OrderBy(e => e.OrderDate).FirstOrDefault()
+                      where o != new Order()
+                      select new
+                      {
+                          c.CustomerID,
+                          A = (o != null ? o.OrderDate : null)
+                      });
+        }
     }
 }

--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -65,6 +65,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             TrackQueryResults = trackQueryResults;
         }
 
+        internal ISet<QueryModel> DuplicateQueryModels = new HashSet<QueryModel>();
+
         /// <summary>
         ///     Registers a mapping between correlated collection query models and metadata needed to process them.
         /// </summary>

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -4514,6 +4514,120 @@ WHERE EXISTS (
     WHERE ([od].[Quantity] < CAST(10 AS smallint)) AND ([o].[OrderID] = [od].[OrderID]))");
         }
 
+        public override void Let_entity_equality_to_null()
+        {
+            base.Let_entity_equality_to_null();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], (
+    SELECT TOP(1) [e0].[OrderDate]
+    FROM [Orders] AS [e0]
+    WHERE [c].[CustomerID] = [e0].[CustomerID]
+    ORDER BY [e0].[OrderDate]
+) AS [OrderDate]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')",
+                //
+                @"@_outer_CustomerID='ALFKI' (Size = 5)
+
+SELECT TOP(1) [e].[OrderID], [e].[CustomerID], [e].[EmployeeID], [e].[OrderDate]
+FROM [Orders] AS [e]
+WHERE @_outer_CustomerID = [e].[CustomerID]
+ORDER BY [e].[OrderDate]",
+                //
+                @"@_outer_CustomerID='ANATR' (Size = 5)
+
+SELECT TOP(1) [e].[OrderID], [e].[CustomerID], [e].[EmployeeID], [e].[OrderDate]
+FROM [Orders] AS [e]
+WHERE @_outer_CustomerID = [e].[CustomerID]
+ORDER BY [e].[OrderDate]",
+                //
+                @"@_outer_CustomerID='ANTON' (Size = 5)
+
+SELECT TOP(1) [e].[OrderID], [e].[CustomerID], [e].[EmployeeID], [e].[OrderDate]
+FROM [Orders] AS [e]
+WHERE @_outer_CustomerID = [e].[CustomerID]
+ORDER BY [e].[OrderDate]",
+                //
+                @"@_outer_CustomerID='AROUT' (Size = 5)
+
+SELECT TOP(1) [e].[OrderID], [e].[CustomerID], [e].[EmployeeID], [e].[OrderDate]
+FROM [Orders] AS [e]
+WHERE @_outer_CustomerID = [e].[CustomerID]
+ORDER BY [e].[OrderDate]");
+        }
+
+        public override void Let_entity_equality_to_other_entity()
+        {
+            base.Let_entity_equality_to_other_entity();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], (
+    SELECT TOP(1) [e2].[OrderDate]
+    FROM [Orders] AS [e2]
+    WHERE [c].[CustomerID] = [e2].[CustomerID]
+    ORDER BY [e2].[OrderDate]
+)
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')",
+                //
+                @"@_outer_CustomerID='ALFKI' (Size = 5)
+
+SELECT TOP(1) [e].[OrderID], [e].[CustomerID], [e].[EmployeeID], [e].[OrderDate]
+FROM [Orders] AS [e]
+WHERE @_outer_CustomerID = [e].[CustomerID]
+ORDER BY [e].[OrderDate]",
+                //
+                @"@_outer_CustomerID1='ALFKI' (Size = 5)
+
+SELECT TOP(1) [e1].[OrderID], [e1].[CustomerID], [e1].[EmployeeID], [e1].[OrderDate]
+FROM [Orders] AS [e1]
+WHERE @_outer_CustomerID1 = [e1].[CustomerID]
+ORDER BY [e1].[OrderDate]",
+                //
+                @"@_outer_CustomerID='ANATR' (Size = 5)
+
+SELECT TOP(1) [e].[OrderID], [e].[CustomerID], [e].[EmployeeID], [e].[OrderDate]
+FROM [Orders] AS [e]
+WHERE @_outer_CustomerID = [e].[CustomerID]
+ORDER BY [e].[OrderDate]",
+                //
+                @"@_outer_CustomerID1='ANATR' (Size = 5)
+
+SELECT TOP(1) [e1].[OrderID], [e1].[CustomerID], [e1].[EmployeeID], [e1].[OrderDate]
+FROM [Orders] AS [e1]
+WHERE @_outer_CustomerID1 = [e1].[CustomerID]
+ORDER BY [e1].[OrderDate]",
+                //
+                @"@_outer_CustomerID='ANTON' (Size = 5)
+
+SELECT TOP(1) [e].[OrderID], [e].[CustomerID], [e].[EmployeeID], [e].[OrderDate]
+FROM [Orders] AS [e]
+WHERE @_outer_CustomerID = [e].[CustomerID]
+ORDER BY [e].[OrderDate]",
+                //
+                @"@_outer_CustomerID1='ANTON' (Size = 5)
+
+SELECT TOP(1) [e1].[OrderID], [e1].[CustomerID], [e1].[EmployeeID], [e1].[OrderDate]
+FROM [Orders] AS [e1]
+WHERE @_outer_CustomerID1 = [e1].[CustomerID]
+ORDER BY [e1].[OrderDate]",
+                //
+                @"@_outer_CustomerID='AROUT' (Size = 5)
+
+SELECT TOP(1) [e].[OrderID], [e].[CustomerID], [e].[EmployeeID], [e].[OrderDate]
+FROM [Orders] AS [e]
+WHERE @_outer_CustomerID = [e].[CustomerID]
+ORDER BY [e].[OrderDate]",
+                //
+                @"@_outer_CustomerID1='AROUT' (Size = 5)
+
+SELECT TOP(1) [e1].[OrderID], [e1].[CustomerID], [e1].[EmployeeID], [e1].[OrderDate]
+FROM [Orders] AS [e1]
+WHERE @_outer_CustomerID1 = [e1].[CustomerID]
+ORDER BY [e1].[OrderDate]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Resolves #11728

