### PR TITLE
Fix to #11670 - improve ExpressionPrinter debug mode to add unique IDs for query sources referenced by qsres

### DIFF
--- a/src/EFCore.Relational/Query/Expressions/DiscriminatorPredicateExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/DiscriminatorPredicateExpression.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Remotion.Linq.Clauses;
 
@@ -12,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
     /// <summary>
     ///     Represents a discriminator predicate.
     /// </summary>
-    public class DiscriminatorPredicateExpression : Expression
+    public class DiscriminatorPredicateExpression : Expression, IPrintable
     {
         private readonly Expression _predicate;
 
@@ -126,6 +128,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             {
                 return (_predicate.GetHashCode() * 397) ^ (QuerySource?.GetHashCode() ?? 0);
             }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void Print(ExpressionPrinter expressionPrinter)
+        {
+            expressionPrinter.Visit(_predicate);
         }
 
         /// <summary>

--- a/src/EFCore/Query/Internal/IExpressionPrinter.cs
+++ b/src/EFCore/Query/Internal/IExpressionPrinter.cs
@@ -22,6 +22,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        string PrintDebug([NotNull] Expression expression, bool highlightNonreducibleNodes = true);
+        string PrintDebug(
+            [NotNull] Expression expression,
+            bool highlightNonreducibleNodes = true,
+            bool reduceBeforePrinting = true,
+            bool generateUniqueQsreIds = true);
     }
 }

--- a/src/EFCore/Query/Internal/IQueryModelPrinter.cs
+++ b/src/EFCore/Query/Internal/IQueryModelPrinter.cs
@@ -16,6 +16,20 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        string Print([NotNull] QueryModel queryModel, bool removeFormatting = false, int? characterLimit = null);
+        string Print(
+            [NotNull] QueryModel queryModel,
+            bool removeFormatting = false,
+            int? characterLimit = null,
+            bool generateUniqueQsreIds = false);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        string PrintDebug(
+            [NotNull] QueryModel queryModel,
+            bool removeFormatting = false,
+            int? characterLimit = null,
+            bool generateUniqueQsreIds = true);
     }
 }

--- a/src/EFCore/Query/Internal/QueryModelExtensions.cs
+++ b/src/EFCore/Query/Internal/QueryModelExtensions.cs
@@ -60,8 +60,22 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public static string Print([NotNull] this QueryModel queryModel, bool removeFormatting = false, int? characterLimit = null)
+        public static string Print(
+            [NotNull] this QueryModel queryModel,
+            bool removeFormatting = false,
+            int? characterLimit = null)
             => new QueryModelPrinter().Print(queryModel, removeFormatting, characterLimit);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string PrintDebug(
+            [NotNull] this QueryModel queryModel,
+            bool removeFormatting = false, int?
+            characterLimit = null,
+            bool generateUniqueQsreIds = true)
+            => new QueryModelPrinter().PrintDebug(queryModel, removeFormatting, characterLimit, generateUniqueQsreIds);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Query/Internal/QueryModelPrinter.cs
+++ b/src/EFCore/Query/Internal/QueryModelPrinter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.ObjectModel;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
@@ -37,13 +38,37 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual string Print(QueryModel queryModel, bool removeFormatting = false, int? characterLimit = null)
+        public virtual string Print(
+            QueryModel queryModel,
+            bool removeFormatting = false,
+            int? characterLimit = null,
+            bool generateUniqueQsreIds = false)
+            => PrintInternal(queryModel, removeFormatting, characterLimit, generateUniqueQsreIds);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual string PrintDebug(
+            QueryModel queryModel,
+            bool removeFormatting = false,
+            int? characterLimit = null,
+            bool generateUniqueQsreIds = true)
+            => PrintInternal(queryModel, removeFormatting, characterLimit, generateUniqueQsreIds);
+
+        private string PrintInternal(
+            QueryModel queryModel,
+            bool removeFormatting = false,
+            int? characterLimit = null,
+            bool generateUniqueQsreIds = false)
         {
             _expressionPrinter.StringBuilder.Clear();
 
             _queryModelPrintingVisitor.RemoveFormatting = removeFormatting;
             _expressionPrinter.RemoveFormatting = removeFormatting;
             _expressionPrinter.CharacterLimit = characterLimit;
+            _expressionPrinter.GenerateUniqueQsreIds = generateUniqueQsreIds;
+
             _queryModelPrintingVisitor.VisitQueryModel(queryModel);
 
             var result = _expressionPrinter.StringBuilder.ToString();
@@ -113,21 +138,68 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     TransformingVisitor.StringBuilder.Append("(");
                 }
 
-                TransformingVisitor.StringBuilder.Append($"from {fromClause.ItemType.ShortDisplayName()} {fromClause.ItemName} in ");
+                if (TransformingVisitor.GenerateUniqueQsreIds)
+                {
+                    var i = TransformingVisitor.VisitedQuerySources.IndexOf(fromClause);
+                    if (i == -1)
+                    {
+                        i = TransformingVisitor.VisitedQuerySources.Count;
+                        TransformingVisitor.VisitedQuerySources.Add(fromClause);
+                    }
+
+                    TransformingVisitor.StringBuilder.Append($"from {fromClause.ItemType.ShortDisplayName()} {fromClause.ItemName}{{{i}}} in ");
+                }
+                else
+                {
+                    TransformingVisitor.StringBuilder.Append($"from {fromClause.ItemType.ShortDisplayName()} {fromClause.ItemName} in ");
+                }
+
                 base.VisitMainFromClause(fromClause, queryModel);
             }
 
             public override void VisitAdditionalFromClause(AdditionalFromClause fromClause, QueryModel queryModel, int index)
             {
                 AppendLine();
-                TransformingVisitor.StringBuilder.Append($"from {fromClause.ItemType.ShortDisplayName()} {fromClause.ItemName} in ");
+
+                if (TransformingVisitor.GenerateUniqueQsreIds)
+                {
+                    var i = TransformingVisitor.VisitedQuerySources.IndexOf(fromClause);
+                    if (i == -1)
+                    {
+                        i = TransformingVisitor.VisitedQuerySources.Count;
+                        TransformingVisitor.VisitedQuerySources.Add(fromClause);
+                    }
+
+                    TransformingVisitor.StringBuilder.Append($"from {fromClause.ItemType.ShortDisplayName()} {fromClause.ItemName}{{{i}}} in ");
+                }
+                else
+                {
+                    TransformingVisitor.StringBuilder.Append($"from {fromClause.ItemType.ShortDisplayName()} {fromClause.ItemName} in ");
+                }
+
                 base.VisitAdditionalFromClause(fromClause, queryModel, index);
             }
 
             public override void VisitJoinClause(JoinClause joinClause, QueryModel queryModel, int index)
             {
                 AppendLine();
-                TransformingVisitor.StringBuilder.Append($"join {joinClause.ItemType.ShortDisplayName()} {joinClause.ItemName} in ");
+
+                if (TransformingVisitor.GenerateUniqueQsreIds)
+                {
+                    var i = TransformingVisitor.VisitedQuerySources.IndexOf(joinClause);
+                    if (i == -1)
+                    {
+                        i = TransformingVisitor.VisitedQuerySources.Count;
+                        TransformingVisitor.VisitedQuerySources.Add(joinClause);
+                    }
+
+                    TransformingVisitor.StringBuilder.Append($"join {joinClause.ItemType.ShortDisplayName()} {joinClause.ItemName}{{{i}}} in ");
+                }
+                else
+                {
+                    TransformingVisitor.StringBuilder.Append($"join {joinClause.ItemType.ShortDisplayName()} {joinClause.ItemName} in ");
+                }
+
                 TransformingVisitor.Visit(joinClause.InnerSequence);
                 AppendLine();
                 TransformingVisitor.StringBuilder.Append("on ");
@@ -138,7 +210,23 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
             public override void VisitJoinClause(JoinClause joinClause, QueryModel queryModel, GroupJoinClause groupJoinClause)
             {
-                TransformingVisitor.StringBuilder.Append($"join {joinClause.ItemType.ShortDisplayName()} {joinClause.ItemName} in ");
+                if (TransformingVisitor.GenerateUniqueQsreIds)
+                {
+                    var i = TransformingVisitor.VisitedQuerySources.IndexOf(joinClause);
+                    if (i == -1)
+                    {
+                        i = TransformingVisitor.VisitedQuerySources.Count;
+                        TransformingVisitor.VisitedQuerySources.Add(joinClause);
+                    }
+
+                    TransformingVisitor.StringBuilder.Append($"join {joinClause.ItemType.ShortDisplayName()} {joinClause.ItemName}{{{i}}} in ");
+
+                }
+                else
+                {
+                    TransformingVisitor.StringBuilder.Append($"join {joinClause.ItemType.ShortDisplayName()} {joinClause.ItemName} in ");
+                }
+
                 TransformingVisitor.Visit(joinClause.InnerSequence);
                 AppendLine();
                 TransformingVisitor.StringBuilder.Append("on ");


### PR DESCRIPTION
Only affects PrintDebug mode (by default) - adding a number next to each unique qsre, to make debugging easier for scenarios with let and other cases where multiple qsres have the same names.
Also added option for Debug to print reduced forms of reducible nodes.