### PR TITLE
Add 'virtual' keyword to the navigation properties

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpEntityTypeGenerator.cs
@@ -312,7 +312,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
                     var referencedTypeName = navigation.GetTargetType().Name;
                     var navigationType = navigation.IsCollection() ? $"ICollection<{referencedTypeName}>" : referencedTypeName;
-                    _sb.AppendLine($"public {navigationType} {navigation.Name} {{ get; set; }}");
+                    _sb.AppendLine($"public virtual {navigationType} {navigation.Name} {{ get; set; }}");
                 }
             }
         }


### PR DESCRIPTION
Since EF Core 2.1 supports Lazy loading scaffold should generate virtual navigation properties

    Summary of the changes
    - Added 'virtual' keyword to code generation string

Please review the guidelines for CONTRIBUTING.md for more details.