### PR TITLE
Query: Update OrderBy list properly when updating projection for alias-ing

### DIFF
--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -883,5 +883,18 @@ namespace Microsoft.EntityFrameworkCore.Query
                     .AsNoTracking() // Just to cause a subquery
                     .Select(e => e.B));
         }
+
+        [ConditionalFact]
+        public virtual void Anonymous_projection_with_repeated_property_being_ordered()
+        {
+            AssertQuery<Customer>(
+                cs => from c in cs
+                      orderby c.CustomerID
+                      select new
+                      {
+                          A = c.CustomerID,
+                          B = c.CustomerID
+                      });
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
@@ -896,5 +896,15 @@ FROM [Customers] AS [c]");
                 @"SELECT [o].[CustomerID] AS [A], [o].[OrderDate] AS [B]
 FROM [Orders] AS [o]");
         }
+
+        public override void Anonymous_projection_with_repeated_property_being_ordered()
+        {
+            base.Anonymous_projection_with_repeated_property_being_ordered();
+
+            AssertSql(
+                @"SELECT [c].[CustomerID] AS [B]
+FROM [Customers] AS [c]
+ORDER BY [B]");
+        }
     }
 }


### PR DESCRIPTION
Issue:
Since the projection has same property repeated twice in the DTO, we would add alias from member name. We match projection based on unwrapped alias but we don't do that in ordering.
So we updated the projection but we did not update the ordering for new alias.
Fix:
Remember the removed projection and also use that while searching inside order by so we update ordering too and don't end up with incorrect column in order by list

Resolves #12180


