### PR TITLE
[2.1] Fix to #11831 - Query: compilation error for queries with groupby anonymous object and table splitting

### DIFF
--- a/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
@@ -492,7 +492,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                 // if qsre is pointing to a subquery, look for DefaulIfEmpty result operators inside
                 // if such operator is found then we need to add null-compensation logic
-                if (subQuery != null)
+                // unless the query model has a GroupBy operator - qsre coming from groupby can never be null
+                if (subQuery != null && !(subQuery.QueryModel.ResultOperators.LastOrDefault() is GroupResultOperator))
                 {
                     var containsDefaultIfEmptyChecker = new ContainsDefaultIfEmptyCheckingVisitor();
                     containsDefaultIfEmptyChecker.VisitQueryModel(subQuery.QueryModel);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -3321,10 +3321,10 @@ WHERE [b].[IsTwo] IN (1, 0)");
                 using (var context = new MyContext11818(_options))
                 {
                     var query = (from e in context.Set<Entity11818>()
-                                  join a in context.Set<AnotherEntity11818>()
-                                    on e.Id equals a.Id into grouping
-                                  from a in grouping.DefaultIfEmpty()
-                                  select new { ename = e.Name, aname = a.Name })
+                                 join a in context.Set<AnotherEntity11818>()
+                                   on e.Id equals a.Id into grouping
+                                 from a in grouping.DefaultIfEmpty()
+                                 select new { ename = e.Name, aname = a.Name })
                                   .GroupBy(g => g.aname)
                                   .Select(g => new { g.Key, cnt = g.Count() + 5 })
                                   .ToList();
@@ -3337,7 +3337,7 @@ GROUP BY [e].[Name]");
             }
         }
 
-        [Fact(Skip = "See issue#11831")]
+        [Fact]
         public virtual void GroupJoin_Anonymous_projection_GroupBy_Aggregate_join_elimination_2()
         {
             using (CreateDatabase11818())
@@ -3357,9 +3357,60 @@ GROUP BY [e].[Name]");
                                   .ToList();
 
                     AssertSql(
-                        @"SELECT [e].[Name] AS [Key], COUNT(*) + 5 AS [cnt]
+                        @"SELECT [e].[Name] AS [MyKey], COUNT(*) + 5 AS [cnt]
 FROM [Table] AS [e]
-GROUP BY [e].[Name]");
+GROUP BY [e].[Name], [e].[MaumarEntity11818_Name]");
+                }
+            }
+        }
+
+        [Fact(Skip = "Issue #11870")]
+        public virtual void GroupJoin_Anonymous_projection_GroupBy_Aggregate_join_elimination_3()
+        {
+            using (CreateDatabase11818())
+            {
+                using (var context = new MyContext11818(_options))
+                {
+                    var query = (from e in context.Set<Entity11818>()
+                                 join a in context.Set<AnotherEntity11818>()
+                                   on e.Id equals a.Id into grouping
+                                 from a in grouping.DefaultIfEmpty()
+                                 join m in context.Set<MaumarEntity11818>()
+                                   on e.Id equals m.Id into grouping2
+                                 from m in grouping2.DefaultIfEmpty()
+                                 select new { aname = a.Name, mname = m.Name })
+                                  .GroupBy(g => new { g.aname, g.mname }).DefaultIfEmpty()
+                                  .Select(g => new { MyKey = g.Key.aname, cnt = g.Count() + 5 })
+                                  .ToList();
+
+                    AssertSql(
+                        @"");
+                }
+            }
+        }
+
+        [Fact(Skip = "Issue #11871")]
+        public virtual void GroupJoin_Anonymous_projection_GroupBy_Aggregate_join_elimination_4()
+        {
+            using (CreateDatabase11818())
+            {
+                using (var context = new MyContext11818(_options))
+                {
+                    var query = (from e in context.Set<Entity11818>()
+                                 join a in context.Set<AnotherEntity11818>()
+                                   on e.Id equals a.Id into grouping
+                                 from a in grouping.DefaultIfEmpty()
+                                 join m in context.Set<MaumarEntity11818>()
+                                   on e.Id equals m.Id into grouping2
+                                 from m in grouping2.DefaultIfEmpty()
+                                 select new { aname = a.Name, mname = m.Name })
+                                  .OrderBy(g => g.aname)
+                                  .GroupBy(g => new { g.aname, g.mname }).FirstOrDefault()
+                                  .Select(g => new { MyKey = g.aname, cnt = g.mname })
+                                  .ToList();
+
+                    AssertSql(
+                        @"");
                 }
             }
         }


### PR DESCRIPTION
When remapping member infos in a table splitting scenario we were not taking into the account that the element could be not a MemberInfo (it was a NullConditionalExpression because nav rewrite added null protection to it). However in case of accessing a property of an IGrouping, it's not necessary, because grouping can never be null.

Fix is to check for presence of GroupResultOperator when determining whether a given member access needs null compensation.