### PR TITLE
Query: Appropriately save bindings when grouping key is also part of …

### DIFF
--- a/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
@@ -408,13 +408,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
 
                 var outerProjection = expressionToAdd.LiftExpressionFromSubquery(subquery);
 
-                var memberInfo = _memberInfoProjectionMapping.FirstOrDefault(
-                        kvp => ExpressionEqualityComparer.Instance.Equals(kvp.Value, expression))
-                    .Key;
-
-                if (memberInfo != null)
+                foreach (var memberInfoMapping
+                            in _memberInfoProjectionMapping.Where(
+                                kvp => ExpressionEqualityComparer.Instance.Equals(kvp.Value, expression))
+                                .ToList())
                 {
-                    _memberInfoProjectionMapping[memberInfo] = outerProjection;
+                    _memberInfoProjectionMapping[memberInfoMapping.Key] = outerProjection;
                 }
 
                 outerProjections.Add(outerProjection);
@@ -945,15 +944,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             Check.NotNull(memberInfo, nameof(memberInfo));
             Check.NotNull(projection, nameof(projection));
 
-            var existingMemberInfo = _memberInfoProjectionMapping.FirstOrDefault(
-                        kvp => ExpressionEqualityComparer.Instance.Equals(kvp.Value, projection))
-                    .Key;
-
-            if (existingMemberInfo != null)
-            {
-                _memberInfoProjectionMapping.Remove(existingMemberInfo);
-            }
-
             _memberInfoProjectionMapping[memberInfo] = CreateUniqueProjection(projection, memberInfo.Name);
         }
 
@@ -1349,15 +1339,14 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
                     _orderBy.Insert(currentOrderingIndex, new Ordering(projection[i], oldOrdering.OrderingDirection));
                 }
 
-                var memberInfo = _memberInfoProjectionMapping.FirstOrDefault(
-                        kvp => ExpressionEqualityComparer.Instance.Equals(kvp.Value, oldProjection))
-                    .Key;
-                if (memberInfo != null)
+                foreach (var memberInfoMapping
+                            in _memberInfoProjectionMapping.Where(
+                                kvp => ExpressionEqualityComparer.Instance.Equals(kvp.Value, oldProjection))
+                                .ToList())
                 {
-                    _memberInfoProjectionMapping[memberInfo] = projection[i];
+                    _memberInfoProjectionMapping[memberInfoMapping.Key] = projection[i];
                 }
             }
-
         }
 
         private class SqlTableReferenceReplacingVisitor : ExpressionVisitor

--- a/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
@@ -1416,6 +1416,32 @@ namespace Microsoft.EntityFrameworkCore.Query
                       select g.Where(e => e.OrderID < 10300).Count());
         }
 
+        [ConditionalFact]
+        public virtual async Task GroupBy_Key_as_part_of_element_selector()
+        {
+            await AssertQuery<Order>(
+                os => os.GroupBy(o => o.OrderID, o => new { o.OrderID, o.OrderDate })
+                        .Select(g => new
+                        {
+                            g.Key,
+                            Avg = g.Average(e => e.OrderID),
+                            Max = g.Max(o => o.OrderDate)
+                        }));
+        }
+
+        [ConditionalFact]
+        public virtual async Task GroupBy_composite_Key_as_part_of_element_selector()
+        {
+            await AssertQuery<Order>(
+                os => os.GroupBy(o => new { o.OrderID, o.CustomerID }, o => new { o.OrderID, o.OrderDate })
+                        .Select(g => new
+                        {
+                            g.Key,
+                            Avg = g.Average(e => e.OrderID),
+                            Max = g.Max(o => o.OrderDate)
+                        }));
+        }
+
         #endregion
 
         #region GroupByWithoutAggregate
@@ -1908,6 +1934,5 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         #endregion
-
     }
 }

--- a/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -1421,6 +1421,32 @@ namespace Microsoft.EntityFrameworkCore.Query
                       select g.Where(e => e.OrderID < 10300).Count());
         }
 
+        [ConditionalFact]
+        public virtual void GroupBy_Key_as_part_of_element_selector()
+        {
+            AssertQuery<Order>(
+                os => os.GroupBy(o => o.OrderID, o => new { o.OrderID, o.OrderDate })
+                        .Select(g => new
+                        {
+                            g.Key,
+                            Avg = g.Average(e => e.OrderID),
+                            Max = g.Max(o => o.OrderDate)
+                        }));
+        }
+
+        [ConditionalFact]
+        public virtual void GroupBy_composite_Key_as_part_of_element_selector()
+        {
+            AssertQuery<Order>(
+                os => os.GroupBy(o => new { o.OrderID, o.CustomerID }, o => new { o.OrderID, o.OrderDate })
+                        .Select(g => new
+                        {
+                            g.Key,
+                            Avg = g.Average(e => e.OrderID),
+                            Max = g.Max(o => o.OrderDate)
+                        }));
+        }
+
         #endregion
 
         #region GroupByWithoutAggregate

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
@@ -1289,6 +1289,26 @@ FROM [Orders] AS [o]
 ORDER BY [o].[CustomerID]");
         }
 
+        public override void GroupBy_Key_as_part_of_element_selector()
+        {
+            base.GroupBy_Key_as_part_of_element_selector();
+
+            AssertSql(
+                @"SELECT [o].[OrderID] AS [Key], AVG(CAST([o].[OrderID] AS float)) AS [Avg], MAX([o].[OrderDate]) AS [Max]
+FROM [Orders] AS [o]
+GROUP BY [o].[OrderID]");
+        }
+
+        public override void GroupBy_composite_Key_as_part_of_element_selector()
+        {
+            base.GroupBy_composite_Key_as_part_of_element_selector();
+
+            AssertSql(
+                @"SELECT [o].[OrderID], [o].[CustomerID], AVG(CAST([o].[OrderID] AS float)) AS [Avg], MAX([o].[OrderDate]) AS [Max]
+FROM [Orders] AS [o]
+GROUP BY [o].[OrderID], [o].[CustomerID]");
+        }
+
         public override void GroupBy_anonymous()
         {
             base.GroupBy_anonymous();


### PR DESCRIPTION
…Element selector

Resolves #11999

