### PR TITLE
Fix to #11904 - 2.1 regression: "variable referenced from scope '', but it is not defined" exception in GroupBy query translation

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -1293,16 +1293,15 @@ namespace Microsoft.EntityFrameworkCore.Query
                         queryModel.BodyClauses.Add(orderByClause);
                     }
 
-                    foreach (var groupResultOperator in groupResultOperators)
-                    {
-                        var groupKeys = groupResultOperator.KeySelector is NewExpression compositeGroupKey
-                            ? compositeGroupKey.Arguments.Reverse()
-                            : new[] { groupResultOperator.KeySelector };
+                    var firstGroupResultOperator = groupResultOperators[0];
 
-                        foreach (var groupKey in groupKeys)
-                        {
-                            orderByClause.Orderings.Insert(0, new Ordering(groupKey, OrderingDirection.Asc));
-                        }
+                    var groupKeys = firstGroupResultOperator.KeySelector is NewExpression compositeGroupKey
+                        ? compositeGroupKey.Arguments.Reverse()
+                        : new[] { firstGroupResultOperator.KeySelector };
+
+                    foreach (var groupKey in groupKeys)
+                    {
+                        orderByClause.Orderings.Insert(0, new Ordering(groupKey, OrderingDirection.Asc));
                     }
                 }
             }

--- a/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
@@ -1851,5 +1851,37 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         #endregion
+
+        #region DoubleGroupBy
+
+        [ConditionalFact(Skip = "Issue #11917")]
+        public virtual async Task Double_GroupBy_with_aggregate()
+        {
+            using (var context = CreateContext())
+            {
+                var actual = await context.Set<Order>()
+                    .GroupBy(o => new { o.OrderID, o.OrderDate })
+                    .GroupBy(g => g.Key.OrderDate)
+                    .Select(g => new { g.Key, Lastest = g.OrderBy(e => e.Key.OrderID).FirstOrDefault() })
+                    .ToListAsync();
+
+                var expected = Fixture.QueryAsserter.ExpectedData.Set<Order>()
+                    .GroupBy(o => new { o.OrderID, o.OrderDate })
+                    .GroupBy(g => g.Key.OrderDate)
+                    .Select(g => new { g.Key, Lastest = g.OrderBy(e => e.Key.OrderID).FirstOrDefault() })
+                    .ToList();
+
+                Assert.Equal(expected.Count, actual.Count);
+                for (var i = 0; i < expected.Count; i++)
+                {
+                    Assert.Equal(expected[i].Key, actual[i].Key);
+                    Assert.Equal(expected[i].Lastest.Key, actual[i].Lastest.Key);
+                    Assert.Equal(expected[i].Lastest.Count(), actual[i].Lastest.Count());
+                }
+            }
+        }
+
+        #endregion
+
     }
 }

--- a/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -1856,5 +1856,36 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         #endregion
+
+        #region DoubleGroupBy
+
+        [ConditionalFact]
+        public virtual void Double_GroupBy_with_aggregate()
+        {
+            using (var context = CreateContext())
+            {
+                var actual = context.Set<Order>()
+                    .GroupBy(o => new { o.OrderID, o.OrderDate })
+                    .GroupBy(g => g.Key.OrderDate)
+                    .Select(g => new { g.Key, Lastest = g.OrderBy(e => e.Key.OrderID).FirstOrDefault() })
+                    .ToList();
+
+                var expected = Fixture.QueryAsserter.ExpectedData.Set<Order>()
+                    .GroupBy(o => new { o.OrderID, o.OrderDate })
+                    .GroupBy(g => g.Key.OrderDate)
+                    .Select(g => new { g.Key, Lastest = g.OrderBy(e => e.Key.OrderID).FirstOrDefault() })
+                    .ToList();
+
+                Assert.Equal(expected.Count, actual.Count);
+                for (var i = 0; i < expected.Count; i++)
+                {
+                    Assert.Equal(expected[i].Key, actual[i].Key);
+                    Assert.Equal(expected[i].Lastest.Key, actual[i].Lastest.Key);
+                    Assert.Equal(expected[i].Lastest.Count(), actual[i].Lastest.Count());
+                }
+            }
+        }
+
+        #endregion
     }
 }

--- a/src/EFCore.Specification.Tests/Query/IncludeTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/IncludeTestBase.cs
@@ -3996,6 +3996,73 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
+        [Theory(Skip = "Issue #11916")]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        // async blocked by issue #11917
+        //[InlineData(false, true)] 
+        //[InlineData(true, true)]
+        public virtual async Task Include_with_double_group_by(bool useString, bool async)
+        {
+            using (var context = CreateContext())
+            {
+                var groups = (useString
+                    ? context.Orders.Include(nameof(Order.OrderDetails))
+                    : context.Orders.Include(e => e.OrderDetails))
+                    .GroupBy(o => new { o.OrderID, o.OrderDate })
+                    .GroupBy(g => g.Key.OrderDate);
+
+                var employee = async
+                    ? await groups.ToListAsync()
+                    : groups.ToList();
+            }
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        // async blocked by issue #11917
+        //[InlineData(false, true)] 
+        //[InlineData(true, true)]
+        public virtual async Task Include_with_double_group_by_no_tracking(bool useString, bool async)
+        {
+            using (var context = CreateContext())
+            {
+                var groups = (useString
+                    ? context.Orders.Include(nameof(Order.OrderDetails)).AsNoTracking()
+                    : context.Orders.Include(e => e.OrderDetails)).AsNoTracking()
+                    .GroupBy(o => new { o.OrderID, o.OrderDate })
+                    .GroupBy(g => g.Key.OrderDate);
+
+                var employee = async
+                    ? await groups.ToListAsync()
+                    : groups.ToList();
+            }
+        }
+
+        [Theory]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        // async blocked by issue #11917
+        //[InlineData(false, true)] 
+        //[InlineData(true, true)]
+        public virtual async Task Include_with_double_group_by_and_aggregate(bool useString, bool async)
+        {
+            using (var context = CreateContext())
+            {
+                var groups = (useString
+                    ? context.Orders.Include(nameof(Order.OrderDetails))
+                    : context.Orders.Include(e => e.OrderDetails))
+                    .GroupBy(o => new { o.OrderID, o.OrderDate })
+                    .GroupBy(g => g.Key.OrderDate)
+                    .Select(g => new { g.Key, Lastest = g.OrderBy(e => e.Key.OrderID).FirstOrDefault() });
+
+                var query = async
+                    ? await groups.ToListAsync()
+                    : groups.ToList();
+            }
+        }
+
         private static void CheckIsLoaded(
             NorthwindContext context,
             Customer customer,

--- a/src/EFCore/Query/ExpressionVisitors/Internal/RequiresMaterializationExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/RequiresMaterializationExpressionVisitor.cs
@@ -428,7 +428,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             var isSubQuery = _queryModelStack.Count > 0;
             var finalResultOperator = queryModel.ResultOperators.LastOrDefault();
 
-            if (isSubQuery && finalResultOperator is GroupResultOperator groupResultOperator)
+            if (isSubQuery
+                && finalResultOperator is GroupResultOperator groupResultOperator
+                && queryModel.ResultOperators.OfType<GroupResultOperator>().Count() == 1)
             {
                 if (!(groupResultOperator.KeySelector is MemberInitExpression))
                 {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
@@ -1655,6 +1655,16 @@ INNER JOIN (
 ) AS [t2] ON [t1].[CustomerID] = [t2].[CustomerID]");
         }
 
+        public override void Double_GroupBy_with_aggregate()
+        {
+            base.Double_GroupBy_with_aggregate();
+
+            AssertSql(
+                @"SELECT [o0].[OrderID], [o0].[CustomerID], [o0].[EmployeeID], [o0].[OrderDate]
+FROM [Orders] AS [o0]
+ORDER BY [o0].[OrderID], [o0].[OrderDate]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Problem was that we were not correctly handling scenarios where multiple groupbys are present:

- if combined with Include, we would try to create orderings based on grouping keys for each group by. This is incorrect because all group keys apart from the innermost are out of scope of the inner query model (where we attempted to add them)
- if combined with aggregate we would try to translate into group-aggregate pattern and fail.

Fix is to only add ordering for the first grouping in case of include (includes are ignored for multi-groupby scenarios, so there is no risk of collection misalignment) and don't try to convert queries into group-aggregate pattern if multiple groupbys are present in the query.
