### PR TITLE
Value conversions from strings to other types

### DIFF
--- a/src/EFCore/Storage/ValueConversion/CharToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/CharToStringConverter.cs
@@ -1,15 +1,15 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Globalization;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
     ///     Converts a <see cref="char" /> to and from a single-character <see cref="string" />.
     /// </summary>
-    public class CharToStringConverter : ValueConverter<char, string>
+    public class CharToStringConverter : StringCharConverter<char, string>
     {
         private static readonly ConverterMappingHints _defaultHints
             = new ConverterMappingHints(size: 1);
@@ -23,8 +23,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// </param>
         public CharToStringConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
-                v => string.Format(CultureInfo.InvariantCulture, "{0}", v),
-                v => v != null && v.Length >= 1 ? v[0] : (char)0,
+                ToString(),
+                ToChar(),
                 _defaultHints.With(mappingHints))
         {
         }

--- a/src/EFCore/Storage/ValueConversion/DateTimeOffsetToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/DateTimeOffsetToStringConverter.cs
@@ -4,17 +4,15 @@
 using System;
 using System.Globalization;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
-    ///     Converts <see cref="DateTime" /> to and from strings.
+    ///     Converts <see cref="DateTimeOffset" /> to and from strings.
     /// </summary>
-    public class DateTimeOffsetToStringConverter : ValueConverter<DateTimeOffset, string>
+    public class DateTimeOffsetToStringConverter : StringDateTimeOffsetConverter<DateTimeOffset, string>
     {
-        private static readonly ConverterMappingHints _defaultHints
-            = new ConverterMappingHints(size: 48);
-
         /// <summary>
         ///     Creates a new instance of this converter.
         /// </summary>
@@ -24,8 +22,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// </param>
         public DateTimeOffsetToStringConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
-                v => v.ToString(@"yyyy\-MM\-dd HH\:mm\:ss.FFFFFFFzzz"),
-                v => v == null ? default : DateTimeOffset.Parse(v, CultureInfo.InvariantCulture),
+                ToString(),
+                ToDateTimeOffset(),
                 _defaultHints.With(mappingHints))
         {
         }

--- a/src/EFCore/Storage/ValueConversion/DateTimeToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/DateTimeToStringConverter.cs
@@ -2,19 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
     ///     Converts <see cref="DateTime" /> to and from strings.
     /// </summary>
-    public class DateTimeToStringConverter : ValueConverter<DateTime, string>
+    public class DateTimeToStringConverter : StringDateTimeConverter<DateTime, string>
     {
-        private static readonly ConverterMappingHints _defaultHints
-            = new ConverterMappingHints(size: 48);
-
         /// <summary>
         ///     Creates a new instance of this converter.
         /// </summary>
@@ -24,8 +21,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// </param>
         public DateTimeToStringConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
-                v => v.ToString(@"yyyy\-MM\-dd HH\:mm\:ss.FFFFFFF"),
-                v => v == null ? default : DateTime.Parse(v, CultureInfo.InvariantCulture),
+                ToString(),
+                ToDateTime(),
                 _defaultHints.With(mappingHints))
         {
         }

--- a/src/EFCore/Storage/ValueConversion/GuidToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/GuidToStringConverter.cs
@@ -3,6 +3,7 @@
 
 using System;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
@@ -11,13 +12,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
     ///     Converts a <see cref="Guid" /> to and from a <see cref="string" /> using the
     ///     standard "8-4-4-4-12" format./>.
     /// </summary>
-    public class GuidToStringConverter : ValueConverter<Guid, string>
+    public class GuidToStringConverter : StringGuidConverter<Guid, string>
     {
-        private static readonly ConverterMappingHints _defaultHints
-            = new ConverterMappingHints(
-                size: 36,
-                valueGeneratorFactory: (p, t) => new SequentialGuidValueGenerator());
-
         /// <summary>
         ///     Creates a new instance of this converter.
         /// </summary>
@@ -27,8 +23,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// </param>
         public GuidToStringConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
-                v => v.ToString("D"),
-                v => v == null ? Guid.Empty : new Guid(v),
+                ToString(),
+                ToGuid(),
                 _defaultHints.With(mappingHints))
         {
         }

--- a/src/EFCore/Storage/ValueConversion/Internal/StringCharConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringCharConverter.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class StringCharConverter<TModel, TProvider> : ValueConverter<TModel, TProvider>
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public StringCharConverter(
+            [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
+            [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
+            [CanBeNull] ConverterMappingHints mappingHints = null)
+            : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
+        {
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected new static Expression<Func<char, string>> ToString()
+            => v => string.Format(CultureInfo.InvariantCulture, "{0}", v);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected static Expression<Func<string, char>> ToChar()
+            => v => v != null && v.Length >= 1 ? v[0] : (char)0;
+    }
+}

--- a/src/EFCore/Storage/ValueConversion/Internal/StringDateTimeConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringDateTimeConverter.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class StringDateTimeConverter<TModel, TProvider> : ValueConverter<TModel, TProvider>
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        // ReSharper disable once StaticMemberInGenericType
+        protected static readonly ConverterMappingHints _defaultHints
+            = new ConverterMappingHints(size: 48);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public StringDateTimeConverter(
+            [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
+            [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
+            [CanBeNull] ConverterMappingHints mappingHints = null)
+            : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
+        {
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected new static Expression<Func<DateTime, string>> ToString()
+            => v => v.ToString(@"yyyy\-MM\-dd HH\:mm\:ss.FFFFFFF");
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected static Expression<Func<string, DateTime>> ToDateTime()
+            => v => v == null ? default : DateTime.Parse(v, CultureInfo.InvariantCulture);
+    }
+}

--- a/src/EFCore/Storage/ValueConversion/Internal/StringDateTimeOffsetConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringDateTimeOffsetConverter.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
         /// </summary>
         // ReSharper disable once StaticMemberInGenericType
         protected static readonly ConverterMappingHints _defaultHints
-            = new ConverterMappingHints(size: 64);
+            = new ConverterMappingHints(size: 48);
 
 
         /// <summary>

--- a/src/EFCore/Storage/ValueConversion/Internal/StringDateTimeOffsetConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringDateTimeOffsetConverter.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class StringDateTimeOffsetConverter<TModel, TProvider> : ValueConverter<TModel, TProvider>
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        // ReSharper disable once StaticMemberInGenericType
+        protected static readonly ConverterMappingHints _defaultHints
+            = new ConverterMappingHints(size: 64);
+
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public StringDateTimeOffsetConverter(
+            [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
+            [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
+            [CanBeNull] ConverterMappingHints mappingHints = null)
+            : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
+        {
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected new static Expression<Func<DateTimeOffset, string>> ToString()
+            => v => v.ToString(@"yyyy\-MM\-dd HH\:mm\:ss.FFFFFFFzzz");
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected static Expression<Func<string, DateTimeOffset>> ToDateTimeOffset()
+            => v => v == null ? default : DateTimeOffset.Parse(v, CultureInfo.InvariantCulture);
+    }
+}

--- a/src/EFCore/Storage/ValueConversion/Internal/StringEnumConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringEnumConverter.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class StringEnumConverter<TModel, TProvider, TEnum> : ValueConverter<TModel, TProvider>
+        where TEnum : struct
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public StringEnumConverter(
+            [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
+            [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
+            [CanBeNull] ConverterMappingHints mappingHints = null)
+            : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
+        {
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected new static Expression<Func<TEnum, string>> ToString()
+            => v => v.ToString();
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected static Expression<Func<string, TEnum>> ToEnum()
+        {
+            if (!typeof(TEnum).UnwrapNullableType().IsEnum)
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.ConverterBadType(
+                        typeof(StringEnumConverter<TModel, TProvider, TEnum>).ShortDisplayName(),
+                        typeof(TEnum).ShortDisplayName(),
+                        "enum types"));
+            }
+
+            return v => ConvertToEnum(v);
+        }
+
+        private static TEnum ConvertToEnum(string value)
+            => Enum.TryParse<TEnum>(value, out var result)
+                ? result
+                : Enum.TryParse(value, true, out result)
+                    ? result
+                    : ulong.TryParse(value, out var ulongValue)
+                        ? (TEnum)(object)ulongValue
+                        : long.TryParse(value, out var longValue)
+                            ? (TEnum)(object)longValue
+                            : default;
+    }
+}

--- a/src/EFCore/Storage/ValueConversion/Internal/StringGuidConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringGuidConverter.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
+
+namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class StringGuidConverter<TModel, TProvider> : ValueConverter<TModel, TProvider>
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        // ReSharper disable once StaticMemberInGenericType
+        protected static readonly ConverterMappingHints _defaultHints
+            = new ConverterMappingHints(
+                size: 36,
+                valueGeneratorFactory: (p, t) => new SequentialGuidValueGenerator());
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public StringGuidConverter(
+            [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
+            [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
+            [CanBeNull] ConverterMappingHints mappingHints = null)
+            : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
+        {
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected new static Expression<Func<Guid, string>> ToString()
+            => v => v.ToString("D");
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected static Expression<Func<string, Guid>> ToGuid()
+            => v => v == null ? default : new Guid(v);
+    }
+}

--- a/src/EFCore/Storage/ValueConversion/Internal/StringNumberConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringNumberConverter.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class StringNumberConverter<TModel, TProvider, TNumber> : ValueConverter<TModel, TProvider>
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        // ReSharper disable once StaticMemberInGenericType
+        protected static readonly ConverterMappingHints _defaultHints
+            = new ConverterMappingHints(size: 64);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public StringNumberConverter(
+            [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
+            [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
+            [CanBeNull] ConverterMappingHints mappingHints = null)
+            : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
+        {
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected static Expression<Func<string, TNumber>> ToNumber()
+        {
+            var type = typeof(TNumber).UnwrapNullableType();
+
+            CheckTypeSupported(
+                type,
+                typeof(StringNumberConverter<TModel, TProvider, TNumber>),
+                typeof(int), typeof(long), typeof(short), typeof(byte),
+                typeof(uint), typeof(ulong), typeof(ushort), typeof(sbyte),
+                typeof(decimal), typeof(float), typeof(double));
+
+            var tryParseMethod = type.GetMethod(
+                nameof(int.TryParse),
+                new[] { typeof(string), typeof(NumberStyles), typeof(IFormatProvider), type.MakeByRefType() });
+
+            var parsedVariable = Expression.Variable(type, "parsed");
+            var param = Expression.Parameter(typeof(string), "v");
+
+            return Expression.Lambda<Func<string, TNumber>>(
+                Expression.Block(
+                    typeof(TNumber),
+                    new[] { parsedVariable },
+                    Expression.Condition(
+                        Expression.Call(
+                            tryParseMethod,
+                            param,
+                            Expression.Constant(NumberStyles.Any),
+                            Expression.Constant(CultureInfo.InvariantCulture, typeof(IFormatProvider)),
+                            parsedVariable),
+                        typeof(TNumber).IsNullableType()
+                            ? (Expression)Expression.Convert(parsedVariable, typeof(TNumber))
+                            : parsedVariable,
+                        Expression.Constant(default(TNumber), typeof(TNumber)))),
+                param);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected new static Expression<Func<TNumber, string>> ToString()
+        {
+            var type = typeof(TNumber).UnwrapNullableType();
+
+            CheckTypeSupported(
+                type,
+                typeof(StringNumberConverter<TModel, TProvider, TNumber>),
+                typeof(int), typeof(long), typeof(short), typeof(byte),
+                typeof(uint), typeof(ulong), typeof(ushort), typeof(sbyte),
+                typeof(decimal), typeof(float), typeof(double));
+
+            return v => v == null
+                ? null
+                : string.Format(
+                    CultureInfo.InvariantCulture,
+                    type == typeof(float) || type == typeof(double) ? "{0:R}" : "{0}",
+                    v);
+        }
+    }
+}

--- a/src/EFCore/Storage/ValueConversion/Internal/StringTimeSpanConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/Internal/StringTimeSpanConverter.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class StringTimeSpanConverter<TModel, TProvider> : ValueConverter<TModel, TProvider>
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        // ReSharper disable once StaticMemberInGenericType
+        protected static readonly ConverterMappingHints _defaultHints
+            = new ConverterMappingHints(size: 48);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public StringTimeSpanConverter(
+            [NotNull] Expression<Func<TModel, TProvider>> convertToProviderExpression,
+            [NotNull] Expression<Func<TProvider, TModel>> convertFromProviderExpression,
+            [CanBeNull] ConverterMappingHints mappingHints = null)
+            : base(convertToProviderExpression, convertFromProviderExpression, mappingHints)
+        {
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected new static Expression<Func<TimeSpan, string>> ToString()
+            => v => v.ToString("c");
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected static Expression<Func<string, TimeSpan>> ToTimeSpan()
+            => v => v == null ? default : TimeSpan.Parse(v, CultureInfo.InvariantCulture);
+    }
+}

--- a/src/EFCore/Storage/ValueConversion/NumberToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/NumberToStringConverter.cs
@@ -1,22 +1,16 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Globalization;
-using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
     ///     Converts numeric values to and from their string representation.
     /// </summary>
-    public class NumberToStringConverter<TNumber> : ValueConverter<TNumber, string>
+    public class NumberToStringConverter<TNumber> : StringNumberConverter<TNumber, string, TNumber>
     {
-        // ReSharper disable once StaticMemberInGenericType
-        private static readonly ConverterMappingHints _defaultHints
-            = new ConverterMappingHints(size: 64);
-
         /// <summary>
         ///     Creates a new instance of this converter.
         /// </summary>
@@ -27,8 +21,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         public NumberToStringConverter(
             [CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
-                ToStringExpression(),
-                ToIntegerExpression(),
+                ToString(),
+                ToNumber(),
                 _defaultHints.With(mappingHints))
         {
         }
@@ -38,53 +32,5 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// </summary>
         public static ValueConverterInfo DefaultInfo { get; }
             = new ValueConverterInfo(typeof(TNumber), typeof(string), i => new NumberToStringConverter<TNumber>(i.MappingHints), _defaultHints);
-
-        private static Expression<Func<TNumber, string>> ToStringExpression()
-        {
-            var type = typeof(TNumber).UnwrapNullableType();
-
-            CheckTypeSupported(
-                type,
-                typeof(NumberToStringConverter<TNumber>),
-                typeof(int), typeof(long), typeof(short), typeof(byte),
-                typeof(uint), typeof(ulong), typeof(ushort), typeof(sbyte),
-                typeof(decimal), typeof(float), typeof(double));
-
-            return v => v == null
-                ? null
-                : string.Format(
-                    CultureInfo.InvariantCulture,
-                    type == typeof(float) || type == typeof(double) ? "{0:R}" : "{0}",
-                    v);
-        }
-
-        private static Expression<Func<string, TNumber>> ToIntegerExpression()
-        {
-            var type = typeof(TNumber).UnwrapNullableType();
-
-            var tryParseMethod = type.GetMethod(
-                nameof(int.TryParse),
-                new[] { typeof(string), typeof(NumberStyles), typeof(IFormatProvider), type.MakeByRefType() });
-
-            var parsedVariable = Expression.Variable(type, "parsed");
-            var param = Expression.Parameter(typeof(string), "v");
-
-            return Expression.Lambda<Func<string, TNumber>>(
-                Expression.Block(
-                    typeof(TNumber),
-                    new[] { parsedVariable },
-                    Expression.Condition(
-                        Expression.Call(
-                            tryParseMethod,
-                            param,
-                            Expression.Constant(NumberStyles.Any),
-                            Expression.Constant(CultureInfo.InvariantCulture, typeof(IFormatProvider)),
-                            parsedVariable),
-                        typeof(TNumber).IsNullableType()
-                            ? (Expression)Expression.Convert(parsedVariable, typeof(TNumber))
-                            : parsedVariable,
-                        Expression.Constant(default(TNumber), typeof(TNumber)))),
-                param);
-        }
     }
 }

--- a/src/EFCore/Storage/ValueConversion/StringToBoolConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToBoolConverter.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Text;
 using JetBrains.Annotations;
 
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion

--- a/src/EFCore/Storage/ValueConversion/StringToBoolConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToBoolConverter.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
+{
+    /// <summary>
+    ///     Converts strings to and from <see cref="bool" /> values.
+    /// </summary>
+    public class StringToBoolConverter : ValueConverter<string, bool>
+    {
+        /// <summary>
+        ///     Creates a new instance of this converter.
+        /// </summary>
+        /// <param name="mappingHints">
+        ///     Hints that can be used by the <see cref="ITypeMappingSource"/> to create data types with appropriate
+        ///     facets for the converted data.
+        /// </param>
+        public StringToBoolConverter(
+            [CanBeNull] ConverterMappingHints mappingHints = null)
+            : base(
+                v => Convert.ToBoolean(v),
+                v => Convert.ToString(v),
+                mappingHints)
+        {
+        }
+
+        /// <summary>
+        ///     A <see cref="ValueConverterInfo" /> for the default use of this converter.
+        /// </summary>
+        public static ValueConverterInfo DefaultInfo { get; }
+            = new ValueConverterInfo(typeof(string), typeof(bool), i => new StringToBoolConverter(i.MappingHints));
+    }
+}

--- a/src/EFCore/Storage/ValueConversion/StringToCharConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToCharConverter.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Globalization;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
+{
+    /// <summary>
+    ///     Converts strings to and from <see cref="char" /> values.
+    /// </summary>
+    public class StringToCharConverter : ValueConverter<string, char>
+    {
+        private static readonly ConverterMappingHints _defaultHints
+            = new ConverterMappingHints(size: 1);
+
+        /// <summary>
+        ///     Creates a new instance of this converter. This converter preserves order.
+        /// </summary>
+        /// <param name="mappingHints">
+        ///     Hints that can be used by the <see cref="ITypeMappingSource"/> to create data types with appropriate
+        ///     facets for the converted data.
+        /// </param>
+        public StringToCharConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+            : base(
+                v => v == null || v.Length == 0 ? default : v[0],
+                v => string.Format(CultureInfo.InvariantCulture, "{0}", v),
+                _defaultHints.With(mappingHints))
+        {
+        }
+
+        /// <summary>
+        ///     A <see cref="ValueConverterInfo" /> for the default use of this converter.
+        /// </summary>
+        public static ValueConverterInfo DefaultInfo { get; }
+            = new ValueConverterInfo(typeof(string), typeof(char), i => new StringToCharConverter(i.MappingHints), _defaultHints);
+    }
+}

--- a/src/EFCore/Storage/ValueConversion/StringToCharConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToCharConverter.cs
@@ -1,15 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System.Globalization;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
     ///     Converts strings to and from <see cref="char" /> values.
     /// </summary>
-    public class StringToCharConverter : ValueConverter<string, char>
+    public class StringToCharConverter : StringCharConverter<string, char>
     {
         private static readonly ConverterMappingHints _defaultHints
             = new ConverterMappingHints(size: 1);
@@ -23,8 +23,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// </param>
         public StringToCharConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
-                v => v == null || v.Length == 0 ? default : v[0],
-                v => string.Format(CultureInfo.InvariantCulture, "{0}", v),
+                ToChar(),
+                ToString(),
                 _defaultHints.With(mappingHints))
         {
         }

--- a/src/EFCore/Storage/ValueConversion/StringToDateTimeConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToDateTimeConverter.cs
@@ -2,19 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
     ///     Converts strings to and from <see cref="DateTime" /> values.
     /// </summary>
-    public class StringToDateTimeConverter : ValueConverter<string, DateTime>
+    public class StringToDateTimeConverter : StringDateTimeConverter<string, DateTime>
     {
-        private static readonly ConverterMappingHints _defaultHints
-            = new ConverterMappingHints(size: 48);
-
         /// <summary>
         ///     Creates a new instance of this converter.
         /// </summary>
@@ -24,8 +21,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// </param>
         public StringToDateTimeConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
-                v => v == null ? default : DateTime.Parse(v, CultureInfo.InvariantCulture),
-                v => v.ToString(@"yyyy\-MM\-dd HH\:mm\:ss.FFFFFFF"),
+                ToDateTime(),
+                ToString(),
                 _defaultHints.With(mappingHints))
         {
         }

--- a/src/EFCore/Storage/ValueConversion/StringToDateTimeConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToDateTimeConverter.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
+{
+    /// <summary>
+    ///     Converts strings to and from <see cref="DateTime" /> values.
+    /// </summary>
+    public class StringToDateTimeConverter : ValueConverter<string, DateTime>
+    {
+        private static readonly ConverterMappingHints _defaultHints
+            = new ConverterMappingHints(size: 48);
+
+        /// <summary>
+        ///     Creates a new instance of this converter.
+        /// </summary>
+        /// <param name="mappingHints">
+        ///     Hints that can be used by the <see cref="ITypeMappingSource"/> to create data types with appropriate
+        ///     facets for the converted data.
+        /// </param>
+        public StringToDateTimeConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+            : base(
+                v => v == null ? default : DateTime.Parse(v, CultureInfo.InvariantCulture),
+                v => v.ToString(@"yyyy\-MM\-dd HH\:mm\:ss.FFFFFFF"),
+                _defaultHints.With(mappingHints))
+        {
+        }
+
+        /// <summary>
+        ///     A <see cref="ValueConverterInfo" /> for the default use of this converter.
+        /// </summary>
+        public static ValueConverterInfo DefaultInfo { get; }
+            = new ValueConverterInfo(typeof(string), typeof(DateTime), i => new StringToDateTimeConverter(i.MappingHints), _defaultHints);
+    }
+}

--- a/src/EFCore/Storage/ValueConversion/StringToDateTimeOffsetConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToDateTimeOffsetConverter.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
+{
+    /// <summary>
+    ///     Converts strings to and from <see cref="DateTime" /> values.
+    /// </summary>
+    public class StringToDateTimeOffsetConverter : ValueConverter<string, DateTimeOffset>
+    {
+        private static readonly ConverterMappingHints _defaultHints
+            = new ConverterMappingHints(size: 48);
+
+        /// <summary>
+        ///     Creates a new instance of this converter.
+        /// </summary>
+        /// <param name="mappingHints">
+        ///     Hints that can be used by the <see cref="ITypeMappingSource"/> to create data types with appropriate
+        ///     facets for the converted data.
+        /// </param>
+        public StringToDateTimeOffsetConverter(
+            [CanBeNull] ConverterMappingHints mappingHints = null)
+            : base(
+                v => v == null ? default : DateTimeOffset.Parse(v, CultureInfo.InvariantCulture),
+                v => v.ToString(@"yyyy\-MM\-dd HH\:mm\:ss.FFFFFFFzzz"),
+                _defaultHints.With(mappingHints))
+        {
+        }
+
+        /// <summary>
+        ///     A <see cref="ValueConverterInfo" /> for the default use of this converter.
+        /// </summary>
+        public static ValueConverterInfo DefaultInfo { get; }
+            = new ValueConverterInfo(typeof(string), typeof(DateTimeOffset), i => new StringToDateTimeOffsetConverter(i.MappingHints), _defaultHints);
+    }
+}

--- a/src/EFCore/Storage/ValueConversion/StringToDateTimeOffsetConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToDateTimeOffsetConverter.cs
@@ -9,7 +9,7 @@ using JetBrains.Annotations;
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
-    ///     Converts strings to and from <see cref="DateTime" /> values.
+    ///     Converts strings to and from <see cref="DateTimeOffset" /> values.
     /// </summary>
     public class StringToDateTimeOffsetConverter : ValueConverter<string, DateTimeOffset>
     {

--- a/src/EFCore/Storage/ValueConversion/StringToDateTimeOffsetConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToDateTimeOffsetConverter.cs
@@ -3,19 +3,16 @@
 
 using System;
 using System.Globalization;
-using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
     ///     Converts strings to and from <see cref="DateTimeOffset" /> values.
     /// </summary>
-    public class StringToDateTimeOffsetConverter : ValueConverter<string, DateTimeOffset>
+    public class StringToDateTimeOffsetConverter : StringDateTimeOffsetConverter<string, DateTimeOffset>
     {
-        private static readonly ConverterMappingHints _defaultHints
-            = new ConverterMappingHints(size: 48);
-
         /// <summary>
         ///     Creates a new instance of this converter.
         /// </summary>
@@ -26,8 +23,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         public StringToDateTimeOffsetConverter(
             [CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
-                v => v == null ? default : DateTimeOffset.Parse(v, CultureInfo.InvariantCulture),
-                v => v.ToString(@"yyyy\-MM\-dd HH\:mm\:ss.FFFFFFFzzz"),
+                ToDateTimeOffset(),
+                ToString(),
                 _defaultHints.With(mappingHints))
         {
         }

--- a/src/EFCore/Storage/ValueConversion/StringToEnumConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToEnumConverter.cs
@@ -1,17 +1,15 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Linq.Expressions;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
     ///     Converts strings to and from enum values.
     /// </summary>
-    public class StringToEnumConverter<TEnum> : ValueConverter<string, TEnum>
+    public class StringToEnumConverter<TEnum> : StringEnumConverter<string, TEnum, TEnum>
         where TEnum : struct
     {
         /// <summary>
@@ -24,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         public StringToEnumConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
                 ToEnum(),
-                v => v.ToString(),
+                ToString(),
                 mappingHints)
         {
         }
@@ -34,30 +32,5 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// </summary>
         public static ValueConverterInfo DefaultInfo { get; }
             = new ValueConverterInfo(typeof(string), typeof(TEnum), i => new StringToEnumConverter<TEnum>(i.MappingHints));
-
-        private static Expression<Func<string, TEnum>> ToEnum()
-        {
-            if (!typeof(TEnum).UnwrapNullableType().IsEnum)
-            {
-                throw new InvalidOperationException(
-                    CoreStrings.ConverterBadType(
-                        typeof(StringToEnumConverter<TEnum>).ShortDisplayName(),
-                        typeof(TEnum).ShortDisplayName(),
-                        "enum types"));
-            }
-
-            return v => ConvertToEnum(v);
-        }
-
-        private static TEnum ConvertToEnum(string value)
-            => Enum.TryParse<TEnum>(value, out var result)
-                ? result
-                : Enum.TryParse(value, true, out result)
-                    ? result
-                    : ulong.TryParse(value, out var ulongValue)
-                        ? (TEnum)(object)ulongValue
-                        : long.TryParse(value, out var longValue)
-                            ? (TEnum)(object)longValue
-                            : default;
     }
 }

--- a/src/EFCore/Storage/ValueConversion/StringToEnumConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToEnumConverter.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
+{
+    /// <summary>
+    ///     Converts strings to and from enum values.
+    /// </summary>
+    public class StringToEnumConverter<TEnum> : ValueConverter<string, TEnum>
+        where TEnum : struct
+    {
+        /// <summary>
+        ///     Creates a new instance of this converter. This converter does not preserve order.
+        /// </summary>
+        /// <param name="mappingHints">
+        ///     Hints that can be used by the <see cref="ITypeMappingSource"/> to create data types with appropriate
+        ///     facets for the converted data.
+        /// </param>
+        public StringToEnumConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+            : base(
+                ToEnum(),
+                v => v.ToString(),
+                mappingHints)
+        {
+        }
+
+        /// <summary>
+        ///     A <see cref="ValueConverterInfo" /> for the default use of this converter.
+        /// </summary>
+        public static ValueConverterInfo DefaultInfo { get; }
+            = new ValueConverterInfo(typeof(string), typeof(TEnum), i => new StringToEnumConverter<TEnum>(i.MappingHints));
+
+        private static Expression<Func<string, TEnum>> ToEnum()
+        {
+            if (!typeof(TEnum).UnwrapNullableType().IsEnum)
+            {
+                throw new InvalidOperationException(
+                    CoreStrings.ConverterBadType(
+                        typeof(StringToEnumConverter<TEnum>).ShortDisplayName(),
+                        typeof(TEnum).ShortDisplayName(),
+                        "enum types"));
+            }
+
+            return v => ConvertToEnum(v);
+        }
+
+        private static TEnum ConvertToEnum(string value)
+            => Enum.TryParse<TEnum>(value, out var result)
+                ? result
+                : Enum.TryParse(value, true, out result)
+                    ? result
+                    : ulong.TryParse(value, out var ulongValue)
+                        ? (TEnum)(object)ulongValue
+                        : long.TryParse(value, out var longValue)
+                            ? (TEnum)(object)longValue
+                            : default;
+    }
+}

--- a/src/EFCore/Storage/ValueConversion/StringToGuidConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToGuidConverter.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
+
+namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
+{
+    /// <summary>
+    ///     Converts strings to and from a <see cref="Guid" /> using the
+    ///     standard "8-4-4-4-12" format./>.
+    /// </summary>
+    public class StringToGuidConverter : ValueConverter<string, Guid>
+    {
+        private static readonly ConverterMappingHints _defaultHints
+            = new ConverterMappingHints(
+                size: 36,
+                valueGeneratorFactory: (p, t) => new SequentialGuidValueGenerator());
+
+        /// <summary>
+        ///     Creates a new instance of this converter.
+        /// </summary>
+        /// <param name="mappingHints">
+        ///     Hints that can be used by the <see cref="ITypeMappingSource"/> to create data types with appropriate
+        ///     facets for the converted data.
+        /// </param>
+        public StringToGuidConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+            : base(
+                v => v == null ? default : new Guid(v),
+                v => v.ToString("D"),
+                _defaultHints.With(mappingHints))
+        {
+        }
+
+        /// <summary>
+        ///     A <see cref="ValueConverterInfo" /> for the default use of this converter.
+        /// </summary>
+        public static ValueConverterInfo DefaultInfo { get; }
+            = new ValueConverterInfo(typeof(string), typeof(Guid), i => new StringToGuidConverter(i.MappingHints), _defaultHints);
+    }
+}

--- a/src/EFCore/Storage/ValueConversion/StringToGuidConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToGuidConverter.cs
@@ -3,7 +3,7 @@
 
 using System;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.ValueGeneration;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
@@ -11,13 +11,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
     ///     Converts strings to and from a <see cref="Guid" /> using the
     ///     standard "8-4-4-4-12" format./>.
     /// </summary>
-    public class StringToGuidConverter : ValueConverter<string, Guid>
+    public class StringToGuidConverter : StringGuidConverter<string, Guid>
     {
-        private static readonly ConverterMappingHints _defaultHints
-            = new ConverterMappingHints(
-                size: 36,
-                valueGeneratorFactory: (p, t) => new SequentialGuidValueGenerator());
-
         /// <summary>
         ///     Creates a new instance of this converter.
         /// </summary>
@@ -27,8 +22,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// </param>
         public StringToGuidConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
-                v => v == null ? default : new Guid(v),
-                v => v.ToString("D"),
+                ToGuid(),
+                ToString(),
                 _defaultHints.With(mappingHints))
         {
         }

--- a/src/EFCore/Storage/ValueConversion/StringToNumberConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToNumberConverter.cs
@@ -1,22 +1,16 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Globalization;
-using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
     ///     Converts strings to and from numeric values.
     /// </summary>
-    public class StringToNumberConverter<TNumber> : ValueConverter<string, TNumber>
+    public class StringToNumberConverter<TNumber> : StringNumberConverter<string, TNumber, TNumber>
     {
-        // ReSharper disable once StaticMemberInGenericType
-        private static readonly ConverterMappingHints _defaultHints
-            = new ConverterMappingHints(size: 64);
-
         /// <summary>
         ///     Creates a new instance of this converter.
         /// </summary>
@@ -27,8 +21,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         public StringToNumberConverter(
             [CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
-                  ToIntegerExpression(),
-                  ToStringExpression(),
+                  ToNumber(),
+                  ToString(),
                   _defaultHints.With(mappingHints))
         {
         }
@@ -38,53 +32,5 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// </summary>
         public static ValueConverterInfo DefaultInfo { get; }
             = new ValueConverterInfo(typeof(string), typeof(TNumber), i => new StringToNumberConverter<TNumber>(i.MappingHints), _defaultHints);
-
-        private static Expression<Func<string, TNumber>> ToIntegerExpression()
-        {
-            var type = typeof(TNumber).UnwrapNullableType();
-
-            var tryParseMethod = type.GetMethod(
-                nameof(int.TryParse),
-                new[] { typeof(string), typeof(NumberStyles), typeof(IFormatProvider), type.MakeByRefType() });
-
-            var parsedVariable = Expression.Variable(type, "parsed");
-            var param = Expression.Parameter(typeof(string), "v");
-
-            return Expression.Lambda<Func<string, TNumber>>(
-                Expression.Block(
-                    typeof(TNumber),
-                    new[] { parsedVariable },
-                    Expression.Condition(
-                        Expression.Call(
-                            tryParseMethod,
-                            param,
-                            Expression.Constant(NumberStyles.Any),
-                            Expression.Constant(CultureInfo.InvariantCulture, typeof(IFormatProvider)),
-                            parsedVariable),
-                        typeof(TNumber).IsNullableType()
-                            ? (Expression)Expression.Convert(parsedVariable, typeof(TNumber))
-                            : parsedVariable,
-                        Expression.Constant(default(TNumber), typeof(TNumber)))),
-                param);
-        }
-
-        private static Expression<Func<TNumber, string>> ToStringExpression()
-        {
-            var type = typeof(TNumber).UnwrapNullableType();
-
-            CheckTypeSupported(
-                type,
-                typeof(StringToNumberConverter<TNumber>),
-                typeof(int), typeof(long), typeof(short), typeof(byte),
-                typeof(uint), typeof(ulong), typeof(ushort), typeof(sbyte),
-                typeof(decimal), typeof(float), typeof(double));
-
-            return v => v == null
-                ? null
-                : string.Format(
-                    CultureInfo.InvariantCulture,
-                    type == typeof(float) || type == typeof(double) ? "{0:R}" : "{0}",
-                    v);
-        }
     }
 }

--- a/src/EFCore/Storage/ValueConversion/StringToNumberConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToNumberConverter.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
+{
+    /// <summary>
+    ///     Converts strings to and from numeric values.
+    /// </summary>
+    public class StringToNumberConverter<TNumber> : ValueConverter<string, TNumber>
+    {
+        // ReSharper disable once StaticMemberInGenericType
+        private static readonly ConverterMappingHints _defaultHints
+            = new ConverterMappingHints(size: 64);
+
+        /// <summary>
+        ///     Creates a new instance of this converter.
+        /// </summary>
+        /// <param name="mappingHints">
+        ///     Hints that can be used by the <see cref="ITypeMappingSource"/> to create data types with appropriate
+        ///     facets for the converted data.
+        /// </param>
+        public StringToNumberConverter(
+            [CanBeNull] ConverterMappingHints mappingHints = null)
+            : base(
+                  ToIntegerExpression(),
+                  ToStringExpression(),
+                  _defaultHints.With(mappingHints))
+        {
+        }
+
+        /// <summary>
+        ///     A <see cref="ValueConverterInfo" /> for the default use of this converter.
+        /// </summary>
+        public static ValueConverterInfo DefaultInfo { get; }
+            = new ValueConverterInfo(typeof(string), typeof(TNumber), i => new StringToNumberConverter<TNumber>(i.MappingHints), _defaultHints);
+
+        private static Expression<Func<string, TNumber>> ToIntegerExpression()
+        {
+            var type = typeof(TNumber).UnwrapNullableType();
+
+            var tryParseMethod = type.GetMethod(
+                nameof(int.TryParse),
+                new[] { typeof(string), typeof(NumberStyles), typeof(IFormatProvider), type.MakeByRefType() });
+
+            var parsedVariable = Expression.Variable(type, "parsed");
+            var param = Expression.Parameter(typeof(string), "v");
+
+            return Expression.Lambda<Func<string, TNumber>>(
+                Expression.Block(
+                    typeof(TNumber),
+                    new[] { parsedVariable },
+                    Expression.Condition(
+                        Expression.Call(
+                            tryParseMethod,
+                            param,
+                            Expression.Constant(NumberStyles.Any),
+                            Expression.Constant(CultureInfo.InvariantCulture, typeof(IFormatProvider)),
+                            parsedVariable),
+                        typeof(TNumber).IsNullableType()
+                            ? (Expression)Expression.Convert(parsedVariable, typeof(TNumber))
+                            : parsedVariable,
+                        Expression.Constant(default(TNumber), typeof(TNumber)))),
+                param);
+        }
+
+        private static Expression<Func<TNumber, string>> ToStringExpression()
+        {
+            var type = typeof(TNumber).UnwrapNullableType();
+
+            CheckTypeSupported(
+                type,
+                typeof(StringToNumberConverter<TNumber>),
+                typeof(int), typeof(long), typeof(short), typeof(byte),
+                typeof(uint), typeof(ulong), typeof(ushort), typeof(sbyte),
+                typeof(decimal), typeof(float), typeof(double));
+
+            return v => v == null
+                ? null
+                : string.Format(
+                    CultureInfo.InvariantCulture,
+                    type == typeof(float) || type == typeof(double) ? "{0:R}" : "{0}",
+                    v);
+        }
+    }
+}

--- a/src/EFCore/Storage/ValueConversion/StringToTimeSpanConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToTimeSpanConverter.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
+{
+    /// <summary>
+    ///     Converts strings to and from <see cref="TimeSpan" /> values.
+    /// </summary>
+    public class StringToTimeSpanConverter : ValueConverter<string, TimeSpan>
+    {
+        private static readonly ConverterMappingHints _defaultHints
+            = new ConverterMappingHints(size: 48);
+
+        /// <summary>
+        ///     Creates a new instance of this converter.
+        /// </summary>
+        /// <param name="mappingHints">
+        ///     Hints that can be used by the <see cref="ITypeMappingSource"/> to create data types with appropriate
+        ///     facets for the converted data.
+        /// </param>
+        public StringToTimeSpanConverter([CanBeNull] ConverterMappingHints mappingHints = null)
+            : base(
+                v => v == null ? default : TimeSpan.Parse(v, CultureInfo.InvariantCulture),
+                v => v.ToString("c"),
+                _defaultHints.With(mappingHints))
+        {
+        }
+
+        /// <summary>
+        ///     A <see cref="ValueConverterInfo" /> for the default use of this converter.
+        /// </summary>
+        public static ValueConverterInfo DefaultInfo { get; }
+            = new ValueConverterInfo(typeof(string), typeof(TimeSpan), i => new StringToTimeSpanConverter(i.MappingHints), _defaultHints);
+    }
+}

--- a/src/EFCore/Storage/ValueConversion/StringToTimeSpanConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/StringToTimeSpanConverter.cs
@@ -2,19 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
     ///     Converts strings to and from <see cref="TimeSpan" /> values.
     /// </summary>
-    public class StringToTimeSpanConverter : ValueConverter<string, TimeSpan>
+    public class StringToTimeSpanConverter : StringTimeSpanConverter<string, TimeSpan>
     {
-        private static readonly ConverterMappingHints _defaultHints
-            = new ConverterMappingHints(size: 48);
-
         /// <summary>
         ///     Creates a new instance of this converter.
         /// </summary>
@@ -24,8 +21,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// </param>
         public StringToTimeSpanConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
-                v => v == null ? default : TimeSpan.Parse(v, CultureInfo.InvariantCulture),
-                v => v.ToString("c"),
+                ToTimeSpan(),
+                ToString(),
                 _defaultHints.With(mappingHints))
         {
         }

--- a/src/EFCore/Storage/ValueConversion/TimeSpanToStringConverter.cs
+++ b/src/EFCore/Storage/ValueConversion/TimeSpanToStringConverter.cs
@@ -2,19 +2,16 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Globalization;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
 {
     /// <summary>
     ///     Converts <see cref="TimeSpan" /> to and from strings.
     /// </summary>
-    public class TimeSpanToStringConverter : ValueConverter<TimeSpan, string>
+    public class TimeSpanToStringConverter : StringTimeSpanConverter<TimeSpan, string>
     {
-        private static readonly ConverterMappingHints _defaultHints
-            = new ConverterMappingHints(size: 48);
-
         /// <summary>
         ///     Creates a new instance of this converter.
         /// </summary>
@@ -24,8 +21,8 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
         /// </param>
         public TimeSpanToStringConverter([CanBeNull] ConverterMappingHints mappingHints = null)
             : base(
-                v => v.ToString("c"),
-                v => v == null ? default : TimeSpan.Parse(v, CultureInfo.InvariantCulture),
+                ToString(),
+                ToTimeSpan(),
                 _defaultHints.With(mappingHints))
         {
         }

--- a/src/EFCore/Storage/ValueConversion/ValueConverterSelector.cs
+++ b/src/EFCore/Storage/ValueConversion/ValueConverterSelector.cs
@@ -152,6 +152,76 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
             else if (underlyingModelType == typeof(string))
             {
                 if (underlyingProviderType == null
+                    || underlyingProviderType.IsEnum)
+                {
+                    yield return _converters.GetOrAdd(
+                        (typeof(string), underlyingProviderType),
+                        k => (ValueConverterInfo)typeof(StringToEnumConverter<>)
+                            .MakeGenericType(k.ProviderClrType)
+                            .GetAnyProperty("DefaultInfo")
+                            .GetValue(null));
+                }
+
+                if (underlyingProviderType == null
+                    || _numerics.Contains(underlyingProviderType))
+                {
+                    yield return _converters.GetOrAdd(
+                        (typeof(string), underlyingProviderType),
+                        k => (ValueConverterInfo)typeof(StringToNumberConverter<>)
+                            .MakeGenericType(k.ProviderClrType)
+                            .GetAnyProperty("DefaultInfo")
+                            .GetValue(null));
+                }
+
+                if (underlyingProviderType == null
+                    || underlyingProviderType == typeof(DateTime))
+                {
+                    yield return _converters.GetOrAdd(
+                        (underlyingModelType, typeof(DateTime)),
+                        k => StringToDateTimeConverter.DefaultInfo);
+                }
+
+                if (underlyingProviderType == null
+                    || underlyingProviderType == typeof(DateTimeOffset))
+                {
+                    yield return _converters.GetOrAdd(
+                        (underlyingModelType, typeof(DateTimeOffset)),
+                        k => StringToDateTimeOffsetConverter.DefaultInfo);
+                }
+
+                if (underlyingProviderType == null
+                    || underlyingProviderType == typeof(TimeSpan))
+                {
+                    yield return _converters.GetOrAdd(
+                        (underlyingModelType, typeof(TimeSpan)),
+                        k => StringToTimeSpanConverter.DefaultInfo);
+                }
+
+                if (underlyingProviderType == null
+                    || underlyingProviderType == typeof(Guid))
+                {
+                    yield return _converters.GetOrAdd(
+                        (underlyingModelType, typeof(Guid)),
+                        k => StringToGuidConverter.DefaultInfo);
+                }
+
+                if (underlyingProviderType == null
+                    || underlyingProviderType == typeof(bool))
+                {
+                    yield return _converters.GetOrAdd(
+                        (underlyingModelType, typeof(bool)),
+                        k => StringToBoolConverter.DefaultInfo);
+                }
+
+                if (underlyingProviderType == null
+                    || underlyingProviderType == typeof(char))
+                {
+                    yield return _converters.GetOrAdd(
+                        (underlyingModelType, typeof(char)),
+                        k => StringToCharConverter.DefaultInfo);
+                }
+
+                if (underlyingProviderType == null
                     || underlyingProviderType == typeof(byte[]))
                 {
                     yield return _converters.GetOrAdd(

--- a/src/EFCore/Storage/ValueConversion/ValueConverterSelector.cs
+++ b/src/EFCore/Storage/ValueConversion/ValueConverterSelector.cs
@@ -151,7 +151,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
             }
             else if (underlyingModelType == typeof(string))
             {
-                if (underlyingProviderType?.IsEnum == true)
+                if (underlyingProviderType == null
+                    || underlyingProviderType == typeof(byte[]))
+                {
+                    yield return _converters.GetOrAdd(
+                        (underlyingModelType, typeof(byte[])),
+                        k => StringToBytesConverter.DefaultInfo);
+                }
+                else if (underlyingProviderType.IsEnum)
                 {
                     yield return _converters.GetOrAdd(
                         (typeof(string), underlyingProviderType),
@@ -160,9 +167,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
                             .GetAnyProperty("DefaultInfo")
                             .GetValue(null));
                 }
-
-                if (underlyingProviderType == null
-                    || _numerics.Contains(underlyingProviderType))
+                else if (_numerics.Contains(underlyingProviderType))
                 {
                     foreach (var converterInfo in FindNumericConvertions(
                         typeof(string),
@@ -173,61 +178,41 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
                         yield return converterInfo;
                     }
                 }
-
-                if (underlyingProviderType == null
-                    || underlyingProviderType == typeof(DateTime))
+                else if (underlyingProviderType == typeof(DateTime))
                 {
                     yield return _converters.GetOrAdd(
                         (underlyingModelType, typeof(DateTime)),
                         k => StringToDateTimeConverter.DefaultInfo);
                 }
-
-                if (underlyingProviderType == null
-                    || underlyingProviderType == typeof(DateTimeOffset))
+                else if (underlyingProviderType == typeof(DateTimeOffset))
                 {
                     yield return _converters.GetOrAdd(
                         (underlyingModelType, typeof(DateTimeOffset)),
                         k => StringToDateTimeOffsetConverter.DefaultInfo);
                 }
-
-                if (underlyingProviderType == null
-                    || underlyingProviderType == typeof(TimeSpan))
+                else if (underlyingProviderType == typeof(TimeSpan))
                 {
                     yield return _converters.GetOrAdd(
                         (underlyingModelType, typeof(TimeSpan)),
                         k => StringToTimeSpanConverter.DefaultInfo);
                 }
-
-                if (underlyingProviderType == null
-                    || underlyingProviderType == typeof(Guid))
+                else if (underlyingProviderType == typeof(Guid))
                 {
                     yield return _converters.GetOrAdd(
                         (underlyingModelType, typeof(Guid)),
                         k => StringToGuidConverter.DefaultInfo);
                 }
-
-                if (underlyingProviderType == null
-                    || underlyingProviderType == typeof(bool))
+                else if (underlyingProviderType == typeof(bool))
                 {
                     yield return _converters.GetOrAdd(
                         (underlyingModelType, typeof(bool)),
                         k => StringToBoolConverter.DefaultInfo);
                 }
-
-                if (underlyingProviderType == null
-                    || underlyingProviderType == typeof(char))
+                else if (underlyingProviderType == typeof(char))
                 {
                     yield return _converters.GetOrAdd(
                         (underlyingModelType, typeof(char)),
                         k => StringToCharConverter.DefaultInfo);
-                }
-
-                if (underlyingProviderType == null
-                    || underlyingProviderType == typeof(byte[]))
-                {
-                    yield return _converters.GetOrAdd(
-                        (underlyingModelType, typeof(byte[])),
-                        k => StringToBytesConverter.DefaultInfo);
                 }
             }
             else if (underlyingModelType == typeof(DateTime)

--- a/src/EFCore/Storage/ValueConversion/ValueConverterSelector.cs
+++ b/src/EFCore/Storage/ValueConversion/ValueConverterSelector.cs
@@ -151,8 +151,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
             }
             else if (underlyingModelType == typeof(string))
             {
-                if (underlyingProviderType == null
-                    || underlyingProviderType.IsEnum)
+                if (underlyingProviderType?.IsEnum == true)
                 {
                     yield return _converters.GetOrAdd(
                         (typeof(string), underlyingProviderType),
@@ -165,12 +164,14 @@ namespace Microsoft.EntityFrameworkCore.Storage.ValueConversion
                 if (underlyingProviderType == null
                     || _numerics.Contains(underlyingProviderType))
                 {
-                    yield return _converters.GetOrAdd(
-                        (typeof(string), underlyingProviderType),
-                        k => (ValueConverterInfo)typeof(StringToNumberConverter<>)
-                            .MakeGenericType(k.ProviderClrType)
-                            .GetAnyProperty("DefaultInfo")
-                            .GetValue(null));
+                    foreach (var converterInfo in FindNumericConvertions(
+                        typeof(string),
+                        underlyingProviderType,
+                        typeof(StringToNumberConverter<>),
+                        null))
+                    {
+                        yield return converterInfo;
+                    }
                 }
 
                 if (underlyingProviderType == null

--- a/test/EFCore.Tests/Storage/NumberToStringConverterTest.cs
+++ b/test/EFCore.Tests/Storage/NumberToStringConverterTest.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Storage
@@ -576,7 +577,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             Assert.Equal(
                 CoreStrings.ConverterBadType(
-                    typeof(NumberToStringConverter<Guid>).ShortDisplayName(),
+                    typeof(StringNumberConverter<Guid, string, Guid>).ShortDisplayName(),
                     "Guid",
                     "int, long, short, byte, uint, ulong, ushort, sbyte, decimal, float, double"),
                 Assert.Throws<InvalidOperationException>(

--- a/test/EFCore.Tests/Storage/StringToBoolConverterTest.cs
+++ b/test/EFCore.Tests/Storage/StringToBoolConverterTest.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    public class StringToBoolConverterTest
+    {
+        private static readonly StringToBoolConverter _stringToBool
+            = new StringToBoolConverter();
+
+        [Fact]
+        public void Can_convert_strings_to_bools()
+        {
+            var converter = _stringToBool.ConvertToProviderExpression.Compile();
+
+            Assert.False(converter("False"));
+            Assert.True(converter("True"));
+            Assert.False(converter("false"));
+            Assert.True(converter("true"));
+            Assert.False(converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_bools_to_strings()
+        {
+            var converter = _stringToBool.ConvertFromProviderExpression.Compile();
+
+            Assert.Equal("True", converter(true));
+            Assert.Equal("False", converter(false));
+        }
+    }
+}

--- a/test/EFCore.Tests/Storage/StringToCharConverterTest.cs
+++ b/test/EFCore.Tests/Storage/StringToCharConverterTest.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    public class StringToCharConverterTest
+    {
+        private static readonly StringToCharConverter _stringToChar
+            = new StringToCharConverter();
+
+        [Fact]
+        public void Can_convert_strings_to_chars()
+        {
+            var converter = _stringToChar.ConvertToProviderExpression.Compile();
+
+            Assert.Equal('A', converter("A"));
+            Assert.Equal('z', converter("z"));
+            Assert.Equal('F', converter("Funkadelic"));
+            Assert.Equal('\0', converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_strings_to_chars_object()
+        {
+            var converter = _stringToChar.ConvertToProvider;
+
+            Assert.Equal('A', converter("A"));
+            Assert.Equal('z', converter("z"));
+            Assert.Equal('F', converter("Funkadelic"));
+            Assert.Null(converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_chars_to_strings()
+        {
+            var converter = _stringToChar.ConvertFromProviderExpression.Compile();
+
+            Assert.Equal("A", converter('A'));
+            Assert.Equal("!", converter('!'));
+        }
+
+        [Fact]
+        public void Can_convert_chars_to_strings_object()
+        {
+            var converter = _stringToChar.ConvertFromProvider;
+
+            Assert.Equal("A", converter('A'));
+            Assert.Equal("!", converter('!'));
+            Assert.Equal("A", converter((char?)'A'));
+            Assert.Equal("!", converter((char?)'!'));
+            Assert.Null(converter(null));
+        }
+    }
+}

--- a/test/EFCore.Tests/Storage/StringToDateTimeConverterTest.cs
+++ b/test/EFCore.Tests/Storage/StringToDateTimeConverterTest.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    public class StringToDateTimeConverterTest
+    {
+        private static readonly StringToDateTimeConverter _stringToDateTime
+            = new StringToDateTimeConverter();
+
+        [Fact]
+        public void Can_convert_string_to_DateTime()
+        {
+            var converter = _stringToDateTime.ConvertToProviderExpression.Compile();
+
+            Assert.Equal(new DateTime(1973, 9, 3, 0, 10, 15), converter("1973-09-03 00:10:15"));
+            Assert.Equal(new DateTime(1973, 9, 3, 0, 10, 15), converter("1973-09-03 00:10:15"));
+            // Kind is not preserved
+            Assert.NotEqual(DateTimeKind.Utc, converter("1973-09-03 00:10:15").Kind);
+            Assert.Equal(new DateTime(), converter("0001-01-01 00:00:00"));
+        }
+
+        [Fact]
+        public void Can_convert_DateTime_to_string()
+        {
+            var converter = _stringToDateTime.ConvertFromProviderExpression.Compile();
+
+            Assert.Equal("1973-09-03 00:10:15", converter(new DateTime(1973, 9, 3, 0, 10, 15, DateTimeKind.Utc)));
+            Assert.Equal("1973-09-03 00:10:15", converter(new DateTime(1973, 9, 3, 0, 10, 15)));
+            Assert.Equal("0001-01-01 00:00:00", converter(new DateTime()));
+        }
+    }
+}

--- a/test/EFCore.Tests/Storage/StringToDateTimeOffsetConverterTest.cs
+++ b/test/EFCore.Tests/Storage/StringToDateTimeOffsetConverterTest.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    public class StringToDateTimeOffsetConverterTest
+    {
+        private static readonly StringToDateTimeOffsetConverter _stringToDateTimeOffset
+            = new StringToDateTimeOffsetConverter();
+
+        [Fact]
+        public void Can_convert_string_to_DateTimeOffset()
+        {
+            var converter = _stringToDateTimeOffset.ConvertToProviderExpression.Compile();
+
+            Assert.Equal(
+                new DateTimeOffset(1973, 9, 3, 0, 10, 15, new TimeSpan(7, 30, 0)),
+                converter("1973-09-03 00:10:15+07:30"));
+
+            Assert.Equal(
+                new DateTimeOffset(), converter("0001-01-01 00:00:00+00:00"));
+        }
+
+        [Fact]
+        public void Can_convert_DateTimeOffset_to_string()
+        {
+            var converter = _stringToDateTimeOffset.ConvertFromProviderExpression.Compile();
+
+            Assert.Equal(
+                "1973-09-03 00:10:15+07:30",
+                converter(new DateTimeOffset(1973, 9, 3, 0, 10, 15, new TimeSpan(7, 30, 0))));
+
+            Assert.Equal(
+                "0001-01-01 00:00:00+00:00",
+                converter(new DateTimeOffset()));
+        }
+    }
+}

--- a/test/EFCore.Tests/Storage/StringToEnumConverterTest.cs
+++ b/test/EFCore.Tests/Storage/StringToEnumConverterTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -9,42 +9,15 @@ using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Storage
 {
-    public class EnumToStringConverterTest
+    public class StringToEnumConverterTest
     {
-        private static readonly ValueConverter<Beatles, string> _enumToString
-            = new EnumToStringConverter<Beatles>();
-
-        [Fact]
-        public void Can_convert_enums_to_strings()
-        {
-            var converter = _enumToString.ConvertToProviderExpression.Compile();
-
-            Assert.Equal("John", converter(Beatles.John));
-            Assert.Equal("Paul", converter(Beatles.Paul));
-            Assert.Equal("George", converter(Beatles.George));
-            Assert.Equal("Ringo", converter(Beatles.Ringo));
-            Assert.Equal("77", converter((Beatles)77));
-            Assert.Equal("0", converter(default));
-        }
-
-        [Fact]
-        public void Can_convert_enums_to_strings_object()
-        {
-            var converter = _enumToString.ConvertToProvider;
-
-            Assert.Equal("John", converter(Beatles.John));
-            Assert.Equal("Paul", converter(Beatles.Paul));
-            Assert.Equal("George", converter(Beatles.George));
-            Assert.Equal("Ringo", converter(Beatles.Ringo));
-            Assert.Equal("77", converter((Beatles)77));
-            Assert.Equal("0", converter(default(Beatles)));
-            Assert.Null(converter(null));
-        }
+        private static readonly ValueConverter<string, Beatles> _stringToEnum
+            = new StringToEnumConverter<Beatles>();
 
         [Fact]
         public void Can_convert_strings_to_enums()
         {
-            var converter = _enumToString.ConvertFromProviderExpression.Compile();
+            var converter = _stringToEnum.ConvertToProviderExpression.Compile();
 
             Assert.Equal(Beatles.John, converter("John"));
             Assert.Equal(Beatles.Paul, converter("Paul"));
@@ -61,7 +34,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
         [Fact]
         public void Can_convert_strings_to_enums_object()
         {
-            var converter = _enumToString.ConvertFromProvider;
+            var converter = _stringToEnum.ConvertToProvider;
 
             Assert.Equal(Beatles.John, converter("John"));
             Assert.Equal(Beatles.Paul, converter("Paul"));
@@ -76,15 +49,42 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         [Fact]
-        public void Enum_to_string_converter_throws_for_bad_types()
+        public void Can_convert_enums_to_strings()
+        {
+            var converter = _stringToEnum.ConvertFromProviderExpression.Compile();
+
+            Assert.Equal("John", converter(Beatles.John));
+            Assert.Equal("Paul", converter(Beatles.Paul));
+            Assert.Equal("George", converter(Beatles.George));
+            Assert.Equal("Ringo", converter(Beatles.Ringo));
+            Assert.Equal("77", converter((Beatles)77));
+            Assert.Equal("0", converter(default));
+        }
+
+        [Fact]
+        public void Can_convert_enums_to_strings_object()
+        {
+            var converter = _stringToEnum.ConvertFromProvider;
+
+            Assert.Equal("John", converter(Beatles.John));
+            Assert.Equal("Paul", converter(Beatles.Paul));
+            Assert.Equal("George", converter(Beatles.George));
+            Assert.Equal("Ringo", converter(Beatles.Ringo));
+            Assert.Equal("77", converter((Beatles)77));
+            Assert.Equal("0", converter(default(Beatles)));
+            Assert.Null(converter(null));
+        }
+
+        [Fact]
+        public void String_to_enum_converter_throws_for_bad_types()
         {
             Assert.Equal(
                 CoreStrings.ConverterBadType(
-                    typeof(StringEnumConverter<Guid, string, Guid>).ShortDisplayName(),
+                    typeof(StringEnumConverter<string, Guid, Guid>).ShortDisplayName(),
                     "Guid",
                     "enum types"),
                 Assert.Throws<InvalidOperationException>(
-                    () => new EnumToStringConverter<Guid>()).Message);
+                    () => new StringToEnumConverter<Guid>()).Message);
         }
 
         private enum Beatles

--- a/test/EFCore.Tests/Storage/StringToGuidConverterTest.cs
+++ b/test/EFCore.Tests/Storage/StringToGuidConverterTest.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    public class StringToGuidConverterTest
+    {
+        private static readonly StringToGuidConverter _stringToGuid
+            = new StringToGuidConverter();
+
+        [Fact]
+        public void Can_convert_String_to_GUIDs()
+        {
+            var converter = _stringToGuid.ConvertToProviderExpression.Compile();
+
+            Assert.Equal(
+                new Guid("96EE27B4-868B-4049-BA67-CBB83CE5B462"),
+                converter("96EE27B4-868B-4049-BA67-CBB83CE5B462"));
+
+            Assert.Equal(
+                Guid.Empty,
+                converter("00000000-0000-0000-0000-000000000000"));
+
+            Assert.Equal(Guid.Empty, converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_GUIDs_to_String()
+        {
+            var converter = _stringToGuid.ConvertFromProviderExpression.Compile();
+
+            Assert.Equal(
+                "96ee27b4-868b-4049-ba67-cbb83ce5b462",
+                converter(new Guid("96EE27B4-868B-4049-BA67-CBB83CE5B462")));
+
+            Assert.Equal(
+                "00000000-0000-0000-0000-000000000000",
+                converter(Guid.Empty));
+        }
+    }
+}

--- a/test/EFCore.Tests/Storage/StringToNumberConverterTest.cs
+++ b/test/EFCore.Tests/Storage/StringToNumberConverterTest.cs
@@ -1,0 +1,587 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion.Internal;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    public class StringToNumberConverterTest
+    {
+        private static readonly StringToNumberConverter<ulong> _naturalStringToUlong
+            = new StringToNumberConverter<ulong>();
+
+        [Fact]
+        public void Can_convert_natural_strings_to_ulongs()
+        {
+            var converter = _naturalStringToUlong.ConvertToProviderExpression.Compile();
+
+            Assert.Equal(ulong.MaxValue, converter("18446744073709551615"));
+            Assert.Equal((ulong)77, converter("77"));
+            Assert.Equal((ulong)0, converter("-1"));
+            Assert.Equal((ulong)0, converter("0"));
+            Assert.Equal((ulong)0, converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_natural_strings_to_ulongs_object()
+        {
+            var converter = _naturalStringToUlong.ConvertToProvider;
+
+            Assert.Equal(ulong.MaxValue, converter("18446744073709551615"));
+            Assert.Equal((ulong)77, converter("77"));
+            Assert.Equal((ulong)0, converter("-1"));
+            Assert.Equal((ulong)0, converter("0"));
+            Assert.Null(converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_ulongs_to_natural_strings()
+        {
+            var converter = _naturalStringToUlong.ConvertFromProviderExpression.Compile();
+
+            Assert.Equal("18446744073709551615", converter(ulong.MaxValue));
+            Assert.Equal("77", converter(77));
+            Assert.Equal("0", converter(0));
+        }
+
+        [Fact]
+        public void Can_convert_ulongs_to_natural_strings_object()
+        {
+            var converter = _naturalStringToUlong.ConvertFromProvider;
+
+            Assert.Equal("18446744073709551615", converter(ulong.MaxValue));
+            Assert.Equal("77", converter(77));
+            Assert.Equal("77", converter((ulong?)77));
+            Assert.Equal("0", converter((ulong)0));
+            Assert.Null(converter(null));
+        }
+
+        private static readonly StringToNumberConverter<long> _naturalStringToLong
+            = new StringToNumberConverter<long>();
+
+        [Fact]
+        public void Can_convert_natural_strings_to_longs()
+        {
+            var converter = _naturalStringToLong.ConvertToProviderExpression.Compile();
+
+            Assert.Equal(long.MaxValue, converter("9223372036854775807"));
+            Assert.Equal(long.MinValue, converter("-9223372036854775808"));
+            Assert.Equal(77, converter("77"));
+            Assert.Equal(-77, converter("-77"));
+            Assert.Equal(0, converter("0"));
+            Assert.Equal(0, converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_natural_strings_to_longs_object()
+        {
+            var converter = _naturalStringToLong.ConvertToProvider;
+
+            Assert.Equal(long.MaxValue, converter("9223372036854775807"));
+            Assert.Equal(long.MinValue, converter("-9223372036854775808"));
+            Assert.Equal((long)77, converter("77"));
+            Assert.Equal((long)-77, converter("-77"));
+            Assert.Equal((long)0, converter("0"));
+            Assert.Null(converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_longs_to_natural_strings()
+        {
+            var converter = _naturalStringToLong.ConvertFromProviderExpression.Compile();
+
+            Assert.Equal("9223372036854775807", converter(long.MaxValue));
+            Assert.Equal("-9223372036854775808", converter(long.MinValue));
+            Assert.Equal("77", converter(77));
+            Assert.Equal("-77", converter(-77));
+            Assert.Equal("0", converter(0));
+        }
+
+        [Fact]
+        public void Can_convert_longs_to_natural_strings_object()
+        {
+            var converter = _naturalStringToLong.ConvertFromProvider;
+
+            Assert.Equal("9223372036854775807", converter(long.MaxValue));
+            Assert.Equal("-9223372036854775808", converter(long.MinValue));
+            Assert.Equal("77", converter(77));
+            Assert.Equal("-77", converter(-77));
+            Assert.Equal("77", converter((long?)77));
+            Assert.Equal("0", converter((long)0));
+            Assert.Null(converter(null));
+        }
+
+        private static readonly StringToNumberConverter<uint> _naturalStringToUint
+            = new StringToNumberConverter<uint>();
+
+        [Fact]
+        public void Can_convert_natural_strings_to_uints()
+        {
+            var converter = _naturalStringToUint.ConvertToProviderExpression.Compile();
+
+            Assert.Equal(uint.MaxValue, converter("4294967295"));
+            Assert.Equal((uint)77, converter("77"));
+            Assert.Equal((uint)0, converter("-1"));
+            Assert.Equal((uint)0, converter("0"));
+            Assert.Equal((uint)0, converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_natural_strings_to_uints_object()
+        {
+            var converter = _naturalStringToUint.ConvertToProvider;
+
+            Assert.Equal(uint.MaxValue, converter("4294967295"));
+            Assert.Equal((uint)77, converter("77"));
+            Assert.Equal((uint)0, converter("-1"));
+            Assert.Equal((uint)0, converter("0"));
+            Assert.Null(converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_uints_to_natural_strings()
+        {
+            var converter = _naturalStringToUint.ConvertFromProviderExpression.Compile();
+
+            Assert.Equal("4294967295", converter(uint.MaxValue));
+            Assert.Equal("77", converter(77));
+            Assert.Equal("0", converter(0));
+        }
+
+        [Fact]
+        public void Can_convert_uints_to_natural_strings_object()
+        {
+            var converter = _naturalStringToUint.ConvertFromProvider;
+
+            Assert.Equal("4294967295", converter(uint.MaxValue));
+            Assert.Equal("77", converter(77));
+            Assert.Equal("77", converter((uint?)77));
+            Assert.Equal("0", converter((uint)0));
+            Assert.Null(converter(null));
+        }
+
+        private static readonly StringToNumberConverter<int> _naturalStringToInt
+            = new StringToNumberConverter<int>();
+
+        [Fact]
+        public void Can_convert_natural_strings_to_ints()
+        {
+            var converter = _naturalStringToInt.ConvertToProviderExpression.Compile();
+
+            Assert.Equal(int.MaxValue, converter("2147483647"));
+            Assert.Equal(int.MinValue, converter("-2147483648"));
+            Assert.Equal(77, converter("77"));
+            Assert.Equal(-77, converter("-77"));
+            Assert.Equal(0, converter("0"));
+            Assert.Equal(0, converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_natural_strings_to_ints_object()
+        {
+            var converter = _naturalStringToInt.ConvertToProvider;
+
+            Assert.Equal(int.MaxValue, converter("2147483647"));
+            Assert.Equal(int.MinValue, converter("-2147483648"));
+            Assert.Equal(77, converter("77"));
+            Assert.Equal(-77, converter("-77"));
+            Assert.Equal(0, converter("0"));
+            Assert.Null(converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_ints_to_natural_strings()
+        {
+            var converter = _naturalStringToInt.ConvertFromProviderExpression.Compile();
+
+            Assert.Equal("2147483647", converter(int.MaxValue));
+            Assert.Equal("-2147483648", converter(int.MinValue));
+            Assert.Equal("77", converter(77));
+            Assert.Equal("-77", converter(-77));
+            Assert.Equal("0", converter(0));
+        }
+
+        [Fact]
+        public void Can_convert_ints_to_natural_strings_object()
+        {
+            var converter = _naturalStringToInt.ConvertFromProvider;
+
+            Assert.Equal("2147483647", converter(int.MaxValue));
+            Assert.Equal("-2147483648", converter(int.MinValue));
+            Assert.Equal("77", converter(77));
+            Assert.Equal("-77", converter(-77));
+            Assert.Equal("77", converter((int?)77));
+            Assert.Equal("0", converter((int?)0));
+            Assert.Null(converter(null));
+        }
+
+        private static readonly StringToNumberConverter<ushort> _naturalStringToUshort
+            = new StringToNumberConverter<ushort>();
+
+        [Fact]
+        public void Can_convert_natural_strings_to_ushorts()
+        {
+            var converter = _naturalStringToUshort.ConvertToProviderExpression.Compile();
+
+            Assert.Equal(ushort.MaxValue, converter("65535"));
+            Assert.Equal((ushort)77, converter("77"));
+            Assert.Equal((ushort)0, converter("-1"));
+            Assert.Equal((ushort)0, converter("0"));
+            Assert.Equal((ushort)0, converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_natural_strings_to_ushorts_object()
+        {
+            var converter = _naturalStringToUshort.ConvertToProvider;
+
+            Assert.Equal(ushort.MaxValue, converter("65535"));
+            Assert.Equal((ushort)77, converter("77"));
+            Assert.Equal((ushort)0, converter("-1"));
+            Assert.Equal((ushort)0, converter("0"));
+            Assert.Null(converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_ushorts_to_natural_strings()
+        {
+            var converter = _naturalStringToUshort.ConvertFromProviderExpression.Compile();
+
+            Assert.Equal("65535", converter(ushort.MaxValue));
+            Assert.Equal("77", converter(77));
+            Assert.Equal("0", converter(0));
+        }
+
+        [Fact]
+        public void Can_convert_ushorts_to_natural_strings_object()
+        {
+            var converter = _naturalStringToUshort.ConvertFromProvider;
+
+            Assert.Equal("65535", converter(ushort.MaxValue));
+            Assert.Equal("77", converter(77));
+            Assert.Equal("77", converter((ushort?)77));
+            Assert.Equal("0", converter((ushort)0));
+            Assert.Null(converter(null));
+        }
+
+        private static readonly StringToNumberConverter<short> _naturalStringToShort
+            = new StringToNumberConverter<short>();
+
+        [Fact]
+        public void Can_convert_natural_strings_to_shorts()
+        {
+            var converter = _naturalStringToShort.ConvertToProviderExpression.Compile();
+
+            Assert.Equal(short.MaxValue, converter("32767"));
+            Assert.Equal(short.MinValue, converter("-32768"));
+            Assert.Equal(77, converter("77"));
+            Assert.Equal(-77, converter("-77"));
+            Assert.Equal(0, converter("0"));
+            Assert.Equal(0, converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_natural_strings_to_shorts_object()
+        {
+            var converter = _naturalStringToShort.ConvertToProvider;
+
+            Assert.Equal(short.MaxValue, converter("32767"));
+            Assert.Equal(short.MinValue, converter("-32768"));
+            Assert.Equal((short)77, converter("77"));
+            Assert.Equal((short)-77, converter("-77"));
+            Assert.Equal((short)0, converter("0"));
+            Assert.Null(converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_shorts_to_natural_strings()
+        {
+            var converter = _naturalStringToShort.ConvertFromProviderExpression.Compile();
+
+            Assert.Equal("32767", converter(short.MaxValue));
+            Assert.Equal("-32768", converter(short.MinValue));
+            Assert.Equal("77", converter(77));
+            Assert.Equal("-77", converter(-77));
+            Assert.Equal("0", converter(0));
+        }
+
+        [Fact]
+        public void Can_convert_shorts_to_natural_strings_object()
+        {
+            var converter = _naturalStringToShort.ConvertFromProvider;
+
+            Assert.Equal("32767", converter(short.MaxValue));
+            Assert.Equal("-32768", converter(short.MinValue));
+            Assert.Equal("77", converter(77));
+            Assert.Equal("-77", converter(-77));
+            Assert.Equal("77", converter((short?)77));
+            Assert.Equal("0", converter((short)0));
+            Assert.Null(converter(null));
+        }
+
+        private static readonly StringToNumberConverter<byte> _naturalStringToByte
+            = new StringToNumberConverter<byte>();
+
+        [Fact]
+        public void Can_convert_natural_strings_to_bytes()
+        {
+            var converter = _naturalStringToByte.ConvertToProviderExpression.Compile();
+
+            Assert.Equal(byte.MaxValue, converter("255"));
+            Assert.Equal((byte)77, converter("77"));
+            Assert.Equal((byte)0, converter("-1"));
+            Assert.Equal((byte)0, converter("0"));
+            Assert.Equal((byte)0, converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_natural_strings_to_bytes_object()
+        {
+            var converter = _naturalStringToByte.ConvertToProvider;
+
+            Assert.Equal(byte.MaxValue, converter("255"));
+            Assert.Equal((byte)77, converter("77"));
+            Assert.Equal((byte)0, converter("-1"));
+            Assert.Equal((byte)0, converter("0"));
+            Assert.Null(converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_bytes_to_natural_strings()
+        {
+            var converter = _naturalStringToByte.ConvertFromProviderExpression.Compile();
+
+            Assert.Equal("255", converter(byte.MaxValue));
+            Assert.Equal("77", converter(77));
+            Assert.Equal("0", converter(0));
+        }
+
+        [Fact]
+        public void Can_convert_bytes_to_natural_strings_object()
+        {
+            var converter = _naturalStringToByte.ConvertFromProvider;
+
+            Assert.Equal("255", converter(byte.MaxValue));
+            Assert.Equal("77", converter(77));
+            Assert.Equal("77", converter((byte?)77));
+            Assert.Equal("0", converter((byte)0));
+            Assert.Null(converter(null));
+        }
+
+        private static readonly StringToNumberConverter<sbyte> _naturalStringToSbyte
+            = new StringToNumberConverter<sbyte>();
+
+        [Fact]
+        public void Can_convert_natural_strings_to_sbytes()
+        {
+            var converter = _naturalStringToSbyte.ConvertToProviderExpression.Compile();
+
+            Assert.Equal(sbyte.MaxValue, converter("127"));
+            Assert.Equal(sbyte.MinValue, converter("-128"));
+            Assert.Equal(77, converter("77"));
+            Assert.Equal(-77, converter("-77"));
+            Assert.Equal(0, converter("0"));
+            Assert.Equal(0, converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_natural_strings_to_sbytes_object()
+        {
+            var converter = _naturalStringToSbyte.ConvertToProvider;
+
+            Assert.Equal(sbyte.MaxValue, converter("127"));
+            Assert.Equal(sbyte.MinValue, converter("-128"));
+            Assert.Equal((sbyte)77, converter("77"));
+            Assert.Equal((sbyte)-77, converter("-77"));
+            Assert.Equal((sbyte)0, converter("0"));
+            Assert.Null(converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_sbytes_to_natural_strings()
+        {
+            var converter = _naturalStringToSbyte.ConvertFromProviderExpression.Compile();
+
+            Assert.Equal("127", converter(sbyte.MaxValue));
+            Assert.Equal("-128", converter(sbyte.MinValue));
+            Assert.Equal("77", converter(77));
+            Assert.Equal("-77", converter(-77));
+            Assert.Equal("0", converter(0));
+        }
+
+        [Fact]
+        public void Can_convert_sbytes_to_natural_strings_object()
+        {
+            var converter = _naturalStringToSbyte.ConvertFromProvider;
+
+            Assert.Equal("127", converter(sbyte.MaxValue));
+            Assert.Equal("-128", converter(sbyte.MinValue));
+            Assert.Equal("77", converter(77));
+            Assert.Equal("-77", converter(-77));
+            Assert.Equal("77", converter((sbyte?)77));
+            Assert.Equal("0", converter((sbyte)0));
+            Assert.Null(converter(null));
+        }
+
+        private static readonly StringToNumberConverter<decimal> _naturalStringToDecimal
+            = new StringToNumberConverter<decimal>();
+
+        [Fact]
+        public void Can_convert_natural_strings_to_decimals()
+        {
+            var converter = _naturalStringToDecimal.ConvertToProviderExpression.Compile();
+
+            Assert.Equal(decimal.MaxValue, converter("79228162514264337593543950335"));
+            Assert.Equal(decimal.MinValue, converter("-79228162514264337593543950335"));
+            Assert.Equal((decimal)-792264.3375935, converter("-792264.3375935"));
+            Assert.Equal((decimal)0.000000001, converter("0.000000001"));
+            Assert.Equal((decimal)0.00000000000000000001, converter("0.00000000000000000001"));
+            Assert.Equal((decimal)-0.00000000000000000001, converter("-0.00000000000000000001"));
+            Assert.Equal(0, converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_decimals_to_natural_strings()
+        {
+            var converter = _naturalStringToDecimal.ConvertFromProviderExpression.Compile();
+
+            Assert.Equal("79228162514264337593543950335", converter(decimal.MaxValue));
+            Assert.Equal("-79228162514264337593543950335", converter(decimal.MinValue));
+            Assert.Equal("-792264.3375935", converter((decimal)-792264.3375935));
+            Assert.Equal("0.000000001", converter((decimal)0.000000001));
+            Assert.Equal("0.00000000000000000001", converter((decimal)0.00000000000000000001));
+            Assert.Equal("-0.00000000000000000001", converter((decimal)-0.00000000000000000001));
+        }
+
+        private static readonly StringToNumberConverter<double> _naturalStringToDouble
+            = new StringToNumberConverter<double>();
+
+        [Fact]
+        public void Can_convert_natural_strings_to_doubles()
+        {
+            var converter = _naturalStringToDouble.ConvertToProviderExpression.Compile();
+
+            Assert.Equal(double.MaxValue, converter("1.7976931348623157E+308"));
+            Assert.Equal(double.MinValue, converter("-1.7976931348623157E+308"));
+            Assert.Equal(-792264.3375935, converter("-792264.3375935"));
+            Assert.Equal(0.000000001, converter("1E-09"));
+            Assert.Equal(0.00000000000000000001, converter("1E-20"));
+            Assert.Equal(-0.00000000000000000001, converter("-1E-20"));
+            Assert.Equal(0, converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_doubles_to_natural_strings()
+        {
+            var converter = _naturalStringToDouble.ConvertFromProviderExpression.Compile();
+
+            Assert.Equal("1.7976931348623157E+308", converter(double.MaxValue));
+            Assert.Equal("-1.7976931348623157E+308", converter(double.MinValue));
+            Assert.Equal("-792264.3375935", converter(-792264.3375935));
+            Assert.Equal("1E-09", converter(0.000000001));
+            Assert.Equal("1E-20", converter(0.00000000000000000001));
+            Assert.Equal("-1E-20", converter(-0.00000000000000000001));
+        }
+
+        private static readonly StringToNumberConverter<float> _naturalStringToFloat
+            = new StringToNumberConverter<float>();
+
+        [Fact]
+        public void Can_convert_natural_strings_to_floats()
+        {
+            var converter = _naturalStringToFloat.ConvertToProviderExpression.Compile();
+
+            Assert.Equal(float.MaxValue, converter("3.40282347E+38"));
+            Assert.Equal(float.MinValue, converter("-3.40282347E+38"));
+            Assert.Equal((float)-79.3335, converter("-79.3335"));
+            Assert.Equal((float)0.000000001, converter("1E-09"));
+            Assert.Equal((float)0.00000000000000000001, converter("1E-20"));
+            Assert.Equal((float)-0.00000000000000000001, converter("-1E-20"));
+            Assert.Equal(0, converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_floats_to_natural_strings()
+        {
+            var converter = _naturalStringToFloat.ConvertFromProviderExpression.Compile();
+
+            Assert.Equal("3.40282347E+38", converter(float.MaxValue));
+            Assert.Equal("-3.40282347E+38", converter(float.MinValue));
+            Assert.Equal("-79.3335", converter((float)-79.3335));
+            Assert.Equal("1E-09", converter((float)0.000000001));
+            Assert.Equal("1E-20", converter((float)0.00000000000000000001));
+            Assert.Equal("-1E-20", converter((float)-0.00000000000000000001));
+        }
+
+        private static readonly StringToNumberConverter<sbyte?> _naturalStringToNullableSbyte
+            = new StringToNumberConverter<sbyte?>();
+
+        [Fact]
+        public void Can_convert_natural_strings_to_nullable_sbytes()
+        {
+            var converter = _naturalStringToNullableSbyte.ConvertToProviderExpression.Compile();
+
+            Assert.Equal(sbyte.MaxValue, converter("127"));
+            Assert.Equal(sbyte.MinValue, converter("-128"));
+            Assert.Equal((sbyte?)77, converter("77"));
+            Assert.Equal((sbyte?)-77, converter("-77"));
+            Assert.Equal((sbyte?)0, converter("0"));
+            Assert.Null(converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_natural_strings_to_nullable_sbytes_object()
+        {
+            var converter = _naturalStringToNullableSbyte.ConvertToProvider;
+
+            Assert.Equal(sbyte.MaxValue, converter("127"));
+            Assert.Equal(sbyte.MinValue, converter("-128"));
+            Assert.Equal((sbyte)77, converter("77"));
+            Assert.Equal((sbyte)-77, converter("-77"));
+            Assert.Equal((sbyte?)0, converter("0"));
+            Assert.Null(converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_nullable_sbytes_to_natural_strings()
+        {
+            var converter = _naturalStringToNullableSbyte.ConvertFromProviderExpression.Compile();
+
+            Assert.Equal("127", converter(sbyte.MaxValue));
+            Assert.Equal("-128", converter(sbyte.MinValue));
+            Assert.Equal("77", converter(77));
+            Assert.Equal("-77", converter(-77));
+            Assert.Equal("0", converter(0));
+            Assert.Null(converter(null));
+        }
+
+        [Fact]
+        public void Can_convert_nullable_sbytes_to_natural_strings_object()
+        {
+            var converter = _naturalStringToNullableSbyte.ConvertFromProvider;
+
+            Assert.Equal("127", converter((sbyte?)sbyte.MaxValue));
+            Assert.Equal("-128", converter((sbyte?)sbyte.MinValue));
+            Assert.Equal("77", converter((sbyte?)77));
+            Assert.Equal("-77", converter((sbyte?)-77));
+            Assert.Equal("0", converter((sbyte?)0));
+            Assert.Null(converter(null));
+        }
+
+        [Fact]
+        public void String_to_integer_converter_throws_for_bad_type()
+        {
+            Assert.Equal(
+                CoreStrings.ConverterBadType(
+                    typeof(StringNumberConverter<string, Guid, Guid>).ShortDisplayName(),
+                    "Guid",
+                    "int, long, short, byte, uint, ulong, ushort, sbyte, decimal, float, double"),
+                Assert.Throws<InvalidOperationException>(
+                    () => new StringToNumberConverter<Guid>()).Message);
+        }
+    }
+}

--- a/test/EFCore.Tests/Storage/StringToTimeSpanConverterTest.cs
+++ b/test/EFCore.Tests/Storage/StringToTimeSpanConverterTest.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    public class StringToTimeSpanConverterTest
+    {
+        private static readonly StringToTimeSpanConverter _stringToTimeSpan
+            = new StringToTimeSpanConverter();
+
+        [Fact]
+        public void Can_convert_string_to_TimeSpan()
+        {
+            var converter = _stringToTimeSpan.ConvertToProviderExpression.Compile();
+
+            Assert.Equal(
+                new TimeSpan(10, 7, 30, 15, 3333),
+                converter("10.07:30:18.3330000"));
+
+            Assert.Equal(new TimeSpan(), converter("00:00:00"));
+        }
+
+        [Fact]
+        public void Can_convert_TimeSpan_to_string()
+        {
+            var converter = _stringToTimeSpan.ConvertFromProviderExpression.Compile();
+
+            Assert.Equal(
+                "10.07:30:18.3330000",
+                converter(new TimeSpan(10, 7, 30, 15, 3333)));
+
+            Assert.Equal("00:00:00", converter(new TimeSpan()));
+        }
+    }
+}

--- a/test/EFCore.Tests/Storage/ValueConverterSelectorTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConverterSelectorTest.cs
@@ -421,6 +421,150 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         [Fact]
+        public void Can_get_converters_for_string_to_int()
+        {
+            AssertConverters(
+                _selector.Select(typeof(string), typeof(int)).ToList(),
+                (typeof(StringToNumberConverter<int>), new ConverterMappingHints(size: 64)));
+        }
+
+        [Fact]
+        public void Can_get_converters_for_string_to_long()
+        {
+            AssertConverters(
+                _selector.Select(typeof(string), typeof(long)).ToList(),
+                (typeof(StringToNumberConverter<long>), new ConverterMappingHints(size: 64)));
+        }
+
+        [Fact]
+        public void Can_get_converters_for_string_to_short()
+        {
+            AssertConverters(
+                _selector.Select(typeof(string), typeof(short)).ToList(),
+                (typeof(StringToNumberConverter<short>), new ConverterMappingHints(size: 64)));
+        }
+
+        [Fact]
+        public void Can_get_converters_for_string_to_byte()
+        {
+            AssertConverters(
+                _selector.Select(typeof(string), typeof(byte)).ToList(),
+                (typeof(StringToNumberConverter<byte>), new ConverterMappingHints(size: 64)));
+        }
+
+        [Fact]
+        public void Can_get_converters_for_string_to_ulong()
+        {
+            AssertConverters(
+                _selector.Select(typeof(string), typeof(ulong)).ToList(),
+                (typeof(StringToNumberConverter<ulong>), new ConverterMappingHints(size: 64)));
+        }
+
+        [Fact]
+        public void Can_get_converters_for_string_to_uint()
+        {
+            AssertConverters(
+                _selector.Select(typeof(string), typeof(uint)).ToList(),
+                (typeof(StringToNumberConverter<uint>), new ConverterMappingHints(size: 64)));
+        }
+
+        [Fact]
+        public void Can_get_converters_for_string_to_ushort()
+        {
+            AssertConverters(
+                _selector.Select(typeof(string), typeof(ushort)).ToList(),
+                (typeof(StringToNumberConverter<ushort>), new ConverterMappingHints(size: 64)));
+        }
+
+        [Fact]
+        public void Can_get_converters_for_string_to_sbyte()
+        {
+            AssertConverters(
+                _selector.Select(typeof(string), typeof(sbyte)).ToList(),
+                (typeof(StringToNumberConverter<sbyte>), new ConverterMappingHints(size: 64)));
+        }
+
+        [Fact]
+        public void Can_get_converters_for_string_to_decimal()
+        {
+            AssertConverters(
+                _selector.Select(typeof(string), typeof(decimal)).ToList(),
+                (typeof(StringToNumberConverter<decimal>), new ConverterMappingHints(size: 64)));
+        }
+
+        [Fact]
+        public void Can_get_converters_for_string_to_double()
+        {
+            AssertConverters(
+                _selector.Select(typeof(string), typeof(double)).ToList(),
+                (typeof(StringToNumberConverter<double>), new ConverterMappingHints(size: 64)));
+        }
+
+        [Fact]
+        public void Can_get_converters_for_string_to_float()
+        {
+            AssertConverters(
+                _selector.Select(typeof(string), typeof(float)).ToList(),
+                (typeof(StringToNumberConverter<float>), new ConverterMappingHints(size: 64)));
+        }
+
+        [Fact]
+        public void Can_get_converters_for_string_to_enum()
+        {
+            AssertConverters(
+                _selector.Select(typeof(string), typeof(Queen)).ToList(),
+                (typeof(StringToEnumConverter<Queen>), default));
+        }
+
+        [Fact]
+        public void Can_get_converters_for_string_to_DateTime()
+        {
+            AssertConverters(
+                _selector.Select(typeof(string), typeof(DateTime)).ToList(),
+                (typeof(StringToDateTimeConverter), new ConverterMappingHints(size: 48)));
+        }
+
+        [Fact]
+        public void Can_get_converters_for_string_to_DateTimeOffset()
+        {
+            AssertConverters(
+                _selector.Select(typeof(string), typeof(DateTimeOffset)).ToList(),
+                (typeof(StringToDateTimeOffsetConverter), new ConverterMappingHints(size: 48)));
+        }
+
+        [Fact]
+        public void Can_get_converters_for_string_to_TimeSpan()
+        {
+            AssertConverters(
+                _selector.Select(typeof(string), typeof(TimeSpan)).ToList(),
+                (typeof(StringToTimeSpanConverter), new ConverterMappingHints(size: 48)));
+        }
+
+        [Fact]
+        public void Can_get_converters_for_string_to_Guid()
+        {
+            AssertConverters(
+                _selector.Select(typeof(string), typeof(Guid)).ToList(),
+                (typeof(StringToGuidConverter), new ConverterMappingHints(size: 36)));
+        }
+
+        [Fact]
+        public void Can_get_converters_for_string_to_bool()
+        {
+            AssertConverters(
+                _selector.Select(typeof(string), typeof(bool)).ToList(),
+                (typeof(StringToBoolConverter), default));
+        }
+
+        [Fact]
+        public void Can_get_converters_for_string_to_char()
+        {
+            AssertConverters(
+                _selector.Select(typeof(string), typeof(char)).ToList(),
+                (typeof(StringToCharConverter), new ConverterMappingHints(size: 1)));
+        }
+
+        [Fact]
         public void Can_get_converters_for_string_to_bytes()
         {
             AssertConverters(

--- a/test/EFCore.Tests/Storage/ValueConverterSelectorTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConverterSelectorTest.cs
@@ -400,23 +400,6 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             AssertConverters(
                 _selector.Select(typeof(string)).ToList(),
-                (typeof(StringToNumberConverter<int>), new ConverterMappingHints(size: 64)),
-                (typeof(StringToNumberConverter<long>), new ConverterMappingHints(size: 64)),
-                (typeof(StringToNumberConverter<short>), new ConverterMappingHints(size: 64)),
-                (typeof(StringToNumberConverter<byte>), new ConverterMappingHints(size: 64)),
-                (typeof(StringToNumberConverter<ulong>), new ConverterMappingHints(size: 64)),
-                (typeof(StringToNumberConverter<uint>), new ConverterMappingHints(size: 64)),
-                (typeof(StringToNumberConverter<ushort>), new ConverterMappingHints(size: 64)),
-                (typeof(StringToNumberConverter<sbyte>), new ConverterMappingHints(size: 64)),
-                (typeof(StringToNumberConverter<decimal>), new ConverterMappingHints(size: 64)),
-                (typeof(StringToNumberConverter<double>), new ConverterMappingHints(size: 64)),
-                (typeof(StringToNumberConverter<float>), new ConverterMappingHints(size: 64)),
-                (typeof(StringToDateTimeConverter), new ConverterMappingHints(size: 48)),
-                (typeof(StringToDateTimeOffsetConverter), new ConverterMappingHints(size: 48)),
-                (typeof(StringToTimeSpanConverter), new ConverterMappingHints(size: 48)),
-                (typeof(StringToGuidConverter), new ConverterMappingHints(size: 36)),
-                (typeof(StringToBoolConverter), default),
-                (typeof(StringToCharConverter), new ConverterMappingHints(size: 1)),
                 (typeof(StringToBytesConverter), default));
         }
 

--- a/test/EFCore.Tests/Storage/ValueConverterSelectorTest.cs
+++ b/test/EFCore.Tests/Storage/ValueConverterSelectorTest.cs
@@ -400,6 +400,23 @@ namespace Microsoft.EntityFrameworkCore.Storage
         {
             AssertConverters(
                 _selector.Select(typeof(string)).ToList(),
+                (typeof(StringToNumberConverter<int>), new ConverterMappingHints(size: 64)),
+                (typeof(StringToNumberConverter<long>), new ConverterMappingHints(size: 64)),
+                (typeof(StringToNumberConverter<short>), new ConverterMappingHints(size: 64)),
+                (typeof(StringToNumberConverter<byte>), new ConverterMappingHints(size: 64)),
+                (typeof(StringToNumberConverter<ulong>), new ConverterMappingHints(size: 64)),
+                (typeof(StringToNumberConverter<uint>), new ConverterMappingHints(size: 64)),
+                (typeof(StringToNumberConverter<ushort>), new ConverterMappingHints(size: 64)),
+                (typeof(StringToNumberConverter<sbyte>), new ConverterMappingHints(size: 64)),
+                (typeof(StringToNumberConverter<decimal>), new ConverterMappingHints(size: 64)),
+                (typeof(StringToNumberConverter<double>), new ConverterMappingHints(size: 64)),
+                (typeof(StringToNumberConverter<float>), new ConverterMappingHints(size: 64)),
+                (typeof(StringToDateTimeConverter), new ConverterMappingHints(size: 48)),
+                (typeof(StringToDateTimeOffsetConverter), new ConverterMappingHints(size: 48)),
+                (typeof(StringToTimeSpanConverter), new ConverterMappingHints(size: 48)),
+                (typeof(StringToGuidConverter), new ConverterMappingHints(size: 36)),
+                (typeof(StringToBoolConverter), default),
+                (typeof(StringToCharConverter), new ConverterMappingHints(size: 1)),
                 (typeof(StringToBytesConverter), default));
         }
 


### PR DESCRIPTION
Resolves #11492 
Finally I have found some time to work on this, sadly too late for 2.1.

This PR adds value conversions from `string` to the following types:

- `bool`
- `char`
- `DateTime`
- `DateTimeOffset`
- Enum
- `Guid`
- Number
- `TimeSpan`

I will also add unit tests, but I think it would be better, if someone briefly review this first.

Cc: @ajcvickers 