### PR TITLE
[2.1.1] RevEng: Don't throw for type mappings that require an explicit store type

### DIFF
--- a/src/EFCore.Design/Scaffolding/Internal/ScaffoldingTypeMapper.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/ScaffoldingTypeMapper.cs
@@ -137,9 +137,9 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
             }
             else
             {
-                var defaultMapping = _typeMappingSource.GetMapping(mapping.ClrType);
+                var defaultMapping = _typeMappingSource.FindMapping(mapping.ClrType);
 
-                if (defaultMapping.StoreType.Equals(storeType, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(defaultMapping?.StoreType, storeType, StringComparison.OrdinalIgnoreCase))
                 {
                     canInfer = true;
                 }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/RelationalScaffoldingModelFactoryTest.cs
@@ -436,6 +436,37 @@ namespace Microsoft.EntityFrameworkCore
             Assert.Single(_reporter.Messages, t => t.Contains(DesignStrings.CannotFindTypeMappingForColumn("E.Coli", StoreType)));
         }
 
+        [Fact]
+        public void Sql_variant()
+        {
+            var databaseModel = new DatabaseModel
+            {
+                Tables =
+                {
+                    new DatabaseTable
+                    {
+                        Name = "MyTable",
+                        Columns =
+                        {
+                            IdColumn,
+                            new DatabaseColumn
+                            {
+                                Name = "MyColumn",
+                                StoreType = "sql_variant"
+                            }
+                        },
+                        PrimaryKey = IdPrimaryKey
+                    }
+                }
+            };
+
+            var model = _factory.Create(databaseModel, useDatabaseNames: true);
+
+            var property = model.FindEntityType("MyTable").GetProperty("MyColumn");
+            Assert.Equal(typeof(object), property.ClrType);
+            Assert.Equal("sql_variant", property.Relational().ColumnType);
+        }
+
         [Theory]
         [InlineData(new[] { "Id" }, 1)]
         [InlineData(new[] { "Id", "AltId" }, 2)]


### PR DESCRIPTION
Fixes #11977