### PR TITLE
Fix scaffolding unmapped type with underlying

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/RelationalScaffoldingModelFactory.cs
@@ -856,6 +856,11 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                 column.IsKeyOrIndex(),
                 column.IsRowVersion());
 
+            if (typeScaffoldingInfo == null)
+            {
+                return null;
+            }
+
             if (column.GetUnderlyingStoreType() != null)
             {
                 return new TypeScaffoldingInfo(

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
@@ -1644,6 +1644,41 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Null(model.FindEntityType("Dependent").FindProperty("BlogAlternateKey").Relational().ColumnType);
         }
 
+        [Fact]
+        public void Unmapped_column_with_underlying_store_type_is_ignored()
+        {
+            var columnWithUnknownType = new DatabaseColumn
+            {
+                Name = "ColumnWithUnknownStoreType",
+                StoreType = "unknown_type_alias"
+            };
+
+            columnWithUnknownType.SetUnderlyingStoreType("unknown_type");
+
+            var dbModel = new DatabaseModel
+            {
+                Tables =
+                {
+                    new DatabaseTable
+                    {
+                        Name = "Table",
+                        Columns =
+                        {
+                            IdColumn,
+                            columnWithUnknownType
+                        },
+                        PrimaryKey = IdPrimaryKey
+                    }
+                }
+            };
+
+            var model = _factory.Create(dbModel, false);
+
+            var columns = model.FindEntityType("Table").GetProperties().ToList();
+
+            Assert.Equal(1, columns.Count);
+        }
+
         public class FakePluralizer : IPluralizer
         {
             public string Pluralize(string name)


### PR DESCRIPTION
When scaffolding, a database column with an underlying store type but which itself has no mapping caused an NRE.

Fixes #12016