### PR TITLE
SQLite: Client-eval more expressions

### DIFF
--- a/benchmarks/test/EFCore.Benchmarks.Sqlite.Dev/Query/NavigationsQuerySqliteTests.cs
+++ b/benchmarks/test/EFCore.Benchmarks.Sqlite.Dev/Query/NavigationsQuerySqliteTests.cs
@@ -7,9 +7,6 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks.Query
 {
     public class NavigationsQuerySqliteTests : NavigationsQueryTests
     {
-        // Work around issue #10534
-        protected override int UnfilteredCount => 586;
-
         protected override AdventureWorksContextBase CreateContext()
         {
             return AdventureWorksFixture.CreateContext();

--- a/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -1024,7 +1024,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     typeof(bool)));
         }
 
-        private static void PrepareSelectExpressionForAggregate(SelectExpression selectExpression)
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected static void PrepareSelectExpressionForAggregate(SelectExpression selectExpression)
         {
             if (selectExpression.IsDistinct
                 || selectExpression.Limit != null

--- a/src/EFCore.Sqlite.Core/Infrastructure/SqliteServiceCollectionExtensions.cs
+++ b/src/EFCore.Sqlite.Core/Infrastructure/SqliteServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
 using Microsoft.EntityFrameworkCore.Query.Sql;
@@ -14,6 +15,7 @@ using Microsoft.EntityFrameworkCore.Sqlite.Infrastructure.Internal;
 using Microsoft.EntityFrameworkCore.Sqlite.Migrations.Internal;
 using Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionTranslators.Internal;
 using Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionVisitors.Internal;
+using Microsoft.EntityFrameworkCore.Sqlite.Query.Internal;
 using Microsoft.EntityFrameworkCore.Sqlite.Query.Sql.Internal;
 using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Sqlite.Update.Internal;
@@ -83,6 +85,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAdd<ICompositeMethodCallTranslator, SqliteCompositeMethodCallTranslator>()
                 .TryAdd<IQuerySqlGeneratorFactory, SqliteQuerySqlGeneratorFactory>()
                 .TryAdd<ISqlTranslatingExpressionVisitorFactory, SqliteSqlTranslatingExpressionVisitorFactory>()
+                .TryAdd<IRelationalResultOperatorHandler, SqliteResultOperatorHandler>()
                 .TryAddProviderSpecificServices(
                     b => b.TryAddScoped<ISqliteRelationalConnection, SqliteRelationalConnection>());
 

--- a/src/EFCore.Sqlite.Core/Query/ExpressionVisitors/Internal/SqliteSqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Sqlite.Core/Query/ExpressionVisitors/Internal/SqliteSqlTranslatingExpressionVisitor.cs
@@ -1,14 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
-using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
-using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionVisitors.Internal
 {
@@ -36,6 +37,47 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionVisitors.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        protected override Expression VisitUnary(UnaryExpression expression)
+        {
+            var visitedExpression = base.VisitUnary(expression);
+
+            if (visitedExpression == null)
+            {
+                return null;
+            }
+
+            if (visitedExpression.NodeType == ExpressionType.Negate
+                && visitedExpression is UnaryExpression visitedUnaryExpression)
+            {
+                var operandType = GetProviderType(visitedUnaryExpression.Operand);
+                if (operandType == typeof(decimal)
+                    || operandType == typeof(TimeSpan))
+                {
+                    return null;
+                }
+            }
+
+            return visitedExpression;
+        }
+
+        private static readonly IReadOnlyDictionary<ExpressionType, IReadOnlyCollection<Type>> _restrictedBinaryExpressions
+            = new Dictionary<ExpressionType, IReadOnlyCollection<Type>>
+            {
+                [ExpressionType.Add] = new HashSet<Type> { typeof(DateTime), typeof(DateTimeOffset), typeof(decimal), typeof(TimeSpan) },
+                [ExpressionType.Divide] = new HashSet<Type> { typeof(decimal), typeof(TimeSpan), typeof(ulong) },
+                [ExpressionType.GreaterThan] = new HashSet<Type> { typeof(DateTimeOffset), typeof(decimal), typeof(TimeSpan), typeof(ulong) },
+                [ExpressionType.GreaterThanOrEqual] = new HashSet<Type> { typeof(DateTimeOffset), typeof(decimal), typeof(TimeSpan), typeof(ulong) },
+                [ExpressionType.LessThan] = new HashSet<Type> { typeof(DateTimeOffset), typeof(decimal), typeof(TimeSpan), typeof(ulong) },
+                [ExpressionType.LessThanOrEqual] = new HashSet<Type> { typeof(DateTimeOffset), typeof(decimal), typeof(TimeSpan), typeof(ulong) },
+                [ExpressionType.Modulo] = new HashSet<Type> { typeof(decimal), typeof(ulong) },
+                [ExpressionType.Multiply] = new HashSet<Type> { typeof(decimal), typeof(TimeSpan), typeof(ulong) },
+                [ExpressionType.Subtract] = new HashSet<Type> { typeof(DateTime), typeof(DateTimeOffset), typeof(decimal), typeof(TimeSpan) }
+            };
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         protected override Expression VisitBinary(BinaryExpression binaryExpression)
         {
             var visitedExpression = base.VisitBinary(binaryExpression);
@@ -45,41 +87,19 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Query.ExpressionVisitors.Internal
                 return null;
             }
 
-            switch (visitedExpression.NodeType)
+            if (_restrictedBinaryExpressions.TryGetValue(visitedExpression.NodeType, out var restrictedTypes)
+                && visitedExpression is BinaryExpression visitedBinaryExpression
+                && (restrictedTypes.Contains(GetProviderType(visitedBinaryExpression.Left))
+                    || restrictedTypes.Contains(GetProviderType(visitedBinaryExpression.Right))))
             {
-                case ExpressionType.Add:
-                case ExpressionType.Subtract:
-                case ExpressionType.Multiply:
-                case ExpressionType.Divide:
-                case ExpressionType.Modulo:
-                    return IsDateTimeBasedOperation(visitedExpression)
-                        ? null
-                        : visitedExpression;
+                return null;
             }
 
             return visitedExpression;
         }
 
-        private static bool IsDateTimeBasedOperation(Expression expression)
-        {
-            if (expression is BinaryExpression binaryExpression)
-            {
-                var typeMapping = InferTypeMappingFromColumn(binaryExpression.Left)
-                    ?? InferTypeMappingFromColumn(binaryExpression.Right);
-
-                if (typeMapping != null
-                    && (typeMapping is SqliteDateTimeOffsetTypeMapping
-                        || typeMapping is SqliteDateTimeTypeMapping))
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private static RelationalTypeMapping InferTypeMappingFromColumn(Expression expression)
-            => expression.FindProperty(expression.Type)?.FindRelationalMapping();
-
+        private static Type GetProviderType(Expression expression)
+            => (expression.FindProperty(expression.Type)?.FindRelationalMapping().ClrType ?? expression.Type)
+                .UnwrapNullableType();
     }
 }

--- a/src/EFCore.Sqlite.Core/Query/Internal/SqliteResultOperatorHandler.cs
+++ b/src/EFCore.Sqlite.Core/Query/Internal/SqliteResultOperatorHandler.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.ResultOperators;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Query.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class SqliteResultOperatorHandler : RelationalResultOperatorHandler
+    {
+        private static readonly IDictionary<Type, IReadOnlyCollection<Type>> _restrictedOperators
+            = new Dictionary<Type, IReadOnlyCollection<Type>>
+            {
+                [typeof(AverageResultOperator)] = new HashSet<Type> { typeof(decimal) },
+                [typeof(MaxResultOperator)] = new HashSet<Type> { typeof(DateTimeOffset), typeof(decimal), typeof(TimeSpan), typeof(ulong) },
+                [typeof(MinResultOperator)] = new HashSet<Type> { typeof(DateTimeOffset), typeof(decimal), typeof(TimeSpan), typeof(ulong) },
+                [typeof(SumResultOperator)] = new HashSet<Type> { typeof(decimal) }
+            };
+
+        private readonly IResultOperatorHandler _resultOperatorHandler;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public SqliteResultOperatorHandler(
+            [NotNull] IModel model,
+            [NotNull] ISqlTranslatingExpressionVisitorFactory sqlTranslatingExpressionVisitorFactory,
+            [NotNull] ISelectExpressionFactory selectExpressionFactory,
+            [NotNull] IResultOperatorHandler resultOperatorHandler)
+            : base(model, sqlTranslatingExpressionVisitorFactory, selectExpressionFactory, resultOperatorHandler)
+        {
+            _resultOperatorHandler = resultOperatorHandler;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override Expression HandleResultOperator(
+            EntityQueryModelVisitor entityQueryModelVisitor,
+            ResultOperatorBase resultOperator,
+            QueryModel queryModel)
+        {
+            var relationalQueryModelVisitor = (RelationalQueryModelVisitor)entityQueryModelVisitor;
+            var selectExpression = relationalQueryModelVisitor.TryGetQuery(queryModel.MainFromClause);
+
+            if (!relationalQueryModelVisitor.RequiresClientResultOperator
+                && selectExpression != null
+                && selectExpression.Projection.Count == 1
+                && _restrictedOperators.TryGetValue(resultOperator.GetType(), out var restrictedTypes))
+            {
+                PrepareSelectExpressionForAggregate(selectExpression);
+
+                if (!(selectExpression.Projection[0].RemoveConvert() is SelectExpression))
+                {
+                    if (restrictedTypes.Contains(queryModel.SelectClause.Selector.Type.UnwrapNullableType()))
+                    {
+                        relationalQueryModelVisitor.RequiresClientResultOperator = true;
+
+                        return _resultOperatorHandler.HandleResultOperator(
+                            entityQueryModelVisitor,
+                            resultOperator,
+                            queryModel);
+                    }
+                }
+            }
+
+            return base.HandleResultOperator(entityQueryModelVisitor, resultOperator, queryModel);
+        }
+    }
+}

--- a/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/BuiltInDataTypesSqliteTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore
             //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
-        [Fact(Skip = "See issue #8205")]
+        [Fact]
         public virtual void Can_insert_and_query_decimal()
         {
             using (var context = CreateContext())
@@ -35,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore
                 context.Set<BuiltInNullableDataTypes>().Add(
                     new BuiltInNullableDataTypes
                     {
-                        Id = 13,
+                        Id = 14,
                         TestNullableDecimal = 3m
                     });
 
@@ -44,9 +44,9 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = CreateContext())
             {
-                var entity = context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 13);
+                var entity = context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 14);
 
-                Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 13 && e.TestNullableDecimal == 3m));
+                Assert.Same(entity, context.Set<BuiltInNullableDataTypes>().Single(e => e.Id == 14 && e.TestNullableDecimal == 3m));
             }
         }
 
@@ -846,6 +846,579 @@ namespace Microsoft.EntityFrameworkCore
                             typeMapper.FindMapping(property).StoreType.ToLowerInvariant());
                     }
                 }
+            }
+        }
+
+        [Fact]
+        public virtual void Can_query_Min_of_converted_types()
+        {
+            using (var context = CreateContext())
+            {
+                var min = new BuiltInNullableDataTypes
+                {
+                    Id = 201,
+                    PartitionId = 200,
+                    TestNullableDecimal = 2,
+                    TestNullableDateTime = new DateTime(2018, 2, 2, 0, 0, 0),
+                    TestNullableDateTimeOffset = new DateTimeOffset(2018, 1, 1, 12, 0, 0, TimeSpan.Zero),
+                    TestNullableTimeSpan = TimeSpan.FromDays(2),
+                    TestNullableUnsignedInt64 = 0,
+                    TestNullableCharacter = 'A',
+                };
+                context.Add(min);
+
+                var max = new BuiltInNullableDataTypes
+                {
+                    Id = 202,
+                    PartitionId = 200,
+
+                    TestNullableDecimal = 10,
+                    TestNullableDateTime = new DateTime(2018, 10, 10, 0, 0, 0),
+                    TestNullableDateTimeOffset = new DateTimeOffset(2018, 1, 1, 11, 0, 0, TimeSpan.FromHours(-2)),
+                    TestNullableTimeSpan = TimeSpan.FromDays(10),
+                    TestNullableUnsignedInt64 = ulong.MaxValue,
+                    TestNullableCharacter = 'B'
+                };
+                context.Add(max);
+
+                context.SaveChanges();
+
+                var result = context.Set<BuiltInNullableDataTypes>()
+                    .Where(e => e.PartitionId == 200)
+                    .GroupBy(_ => true)
+                    .Select(
+                        g => new BuiltInNullableDataTypes
+                        {
+                            TestNullableDecimal = g.Min(e => e.TestNullableDecimal),
+                            TestNullableDateTime = g.Min(e => e.TestNullableDateTime),
+                            TestNullableDateTimeOffset = g.Min(e => e.TestNullableDateTimeOffset),
+                            TestNullableTimeSpan = g.Min(e => e.TestNullableTimeSpan),
+                            TestNullableUnsignedInt64 = g.Min(e => e.TestNullableUnsignedInt64),
+                            TestNullableCharacter = g.Min(e => e.TestNullableCharacter),
+                        })
+                    .ToList()[0];
+
+                Assert.Equal(min.TestNullableDecimal, result.TestNullableDecimal);
+                Assert.Equal(min.TestNullableDateTime, result.TestNullableDateTime);
+                Assert.Equal(min.TestNullableDateTimeOffset, result.TestNullableDateTimeOffset);
+                Assert.Equal(min.TestNullableTimeSpan, result.TestNullableTimeSpan);
+                Assert.Equal(min.TestNullableUnsignedInt64, result.TestNullableUnsignedInt64);
+                Assert.Equal(min.TestNullableCharacter, result.TestNullableCharacter);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_query_Max_of_converted_types()
+        {
+            using (var context = CreateContext())
+            {
+                var min = new BuiltInNullableDataTypes
+                {
+                    Id = 203,
+                    PartitionId = 201,
+                    TestNullableDecimal = 2,
+                    TestNullableDateTime = new DateTime(2018, 2, 2, 0, 0, 0),
+                    TestNullableDateTimeOffset = new DateTimeOffset(2018, 1, 1, 12, 0, 0, TimeSpan.Zero),
+                    TestNullableTimeSpan = TimeSpan.FromDays(2),
+                    TestNullableUnsignedInt64 = 0,
+                    TestNullableCharacter = 'A',
+                };
+                context.Add(min);
+
+                var max = new BuiltInNullableDataTypes
+                {
+                    Id = 204,
+                    PartitionId = 201,
+                    TestNullableDecimal = 10,
+                    TestNullableDateTime = new DateTime(2018, 10, 10, 0, 0, 0),
+                    TestNullableDateTimeOffset = new DateTimeOffset(2018, 1, 1, 11, 0, 0, TimeSpan.FromHours(-2)),
+                    TestNullableTimeSpan = TimeSpan.FromDays(10),
+                    TestNullableUnsignedInt64 = ulong.MaxValue,
+                    TestNullableCharacter = 'B'
+                };
+                context.Add(max);
+
+                context.SaveChanges();
+
+                var result = context.Set<BuiltInNullableDataTypes>()
+                    .Where(e => e.PartitionId == 201)
+                    .GroupBy(_ => true)
+                    .Select(
+                        g => new BuiltInNullableDataTypes
+                        {
+                            TestNullableDecimal = g.Max(e => e.TestNullableDecimal),
+                            TestNullableDateTime = g.Max(e => e.TestNullableDateTime),
+                            TestNullableDateTimeOffset = g.Max(e => e.TestNullableDateTimeOffset),
+                            TestNullableTimeSpan = g.Max(e => e.TestNullableTimeSpan),
+                            TestNullableUnsignedInt64 = g.Max(e => e.TestNullableUnsignedInt64),
+                            TestNullableCharacter = g.Max(e => e.TestNullableCharacter),
+                        })
+                    .ToList()[0];
+
+                Assert.Equal(max.TestNullableDecimal, result.TestNullableDecimal);
+                Assert.Equal(max.TestNullableDateTime, result.TestNullableDateTime);
+                Assert.Equal(max.TestNullableDateTimeOffset, result.TestNullableDateTimeOffset);
+                Assert.Equal(max.TestNullableTimeSpan, result.TestNullableTimeSpan);
+                Assert.Equal(max.TestNullableUnsignedInt64, result.TestNullableUnsignedInt64);
+                Assert.Equal(max.TestNullableCharacter, result.TestNullableCharacter);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_query_Average_of_converted_types()
+        {
+            using (var context = CreateContext())
+            {
+                context.Add(
+                    new BuiltInNullableDataTypes
+                    {
+                        Id = 205,
+                        PartitionId = 202,
+                        TestNullableDecimal = 1.000000000000001m
+                    });
+
+                context.Add(new BuiltInNullableDataTypes
+                {
+                    Id = 206,
+                    PartitionId = 202,
+                    TestNullableDecimal = 1.000000000000001m
+                });
+
+                context.SaveChanges();
+
+                var result = context.Set<BuiltInNullableDataTypes>()
+                    .Where(e => e.PartitionId == 202)
+                    .Average(e => e.TestNullableDecimal);
+
+                Assert.Equal(1.000000000000001m, result);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_query_Sum_of_converted_types()
+        {
+            using (var context = CreateContext())
+            {
+                context.Add(
+                    new BuiltInDataTypes
+                    {
+                        Id = 205,
+                        PartitionId = 203,
+                        TestDecimal = 1.000000000000001m
+                    });
+
+                context.Add(new BuiltInDataTypes
+                {
+                    Id = 206,
+                    PartitionId = 203,
+                    TestDecimal = 1.000000000000001m
+                });
+
+                context.SaveChanges();
+
+                var result = context.Set<BuiltInDataTypes>()
+                    .Where(e => e.PartitionId == 203)
+                    .Sum(e => e.TestDecimal);
+
+                Assert.Equal(2.000000000000002m, result);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_query_negation_of_converted_types()
+        {
+            using (var context = CreateContext())
+            {
+                context.Add(
+                    new BuiltInDataTypes
+                    {
+                        Id = 207,
+                        PartitionId = 204,
+                        TestDecimal = 1.000000000000001m,
+                        TestTimeSpan = TimeSpan.FromMinutes(1)
+                    });
+
+                context.SaveChanges();
+
+                var result = context.Set<BuiltInDataTypes>()
+                    .Select(
+                        e => new BuiltInDataTypes
+                        {
+                            Id = e.Id,
+                            TestDecimal = -e.TestDecimal,
+                            TestTimeSpan = -e.TestTimeSpan,
+                        })
+                    .First(e => e.Id == 207);
+
+                Assert.Equal(-1.000000000000001m, result.TestDecimal);
+                Assert.Equal(TimeSpan.FromMinutes(-1), result.TestTimeSpan);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_query_add_of_converted_types()
+        {
+            using (var context = CreateContext())
+            {
+                context.Add(
+                    new BuiltInDataTypes
+                    {
+                        Id = 208,
+                        PartitionId = 204,
+                        TestDecimal = 1.000000000000001m,
+                        TestDateTime = new DateTime(2018, 1, 1, 0, 0, 0),
+                        TestDateTimeOffset = new DateTimeOffset(2018, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                        TestTimeSpan = TimeSpan.FromMinutes(1),
+                        TestUnsignedInt64 = ulong.MaxValue - 1ul
+                    });
+
+                context.SaveChanges();
+
+                var result = context.Set<BuiltInDataTypes>()
+                    .Select(
+                        e => new BuiltInDataTypes
+                        {
+                            Id = e.Id,
+                            TestDecimal = e.TestDecimal + 1m,
+                            TestDateTime = e.TestDateTime + new TimeSpan(0, 1, 0),
+                            TestDateTimeOffset = e.TestDateTimeOffset + new TimeSpan(0, 1, 0),
+                            TestTimeSpan = e.TestTimeSpan + new TimeSpan(0, 1, 0),
+                            TestUnsignedInt64 = e.TestUnsignedInt64 + 1ul
+                        })
+                    .First(e => e.Id == 208);
+
+                Assert.Equal(2.000000000000001m, result.TestDecimal);
+                Assert.Equal(new DateTime(2018, 1, 1, 0, 1, 0), result.TestDateTime);
+                Assert.Equal(new DateTimeOffset(2018, 1, 1, 0, 1, 0, TimeSpan.Zero), result.TestDateTimeOffset);
+                Assert.Equal(TimeSpan.FromMinutes(2), result.TestTimeSpan);
+                Assert.Equal(ulong.MaxValue, result.TestUnsignedInt64);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_query_subtract_of_converted_types()
+        {
+            using (var context = CreateContext())
+            {
+                context.Add(
+                    new BuiltInDataTypes
+                    {
+                        Id = 209,
+                        PartitionId = 204,
+                        TestDecimal = 2.000000000000001m,
+                        TestDateTime = new DateTime(2018, 1, 1, 0, 1, 0),
+                        TestDateTimeOffset = new DateTimeOffset(2018, 1, 1, 0, 1, 0, TimeSpan.Zero),
+                        TestTimeSpan = TimeSpan.FromMinutes(2),
+                        TestUnsignedInt64 = ulong.MaxValue
+                    });
+
+                context.SaveChanges();
+
+                var result = context.Set<BuiltInDataTypes>()
+                    .Select(
+                        e => new
+                        {
+                            Id = e.Id,
+                            TestDecimal = e.TestDecimal - 1m,
+                            TestDateTime1 = e.TestDateTime - new TimeSpan(0, 1, 0),
+                            TestDateTime2 = e.TestDateTime - new DateTime(2018, 1, 1, 0, 0, 0),
+                            TestDateTimeOffset1 = e.TestDateTimeOffset - new TimeSpan(0, 1, 0),
+                            TestDateTimeOffset2 = e.TestDateTimeOffset - new DateTimeOffset(2018, 1, 1, 0, 0, 0, TimeSpan.Zero),
+                            TestTimeSpan = e.TestTimeSpan - new TimeSpan(0, 1, 0),
+                            TestUnsignedInt64 = e.TestUnsignedInt64 - 1ul
+                        })
+                    .First(e => e.Id == 209);
+
+                Assert.Equal(1.000000000000001m, result.TestDecimal);
+                Assert.Equal(new DateTime(2018, 1, 1, 0, 0, 0), result.TestDateTime1);
+                Assert.Equal(TimeSpan.FromMinutes(1), result.TestDateTime2);
+                Assert.Equal(new DateTimeOffset(2018, 1, 1, 0, 0, 0, TimeSpan.Zero), result.TestDateTimeOffset1);
+                Assert.Equal(TimeSpan.FromMinutes(1), result.TestDateTimeOffset2);
+                Assert.Equal(TimeSpan.FromMinutes(1), result.TestTimeSpan);
+                Assert.Equal(ulong.MaxValue - 1ul, result.TestUnsignedInt64);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_query_less_than_of_converted_types()
+        {
+            using (var context = CreateContext())
+            {
+                context.Add(
+                    new BuiltInDataTypes
+                    {
+                        Id = 210,
+                        PartitionId = 204,
+                        TestDecimal = 2,
+                        TestDateTime = new DateTime(2018, 2, 2, 0, 0, 0),
+                        TestDateTimeOffset = new DateTimeOffset(2018, 1, 1, 12, 0, 0, TimeSpan.Zero),
+                        TestTimeSpan = TimeSpan.FromDays(2),
+                        TestUnsignedInt64 = 0,
+                        TestCharacter = 'A'
+                    });
+
+                context.SaveChanges();
+
+                var result = context.Set<BuiltInDataTypes>()
+                    .Select(
+                        e => new
+                        {
+                            e.Id,
+                            TestDecimal = e.TestDecimal < 10m,
+                            TestDateTime = e.TestDateTime < new DateTime(2018, 10, 10, 0, 0, 0),
+                            TestDateTimeOffset = e.TestDateTimeOffset < new DateTimeOffset(2018, 1, 1, 11, 0, 0, TimeSpan.FromHours(-2)),
+                            TestTimeSpan = e.TestTimeSpan < new TimeSpan(10, 0, 0, 0),
+                            TestUnsignedInt64 = e.TestUnsignedInt64 < ulong.MaxValue,
+                            TestCharacter = e.TestCharacter < 'B'
+                        })
+                    .First(e => e.Id == 210);
+
+                Assert.True(result.TestDecimal);
+                Assert.True(result.TestDateTime);
+                Assert.True(result.TestDateTimeOffset);
+                Assert.True(result.TestTimeSpan);
+                Assert.True(result.TestUnsignedInt64);
+                Assert.True(result.TestCharacter);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_query_less_than_or_equal_of_converted_types()
+        {
+            using (var context = CreateContext())
+            {
+                context.Add(
+                    new BuiltInDataTypes
+                    {
+                        Id = 211,
+                        PartitionId = 204,
+                        TestDecimal = 2,
+                        TestDateTime = new DateTime(2018, 2, 2, 0, 0, 0),
+                        TestDateTimeOffset = new DateTimeOffset(2018, 1, 1, 12, 0, 0, TimeSpan.Zero),
+                        TestTimeSpan = TimeSpan.FromDays(2),
+                        TestUnsignedInt64 = 0,
+                        TestCharacter = 'A'
+                    });
+
+                context.SaveChanges();
+
+                var result = context.Set<BuiltInDataTypes>()
+                    .Select(
+                        e => new
+                        {
+                            e.Id,
+                            TestDecimal = e.TestDecimal <= 10m,
+                            TestDateTime = e.TestDateTime <= new DateTime(2018, 10, 10, 0, 0, 0),
+                            TestDateTimeOffset = e.TestDateTimeOffset <= new DateTimeOffset(2018, 1, 1, 11, 0, 0, TimeSpan.FromHours(-2)),
+                            TestTimeSpan = e.TestTimeSpan <= new TimeSpan(10, 0, 0, 0),
+                            TestUnsignedInt64 = e.TestUnsignedInt64 <= ulong.MaxValue,
+                            TestCharacter = e.TestCharacter <= 'B'
+                        })
+                    .First(e => e.Id == 211);
+
+                Assert.True(result.TestDecimal);
+                Assert.True(result.TestDateTime);
+                Assert.True(result.TestDateTimeOffset);
+                Assert.True(result.TestTimeSpan);
+                Assert.True(result.TestUnsignedInt64);
+                Assert.True(result.TestCharacter);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_query_greater_than_of_converted_types()
+        {
+            using (var context = CreateContext())
+            {
+                context.Add(
+                    new BuiltInDataTypes
+                    {
+                        Id = 212,
+                        PartitionId = 204,
+                        TestDecimal = 2,
+                        TestDateTime = new DateTime(2018, 2, 2, 0, 0, 0),
+                        TestDateTimeOffset = new DateTimeOffset(2018, 1, 1, 12, 0, 0, TimeSpan.Zero),
+                        TestTimeSpan = TimeSpan.FromDays(2),
+                        TestUnsignedInt64 = 0,
+                        TestCharacter = 'A'
+                    });
+
+                context.SaveChanges();
+
+                var result = context.Set<BuiltInDataTypes>()
+                    .Select(
+                        e => new
+                        {
+                            e.Id,
+                            TestDecimal = e.TestDecimal > 10m,
+                            TestDateTime = e.TestDateTime > new DateTime(2018, 10, 10, 0, 0, 0),
+                            TestDateTimeOffset = e.TestDateTimeOffset > new DateTimeOffset(2018, 1, 1, 11, 0, 0, TimeSpan.FromHours(-2)),
+                            TestTimeSpan = e.TestTimeSpan > new TimeSpan(10, 0, 0, 0),
+                            TestUnsignedInt64 = e.TestUnsignedInt64 > ulong.MaxValue,
+                            TestCharacter = e.TestCharacter > 'B'
+                        })
+                    .First(e => e.Id == 212);
+
+                Assert.False(result.TestDecimal);
+                Assert.False(result.TestDateTime);
+                Assert.False(result.TestDateTimeOffset);
+                Assert.False(result.TestTimeSpan);
+                Assert.False(result.TestUnsignedInt64);
+                Assert.False(result.TestCharacter);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_query_greater_than_or_equal_of_converted_types()
+        {
+            using (var context = CreateContext())
+            {
+                context.Add(
+                    new BuiltInDataTypes
+                    {
+                        Id = 213,
+                        PartitionId = 204,
+                        TestDecimal = 2,
+                        TestDateTime = new DateTime(2018, 2, 2, 0, 0, 0),
+                        TestDateTimeOffset = new DateTimeOffset(2018, 1, 1, 12, 0, 0, TimeSpan.Zero),
+                        TestTimeSpan = TimeSpan.FromDays(2),
+                        TestUnsignedInt64 = 0,
+                        TestCharacter = 'A'
+                    });
+
+                context.SaveChanges();
+
+                var result = context.Set<BuiltInDataTypes>()
+                    .Select(
+                        e => new
+                        {
+                            e.Id,
+                            TestDecimal = e.TestDecimal >= 10m,
+                            TestDateTime = e.TestDateTime >= new DateTime(2018, 10, 10, 0, 0, 0),
+                            TestDateTimeOffset = e.TestDateTimeOffset >= new DateTimeOffset(2018, 1, 1, 11, 0, 0, TimeSpan.FromHours(-2)),
+                            TestTimeSpan = e.TestTimeSpan >= new TimeSpan(10, 0, 0, 0),
+                            TestUnsignedInt64 = e.TestUnsignedInt64 >= ulong.MaxValue,
+                            TestCharacter = e.TestCharacter >= 'B'
+                        })
+                    .First(e => e.Id == 213);
+
+                Assert.False(result.TestDecimal);
+                Assert.False(result.TestDateTime);
+                Assert.False(result.TestDateTimeOffset);
+                Assert.False(result.TestTimeSpan);
+                Assert.False(result.TestUnsignedInt64);
+                Assert.False(result.TestCharacter);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_query_divide_of_converted_types()
+        {
+            using (var context = CreateContext())
+            {
+                context.Add(
+                    new BuiltInDataTypes
+                    {
+                        Id = 214,
+                        PartitionId = 204,
+                        TestDecimal = 2.000000000000002m,
+                        TestTimeSpan = TimeSpan.FromMinutes(2),
+                        TestUnsignedInt64 = ulong.MaxValue
+                    });
+
+                context.SaveChanges();
+
+                var result = context.Set<BuiltInDataTypes>()
+                    .Select(
+                        e => new
+                        {
+                            e.Id,
+                            TestDecimal = e.TestDecimal / 2m,
+#if !NET461
+                            TestTimeSpan1 = e.TestTimeSpan / 2.0,
+                            TestTimeSpan2 = e.TestTimeSpan / new TimeSpan(0, 2, 0),
+#endif
+                            TestUnsignedInt64 = e.TestUnsignedInt64 / 5ul
+                        })
+                    .First(e => e.Id == 214);
+
+                Assert.Equal(1.000000000000001m, result.TestDecimal);
+#if !NET461
+                Assert.Equal(TimeSpan.FromMinutes(1), result.TestTimeSpan1);
+                Assert.Equal(1.0, result.TestTimeSpan2);
+#endif
+                Assert.Equal(ulong.MaxValue / 5, result.TestUnsignedInt64);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_query_multiply_of_converted_types()
+        {
+            using (var context = CreateContext())
+            {
+                context.Add(
+                    new BuiltInDataTypes
+                    {
+                        Id = 215,
+                        PartitionId = 204,
+                        TestDecimal = 1.000000000000001m,
+                        TestTimeSpan = TimeSpan.FromMinutes(1),
+                        TestUnsignedInt64 = ulong.MaxValue / 5
+                    });
+
+                context.SaveChanges();
+
+                var result = context.Set<BuiltInDataTypes>()
+                    .Select(
+                        e => new
+                        {
+                            e.Id,
+                            TestDecimal = e.TestDecimal * 2m,
+#if !NET461
+                            TestTimeSpan1 = e.TestTimeSpan * 2.0,
+                            TestTimeSpan2 = 2.0 * e.TestTimeSpan,
+#endif
+                            TestUnsignedInt64 = e.TestUnsignedInt64 * 5ul
+                        })
+                    .First(e => e.Id == 215);
+
+                Assert.Equal(2.000000000000002m, result.TestDecimal);
+#if !NET461
+                Assert.Equal(TimeSpan.FromMinutes(2), result.TestTimeSpan1);
+                Assert.Equal(TimeSpan.FromMinutes(2), result.TestTimeSpan2);
+#endif
+                Assert.Equal(ulong.MaxValue, result.TestUnsignedInt64);
+            }
+        }
+
+        [Fact]
+        public virtual void Can_query_modulo_of_converted_types()
+        {
+            using (var context = CreateContext())
+            {
+                context.Add(
+                    new BuiltInDataTypes
+                    {
+                        Id = 216,
+                        PartitionId = 204,
+                        TestDecimal = 3.000000000000003m,
+                        TestUnsignedInt64 = 10000000000000000001
+                    });
+
+                context.SaveChanges();
+
+                var result = context.Set<BuiltInDataTypes>()
+                    .Select(
+                        e => new BuiltInDataTypes
+                        {
+                            Id = e.Id,
+                            TestDecimal = e.TestDecimal % 2.000000000000002m,
+                            TestUnsignedInt64 = e.TestUnsignedInt64 % 10000000000000000000
+                        })
+                    .First(e => e.Id == 216);
+
+                Assert.Equal(1.000000000000001m, result.TestDecimal);
+                Assert.Equal(1ul, result.TestUnsignedInt64);
             }
         }
 

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SimpleQuerySqliteTest.cs
@@ -606,7 +606,7 @@ WHERE trim(""c"".""ContactTitle"", 'Or') = 'wne'");
             base.Sum_with_coalesce();
 
             AssertSql(
-                @"SELECT SUM(COALESCE(""p"".""UnitPrice"", '0.0'))
+                @"SELECT COALESCE(""p"".""UnitPrice"", '0.0')
 FROM ""Products"" AS ""p""
 WHERE ""p"".""ProductID"" < 40");
         }


### PR DESCRIPTION
Many operations involving the following types are problematic and should not be performed on the server:
- DateTime
- DateTimeOffset
- decimal
- TimeSpan
- ulong

Fixes #10534