### PR TITLE
Add support for defining included column for indexes in SQL server

### DIFF
--- a/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
+++ b/src/EFCore.Relational/Migrations/Internal/MigrationsModelDiffer.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -1896,7 +1897,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
             foreach (var annotation in source)
             {
-                var index = unmatched.FindIndex(a => a.Name == annotation.Name && Equals(a.Value, annotation.Value));
+                var index = unmatched.FindIndex(a => a.Name == annotation.Name && StructuralComparisons.StructuralEqualityComparer.Equals(a.Value, annotation.Value));
                 if (index == -1)
                 {
                     return true;

--- a/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
+++ b/src/EFCore.Relational/Migrations/MigrationsSqlGenerator.cs
@@ -477,12 +477,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 .Append(ColumnList(operation.Columns))
                 .Append(")");
 
-            if (!string.IsNullOrEmpty(operation.Filter))
-            {
-                builder
-                    .Append(" WHERE ")
-                    .Append(operation.Filter);
-            }
+            IndexExtras(operation, model, builder);
 
             if (terminate)
             {
@@ -1558,6 +1553,25 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             [CanBeNull] IModel model,
             [NotNull] MigrationCommandListBuilder builder)
         {
+        }
+
+        /// <summary>
+        ///     Generates a SQL fragment for extras (filter, included columns, options) of an index from a <see cref="CreateIndexOperation" />.
+        /// </summary>
+        /// <param name="operation"> The operation. </param>
+        /// <param name="model"> The target model which may be <c>null</c> if the operations exist without a model. </param>
+        /// <param name="builder"> The command builder to use to add the SQL fragment. </param>
+        protected virtual void IndexExtras(
+            [NotNull] CreateIndexOperation operation,
+            [CanBeNull] IModel model,
+            [NotNull] MigrationCommandListBuilder builder)
+        {
+            if (!string.IsNullOrEmpty(operation.Filter))
+            {
+                builder
+                    .Append(" WHERE ")
+                    .Append(operation.Filter);
+            }
         }
 
         /// <summary>

--- a/src/EFCore.Relational/RelationalIndexBuilderExtensions.cs
+++ b/src/EFCore.Relational/RelationalIndexBuilderExtensions.cs
@@ -32,6 +32,16 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
+        ///     Configures the name of the index in the database when targeting a relational database.
+        /// </summary>
+        /// <typeparam name="TEntity"> The entity type being configured. </typeparam>
+        /// <param name="indexBuilder"> The builder for the index being configured. </param>
+        /// <param name="name"> The name of the index. </param>
+        /// <returns> A builder to further configure the index. </returns>
+        public static IndexBuilder<TEntity> HasName<TEntity>([NotNull] this IndexBuilder<TEntity> indexBuilder, [CanBeNull] string name)
+            => (IndexBuilder<TEntity>)HasName((IndexBuilder)indexBuilder, name);
+
+        /// <summary>
         ///     Determines whether the specified index has filter expression.
         /// </summary>
         /// <param name="indexBuilder"> The builder for the index being configured. </param>
@@ -43,5 +53,15 @@ namespace Microsoft.EntityFrameworkCore
 
             return indexBuilder;
         }
+
+        /// <summary>
+        ///     Determines whether the specified index has filter expression.
+        /// </summary>
+        /// <typeparam name="TEntity"> The entity type being configured. </typeparam>
+        /// <param name="indexBuilder"> The builder for the index being configured. </param>
+        /// <param name="sql"> The filter expression for the index. </param>
+        /// <returns>A builder to further configure the index. </returns>
+        public static IndexBuilder<TEntity> HasFilter<TEntity>([NotNull] this IndexBuilder<TEntity> indexBuilder, [CanBeNull] string sql)
+            => (IndexBuilder<TEntity>)HasFilter((IndexBuilder)indexBuilder, sql);
     }
 }

--- a/src/EFCore.SqlServer/Extensions/SqlServerEntityTypeBuilderExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerEntityTypeBuilderExtensions.cs
@@ -1,8 +1,13 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 // ReSharper disable once CheckNamespace
@@ -40,5 +45,35 @@ namespace Microsoft.EntityFrameworkCore
             [NotNull] this EntityTypeBuilder<TEntity> entityTypeBuilder, bool memoryOptimized = true)
             where TEntity : class
             => (EntityTypeBuilder<TEntity>)ForSqlServerIsMemoryOptimized((EntityTypeBuilder)entityTypeBuilder, memoryOptimized);
+
+        /// <summary>
+        ///     Configures an index on the specified properties. If there is an existing index on the given
+        ///     set of properties, then the existing index will be returned for configuration.
+        /// </summary>
+        /// <typeparam name="TEntity"> The entity type being configured. </typeparam>
+        /// <param name="entityTypeBuilder"> The builder for the entity type being configured. </param>
+        /// <param name="indexExpression">
+        ///     <para>
+        ///         A lambda expression representing the property(s) to be included in the index
+        ///         (<c>blog => blog.Url</c>).
+        ///     </para>
+        ///     <para>
+        ///         If the index is made up of multiple properties then specify an anonymous type including the
+        ///         properties (<c>post => new { post.Title, post.BlogId }</c>).
+        ///     </para>
+        /// </param>
+        /// <returns> An object that can be used to configure the index. </returns>
+        public static IndexBuilder<TEntity> ForSqlServerHasIndex<TEntity>(
+            [NotNull] this EntityTypeBuilder<TEntity> entityTypeBuilder, [NotNull] Expression<Func<TEntity, object>> indexExpression)
+            where TEntity : class
+        {
+            Check.NotNull(entityTypeBuilder, nameof(entityTypeBuilder));
+            Check.NotNull(indexExpression, nameof(indexExpression));
+
+            var builder = ((IInfrastructure<InternalEntityTypeBuilder>)entityTypeBuilder).GetInfrastructure();
+
+            return new IndexBuilder<TEntity>(
+                builder.HasIndex(indexExpression.GetPropertyAccessList(), ConfigurationSource.Explicit));
+        }
     }
 }

--- a/src/EFCore.SqlServer/Extensions/SqlServerIndexBuilderExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerIndexBuilderExtensions.cs
@@ -1,7 +1,11 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Linq;
+using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -24,6 +28,56 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(indexBuilder, nameof(indexBuilder));
 
             indexBuilder.Metadata.SqlServer().IsClustered = clustered;
+
+            return indexBuilder;
+        }
+
+        /// <summary>
+        ///     Configures whether the index is clustered when targeting SQL Server.
+        /// </summary>
+        /// <param name="indexBuilder"> The builder for the index being configured. </param>
+        /// <param name="clustered"> A value indicating whether the index is clustered. </param>
+        /// <returns> A builder to further configure the index. </returns>
+        public static IndexBuilder<TEntity> ForSqlServerIsClustered<TEntity>([NotNull] this IndexBuilder<TEntity> indexBuilder, bool clustered = true)
+            => (IndexBuilder<TEntity>)ForSqlServerIsClustered((IndexBuilder)indexBuilder, clustered);
+
+        /// <summary>
+        ///     Configures index include properties when targeting SQL Server.
+        /// </summary>
+        /// <param name="indexBuilder"> The builder for the index being configured. </param>
+        /// <param name="propertyNames"> An array of property names to be used in 'include' clause. </param>
+        /// <returns> A builder to further configure the index. </returns>
+        public static IndexBuilder ForSqlServerInclude([NotNull] this IndexBuilder indexBuilder, [NotNull] params string[] propertyNames)
+        {
+            Check.NotNull(indexBuilder, nameof(indexBuilder));
+            Check.NotNull(propertyNames, nameof(propertyNames));
+
+            indexBuilder.Metadata.SqlServer().IncludeProperties = propertyNames;
+
+            return indexBuilder;
+        }
+
+        /// <summary>
+        ///     Configures index include properties when targeting SQL Server.
+        /// </summary>
+        /// <param name="indexBuilder"> The builder for the index being configured. </param>
+        /// <param name="includeExpression">
+        ///     <para>
+        ///         A lambda expression representing the property(s) to be included in the 'include' clause
+        ///         (<c>blog => blog.Url</c>).
+        ///     </para>
+        ///     <para>
+        ///         If multiple properties are to be included then specify an anonymous type including the
+        ///         properties (<c>post => new { post.Title, post.BlogId }</c>).
+        ///     </para>
+        /// </param>
+        /// <returns> A builder to further configure the index. </returns>
+        public static IndexBuilder<TEntity> ForSqlServerInclude<TEntity>([NotNull] this IndexBuilder<TEntity> indexBuilder, [NotNull] Expression<Func<TEntity, object>> includeExpression)
+        {
+            Check.NotNull(indexBuilder, nameof(indexBuilder));
+            Check.NotNull(includeExpression, nameof(includeExpression));
+
+            ForSqlServerInclude(indexBuilder, includeExpression.GetPropertyAccessList().Select(p => p.Name).ToArray());
 
             return indexBuilder;
         }

--- a/src/EFCore.SqlServer/Metadata/ISqlServerIndexAnnotations.cs
+++ b/src/EFCore.SqlServer/Metadata/ISqlServerIndexAnnotations.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+
 namespace Microsoft.EntityFrameworkCore.Metadata
 {
     /// <summary>
@@ -14,5 +16,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     been specified.
         /// </summary>
         bool? IsClustered { get; }
+
+        /// <summary>
+        ///     Returns included property names, or <c>null</c> if they have not been specified.
+        /// </summary>
+        IReadOnlyList<string> IncludeProperties { get; }
     }
 }

--- a/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationNames.cs
+++ b/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationNames.cs
@@ -25,6 +25,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public const string Include = Prefix + "Include";
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public const string ValueGenerationStrategy = Prefix + "ValueGenerationStrategy";
 
         /// <summary>

--- a/src/EFCore.SqlServer/Metadata/Internal/SqlServerIndexBuilderAnnotations.cs
+++ b/src/EFCore.SqlServer/Metadata/Internal/SqlServerIndexBuilderAnnotations.cs
@@ -42,6 +42,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public new virtual bool IsClustered(bool? value) => SetIsClustered(value);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public new virtual bool Include([CanBeNull] string[] value) => SetInclude(value);
 #pragma warning restore 109
     }
 }

--- a/src/EFCore.SqlServer/Metadata/SqlServerIndexAnnotations.cs
+++ b/src/EFCore.SqlServer/Metadata/SqlServerIndexAnnotations.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal;
 
@@ -50,6 +51,24 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         /// <returns> <c>True</c> if the annotation was set; <c>false</c> otherwise. </returns>
         protected virtual bool SetIsClustered(bool? value) => Annotations.SetAnnotation(
             SqlServerAnnotationNames.Clustered,
+            value);
+
+        /// <summary>
+        ///     Returns included property names, or <c>null</c> if they have not been specified.
+        /// </summary>
+        public virtual IReadOnlyList<string> IncludeProperties
+        {
+            get => (string[])Annotations.Metadata[SqlServerAnnotationNames.Include];
+            set => SetInclude(value);
+        }
+
+        /// <summary>
+        ///     Attempts to set included property names using the semantics of the <see cref="RelationalAnnotations" /> in use.
+        /// </summary>
+        /// <param name="value"> The value to set. </param>
+        /// <returns> <c>True</c> if the annotation was set; <c>false</c> otherwise. </returns>
+        protected virtual bool SetInclude([CanBeNull] IReadOnlyList<string> value) => Annotations.SetAnnotation(
+            SqlServerAnnotationNames.Include,
             value);
     }
 }

--- a/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationsAnnotationProvider.cs
+++ b/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationsAnnotationProvider.cs
@@ -67,6 +67,14 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Migrations.Internal
                     SqlServerAnnotationNames.Clustered,
                     isClustered.Value);
             }
+
+            var includeProperties = index.SqlServer().IncludeProperties;
+            if (includeProperties != null)
+            {
+                yield return new Annotation(
+                    SqlServerAnnotationNames.Include,
+                    includeProperties);
+            }
         }
 
         /// <summary>

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -321,6 +321,30 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         public static string InvalidColumnNameForFreeText
             => GetString("InvalidColumnNameForFreeText");
 
+        /// <summary>
+        ///     Include property '{entityType}.{property}' cannot be defined multiple times
+        /// </summary>
+        public static string IncludePropertyDuplicated([CanBeNull] object entityType, [CanBeNull] object property)
+            => string.Format(
+                GetString("IncludePropertyDuplicated", nameof(entityType), nameof(property)),
+                entityType, property);
+
+        /// <summary>
+        ///     Include property '{entityType}.{property}' is already included in the index
+        /// </summary>
+        public static string IncludePropertyInIndex([CanBeNull] object entityType, [CanBeNull] object property)
+            => string.Format(
+                GetString("IncludePropertyInIndex", nameof(entityType), nameof(property)),
+                entityType, property);
+
+        /// <summary>
+        ///     Include property '{entityType}.{property}' not found
+        /// </summary>
+        public static string IncludePropertyNotFound([CanBeNull] object entityType, [CanBeNull] object property)
+            => string.Format(
+                GetString("IncludePropertyNotFound", nameof(entityType), nameof(property)),
+                entityType, property);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -225,4 +225,13 @@
   <data name="InvalidColumnNameForFreeText" xml:space="preserve">
     <value>The expression passed to the 'propertyReference' parameter of the 'FreeText' method is not a valid reference to a property. The expression should represent a reference to a full-text indexed property on the object referenced in the from clause: 'from e in context.Entities where EF.Functions.FreeText(e.SomeProperty, textToSearchFor) select e'</value>
   </data>
+  <data name="IncludePropertyDuplicated" xml:space="preserve">
+    <value>Include property '{entityType}.{property}' cannot be defined multiple times</value>
+  </data>
+  <data name="IncludePropertyInIndex" xml:space="preserve">
+    <value>Include property '{entityType}.{property}' is already included in the index</value>
+  </data>
+  <data name="IncludePropertyNotFound" xml:space="preserve">
+    <value>Include property '{entityType}.{property}' not found</value>
+  </data>
 </root>

--- a/src/EFCore.SqlServer/breakingchanges.netcore.json
+++ b/src/EFCore.SqlServer/breakingchanges.netcore.json
@@ -7,5 +7,10 @@
       "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.SqlServerMigrationsSqlGenerator : Microsoft.EntityFrameworkCore.Migrations.MigrationsSqlGenerator",
       "MemberId": "protected override System.Void ColumnDefinition(System.String schema, System.String table, System.String name, System.Type clrType, System.String type, System.Nullable<System.Boolean> unicode, System.Nullable<System.Int32> maxLength, System.Boolean rowVersion, System.Boolean nullable, System.Object defaultValue, System.String defaultValueSql, System.String computedColumnSql, Microsoft.EntityFrameworkCore.Infrastructure.IAnnotatable annotatable, Microsoft.EntityFrameworkCore.Metadata.IModel model, Microsoft.EntityFrameworkCore.Migrations.MigrationCommandListBuilder builder)",
       "Kind": "Removal"
-    }
+    },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.ISqlServerIndexAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalIndexAnnotations",
+    "MemberId": "System.Collections.Generic.IReadOnlyList<System.String> get_IncludeProperties()",
+    "Kind": "Addition"
+  }
 ]

--- a/src/EFCore/Metadata/Builders/IndexBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/IndexBuilder`.cs
@@ -1,0 +1,50 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Builders
+{
+    /// <summary>
+    ///     <para>
+    ///         Provides a simple API for configuring an <see cref="Index" />.
+    ///     </para>
+    ///     <para>
+    ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
+    ///         and it is not designed to be directly constructed in your application code.
+    ///     </para>
+    /// </summary>
+    // ReSharper disable once UnusedTypeParameter
+    public class IndexBuilder<T> : IndexBuilder
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public IndexBuilder([NotNull] InternalIndexBuilder builder)
+            : base(builder)
+        {
+        }
+
+        /// <summary>
+        ///     Adds or updates an annotation on the index. If an annotation with the key specified in
+        ///     <paramref name="annotation" />
+        ///     already exists its value will be updated.
+        /// </summary>
+        /// <param name="annotation"> The key of the annotation to be added or updated. </param>
+        /// <param name="value"> The value to be stored in the annotation. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public new virtual IndexBuilder<T> HasAnnotation([NotNull] string annotation, [NotNull] object value)
+            => (IndexBuilder<T>)base.HasAnnotation(annotation, value);
+
+        /// <summary>
+        ///     Configures whether this index is unique (i.e. the value(s) for each instance must be unique).
+        /// </summary>
+        /// <param name="unique"> A value indicating whether this index is unique. </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public new virtual IndexBuilder<T> IsUnique(bool unique = true)
+            => (IndexBuilder<T>)base.IsUnique(unique);
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
@@ -444,6 +444,48 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [Fact]
+        public virtual void AlterColumnOperation_with_index_included_column()
+        {
+            Generate(
+                modelBuilder => modelBuilder
+                    .HasAnnotation(CoreAnnotationNames.ProductVersionAnnotation, "1.1.0")
+                    .Entity(
+                        "Person", x =>
+                        {
+                            x.Property<string>("Name").HasMaxLength(30);
+                            x.Property<string>("FirstName");
+                            x.Property<string>("LastName");
+                            x.HasIndex("FirstName", "LastName")
+                                .ForSqlServerInclude("Name");
+                        }),
+                new AlterColumnOperation
+                {
+                    Table = "Person",
+                    Name = "Name",
+                    ClrType = typeof(string),
+                    MaxLength = 30,
+                    IsNullable = true,
+                    OldColumn = new ColumnOperation
+                    {
+                        ClrType = typeof(string),
+                        IsNullable = true
+                    }
+                });
+
+            Assert.Equal(
+                "DROP INDEX [IX_Person_FirstName_LastName] ON [Person];" + EOL +
+                "DECLARE @var0 sysname;" + EOL +
+                "SELECT @var0 = [d].[name]" + EOL +
+                "FROM [sys].[default_constraints] [d]" + EOL +
+                "INNER JOIN [sys].[columns] [c] ON [d].[parent_column_id] = [c].[column_id] AND [d].[parent_object_id] = [c].[object_id]" + EOL +
+                "WHERE ([d].[parent_object_id] = OBJECT_ID(N'[Person]') AND [c].[name] = N'Name');" + EOL +
+                "IF @var0 IS NOT NULL EXEC(N'ALTER TABLE [Person] DROP CONSTRAINT [' + @var0 + '];');" + EOL +
+                "ALTER TABLE [Person] ALTER COLUMN [Name] nvarchar(30) NULL;" + EOL +
+                "CREATE INDEX [IX_Person_FirstName_LastName] ON [Person] ([FirstName], [LastName]) INCLUDE ([Name]);" + EOL,
+                Sql);
+        }
+
+        [Fact]
         public virtual void AlterColumnOperation_with_index_no_oldColumn()
         {
             Generate(
@@ -826,6 +868,97 @@ namespace Microsoft.EntityFrameworkCore
 
             Assert.Equal(
                 "CREATE UNIQUE CLUSTERED INDEX [IX_People_Name] ON [People] ([Name]);" + EOL,
+                Sql);
+        }
+
+        [Fact]
+        public virtual void CreateIndexOperation_with_include()
+        {
+            Generate(
+                new CreateIndexOperation
+                {
+                    Name = "IX_People_Name",
+                    Table = "People",
+                    Columns = new[] { "Name" },
+                    [SqlServerAnnotationNames.Include] = new[] { "FirstName", "LastName" }
+                });
+
+            Assert.Equal(
+                "CREATE INDEX [IX_People_Name] ON [People] ([Name]) INCLUDE ([FirstName], [LastName]);" + EOL,
+                Sql);
+        }
+
+        [Fact]
+        public virtual void CreateIndexOperation_with_include_and_filter()
+        {
+            Generate(
+                new CreateIndexOperation
+                {
+                    Name = "IX_People_Name",
+                    Table = "People",
+                    Columns = new[] { "Name" },
+                    Filter = "[Name] IS NOT NULL AND <> ''",
+                    [SqlServerAnnotationNames.Include] = new[] { "FirstName", "LastName" }
+                });
+
+            Assert.Equal(
+                "CREATE INDEX [IX_People_Name] ON [People] ([Name]) INCLUDE ([FirstName], [LastName]) WHERE [Name] IS NOT NULL AND <> '';" + EOL,
+                Sql);
+        }
+
+        [Fact]
+        public virtual void CreateIndexOperation_unique_with_include()
+        {
+            Generate(
+                new CreateIndexOperation
+                {
+                    Name = "IX_People_Name",
+                    Table = "People",
+                    Columns = new[] { "Name" },
+                    IsUnique = true,
+                    [SqlServerAnnotationNames.Include] = new[] { "FirstName", "LastName" }
+                });
+
+            Assert.Equal(
+                "CREATE UNIQUE INDEX [IX_People_Name] ON [People] ([Name]) INCLUDE ([FirstName], [LastName]) WHERE [Name] IS NOT NULL;" + EOL,
+                Sql);
+        }
+
+        [Fact]
+        public virtual void CreateIndexOperation_unique_with_include_and_filter()
+        {
+            Generate(
+                new CreateIndexOperation
+                {
+                    Name = "IX_People_Name",
+                    Table = "People",
+                    Columns = new[] { "Name" },
+                    IsUnique = true,
+                    Filter = "[Name] IS NOT NULL AND <> ''",
+                    [SqlServerAnnotationNames.Include] = new[] { "FirstName", "LastName" }
+                });
+
+            Assert.Equal(
+                "CREATE UNIQUE INDEX [IX_People_Name] ON [People] ([Name]) INCLUDE ([FirstName], [LastName]) WHERE [Name] IS NOT NULL AND <> '';" + EOL,
+                Sql);
+        }
+
+        [Fact]
+        public virtual void CreateIndexOperation_unique_with_include_non_legacy()
+        {
+            Generate(
+                modelBuilder => modelBuilder.HasAnnotation(CoreAnnotationNames.ProductVersionAnnotation, "2.0.0"),
+                new CreateIndexOperation
+                {
+                    Name = "IX_People_Name",
+                    Table = "People",
+                    Columns = new[] { "Name" },
+                    IsUnique = true,
+                    [SqlServerAnnotationNames.Include] = new[] { "FirstName", "LastName" }
+                });
+
+            Assert.Equal(
+                "CREATE UNIQUE INDEX [IX_People_Name] ON [People] ([Name]) INCLUDE ([FirstName], [LastName]);" + EOL,
                 Sql);
         }
 


### PR DESCRIPTION
This PR adds `ForSqlServerInclude` extension to `IndexBuilder` allowing defining columns to be included in a index on sql server.

To support expression parameter a generic version of `IndexBuilder` is introduced in main EF assembly, however to avoid breaking changes (as requested in https://github.com/aspnet/EntityFrameworkCore/issues/4846#issuecomment-395213518) this type is available only with new extension `ForSqlServerHasIndex` for the time being.

There is a breaking change in `EFCore.SqlServer` adding a property to interface -
 `ISqlServerIndexAnnotations.Include`, which might be ok since it's maybe not really meant to be implemented by others? @ajcvickers 

I'm still investigating possible problems with migrations, so this is not yet ready.

Fixes #4846 