### PR TITLE
Query: Translate to server Group By when key selector is using EF.Property

### DIFF
--- a/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -497,6 +497,13 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         key = new[] { sql };
                         break;
 
+                    case MethodCallExpression methodCallExpression
+                    when methodCallExpression.IsEFProperty():
+                        sql = sqlTranslatingExpressionVisitor.Visit(methodCallExpression);
+                        memberInfoMappings[groupByKeyMemberInfo] = sql;
+                        key = new[] { sql };
+                        break;
+
                     case NullConditionalExpression nullConditionalExpression:
                         sql = sqlTranslatingExpressionVisitor.Visit(nullConditionalExpression);
                         memberInfoMappings[groupByKeyMemberInfo] = sql;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
@@ -1091,6 +1091,17 @@ WHERE [o].[OrderID] < 10300
 GROUP BY [o].[CustomerID]");
         }
 
+        public override void GroupBy_principal_key_property_optimization()
+        {
+            base.GroupBy_principal_key_property_optimization();
+
+            AssertSql(
+                @"SELECT [o].[CustomerID] AS [Key], COUNT(*) AS [Count]
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]");
+
+        }
+
         public override void GroupBy_OrderBy_key()
         {
             base.GroupBy_OrderBy_key();


### PR DESCRIPTION


Resolves #12228
