### PR TITLE
[2.1] Query: Remap MemberInfo mapping while eleminating joins

### DIFF
--- a/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
@@ -1295,6 +1295,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             UpdateProjection(visitor, _starProjection);
             UpdateProjection(visitor, _projection);
 
+            foreach (var kvp in _memberInfoProjectionMapping.ToList())
+            {
+                _memberInfoProjectionMapping[kvp.Key] = visitor.Visit(kvp.Value);
+            }
+
             for (var i = 0; i < _tables.Count; i++)
             {
                 _tables[i] = (TableExpressionBase)visitor.Visit(_tables[i]);


### PR DESCRIPTION
Issue: When eliminating joins, we updated projections and alongwith their tied member info mappings.
But in this case projection was empty so we did not update the mappings.
Fix is to update the mapping regardless of projection being there or not.

Resolves #11818
