### PR TITLE
Query: Relational: Adds DbContextOptionsBuilder.EnableRichDataErrorHa…

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/Query/NorthwindQueryRelationalFixture.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/NorthwindQueryRelationalFixture.cs
@@ -23,7 +23,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .Log(RelationalEventId.QueryClientEvaluationWarning)
                     .Log(RelationalEventId.QueryPossibleUnintendedUseOfEqualsWarning)
                     .Log(RelationalEventId.QueryPossibleExceptionWithAggregateOperator)
-                    .Log(RelationalEventId.ValueConversionSqlLiteralWarning));
+                    .Log(RelationalEventId.ValueConversionSqlLiteralWarning))
+                    .EnableRichDataErrorHandling();
 
         protected override Type ContextType => typeof(NorthwindRelationalContext);
     }

--- a/src/EFCore.Relational/Extensions/RelationalExpressionExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalExpressionExtensions.cs
@@ -115,5 +115,29 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
             return null;
         }
+        
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static ColumnExpression FindOriginatingColumnExpression([NotNull] this Expression expression)
+        {
+            switch (expression)
+            {
+                case ColumnExpression columnExpression:
+                    return columnExpression;
+                
+                case ColumnReferenceExpression columnReferenceExpression:
+                    return columnReferenceExpression.Expression.FindOriginatingColumnExpression();
+                
+                case AliasExpression aliasExpression:
+                    return aliasExpression.Expression.FindOriginatingColumnExpression();
+                
+                case UnaryExpression unaryExpression:
+                    return unaryExpression.Operand.FindOriginatingColumnExpression();
+            }
+
+            return null;
+        }
     }
 }

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/Shaper.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/Shaper.cs
@@ -114,8 +114,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual Shaper Unwrap([NotNull] IQuerySource querySource)
-        {
-            return _querySource == querySource ? this : null;
-        }
+            => _querySource == querySource ? this : null;
     }
 }

--- a/src/EFCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -234,7 +235,14 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                     .ShapedQueryMethod
                     .MakeGenericMethod(shaper.Type),
                 EntityQueryModelVisitor.QueryContextParameter,
-                Expression.Constant(_shaperCommandContextFactory.Create(querySqlGeneratorFunc)),
+                Expression.Constant(
+                    _shaperCommandContextFactory
+                        .Create(
+                            querySqlGeneratorFunc, 
+                            QueryModelVisitor
+                                .QueryCompilationContext
+                                .ContextOptions
+                                .FindExtension<CoreOptionsExtension>()?.IsRichDataErrorHandingEnabled ?? false)),
                 Expression.Constant(shaper));
         }
 

--- a/src/EFCore.Relational/Query/Internal/IShaperCommandContextFactory.cs
+++ b/src/EFCore.Relational/Query/Internal/IShaperCommandContextFactory.cs
@@ -17,6 +17,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        ShaperCommandContext Create([NotNull] Func<IQuerySqlGenerator> sqlGeneratorFunc);
+        ShaperCommandContext Create([NotNull] Func<IQuerySqlGenerator> sqlGeneratorFunc, bool richDataErrorHandling);
     }
 }

--- a/src/EFCore.Relational/Query/Internal/ShaperCommandContextFactory.cs
+++ b/src/EFCore.Relational/Query/Internal/ShaperCommandContextFactory.cs
@@ -32,9 +32,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual ShaperCommandContext Create(Func<IQuerySqlGenerator> sqlGeneratorFunc)
+        public virtual ShaperCommandContext Create(Func<IQuerySqlGenerator> sqlGeneratorFunc, bool richDataErrorHandling)
             => new ShaperCommandContext(
                 _valueBufferFactoryFactory,
-                sqlGeneratorFunc);
+                sqlGeneratorFunc,
+                richDataErrorHandling);
     }
 }

--- a/src/EFCore.Relational/Query/RelationalCompiledQueryCacheKeyGenerator.cs
+++ b/src/EFCore.Relational/Query/RelationalCompiledQueryCacheKeyGenerator.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -76,13 +77,17 @@ namespace Microsoft.EntityFrameworkCore.Query
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
             public override bool Equals(object obj)
-                => !(obj is null)
-                   && obj is RelationalCompiledQueryCacheKey
-                   && Equals((RelationalCompiledQueryCacheKey)obj);
+                => obj is RelationalCompiledQueryCacheKey other
+                   && Equals(other);
 
-            private bool Equals(RelationalCompiledQueryCacheKey other)
-                => _compiledQueryCacheKey.Equals(other._compiledQueryCacheKey)
-                   && _useRelationalNulls == other._useRelationalNulls;
+            /// <summary>
+            ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+            ///     directly from your code. This API may change or be removed in future releases.
+            /// </summary>
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public bool Equals(in RelationalCompiledQueryCacheKey other)
+                => _useRelationalNulls == other._useRelationalNulls
+                   && _compiledQueryCacheKey.Equals(other._compiledQueryCacheKey);
 
             /// <summary>
             ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -110,7 +110,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                     {
                         var valueBufferAssignmentExpressions
                             = typedRelationalValueBufferFactoryFactory
-                                .CreateAssignmentExpressions(defaultQuerySqlGenerator.GetTypeMaterializationInfos());
+                                .CreateAssignmentExpressions(
+                                    defaultQuerySqlGenerator.GetTypeMaterializationInfos(),
+                                    QueryCompilationContext.ContextOptions
+                                        .FindExtension<CoreOptionsExtension>()?.IsRichDataErrorHandingEnabled ?? false);
 
                         var materializer = (LambdaExpression)entityShaper.MaterializerExpression;
 

--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -8,6 +8,7 @@ using System.Data.Common;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
@@ -146,20 +147,23 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         /// </summary>
         /// <param name="relationalValueBufferFactoryFactory"> The relational value buffer factory. </param>
         /// <param name="dataReader"> The data reader. </param>
+        /// <param name="richDataErrorHandling"> Generate rich data error handling support. </param>
         /// <returns>
         ///     The new value buffer factory.
         /// </returns>
         public virtual IRelationalValueBufferFactory CreateValueBufferFactory(
-            IRelationalValueBufferFactoryFactory relationalValueBufferFactoryFactory, DbDataReader dataReader)
+            IRelationalValueBufferFactoryFactory relationalValueBufferFactoryFactory,
+            DbDataReader dataReader,
+            bool richDataErrorHandling)
         {
             Check.NotNull(relationalValueBufferFactoryFactory, nameof(relationalValueBufferFactoryFactory));
 
             return relationalValueBufferFactoryFactory
-                .Create(SelectExpression.GetMappedProjectionTypes().ToArray());
+                .Create(GetTypeMaterializationInfos(), richDataErrorHandling);
         }
 
         /// <summary>
-        ///     Information about the types being projected by this query.
+        ///     Returns information about the types being projected by this query.
         /// </summary>
         public virtual IReadOnlyList<TypeMaterializationInfo> GetTypeMaterializationInfos()
             => SelectExpression.GetMappedProjectionTypes().ToArray();

--- a/src/EFCore.Relational/Query/Sql/IQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/IQuerySqlGenerator.cs
@@ -35,11 +35,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         /// </summary>
         /// <param name="relationalValueBufferFactoryFactory"> The relational value buffer factory. </param>
         /// <param name="dataReader"> The data reader. </param>
+        /// <param name="richDataErrorHandling"> Generate rich data error handling support. </param>
         /// <returns>
         ///     The new value buffer factory.
         /// </returns>
         IRelationalValueBufferFactory CreateValueBufferFactory(
             [NotNull] IRelationalValueBufferFactoryFactory relationalValueBufferFactoryFactory,
-            [NotNull] DbDataReader dataReader);
+            [NotNull] DbDataReader dataReader,
+            bool richDataErrorHandling);
     }
 }

--- a/src/EFCore.Relational/Query/Sql/Internal/FromSqlNonComposedQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/Internal/FromSqlNonComposedQuerySqlGenerator.cs
@@ -6,6 +6,7 @@ using System.Data.Common;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -61,7 +62,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public override IRelationalValueBufferFactory CreateValueBufferFactory(
-            IRelationalValueBufferFactoryFactory relationalValueBufferFactoryFactory, DbDataReader dataReader)
+            IRelationalValueBufferFactoryFactory relationalValueBufferFactoryFactory,
+            DbDataReader dataReader,
+            bool richDataErrorHandling)
         {
             Check.NotNull(relationalValueBufferFactoryFactory, nameof(relationalValueBufferFactoryFactory));
             Check.NotNull(dataReader, nameof(dataReader));
@@ -101,12 +104,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql.Internal
                             columnExpression.Type,
                             columnExpression.Property,
                             Dependencies.TypeMappingSource,
-                            readerColumn.Ordinal);
+                            readerColumn.Ordinal,
+                            fromLeftOuterJoin: false);
                     }
                 }
             }
 
-            return relationalValueBufferFactoryFactory.Create(types);
+            return relationalValueBufferFactoryFactory.Create(types, richDataErrorHandling);
         }
     }
 }

--- a/src/EFCore.Relational/Query/Sql/QuerySqlGeneratorDependencies.cs
+++ b/src/EFCore.Relational/Query/Sql/QuerySqlGeneratorDependencies.cs
@@ -4,6 +4,7 @@
 using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -46,7 +47,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         /// <param name="parameterNameGeneratorFactory"> The parameter name generator factory. </param>
         /// <param name="relationalTypeMapper"> The relational type mapper. </param>
         /// <param name="typeMappingSource"> The type mapper. </param>
-        /// <param name="logger"> The logger. </param> 
+        /// <param name="logger"> The logger. </param>
         public QuerySqlGeneratorDependencies(
             [NotNull] IRelationalCommandBuilderFactory commandBuilderFactory,
             [NotNull] ISqlGenerationHelper sqlGenerationHelper,
@@ -71,7 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
             RelationalTypeMapper = relationalTypeMapper;
 #pragma warning restore 618
             TypeMappingSource = typeMappingSource;
-            Logger = logger; 
+            Logger = logger;
         }
 
         /// <summary>
@@ -103,7 +104,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         /// <summary> 
         ///     The logger. 
         /// </summary> 
-        public IDiagnosticsLogger<DbLoggerCategory.Query> Logger { get; } 
+        public IDiagnosticsLogger<DbLoggerCategory.Query> Logger { get; }
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -198,6 +199,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                 RelationalTypeMapper, 
 #pragma warning restore 618 
                 TypeMappingSource, 
-                logger); 
+                logger);
     }
 }

--- a/src/EFCore.Relational/Storage/IRelationalValueBufferFactoryFactory.cs
+++ b/src/EFCore.Relational/Storage/IRelationalValueBufferFactoryFactory.cs
@@ -42,7 +42,9 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     Creates a new <see cref="IRelationalValueBufferFactory" />.
         /// </summary>
         /// <param name="types"> Types and mapping for the values to be read. </param>
+        /// <param name="richDataErrorHandling"> Generate rich data error handling support. </param>
         /// <returns> The newly created <see cref="IRelationalValueBufferFactoryFactory" />. </returns>
-        IRelationalValueBufferFactory Create([NotNull] IReadOnlyList<TypeMaterializationInfo> types);
+        IRelationalValueBufferFactory Create(
+            [NotNull] IReadOnlyList<TypeMaterializationInfo> types, bool richDataErrorHandling);
     }
 }

--- a/src/EFCore.Relational/Storage/TypeMaterializationInfo.cs
+++ b/src/EFCore.Relational/Storage/TypeMaterializationInfo.cs
@@ -25,11 +25,13 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     The index of the underlying result set that should be used for this type,
         ///     or -1 if no index mapping is needed.
         /// </param>
+        /// <param name="fromLeftOuterJoin"> Whether or not the value is coming from a LEFT OUTER JOIN operation. </param>
         public TypeMaterializationInfo(
             [NotNull] Type modelClrType,
             [CanBeNull] IProperty property,
-            [CanBeNull] IRelationalTypeMappingSource typeMappingSource, 
-            int index = -1)
+            [CanBeNull] IRelationalTypeMappingSource typeMappingSource,
+            int index = -1,
+            bool? fromLeftOuterJoin = null)
         {
             Check.NotNull(modelClrType, nameof(modelClrType));
 
@@ -43,6 +45,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             Mapping = mapping;
             Property = property;
             Index = index;
+            IsFromLeftOuterJoin = fromLeftOuterJoin;
         }
 
         /// <summary>
@@ -72,6 +75,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public virtual int Index { get; }
 
         /// <summary>
+        ///     Whether or not the value is coming from a LEFT OUTER JOIN operation.
+        /// </summary>
+        public virtual bool? IsFromLeftOuterJoin { get; }
+        
+        /// <summary>
         ///     Determines whether the specified object is equal to the current object.
         /// </summary>
         /// <param name="other"> The object to compare with the current object. </param>
@@ -81,7 +89,8 @@ namespace Microsoft.EntityFrameworkCore.Storage
                && ModelClrType == other.ModelClrType
                && Equals(Mapping, other.Mapping)
                && Equals(Property, other.Property)
-               && Index == other.Index;
+               && Index == other.Index
+               && IsFromLeftOuterJoin == other.IsFromLeftOuterJoin;
 
         /// <summary>
         ///     Determines whether the specified object is equal to the current object.
@@ -107,6 +116,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 hashCode = (hashCode * 397) ^ (Mapping?.GetHashCode() ?? 0);
                 hashCode = (hashCode * 397) ^ (Property?.GetHashCode() ?? 0);
                 hashCode = (hashCode * 397) ^ Index;
+                hashCode = (hashCode * 397) ^ (IsFromLeftOuterJoin?.GetHashCode() ?? 0);
                 return hashCode;
             }
         }

--- a/src/EFCore.Relational/Storage/UntypedRelationalValueBufferFactoryFactory.cs
+++ b/src/EFCore.Relational/Storage/UntypedRelationalValueBufferFactoryFactory.cs
@@ -93,15 +93,17 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var mappingSource = Dependencies.TypeMappingSource;
 
             return Create(valueTypes.Select(
-                (t, i) => new TypeMaterializationInfo(t, null, mappingSource, indexMap?[i] ?? -1)).ToList());
+                (t, i) => new TypeMaterializationInfo(t, null, mappingSource, indexMap?[i] ?? -1)).ToList(), true);
         }
 
         /// <summary>
         ///     Creates a new <see cref="IRelationalValueBufferFactory" />.
         /// </summary>
         /// <param name="types"> Types and mapping for the values to be read. </param>
+        /// <param name="richDataErrorHandling"> Generate rich data error handling support. </param>
         /// <returns> The newly created <see cref="IRelationalValueBufferFactoryFactory" />. </returns>
-        public virtual IRelationalValueBufferFactory Create(IReadOnlyList<TypeMaterializationInfo> types)
+        public virtual IRelationalValueBufferFactory Create(
+            IReadOnlyList<TypeMaterializationInfo> types, bool richDataErrorHandling)
         {
             Check.NotNull(types, nameof(types));
 

--- a/src/EFCore.Relational/Update/ReaderModificationCommandBatch.cs
+++ b/src/EFCore.Relational/Update/ReaderModificationCommandBatch.cs
@@ -326,12 +326,14 @@ namespace Microsoft.EntityFrameworkCore.Update
         ///     being modified such that a ValueBuffer with appropriate slots can be created.
         /// </param>
         /// <returns> The factory. </returns>
-        protected virtual IRelationalValueBufferFactory CreateValueBufferFactory([NotNull] IReadOnlyList<ColumnModification> columnModifications)
+        protected virtual IRelationalValueBufferFactory CreateValueBufferFactory(
+            [NotNull] IReadOnlyList<ColumnModification> columnModifications)
             => _valueBufferFactoryFactory
                 .Create(
                     Check.NotNull(columnModifications, nameof(columnModifications))
                         .Where(c => c.IsRead)
-                        .Select(c => new TypeMaterializationInfo(c.Property.ClrType, c.Property, null))
-                        .ToArray());
+                        .Select(c => new TypeMaterializationInfo(c.Property.ClrType, c.Property, typeMappingSource: null))
+                        .ToArray(),
+                    richDataErrorHandling: true);
     }
 }

--- a/src/EFCore.Relational/breakingchanges.netcore.json
+++ b/src/EFCore.Relational/breakingchanges.netcore.json
@@ -35,11 +35,6 @@
       "Kind": "Removal"
     },
     {
-      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalValueBufferFactoryFactory",
-      "MemberId": "Microsoft.EntityFrameworkCore.Storage.IRelationalValueBufferFactory Create(System.Collections.Generic.IReadOnlyList<Microsoft.EntityFrameworkCore.Storage.TypeMaterializationInfo> types)",
-      "Kind": "Addition"
-    },
-    {
       "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalDatabaseCreator : Microsoft.EntityFrameworkCore.Storage.IDatabaseCreator",
       "MemberId": "System.String GenerateCreateScript()",
       "Kind": "Addition"
@@ -112,6 +107,26 @@
     {
       "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.IQueryMethodProvider",
       "MemberId": "System.Reflection.MethodInfo get_FastQueryMethod()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGenerator",
+      "MemberId": "Microsoft.EntityFrameworkCore.Storage.IRelationalValueBufferFactory CreateValueBufferFactory(Microsoft.EntityFrameworkCore.Storage.IRelationalValueBufferFactoryFactory relationalValueBufferFactoryFactory, System.Data.Common.DbDataReader dataReader)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public class Microsoft.EntityFrameworkCore.Query.Sql.DefaultQuerySqlGenerator : Remotion.Linq.Parsing.ThrowingExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor, Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGenerator",
+      "MemberId": "public Microsoft.EntityFrameworkCore.Storage.IRelationalValueBufferFactory CreateValueBufferFactory(Microsoft.EntityFrameworkCore.Storage.IRelationalValueBufferFactoryFactory relationalValueBufferFactoryFactory, System.Data.Common.DbDataReader dataReader)",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalValueBufferFactoryFactory",
+      "MemberId": "Microsoft.EntityFrameworkCore.Storage.IRelationalValueBufferFactory Create(System.Collections.Generic.IReadOnlyList<Microsoft.EntityFrameworkCore.Storage.TypeMaterializationInfo> types, System.Boolean richDataErrorHandling)",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.Sql.IQuerySqlGenerator",
+      "MemberId": "Microsoft.EntityFrameworkCore.Storage.IRelationalValueBufferFactory CreateValueBufferFactory(Microsoft.EntityFrameworkCore.Storage.IRelationalValueBufferFactoryFactory relationalValueBufferFactoryFactory, System.Data.Common.DbDataReader dataReader, System.Boolean richDataErrorHandling)",
       "Kind": "Addition"
     }
 ]

--- a/src/EFCore.Specification.Tests/ServiceProviderFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/ServiceProviderFixtureBase.cs
@@ -20,6 +20,7 @@ namespace Microsoft.EntityFrameworkCore
 
         public DbContextOptions CreateOptions(TestStore testStore)
             => AddOptions(testStore.AddProviderOptions(new DbContextOptionsBuilder()))
+                .EnableRichDataErrorHandling()
                 .UseInternalServiceProvider(ServiceProvider)
                 .Options;
     }

--- a/src/EFCore.SqlServer/Query/Internal/SqlServerCompiledQueryCacheKeyGenerator.cs
+++ b/src/EFCore.SqlServer/Query/Internal/SqlServerCompiledQueryCacheKeyGenerator.cs
@@ -47,13 +47,9 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Internal
             }
 
             public override bool Equals(object obj)
-                => !(obj is null)
-                   && obj is SqlServerCompiledQueryCacheKey
-                   && Equals((SqlServerCompiledQueryCacheKey)obj);
-
-            private bool Equals(SqlServerCompiledQueryCacheKey other)
-                => _relationalCompiledQueryCacheKey.Equals(other._relationalCompiledQueryCacheKey)
-                   && _useRowNumberOffset == other._useRowNumberOffset;
+                => obj is SqlServerCompiledQueryCacheKey other
+                   && _useRowNumberOffset == other._useRowNumberOffset
+                   && _relationalCompiledQueryCacheKey.Equals(other._relationalCompiledQueryCacheKey);
 
             public override int GetHashCode()
             {

--- a/src/EFCore/DbContextOptionsBuilder.cs
+++ b/src/EFCore/DbContextOptionsBuilder.cs
@@ -183,6 +183,28 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     <para>
+        ///         Enables rich error handling of data value exceptions that occur during processing of store query results. Such errors
+        ///         most often occur due to misconfiguration of entity properties. E.g. If a property is configured to be of type
+        ///         'int', but the underlying data in the store is actually of type 'string', then an exception will be generated
+        ///         at runtime during processing of the data value. When this option is enabled and a data error is encountered, the
+        ///         generated exception will include details of the specific entity property that generated the error.
+        ///     </para>
+        ///     <para>
+        ///         Enabling this option incurs a small performance overhead during query execution.
+        ///     </para>
+        ///     <para>
+        ///         Note that if the application is setting the internal service provider through a call to
+        ///         <see cref="UseInternalServiceProvider" />, then this option must configured the same way
+        ///         for all uses of that service provider. Consider instead not calling <see cref="UseInternalServiceProvider" />
+        ///         so that EF will manage the service providers and can create new instances as required.
+        ///     </para>
+        /// </summary>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public virtual DbContextOptionsBuilder EnableRichDataErrorHandling(bool richDataErrorHandlingEnabled = true)
+            => WithOption(e => e.WithRichDataErrorHandling(richDataErrorHandlingEnabled));
+
+        /// <summary>
+        ///     <para>
         ///         Sets the tracking behavior for LINQ queries run against the context. Disabling change tracking
         ///         is useful for read-only scenarios because it avoids the overhead of setting up change tracking for each
         ///         entity instance. You should not disable change tracking if you want to manipulate entity instances and

--- a/src/EFCore/DbContextOptionsBuilder`.cs
+++ b/src/EFCore/DbContextOptionsBuilder`.cs
@@ -165,6 +165,28 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     <para>
+        ///         Enables rich error handling of data value exceptions that occur during processing of store query results. Such errors
+        ///         most often occur due to misconfiguration of entity properties. E.g. If a property is configured to be of type
+        ///         'int', but the underlying data in the store is actually of type 'string', then an exception will be generated
+        ///         at runtime during processing of the data value. When this option is enabled and a data error is encountered, the
+        ///         generated exception will include details of the specific entity property that generated the error.
+        ///     </para>
+        ///     <para>
+        ///         Enabling this option incurs a small performance overhead during query execution.
+        ///     </para>
+        ///     <para>
+        ///         Note that if the application is setting the internal service provider through a call to
+        ///         <see cref="UseInternalServiceProvider" />, then this option must configured the same way
+        ///         for all uses of that service provider. Consider instead not calling <see cref="UseInternalServiceProvider" />
+        ///         so that EF will manage the service providers and can create new instances as required.
+        ///     </para>
+        /// </summary>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public new virtual DbContextOptionsBuilder<TContext> EnableRichDataErrorHandling(bool richDataErrorHandlingEnabled = true)
+            => (DbContextOptionsBuilder<TContext>)base.EnableRichDataErrorHandling(richDataErrorHandlingEnabled);
+
+        /// <summary>
+        ///     <para>
         ///         Sets the tracking behavior for LINQ queries run against the context. Disabling change tracking
         ///         is useful for read-only scenarios because it avoids the overhead of setting up change tracking for each
         ///         entity instance. You should not disable change tracking if you want to manipulate entity instances and

--- a/src/EFCore/Infrastructure/CoreOptionsExtension.cs
+++ b/src/EFCore/Infrastructure/CoreOptionsExtension.cs
@@ -33,6 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         private ILoggerFactory _loggerFactory;
         private IMemoryCache _memoryCache;
         private bool _sensitiveDataLoggingEnabled;
+        private bool _richDataErrorHandingEnabled;
         private QueryTrackingBehavior _queryTrackingBehavior = QueryTrackingBehavior.TrackAll;
         private IDictionary<Type, Type> _replacedServices;
         private int? _maxPoolSize;
@@ -63,6 +64,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             _loggerFactory = copyFrom.LoggerFactory;
             _memoryCache = copyFrom.MemoryCache;
             _sensitiveDataLoggingEnabled = copyFrom.IsSensitiveDataLoggingEnabled;
+            _richDataErrorHandingEnabled = copyFrom.IsRichDataErrorHandingEnabled;
             _warningsConfiguration = copyFrom.WarningsConfiguration;
             _queryTrackingBehavior = copyFrom.QueryTrackingBehavior;
             _maxPoolSize = copyFrom.MaxPoolSize;
@@ -173,6 +175,21 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     Creates a new instance with all options the same as for this instance, but with the given option changed.
         ///     It is unusual to call this method directly. Instead use <see cref="DbContextOptionsBuilder" />.
         /// </summary>
+        /// <param name="richDataErrorHandingEnabled"> The option to change. </param>
+        /// <returns> A new instance with the option changed. </returns>
+        public virtual CoreOptionsExtension WithRichDataErrorHandling(bool richDataErrorHandingEnabled)
+        {
+            var clone = Clone();
+
+            clone._richDataErrorHandingEnabled = richDataErrorHandingEnabled;
+
+            return clone;
+        }
+
+        /// <summary>
+        ///     Creates a new instance with all options the same as for this instance, but with the given option changed.
+        ///     It is unusual to call this method directly. Instead use <see cref="DbContextOptionsBuilder" />.
+        /// </summary>
         /// <param name="queryTrackingBehavior"> The option to change. </param>
         /// <returns> A new instance with the option changed. </returns>
         public virtual CoreOptionsExtension WithQueryTrackingBehavior(QueryTrackingBehavior queryTrackingBehavior)
@@ -239,6 +256,11 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         ///     The option set from the <see cref="DbContextOptionsBuilder.EnableSensitiveDataLogging" /> method.
         /// </summary>
         public virtual bool IsSensitiveDataLoggingEnabled => _sensitiveDataLoggingEnabled;
+
+        /// <summary>
+        ///     The option set from the <see cref="DbContextOptionsBuilder.EnableRichDataErrorHandling" /> method.
+        /// </summary>
+        public virtual bool IsRichDataErrorHandingEnabled => _richDataErrorHandingEnabled;
 
         /// <summary>
         ///     The option set from the <see cref="DbContextOptionsBuilder.UseModel" /> method.
@@ -401,6 +423,11 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                     if (_sensitiveDataLoggingEnabled)
                     {
                         builder.Append("SensitiveDataLoggingEnabled ");
+                    }
+
+                    if (_richDataErrorHandingEnabled)
+                    {
+                        builder.Append("RichDataErrorHandlingEnabled ");
                     }
 
                     if (_maxPoolSize != null)

--- a/src/EFCore/Metadata/Internal/EntityMaterializerSource.cs
+++ b/src/EFCore/Metadata/Internal/EntityMaterializerSource.cs
@@ -47,70 +47,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static TValue TryReadValue<TValue>(
-            in ValueBuffer valueBuffer,
-            int index,
-            IPropertyBase property = null)
-        {
-            var untypedValue = valueBuffer[index];
-            try
-            {
-                return (TValue)untypedValue;
-            }
-            catch (Exception e)
-            {
-                ThrowReadValueException<TValue>(e, untypedValue, property);
-            }
-
-            return default;
-        }
+            in ValueBuffer valueBuffer, int index, IPropertyBase property = null)
+            => (TValue)valueBuffer[index];
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public static readonly MethodInfo ThrowReadValueExceptionMethod
-            = typeof(EntityMaterializerSource).GetTypeInfo()
-                .GetDeclaredMethod(nameof(ThrowReadValueException));
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static TValue ThrowReadValueException<TValue>(
-            Exception exception, object value, IPropertyBase property = null)
-        {
-            var expectedType = typeof(TValue);
-            var actualType = value?.GetType();
-
-            string message;
-
-            if (property != null)
-            {
-                var entityType = property.DeclaringType.DisplayName();
-                var propertyName = property.Name;
-
-                message
-                    = exception is NullReferenceException
-                        ? CoreStrings.ErrorMaterializingPropertyNullReference(entityType, propertyName, expectedType)
-                        : exception is InvalidCastException
-                            ? CoreStrings.ErrorMaterializingPropertyInvalidCast(entityType, propertyName, expectedType, actualType)
-                            : CoreStrings.ErrorMaterializingProperty(entityType, propertyName);
-            }
-            else
-            {
-                message
-                    = exception is NullReferenceException
-                        ? CoreStrings.ErrorMaterializingValueNullReference(expectedType)
-                        : exception is InvalidCastException
-                            ? CoreStrings.ErrorMaterializingValueInvalidCast(expectedType, actualType)
-                            : CoreStrings.ErrorMaterializingValue;
-            }
-
-            throw new InvalidOperationException(message, exception);
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        [Obsolete("Use CreateReadValueExpression making sure to pass bound property if available.")]
+        [Obsolete(message: "Use CreateReadValueExpression making sure to pass bound property if available.")]
         public virtual Expression CreateReadValueCallExpression(Expression valueBuffer, int index)
             => Expression.Call(valueBuffer, ValueBuffer.GetValueMethod, Expression.Constant(index));
 
@@ -137,7 +81,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             if (constructorBinding == null)
             {
-                var constructorInfo = entityType.ClrType.GetDeclaredConstructor(null);
+                var constructorInfo = entityType.ClrType.GetDeclaredConstructor(types: null);
 
                 if (constructorInfo == null)
                 {
@@ -165,9 +109,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             var properties = new HashSet<IPropertyBase>(
                 entityType.GetServiceProperties().Cast<IPropertyBase>()
-                    .Concat(entityType
-                        .GetProperties()
-                        .Where(p => !p.IsShadowProperty)));
+                    .Concat(
+                        entityType
+                            .GetProperties()
+                            .Where(p => !p.IsShadowProperty)));
 
             foreach (var consumedProperty in constructorBinding
                 .ParameterBindings
@@ -183,7 +128,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return constructorExpression;
             }
 
-            var instanceVariable = Expression.Variable(constructorBinding.RuntimeType, "instance");
+            var instanceVariable = Expression.Variable(constructorBinding.RuntimeType, name: "instance");
 
             var blockExpressions
                 = new List<Expression>
@@ -192,7 +137,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         instanceVariable,
                         constructorExpression)
                 };
-
 
             blockExpressions.AddRange(
                 from property in properties
@@ -229,7 +173,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 entityType, e =>
                     {
                         var materializationContextParameter
-                            = Expression.Parameter(typeof(MaterializationContext), "materializationContext");
+                            = Expression.Parameter(typeof(MaterializationContext), name: "materializationContext");
 
                         return Expression.Lambda<Func<MaterializationContext, object>>(
                                 CreateMaterializeExpression(e, materializationContextParameter),

--- a/src/EFCore/Query/CompiledQueryCacheKeyGeneratorDependencies.cs
+++ b/src/EFCore/Query/CompiledQueryCacheKeyGeneratorDependencies.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -46,13 +47,19 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// </summary>
         /// <param name="model"> The model that queries will be written against. </param>
         /// <param name="currentContext"> The context that queries will be executed for. </param>
-        public CompiledQueryCacheKeyGeneratorDependencies([NotNull] IModel model, [NotNull] ICurrentDbContext currentContext)
+        /// <param name="contextOptions"> Options for the current <see cref="DbContext" /> instance. </param>
+        public CompiledQueryCacheKeyGeneratorDependencies(
+            [NotNull] IModel model,
+            [NotNull] ICurrentDbContext currentContext,
+            [NotNull] IDbContextOptions contextOptions)
         {
             Check.NotNull(model, nameof(model));
             Check.NotNull(currentContext, nameof(currentContext));
+            Check.NotNull(contextOptions, nameof(contextOptions));
 
             Model = model;
             Context = currentContext;
+            ContextOptions = contextOptions;
         }
 
         /// <summary>
@@ -66,12 +73,17 @@ namespace Microsoft.EntityFrameworkCore.Query
         public ICurrentDbContext Context { get; }
 
         /// <summary>
+        ///     Options for the current <see cref="DbContext" /> instance.
+        /// </summary>
+        public IDbContextOptions ContextOptions { get; }
+
+        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="model"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public CompiledQueryCacheKeyGeneratorDependencies With([NotNull] IModel model)
-            => new CompiledQueryCacheKeyGeneratorDependencies(model, Context);
+            => new CompiledQueryCacheKeyGeneratorDependencies(model, Context, ContextOptions);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -79,6 +91,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         /// <param name="currentContext"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public CompiledQueryCacheKeyGeneratorDependencies With([NotNull] ICurrentDbContext currentContext)
-            => new CompiledQueryCacheKeyGeneratorDependencies(Model, currentContext);
+            => new CompiledQueryCacheKeyGeneratorDependencies(Model, currentContext, ContextOptions);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="contextOptions"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public CompiledQueryCacheKeyGeneratorDependencies With([NotNull] IDbContextOptions contextOptions)
+            => new CompiledQueryCacheKeyGeneratorDependencies(Model, Context, contextOptions);
     }
 }

--- a/src/EFCore/Query/Internal/QueryBuffer.cs
+++ b/src/EFCore/Query/Internal/QueryBuffer.cs
@@ -32,8 +32,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private readonly Dictionary<int, IDisposable> _includedCollections
             = new Dictionary<int, IDisposable>(); // IDisposable as IEnumerable/IAsyncEnumerable
 
-        private Dictionary<int, (IDisposable Enumerator, MaterializedAnonymousObject PreviousOriginKey)> _correlatedCollectionMetadata
-            = new Dictionary<int, (IDisposable, MaterializedAnonymousObject)>();
+        private readonly Dictionary<int, (IDisposable Enumerator, MaterializedAnonymousObject PreviousOriginKey)>
+            _correlatedCollectionMetadata = new Dictionary<int, (IDisposable, MaterializedAnonymousObject)>();
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Query/Internal/QueryCompilationContextDependencies.cs
+++ b/src/EFCore/Query/Internal/QueryCompilationContextDependencies.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
@@ -26,19 +27,22 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger,
             [NotNull] IEntityQueryModelVisitorFactory entityQueryModelVisitorFactory,
             [NotNull] IRequiresMaterializationExpressionVisitorFactory requiresMaterializationExpressionVisitorFactory,
-            [NotNull] ICurrentDbContext currentContext)
+            [NotNull] ICurrentDbContext currentContext,
+            [NotNull] IDbContextOptions contextOptions)
         {
             Check.NotNull(model, nameof(model));
             Check.NotNull(logger, nameof(logger));
             Check.NotNull(entityQueryModelVisitorFactory, nameof(entityQueryModelVisitorFactory));
             Check.NotNull(requiresMaterializationExpressionVisitorFactory, nameof(requiresMaterializationExpressionVisitorFactory));
             Check.NotNull(currentContext, nameof(currentContext));
+            Check.NotNull(contextOptions, nameof(contextOptions));
 
             Model = model;
             Logger = logger;
             EntityQueryModelVisitorFactory = entityQueryModelVisitorFactory;
             RequiresMaterializationExpressionVisitorFactory = requiresMaterializationExpressionVisitorFactory;
             CurrentContext = currentContext;
+            ContextOptions = contextOptions;
         }
 
         /// <summary>
@@ -75,13 +79,20 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public IDbContextOptions ContextOptions { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public QueryCompilationContextDependencies With([NotNull] IModel model)
             => new QueryCompilationContextDependencies(
                 model,
                 Logger,
                 EntityQueryModelVisitorFactory,
                 RequiresMaterializationExpressionVisitorFactory,
-                CurrentContext);
+                CurrentContext,
+                ContextOptions);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -93,7 +104,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 logger,
                 EntityQueryModelVisitorFactory,
                 RequiresMaterializationExpressionVisitorFactory,
-                CurrentContext);
+                CurrentContext,
+                ContextOptions);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -105,7 +117,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 Logger,
                 entityQueryModelVisitorFactory,
                 RequiresMaterializationExpressionVisitorFactory,
-                CurrentContext);
+                CurrentContext,
+                ContextOptions);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -118,7 +131,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 Logger,
                 EntityQueryModelVisitorFactory,
                 requiresMaterializationExpressionVisitorFactory,
-                CurrentContext);
+                CurrentContext,
+                ContextOptions);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -130,6 +144,20 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 Logger,
                 EntityQueryModelVisitorFactory,
                 RequiresMaterializationExpressionVisitorFactory,
-                currentContext);
+                currentContext,
+                ContextOptions);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public QueryCompilationContextDependencies With([NotNull] IDbContextOptions contextOptions)
+            => new QueryCompilationContextDependencies(
+                Model,
+                Logger,
+                EntityQueryModelVisitorFactory,
+                RequiresMaterializationExpressionVisitorFactory,
+                CurrentContext,
+                contextOptions);
     }
 }

--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -9,6 +9,7 @@ using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Extensions.Internal;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -62,6 +63,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             LinqOperatorProvider = linqOperatorProvider;
             ContextType = dependencies.CurrentContext.Context.GetType();
+            ContextOptions = dependencies.ContextOptions;
             TrackQueryResults = trackQueryResults;
         }
 
@@ -144,12 +146,20 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual ILinqOperatorProvider LinqOperatorProvider { get; }
 
         /// <summary>
-        ///     Gets the type of the context./
+        ///     Gets the type of the context.
         /// </summary>
         /// <value>
         ///     The type of the context.
         /// </value>
         public virtual Type ContextType { get; }
+
+        /// <summary>
+        ///     Gets the options for the DbContext.
+        /// </summary>
+        /// <value>
+        ///     The options for the DbContext.
+        /// </value>
+        public virtual IDbContextOptions ContextOptions { get; }
 
         /// <summary>
         ///     Gets a value indicating the default configured tracking behavior.

--- a/src/EFCore/Storage/MaterializationContext.cs
+++ b/src/EFCore/Storage/MaterializationContext.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -57,11 +58,19 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <summary>
         ///     The <see cref="ValueBuffer" /> to use to materialize an entity.
         /// </summary>
-        public ValueBuffer ValueBuffer { get; }
+        public ValueBuffer ValueBuffer
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get;
+        }
 
         /// <summary>
         ///     The current <see cref="DbContext" /> instance being used.
         /// </summary>
-        public DbContext Context { get; }
+        public DbContext Context
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get;
+        }
     }
 }

--- a/src/EFCore/Storage/ValueBuffer.cs
+++ b/src/EFCore/Storage/ValueBuffer.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -59,6 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <returns> The value at the requested index. </returns>
         public object this[int index]
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get => _values[_offset + index];
             [param: CanBeNull] set => _values[_offset + index] = value;
         }

--- a/src/EFCore/breakingchanges.netcore.json
+++ b/src/EFCore/breakingchanges.netcore.json
@@ -113,5 +113,15 @@
     "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IEntityType : Microsoft.EntityFrameworkCore.Metadata.ITypeBase",
     "MemberId": "System.Collections.Generic.IEnumerable<Microsoft.EntityFrameworkCore.Metadata.IServiceProperty> GetServiceProperties()",
     "Kind": "Addition"
+  },
+  {
+    "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Query.CompiledQueryCacheKeyGeneratorDependencies",
+    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Metadata.IModel model, Microsoft.EntityFrameworkCore.Internal.ICurrentDbContext currentContext)",
+    "Kind": "Removal"
+  },
+  {
+    "TypeId": "protected struct Microsoft.EntityFrameworkCore.Query.CompiledQueryCacheKeyGenerator+CompiledQueryCacheKey",
+    "MemberId": "public .ctor(System.Linq.Expressions.Expression query, Microsoft.EntityFrameworkCore.Metadata.IModel model, Microsoft.EntityFrameworkCore.QueryTrackingBehavior queryTrackingBehavior, System.Boolean async)",                                                                                                                               
+    "Kind": "Removal"
   }
 ]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -241,7 +241,7 @@ INSERT [dbo].[Postcodes] ([PostcodeID], [PostcodeValue], [TownName]) VALUES (5, 
                 using (var context = new NullKeyContext(Fixture.CreateOptions(testStore)))
                 {
                     Assert.Equal(
-                        CoreStrings.InvalidKeyValue("ZeroKey", "Id"),
+                        CoreStrings.ErrorMaterializingPropertyNullReference("ZeroKey", "Id", typeof(int)),
                         Assert.Throws<InvalidOperationException>(() => context.ZeroKeys.ToList()).Message);
                 }
             }
@@ -954,17 +954,17 @@ WHERE ([c].[FirstName] = @__firstName_0) AND ([c].[LastName] = @__8__locals1_det
         {
             using (CreateDatabase3409())
             {
-                using (var context = new MyContext3409(_options))
-                {
-                    var results = context.Parents
-                        .Include(p => p.ChildCollection)
-                        .ThenInclude(c => c.SelfReferenceCollection)
-                        .ToList();
-
-                    Assert.Equal(1, results.Count);
-                    Assert.Equal(1, results[0].ChildCollection.Count);
-                    Assert.Equal(2, results[0].ChildCollection.Single().SelfReferenceCollection.Count);
-                }
+                 using (var context = new MyContext3409(_options))
+                 {
+                     var results = context.Parents
+                         .Include(p => p.ChildCollection)
+                         .ThenInclude(c => c.SelfReferenceCollection)
+                         .ToList();
+                
+                     Assert.Equal(1, results.Count);
+                     Assert.Equal(1, results[0].ChildCollection.Count);
+                     Assert.Equal(2, results[0].ChildCollection.Single().SelfReferenceCollection.Count);
+                 }
 
                 using (var context = new MyContext3409(_options))
                 {
@@ -982,37 +982,37 @@ WHERE ([c].[FirstName] = @__firstName_0) AND ([c].[LastName] = @__8__locals1_det
                     Assert.Equal(2, results.Count(c => c.ParentBackNavigation != null));
                 }
 
-                using (var context = new MyContext3409(_options))
-                {
-                    var results = context.Children
-                        .Select(
-                            c => new
-                            {
-                                SelfReferenceBackNavigation
-                                = EF.Property<IChild3409>(c, "SelfReferenceBackNavigation"),
-                                ParentBackNavigationB
-                                = EF.Property<IParent3409>(
-                                    EF.Property<IChild3409>(c, "SelfReferenceBackNavigation"),
-                                    "ParentBackNavigation")
-                            })
-                        .ToList();
-
-                    Assert.Equal(3, results.Count);
-                    Assert.Equal(2, results.Count(c => c.SelfReferenceBackNavigation != null));
-                    Assert.Equal(2, results.Count(c => c.ParentBackNavigationB != null));
-                }
-
-                using (var context = new MyContext3409(_options))
-                {
-                    var results = context.Children
-                        .Include(c => c.SelfReferenceBackNavigation)
-                        .ThenInclude(c => c.ParentBackNavigation)
-                        .ToList();
-
-                    Assert.Equal(3, results.Count);
-                    Assert.Equal(2, results.Count(c => c.SelfReferenceBackNavigation != null));
-                    Assert.Equal(1, results.Count(c => c.ParentBackNavigation != null));
-                }
+                 using (var context = new MyContext3409(_options))
+                 {
+                     var results = context.Children
+                         .Select(
+                             c => new
+                             {
+                                 SelfReferenceBackNavigation
+                                 = EF.Property<IChild3409>(c, "SelfReferenceBackNavigation"),
+                                 ParentBackNavigationB
+                                 = EF.Property<IParent3409>(
+                                     EF.Property<IChild3409>(c, "SelfReferenceBackNavigation"),
+                                     "ParentBackNavigation")
+                             })
+                         .ToList();
+                
+                     Assert.Equal(3, results.Count);
+                     Assert.Equal(2, results.Count(c => c.SelfReferenceBackNavigation != null));
+                     Assert.Equal(2, results.Count(c => c.ParentBackNavigationB != null));
+                 }
+                
+                 using (var context = new MyContext3409(_options))
+                 {
+                     var results = context.Children
+                         .Include(c => c.SelfReferenceBackNavigation)
+                         .ThenInclude(c => c.ParentBackNavigation)
+                         .ToList();
+                
+                     Assert.Equal(3, results.Count);
+                     Assert.Equal(2, results.Count(c => c.SelfReferenceBackNavigation != null));
+                     Assert.Equal(1, results.Count(c => c.ParentBackNavigation != null));
+                 }
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -21,6 +21,15 @@ namespace Microsoft.EntityFrameworkCore.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
+        public override void Queryable_simple()
+        {
+            base.Queryable_simple();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
+        }
+
         public override void Shaper_command_caching_when_parameter_names_different()
         {
             base.Shaper_command_caching_when_parameter_names_different();
@@ -1038,15 +1047,6 @@ WHERE [c].[CustomerID] = N'ALFKI'");
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
 WHERE CAST(LEN([c].[CustomerID]) AS int) = 5");
-        }
-
-        public override void Queryable_simple()
-        {
-            base.Queryable_simple();
-
-            AssertSql(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]");
         }
 
         public override void Queryable_simple_anonymous()

--- a/test/EFCore.Tests/DbContextOptionsTest.cs
+++ b/test/EFCore.Tests/DbContextOptionsTest.cs
@@ -187,6 +187,12 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [Fact]
+        public void EnableRichDataErrorHandling_on_generic_builder_returns_generic_builder()
+        {
+            GenericCheck(new DbContextOptionsBuilder<UnkoolContext>().EnableRichDataErrorHandling());
+        }
+
+        [Fact]
         public void UseQueryTrackingBehavior_on_generic_builder_returns_generic_builder()
         {
             var optionsBuilder = GenericCheck(


### PR DESCRIPTION
…ndling and IsDbNull optimization in TypedRelationalValueBufferFactoryFactory.

- EnableRichDataErrorHandling (default false). Controls whether we generate try/catch error handling around value read expressions. Also removes rich handling from EntityMaterializerSource; we now only need it in TypedRelationalValueBufferFactoryFactory.
- No longer always generate IsDbNull calls when reading values.
