### PR TITLE
Always do tracking query for Load

### DIFF
--- a/src/EFCore/Internal/EntityFinder.cs
+++ b/src/EFCore/Internal/EntityFinder.cs
@@ -210,7 +210,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
         }
 
         private IQueryable<TEntity> Query(INavigation navigation, object[] keyValues)
-            => _queryRoot.Where(BuildLambda(GetLoadProperties(navigation), new ValueBuffer(keyValues)));
+            => _queryRoot.Where(BuildLambda(GetLoadProperties(navigation), new ValueBuffer(keyValues))).AsTracking();
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used


### PR DESCRIPTION
Issue: If the ChangeTracking behaviour is set to NoTracking then calling Load on tracked entity won't track resuls of load query. Which results in load failing.
The fix is to issue AsTracking query so that results from load query are added to state manager and will be fixed up with tracked query

Currently calling Load on non tracked query does not work so this fix is safe in that regard.

Resolves #12209

