### PR TITLE
Query: Translate GroupBy new {} to GroupBy constant 1

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
@@ -210,7 +210,15 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                         = (GroupResultOperator)((SubQueryExpression)((FromClauseBase)_querySource).FromExpression)
                             .QueryModel.ResultOperators.Last();
 
-                    if (groupResultOperator.KeySelector is NewExpression)
+                    var sqlTranslation
+                        = _sqlTranslatingExpressionVisitorFactory
+                            .Create(
+                                QueryModelVisitor,
+                                _isGroupAggregate ? _groupAggregateTargetSelectExpression : _targetSelectExpression,
+                                inProjection: true)
+                            .Visit(expression);
+
+                    if (sqlTranslation == null)
                     {
                         // If the key is composite then we need to visit actual keySelector to construct the type.
                         // Since we are mapping translating actual KeySelector now, we need to re-map QuerySources

--- a/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
@@ -780,6 +780,24 @@ namespace Microsoft.EntityFrameworkCore.Query
         #region GroupByAfterComposition
 
         [ConditionalFact]
+        public virtual async Task GroupBy_empty_key_Aggregate()
+        {
+            await AssertQueryScalar<Order>(
+                os =>
+                    os.GroupBy(o => new { })
+                        .Select(g => g.Sum(o => o.OrderID)));
+        }
+
+        [ConditionalFact]
+        public virtual async Task GroupBy_empty_key_Aggregate_Key()
+        {
+            await AssertQuery<Order>(
+                os =>
+                    os.GroupBy(o => new { })
+                        .Select(g => new { g.Key, Sum = g.Sum(o => o.OrderID) }));
+        }
+
+        [ConditionalFact]
         public virtual async Task OrderBy_GroupBy_Aggregate()
         {
             await AssertQueryScalar<Order>(

--- a/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -783,6 +783,24 @@ namespace Microsoft.EntityFrameworkCore.Query
         #region GroupByAfterComposition
 
         [ConditionalFact]
+        public virtual void GroupBy_empty_key_Aggregate()
+        {
+            AssertQueryScalar<Order>(
+                os =>
+                    os.GroupBy(o => new { })
+                        .Select(g => g.Sum(o => o.OrderID)));
+        }
+
+        [ConditionalFact]
+        public virtual void GroupBy_empty_key_Aggregate_Key()
+        {
+            AssertQuery<Order>(
+                os =>
+                    os.GroupBy(o => new { })
+                        .Select(g => new { g.Key, Sum = g.Sum(o => o.OrderID) }));
+        }
+
+        [ConditionalFact]
         public virtual void OrderBy_GroupBy_Aggregate()
         {
             AssertQueryScalar<Order>(
@@ -1246,11 +1264,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                 (os, cs) =>
                     from o in os.Where(o => o.OrderID < 10400)
                     join i in (from c in cs
-                                join a in os.GroupBy(o => o.CustomerID)
-                                            .Where(g => g.Count() > 5)
-                                            .Select(g => new { CustomerID = g.Key, LastOrderID = g.Max(o => o.OrderID) })
-                                    on c.CustomerID equals a.CustomerID
-                                select new { c, a.LastOrderID })
+                               join a in os.GroupBy(o => o.CustomerID)
+                                           .Where(g => g.Count() > 5)
+                                           .Select(g => new { CustomerID = g.Key, LastOrderID = g.Max(o => o.OrderID) })
+                                   on c.CustomerID equals a.CustomerID
+                               select new { c, a.LastOrderID })
                         on o.CustomerID equals i.c.CustomerID
                     select new { o, i.c, i.c.CustomerID },
                 entryCount: 133);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
@@ -659,6 +659,32 @@ FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
         }
 
+        public override void GroupBy_empty_key_Aggregate()
+        {
+            base.GroupBy_empty_key_Aggregate();
+
+            AssertSql(
+                @"SELECT SUM([t].[OrderID])
+FROM (
+    SELECT [o].*, 1 AS [Key]
+    FROM [Orders] AS [o]
+) AS [t]
+GROUP BY [t].[Key]");
+        }
+
+        public override void GroupBy_empty_key_Aggregate_Key()
+        {
+            base.GroupBy_empty_key_Aggregate_Key();
+
+            AssertSql(
+                @"SELECT SUM([t].[OrderID]) AS [Sum]
+FROM (
+    SELECT [o].*, 1 AS [Key]
+    FROM [Orders] AS [o]
+) AS [t]
+GROUP BY [t].[Key]");
+        }
+
         public override void OrderBy_GroupBy_Aggregate()
         {
             base.OrderBy_GroupBy_Aggregate();


### PR DESCRIPTION
Resolves #11905

Issue: GroupBy(g => new {}) converts to GroupBy(Constant) because of key not being correlated with range variable.
We translate GroupBy constant to server but in this case, the constant is of anon type which cannot be put in SQL tree hence translation pipeline failed.
Fix is to inject `1` as constant whenever we see GroupBy constant of a type which cannot be represented in SQL
