### PR TITLE
Infer CLR type where possible when using OwnsOne

### DIFF
--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -2105,30 +2105,34 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
 
                 var principalBuilder = this;
-                ownedEntityType = targetEntityType.Type == null
-                    ? ModelBuilder.Metadata.FindEntityType(targetEntityType.Name)?.Builder
-                    : ModelBuilder.Metadata.FindEntityType(targetEntityType.Type)?.Builder;
+                var targetTypeName = targetEntityType.Name;
+                var targetType = targetEntityType.Type
+                                 ?? existingNavigation?.GetIdentifyingMemberInfo()?.GetMemberType();
+
+                ownedEntityType = targetType == null
+                    ? ModelBuilder.Metadata.FindEntityType(targetTypeName)?.Builder
+                    : ModelBuilder.Metadata.FindEntityType(targetType)?.Builder;
                 if (ownedEntityType == null)
                 {
-                    if (Metadata.Model.HasEntityTypeWithDefiningNavigation(targetEntityType.Name))
+                    if (Metadata.Model.HasEntityTypeWithDefiningNavigation(targetTypeName))
                     {
                         if (!configurationSource.Overrides(ConfigurationSource.Explicit)
-                            && (targetEntityType.Type == null
-                                ? Metadata.IsInDefinitionPath(targetEntityType.Name)
-                                : Metadata.IsInDefinitionPath(targetEntityType.Type)))
+                            && (targetType == null
+                                ? Metadata.IsInDefinitionPath(targetTypeName)
+                                : Metadata.IsInDefinitionPath(targetType)))
                         {
                             return null;
                         }
 
-                        ownedEntityType = targetEntityType.Type == null
-                            ? ModelBuilder.Entity(targetEntityType.Name, navigation.Name, Metadata, configurationSource)
-                            : ModelBuilder.Entity(targetEntityType.Type, navigation.Name, Metadata, configurationSource);
+                        ownedEntityType = targetType == null
+                            ? ModelBuilder.Entity(targetTypeName, navigation.Name, Metadata, configurationSource)
+                            : ModelBuilder.Entity(targetType, navigation.Name, Metadata, configurationSource);
                     }
                     else
                     {
-                        ownedEntityType = targetEntityType.Type == null
-                            ? ModelBuilder.Entity(targetEntityType.Name, configurationSource)
-                            : ModelBuilder.Entity(targetEntityType.Type, configurationSource);
+                        ownedEntityType = targetType == null
+                            ? ModelBuilder.Entity(targetTypeName, configurationSource)
+                            : ModelBuilder.Entity(targetType, configurationSource);
                     }
 
                     if (ownedEntityType == null)
@@ -2142,9 +2146,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     if (otherOwnership != null)
                     {
                         if (!configurationSource.Overrides(ConfigurationSource.Explicit)
-                            && (targetEntityType.Type == null
-                                ? Metadata.IsInDefinitionPath(targetEntityType.Name)
-                                : Metadata.IsInDefinitionPath(targetEntityType.Type)))
+                            && (targetType == null
+                                ? Metadata.IsInDefinitionPath(targetTypeName)
+                                : Metadata.IsInDefinitionPath(targetType)))
                         {
                             return null;
                         }
@@ -2160,9 +2164,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                             principalBuilder = newOtherOwnership.Metadata.DeclaringEntityType.Builder;
                         }
 
-                        ownedEntityType = targetEntityType.Type == null
-                            ? ModelBuilder.Entity(targetEntityType.Name, navigation.Name, principalBuilder.Metadata, configurationSource)
-                            : ModelBuilder.Entity(targetEntityType.Type, navigation.Name, principalBuilder.Metadata, configurationSource);
+                        ownedEntityType = targetType == null
+                            ? ModelBuilder.Entity(targetTypeName, navigation.Name, principalBuilder.Metadata, configurationSource)
+                            : ModelBuilder.Entity(targetType, navigation.Name, principalBuilder.Metadata, configurationSource);
                     }
                 }
 

--- a/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalModelBuilder.cs
@@ -200,7 +200,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return null;
             }
 
-            var clrType = type.Type;
+            var clrType = type.Type
+                          ?? Metadata.FindClrType(type.Name);
+
             var weakEntityType = clrType == null
                 ? Metadata.FindEntityType(type.Name, definingNavigationName, definingEntityType)
                 : Metadata.FindEntityType(clrType, definingNavigationName, definingEntityType);

--- a/src/EFCore/Metadata/Internal/Model.cs
+++ b/src/EFCore/Metadata/Internal/Model.cs
@@ -395,6 +395,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public virtual Type FindClrType([NotNull] string name)
+            => _entityTypes.TryGetValue(name, out var entityType)
+                ? entityType.ClrType
+                : (_entityTypesWithDefiningNavigation.TryGetValue(name, out var entityTypesWithSameType)
+                    ? entityTypesWithSameType.FirstOrDefault()?.ClrType
+                    : null);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual IReadOnlyCollection<EntityType> GetEntityTypes([NotNull] Type type)
             => GetEntityTypes(GetDisplayName(type));
 

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericStringTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericStringTest.cs
@@ -17,12 +17,23 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 {
     public class ModelBuilderNonGenericStringTest : ModelBuilderNonGenericTest
     {
-        // TODO: See issue#11712
-        //public class NonGenericStringOwnedTypes : OwnedTypesTestBase
-        //{
-        //    protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
-        //        => new NonGenericStringTestModelBuilder(testHelpers);
-        //}
+        public class NonGenericStringOwnedTypes : OwnedTypesTestBase
+        {
+            protected override TestModelBuilder CreateTestModelBuilder(TestHelpers testHelpers)
+                => new NonGenericStringTestModelBuilder(testHelpers);
+
+            public override void Can_configure_one_to_one_relationship_from_an_owned_type()
+            {
+                var modelBuilder = CreateModelBuilder();
+
+                // Test issue: HasOne<SpecialCustomer> in the base test is adding a shadow entity type when strings are
+                // used. This would not normally happen, but it happens here because no navigation property
+                // or type to do otherwise.
+                modelBuilder.Entity<SpecialCustomer>();
+
+                Can_configure_one_to_one_relationship_from_an_owned_type(modelBuilder);
+            }
+        }
 
         public class NonGenericStringOneToManyType : OneToManyTestBase
         {

--- a/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
@@ -158,7 +158,11 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             [Fact]
             public virtual void Can_configure_one_to_one_relationship_from_an_owned_type()
             {
-                var modelBuilder = CreateModelBuilder();
+                Can_configure_one_to_one_relationship_from_an_owned_type(CreateModelBuilder());
+            }
+
+            public virtual void Can_configure_one_to_one_relationship_from_an_owned_type(TestModelBuilder modelBuilder)
+            {
                 var model = modelBuilder.Model;
 
                 modelBuilder.Ignore<Customer>();


### PR DESCRIPTION
Fixes #11712

The idea is that if we already have a CLR type associated with the name given, then use that CLR type.
