### PR TITLE
Query: Improve alias-ing of projection in SelectExpression

### DIFF
--- a/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -909,10 +909,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                     (from c in cs
                      join o in os
                          on c.CustomerID equals o.CustomerID into grouping
-                     from o in grouping
+                     from o in grouping.DefaultIfEmpty()
+                     where o != null
                      select o)
                     .GroupBy(o => o.CustomerID)
-                    .Select(g => new { g.Key, Count = g.Average(o => o.OrderID) }),
+                    .Select(g => new { g.Key, Average = g.Average(o => o.OrderID) }),
                 e => e.Key);
         }
 
@@ -924,10 +925,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                     (from c in cs
                      join o in os
                          on c.CustomerID equals o.CustomerID into grouping
-                     from o in grouping
+                     from o in grouping.DefaultIfEmpty()
                      select c)
                     .GroupBy(c => c.CustomerID)
-                    .Select(g => new { g.Key, Count = g.Max(c => c.City) }),
+                    .Select(g => new { g.Key, Max = g.Max(c => c.City) }),
                 e => e.Key);
         }
 
@@ -939,11 +940,41 @@ namespace Microsoft.EntityFrameworkCore.Query
                     (from o in os
                      join c in cs
                          on o.CustomerID equals c.CustomerID into grouping
-                     from c in grouping
+                     from c in grouping.DefaultIfEmpty()
                      select o)
                     .GroupBy(o => o.CustomerID)
-                    .Select(g => new { g.Key, Count = g.Average(o => o.OrderID) }),
+                    .Select(g => new { g.Key, Average = g.Average(o => o.OrderID) }),
                 e => e.Key);
+        }
+
+        [ConditionalFact]
+        public virtual void GroupJoin_GroupBy_Aggregate_4()
+        {
+            AssertQuery<Order, Customer>(
+                (os, cs) =>
+                    (from c in cs
+                     join o in os
+                         on c.CustomerID equals o.CustomerID into grouping
+                     from o in grouping.DefaultIfEmpty()
+                     select c)
+                    .GroupBy(c => c.CustomerID)
+                    .Select(g => new { Value = g.Key, Max = g.Max(c => c.City) }),
+                e => e.Value);
+        }
+
+        [ConditionalFact]
+        public virtual void GroupJoin_GroupBy_Aggregate_5()
+        {
+            AssertQuery<Order, Customer>(
+                (os, cs) =>
+                    (from o in os
+                     join c in cs
+                         on o.CustomerID equals c.CustomerID into grouping
+                     from c in grouping.DefaultIfEmpty()
+                     select o)
+                    .GroupBy(o => o.OrderID)
+                    .Select(g => new { Value = g.Key, Average = g.Average(o => o.OrderID) }),
+                e => e.Value);
         }
 
         [ConditionalFact]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
@@ -810,9 +810,10 @@ GROUP BY [t0].[CustomerID]");
             base.GroupJoin_GroupBy_Aggregate();
 
             AssertSql(
-                @"SELECT [o].[CustomerID] AS [Key], AVG(CAST([o].[OrderID] AS float)) AS [Count]
+                @"SELECT [o].[CustomerID] AS [Key], AVG(CAST([o].[OrderID] AS float)) AS [Average]
 FROM [Customers] AS [c]
-INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+WHERE [o].[OrderID] IS NOT NULL
 GROUP BY [o].[CustomerID]");
         }
 
@@ -821,9 +822,9 @@ GROUP BY [o].[CustomerID]");
             base.GroupJoin_GroupBy_Aggregate_2();
 
             AssertSql(
-                @"SELECT [c].[CustomerID] AS [Key], MAX([c].[City]) AS [Count]
+                @"SELECT [c].[CustomerID] AS [Key], MAX([c].[City]) AS [Max]
 FROM [Customers] AS [c]
-INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
 GROUP BY [c].[CustomerID]");
         }
 
@@ -832,10 +833,33 @@ GROUP BY [c].[CustomerID]");
             base.GroupJoin_GroupBy_Aggregate_3();
 
             AssertSql(
-                @"SELECT [o].[CustomerID] AS [Key], AVG(CAST([o].[OrderID] AS float)) AS [Count]
+                @"SELECT [o].[CustomerID] AS [Key], AVG(CAST([o].[OrderID] AS float)) AS [Average]
 FROM [Orders] AS [o]
-INNER JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 GROUP BY [o].[CustomerID]");
+        }
+
+        public override void GroupJoin_GroupBy_Aggregate_4()
+        {
+            base.GroupJoin_GroupBy_Aggregate_4();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID] AS [Value], MAX([c].[City]) AS [Max]
+FROM [Customers] AS [c]
+LEFT JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]
+GROUP BY [c].[CustomerID]");
+        }
+
+        public override void GroupJoin_GroupBy_Aggregate_5()
+        {
+            base.GroupJoin_GroupBy_Aggregate_5();
+
+            AssertSql(
+                @"SELECT [o].[OrderID] AS [Value], AVG(CAST([o].[OrderID] AS float)) AS [Average]
+FROM [Orders] AS [o]
+LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
+GROUP BY [o].[OrderID]");
+
         }
 
         public override void GroupBy_optional_navigation_member_Aggregate()


### PR DESCRIPTION
Issue: When we try to find name of the projection, we go through Convert/NullableExpression nodes. But when updating the alias we just wrap it inside a new AliasExpression. If the inner expression had AliasExpression giving it a name, then we would have multiple "AS" in SQL
Fix: When assigning new alias to projection, we run visitor and tries to replace old name to new name to avoid multiple aliases.

Resolves #11757

