### PR TITLE
Allow customizable SQL delimeters in tests

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/Query/AsyncFromSqlQueryTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/AsyncFromSqlQueryTestBase.cs
@@ -29,8 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                var actual = await context.Set<Customer>()
-                    .FromSql(@"SELECT * FROM ""Customers"" WHERE ""ContactName"" LIKE '%z%'")
+                var actual = await context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers] WHERE [ContactName] LIKE '%z%'"))
                     .ToArrayAsync();
 
                 Assert.Equal(14, actual.Length);
@@ -43,8 +42,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                var actual = await context.Set<Customer>()
-                    .FromSql(@"SELECT ""Region"", ""PostalCode"", ""Phone"", ""Fax"", ""CustomerID"", ""Country"", ""ContactTitle"", ""ContactName"", ""CompanyName"", ""City"", ""Address"" FROM ""Customers""")
+                var actual = await context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT [Region], [PostalCode], [Phone], [Fax], [CustomerID], [Country], [ContactTitle], [ContactName], [CompanyName], [City], [Address] FROM [Customers]"))
                     .ToArrayAsync();
 
                 Assert.Equal(91, actual.Length);
@@ -57,8 +55,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                var actual = await context.Set<Customer>()
-                    .FromSql(@"SELECT ""Region"", ""PostalCode"", ""PostalCode"" AS ""Foo"", ""Phone"", ""Fax"", ""CustomerID"", ""Country"", ""ContactTitle"", ""ContactName"", ""CompanyName"", ""City"", ""Address"" FROM ""Customers""")
+                var actual = await context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT [Region], [PostalCode], [PostalCode] AS [Foo], [Phone], [Fax], [CustomerID], [Country], [ContactTitle], [ContactName], [CompanyName], [City], [Address] FROM [Customers]"))
                     .ToArrayAsync();
 
                 Assert.Equal(91, actual.Length);
@@ -71,8 +68,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                var actual = await context.Set<Customer>()
-                    .FromSql(@"SELECT * FROM ""Customers""")
+                var actual = await context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers]"))
                     .Where(c => c.ContactName.Contains("z"))
                     .ToArrayAsync();
 
@@ -86,8 +82,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var actual
-                    = await (from c in context.Set<Customer>().FromSql(@"SELECT * FROM ""Customers""")
-                             from o in context.Set<Order>().FromSql(@"SELECT * FROM ""Orders""")
+                    = await (from c in context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers]"))
+                             from o in context.Set<Order>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Orders]"))
                              where c.CustomerID == o.CustomerID
                              select new { c, o })
                         .ToArrayAsync();
@@ -105,11 +101,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var actual
-                    = await (from c in context.Set<Customer>().FromSql(@"SELECT * FROM ""Customers""")
-                             from o in context.Set<Order>().FromSql(
-                                 @"SELECT * FROM ""Orders"" WHERE ""OrderDate"" BETWEEN {0} AND {1}",
-                                 startDate,
-                                 endDate)
+                    = await (from c in context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers]"))
+                             from o in context.Set<Order>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {0} AND {1}"), startDate, endDate)
                              where c.CustomerID == o.CustomerID
                              select new { c, o })
                         .ToArrayAsync();
@@ -128,11 +121,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var actual
-                    = await (from c in context.Set<Customer>().FromSql(@"SELECT * FROM ""Customers"" WHERE ""City"" = {0}", city)
-                             from o in context.Set<Order>().FromSql(
-                                 @"SELECT * FROM ""Orders"" WHERE ""OrderDate"" BETWEEN {0} AND {1}",
-                                 startDate,
-                                 endDate)
+                    = await (from c in context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers] WHERE [City] = {0}"), city)
+                             from o in context.Set<Order>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {0} AND {1}"), startDate, endDate)
                              where c.CustomerID == o.CustomerID
                              select new { c, o })
                         .ToArrayAsync();
@@ -146,11 +136,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                var actual = await context.Set<Customer>()
-                    .FromSql(
-                        @"SELECT *
-FROM ""Customers""
-WHERE ""City"" = 'London'")
+                var actual = await context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT *
+FROM [Customers]
+WHERE [City] = 'London'"))
                     .ToArrayAsync();
 
                 Assert.Equal(6, actual.Length);
@@ -163,10 +151,8 @@ WHERE ""City"" = 'London'")
         {
             using (var context = CreateContext())
             {
-                var actual = await context.Set<Customer>()
-                    .FromSql(
-                        @"SELECT *
-FROM ""Customers""")
+                var actual = await context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT *
+FROM [Customers]"))
                     .Where(c => c.City == "London")
                     .ToArrayAsync();
 
@@ -183,11 +169,7 @@ FROM ""Customers""")
 
             using (var context = CreateContext())
             {
-                var actual = await context.Set<Customer>()
-                    .FromSql(
-                        @"SELECT * FROM ""Customers"" WHERE ""City"" = {0} AND ""ContactTitle"" = {1}",
-                        city,
-                        contactTitle)
+                var actual = await context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers] WHERE [City] = {0} AND [ContactTitle] = {1}"), city, contactTitle)
                     .ToArrayAsync();
 
                 Assert.Equal(3, actual.Length);
@@ -204,10 +186,7 @@ FROM ""Customers""")
 
             using (var context = CreateContext())
             {
-                var actual = await context.Set<Customer>()
-                    .FromSql(
-                        @"SELECT * FROM ""Customers"" WHERE ""City"" = {0}",
-                        city)
+                var actual = await context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers] WHERE [City] = {0}"), city)
                     .Where(c => c.ContactTitle == contactTitle)
                     .ToArrayAsync();
 
@@ -222,15 +201,13 @@ FROM ""Customers""")
         {
             using (var context = CreateContext())
             {
-                var actual = await context.Set<Customer>()
-                    .FromSql(@"SELECT * FROM ""Customers"" WHERE ""City"" = 'London'")
+                var actual = await context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers] WHERE [City] = 'London'"))
                     .ToArrayAsync();
 
                 Assert.Equal(6, actual.Length);
                 Assert.True(actual.All(c => c.City == "London"));
 
-                actual = await context.Set<Customer>()
-                    .FromSql(@"SELECT * FROM ""Customers"" WHERE ""City"" = 'Seattle'")
+                actual = await context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers] WHERE [City] = 'Seattle'"))
                     .ToArrayAsync();
 
                 Assert.Equal(1, actual.Length);
@@ -243,12 +220,11 @@ FROM ""Customers""")
         {
             var city = "London";
             var contactTitle = "Sales Representative";
-            var sql = @"SELECT * FROM ""Customers"" WHERE ""City"" = {0} AND ""ContactTitle"" = {1}";
+            var sql = @"SELECT * FROM [Customers] WHERE [City] = {0} AND [ContactTitle] = {1}";
 
             using (var context = CreateContext())
             {
-                var actual = await context.Set<Customer>()
-                    .FromSql(sql, city, contactTitle)
+                var actual = await context.Set<Customer>().FromSql(NormalizeDelimeters(sql), city, contactTitle)
                     .ToArrayAsync();
 
                 Assert.Equal(3, actual.Length);
@@ -258,8 +234,7 @@ FROM ""Customers""")
                 city = "Madrid";
                 contactTitle = "Accounting Manager";
 
-                actual = await context.Set<Customer>()
-                    .FromSql(sql, city, contactTitle)
+                actual = await context.Set<Customer>().FromSql(NormalizeDelimeters(sql), city, contactTitle)
                     .ToArrayAsync();
 
                 Assert.Equal(2, actual.Length);
@@ -273,8 +248,7 @@ FROM ""Customers""")
         {
             using (var context = CreateContext())
             {
-                var actual = await context.Set<Customer>()
-                    .FromSql(@"SELECT * FROM ""Customers""")
+                var actual = await context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers]"))
                     .AsNoTracking()
                     .ToArrayAsync();
 
@@ -288,8 +262,7 @@ FROM ""Customers""")
         {
             using (var context = CreateContext())
             {
-                var actual = await context.Set<Customer>()
-                    .FromSql(@"SELECT * FROM ""Customers""")
+                var actual = await context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers]"))
                     .Select(c => new { c.CustomerID, c.City })
                     .AsNoTracking()
                     .ToArrayAsync();
@@ -304,8 +277,7 @@ FROM ""Customers""")
         {
             using (var context = CreateContext())
             {
-                var actual = await context.Set<Customer>()
-                    .FromSql(@"SELECT * FROM ""Customers""")
+                var actual = await context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers]"))
                     .Include(c => c.Orders)
                     .ToArrayAsync();
 
@@ -318,8 +290,7 @@ FROM ""Customers""")
         {
             using (var context = CreateContext())
             {
-                var actual = await context.Set<Customer>()
-                    .FromSql(@"SELECT * FROM ""Customers""")
+                var actual = await context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers]"))
                     .Where(c => c.City == "London")
                     .Include(c => c.Orders)
                     .ToArrayAsync();
@@ -333,8 +304,7 @@ FROM ""Customers""")
         {
             using (var context = CreateContext())
             {
-                var actual = await context.Customers
-                    .FromSql(@"SELECT * FROM ""Customers"" WHERE ""ContactName"" LIKE '%z%'")
+                var actual = await context.Customers.FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers] WHERE [ContactName] LIKE '%z%'"))
                     .ToArrayAsync();
 
                 Assert.Equal(14, actual.Length);
@@ -351,8 +321,7 @@ FROM ""Customers""")
         {
             using (var context = CreateContext())
             {
-                var actual = await context.Set<Customer>()
-                    .FromSql(@"SELECT * FROM ""Customers""")
+                var actual = await context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers]"))
                     .Where(c => c.ContactName == c.CompanyName)
                     .ToArrayAsync();
 
@@ -396,6 +365,12 @@ FROM ""Customers""")
                 Assert.Equal(ConnectionState.Closed, connection.State);
             }
         }
+
+        private RawSqlString NormalizeDelimeters(RawSqlString sql)
+            => Fixture.TestStore.NormalizeDelimeters(sql);
+
+        private FormattableString NormalizeDelimeters(FormattableString sql)
+            => Fixture.TestStore.NormalizeDelimeters(sql);
 
         protected NorthwindContext CreateContext() => Fixture.CreateContext();
     }

--- a/src/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
@@ -21,7 +21,8 @@ namespace Microsoft.EntityFrameworkCore.Query
     public abstract class FromSqlQueryTestBase<TFixture> : IClassFixture<TFixture>
         where TFixture : NorthwindQueryRelationalFixture<NoopModelCustomizer>, new()
     {
-        private static readonly string EOL = Environment.NewLine;
+        // ReSharper disable once StaticMemberInGenericType
+        private static readonly string _eol = Environment.NewLine;
 
         protected FromSqlQueryTestBase(TFixture fixture)
         {
@@ -40,10 +41,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     CoreStrings.ErrorMaterializingPropertyInvalidCast("Product", "ProductID", typeof(int), typeof(string)),
                     Assert.Throws<InvalidOperationException>(
                         () =>
-                            context.Set<Product>()
-                                .FromSql(
-                                    @"SELECT ""ProductID"" AS ""ProductName"", ""ProductName"" AS ""ProductID"", ""SupplierID"", ""UnitPrice"", ""UnitsInStock"", ""Discontinued""
-                               FROM ""Products""")
+                            context.Set<Product>().FromSql(NormalizeDelimeters(@"SELECT [ProductID] AS [ProductName], [ProductName] AS [ProductID], [SupplierID], [UnitPrice], [UnitsInStock], [Discontinued]
+                               FROM [Products]"))
                                 .ToList()).Message);
             }
         }
@@ -57,10 +56,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     CoreStrings.ErrorMaterializingPropertyInvalidCast("Product", "UnitPrice", typeof(decimal?), typeof(int)),
                     Assert.Throws<InvalidOperationException>(
                         () =>
-                            context.Set<Product>()
-                                .FromSql(
-                                    @"SELECT ""ProductID"", ""SupplierID"" AS ""UnitPrice"", ""ProductName"", ""SupplierID"", ""UnitsInStock"", ""Discontinued""
-                               FROM ""Products""")
+                            context.Set<Product>().FromSql(NormalizeDelimeters(@"SELECT [ProductID], [SupplierID] AS [UnitPrice], [ProductName], [SupplierID], [UnitsInStock], [Discontinued]
+                               FROM [Products]"))
                                 .ToList()).Message);
             }
         }
@@ -74,10 +71,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     CoreStrings.ErrorMaterializingPropertyInvalidCast("Product", "UnitPrice", typeof(decimal?), typeof(int)),
                     Assert.Throws<InvalidOperationException>(
                         () =>
-                            context.Set<Product>()
-                                .FromSql(
-                                    @"SELECT ""ProductID"", ""SupplierID"" AS ""UnitPrice"", ""ProductName"", ""UnitsInStock"", ""Discontinued""
-                               FROM ""Products""")
+                            context.Set<Product>().FromSql(NormalizeDelimeters(@"SELECT [ProductID], [SupplierID] AS [UnitPrice], [ProductName], [UnitsInStock], [Discontinued]
+                               FROM [Products]"))
                                 .Select(p => p.UnitPrice)
                                 .ToList()).Message);
             }
@@ -93,10 +88,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     Assert.Throws<InvalidOperationException>(
                         () =>
                             context.Set<Product>()
-                                .AsNoTracking()
-                                .FromSql(
-                                    @"SELECT ""ProductID"" AS ""ProductName"", ""ProductName"" AS ""ProductID"", ""SupplierID"", ""UnitPrice"", ""UnitsInStock"", ""Discontinued""
-                               FROM ""Products""")
+                                .AsNoTracking().FromSql(NormalizeDelimeters(@"SELECT [ProductID] AS [ProductName], [ProductName] AS [ProductID], [SupplierID], [UnitPrice], [UnitsInStock], [Discontinued]
+                               FROM [Products]"))
                                 .ToList()).Message);
             }
         }
@@ -110,10 +103,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     CoreStrings.ErrorMaterializingPropertyNullReference("Product", "Discontinued", typeof(bool)),
                     Assert.Throws<InvalidOperationException>(
                         () =>
-                            context.Set<Product>()
-                                .FromSql(
-                                    @"SELECT ""ProductID"", ""ProductName"", ""SupplierID"", ""UnitPrice"", ""UnitsInStock"", NULL AS ""Discontinued""
-                               FROM ""Products""")
+                            context.Set<Product>().FromSql(NormalizeDelimeters(@"SELECT [ProductID], [ProductName], [SupplierID], [UnitPrice], [UnitsInStock], NULL AS [Discontinued]
+                               FROM [Products]"))
                                 .ToList()).Message);
             }
         }
@@ -127,10 +118,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     CoreStrings.ErrorMaterializingPropertyNullReference("Product", "Discontinued", typeof(bool)),
                     Assert.Throws<InvalidOperationException>(
                         () =>
-                            context.Set<Product>()
-                                .FromSql(
-                                    @"SELECT ""ProductID"", ""ProductName"", ""SupplierID"", ""UnitPrice"", ""UnitsInStock"", NULL AS ""Discontinued""
-                               FROM ""Products""")
+                            context.Set<Product>().FromSql(NormalizeDelimeters(@"SELECT [ProductID], [ProductName], [SupplierID], [UnitPrice], [UnitsInStock], NULL AS [Discontinued]
+                               FROM [Products]"))
                                 .Select(p => p.Discontinued)
                                 .ToList()).Message);
             }
@@ -146,10 +135,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                     Assert.Throws<InvalidOperationException>(
                         () =>
                             context.Set<Product>()
-                                .AsNoTracking()
-                                .FromSql(
-                                    @"SELECT ""ProductID"", ""ProductName"", ""SupplierID"", ""UnitPrice"", ""UnitsInStock"", NULL AS ""Discontinued""
-                               FROM ""Products""")
+                                .AsNoTracking().FromSql(NormalizeDelimeters(@"SELECT [ProductID], [ProductName], [SupplierID], [UnitPrice], [UnitsInStock], NULL AS [Discontinued]
+                               FROM [Products]"))
                                 .ToList()).Message);
             }
         }
@@ -159,8 +146,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                var actual = context.Set<Customer>()
-                    .FromSql(@"SELECT * FROM ""Customers"" WHERE ""ContactName"" LIKE '%z%'")
+                var actual = context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers] WHERE [ContactName] LIKE '%z%'"))
                     .ToArray();
 
                 Assert.Equal(14, actual.Length);
@@ -173,8 +159,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                var actual = context.Set<Customer>()
-                    .FromSql(@"SELECT ""Region"", ""PostalCode"", ""Phone"", ""Fax"", ""CustomerID"", ""Country"", ""ContactTitle"", ""ContactName"", ""CompanyName"", ""City"", ""Address"" FROM ""Customers""")
+                var actual = context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT [Region], [PostalCode], [Phone], [Fax], [CustomerID], [Country], [ContactTitle], [ContactName], [CompanyName], [City], [Address] FROM [Customers]"))
                     .ToArray();
 
                 Assert.Equal(91, actual.Length);
@@ -187,8 +172,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                var actual = context.Set<Customer>()
-                    .FromSql(@"SELECT ""Region"", ""PostalCode"", ""PostalCode"" AS ""Foo"", ""Phone"", ""Fax"", ""CustomerID"", ""Country"", ""ContactTitle"", ""ContactName"", ""CompanyName"", ""City"", ""Address"" FROM ""Customers""")
+                var actual = context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT [Region], [PostalCode], [PostalCode] AS [Foo], [Phone], [Fax], [CustomerID], [Country], [ContactTitle], [ContactName], [CompanyName], [City], [Address] FROM [Customers]"))
                     .ToArray();
 
                 Assert.Equal(91, actual.Length);
@@ -204,8 +188,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal(
                     RelationalStrings.FromSqlMissingColumn("Region"),
                     Assert.Throws<InvalidOperationException>(
-                        () => context.Set<Customer>()
-                            .FromSql(@"SELECT ""PostalCode"", ""Phone"", ""Fax"", ""CustomerID"", ""Country"", ""ContactTitle"", ""ContactName"", ""CompanyName"", ""City"", ""Address"" FROM ""Customers""")
+                        () => context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT [PostalCode], [Phone], [Fax], [CustomerID], [Country], [ContactTitle], [ContactName], [CompanyName], [City], [Address] FROM [Customers]"))
                             .ToArray()
                     ).Message);
             }
@@ -216,8 +199,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                var actual = context.Set<Customer>()
-                    .FromSql(@"SELECT * FROM ""Customers""")
+                var actual = context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers]"))
                     .Where(c => c.ContactName.Contains("z"))
                     .ToArray();
 
@@ -230,14 +212,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                var actual = context.Set<Customer>()
-                    .FromSql(
-                        EOL +
-                        @"    " + EOL +
-                        EOL +
-                        EOL +
-                        @"SELECT" + EOL +
-                        @"* FROM ""Customers""")
+                var actual = context.Set<Customer>().FromSql(NormalizeDelimeters(
+                    _eol +
+                    @"    " + _eol +
+                    _eol +
+                    _eol +
+                    @"SELECT" + _eol +
+                    @"* FROM [Customers]"))
                     .Where(c => c.ContactName.Contains("z"))
                     .ToArray();
 
@@ -249,8 +230,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void From_sql_queryable_composed_compiled()
         {
             var query = EF.CompileQuery(
-                (NorthwindContext context) => context.Set<Customer>()
-                    .FromSql(@"SELECT * FROM ""Customers""")
+                (NorthwindContext context) => context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers]"))
                     .Where(c => c.ContactName.Contains("z")));
 
             using (var context = CreateContext())
@@ -268,7 +248,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 var actual
                     = (from c in context.Set<Customer>()
-                       where context.Orders.FromSql(@"SELECT * FROM ""Orders""")
+                       where context.Orders.FromSql(NormalizeDelimeters(@"SELECT * FROM [Orders]"))
                            .Select(o => o.CustomerID)
                            .Contains(c.CustomerID)
                        select c)
@@ -287,7 +267,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     = (from c in context.Set<Customer>()
                        where
                            c.CustomerID == "ALFKI"
-                           && context.Orders.FromSql(@"SELECT * FROM ""Orders""")
+                           && context.Orders.FromSql(NormalizeDelimeters(@"SELECT * FROM [Orders]"))
                                .Select(o => o.CustomerID)
                                .Contains(c.CustomerID)
                        select c)
@@ -303,8 +283,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var actual
-                    = (from c in context.Set<Customer>().FromSql(@"SELECT * FROM ""Customers""")
-                       from o in context.Set<Order>().FromSql(@"SELECT * FROM ""Orders""")
+                    = (from c in context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers]"))
+                       from o in context.Set<Order>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Orders]"))
                        where c.CustomerID == o.CustomerID
                        select new { c, o })
                     .ToArray();
@@ -322,9 +302,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var actual
-                    = (from c in context.Set<Customer>().FromSql(@"SELECT * FROM ""Customers""")
-                       from o in context.Set<Order>().FromSql(
-                           @"SELECT * FROM ""Orders"" WHERE ""OrderDate"" BETWEEN {0} AND {1}",
+                    = (from c in context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers]"))
+                       from o in context.Set<Order>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {0} AND {1}"),
                            startDate,
                            endDate)
                        where c.CustomerID == o.CustomerID
@@ -345,9 +324,10 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var actual
-                    = (from c in context.Set<Customer>().FromSql(@"SELECT * FROM ""Customers"" WHERE ""City"" = {0}", city)
+                    = (from c in context.Set<Customer>().FromSql(
+                           NormalizeDelimeters(@"SELECT * FROM [Customers] WHERE [City] = {0}"), city)
                        from o in context.Set<Order>().FromSql(
-                           @"SELECT * FROM ""Orders"" WHERE ""OrderDate"" BETWEEN {0} AND {1}",
+                           NormalizeDelimeters(@"SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {0} AND {1}"),
                            startDate,
                            endDate)
                        where c.CustomerID == o.CustomerID
@@ -361,9 +341,10 @@ namespace Microsoft.EntityFrameworkCore.Query
                 endDate = new DateTime(1998, 5, 1);
 
                 actual
-                    = (from c in context.Set<Customer>().FromSql(@"SELECT * FROM ""Customers"" WHERE ""City"" = {0}", city)
+                    = (from c in context.Set<Customer>().FromSql(
+                           NormalizeDelimeters(@"SELECT * FROM [Customers] WHERE [City] = {0}"), city)
                        from o in context.Set<Order>().FromSql(
-                           @"SELECT * FROM ""Orders"" WHERE ""OrderDate"" BETWEEN {0} AND {1}",
+                           NormalizeDelimeters(@"SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {0} AND {1}"),
                            startDate,
                            endDate)
                        where c.CustomerID == o.CustomerID
@@ -379,11 +360,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                var actual = context.Set<Customer>()
-                    .FromSql(
-                        @"SELECT *
-FROM ""Customers""
-WHERE ""City"" = 'London'")
+                var actual = context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT *
+FROM [Customers]
+WHERE [City] = 'London'"))
                     .ToArray();
 
                 Assert.Equal(6, actual.Length);
@@ -396,10 +375,8 @@ WHERE ""City"" = 'London'")
         {
             using (var context = CreateContext())
             {
-                var actual = context.Set<Customer>()
-                    .FromSql(
-                        @"SELECT *
-FROM ""Customers""")
+                var actual = context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT *
+FROM [Customers]"))
                     .Where(c => c.City == "London")
                     .ToArray();
 
@@ -416,11 +393,7 @@ FROM ""Customers""")
 
             using (var context = CreateContext())
             {
-                var actual = context.Set<Customer>()
-                    .FromSql(
-                        @"SELECT * FROM ""Customers"" WHERE ""City"" = {0} AND ""ContactTitle"" = {1}",
-                        city,
-                        contactTitle)
+                var actual = context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers] WHERE [City] = {0} AND [ContactTitle] = {1}"), city, contactTitle)
                     .ToArray();
 
                 Assert.Equal(3, actual.Length);
@@ -434,11 +407,7 @@ FROM ""Customers""")
         {
             using (var context = CreateContext())
             {
-                var actual = context.Set<Customer>()
-                    .FromSql(
-                        @"SELECT * FROM ""Customers"" WHERE ""City"" = {0} AND ""ContactTitle"" = {1}",
-                        "London",
-                        "Sales Representative")
+                var actual = context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers] WHERE [City] = {0} AND [ContactTitle] = {1}"), "London", "Sales Representative")
                     .ToArray();
 
                 Assert.Equal(3, actual.Length);
@@ -455,9 +424,8 @@ FROM ""Customers""")
 
             using (var context = CreateContext())
             {
-                var actual = context.Set<Customer>()
-                    .FromSql(
-                        $@"SELECT * FROM ""Customers"" WHERE ""City"" = {city} AND ""ContactTitle"" = {contactTitle}")
+                var actual = context.Set<Customer>().FromSql(NormalizeDelimeters(
+                        $@"SELECT * FROM [Customers] WHERE [City] = {city} AND [ContactTitle] = {contactTitle}"))
                     .ToArray();
 
                 Assert.Equal(3, actual.Length);
@@ -471,9 +439,8 @@ FROM ""Customers""")
         {
             using (var context = CreateContext())
             {
-                var actual = context.Set<Customer>()
-                    .FromSql(
-                        $@"SELECT * FROM ""Customers"" WHERE ""City"" = {"London"} AND ""ContactTitle"" = {"Sales Representative"}")
+                var actual = context.Set<Customer>().FromSql(NormalizeDelimeters(
+                        $@"SELECT * FROM [Customers] WHERE [City] = {"London"} AND [ContactTitle] = {"Sales Representative"}"))
                     .ToArray();
 
                 Assert.Equal(3, actual.Length);
@@ -492,8 +459,8 @@ FROM ""Customers""")
             using (var context = CreateContext())
             {
                 var actual
-                    = (from c in context.Set<Customer>().FromSql(@"SELECT * FROM ""Customers"" WHERE ""City"" = {0}", city)
-                       from o in context.Set<Order>().FromSql($@"SELECT * FROM ""Orders"" WHERE ""OrderDate"" BETWEEN {startDate} AND {endDate}")
+                    = (from c in context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers] WHERE [City] = {0}"), city)
+                       from o in context.Set<Order>().FromSql(NormalizeDelimeters($@"SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {startDate} AND {endDate}"))
                        where c.CustomerID == o.CustomerID
                        select new { c, o })
                     .ToArray();
@@ -505,8 +472,8 @@ FROM ""Customers""")
                 endDate = new DateTime(1998, 5, 1);
 
                 actual
-                    = (from c in context.Set<Customer>().FromSql(@"SELECT * FROM ""Customers"" WHERE ""City"" = {0}", city)
-                       from o in context.Set<Order>().FromSql($@"SELECT * FROM ""Orders"" WHERE ""OrderDate"" BETWEEN {startDate} AND {endDate}")
+                    = (from c in context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers] WHERE [City] = {0}"), city)
+                       from o in context.Set<Order>().FromSql(NormalizeDelimeters($@"SELECT * FROM [Orders] WHERE [OrderDate] BETWEEN {startDate} AND {endDate}"))
                        where c.CustomerID == o.CustomerID
                        select new { c, o })
                     .ToArray();
@@ -522,11 +489,9 @@ FROM ""Customers""")
 
             using (var context = CreateContext())
             {
-                var actual = context.Set<Employee>()
-                    .FromSql(
-                        @"SELECT * FROM ""Employees"" WHERE ""ReportsTo"" = {0} OR (""ReportsTo"" IS NULL AND {0} IS NULL)",
-                        // ReSharper disable once ExpressionIsAlwaysNull
-                        reportsTo)
+                var actual = context.Set<Employee>().FromSql(NormalizeDelimeters(
+                    // ReSharper disable once ExpressionIsAlwaysNull
+                    @"SELECT * FROM [Employees] WHERE [ReportsTo] = {0} OR (]ReportsTo] IS NULL AND {0} IS NULL)"), reportsTo)
                     .ToArray();
 
                 Assert.Equal(1, actual.Length);
@@ -541,8 +506,7 @@ FROM ""Customers""")
 
             using (var context = CreateContext())
             {
-                var actual = context.Set<Customer>()
-                    .FromSql(@"SELECT * FROM ""Customers"" WHERE ""City"" = {0}", city)
+                var actual = context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers] WHERE [City] = {0}"), city)
                     .Where(c => c.ContactTitle == contactTitle)
                     .ToArray();
 
@@ -557,15 +521,13 @@ FROM ""Customers""")
         {
             using (var context = CreateContext())
             {
-                var actual = context.Set<Customer>()
-                    .FromSql(@"SELECT * FROM ""Customers"" WHERE ""City"" = 'London'")
+                var actual = context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers] WHERE [City] = 'London'"))
                     .ToArray();
 
                 Assert.Equal(6, actual.Length);
                 Assert.True(actual.All(c => c.City == "London"));
 
-                actual = context.Set<Customer>()
-                    .FromSql(@"SELECT * FROM ""Customers"" WHERE ""City"" = 'Seattle'")
+                actual = context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers] WHERE [City] = 'Seattle'"))
                     .ToArray();
 
                 Assert.Equal(1, actual.Length);
@@ -578,12 +540,11 @@ FROM ""Customers""")
         {
             var city = "London";
             var contactTitle = "Sales Representative";
-            var sql = @"SELECT * FROM ""Customers"" WHERE ""City"" = {0} AND ""ContactTitle"" = {1}";
+            var sql = @"SELECT * FROM [Customers] WHERE [City] = {0} AND [ContactTitle] = {1}";
 
             using (var context = CreateContext())
             {
-                var actual = context.Set<Customer>()
-                    .FromSql(sql, city, contactTitle)
+                var actual = context.Set<Customer>().FromSql(NormalizeDelimeters(sql), city, contactTitle )
                     .ToArray();
 
                 Assert.Equal(3, actual.Length);
@@ -593,8 +554,7 @@ FROM ""Customers""")
                 city = "Madrid";
                 contactTitle = "Accounting Manager";
 
-                actual = context.Set<Customer>()
-                    .FromSql(sql, city, contactTitle)
+                actual = context.Set<Customer>().FromSql(NormalizeDelimeters(sql), city, contactTitle)
                     .ToArray();
 
                 Assert.Equal(2, actual.Length);
@@ -608,8 +568,7 @@ FROM ""Customers""")
         {
             using (var context = CreateContext())
             {
-                var actual = context.Set<Customer>()
-                    .FromSql(@"SELECT * FROM ""Customers""")
+                var actual = context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers]"))
                     .AsNoTracking()
                     .ToArray();
 
@@ -624,12 +583,10 @@ FROM ""Customers""")
             using (var context = CreateContext())
             {
                 var boolMapping = (RelationalTypeMapping)context.GetService<ITypeMappingSource>().FindMapping(typeof(bool));
-                var actual = context.Set<Product>()
-                    .FromSql(
-                        @"SELECT *
-FROM ""Products""
-WHERE ""Discontinued"" <> " + boolMapping.GenerateSqlLiteral(true) + @"
-AND ((""UnitsInStock"" + ""UnitsOnOrder"") < ""ReorderLevel"")")
+                var actual = context.Set<Product>().FromSql(NormalizeDelimeters(@"SELECT *
+FROM [Products]
+WHERE [Discontinued] <> " + boolMapping.GenerateSqlLiteral(true) + @"
+AND ((]UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
                     .Select(p => p.ProductName)
                     .ToArray();
 
@@ -642,8 +599,7 @@ AND ((""UnitsInStock"" + ""UnitsOnOrder"") < ""ReorderLevel"")")
         {
             using (var context = CreateContext())
             {
-                var actual = context.Set<Customer>()
-                    .FromSql(@"SELECT * FROM ""Customers""")
+                var actual = context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers]"))
                     .Include(c => c.Orders)
                     .ToArray();
 
@@ -656,8 +612,7 @@ AND ((""UnitsInStock"" + ""UnitsOnOrder"") < ""ReorderLevel"")")
         {
             using (var context = CreateContext())
             {
-                var actual = context.Set<Customer>()
-                    .FromSql(@"SELECT * FROM ""Customers""")
+                var actual = context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers]"))
                     .Where(c => c.City == "London")
                     .Include(c => c.Orders)
                     .ToArray();
@@ -671,8 +626,7 @@ AND ((""UnitsInStock"" + ""UnitsOnOrder"") < ""ReorderLevel"")")
         {
             using (var context = CreateContext())
             {
-                var actual = context.Customers
-                    .FromSql(@"SELECT * FROM ""Customers"" WHERE ""ContactName"" LIKE '%z%'")
+                var actual = context.Customers.FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers] WHERE [ContactName] LIKE '%z%'"))
                     .ToArray();
 
                 Assert.Equal(14, actual.Length);
@@ -689,8 +643,7 @@ AND ((""UnitsInStock"" + ""UnitsOnOrder"") < ""ReorderLevel"")")
         {
             using (var context = CreateContext())
             {
-                var actual = context.Set<Customer>()
-                    .FromSql(@"SELECT * FROM ""Customers""")
+                var actual = context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers]"))
                     .Where(c => c.ContactName == c.CompanyName)
                     .ToArray();
 
@@ -705,8 +658,7 @@ AND ((""UnitsInStock"" + ""UnitsOnOrder"") < ""ReorderLevel"")")
             {
                 var parameter = CreateDbParameter("@city", "London");
 
-                var actual = context.Customers
-                    .FromSql(@"SELECT * FROM ""Customers"" WHERE ""City"" = @city", parameter)
+                var actual = context.Customers.FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers] WHERE [City] = @city"), parameter)
                     .ToArray();
 
                 Assert.Equal(6, actual.Length);
@@ -724,11 +676,8 @@ AND ((""UnitsInStock"" + ""UnitsOnOrder"") < ""ReorderLevel"")")
 
                 var titleParameter = CreateDbParameter("@title", title);
 
-                var actual = context.Customers
-                    .FromSql(
-                        @"SELECT * FROM ""Customers"" WHERE ""City"" = {0} AND ""ContactTitle"" = @title",
-                        city,
-                        titleParameter)
+                var actual = context.Customers.FromSql(NormalizeDelimeters(
+                        @"SELECT * FROM [Customers] WHERE [City] = {0} AND [ContactTitle] = @title"), city, titleParameter)
                     .ToArray();
 
                 Assert.Equal(3, actual.Length);
@@ -737,11 +686,8 @@ AND ((""UnitsInStock"" + ""UnitsOnOrder"") < ""ReorderLevel"")")
 
                 var cityParameter = CreateDbParameter("@city", city);
 
-                actual = context.Customers
-                    .FromSql(
-                        @"SELECT * FROM ""Customers"" WHERE ""City"" = @city AND ""ContactTitle"" = {1}",
-                        cityParameter,
-                        title)
+                actual = context.Customers.FromSql(NormalizeDelimeters(
+                        @"SELECT * FROM [Customers] WHERE [City] = @city AND [ContactTitle] = {1}"), cityParameter, title )
                     .ToArray();
 
                 Assert.Equal(3, actual.Length);
@@ -774,8 +720,7 @@ AND ((""UnitsInStock"" + ""UnitsOnOrder"") < ""ReorderLevel"")")
             {
                 var parameter = CreateDbParameter("@id", "ALFKI");
 
-                var query = context.Customers
-                    .FromSql(@"SELECT * FROM ""Customers"" WHERE ""CustomerID"" = @id", parameter);
+                var query = context.Customers.FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers] WHERE [CustomerID] = @id"), parameter);
 
                 // ReSharper disable PossibleMultipleEnumeration
                 var result1 = query.ToList();
@@ -794,10 +739,8 @@ AND ((""UnitsInStock"" + ""UnitsOnOrder"") < ""ReorderLevel"")")
         {
             using (var context = CreateContext())
             {
-                var query = from c1 in context.Set<Customer>()
-                                .FromSql(@"SELECT * FROM ""Customers"" WHERE ""CustomerID"" = 'ALFKI'")
-                            from c2 in context.Set<Customer>()
-                                .FromSql(@"SELECT * FROM ""Customers"" WHERE ""CustomerID"" = 'AROUT'")
+                var query = from c1 in context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers] WHERE [CustomerID] = 'ALFKI'"))
+                            from c2 in context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers] WHERE [CustomerID] = 'AROUT'"))
                                 .Include(c => c.Orders)
                             select new { c1, c2 };
 
@@ -823,8 +766,8 @@ AND ((""UnitsInStock"" + ""UnitsOnOrder"") < ""ReorderLevel"")")
         {
             using (var context = CreateContext())
             {
-                var query = from c in context.Set<Customer>().FromSql(@"SELECT * FROM ""Customers"" WHERE ""CustomerID"" = 'ALFKI'")
-                            join o in context.Set<Order>().FromSql(@"SELECT * FROM ""Orders"" WHERE ""OrderID"" <> 1").Include(o => o.OrderDetails)
+                var query = from c in context.Set<Customer>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Customers] WHERE [CustomerID] = 'ALFKI'"))
+                            join o in context.Set<Order>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Orders] WHERE [OrderID] <> 1")).Include(o => o.OrderDetails)
                                 on c.CustomerID equals o.CustomerID
                             select new { c, o };
 
@@ -859,6 +802,12 @@ AND ((""UnitsInStock"" + ""UnitsOnOrder"") < ""ReorderLevel"")")
                 Assert.Equal(ConnectionState.Closed, connection.State);
             }
         }
+
+        private RawSqlString NormalizeDelimeters(RawSqlString sql)
+            => Fixture.TestStore.NormalizeDelimeters(sql);
+
+        private FormattableString NormalizeDelimeters(FormattableString sql)
+            => Fixture.TestStore.NormalizeDelimeters(sql);
 
         protected abstract DbParameter CreateDbParameter(string name, object value);
 

--- a/src/EFCore.Relational.Specification.Tests/Query/FromSqlSprocQueryTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/FromSqlSprocQueryTestBase.cs
@@ -206,10 +206,11 @@ namespace Microsoft.EntityFrameworkCore.Query
                 var actual
                     = (from mep in context.Set<MostExpensiveProduct>()
                            .FromSql(TenMostExpensiveProductsSproc, GetTenMostExpensiveProductsParameters())
-                       from p in context.Set<Product>().FromSql("SELECT * FROM \"Products\"")
+                       from p in context.Set<Product>()
+                           .FromSql(NormalizeDelimeters(@"SELECT * FROM [Products]"))
                        where mep.TenMostExpensiveProducts == p.ProductName
                        select new { mep, p })
-                    .ToArray();
+                        .ToArray();
 
                 Assert.Equal(10, actual.Length);
             }
@@ -221,16 +222,22 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var actual
-                    = (from p in context.Set<Product>().FromSql("SELECT * FROM \"Products\"")
+                    = (from p in context.Set<Product>().FromSql(NormalizeDelimeters(@"SELECT * FROM [Products]"))
                        from mep in context.Set<MostExpensiveProduct>()
                            .FromSql(TenMostExpensiveProductsSproc, GetTenMostExpensiveProductsParameters())
                        where mep.TenMostExpensiveProducts == p.ProductName
                        select new { mep, p })
-                    .ToArray();
+                        .ToArray();
 
                 Assert.Equal(10, actual.Length);
             }
         }
+
+        private RawSqlString NormalizeDelimeters(RawSqlString sql)
+            => Fixture.TestStore.NormalizeDelimeters(sql);
+
+        private FormattableString NormalizeDelimeters(FormattableString sql)
+            => Fixture.TestStore.NormalizeDelimeters(sql);
 
         protected NorthwindContext CreateContext()
         {

--- a/src/EFCore.Relational.Specification.Tests/Query/GearsOfWarFromSqlQueryTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/GearsOfWarFromSqlQueryTestBase.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel;
 using Xunit;
@@ -20,8 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                var actual = context.Set<Weapon>()
-                    .FromSql(@"SELECT ""Id"", ""Name"", ""IsAutomatic"", ""AmmunitionType"", ""OwnerFullName"", ""SynergyWithId"" FROM ""Weapons"" ORDER BY ""Name""")
+                var actual = context.Set<Weapon>().FromSql(NormalizeDelimeters(@"SELECT [Id], [Name], [IsAutomatic], [AmmunitionType], [OwnerFullName], [SynergyWithId] FROM [Weapons] ORDER BY [Name]"))
                     .ToArray();
 
                 Assert.Equal(10, actual.Length);
@@ -32,6 +32,12 @@ namespace Microsoft.EntityFrameworkCore.Query
                 Assert.Equal("Baird's Gnasher", first.Name);
             }
         }
+
+        private RawSqlString NormalizeDelimeters(RawSqlString sql)
+            => Fixture.TestStore.NormalizeDelimeters(sql);
+
+        private FormattableString NormalizeDelimeters(FormattableString sql)
+            => Fixture.TestStore.NormalizeDelimeters(sql);
 
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();
 

--- a/src/EFCore.Relational.Specification.Tests/Query/GearsOfWarQueryRelationalFixture.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/GearsOfWarQueryRelationalFixture.cs
@@ -10,6 +10,8 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public abstract class GearsOfWarQueryRelationalFixture : GearsOfWarQueryFixtureBase
     {
+        public new RelationalTestStore TestStore => (RelationalTestStore)base.TestStore;
+
         public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ServiceProvider.GetRequiredService<ILoggerFactory>();
 
         public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)

--- a/src/EFCore.Relational.Specification.Tests/Query/InheritanceRelationalTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/InheritanceRelationalTestBase.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Linq;
 using Microsoft.EntityFrameworkCore.TestModels.Inheritance;
+using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
 // ReSharper disable InconsistentNaming
@@ -20,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                context.Set<Animal>().FromSql(@"select * from ""Animal""").ToList();
+                context.Set<Animal>().FromSql(NormalizeDelimeters(@"select * from [Animal]")).ToList();
             }
         }
 
@@ -29,8 +31,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                context.Set<Eagle>().FromSql(@"select * from ""Animal""").ToList();
+                context.Set<Eagle>().FromSql(NormalizeDelimeters(@"select * from [Animal]")).ToList();
             }
         }
+
+        private RawSqlString NormalizeDelimeters(RawSqlString sql)
+            => ((RelationalTestStore)Fixture.TestStore).NormalizeDelimeters(sql);
+
+        private FormattableString NormalizeDelimeters(FormattableString sql)
+            => ((RelationalTestStore)Fixture.TestStore).NormalizeDelimeters(sql);
     }
 }

--- a/src/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryRelationalFixture.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryRelationalFixture.cs
@@ -10,6 +10,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public abstract class NullSemanticsQueryRelationalFixture : SharedStoreFixtureBase<NullSemanticsContext>
     {
+        public new RelationalTestStore TestStore => (RelationalTestStore)base.TestStore;
         protected override string StoreName { get; } = "NullSemanticsQueryTest";
         public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ServiceProvider.GetRequiredService<ILoggerFactory>();
 

--- a/src/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/NullSemanticsQueryTestBase.cs
@@ -681,7 +681,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext(useRelationalNulls: true))
             {
                 var actual = context.Entities1
-                    .FromSql(@"SELECT * FROM ""Entities1""")
+                    .FromSql(@"SELECT * FROM Entities1")
                     .Where(c => c.StringA == c.StringB)
                     .ToArray();
 

--- a/src/EFCore.Relational.Specification.Tests/Query/QueryNoClientEvalTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/QueryNoClientEvalTestBase.cs
@@ -118,7 +118,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         "RelationalEventId.QueryClientEvaluationWarning"),
                     Assert.Throws<InvalidOperationException>(
                         () => context.Customers
-                            .FromSql(@"select * from ""Customers""")
+                            .FromSql(@"select * from Customers")
                             .Where(c => c.IsLondon)
                             .ToList()).Message);
             }
@@ -131,7 +131,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 var customers
                     = context.Customers
-                        .FromSql(@"select * from ""Customers""")
+                        .FromSql(@"select * from Customers")
                         .ToList();
 
                 Assert.Equal(91, customers.Count);

--- a/src/EFCore.Relational.Specification.Tests/TestModels/Northwind/NorthwindRelationalContext.cs
+++ b/src/EFCore.Relational.Specification.Tests/TestModels/Northwind/NorthwindRelationalContext.cs
@@ -30,7 +30,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.Northwind
             modelBuilder
                 .Query<OrderQuery>()
                 .ToQuery(() => Orders
-                    .FromSql("select * from \"Orders\"")
+                    .FromSql("select * from Orders")
                     .Select(
                         o => new OrderQuery
                         {

--- a/src/EFCore.Relational.Specification.Tests/TestUtilities/RelationalTestStore.cs
+++ b/src/EFCore.Relational.Specification.Tests/TestUtilities/RelationalTestStore.cs
@@ -4,7 +4,9 @@
 using System;
 using System.Data;
 using System.Data.Common;
+using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Query;
 
 namespace Microsoft.EntityFrameworkCore.TestUtilities
 {
@@ -41,5 +43,18 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Connection?.Dispose();
             base.Dispose();
         }
+
+        public virtual RawSqlString NormalizeDelimeters(RawSqlString sql)
+            => NormalizeDelimeters(sql.Format);
+
+        public virtual FormattableString NormalizeDelimeters(FormattableString sql)
+            => new TestFormattableString(NormalizeDelimeters(sql.Format), sql.GetArguments());
+
+        private string NormalizeDelimeters(string sql)
+            => sql.Replace("[", OpenDelimeter).Replace("]", CloseDelimeter);
+
+        protected virtual string OpenDelimeter => "\"";
+
+        protected virtual string CloseDelimeter => "\"";
     }
 }

--- a/src/EFCore.Relational.Specification.Tests/TestUtilities/TestFormattableString.cs
+++ b/src/EFCore.Relational.Specification.Tests/TestUtilities/TestFormattableString.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities
+{
+    public class TestFormattableString : FormattableString
+    {
+        private readonly object[] _arguments;
+
+        public TestFormattableString(string format, object[] arguments)
+        {
+            Format = format;
+            _arguments = arguments;
+        }
+
+        public override object GetArgument(int index)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override object[] GetArguments()
+            => _arguments;
+
+        public override string ToString(IFormatProvider formatProvider)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int ArgumentCount { get; }
+        public override string Format { get; }
+    }
+}

--- a/src/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
+++ b/src/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
@@ -159,8 +159,23 @@ namespace Microsoft.EntityFrameworkCore
                 var param3 = -1234567890123456789L;
                 Assert.Same(entity, set.Where(e => e.Id == 11 && EF.Property<long>(e, nameof(BuiltInDataTypes.TestInt64)) == param3).ToList().Single());
 
-                var param4 = -1.23456789;
-                Assert.Same(entity, set.Where(e => e.Id == 11 && EF.Property<double>(e, nameof(BuiltInDataTypes.TestDouble)) == param4).ToList().Single());
+                double? param4 = -1.23456789;
+                if (Fixture.StrictEquality)
+                {
+                    Assert.Same(entity, set.Where(e => e.Id == 11
+                                                       && EF.Property<double>(e, nameof(BuiltInDataTypes.TestDouble)) == param4).ToList().Single());
+
+                }
+                else
+                {
+                    double? param4l = -1.234567891;
+                    double? param4h = -1.234567889;
+                    Assert.Same(entity, set.Where(e => e.Id == 11
+                                                       && (EF.Property<double>(e, nameof(BuiltInDataTypes.TestDouble)) == param4
+                                                           || (EF.Property<double>(e, nameof(BuiltInDataTypes.TestDouble)) > param4l
+                                                               && EF.Property<double>(e, nameof(BuiltInDataTypes.TestDouble)) < param4h)))
+                        .ToList().Single());
+                }
 
                 var param5 = -1234567890.01M;
                 Assert.Same(entity, set.Where(e => e.Id == 11 && EF.Property<decimal>(e, nameof(BuiltInDataTypes.TestDecimal)) == param5).ToList().Single());
@@ -181,7 +196,20 @@ namespace Microsoft.EntityFrameworkCore
                 }
 
                 var param9 = -1.234F;
-                Assert.Same(entity, set.Where(e => e.Id == 11 && EF.Property<float>(e, nameof(BuiltInDataTypes.TestSingle)) == param9).ToList().Single());
+                if (Fixture.StrictEquality)
+                {
+                    Assert.Same(entity, set.Where(e => e.Id == 11
+                                                       && EF.Property<float>(e, nameof(BuiltInDataTypes.TestSingle)) == param9).ToList().Single());
+                }
+                else
+                {
+                    var param9l = -1.2341F;
+                    var param9h = -1.2339F;
+                    Assert.Same(entity, set.Where(e => e.Id == 11
+                                                       && (EF.Property<float>(e, nameof(BuiltInDataTypes.TestSingle)) == param9
+                                                           || (EF.Property<float>(e, nameof(BuiltInDataTypes.TestSingle)) > param9l
+                                                               && EF.Property<float>(e, nameof(BuiltInDataTypes.TestSingle)) < param9h))).ToList().Single());
+                }
 
                 var param10 = true;
                 Assert.Same(entity, set.Where(e => e.Id == 11 && EF.Property<bool>(e, nameof(BuiltInDataTypes.TestBoolean)) == param10).ToList().Single());
@@ -270,7 +298,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        private EntityEntry<TEntity> AddTestBuiltInDataTypes<TEntity>(DbSet<TEntity> set)
+        protected EntityEntry<TEntity> AddTestBuiltInDataTypes<TEntity>(DbSet<TEntity> set)
             where TEntity : BuiltInDataTypesBase, new()
         {
             var entityEntry = set.Add(new TEntity { Id = 11 });
@@ -354,7 +382,22 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Same(entity, set.Where(e => e.Id == 11 && EF.Property<long?>(e, nameof(BuiltInNullableDataTypes.TestNullableInt64)) == param3).ToList().Single());
 
                 double? param4 = -1.23456789;
-                Assert.Same(entity, set.Where(e => e.Id == 11 && EF.Property<double?>(e, nameof(BuiltInNullableDataTypes.TestNullableDouble)) == param4).ToList().Single());
+                if (Fixture.StrictEquality)
+                {
+                    Assert.Same(entity, set.Where(e => e.Id == 11
+                                                       && EF.Property<double?>(e, nameof(BuiltInNullableDataTypes.TestNullableDouble)) == param4).ToList().Single());
+
+                }
+                else
+                {
+                    double? param4l = -1.234567891;
+                    double? param4h = -1.234567889;
+                    Assert.Same(entity, set.Where(e => e.Id == 11
+                                                       && (EF.Property<double?>(e, nameof(BuiltInNullableDataTypes.TestNullableDouble)) == param4
+                                                           || (EF.Property<double?>(e, nameof(BuiltInNullableDataTypes.TestNullableDouble)) > param4l
+                                                               && EF.Property<double?>(e, nameof(BuiltInNullableDataTypes.TestNullableDouble)) < param4h)))
+                        .ToList().Single());
+                }
 
                 decimal? param5 = -1234567890.01M;
                 Assert.Same(entity, set.Where(e => e.Id == 11 && EF.Property<decimal?>(e, nameof(BuiltInNullableDataTypes.TestNullableDecimal)) == param5).ToList().Single());
@@ -375,7 +418,22 @@ namespace Microsoft.EntityFrameworkCore
                 }
 
                 float? param9 = -1.234F;
-                Assert.Same(entity, set.Where(e => e.Id == 11 && EF.Property<float?>(e, nameof(BuiltInNullableDataTypes.TestNullableSingle)) == param9).ToList().Single());
+                if (Fixture.StrictEquality)
+                {
+                    Assert.Same(entity, set.Where(e => e.Id == 11
+                                                       && EF.Property<float?>(e, nameof(BuiltInNullableDataTypes.TestNullableSingle)) == param9).ToList().Single());
+
+                }
+                else
+                {
+                    float? param9l = -1.2341F;
+                    float? param9h = -1.2339F;
+                    Assert.Same(entity, set.Where(e => e.Id == 11
+                                                       && (EF.Property<float?>(e, nameof(BuiltInNullableDataTypes.TestNullableSingle)) == param9
+                                                           || (EF.Property<float?>(e, nameof(BuiltInNullableDataTypes.TestNullableSingle)) > param9l
+                                                               && EF.Property<float?>(e, nameof(BuiltInNullableDataTypes.TestNullableSingle)) < param9h)))
+                        .ToList().Single());
+                }
 
                 bool? param10 = true;
                 Assert.Same(entity, set.Where(e => e.Id == 11 && EF.Property<bool?>(e, nameof(BuiltInNullableDataTypes.TestNullableBoolean)) == param10).ToList().Single());
@@ -464,7 +522,7 @@ namespace Microsoft.EntityFrameworkCore
             }
         }
 
-        private EntityEntry<TEntity> AddTestBuiltInNullableDataTypes<TEntity>(DbSet<TEntity> set)
+        protected EntityEntry<TEntity> AddTestBuiltInNullableDataTypes<TEntity>(DbSet<TEntity> set)
             where TEntity : BuiltInNullableDataTypesBase, new()
         {
             var entityEntry = set.Add(new TEntity { Id = 11 });
@@ -557,7 +615,9 @@ namespace Microsoft.EntityFrameworkCore
                     entity,
                     Fixture.StrictEquality
                         ? context.Set<BuiltInNullableDataTypes>().Where(e => e.Id == 12 && e.TestNullableDouble == -1.23456789).ToList().Single()
-                        : context.Set<BuiltInNullableDataTypes>().Where(e => e.Id == 12 && -e.TestNullableDouble + -1.23456789 < 1E-5).ToList().Single());
+                        : context.Set<BuiltInNullableDataTypes>().Where(e => e.Id == 12
+                                                                             && -e.TestNullableDouble + -1.23456789 < 1E-5
+                                                                             && -e.TestNullableDouble + -1.23456789 > -1E-5).ToList().Single());
 
                 Assert.Same(
                     entity,

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.QueryTypes.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.QueryTypes.cs
@@ -59,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     = context.Query<CustomerQuery>()
                         .Where(cq => cq.OrderCount > 0)
                         .ToArray();
-            
+
                 Assert.Equal(4, results.Length);
             }
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/NullSemanticsQuerySqlServerTest.cs
@@ -1171,7 +1171,7 @@ WHERE 0 = 1");
             AssertSql(
                 @"SELECT [c].[Id], [c].[BoolA], [c].[BoolB], [c].[BoolC], [c].[IntA], [c].[IntB], [c].[IntC], [c].[NullableBoolA], [c].[NullableBoolB], [c].[NullableBoolC], [c].[NullableIntA], [c].[NullableIntB], [c].[NullableIntC], [c].[NullableStringA], [c].[NullableStringB], [c].[NullableStringC], [c].[StringA], [c].[StringB], [c].[StringC]
 FROM (
-    SELECT * FROM ""Entities1""
+    SELECT * FROM Entities1
 ) AS [c]
 WHERE [c].[StringA] = [c].[StringB]");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.QueryTypes.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.QueryTypes.cs
@@ -63,7 +63,7 @@ FROM [Customers] AS [c]
 CROSS JOIN (
     SELECT [o].[CustomerID]
     FROM (
-        select * from ""Orders""
+        select * from Orders
     ) AS [o]
 ) AS [t]
 WHERE [t].[CustomerID] = [c].[CustomerID]");
@@ -78,7 +78,7 @@ WHERE [t].[CustomerID] = [c].[CustomerID]");
 FROM (
     SELECT [o].[CustomerID]
     FROM (
-        select * from ""Orders""
+        select * from Orders
     ) AS [o]
 ) AS [t]
 WHERE [t].[CustomerID] = N'ALFKI'");
@@ -93,7 +93,7 @@ WHERE [t].[CustomerID] = N'ALFKI'");
 FROM (
     SELECT [o].[CustomerID]
     FROM (
-        select * from ""Orders""
+        select * from Orders
     ) AS [o]
 ) AS [t]
 LEFT JOIN [Customers] AS [ov.Customer] ON [t].[CustomerID] = [ov.Customer].[CustomerID]
@@ -109,7 +109,7 @@ WHERE [t].[CustomerID] = N'ALFKI'");
 FROM (
     SELECT [o].[CustomerID]
     FROM (
-        select * from ""Orders""
+        select * from Orders
     ) AS [o]
 ) AS [t]
 LEFT JOIN [Customers] AS [ov.Customer] ON [t].[CustomerID] = [ov.Customer].[CustomerID]
@@ -123,7 +123,7 @@ INNER JOIN (
     FROM (
         SELECT [o0].[CustomerID]
         FROM (
-            select * from ""Orders""
+            select * from Orders
         ) AS [o0]
     ) AS [t0]
     LEFT JOIN [Customers] AS [ov.Customer0] ON [t0].[CustomerID] = [ov.Customer0].[CustomerID]
@@ -141,7 +141,7 @@ ORDER BY [t1].[CustomerID]");
 FROM (
     SELECT [o].[CustomerID]
     FROM (
-        select * from ""Orders""
+        select * from Orders
     ) AS [o]
 ) AS [t]
 LEFT JOIN [Customers] AS [ov.Customer] ON [t].[CustomerID] = [ov.Customer].[CustomerID]
@@ -157,7 +157,7 @@ WHERE [ov.Customer].[City] = N'Seattle'");
 FROM (
     SELECT [o].[CustomerID]
     FROM (
-        select * from ""Orders""
+        select * from Orders
     ) AS [o]
 ) AS [t]
 LEFT JOIN [Customers] AS [ov.Customer] ON [t].[CustomerID] = [ov.Customer].[CustomerID]

--- a/test/EFCore.Sqlite.FunctionalTests/CustomConvertersSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/CustomConvertersSqliteTest.cs
@@ -2,8 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -30,6 +34,7 @@ namespace Microsoft.EntityFrameworkCore
             public override bool SupportsLargeStringComparisons => true;
 
             protected override ITestStoreFactory TestStoreFactory => SqliteTestStoreFactory.Instance;
+            public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ServiceProvider.GetRequiredService<ILoggerFactory>();
 
             public override bool SupportsBinaryKeys => true;
 


### PR DESCRIPTION
Make strict floating point comparison in BuiltInDataTypesTestBase optional

Fixes #11929
Fixes #11940
