### PR TITLE
fully-fledged sql query can also starts with "WITH"

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
@@ -191,7 +191,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 var useQueryComposition
                     = trimmedSql.StartsWith("SELECT ", StringComparison.OrdinalIgnoreCase)
                       || trimmedSql.StartsWith("SELECT" + Environment.NewLine, StringComparison.OrdinalIgnoreCase)
-                      || trimmedSql.StartsWith("SELECT\t", StringComparison.OrdinalIgnoreCase);
+                      || trimmedSql.StartsWith("SELECT\t", StringComparison.OrdinalIgnoreCase)
+					  || trimmedSql.StartsWith("WITH ", StringComparison.OrdinalIgnoreCase)
+					  || trimmedSql.StartsWith("WITH" + Environment.NewLine, StringComparison.OrdinalIgnoreCase)
+					  || trimmedSql.StartsWith("WITH\t", StringComparison.OrdinalIgnoreCase);
 
                 var requiresClientEval = !useQueryComposition;
 


### PR DESCRIPTION
When I'm trying to use "Include" just after "FromSql", where sql is a common table expression string which is not started with "SELECT" an exception is thrown (InvalidOperationException(RelationalStrings.StoredProcedureIncludeNotSupported)).

some example repro code:


> var exampleSqlCTEQuery = @"with
> subQuery as (
> select someColumn from someTable where Id > @someParam1 and Id < @someParam2
> )
> select * from subQuery";
> 
> var parameters = new[] {
> 	new SqlParameter("@someParam1", 2),
> 	new SqlParameter("@someParam2", 4)
> };
> 
> return await dbSet.FromSql(exampleSqlCTEQuery , parameters).Include(d => d.SomeAdditionalEntity).FirstOrDefaultAsync();
