### PR TITLE
Fix #12054 - Adds recursion guards to analyzer.

### DIFF
--- a/src/EFCore.Analyzers/RawSqlStringInjectionDiagnosticAnalyzer.cs
+++ b/src/EFCore.Analyzers/RawSqlStringInjectionDiagnosticAnalyzer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -65,11 +66,15 @@ namespace Microsoft.EntityFrameworkCore
                             return;
                     }
 
+                    var depth = 0;
+
                     CheckPossibleInjection(
                         analysisContext,
                         sqlArgumentExpressionSyntax,
                         identifierValueText,
-                        invocationExpressionSyntax.GetLocation());
+                        invocationExpressionSyntax.GetLocation(),
+                        visited: new HashSet<SyntaxNode>(),
+                        ref depth);
                 }
             }
         }

--- a/test/EFCore.Analyzers.Tests/RawSqlStringInjectionDiagnosticAnalyzerTest.cs
+++ b/test/EFCore.Analyzers.Tests/RawSqlStringInjectionDiagnosticAnalyzerTest.cs
@@ -21,6 +21,33 @@ namespace Microsoft.EntityFrameworkCore
 
             Assert.Empty(diagnostics);
         }
+        
+        [Fact]
+        public async Task Error_when_sql_expression_recursively_initialized()
+        {
+            var diagnostics
+                = await GetDiagnosticsAsync(
+                    @"string q = null;
+                      q = M2(q);
+                      string M2(string _) { return null; }
+                      RelationalDatabaseFacadeExtensions.ExecuteSqlCommand(null, q);");
+
+            Assert.Empty(diagnostics);
+        }
+        
+        [Fact]
+        public async Task Error_when_sql_expression_recursively_initialized_multi()
+        {
+            var diagnostics
+                = await GetDiagnosticsAsync(
+                    @"string q = null;
+                      q = M2(q);
+                      var s = q;
+                      string M2(string _) { return null; }
+                      RelationalDatabaseFacadeExtensions.ExecuteSqlCommand(null, s);");
+
+            Assert.Empty(diagnostics);
+        }
 
         [Fact]
         public async Task No_warning_when_string_literal_passed_to_execute_sql_command()
@@ -109,7 +136,7 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(1, diagnostic.Location.GetLineSpan().StartLinePosition.Line);
             Assert.Equal(22, diagnostic.Location.GetLineSpan().StartLinePosition.Character);
             Assert.Equal(string.Format(
-                RawSqlStringInjectionDiagnosticAnalyzer.MessageFormat, "ExecuteSqlCommandAsync"), diagnostic.GetMessage());
+                SqlInjectionDiagnosticAnalyzerBase.MessageFormat, "ExecuteSqlCommandAsync"), diagnostic.GetMessage());
         }
 
         [Fact]
@@ -128,7 +155,7 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(2, diagnostic.Location.GetLineSpan().StartLinePosition.Line);
             Assert.Equal(22, diagnostic.Location.GetLineSpan().StartLinePosition.Character);
             Assert.Equal(string.Format(
-                RawSqlStringInjectionDiagnosticAnalyzer.MessageFormat, "ExecuteSqlCommandAsync"), diagnostic.GetMessage());
+                SqlInjectionDiagnosticAnalyzerBase.MessageFormat, "ExecuteSqlCommandAsync"), diagnostic.GetMessage());
         }
 
         [Fact]
@@ -147,7 +174,7 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(2, diagnostic.Location.GetLineSpan().StartLinePosition.Line);
             Assert.Equal(22, diagnostic.Location.GetLineSpan().StartLinePosition.Character);
             Assert.Equal(string.Format(
-                RawSqlStringInjectionDiagnosticAnalyzer.MessageFormat, "FromSql"), diagnostic.GetMessage());
+                SqlInjectionDiagnosticAnalyzerBase.MessageFormat, "FromSql"), diagnostic.GetMessage());
         }
 
         [Fact]
@@ -167,7 +194,7 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Equal(3, diagnostic.Location.GetLineSpan().StartLinePosition.Line);
             Assert.Equal(22, diagnostic.Location.GetLineSpan().StartLinePosition.Character);
             Assert.Equal(string.Format(
-                RawSqlStringInjectionDiagnosticAnalyzer.MessageFormat, "ExecuteSqlCommandAsync"), diagnostic.GetMessage());
+                SqlInjectionDiagnosticAnalyzerBase.MessageFormat, "ExecuteSqlCommandAsync"), diagnostic.GetMessage());
         }
 
         protected override DiagnosticAnalyzer CreateDiagnosticAnalyzer()


### PR DESCRIPTION
- Adds visited node set to prevent re-visiting.
- Also added max recursion depth fail safe in case there are more cases.

