### PR TITLE
Fix to #9455 - Query/Logging: log contents of compiled code (e.g. materializers inside a shaper) as part of the query plan

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/CompositeShaper.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/CompositeShaper.cs
@@ -25,7 +25,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             [NotNull] IQuerySource querySource,
             [NotNull] Shaper outerShaper,
             [NotNull] Shaper innerShaper,
-            [NotNull] LambdaExpression materializer)
+            [NotNull] LambdaExpression materializer,
+            bool storeMaterializerExpression)
         {
             Check.NotNull(querySource, nameof(querySource));
             Check.NotNull(outerShaper, nameof(outerShaper));
@@ -47,7 +48,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                             querySource,
                             outerShaper,
                             innerShaper,
-                            materializer.Compile()
+                            materializer.Compile(),
+                            storeMaterializerExpression ? materializer : null
                         });
 
             return compositeShaper;
@@ -84,7 +86,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                             querySource,
                             outerShaper,
                             innerShaper,
-                            materializer
+                            materializer,
+                            null
                         });
 
             return compositeShaper;
@@ -100,11 +103,12 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 IQuerySource querySource,
                 TOuterShaper outerShaper,
                 TInnerShaper innerShaper,
-                Func<TOuter, TInner, TResult> materializer)
+                Func<TOuter, TInner, TResult> materializer,
+                Expression materializerExpression)
             where TOuterShaper : Shaper, IShaper<TOuter>
             where TInnerShaper : Shaper, IShaper<TInner>
             => new TypedCompositeShaper<TOuterShaper, TOuter, TInnerShaper, TInner, TResult>(
-                querySource, outerShaper, innerShaper, materializer);
+                querySource, outerShaper, innerShaper, materializer, materializerExpression);
 
         private class TypedCompositeShaper<TOuterShaper, TOuter, TInnerShaper, TInner, TResult>
             : Shaper, IShaper<TResult>
@@ -123,8 +127,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 IQuerySource querySource,
                 TOuterShaper outerShaper,
                 TInnerShaper innerShaper,
-                Func<TOuter, TInner, TResult> materializer)
-                : base(querySource)
+                Func<TOuter, TInner, TResult> materializer,
+                Expression materializerExpression)
+                : base(querySource, materializerExpression)
             {
                 _outerShaper = outerShaper;
                 _innerShaper = innerShaper;
@@ -158,7 +163,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     QuerySource,
                     _outerShaper,
                     _innerShaper,
-                    _materializer).AddOffset(offset);
+                    _materializer,
+                    MaterializerExpression).AddOffset(offset);
 
             public override Shaper AddOffset(int offset)
             {

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/EntityShaper.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/EntityShaper.cs
@@ -27,19 +27,12 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             [NotNull] IKey key,
             [NotNull] Func<MaterializationContext, object> materializer,
             [CanBeNull] Expression materializerExpression)
-            : base(querySource)
+            : base(querySource, materializerExpression)
         {
             IsTrackingQuery = trackingQuery;
             Key = key;
             Materializer = materializer;
-            MaterializerExpression = materializerExpression;
         }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public Expression MaterializerExpression { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/Shaper.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/Shaper.cs
@@ -22,9 +22,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected Shaper([NotNull] IQuerySource querySource)
+        protected Shaper([NotNull] IQuerySource querySource, [CanBeNull] Expression materializerExpression)
         {
             _querySource = querySource;
+            MaterializerExpression = materializerExpression;
         }
 
         /// <summary>
@@ -42,6 +43,12 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         {
             _querySource = querySource;
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Expression MaterializerExpression { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/ValueBufferShaper.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/ValueBufferShaper.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public ValueBufferShaper([NotNull] IQuerySource querySource)
-            : base(querySource)
+            : base(querySource, materializerExpression: null)
         {
         }
 

--- a/src/EFCore.Relational/Query/Internal/RelationalExpressionPrinter.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalExpressionPrinter.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Query.Internal
 {
@@ -21,14 +22,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public RelationalExpressionPrinter()
-            : base(
+        {
+            ConstantPrinters.InsertRange(0,
                 new List<ConstantPrinterBase>
                 {
                     new CommandBuilderPrinter(),
                     new EntityTrackingInfoListPrinter(),
-                    new MetadataPropertyCollectionPrinter()
-                })
-        {
+                    new MetadataPropertyCollectionPrinter(),
+                    new ShaperPrinter(this)
+                });
         }
 
         private class CommandBuilderPrinter : ConstantPrinterBase
@@ -123,6 +125,33 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                     stringBuilder.DecrementIndent();
                     stringBuilder.Append("}");
+
+                    return true;
+                }
+
+                return false;
+            }
+        }
+
+        private class ShaperPrinter : ConstantPrinterBase
+        {
+            private RelationalExpressionPrinter _expressionPrinter;
+
+            public ShaperPrinter(RelationalExpressionPrinter expressionPrinter)
+            {
+                _expressionPrinter = expressionPrinter;
+            }
+
+            public override bool TryPrintConstant(
+                ConstantExpression constantExpression,
+                IndentedStringBuilder stringBuilder,
+                bool removeFormatting)
+            {
+                if (constantExpression.Value is Shaper shaper
+                    && !(shaper is EntityShaper)
+                    && shaper.MaterializerExpression != null)
+                {
+                    _expressionPrinter.Visit(shaper.MaterializerExpression);
 
                     return true;
                 }


### PR DESCRIPTION
Shapers (especially projection shapers) contain useful information that gets compiled out of the query plan. For debugging purposes we stash the uncompiled expression on the Shaper as well so we can print the complete query plan.
We only do that if the query plans are getting logged to avoid unnecessary bloating of Shapers when that extra information doesn't get used.