### PR TITLE
Fix to #11937 - Null checking in Automapper Project To throws error

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -1029,7 +1029,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         {
             Check.NotNull(expression, nameof(expression));
 
-            if (expression.Value == null)
+            if (expression.Value == null
+                && expression.Type == typeof(object))
             {
                 return expression;
             }

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -4793,6 +4793,64 @@ namespace Microsoft.EntityFrameworkCore.Query
                 });
         }
 
+        public class MyDTO
+        {
+        }
+
+        [ConditionalFact]
+        public virtual void Select_subquery_projecting_single_constant_null_of_non_mapped_type()
+        {
+            AssertQuery<Squad>(
+                ss => ss.Select(s => new { s.Name, Gear = s.Members.Where(g => g.HasSoulPatch).Select(g => (MyDTO)null).FirstOrDefault() }));
+        }
+
+        [ConditionalFact]
+        public virtual void Select_subquery_projecting_single_constant_of_non_mapped_type()
+        {
+            AssertQuery<Squad>(
+                ss => ss.Select(s => new { s.Name, Gear = s.Members.Where(g => g.HasSoulPatch).Select(g => new MyDTO()).FirstOrDefault() }),
+                elementSorter: e => e.Name,
+                elementAsserter: (e, a) => Assert.Equal(e.Name, a.Name));
+        }
+
+        [ConditionalFact(Skip = "issue #11567")]
+        public virtual void Include_with_order_by_constant_null_of_non_mapped_type()
+        {
+            AssertIncludeQuery<Squad>(
+                ss => ss.Include(s => s.Members).OrderBy(s => (MyDTO)null),
+                expectedQuery: ss => ss,
+                new List<IExpectedInclude> { new ExpectedInclude<Squad>(s => s.Members, "Members") });
+        }
+
+        [ConditionalFact(Skip = "issue #11567")]
+        public virtual void Include_groupby_constant_null_of_non_mapped_type()
+        {
+            using (var ctx = CreateContext())
+            {
+                var query = ctx.Squads.Include(s => s.Members).GroupBy(s => (MyDTO)null);
+                var result = query.ToList();
+
+                Assert.Equal(1, result.Count);
+                var bucket = result[0].ToList();
+                Assert.Equal(2, bucket.Count);
+                Assert.NotNull(bucket[0].Members);
+                Assert.NotNull(bucket[1].Members);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Correlated_collection_order_by_constant_null_of_non_mapped_type()
+        {
+            AssertQuery<Gear>(
+                gs => gs.OrderByDescending(s => (MyDTO)null).Select(g => new { g.Nickname, Weapons = g.Weapons.Select(w => w.Name).ToList() }),
+                elementSorter: e => e.Nickname,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.Nickname, a.Nickname);
+                    CollectionAsserter<string>()(e.Weapons, a.Weapons);
+                });
+        }
+
         [ConditionalFact]
         public virtual void GroupBy_composite_key_with_Include()
         {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -6856,6 +6856,104 @@ INNER JOIN (
 ORDER BY [t].[c] DESC, [t].[Nickname], [t].[SquadId], [t].[FullName]");
         }
 
+        public override void Select_subquery_projecting_single_constant_null_of_non_mapped_type() 
+        {
+            base.Select_subquery_projecting_single_constant_null_of_non_mapped_type();
+
+            AssertSql(
+                @"SELECT [s].[Name], [s].[Id]
+FROM [Squads] AS [s]",
+                //
+                @"@_outer_Id='1'
+
+SELECT TOP(1) 1
+FROM [Gears] AS [g]
+WHERE ([g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 1)) AND (@_outer_Id = [g].[SquadId])",
+                //
+                @"@_outer_Id='2'
+
+SELECT TOP(1) 1
+FROM [Gears] AS [g]
+WHERE ([g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 1)) AND (@_outer_Id = [g].[SquadId])");
+        }
+
+        public override void Select_subquery_projecting_single_constant_of_non_mapped_type()
+        {
+            base.Select_subquery_projecting_single_constant_of_non_mapped_type();
+
+            AssertSql(
+                @"SELECT [s].[Name], [s].[Id]
+FROM [Squads] AS [s]",
+                //
+                @"@_outer_Id='1'
+
+SELECT TOP(1) 1
+FROM [Gears] AS [g]
+WHERE ([g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 1)) AND (@_outer_Id = [g].[SquadId])",
+                //
+                @"@_outer_Id='2'
+
+SELECT TOP(1) 1
+FROM [Gears] AS [g]
+WHERE ([g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 1)) AND (@_outer_Id = [g].[SquadId])");
+        }
+
+        public override void Include_with_order_by_constant_null_of_non_mapped_type()
+        {
+            base.Include_with_order_by_constant_null_of_non_mapped_type();
+
+            AssertSql(
+                @"");
+        }
+
+        public override void Include_groupby_constant_null_of_non_mapped_type()
+        {
+            base.Include_groupby_constant_null_of_non_mapped_type();
+
+            AssertSql(
+                @"");
+        }
+
+        public override void Correlated_collection_order_by_constant_null_of_non_mapped_type()
+        {
+            base.Correlated_collection_order_by_constant_null_of_non_mapped_type();
+
+            AssertSql(
+                @"SELECT [s].[Nickname], [s].[FullName]
+FROM [Gears] AS [s]
+WHERE [s].[Discriminator] IN (N'Officer', N'Gear')",
+                //
+                @"@_outer_FullName='Damon Baird' (Size = 450)
+
+SELECT [w].[Name]
+FROM [Weapons] AS [w]
+WHERE @_outer_FullName = [w].[OwnerFullName]",
+                //
+                @"@_outer_FullName='Augustus Cole' (Size = 450)
+
+SELECT [w].[Name]
+FROM [Weapons] AS [w]
+WHERE @_outer_FullName = [w].[OwnerFullName]",
+                //
+                @"@_outer_FullName='Dominic Santiago' (Size = 450)
+
+SELECT [w].[Name]
+FROM [Weapons] AS [w]
+WHERE @_outer_FullName = [w].[OwnerFullName]",
+                //
+                @"@_outer_FullName='Marcus Fenix' (Size = 450)
+
+SELECT [w].[Name]
+FROM [Weapons] AS [w]
+WHERE @_outer_FullName = [w].[OwnerFullName]",
+                //
+                @"@_outer_FullName='Garron Paduk' (Size = 450)
+
+SELECT [w].[Name]
+FROM [Weapons] AS [w]
+WHERE @_outer_FullName = [w].[OwnerFullName]");
+        }
+
         public override void GroupBy_composite_key_with_Include()
         {
             base.GroupBy_composite_key_with_Include();


### PR DESCRIPTION
Problem was that when addressing issue 11459 we started translating constant values inside subqueries to SQL. This also included constant nulls of non-mapped types, like DTOs - those could get generated as part of null protection/checking or explicitly via cast.

Fix is to only translate constants nulls that we have mapping for (unless they are typed as object). Constant nulls that are not mapped will be evaluated client-side.