### PR TITLE
Query: Fix #1664 - Tagged or named queries

### DIFF
--- a/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
@@ -12,6 +12,7 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
+using Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal;
 using Microsoft.EntityFrameworkCore.Query.Sql;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -40,6 +41,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         // NB: Currently unsafe to access this outside of compiler. #11601
         private RelationalQueryCompilationContext _queryCompilationContext;
 
+        private IReadOnlyCollection<string> _tags;
+        
         private Expression _limit;
         private Expression _offset;
         private TableExpressionBase _projectStarTable;
@@ -251,6 +254,28 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
         /// </summary>
         public virtual IReadOnlyList<Ordering> OrderBy => _orderBy;
 
+        /// <summary>
+        ///     Any tags associated with this SelectExpression.
+        /// </summary>
+        public virtual IReadOnlyCollection<string> Tags
+        {
+            get
+            {
+                if (_tags == null)
+                {
+                    _tags = _queryCompilationContext?.QueryAnnotations != null
+                                ? _queryCompilationContext.QueryAnnotations
+                                    .OfType<TagResultOperator>()
+                                    .Select(tro => tro.Tag)
+                                    .Distinct()
+                                    .ToArray()
+                                : Array.Empty<string>();
+                }
+                
+                return _tags;
+            }
+        }
+        
         /// <summary>
         ///     Makes a copy of this SelectExpression.
         /// </summary>

--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -134,11 +134,29 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
             _parametersValues = parameterValues;
             _nullComparisonTransformingVisitor = new NullComparisonTransformingVisitor(parameterValues);
             _inExpressionValuesExpandingVisitor = new InExpressionValuesExpandingVisitor(parameterValues);
+            
             IsCacheable = true;
 
+            GenerateTagsHeaderComment();
+            
             Visit(SelectExpression);
 
             return _relationalCommandBuilder.Build();
+        }
+
+        /// <summary>
+        ///     Generates the tags header comment.
+        /// </summary>
+        protected virtual void GenerateTagsHeaderComment()
+        {
+            if (SelectExpression.Tags.Count > 0)
+            {
+                _relationalCommandBuilder
+                    .Append(SingleLineComment)
+                    .Append(" EFCore: (#")
+                    .Append(SelectExpression.Tags.Join(", #"))
+                    .AppendLine(")");
+            }
         }
 
         /// <summary>
@@ -183,6 +201,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         ///     The default alias separator.
         /// </summary>
         protected virtual string AliasSeparator { get; } = " AS ";
+        
+        /// <summary>
+        ///     The default single line comment prefix.
+        /// </summary>
+        protected virtual string SingleLineComment { get; } = "--";
 
         /// <summary>
         ///     Visit a top-level SelectExpression.

--- a/src/EFCore.Specification.Tests/Query/QueryTaggingTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/QueryTaggingTestBase.cs
@@ -1,0 +1,101 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
+using Xunit;
+
+// ReSharper disable InconsistentNaming
+// ReSharper disable AccessToDisposedClosure
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public abstract class QueryTaggingTestBase<TFixture> : IClassFixture<TFixture>
+        where TFixture : NorthwindQueryFixtureBase<NoopModelCustomizer>, new()
+    {
+        protected QueryTaggingTestBase(TFixture fixture) => Fixture = fixture;
+
+        protected TFixture Fixture { get; }
+
+        [ConditionalFact]
+        public virtual void Single_query_tag()
+        {
+            using (var context = CreateContext())
+            {
+                var customer 
+                    = context.Set<Customer>()
+                        .OrderBy(c => c.CustomerID)
+                        .WithTag("Yanni")
+                        .First();
+
+                Assert.NotNull(customer);
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Single_query_multiple_tags()
+        {
+            using (var context = CreateContext())
+            {
+                var customer 
+                    = context.Set<Customer>()
+                        .OrderBy(c => c.CustomerID)
+                        .WithTag("Yanni")
+                        .WithTag("Enya")
+                        .First();
+
+                Assert.NotNull(customer);
+            }
+        }
+        
+        [ConditionalFact]
+        public virtual void Duplicate_tags()
+        {
+            using (var context = CreateContext())
+            {
+                var customer 
+                    = context.Set<Customer>()
+                        .OrderBy(c => c.CustomerID)
+                        .WithTag("Yanni")
+                        .WithTag("Yanni")
+                        .First();
+
+                Assert.NotNull(customer);
+            }
+        }
+        
+        [ConditionalFact]
+        public virtual void Tags_on_subquery()
+        {
+            using (var context = CreateContext())
+            {
+                var customers
+                    = (from c in context.Set<Customer>().Where(c => c.CustomerID == "ALFKI").AsNoTracking().WithTag("Yanni")
+                       from o in context.Orders.OrderBy(o => o.OrderID).Take(5).WithTag("Laurel")
+                       select c).ToList();
+
+                Assert.Equal(5, customers.Count);
+            }
+        }
+        
+        [ConditionalFact]
+        public virtual void Tag_on_include_query()
+        {
+            using (var context = CreateContext())
+            {
+                var customer 
+                    = context.Set<Customer>()
+                        .Include(c => c.Orders)
+                        .OrderBy(c => c.CustomerID)
+                        .WithTag("Yanni")
+                        .First();
+
+                Assert.NotNull(customer);
+            }
+        }
+        
+        protected NorthwindContext CreateContext() => Fixture.CreateContext();
+    }
+}

--- a/src/EFCore/EntityFrameworkQueryableExtensions.cs
+++ b/src/EFCore/EntityFrameworkQueryableExtensions.cs
@@ -2581,6 +2581,42 @@ namespace Microsoft.EntityFrameworkCore
 
         #endregion
 
+        #region Tagging
+
+        internal static readonly MethodInfo WithTagMethodInfo
+            = typeof(EntityFrameworkQueryableExtensions)
+                .GetTypeInfo().GetDeclaredMethod(nameof(WithTag));
+
+        /// <summary>
+        ///    Adds a tag to the collection of tags associated with an EF LINQ query. Tags are query annotations
+        ///    that can provide contextual tracing information at different points in the query pipeline.
+        /// </summary>
+        /// <typeparam name="TEntity"> The type of entity being queried. </typeparam>
+        /// <param name="source"> The source query. </param>
+        /// <param name="tag"> The tag. </param>
+        /// <returns>
+        ///     A new query annotated with the given tag.
+        /// </returns>
+        public static IQueryable<TEntity> WithTag<TEntity>(
+            [NotNull] this IQueryable<TEntity> source, [NotNull] [NotParameterized] string tag)
+            where TEntity : class
+        {
+            Check.NotNull(source, nameof(source));
+            Check.NotEmpty(tag, nameof(tag));
+
+            return
+                source.Provider is EntityQueryProvider
+                    ? source.Provider.CreateQuery<TEntity>(
+                        Expression.Call(
+                            instance: null,
+                            method: WithTagMethodInfo.MakeGenericMethod(typeof(TEntity)),
+                            arg0: source.Expression,
+                            arg1: Expression.Constant(tag)))
+                    : source;
+        }
+
+        #endregion
+
         #region Load
 
         /// <summary>

--- a/src/EFCore/Query/Internal/MethodInfoBasedNodeTypeRegistryFactory.cs
+++ b/src/EFCore/Query/Internal/MethodInfoBasedNodeTypeRegistryFactory.cs
@@ -54,6 +54,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         {
             _methodInfoBasedNodeTypeRegistry
                 .Register(TrackingExpressionNode.SupportedMethods, typeof(TrackingExpressionNode));
+            
+            _methodInfoBasedNodeTypeRegistry
+                .Register(TagExpressionNode.SupportedMethods, typeof(TagExpressionNode));
 
             _methodInfoBasedNodeTypeRegistry
                 .Register(IgnoreQueryFiltersExpressionNode.SupportedMethods, typeof(IgnoreQueryFiltersExpressionNode));

--- a/src/EFCore/Query/ResultOperators/Internal/TagExpressionNode.cs
+++ b/src/EFCore/Query/ResultOperators/Internal/TagExpressionNode.cs
@@ -1,0 +1,57 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class TagExpressionNode : ResultOperatorExpressionNodeBase
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static readonly IReadOnlyCollection<MethodInfo> SupportedMethods = new[]
+        {
+            EntityFrameworkQueryableExtensions.WithTagMethodInfo
+        };
+
+        private readonly ConstantExpression _tagExpression;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public TagExpressionNode(
+            MethodCallExpressionParseInfo parseInfo,
+            [NotNull] ConstantExpression tagExpression)
+            : base(parseInfo, null, null)
+            => _tagExpression = tagExpression;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override ResultOperatorBase CreateResultOperator(ClauseGenerationContext clauseGenerationContext)
+            => new TagResultOperator((string)_tagExpression.Value);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override Expression Resolve(
+            ParameterExpression inputParameter,
+            Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+            => Source.Resolve(inputParameter, expressionToBeResolved, clauseGenerationContext);
+    }
+}

--- a/src/EFCore/Query/ResultOperators/Internal/TagResultOperator.cs
+++ b/src/EFCore/Query/ResultOperators/Internal/TagResultOperator.cs
@@ -1,0 +1,74 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Remotion.Linq;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.ResultOperators;
+using Remotion.Linq.Clauses.StreamedData;
+
+namespace Microsoft.EntityFrameworkCore.Query.ResultOperators.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class TagResultOperator : SequenceTypePreservingResultOperatorBase, IQueryAnnotation
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public TagResultOperator([NotNull] string tag)
+        {
+            Tag = tag;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual string Tag { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual IQuerySource QuerySource { get; [NotNull] set; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual QueryModel QueryModel { get; [NotNull] set; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override string ToString() => $"WithTag(\"{Tag}\")";
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override ResultOperatorBase Clone(CloneContext cloneContext)
+            => new TagResultOperator(Tag);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override void TransformExpressions(Func<Expression, Expression> transformation)
+        {
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override StreamedSequence ExecuteInMemory<T>(StreamedSequence input) => input;
+    }
+}

--- a/test/EFCore.InMemory.FunctionalTests/Query/QueryTaggingInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/QueryTaggingInMemoryTest.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit.Abstractions;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class QueryTaggingInMemoryTest : QueryTaggingTestBase<NorthwindQueryInMemoryFixture<NoopModelCustomizer>>
+    {
+        public QueryTaggingInMemoryTest(
+            NorthwindQueryInMemoryFixture<NoopModelCustomizer> fixture, ITestOutputHelper testOutputHelper)
+            : base(fixture)
+        {
+        }
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryTaggingSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryTaggingSqlServerTest.cs
@@ -1,0 +1,92 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit.Abstractions;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class QueryTaggingSqlServerTest : QueryTaggingTestBase<NorthwindQuerySqlServerFixture<NoopModelCustomizer>>
+    {
+        public QueryTaggingSqlServerTest(
+            NorthwindQuerySqlServerFixture<NoopModelCustomizer> fixture, ITestOutputHelper testOutputHelper)
+            : base(fixture)
+        {
+            Fixture.TestSqlLoggerFactory.Clear();
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+        }
+
+        public override void Single_query_tag()
+        {
+            base.Single_query_tag();
+            
+            AssertSql(
+                @"-- EFCore: (#Yanni)
+SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]");
+        }
+
+        public override void Single_query_multiple_tags()
+        {
+            base.Single_query_multiple_tags();
+            
+            AssertSql(
+                @"-- EFCore: (#Yanni, #Enya)
+SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]");
+        }
+
+        public override void Tags_on_subquery()
+        {
+            base.Tags_on_subquery();
+            
+            AssertSql(
+                @"-- EFCore: (#Yanni, #Laurel)
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+CROSS JOIN (
+    SELECT TOP(5) [o].*
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+) AS [t]
+WHERE [c].[CustomerID] = N'ALFKI'");
+        }
+
+        public override void Duplicate_tags()
+        {
+            base.Duplicate_tags();
+            
+            AssertSql(
+                @"-- EFCore: (#Yanni)
+SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]");
+        }
+
+        public override void Tag_on_include_query()
+        {
+            base.Tag_on_include_query();
+            
+            AssertSql(
+                @"-- EFCore: (#Yanni)
+SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]",
+                //
+                @"-- EFCore: (#Yanni)
+SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
+FROM [Orders] AS [c.Orders]
+INNER JOIN (
+    SELECT TOP(1) [c0].[CustomerID]
+    FROM [Customers] AS [c0]
+    ORDER BY [c0].[CustomerID]
+) AS [t] ON [c.Orders].[CustomerID] = [t].[CustomerID]
+ORDER BY [t].[CustomerID]");
+        }
+
+        private void AssertSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+    }
+}

--- a/test/EFCore.Sqlite.FunctionalTests/Query/QueryTaggingSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/QueryTaggingSqliteTest.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Xunit.Abstractions;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class QueryTaggingSqliteTest : QueryTaggingTestBase<NorthwindQuerySqliteFixture<NoopModelCustomizer>>
+    {
+        public QueryTaggingSqliteTest(
+            NorthwindQuerySqliteFixture<NoopModelCustomizer> fixture, ITestOutputHelper testOutputHelper)
+            : base(fixture)
+        {
+        }
+    }
+}


### PR DESCRIPTION
- Adds WithTag query operator. From the doc comments: "Adds a tag to the collection of tags associated with an EF LINQ query. Tags are query annotations that can provide contextual tracing information at different points in the query pipeline." The first application of tags, included in this PR, is to cause a diagnostic header comment to be prefixed to generated SQL queries. E.g.

```sql
-- EFCore: (#Yanni)
SELECT TOP(1) [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
FROM [Customers] AS [c]
ORDER BY [c].[CustomerID]
```

- Also fixes a bug uncovered in the new parameterization parameter caching - NotParameterized parameters are removed from the set of parameters values, but we can't do that if the parameter is being used in more than one place. Fix is to add simple ref counting to the parameter cache.

