### PR TITLE
Query: Clear out projection when GroupBy has element selector as anon type

### DIFF
--- a/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -567,7 +567,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         key = new[] { projection };
                     }
 
-                    if (selectExpression.Projection.Count > 1)
+                    if (groupResultOperator.ElementSelector.NodeType == ExpressionType.New
+                        || groupResultOperator.ElementSelector.NodeType == ExpressionType.MemberInit)
                     {
                         selectExpression.ClearProjection();
                     }

--- a/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
@@ -1040,6 +1040,38 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Sum + " " + e.Avg);
         }
 
+        [ConditionalFact]
+        public virtual async Task GroupBy_element_selector_complex_aggregate()
+        {
+            await AssertQueryScalar<Order>(
+                os => os.GroupBy(o => o.CustomerID, o => new { o.OrderID })
+                        .Select(g => g.Sum(e => e.OrderID + 1)));
+        }
+
+        [ConditionalFact]
+        public virtual async Task GroupBy_element_selector_complex_aggregate2()
+        {
+            await AssertQueryScalar<Order>(
+                os => os.GroupBy(o => o.CustomerID, o => new { o.OrderID, o.OrderDate })
+                        .Select(g => g.Sum(e => e.OrderID + 1)));
+        }
+
+        [ConditionalFact]
+        public virtual async Task GroupBy_element_selector_complex_aggregate3()
+        {
+            await AssertQueryScalar<Order>(
+                os => os.GroupBy(o => o.CustomerID, o => o.OrderID)
+                        .Select(g => g.Sum(e => e + 1)));
+        }
+
+        [ConditionalFact]
+        public virtual async Task GroupBy_element_selector_complex_aggregate4()
+        {
+            await AssertQueryScalar<Order>(
+                os => os.GroupBy(o => o.CustomerID, o => o.OrderID + 1)
+                        .Select(g => g.Sum(e => e)));
+        }
+
         #endregion
 
         #region GroupByAfterComposition

--- a/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -1043,6 +1043,38 @@ namespace Microsoft.EntityFrameworkCore.Query
                 e => e.Sum + " " + e.Avg);
         }
 
+        [ConditionalFact]
+        public virtual void GroupBy_element_selector_complex_aggregate()
+        {
+            AssertQueryScalar<Order>(
+                os => os.GroupBy(o => o.CustomerID, o => new { o.OrderID })
+                        .Select(g => g.Sum(e => e.OrderID + 1)));
+        }
+
+        [ConditionalFact]
+        public virtual void GroupBy_element_selector_complex_aggregate2()
+        {
+            AssertQueryScalar<Order>(
+                os => os.GroupBy(o => o.CustomerID, o => new { o.OrderID, o.OrderDate })
+                        .Select(g => g.Sum(e => e.OrderID + 1)));
+        }
+
+        [ConditionalFact]
+        public virtual void GroupBy_element_selector_complex_aggregate3()
+        {
+            AssertQueryScalar<Order>(
+                os => os.GroupBy(o => o.CustomerID, o => o.OrderID)
+                        .Select(g => g.Sum(e => e + 1)));
+        }
+
+        [ConditionalFact]
+        public virtual void GroupBy_element_selector_complex_aggregate4()
+        {
+            AssertQueryScalar<Order>(
+                os => os.GroupBy(o => o.CustomerID, o => o.OrderID + 1)
+                        .Select(g => g.Sum(e => e)));
+        }
+
         #endregion
 
         #region GroupByAfterComposition

--- a/src/EFCore/Query/ExpressionVisitors/Internal/RequiresMaterializationExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/RequiresMaterializationExpressionVisitor.cs
@@ -282,8 +282,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                 if (qsre != null
                     || queryModel.SelectClause.Selector.RemoveConvert() is ConstantExpression
-                    || groupResultOperator.ElementSelector is MemberInitExpression
-                    || groupResultOperator.ElementSelector is NewExpression)
+                    || groupResultOperator.ElementSelector.NodeType == ExpressionType.New
+                    || groupResultOperator.ElementSelector.NodeType == ExpressionType.MemberInit)
                 {
                     return true;
                 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
@@ -743,6 +743,46 @@ FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
         }
 
+        public override void GroupBy_element_selector_complex_aggregate()
+        {
+            base.GroupBy_element_selector_complex_aggregate();
+
+            AssertSql(
+                @"SELECT SUM([o].[OrderID] + 1)
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]");
+        }
+
+        public override void GroupBy_element_selector_complex_aggregate2()
+        {
+            base.GroupBy_element_selector_complex_aggregate2();
+
+            AssertSql(
+                @"SELECT SUM([o].[OrderID] + 1)
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]");
+        }
+
+        public override void GroupBy_element_selector_complex_aggregate3()
+        {
+            base.GroupBy_element_selector_complex_aggregate3();
+
+            AssertSql(
+                @"SELECT [o].[CustomerID], [o].[OrderID]
+FROM [Orders] AS [o]
+ORDER BY [o].[CustomerID]");
+        }
+
+        public override void GroupBy_element_selector_complex_aggregate4()
+        {
+            base.GroupBy_element_selector_complex_aggregate4();
+
+            AssertSql(
+                @"SELECT SUM([o].[OrderID] + 1)
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]");
+        }
+
         public override void GroupBy_empty_key_Aggregate()
         {
             base.GroupBy_empty_key_Aggregate();


### PR DESCRIPTION
Issue: When ElementSelector is NewExpression/MemberInitExpression, it could easily bind through mapping and we don't need to preserve projection. In this case when projection is preserved and actual expression is complex, we ended up with multiple projections which we failed to lift during aggregate operation.
Fix: is to clear out projection for NewExpression/MemberInitExpression.
ElementSelector with single property requires aggregate expression over member only for server eval. So with complex aggregate it would do streaming group by.
If elementselector is made complex property then aggregate can be made simple and it still translates.

Resolves #12032

