### PR TITLE
Allow proxy weak types to be picked up by TryGetEntry

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -344,7 +344,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             foreach (var keyValue in _dependentTypeReferenceMap)
             {
                 // ReSharper disable once CheckForReferenceEqualityInstead.2
-                if (Equals(keyValue.Key.ClrType, type)
+                if (keyValue.Key.ClrType.IsAssignableFrom(type)
                     && keyValue.Value.TryGetValue(entity, out var foundEntry))
                 {
                     if (found)


### PR DESCRIPTION
Fixes #11972

The fix is to allow proxies (derived types) in the optimization check.
