### PR TITLE
[2.1] Query: Fix for GroupByAggregate with join on grouping key produces incorrect sql

### DIFF
--- a/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
@@ -938,6 +938,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             Check.NotNull(memberInfo, nameof(memberInfo));
             Check.NotNull(projection, nameof(projection));
 
+            var existingMemberInfo = _memberInfoProjectionMapping.FirstOrDefault(
+                        kvp => ExpressionEqualityComparer.Instance.Equals(kvp.Value, projection))
+                    .Key;
+
+            if (existingMemberInfo != null)
+            {
+                _memberInfoProjectionMapping.Remove(existingMemberInfo);
+            }
+
             _memberInfoProjectionMapping[memberInfo] = CreateUniqueProjection(projection, memberInfo.Name);
         }
 

--- a/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
@@ -1254,6 +1254,21 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual async Task Join_GroupBy_Aggregate_on_key()
+        {
+            await AssertQuery<Order, Customer>(
+                   (os, cs) =>
+                       (from c in cs
+                        join a in os.GroupBy(o => o.CustomerID)
+                                    .Where(g => g.Count() > 5)
+                                    .Select(g => new { g.Key, LastOrderID = g.Max(o => o.OrderID) })
+                            on c.CustomerID equals a.Key
+                        select new { c, a.LastOrderID }),
+                   e => e.c.CustomerID,
+                   entryCount: 63);
+        }
+
+        [ConditionalFact]
         public virtual async Task GroupBy_with_result_selector()
         {
             await AssertQuery<Order>(

--- a/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -1257,6 +1257,21 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void Join_GroupBy_Aggregate_on_key()
+        {
+            AssertQuery<Order, Customer>(
+                (os, cs) =>
+                    (from c in cs
+                     join a in os.GroupBy(o => o.CustomerID)
+                                 .Where(g => g.Count() > 5)
+                                 .Select(g => new { g.Key, LastOrderID = g.Max(o => o.OrderID) })
+                         on c.CustomerID equals a.Key
+                     select new { c, a.LastOrderID }),
+                e => e.c.CustomerID,
+                entryCount: 63);
+        }
+
+        [ConditionalFact]
         public virtual void GroupBy_with_result_selector()
         {
             AssertQuery<Order>(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
@@ -859,7 +859,6 @@ GROUP BY [c].[CustomerID]");
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [c] ON [o].[CustomerID] = [c].[CustomerID]
 GROUP BY [o].[OrderID]");
-
         }
 
         public override void GroupBy_optional_navigation_member_Aggregate()
@@ -1137,6 +1136,21 @@ INNER JOIN (
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
 WHERE [o].[OrderID] < 10400");
+        }
+
+        public override void Join_GroupBy_Aggregate_on_key()
+        {
+            base.Join_GroupBy_Aggregate_on_key();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region], [t].[Key], [t].[LastOrderID]
+FROM [Customers] AS [c]
+INNER JOIN (
+    SELECT [o].[CustomerID] AS [Key], MAX([o].[OrderID]) AS [LastOrderID]
+    FROM [Orders] AS [o]
+    GROUP BY [o].[CustomerID]
+    HAVING COUNT(*) > 5
+) AS [t] ON [c].[CustomerID] = [t].[Key]");
         }
 
         public override void GroupBy_with_result_selector()


### PR DESCRIPTION
Issue: We save `Key` memberInfo to translation mapping in SelectExpression so we can bind `Key` later.
In this query, we also had anonymous projection in aggregate which projected out `Key` which would be essentially same projection but different `MemberInfo`
This causes us to have multiple `MemberInfo`s with same projection.
During `PushDownSubquery()`, we always lifted first `MemberInfo` matching current projection. This caused us to have stale entry in mapping.
In this particular scenario it got used and generated wrong query. (In other cases, we were corrupting mapping but never used it).

Fix:
Correct fix is to remove the stale mapping since the older memberInfo cannot be referenced further. So during the set method, we remove if there is existing mapping to same projection.
This has minor issue in case when GroupBy is done on anonymous object since it causes the inner select to be pushed down inside the elementSelector which requires the older mapping to map correctly. Fix is to update new mapping from key translation only after we have visited elementSelector too.

Resolves #11814

