### PR TITLE
Query: Update tests in QueryFilters to avoid infinite recursion

### DIFF
--- a/src/EFCore.Specification.Tests/TestModels/QueryFilterFuncletizationContext.cs
+++ b/src/EFCore.Specification.Tests/TestModels/QueryFilterFuncletizationContext.cs
@@ -91,7 +91,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         private static void SetDependentFilter(ModelBuilder modelBuilder, DbContext context)
         {
             modelBuilder.Entity<DependentSetFilter>()
-                .HasQueryFilter(p => context.Set<PrincipalSetFilter>().Any(b => b.Id == p.PrincipalSetFilterId));
+                .HasQueryFilter(p => context.Set<MultiContextFilter>().Any(b => b.BossId == p.PrincipalSetFilterId));
         }
 
         #region EntityTypeConfigs

--- a/test/EFCore.InMemory.FunctionalTests/Query/QueryFilterFuncletizationInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/QueryFilterFuncletizationInMemoryTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.TestUtilities;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -14,18 +13,6 @@ namespace Microsoft.EntityFrameworkCore.Query
             QueryFilterFuncletizationInMemoryFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-        }
-
-        [Fact(Skip = "#11879")]
-        public override void Using_DbSet_in_filter_works()
-        {
-            base.Using_DbSet_in_filter_works();
-        }
-
-        [Fact(Skip = "#11879")]
-        public override void Using_Context_set_method_in_filter_works()
-        {
-            base.Using_Context_set_method_in_filter_works();
         }
 
         public class QueryFilterFuncletizationInMemoryFixture : QueryFilterFuncletizationFixtureBase

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryFilterFuncletizationSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryFilterFuncletizationSqlServerTest.cs
@@ -344,32 +344,37 @@ FROM [ExtensionContextFilter] AS [e]
 WHERE [e].[IsEnabled] = @__ef_filter__Enabled_0");
         }
 
-        [Fact(Skip = "#11879")]
         public override void Using_DbSet_in_filter_works()
         {
             base.Using_DbSet_in_filter_works();
 
             AssertSql(
-                @"SELECT [p].[Id]
+                @"@__ef_filter__Property_0='False'
+
+SELECT [p].[Id]
 FROM [PrincipalSetFilter] AS [p]
 WHERE EXISTS (
     SELECT 1
-    FROM [Dependents] AS [d]
-    WHERE [d].[PrincipalSetFilterId] = [p].[Id])");
+    FROM [Dependents] AS [p0]
+    WHERE EXISTS (
+        SELECT 1
+        FROM [MultiContextFilter] AS [e]
+        WHERE (([e].[IsEnabled] = @__ef_filter__Property_0) AND ([e].[BossId] = 1)) AND ([e].[BossId] = [p0].[PrincipalSetFilterId])) AND ([p0].[PrincipalSetFilterId] = [p].[Id]))");
         }
 
-        [Fact(Skip = "#11879")]
         public override void Using_Context_set_method_in_filter_works()
         {
             base.Using_Context_set_method_in_filter_works();
 
             AssertSql(
-                @"SELECT [p].[Id], [p].[PrincipalSetFilterId]
+                @"@__ef_filter__Property_0='False'
+
+SELECT [p].[Id], [p].[PrincipalSetFilterId]
 FROM [Dependents] AS [p]
 WHERE EXISTS (
     SELECT 1
-    FROM [PrincipalSetFilter] AS [b]
-    WHERE [b].[Id] = [p].[PrincipalSetFilterId])");
+    FROM [MultiContextFilter] AS [e]
+    WHERE (([e].[IsEnabled] = @__ef_filter__Property_0) AND ([e].[BossId] = 1)) AND ([e].[BossId] = [p].[PrincipalSetFilterId]))");
         }
 
         public override void Static_member_from_dbContext_is_inlined()

--- a/test/EFCore.Sqlite.FunctionalTests/Query/QueryFilterFuncletizationSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/QueryFilterFuncletizationSqliteTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.TestUtilities;
-using Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -16,18 +15,6 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             Fixture.TestSqlLoggerFactory.Clear();
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
-        }
-
-        [Fact(Skip = "#11879")]
-        public override void Using_DbSet_in_filter_works()
-        {
-            base.Using_DbSet_in_filter_works();
-        }
-
-        [Fact(Skip = "#11879")]
-        public override void Using_Context_set_method_in_filter_works()
-        {
-            base.Using_Context_set_method_in_filter_works();
         }
 
         private void AssertSql(params string[] expected)


### PR DESCRIPTION
Resolves #11879

