### PR TITLE
Add pre-generated tool shim to dotnet-ef package

### DIFF
--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.0-rc1-15774
-commithash:ed5ca9de3c652347dbb0158a9a65eff3471d2114
+version:2.1.0-rtm-15780
+commithash:4b54ae92ccebdf2a5aabca9748cc874eeafe5ac9

--- a/src/dotnet-ef/dotnet-ef.csproj
+++ b/src/dotnet-ef/dotnet-ef.csproj
@@ -1,4 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project>
+
+  <Sdk Name="Microsoft.NET.Sdk" />
+  <Sdk Name="Microsoft.DotNet.GlobalTools.Sdk" />
 
   <PropertyGroup>
     <Description>Entity Framework Core Tools for the .NET Command-Line Interface.
@@ -15,6 +18,7 @@ dotnet ef database update
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
+    <GenerateToolShims>true</GenerateToolShims>
     <RootNamespace>Microsoft.EntityFrameworkCore.Tools</RootNamespace>
     <IncludeSource>false</IncludeSource>
     <EnableApiCheck>false</EnableApiCheck>
@@ -96,6 +100,7 @@ dotnet ef database update
 
         SettingsFile=$(_ToolsSettingsFilePath);
         Output=$(PublishDir)**\*;
+        OutputShims=$(IntermediateOutputPath)shims\**\*;
         OutputBinary=..\ef\bin\$(Configuration)\netcoreapp2.0\ef.dll;
         OutputRuntimeConfig=..\ef\bin\$(Configuration)\netcoreapp2.0\ef.runtimeconfig.json;
         OutputSymbol=..\ef\bin\$(Configuration)\netcoreapp2.0\ef.pdb;

--- a/src/dotnet-ef/dotnet-ef.nuspec
+++ b/src/dotnet-ef/dotnet-ef.nuspec
@@ -23,6 +23,7 @@
   <files>
     <file src="$SettingsFile$" target="tools\$targetFramework$\any" />
     <file src="$Output$" target="tools\$targetFramework$\any" />
+    <file src="$OutputShims$" target="tools\$targetFramework$\any\shims" />
     <file src="$OutputBinary$" target="tools\$targetFramework$\any\tools\netcoreapp2.0\any" />
     <file src="$OutputRuntimeConfig$" target="tools\$targetFramework$\any\tools\netcoreapp2.0\any" />
     <file src="$OutputSymbol$" target="tools\$targetFramework$\any\tools\netcoreapp2.0\any" />


### PR DESCRIPTION
Satisfying even more arbitrary constraints.

As a part of preparing dotnet-ef to ship to nuget.org as a package, we have to include an code-sign a pre-generated exe shim for dotnet-ef. This adds a reference to Microsoft.DotNet.GlobalTools.Sdk and enables shim generation.

Part of https://github.com/aspnet/Universe/issues/1126