### PR TITLE
Fix to #11671 - MQ: improve expression printer by adding lines connecting nodes (similar to EF6 DbExpression printer)

### DIFF
--- a/src/EFCore/Internal/IndentedStringBuilder.cs
+++ b/src/EFCore/Internal/IndentedStringBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using JetBrains.Annotations;
@@ -16,6 +17,10 @@ namespace Microsoft.EntityFrameworkCore.Internal
     public class IndentedStringBuilder
     {
         private const byte IndentSize = 4;
+
+        private readonly string _disconnectedIndent = new string(' ', IndentSize);
+        private readonly string _suspendedIndent = "|" + new string(' ', IndentSize - 1);
+        private readonly string _connectedIndent = "|" + new string('_', IndentSize - 2) + " ";
 
         private byte _indent;
         private bool _indentPending = true;
@@ -136,14 +141,74 @@ namespace Microsoft.EntityFrameworkCore.Internal
             return this;
         }
 
+        private enum NodeConnectionState
+        {
+            Disconnected = 0,
+            Connected = 1,
+            Suspended = 2,
+        };
+
+        private List<NodeConnectionState> _nodeConnectionStates = new List<NodeConnectionState>();
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual IndentedStringBuilder IncrementIndent()
+        public virtual IndentedStringBuilder IncrementIndent(bool connectNode = false)
         {
+            var state = connectNode ? NodeConnectionState.Connected : NodeConnectionState.Disconnected;
+            if (_indent == _nodeConnectionStates.Count)
+            {
+                _nodeConnectionStates.Add(state);
+            }
+            else
+            {
+                _nodeConnectionStates[_indent] = state;
+            }
+
             _indent++;
+
             return this;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void DisconnectCurrentNode()
+        {
+            if (_indent > 0 && _nodeConnectionStates.Count >= _indent)
+            {
+                _nodeConnectionStates[_indent - 1] = NodeConnectionState.Disconnected;
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void SuspendCurrentNode()
+        {
+            if (_indent > 0
+                && _nodeConnectionStates.Count >= _indent
+                && _nodeConnectionStates[_indent - 1] == NodeConnectionState.Connected)
+            {
+                _nodeConnectionStates[_indent - 1] = NodeConnectionState.Suspended;
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void ReconnectCurrentNode()
+        {
+            if (_indent > 0
+                && _nodeConnectionStates.Count >= _indent
+                && _nodeConnectionStates[_indent - 1] == NodeConnectionState.Suspended)
+            {
+                _nodeConnectionStates[_indent - 1] = NodeConnectionState.Connected;
+            }
         }
 
         /// <summary>
@@ -155,7 +220,10 @@ namespace Microsoft.EntityFrameworkCore.Internal
             if (_indent > 0)
             {
                 _indent--;
+
+                _nodeConnectionStates.RemoveAt(_indent);
             }
+
             return this;
         }
 
@@ -175,7 +243,24 @@ namespace Microsoft.EntityFrameworkCore.Internal
         {
             if (_indentPending && (_indent > 0))
             {
-                _stringBuilder.Append(new string(' ', _indent * IndentSize));
+                var indentString = string.Empty;
+                for (var i = 0; i < _nodeConnectionStates.Count; i++)
+                {
+                    if (_nodeConnectionStates[i] == NodeConnectionState.Disconnected)
+                    {
+                        indentString += _disconnectedIndent;
+                    }
+                    else if (i == _nodeConnectionStates.Count -1 && _nodeConnectionStates[i] == NodeConnectionState.Connected)
+                    {
+                        indentString += _connectedIndent;
+                    }
+                    else
+                    {
+                        indentString += _suspendedIndent;
+                    }
+                }
+
+                _stringBuilder.Append(indentString);
             }
 
             _indentPending = false;

--- a/src/EFCore/Query/Internal/IExpressionPrinter.cs
+++ b/src/EFCore/Query/Internal/IExpressionPrinter.cs
@@ -16,7 +16,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        string Print([NotNull] Expression expression, bool removeFormatting = false, int? characterLimit = null);
+        string Print(
+            [NotNull] Expression expression,
+            bool removeFormatting = false,
+            int? characterLimit = null,
+            bool printConnections = true);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -26,6 +30,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             [NotNull] Expression expression,
             bool highlightNonreducibleNodes = true,
             bool reduceBeforePrinting = true,
-            bool generateUniqueQsreIds = true);
+            bool generateUniqueQsreIds = true,
+            bool printConnections = true);
     }
 }

--- a/src/EFCore/Query/Internal/QueryModelPrinter.cs
+++ b/src/EFCore/Query/Internal/QueryModelPrinter.cs
@@ -68,6 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             _expressionPrinter.RemoveFormatting = removeFormatting;
             _expressionPrinter.CharacterLimit = characterLimit;
             _expressionPrinter.GenerateUniqueQsreIds = generateUniqueQsreIds;
+            _expressionPrinter.PrintConnections = false;
 
             _queryModelPrintingVisitor.VisitQueryModel(queryModel);
 


### PR DESCRIPTION
Adding connecting lines between method call expressions and anonymous type members when printing query plans.