### PR TITLE
Implementation for issue #12152 [GenerateParameterNamePlaceholder]

### DIFF
--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -1736,7 +1736,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                     parameterExpression.Type.IsNullableType());
             }
 
-            _relationalCommandBuilder.Append(parameterName);
+            var parameterNamePlaceholder = SqlGenerator.GenerateParameterNamePlaceholder(parameterExpression.Name);
+
+            _relationalCommandBuilder.Append(parameterNamePlaceholder);
 
             return parameterExpression;
         }
@@ -1772,7 +1774,11 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                     propertyParameterExpression.Property);
             }
 
-            _relationalCommandBuilder.Append(parameterName);
+            var parameterNamePlaceholder
+                = SqlGenerator.GenerateParameterNamePlaceholder(
+                    propertyParameterExpression.PropertyParameterName);
+
+            _relationalCommandBuilder.Append(parameterNamePlaceholder);
 
             return propertyParameterExpression;
         }

--- a/src/EFCore.Relational/Storage/ISqlGenerationHelper.cs
+++ b/src/EFCore.Relational/Storage/ISqlGenerationHelper.cs
@@ -47,6 +47,24 @@ namespace Microsoft.EntityFrameworkCore.Storage
         void GenerateParameterName([NotNull] StringBuilder builder, [NotNull] string name);
 
         /// <summary>
+        ///     Generates a valid parameter placehoder name for the given candidate name.
+        /// </summary>
+        /// <param name="name">
+        ///     The candidate name for the parameter placehoder.
+        /// </param>
+        /// <returns> A valid placehoder name based on the candidate name. </returns>
+        string GenerateParameterNamePlaceholder([NotNull] string name);
+
+        /// <summary>
+        ///     Writes a valid parameter placehoder name for the given candidate name.
+        /// </summary>
+        /// <param name="builder"> The <see cref="StringBuilder" /> to write generated string to. </param>
+        /// <param name="name">
+        ///     The candidate name for the parameter placehoder.
+        /// </param>
+        void GenerateParameterNamePlaceholder([NotNull] StringBuilder builder, [NotNull] string name);
+
+        /// <summary>
         ///     Generates the escaped SQL representation of a literal value.
         /// </summary>
         /// <param name="literal"> The value to be escaped. </param>

--- a/src/EFCore.Relational/Storage/RelationalSqlGenerationHelper.cs
+++ b/src/EFCore.Relational/Storage/RelationalSqlGenerationHelper.cs
@@ -57,6 +57,24 @@ namespace Microsoft.EntityFrameworkCore.Storage
             => builder.Append("@").Append(name);
 
         /// <summary>
+        ///     Generates a valid parameter placeholder name for the given candidate name.
+        /// </summary>
+        /// <param name="name">The candidate name for the parameter placeholder.</param>
+        /// <returns>
+        ///     A valid name based on the candidate name.
+        /// </returns>
+        public virtual string GenerateParameterNamePlaceholder(string name)
+            => GenerateParameterName(name);
+
+        /// <summary>
+        ///     Writes a valid parameter placeholder name for the given candidate name.
+        /// </summary>
+        /// <param name="builder">The <see cref="StringBuilder" /> to write generated string to.</param>
+        /// <param name="name">The candidate name for the parameter placeholder.</param>
+        public virtual void GenerateParameterNamePlaceholder(StringBuilder builder, string name)
+            => GenerateParameterName(builder,name);
+
+        /// <summary>
         ///     Generates the escaped SQL representation of a literal value.
         /// </summary>
         /// <param name="literal">The value to be escaped.</param>

--- a/src/EFCore.Relational/Update/UpdateSqlGenerator.cs
+++ b/src/EFCore.Relational/Update/UpdateSqlGenerator.cs
@@ -329,7 +329,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                         }
                         else
                         {
-                            helper.GenerateParameterName(sb, o.ParameterName);
+                            helper.GenerateParameterNamePlaceholder(sb, o.ParameterName);
                         }
                     });
         }
@@ -419,7 +419,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                                 }
                                 else
                                 {
-                                    helper.GenerateParameterName(sb, o.ParameterName);
+                                    helper.GenerateParameterNamePlaceholder(sb, o.ParameterName);
                                 }
                             }
                             else
@@ -537,7 +537,7 @@ namespace Microsoft.EntityFrameworkCore.Update
                 }
                 else
                 {
-                    SqlGenerationHelper.GenerateParameterName(
+                    SqlGenerationHelper.GenerateParameterNamePlaceholder(
                         commandStringBuilder, useOriginalValue
                             ? columnModification.OriginalParameterName
                             : columnModification.ParameterName);

--- a/src/EFCore.Relational/breakingchanges.netcore.json
+++ b/src/EFCore.Relational/breakingchanges.netcore.json
@@ -208,5 +208,15 @@
       "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.UShortTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
       "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
       "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "System.String GenerateParameterNamePlaceholder(System.String name)",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+      "MemberId": "System.Void GenerateParameterNamePlaceholder(System.Text.StringBuilder builder, System.String name)",
+      "Kind": "Addition"
     }
 ]

--- a/src/EFCore/breakingchanges.netcore.json
+++ b/src/EFCore/breakingchanges.netcore.json
@@ -113,5 +113,15 @@
     "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IEntityType : Microsoft.EntityFrameworkCore.Metadata.ITypeBase",
     "MemberId": "System.Collections.Generic.IEnumerable<Microsoft.EntityFrameworkCore.Metadata.IServiceProperty> GetServiceProperties()",
     "Kind": "Addition"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+    "MemberId": "System.String GenerateParameterNamePlaceholder(System.String name)",
+    "Kind": "Addition"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
+    "MemberId": "System.Void GenerateParameterNamePlaceholder(System.Text.StringBuilder builder, System.String name)",
+    "Kind": "Addition"
   }
 ]

--- a/src/EFCore/breakingchanges.netcore.json
+++ b/src/EFCore/breakingchanges.netcore.json
@@ -113,15 +113,5 @@
     "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IEntityType : Microsoft.EntityFrameworkCore.Metadata.ITypeBase",
     "MemberId": "System.Collections.Generic.IEnumerable<Microsoft.EntityFrameworkCore.Metadata.IServiceProperty> GetServiceProperties()",
     "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "System.String GenerateParameterNamePlaceholder(System.String name)",
-    "Kind": "Addition"
-  },
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
-    "MemberId": "System.Void GenerateParameterNamePlaceholder(System.Text.StringBuilder builder, System.String name)",
-    "Kind": "Addition"
   }
 ]


### PR DESCRIPTION
Into interface Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper were added two new methods:
 - string GenerateParameterNamePlaceholder([NotNull] string name);
 - void GenerateParameterNamePlaceholder([NotNull] StringBuilder builder, [NotNull] string name);

By default, RelationalSqlGenerationHelper (implementation of  ISqlGenerationHelper) saves old behavior: ParameterNamePlaceholder == ParameterName.

For generation of another placeholder name, need override GenerateParameterNamePlaceholder methods.

I tested these changes with my adapter for EFCore - seem they work as expected.

One problem - I not know how to test the changes in DefaultQuerySqlGenerator::VisitPropertyParameter. This method similar to VisitParameter. But my tests does not call the VisitPropertyParameter method.