### PR TITLE
Fix to #11953 - Query with coalescing operator causes exception in 2.1.0-rc1

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -1004,7 +1004,12 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
 
                         _queryModelVisitor.LiftInjectedParameters(subQueryModelVisitor);
 
-                        return selectExpression;
+                        return expression.Type != selectExpression.Type
+                            && expression.Type.IsNullableType()
+                            && !selectExpression.Type.IsNullableType()
+                            && expression.Type.UnwrapNullableType() == selectExpression.Type
+                            ? Expression.Convert(selectExpression, expression.Type)
+                            : (Expression)selectExpression;
                     }
 
                     subQueryModel.RecreateQueryModelFromMapping(queryModelMapping);

--- a/src/EFCore.Specification.Tests/Query/AsyncGearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncGearsOfWarQueryTestBase.cs
@@ -1691,5 +1691,26 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true,
                 elementAsserter: CollectionAsserter<Gear>(e => e.Nickname, (e, a) => Assert.Equal(e.Nickname, a.Nickname)));
         }
+
+        [ConditionalFact]
+        public virtual async Task Select_subquery_int_with_inside_cast_and_coalesce()
+        {
+            await AssertQueryScalar<Gear>(
+                gs => gs.Select(g => g.Weapons.OrderBy(w => w.Id).Select(w => (int?)w.Id).FirstOrDefault() ?? 42));
+        }
+
+        [ConditionalFact]
+        public virtual async Task Select_subquery_int_with_outside_cast_and_coalesce()
+        {
+            await AssertQueryScalar<Gear>(
+                gs => gs.Select(g => (int?)g.Weapons.OrderBy(w => w.Id).Select(w => w.Id).FirstOrDefault() ?? 42));
+        }
+
+        [ConditionalFact]
+        public virtual async Task Select_subquery_int_with_pushdown_and_coalesce()
+        {
+            await AssertQueryScalar<Gear>(
+                gs => gs.Select(g => (int?)g.Weapons.OrderBy(w => w.Id).FirstOrDefault().Id ?? 42));
+        }
     }
 }

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -4896,6 +4896,27 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void Select_subquery_int_with_inside_cast_and_coalesce()
+        {
+            AssertQueryScalar<Gear>(
+                gs => gs.Select(g => g.Weapons.OrderBy(w => w.Id).Select(w => (int?)w.Id).FirstOrDefault() ?? 42));
+        }
+
+        [ConditionalFact]
+        public virtual void Select_subquery_int_with_outside_cast_and_coalesce()
+        {
+            AssertQueryScalar<Gear>(
+                gs => gs.Select(g => (int?)g.Weapons.OrderBy(w => w.Id).Select(w => w.Id).FirstOrDefault() ?? 42));
+        }
+
+        [ConditionalFact]
+        public virtual void Select_subquery_int_with_pushdown_and_coalesce()
+        {
+            AssertQueryScalar<Gear>(
+                gs => gs.Select(g => (int?)g.Weapons.OrderBy(w => w.Id).FirstOrDefault().Id ?? 42));
+        }
+
+        [ConditionalFact]
         public virtual void Select_subquery_boolean_empty()
         {
             AssertQueryScalar<Gear>(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7088,6 +7088,51 @@ FROM [Gears] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
         }
 
+        public override void Select_subquery_int_with_inside_cast_and_coalesce()
+        {
+            base.Select_subquery_int_with_inside_cast_and_coalesce();
+
+            AssertSql(
+                @"SELECT COALESCE((
+    SELECT TOP(1) [w].[Id]
+    FROM [Weapons] AS [w]
+    WHERE [g].[FullName] = [w].[OwnerFullName]
+    ORDER BY [w].[Id]
+), 42)
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
+        }
+
+        public override void Select_subquery_int_with_outside_cast_and_coalesce()
+        {
+            base.Select_subquery_int_with_outside_cast_and_coalesce();
+
+            AssertSql(
+                @"SELECT COALESCE(COALESCE((
+    SELECT TOP(1) [w].[Id]
+    FROM [Weapons] AS [w]
+    WHERE [g].[FullName] = [w].[OwnerFullName]
+    ORDER BY [w].[Id]
+), 0), 42)
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
+        }
+
+        public override void Select_subquery_int_with_pushdown_and_coalesce()
+        {
+            base.Select_subquery_int_with_pushdown_and_coalesce();
+
+            AssertSql(
+                @"SELECT COALESCE((
+    SELECT TOP(1) [w].[Id]
+    FROM [Weapons] AS [w]
+    WHERE [g].[FullName] = [w].[OwnerFullName]
+    ORDER BY [w].[Id]
+), 42)
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
+        }
+
         public override void Select_subquery_boolean_empty()
         {
             base.Select_subquery_boolean_empty();


### PR DESCRIPTION
Problem was that when translating a subquery projecting a non-nullable column that was converted to nullable, the information about nullability is lost - the resulting SelectExpression's type is that of the projected column. This in turn causes problem for the coalesce scenario, which requires the first argument to be nullable.
Fix is to account for possible nullability loss during translation of select expressions which project a single scalar.