### PR TITLE
Query: Remove InExpression from Contains when all the values in the l…

### DIFF
--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -393,9 +393,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
                         if (inValues.Count != inValuesNotNull.Count)
                         {
-                            return Expression.OrElse(
+                            return Visit(Expression.OrElse(
                                 new InExpression(inExpression.Operand, inValuesNotNull),
-                                new IsNullExpression(inExpression.Operand));
+                                new IsNullExpression(inExpression.Operand)));
                         }
 
                         return inValuesNotNull.Count > 0

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
@@ -833,6 +833,15 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void Contains_with_local_list_closure_all_null()
+        {
+            var ids = new List<string> { null, null };
+            AssertQuery<Customer>(
+                cs =>
+                    cs.Where(c => ids.Contains(c.CustomerID)));
+        }
+
+        [ConditionalFact]
         public virtual void Contains_with_local_list_inline()
         {
             AssertQuery<Customer>(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
@@ -776,6 +776,16 @@ FROM [Customers] AS [c]
 WHERE [c].[CustomerID] IN (N'ABCDE', N'ALFKI')");
         }
 
+        public override void Contains_with_local_list_closure_all_null()
+        {
+            base.Contains_with_local_list_closure_all_null();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE [c].[CustomerID] IS NULL");
+        }
+
         public override void Contains_with_local_list_inline()
         {
             base.Contains_with_local_list_inline();


### PR DESCRIPTION
…ist are null

Resolves #11901

Issue: When there are null values in the list coming as parameter, we add property is null.
But we still kept the InExpression. Though in this case all values are null so that becomes invalid.
Fix is to remove InExpression from tree if there are no nonNullValues
