### PR TITLE
Don't explicitly set IncludeSymbols to false

### DIFF
--- a/src/EFCore.Tools/EFCore.Tools.csproj
+++ b/src/EFCore.Tools/EFCore.Tools.csproj
@@ -10,7 +10,6 @@
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <IncludeSource>false</IncludeSource>
-    <IncludeSymbols>false</IncludeSymbols>
     <EnableApiCheck>false</EnableApiCheck>
     <Description>Entity Framework Core Tools for the NuGet Package Manager Console in Visual Studio.
 


### PR DESCRIPTION
This was causing our build system to ignore the symbol.nupkg while publishing the artifacts.

@natemcmaster @pranavkm @bricelam 