### PR TITLE
[2.1.1] Query: Fix for GroupBy Constant with element selector produces invalid SQL

### DIFF
--- a/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -527,11 +527,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         handlerContext.QueryModelVisitor.VisitSelectClause(
                             new SelectClause(groupResultOperator.ElementSelector),
                             handlerContext.QueryModel);
-
-                        if (selectExpression.Projection.Count > 1)
-                        {
-                            selectExpression.ClearProjection();
-                        }
                     }
 
                     foreach (var keyValue in memberInfoMappings)
@@ -570,6 +565,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         }
 
                         key = new[] { projection };
+                    }
+
+                    if (selectExpression.Projection.Count > 1)
+                    {
+                        selectExpression.ClearProjection();
                     }
 
                     selectExpression.AddToGroupBy(key);

--- a/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
@@ -604,6 +604,45 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual async Task GroupBy_Constant_with_element_selector_Select_Sum()
+        {
+            await AssertQuery<Order>(
+                os => os.GroupBy(o => 2, o => new { o.OrderID, o.OrderDate }).Select(
+                    g =>
+                        new
+                        {
+                            Sum = g.Sum(o => o.OrderID),
+                        }),
+                e => e.Sum);
+        }
+
+        [ConditionalFact]
+        public virtual async Task GroupBy_Constant_with_element_selector_Select_Sum2()
+        {
+            await AssertQuery<Order>(
+                os => os.GroupBy(o => 2, o => new { o.OrderID }).Select(
+                    g =>
+                        new
+                        {
+                            Sum = g.Sum(o => o.OrderID),
+                        }),
+                e => e.Sum);
+        }
+
+        [ConditionalFact]
+        public virtual async Task GroupBy_Constant_with_element_selector_Select_Sum3()
+        {
+            await AssertQuery<Order>(
+                os => os.GroupBy(o => 2, o => new { o.OrderID, o.OrderDate, o.CustomerID }).Select(
+                    g =>
+                        new
+                        {
+                            Sum = g.Sum(o => o.OrderID),
+                        }),
+                e => e.Sum);
+        }
+
+        [ConditionalFact]
         public virtual async Task GroupBy_after_predicate_Constant_Select_Sum_Min_Key_Max_Avg()
         {
             await AssertQuery<Order>(
@@ -650,6 +689,48 @@ namespace Microsoft.EntityFrameworkCore.Query
                             Avg = g.Average(o => o.OrderID)
                         }),
                 e => e.Min + " " + e.Max);
+        }
+
+        [ConditionalFact]
+        public virtual async Task GroupBy_param_with_element_selector_Select_Sum()
+        {
+            var a = 2;
+            await AssertQuery<Order>(
+                os => os.GroupBy(o => a, o => new { o.OrderID, o.OrderDate }).Select(
+                    g =>
+                        new
+                        {
+                            Sum = g.Sum(o => o.OrderID),
+                        }),
+                e => e.Sum);
+        }
+
+        [ConditionalFact]
+        public virtual async Task GroupBy_param_with_element_selector_Select_Sum2()
+        {
+            var a = 2;
+            await AssertQuery<Order>(
+                os => os.GroupBy(o => a, o => new { o.OrderID }).Select(
+                    g =>
+                        new
+                        {
+                            Sum = g.Sum(o => o.OrderID),
+                        }),
+                e => e.Sum);
+        }
+
+        [ConditionalFact]
+        public virtual async Task GroupBy_param_with_element_selector_Select_Sum3()
+        {
+            var a = 2;
+            await AssertQuery<Order>(
+                os => os.GroupBy(o => a, o => new { o.OrderID, o.OrderDate, o.CustomerID }).Select(
+                    g =>
+                        new
+                        {
+                            Sum = g.Sum(o => o.OrderID),
+                        }),
+                e => e.Sum);
         }
 
         [ConditionalFact]

--- a/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -607,6 +607,45 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void GroupBy_Constant_with_element_selector_Select_Sum()
+        {
+            AssertQuery<Order>(
+                os => os.GroupBy(o => 2, o => new { o.OrderID, o.OrderDate }).Select(
+                    g =>
+                        new
+                        {
+                            Sum = g.Sum(o => o.OrderID),
+                        }),
+                e => e.Sum);
+        }
+
+        [ConditionalFact]
+        public virtual void GroupBy_Constant_with_element_selector_Select_Sum2()
+        {
+            AssertQuery<Order>(
+                os => os.GroupBy(o => 2, o => new { o.OrderID }).Select(
+                    g =>
+                        new
+                        {
+                            Sum = g.Sum(o => o.OrderID),
+                        }),
+                e => e.Sum);
+        }
+
+        [ConditionalFact]
+        public virtual void GroupBy_Constant_with_element_selector_Select_Sum3()
+        {
+            AssertQuery<Order>(
+                os => os.GroupBy(o => 2, o => new { o.OrderID, o.OrderDate, o.CustomerID }).Select(
+                    g =>
+                        new
+                        {
+                            Sum = g.Sum(o => o.OrderID),
+                        }),
+                e => e.Sum);
+        }
+
+        [ConditionalFact]
         public virtual void GroupBy_after_predicate_Constant_Select_Sum_Min_Key_Max_Avg()
         {
             AssertQuery<Order>(
@@ -653,6 +692,48 @@ namespace Microsoft.EntityFrameworkCore.Query
                             Avg = g.Average(o => o.OrderID)
                         }),
                 e => e.Min + " " + e.Max);
+        }
+
+        [ConditionalFact]
+        public virtual void GroupBy_param_with_element_selector_Select_Sum()
+        {
+            var a = 2;
+            AssertQuery<Order>(
+                os => os.GroupBy(o => a, o => new { o.OrderID, o.OrderDate }).Select(
+                    g =>
+                        new
+                        {
+                            Sum = g.Sum(o => o.OrderID),
+                        }),
+                e => e.Sum);
+        }
+
+        [ConditionalFact]
+        public virtual void GroupBy_param_with_element_selector_Select_Sum2()
+        {
+            var a = 2;
+            AssertQuery<Order>(
+                os => os.GroupBy(o => a, o => new { o.OrderID }).Select(
+                    g =>
+                        new
+                        {
+                            Sum = g.Sum(o => o.OrderID),
+                        }),
+                e => e.Sum);
+        }
+
+        [ConditionalFact]
+        public virtual void GroupBy_param_with_element_selector_Select_Sum3()
+        {
+            var a = 2;
+            AssertQuery<Order>(
+                os => os.GroupBy(o => a, o => new { o.OrderID, o.OrderDate, o.CustomerID }).Select(
+                    g =>
+                        new
+                        {
+                            Sum = g.Sum(o => o.OrderID),
+                        }),
+                e => e.Sum);
         }
 
         [ConditionalFact]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
@@ -462,6 +462,45 @@ FROM (
 GROUP BY [t].[Key]");
         }
 
+        public override void GroupBy_Constant_with_element_selector_Select_Sum()
+        {
+            base.GroupBy_Constant_with_element_selector_Select_Sum();
+
+            AssertSql(
+                @"SELECT SUM([t].[OrderID]) AS [Sum]
+FROM (
+    SELECT [o].[OrderID], [o].[OrderDate], 2 AS [Key]
+    FROM [Orders] AS [o]
+) AS [t]
+GROUP BY [t].[Key]");
+        }
+
+        public override void GroupBy_Constant_with_element_selector_Select_Sum2()
+        {
+            base.GroupBy_Constant_with_element_selector_Select_Sum2();
+
+            AssertSql(
+                @"SELECT SUM([t].[OrderID]) AS [Sum]
+FROM (
+    SELECT [o].[OrderID], 2 AS [Key]
+    FROM [Orders] AS [o]
+) AS [t]
+GROUP BY [t].[Key]");
+        }
+
+        public override void GroupBy_Constant_with_element_selector_Select_Sum3()
+        {
+            base.GroupBy_Constant_with_element_selector_Select_Sum3();
+
+            AssertSql(
+                @"SELECT SUM([t].[OrderID]) AS [Sum]
+FROM (
+    SELECT [o].[OrderID], [o].[OrderDate], [o].[CustomerID], 2 AS [Key]
+    FROM [Orders] AS [o]
+) AS [t]
+GROUP BY [t].[Key]");
+        }
+
         public override void GroupBy_after_predicate_Constant_Select_Sum_Min_Key_Max_Avg()
         {
             base.GroupBy_after_predicate_Constant_Select_Sum_Min_Key_Max_Avg();
@@ -499,6 +538,51 @@ GROUP BY [t].[Key]");
 SELECT SUM([t].[OrderID]) AS [Sum], MIN([t].[OrderID]) AS [Min], [t].[Key], MAX([t].[OrderID]) AS [Max], AVG(CAST([t].[OrderID] AS float)) AS [Avg]
 FROM (
     SELECT [o].*, @__a_0 AS [Key]
+    FROM [Orders] AS [o]
+) AS [t]
+GROUP BY [t].[Key]");
+        }
+
+        public override void GroupBy_param_with_element_selector_Select_Sum()
+        {
+            base.GroupBy_param_with_element_selector_Select_Sum();
+
+            AssertSql(
+                @"@__a_0='2'
+
+SELECT SUM([t].[OrderID]) AS [Sum]
+FROM (
+    SELECT [o].[OrderID], [o].[OrderDate], @__a_0 AS [Key]
+    FROM [Orders] AS [o]
+) AS [t]
+GROUP BY [t].[Key]");
+        }
+
+        public override void GroupBy_param_with_element_selector_Select_Sum2()
+        {
+            base.GroupBy_param_with_element_selector_Select_Sum2();
+
+            AssertSql(
+                @"@__a_0='2'
+
+SELECT SUM([t].[OrderID]) AS [Sum]
+FROM (
+    SELECT [o].[OrderID], @__a_0 AS [Key]
+    FROM [Orders] AS [o]
+) AS [t]
+GROUP BY [t].[Key]");
+        }
+
+        public override void GroupBy_param_with_element_selector_Select_Sum3()
+        {
+            base.GroupBy_param_with_element_selector_Select_Sum3();
+
+            AssertSql(
+                @"@__a_0='2'
+
+SELECT SUM([t].[OrderID]) AS [Sum]
+FROM (
+    SELECT [o].[OrderID], [o].[OrderDate], [o].[CustomerID], @__a_0 AS [Key]
     FROM [Orders] AS [o]
 ) AS [t]
 GROUP BY [t].[Key]");


### PR DESCRIPTION
Resolves #11993

Issue: We visit element selector to save mappings for binding later. But in the case of constant key, we create a subquery to inject constant key. This made the mappings for element selector invalid since we cleared projection before pushing down.
Fix is to clear multi-projection after all processing is done.
