### PR TITLE
Query: Improve binding when subquery has multiple SelectExpression

### DIFF
--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -4350,5 +4350,17 @@ namespace Microsoft.EntityFrameworkCore.Query
                           A = (o != null ? o.OrderDate : null)
                       });
         }
+
+        [ConditionalFact]
+        public virtual void SelectMany_after_client_method()
+        {
+            AssertQueryScalar<Customer>(
+                cs => cs.OrderBy(c => ClientOrderBy(c))
+                        .SelectMany(c => c.Orders)
+                        .Distinct()
+                        .Select(o => o.OrderDate));
+        }
+
+        private static string ClientOrderBy(Customer c) => c.CustomerID;
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -4664,6 +4664,18 @@ WHERE @_outer_CustomerID1 = [e1].[CustomerID]
 ORDER BY [e1].[OrderDate]");
         }
 
+        public override void SelectMany_after_client_method()
+        {
+            base.SelectMany_after_client_method();
+
+            AssertContainsSql(
+                @"SELECT [c.Orders0].[CustomerID], [c.Orders0].[OrderDate]
+FROM [Orders] AS [c.Orders0]",
+                //
+                @"SELECT [c0].[CustomerID], [c0].[Address], [c0].[City], [c0].[CompanyName], [c0].[ContactName], [c0].[ContactTitle], [c0].[Country], [c0].[Fax], [c0].[Phone], [c0].[PostalCode], [c0].[Region]
+FROM [Customers] AS [c0]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Issue: In case of client order by in subquery, we could not lift SelectMany and generated 2 SelectExpression.
When binding from outer visitor we always assumed there would be 1 selectExpression inside. In this case, it fails.

To bind with inner SelectExpression, we need to find correct SelectExpression. That would be identified using its QSRE.
Since we are binding EF Property, the inner subquery's selector would be naked QSRE. so we use it as QS to get selectExpression.
To get inner selector, we store the QM on QMV for each lookup.

Resolves #11990
