### PR TITLE
[2.1] Discover relationship to owned type even if configured at a later time.

### DIFF
--- a/src/EFCore.Specification.Tests/DataAnnotationTestBase.cs
+++ b/src/EFCore.Specification.Tests/DataAnnotationTestBase.cs
@@ -2081,6 +2081,32 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [Fact]
+        public virtual void OwnedEntityTypeAttribute_configures_one_reference_as_owned()
+        {
+            var modelBuilder = CreateModelBuilder();
+            var model = modelBuilder.Model;
+
+            modelBuilder.Entity<Order>();
+
+            Validate(modelBuilder);
+
+            Assert.True(model.FindEntityType(typeof(Order)).FindNavigation(nameof(Order.ShippingAddress)).ForeignKey.IsOwnership);
+        }
+
+        [Owned]
+        public class StreetAddress
+        {
+            public string Street { get; set; }
+            public string City { get; set; }
+        }
+
+        public class Order
+        {
+            public int Id { get; set; }
+            public StreetAddress ShippingAddress { get; set; }
+        }
+
+        [Fact]
         public virtual void OwnedEntityTypeAttribute_configures_all_references_as_owned()
         {
             var modelBuilder = CreateModelBuilder();

--- a/src/EFCore/Infrastructure/ModelValidator.cs
+++ b/src/EFCore/Infrastructure/ModelValidator.cs
@@ -43,14 +43,14 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         public virtual void Validate(IModel model)
         {
             ValidateNoShadowEntities(model);
+            ValidateDefiningNavigations(model);
+            ValidateOwnership(model);
             ValidateNonNullPrimaryKeys(model);
             ValidateNoShadowKeys(model);
             ValidateNoMutableKeys(model);
             ValidateNoCycles(model);
             ValidateClrInheritance(model);
             ValidateChangeTrackingStrategy(model);
-            ValidateDefiningNavigations(model);
-            ValidateOwnership(model);
             ValidateForeignKeys(model);
             ValidateFieldMapping(model);
             ValidateQueryTypes(model);
@@ -326,6 +326,10 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                                 entityType.DisplayName(),
                                 ownership.PrincipalEntityType.DisplayName()));
                     }
+                }
+                else if (entityType.HasClrType() ? model.ShouldBeOwnedType(entityType.ClrType) : model.ShouldBeOwnedType(entityType.Name))
+                {
+                    throw new InvalidOperationException(CoreStrings.OwnerlessOwnedType(entityType.DisplayName()));
                 }
             }
         }

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -2193,6 +2193,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public virtual void RemoveNonOwnershipRelationships(ConfigurationSource configurationSource)
+        {
+            foreach (var foreignKey in Metadata.GetDerivedForeignKeysInclusive()
+                .Where(fk => !fk.IsOwnership && fk.PrincipalToDependent != null)
+                .Concat(Metadata.GetDerivedReferencingForeignKeysInclusive()
+                    .Where(fk => !fk.IsOwnership && fk.DependentToPrincipal != null)).ToList())
+            {
+                foreignKey.DeclaringEntityType.Builder.RemoveForeignKey(foreignKey, configurationSource);
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual InternalRelationshipBuilder Navigation(
             [NotNull] InternalEntityTypeBuilder targetEntityTypeBuilder,
             [CanBeNull] string navigationName,

--- a/src/EFCore/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -932,19 +932,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         newRelationshipBuilder.Metadata.DeclaringEntityType.Builder.PrimaryKey(
                             newRelationshipBuilder.Metadata.Properties.Select(p => p.Name).ToList(), ConfigurationSource.Convention);
                     }
+
+                    newRelationshipBuilder.Metadata.DeclaringEntityType.Builder.RemoveNonOwnershipRelationships(configurationSource);
                 }
                 else
                 {
                     newRelationshipBuilder.Metadata.SetIsOwnership(false, configurationSource);
-                }
-
-                foreach (var derivedForeignKey in newRelationshipBuilder.Metadata.DeclaringEntityType.GetDerivedForeignKeys()
-                        .Where(fk => fk.PrincipalToDependent != null)
-                        .Concat(newRelationshipBuilder.Metadata.DeclaringEntityType.GetDerivedReferencingForeignKeys()
-                            .Where(fk => fk.DependentToPrincipal != null)).ToList())
-                {
-                    derivedForeignKey.DeclaringEntityType.Builder
-                        .RemoveForeignKey(derivedForeignKey, configurationSource);
                 }
 
                 return batch.Run(newRelationshipBuilder);

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2671,6 +2671,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 GetString("DerivedQueryTypeDefiningQuery", nameof(queryType), nameof(baseType)),
                 queryType, baseType);
 
+        /// <summary>
+        ///     The owned entity type '{ownedType}' requires to be referenced from another entity type via a navigation. Add a navigation to an entity type that points at '{ownedType}'.
+        /// </summary>
+        public static string OwnerlessOwnedType([CanBeNull] object ownedType)
+            => string.Format(
+                GetString("OwnerlessOwnedType", nameof(ownedType)),
+                ownedType);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1081,4 +1081,7 @@
   <data name="DerivedQueryTypeDefiningQuery" xml:space="preserve">
     <value>The query type '{queryType}' cannot have a defining query bacause it is derived from '{baseType}'. Only base query types can have a defining query.</value>
   </data>
+  <data name="OwnerlessOwnedType" xml:space="preserve">
+    <value>The owned entity type '{ownedType}' requires to be referenced from another entity type via a navigation. Add a navigation to an entity type that points at '{ownedType}'.</value>
+  </data>
 </root>

--- a/test/EFCore.Tests/Infrastructure/CoreModelValidatorTest.cs
+++ b/test/EFCore.Tests/Infrastructure/CoreModelValidatorTest.cs
@@ -498,6 +498,16 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         }
 
         [Fact]
+        public virtual void Detects_owned_entity_type_without_ownership()
+        {
+            var modelBuilder = new InternalModelBuilder(new Model());
+            modelBuilder.Entity(typeof(A), ConfigurationSource.Convention);
+            modelBuilder.Owned(typeof(A), ConfigurationSource.Convention);
+
+            VerifyError(CoreStrings.OwnerlessOwnedType(nameof(A)), modelBuilder.Metadata);
+        }
+
+        [Fact]
         public virtual void Detects_ForeignKey_on_inherited_generated_key_property()
         {
             var modelBuilder = CreateModelBuilder();


### PR DESCRIPTION
Throw a better exception if no relationships found.

Fixes #11855
