### PR TITLE
[2.2] Avoid creating a duplicate property in nested owned type in model snapshot.

### DIFF
--- a/src/EFCore/Metadata/Builders/ReferenceOwnershipBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceOwnershipBuilder`.cs
@@ -344,11 +344,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             Check.NotNull(navigationExpression, nameof(navigationExpression));
             Check.NotNull(buildAction, nameof(buildAction));
 
-            using (DeclaringEntityType.Model.ConventionDispatcher.StartBatch())
-            {
-                buildAction.Invoke(OwnsOneBuilder<TNewRelatedEntity>(navigationExpression.GetPropertyAccess()));
-                return this;
-            }
+            buildAction.Invoke(OwnsOneBuilder<TNewRelatedEntity>(navigationExpression.GetPropertyAccess()));
+            return this;
         }
 
         private ReferenceOwnershipBuilder<TRelatedEntity, TNewRelatedEntity> OwnsOneBuilder<TNewRelatedEntity>(PropertyInfo navigation)

--- a/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
@@ -140,6 +140,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             conventionSet.ModelBuiltConventions.Add(new ConstructorBindingConvention(Dependencies.ConstructorBindingFactory));
             conventionSet.ModelBuiltConventions.Add(new TypeMappingConvention(Dependencies.TypeMappingSource));
             conventionSet.ModelBuiltConventions.Add(new IgnoredMembersValidationConvention());
+            conventionSet.ModelBuiltConventions.Add(foreignKeyIndexConvention);
 
             conventionSet.ModelBuiltConventions.Add(
                 new PropertyMappingValidationConvention(

--- a/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -32,7 +32,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         [DebuggerStepThrough]
         public static string ShortName([NotNull] this IEntityType type)
-            => ((ITypeBase)type).DisplayName();
+        {
+            if (type.ClrType != null)
+            {
+                return type.ClrType.ShortDisplayName();
+            }
+
+            var plusIndex = type.Name.LastIndexOf("+", StringComparison.Ordinal);
+            var dotIndex = type.Name.LastIndexOf(".", StringComparison.Ordinal);
+            return plusIndex == -1
+                ? dotIndex == -1
+                    ? type.Name
+                    : type.Name.Substring(dotIndex + 1, type.Name.Length - dotIndex - 1)
+                : type.Name.Substring(plusIndex + 1, type.Name.Length - plusIndex - 1);
+        }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -42,11 +55,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         // Issue#11266 This method is being used by provider code. Do not break.
         public static string DisplayName([NotNull] this IEntityType type)
         {
-            if (type.ClrType == null)
-            {
-                return type.Name;
-            }
-
             if (!type.HasDefiningNavigation())
             {
                 return ((ITypeBase)type).DisplayName();

--- a/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalEntityTypeBuilder.cs
@@ -310,9 +310,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual InternalPropertyBuilder Property([NotNull] string propertyName, ConfigurationSource configurationSource)
-            => Property(
-                propertyName, propertyType: null, memberInfo: null,
-                configurationSource: configurationSource, typeConfigurationSource: configurationSource);
+            => Property(propertyName, propertyType: null, memberInfo: null, configurationSource, typeConfigurationSource: null);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -328,13 +326,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             ConfigurationSource? configurationSource,
             ConfigurationSource? typeConfigurationSource)
         {
-            if (IsIgnored(propertyName, configurationSource))
-            {
-                return null;
-            }
-
-            Metadata.Unignore(propertyName);
-
             IEnumerable<Property> propertiesToDetach = null;
             var existingProperty = Metadata.FindProperty(propertyName);
             if (existingProperty != null)
@@ -344,10 +335,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     if (memberInfo != null
                         && existingProperty.GetIdentifyingMemberInfo() == null)
                     {
-                        propertiesToDetach = new[] { existingProperty };
+                        if (configurationSource.Overrides(existingProperty.GetConfigurationSource()))
+                        {
+                            propertiesToDetach = new[] { existingProperty };
+                        }
+                        else
+                        {
+                            return null;
+                        }
                     }
                     else
                     {
+                        if (!IsIgnored(propertyName, configurationSource))
+                        {
+                            Metadata.Unignore(propertyName);
+                        }
+
                         return existingProperty.DeclaringEntityType.Builder
                             .Property(existingProperty, propertyName, propertyType, memberInfo, configurationSource, typeConfigurationSource);
                     }
@@ -355,7 +358,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
             else
             {
-                propertiesToDetach = Metadata.FindDerivedProperties(propertyName);
+                if (IsIgnored(propertyName, configurationSource))
+                {
+                    return null;
+                }
 
                 foreach (var conflictingServiceProperty in Metadata.FindServicePropertiesInHierarchy(propertyName))
                 {
@@ -383,6 +389,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                             CoreStrings.PropertyCalledOnNavigation(propertyName, Metadata.DisplayName()));
                     }
                 }
+
+                Metadata.Unignore(propertyName);
+
+                propertiesToDetach = Metadata.FindDerivedProperties(propertyName);
             }
 
             InternalPropertyBuilder builder;
@@ -413,7 +423,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             ConfigurationSource? configurationSource,
             ConfigurationSource? typeConfigurationSource)
         {
-            var property = existingProperty;
+            Property property;
             if (existingProperty == null)
             {
                 if (!configurationSource.HasValue)
@@ -487,17 +497,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 {
                     if (configurationSource.HasValue)
                     {
-                        property.UpdateConfigurationSource(configurationSource.Value);
+                        existingProperty.UpdateConfigurationSource(configurationSource.Value);
                     }
 
-                    if (typeConfigurationSource.HasValue)
+                    if (propertyType != null
+                        && typeConfigurationSource.HasValue)
                     {
-                        property.UpdateTypeConfigurationSource(typeConfigurationSource.Value);
+                        existingProperty.UpdateTypeConfigurationSource(typeConfigurationSource.Value);
                     }
+
+                    return existingProperty.Builder;
                 }
             }
 
-            return property?.Builder;
+            return property.Builder;
         }
 
         private bool CanRemoveProperty(
@@ -948,9 +961,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     detachedProperties = DetachProperties(duplicatedProperties);
 
                     var propertiesToRemove = Metadata.GetDerivedTypesInclusive().SelectMany(et => et.GetDeclaredProperties())
-                        .Where(
-                            p => !p.GetConfigurationSource()
-                                .Overrides(baseEntityType.FindIgnoredMemberConfigurationSource(p.Name)))
+                        .Where(p => !p.GetConfigurationSource()
+                            .Overrides(baseEntityType.FindIgnoredMemberConfigurationSource(p.Name)))
                         .ToList();
                     foreach (var property in propertiesToRemove)
                     {
@@ -2117,12 +2129,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     if (existingNavigation.GetTargetType().ClrType == targetEntityType.Type)
                     {
                         var ownershipBuilder = existingNavigation.ForeignKey.Builder;
-                        ownershipBuilder = ownershipBuilder.RelatedEntityTypes(
-                            Metadata, ownershipBuilder.Metadata.FindNavigationsFromInHierarchy(Metadata).Single().GetTargetType(),
-                            configurationSource);
-                        ownershipBuilder = ownershipBuilder?.Navigations(inverse, navigation, configurationSource);
-                        ownershipBuilder = ownershipBuilder?.IsRequired(true, configurationSource);
-                        ownershipBuilder = ownershipBuilder?.IsOwnership(true, configurationSource);
+                        ownershipBuilder = ownershipBuilder
+                            .IsRequired(true, configurationSource)
+                            ?.RelatedEntityTypes(
+                                Metadata, ownershipBuilder.Metadata.FindNavigationsFromInHierarchy(Metadata).Single().GetTargetType(),
+                                configurationSource)
+                            ?.Navigations(inverse, navigation, configurationSource)
+                            ?.IsOwnership(true, configurationSource);
 
                         return ownershipBuilder == null ? null : batch.Run(ownershipBuilder);
                     }
@@ -2572,12 +2585,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             for (var i = 0; i < actualProperties.Length; i++)
             {
                 var property = properties[i];
+                var typeConfigurationSource = property.GetTypeConfigurationSource();
                 var builder = property.Builder != null && property.DeclaringEntityType.IsAssignableFrom(Metadata)
                     ? property.Builder
-                    : Metadata.FindProperty(property.Name)?.Builder
-                      ?? (property.IsShadowProperty
-                          ? null
-                          : Property(property.Name, property.ClrType, property.GetIdentifyingMemberInfo(), configurationSource, property.GetTypeConfigurationSource()));
+                    : Property(
+                        property.Name,
+                        typeConfigurationSource.HasValue ? property.ClrType : null,
+                        null,
+                        configurationSource,
+                        typeConfigurationSource);
                 if (builder == null)
                 {
                     return null;

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -614,115 +614,6 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
         }
 
         [Fact]
-        public virtual void Owned_types_are_stored_in_snapshot()
-        {
-            Test(
-                builder =>
-                {
-                    builder
-                        .Entity<EntityWithOneProperty>()
-                        .OwnsOne(
-                            eo => eo.EntityWithTwoProperties, eb =>
-                            {
-                                eb.HasForeignKey(e => e.AlternateId);
-                                eb.HasOne(e => e.EntityWithOneProperty)
-                                    .WithOne(e => e.EntityWithTwoProperties);
-                                eb.HasIndex(e => e.Id);
-
-                                eb.OwnsOne(e => e.EntityWithStringProperty);
-
-                                eb.HasData(
-                                    new EntityWithTwoProperties
-                                    {
-                                        AlternateId = 1
-                                    });
-                            })
-                        .HasData(
-                            new EntityWithOneProperty
-                            {
-                                Id = 1
-                            });
-                },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
-
-        b.HasKey(""Id"");
-
-        b.ToTable(""EntityWithOneProperty"");
-
-        b.HasData(
-            new { Id = 1 }
-        );
-    });
-
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
-    {
-        b.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""EntityWithTwoProperties"", b1 =>
-            {
-                b1.Property<int>(""AlternateId"")
-                    .ValueGeneratedOnAdd()
-                    .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
-
-                b1.Property<int>(""Id"");
-
-                b1.HasIndex(""Id"");
-
-                b1.ToTable(""EntityWithOneProperty"");
-
-                b1.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""EntityWithOneProperty"")
-                    .WithOne(""EntityWithTwoProperties"")
-                    .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
-                    .OnDelete(DeleteBehavior.Cascade);
-
-                b1.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", ""EntityWithStringProperty"", b2 =>
-                    {
-                        b2.Property<int>(""Id"")
-                            .ValueGeneratedOnAdd()
-                            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
-
-                        b2.Property<string>(""Name"");
-
-                        b2.ToTable(""EntityWithOneProperty"");
-
-                        b2.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"")
-                            .WithOne(""EntityWithStringProperty"")
-                            .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", ""Id"")
-                            .OnDelete(DeleteBehavior.Cascade);
-                    });
-
-                b1.HasData(
-                    new { AlternateId = 1, Id = 0 }
-                );
-            });
-    });
-",
-                o =>
-                {
-                    var ownership1 = o.FindEntityType(typeof(EntityWithOneProperty)).GetReferencingForeignKeys().Single();
-                    Assert.Equal("AlternateId", ownership1.Properties[0].Name);
-                    Assert.Equal("EntityWithTwoProperties", ownership1.PrincipalToDependent.Name);
-                    Assert.Equal("EntityWithOneProperty", ownership1.DependentToPrincipal.Name);
-                    Assert.True(ownership1.IsRequired);
-                    var ownedType1 = ownership1.DeclaringEntityType;
-                    Assert.Equal("AlternateId", ownedType1.FindPrimaryKey().Properties[0].Name);
-                    Assert.Equal(1, ownedType1.GetKeys().Count());
-                    Assert.Equal("Id", ownedType1.GetIndexes().Single().Properties[0].Name);
-                    var ownership2 = ownedType1.GetReferencingForeignKeys().Single();
-                    Assert.Equal("Id", ownership2.Properties[0].Name);
-                    Assert.Equal("EntityWithStringProperty", ownership2.PrincipalToDependent.Name);
-                    Assert.Null(ownership2.DependentToPrincipal);
-                    Assert.True(ownership2.IsRequired);
-                    var ownedType2 = ownership2.DeclaringEntityType;
-                    Assert.Equal("Id", ownedType2.FindPrimaryKey().Properties[0].Name);
-                    Assert.Equal(1, ownedType2.GetKeys().Count());
-                });
-        }
-
-        [Fact]
         public virtual void TableName_preserved_when_generic()
         {
             IModel originalModel = null;
@@ -889,6 +780,288 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     Assert.Equal(typeof(string), discriminatorProperty.ClrType);
                     Assert.False(discriminatorProperty.IsNullable);
                 });
+        }
+
+        #endregion
+
+        #region Owned types
+
+        [Fact]
+        public virtual void Owned_types_are_stored_in_snapshot()
+        {
+            Test(
+                builder =>
+                {
+                    builder
+                        .Entity<EntityWithOneProperty>()
+                        .OwnsOne(
+                            eo => eo.EntityWithTwoProperties, eb =>
+                            {
+                                eb.HasForeignKey(e => e.AlternateId);
+                                eb.HasOne(e => e.EntityWithOneProperty)
+                                        .WithOne(e => e.EntityWithTwoProperties);
+                                eb.HasIndex(e => e.Id);
+
+                                eb.OwnsOne(e => e.EntityWithStringProperty);
+
+                                eb.HasData(new EntityWithTwoProperties
+                                {
+                                    AlternateId = 1
+                                });
+                            })
+                        .HasData(new EntityWithOneProperty { Id = 1 });
+                },
+                GetHeading() + @"
+builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+    {
+        b.Property<int>(""Id"")
+            .ValueGeneratedOnAdd()
+            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+
+        b.HasKey(""Id"");
+
+        b.ToTable(""EntityWithOneProperty"");
+
+        b.HasData(
+            new { Id = 1 }
+        );
+    });
+
+builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+    {
+        b.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""EntityWithTwoProperties"", b1 =>
+            {
+                b1.Property<int>(""AlternateId"")
+                    .ValueGeneratedOnAdd()
+                    .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+
+                b1.Property<int>(""Id"");
+
+                b1.HasIndex(""Id"");
+
+                b1.ToTable(""EntityWithOneProperty"");
+
+                b1.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""EntityWithOneProperty"")
+                    .WithOne(""EntityWithTwoProperties"")
+                    .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                b1.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", ""EntityWithStringProperty"", b2 =>
+                    {
+                        b2.Property<int>(""Id"")
+                            .ValueGeneratedOnAdd()
+                            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+
+                        b2.Property<string>(""Name"");
+
+                        b2.ToTable(""EntityWithOneProperty"");
+
+                        b2.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"")
+                            .WithOne(""EntityWithStringProperty"")
+                            .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", ""Id"")
+                            .OnDelete(DeleteBehavior.Cascade);
+                    });
+
+                b1.HasData(
+                    new { AlternateId = 1, Id = 0 }
+                );
+            });
+    });
+",
+                o =>
+                {
+                    var ownership1 = o.FindEntityType(typeof(EntityWithOneProperty)).GetReferencingForeignKeys().Single();
+                    Assert.Equal("AlternateId", ownership1.Properties[0].Name);
+                    Assert.Equal("EntityWithTwoProperties", ownership1.PrincipalToDependent.Name);
+                    Assert.Equal("EntityWithOneProperty", ownership1.DependentToPrincipal.Name);
+                    Assert.True(ownership1.IsRequired);
+                    var ownedType1 = ownership1.DeclaringEntityType;
+                    Assert.Equal("AlternateId", ownedType1.FindPrimaryKey().Properties[0].Name);
+                    Assert.Equal(1, ownedType1.GetKeys().Count());
+                    Assert.Equal("Id", ownedType1.GetIndexes().Single().Properties[0].Name);
+                    var ownership2 = ownedType1.GetReferencingForeignKeys().Single();
+                    Assert.Equal("Id", ownership2.Properties[0].Name);
+                    Assert.Equal("EntityWithStringProperty", ownership2.PrincipalToDependent.Name);
+                    Assert.Null(ownership2.DependentToPrincipal);
+                    Assert.True(ownership2.IsRequired);
+                    var ownedType2 = ownership2.DeclaringEntityType;
+                    Assert.Equal("Id", ownedType2.FindPrimaryKey().Properties[0].Name);
+                    Assert.Equal(1, ownedType2.GetKeys().Count());
+                });
+        }
+
+        [Fact]
+        public virtual void Weak_owned_types_are_stored_in_snapshot()
+        {
+            Test(
+                builder =>
+                {
+                    builder.Entity<Order>().OwnsOne(p => p.OrderBillingDetails, od =>
+                    {
+                        od.OwnsOne(c => c.StreetAddress);
+                    });
+                    builder.Entity<Order>().OwnsOne(p => p.OrderShippingDetails, od =>
+                    {
+                        od.OwnsOne(c => c.StreetAddress);
+                    });
+                    builder.Entity<Order>().OwnsOne(p => p.OrderInfo, od =>
+                    {
+                        od.OwnsOne(c => c.StreetAddress);
+                    });
+                },
+                GetHeading() + @"
+builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Order"", b =>
+    {
+        b.Property<int>(""Id"")
+            .ValueGeneratedOnAdd()
+            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+
+        b.HasKey(""Id"");
+
+        b.ToTable(""Order"");
+    });
+
+builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Order"", b =>
+    {
+        b.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderInfo"", ""OrderInfo"", b1 =>
+            {
+                b1.Property<int>(""OrderId"")
+                    .ValueGeneratedOnAdd()
+                    .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+
+                b1.ToTable(""Order"");
+
+                b1.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Order"")
+                    .WithOne(""OrderInfo"")
+                    .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderInfo"", ""OrderId"")
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                b1.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+StreetAddress"", ""StreetAddress"", b2 =>
+                    {
+                        b2.Property<int>(""OrderInfoOrderId"")
+                            .ValueGeneratedOnAdd()
+                            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+
+                        b2.Property<string>(""City"");
+
+                        b2.ToTable(""Order"");
+
+                        b2.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderInfo"")
+                            .WithOne(""StreetAddress"")
+                            .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+StreetAddress"", ""OrderInfoOrderId"")
+                            .OnDelete(DeleteBehavior.Cascade);
+                    });
+            });
+
+        b.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderDetails"", ""OrderBillingDetails"", b1 =>
+            {
+                b1.Property<int>(""OrderId"")
+                    .ValueGeneratedOnAdd()
+                    .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+
+                b1.ToTable(""Order"");
+
+                b1.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Order"")
+                    .WithOne(""OrderBillingDetails"")
+                    .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderDetails"", ""OrderId"")
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                b1.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+StreetAddress"", ""StreetAddress"", b2 =>
+                    {
+                        b2.Property<int>(""OrderDetailsOrderId"")
+                            .ValueGeneratedOnAdd()
+                            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+
+                        b2.Property<string>(""City"");
+
+                        b2.ToTable(""Order"");
+
+                        b2.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderDetails"")
+                            .WithOne(""StreetAddress"")
+                            .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+StreetAddress"", ""OrderDetailsOrderId"")
+                            .OnDelete(DeleteBehavior.Cascade);
+                    });
+            });
+
+        b.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderDetails"", ""OrderShippingDetails"", b1 =>
+            {
+                b1.Property<int>(""OrderId"")
+                    .ValueGeneratedOnAdd()
+                    .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+
+                b1.ToTable(""Order"");
+
+                b1.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Order"")
+                    .WithOne(""OrderShippingDetails"")
+                    .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderDetails"", ""OrderId"")
+                    .OnDelete(DeleteBehavior.Cascade);
+
+                b1.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+StreetAddress"", ""StreetAddress"", b2 =>
+                    {
+                        b2.Property<int>(""OrderDetailsOrderId"")
+                            .ValueGeneratedOnAdd()
+                            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+
+                        b2.Property<string>(""City"");
+
+                        b2.ToTable(""Order"");
+
+                        b2.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderDetails"")
+                            .WithOne(""StreetAddress"")
+                            .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+StreetAddress"", ""OrderDetailsOrderId"")
+                            .OnDelete(DeleteBehavior.Cascade);
+                    });
+            });
+    });
+",
+                o =>
+                {
+                    Assert.Equal(7, o.GetEntityTypes().Count());
+
+                    var order = o.FindEntityType(typeof(Order).FullName);
+                    Assert.Equal(1, order.PropertyCount());
+
+                    var orderInfo = order.FindNavigation(nameof(Order.OrderInfo)).GetTargetType();
+                    Assert.Equal(1, orderInfo.PropertyCount());
+
+                    var orderInfoAddress = orderInfo.FindNavigation(nameof(OrderInfo.StreetAddress)).GetTargetType();
+                    Assert.Equal(2, orderInfoAddress.PropertyCount());
+
+                    var orderBillingDetails = order.FindNavigation(nameof(Order.OrderBillingDetails)).GetTargetType();
+                    Assert.Equal(1, orderBillingDetails.PropertyCount());
+
+                    var orderBillingDetailsAddress = orderBillingDetails.FindNavigation(nameof(OrderDetails.StreetAddress)).GetTargetType();
+                    Assert.Equal(2, orderBillingDetailsAddress.PropertyCount());
+
+                    var orderShippingDetails = order.FindNavigation(nameof(Order.OrderShippingDetails)).GetTargetType();
+                    Assert.Equal(1, orderShippingDetails.PropertyCount());
+
+                    var orderShippingDetailsAddress = orderShippingDetails.FindNavigation(nameof(OrderDetails.StreetAddress)).GetTargetType();
+                    Assert.Equal(2, orderShippingDetailsAddress.PropertyCount());
+                });
+        }
+
+        private class Order
+        {
+            public int Id { get; set; }
+            public OrderDetails OrderBillingDetails { get; set; }
+            public OrderDetails OrderShippingDetails { get; set; }
+            public OrderInfo OrderInfo { get; set; }
+        }
+
+        private class OrderDetails
+        {
+            public StreetAddress StreetAddress { get; set; }
+        }
+
+        private class OrderInfo
+        {
+            public StreetAddress StreetAddress { get; set; }
+        }
+
+        private class StreetAddress
+        {
+            public string City { get; set; }
         }
 
         #endregion

--- a/test/EFCore.SqlServer.Tests/SqlServerDbContextOptionsExtensionsTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerDbContextOptionsExtensionsTest.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal;
 using Xunit;
 
+// ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore
 {
     public class SqlServerDbContextOptionsExtensionsTest

--- a/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/InternalEntityTypeBuilderTest.cs
@@ -1258,6 +1258,26 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         [Fact]
+        public void Property_returns_same_instance_if_type_matches()
+        {
+            var modelBuilder = CreateModelBuilder();
+            var entityBuilder = modelBuilder.Entity(typeof(Order), ConfigurationSource.Explicit);
+
+            var propertyBuilder = entityBuilder.Property(Order.IdProperty, ConfigurationSource.DataAnnotation);
+            Assert.NotNull(propertyBuilder);
+
+            Assert.Same(propertyBuilder, entityBuilder.Property(Order.IdProperty.Name, typeof(int), ConfigurationSource.DataAnnotation, typeConfigurationSource: ConfigurationSource.DataAnnotation));
+
+            Assert.Same(propertyBuilder, entityBuilder.Property(Order.IdProperty.Name, typeof(int), ConfigurationSource.Convention, typeConfigurationSource: null));
+
+            Assert.Same(propertyBuilder, entityBuilder.Property(Order.IdProperty.Name, null, ConfigurationSource.Convention, typeConfigurationSource: ConfigurationSource.Convention));
+
+            Assert.Null(entityBuilder.Property(Order.IdProperty.Name, typeof(string), ConfigurationSource.Convention, typeConfigurationSource: ConfigurationSource.Convention));
+
+            Assert.Equal(new[] { propertyBuilder.Metadata }, entityBuilder.GetActualProperties(new[] { propertyBuilder.Metadata }, null));
+        }
+
+        [Fact]
         public void Property_throws_for_navigation()
         {
             var modelBuilder = CreateModelBuilder();


### PR DESCRIPTION
Fix ShortName() for shadow entity types.
Make the shadow property for identifying FKs be of a non-nullable type in more cases.

Port of #12107 fix
