### PR TITLE
Query: Client GroupBy with anonymous type Key causes binding error

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/RelationalProjectionExpressionVisitor.cs
@@ -204,7 +204,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 case MemberExpression memberExpression
                 when memberExpression.Expression.TryGetReferencedQuerySource() == _querySource
                     && _querySource.ItemType.IsGrouping()
-                    && memberExpression.Member.Name == nameof(IGrouping<int, int>.Key):
+                    && memberExpression.Member.Name == nameof(IGrouping<int, int>.Key)
+                    && QueryModelVisitor.IsShapedQueryExpression(QueryModelVisitor.Expression):
 
                     var groupResultOperator
                         = (GroupResultOperator)((SubQueryExpression)((FromClauseBase)_querySource).FromExpression)

--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -1403,7 +1403,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #region Flattening
 
-        private bool IsShapedQueryExpression(Expression expression)
+        internal bool IsShapedQueryExpression(Expression expression)
         {
             if (!(expression is MethodCallExpression methodCallExpression))
             {

--- a/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
@@ -1700,6 +1700,32 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.max);
         }
 
+        [ConditionalFact]
+        public virtual async Task GroupBy_anonymous_key_without_aggregate()
+        {
+            using (var context = CreateContext())
+            {
+                var actual = (await context.Set<Order>()
+                    .GroupBy(o => new { o.CustomerID, o.OrderDate })
+                    .Select(g => new { g.Key, g })
+                    .ToListAsync())
+                    .OrderBy(g => g.Key + " " + g.g.Count()).ToList();
+
+                var expected = Fixture.QueryAsserter.ExpectedData.Set<Order>()
+                    .GroupBy(o => new { o.CustomerID, o.OrderDate })
+                    .Select(g => new { g.Key, g })
+                    .ToList()
+                    .OrderBy(g => g.Key + " " + g.g.Count()).ToList();
+
+                Assert.Equal(expected.Count, actual.Count);
+                for (var i = 0; i < expected.Count; i++)
+                {
+                    Assert.Equal(expected[i].Key, actual[i].Key);
+                    Assert.Equal(expected[i].g.Count(), actual[i].g.Count());
+                }
+            }
+        }
+
         #endregion
 
         #region GroupBySelectFirst

--- a/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -1703,6 +1703,32 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementSorter: e => e.max);
         }
 
+        [ConditionalFact]
+        public virtual void GroupBy_anonymous_key_without_aggregate()
+        {
+            using (var context = CreateContext())
+            {
+                var actual = context.Set<Order>()
+                    .GroupBy(o => new { o.CustomerID, o.OrderDate })
+                    .Select(g => new { g.Key, g })
+                    .ToList()
+                    .OrderBy(g => g.Key + " " + g.g.Count()).ToList();
+
+                var expected = Fixture.QueryAsserter.ExpectedData.Set<Order>()
+                    .GroupBy(o => new { o.CustomerID, o.OrderDate })
+                    .Select(g => new { g.Key, g })
+                    .ToList()
+                    .OrderBy(g => g.Key + " " + g.g.Count()).ToList();
+
+                Assert.Equal(expected.Count, actual.Count);
+                for (var i = 0; i < expected.Count; i++)
+                {
+                    Assert.Equal(expected[i].Key, actual[i].Key);
+                    Assert.Equal(expected[i].g.Count(), actual[i].g.Count());
+                }
+            }
+        }
+
         #endregion
 
         #region GroupBySelectFirst

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
@@ -1571,6 +1571,16 @@ FROM [Customers] AS [i.Customer0]",
 FROM [Customers] AS [i.Customer0]");
         }
 
+        public override void GroupBy_anonymous_key_without_aggregate()
+        {
+            base.GroupBy_anonymous_key_without_aggregate();
+
+            AssertSql(
+                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+ORDER BY [o].[CustomerID], [o].[OrderDate]");
+        }
+
         public override void GroupBy_Shadow()
         {
             base.GroupBy_Shadow();


### PR DESCRIPTION
Issue: We have custom logic to map the anonymous key in selector to translate key for SQL Group By case which was being applied for client group by causing error during client binding.
Fix for this makes sure that when we do such transformation we are dealing with ShapedQuery only.

Resolves #11973

