### PR TITLE
Fix to #12249 - Ordering by a boolean column twice after an outer join results in invalid SQL

### DIFF
--- a/src/EFCore.Relational/Query/Expressions/ExplicitCastExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/ExplicitCastExpression.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Query.Sql;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -106,7 +107,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             return obj.GetType() == GetType() && Equals((ExplicitCastExpression)obj);
         }
 
-        private bool Equals(ExplicitCastExpression other) => _type == other._type && Equals(Operand, other.Operand);
+        private bool Equals(ExplicitCastExpression other)
+            => _type == other._type && ExpressionEqualityComparer.Instance.Equals(Operand, other.Operand);
 
         /// <summary>
         ///     Returns a hash code for this object.

--- a/src/EFCore.Relational/Query/Expressions/LikeExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/LikeExpression.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Query.Sql;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -140,11 +141,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
 
             return obj.GetType() == GetType() && Equals((LikeExpression)obj);
         }
-
         private bool Equals(LikeExpression other)
-            => Equals(Match, other.Match)
-               && Equals(Pattern, other.Pattern)
-               && Equals(EscapeChar, other.EscapeChar);
+            => ExpressionEqualityComparer.Instance.Equals(Match, other.Match)
+               && ExpressionEqualityComparer.Instance.Equals(Pattern, other.Pattern)
+               && ExpressionEqualityComparer.Instance.Equals(EscapeChar, other.EscapeChar);
 
         /// <summary>
         ///     Returns a hash code for this object.

--- a/src/EFCore.Relational/Query/Expressions/NullCompensatedExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/NullCompensatedExpression.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Query.Expressions
@@ -94,7 +95,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             return obj.GetType() == GetType() && Equals((NullCompensatedExpression)obj);
         }
 
-        private bool Equals([NotNull] NullCompensatedExpression other) => Equals(_operand, other._operand);
+        private bool Equals([NotNull] NullCompensatedExpression other)
+            => ExpressionEqualityComparer.Instance.Equals(_operand, other._operand);
 
         /// <summary>
         ///     Returns a hash code for this object.

--- a/src/EFCore.Relational/Query/Expressions/NullableExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/NullableExpression.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Query.Expressions
@@ -93,7 +94,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             return obj.GetType() == GetType() && Equals((NullableExpression)obj);
         }
 
-        private bool Equals([NotNull] NullableExpression other) => Equals(_operand, other._operand);
+        private bool Equals([NotNull] NullableExpression other)
+            => ExpressionEqualityComparer.Instance.Equals(_operand, other._operand);
 
         /// <summary>
         ///     Returns a hash code for this object.

--- a/src/EFCore.Relational/Query/Expressions/StringCompareExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/StringCompareExpression.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Query.Sql;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -122,8 +123,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
 
         private bool Equals(StringCompareExpression other)
             => Operator == other.Operator
-               && Equals(Left, other.Left)
-               && Equals(Right, other.Right);
+               && ExpressionEqualityComparer.Instance.Equals(Left, other.Left)
+               && ExpressionEqualityComparer.Instance.Equals(Right, other.Right);
 
         /// <summary>
         ///     Returns a hash code for this object.

--- a/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
@@ -2241,7 +2241,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual async Task OrderBy_Skip_Take_GroupBy()
         {
             await AssertQuery<Order>(
-                os => os.OrderBy(o => o.OrderDate).Skip(450).Take(50).GroupBy(o => o.CustomerID),
+                os => os.Where(o => o.CustomerID != "SAVEA").OrderBy(o => o.OrderDate).Skip(450).Take(50).GroupBy(o => o.CustomerID),
                 elementSorter: GroupingSorter<string, object>(),
                 elementAsserter: GroupingAsserter<string, dynamic>(d => d.OrderDate),
                 entryCount: 50);

--- a/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -2244,7 +2244,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void OrderBy_Skip_Take_GroupBy()
         {
             AssertQuery<Order>(
-                os => os.OrderBy(o => o.OrderDate).Skip(450).Take(50).GroupBy(o => o.CustomerID),
+                os => os.Where(o => o.CustomerID != "SAVEA").OrderBy(o => o.OrderDate).Skip(450).Take(50).GroupBy(o => o.CustomerID),
                 elementSorter: GroupingSorter<string, object>(),
                 elementAsserter: GroupingAsserter<string, dynamic>(d => d.OrderDate),
                 entryCount: 50);

--- a/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/GearsOfWarQueryInMemoryTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -11,6 +12,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             : base(fixture)
         {
             //TestLoggerFactory.TestOutputHelper = testOutputHelper;
+        }
+
+        [ConditionalFact(Skip = "issue #12295")]
+        public override void Double_order_by_on_nullable_bool_coming_from_optional_navigation()
+        {
+            base.Double_order_by_on_nullable_bool_coming_from_optional_navigation();
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -135,7 +135,7 @@ WHERE [l].[Level1_Required_Id] = 1");
                 @"SELECT [l].[Id], [l].[Date], [l].[Name], [l].[OneToMany_Optional_Self_InverseId], [l].[OneToMany_Required_Self_InverseId], [l].[OneToOne_Optional_SelfId]
 FROM [LevelOne] AS [l]
 LEFT JOIN [LevelTwo] AS [l.OneToOne_Required_FK] ON [l].[Id] = [l.OneToOne_Required_FK].[Level1_Required_Id]
-WHERE ([l.OneToOne_Required_FK].[Id] = 1) OR ([l.OneToOne_Required_FK].[Id] = 2)");
+WHERE [l.OneToOne_Required_FK].[Id] IN (1, 2)");
         }
 
         public override void Key_equality_two_conditions_on_same_navigation2()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -2737,6 +2737,21 @@ ORDER BY [t0].[SquadId]");
 END");
         }
 
+        public override void Optional_navigation_type_compensation_works_with_negated_predicate()
+        {
+            base.Optional_navigation_type_compensation_works_with_negated_predicate();
+
+            AssertSql(
+                @"SELECT [t].[Id], [t].[GearNickName], [t].[GearSquadId], [t].[Note]
+FROM [Tags] AS [t]
+LEFT JOIN (
+    SELECT [t.Gear].*
+    FROM [Gears] AS [t.Gear]
+    WHERE [t.Gear].[Discriminator] IN (N'Officer', N'Gear')
+) AS [t0] ON ([t].[GearNickName] = [t0].[Nickname]) AND ([t].[GearSquadId] = [t0].[SquadId])
+WHERE (([t].[Note] <> N'K.I.A.') OR [t].[Note] IS NULL) AND (([t0].[HasSoulPatch] <> 1) AND [t0].[HasSoulPatch] IS NOT NULL)");
+        }
+
         public override void Optional_navigation_type_compensation_works_with_contains()
         {
             base.Optional_navigation_type_compensation_works_with_contains();
@@ -7475,6 +7490,78 @@ INNER JOIN (
     WHERE [g0].[Discriminator] IN (N'Officer', N'Gear')
 ) AS [t] ON [g.Weapons].[OwnerFullName] = [t].[FullName]
 ORDER BY [t].[c] DESC, [t].[Nickname], [t].[SquadId], [t].[FullName]");
+        }
+
+        public override void Double_order_by_on_nullable_bool_coming_from_optional_navigation()
+        {
+            base.Double_order_by_on_nullable_bool_coming_from_optional_navigation();
+
+            AssertSql(
+                @"SELECT [w.SynergyWith].[Id], [w.SynergyWith].[AmmunitionType], [w.SynergyWith].[IsAutomatic], [w.SynergyWith].[Name], [w.SynergyWith].[OwnerFullName], [w.SynergyWith].[SynergyWithId]
+FROM [Weapons] AS [w]
+LEFT JOIN [Weapons] AS [w.SynergyWith] ON [w].[SynergyWithId] = [w.SynergyWith].[Id]
+ORDER BY [w.SynergyWith].[IsAutomatic]");
+        }
+
+        public override void Double_order_by_on_Like()
+        {
+            base.Double_order_by_on_Like();
+
+            AssertSql(
+                @"SELECT [w.SynergyWith].[Id], [w.SynergyWith].[AmmunitionType], [w.SynergyWith].[IsAutomatic], [w.SynergyWith].[Name], [w.SynergyWith].[OwnerFullName], [w.SynergyWith].[SynergyWithId]
+FROM [Weapons] AS [w]
+LEFT JOIN [Weapons] AS [w.SynergyWith] ON [w].[SynergyWithId] = [w.SynergyWith].[Id]
+ORDER BY CASE
+    WHEN [w.SynergyWith].[Name] LIKE N'%Lancer'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END");
+        }
+
+        public override void Double_order_by_on_is_null()
+        {
+            base.Double_order_by_on_is_null();
+
+            AssertSql(
+                @"SELECT [w.SynergyWith].[Id], [w.SynergyWith].[AmmunitionType], [w.SynergyWith].[IsAutomatic], [w.SynergyWith].[Name], [w.SynergyWith].[OwnerFullName], [w.SynergyWith].[SynergyWithId]
+FROM [Weapons] AS [w]
+LEFT JOIN [Weapons] AS [w.SynergyWith] ON [w].[SynergyWithId] = [w.SynergyWith].[Id]
+ORDER BY CASE
+    WHEN [w.SynergyWith].[Name] IS NULL
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END");
+        }
+
+        public override void Double_order_by_on_string_compare()
+        {
+            base.Double_order_by_on_string_compare();
+
+            AssertSql(
+                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapons] AS [w]
+ORDER BY CASE
+    WHEN [w].[Name] = N'Marcus'' Lancer'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END");
+        }
+
+        public override void Double_order_by_binary_expression()
+        {
+            base.Double_order_by_binary_expression();
+
+            AssertSql(
+                @"SELECT [w].[Id] + 2 AS [Binary]
+FROM [Weapons] AS [w]
+ORDER BY [Binary]");
+        }
+
+        public override void Order_by_with_complex_ordering_function_and_null_compensated_argument()
+        {
+            base.Order_by_with_complex_ordering_function_and_null_compensated_argument();
+
+            AssertSql(
+                @"SELECT [w.SynergyWith].[Id], [w.SynergyWith].[AmmunitionType], [w.SynergyWith].[IsAutomatic], [w.SynergyWith].[Name], [w.SynergyWith].[OwnerFullName], [w.SynergyWith].[SynergyWithId]
+FROM [Weapons] AS [w]
+LEFT JOIN [Weapons] AS [w.SynergyWith] ON [w].[SynergyWithId] = [w.SynergyWith].[Id]");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
@@ -1691,6 +1691,7 @@ SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
 FROM (
     SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
+    WHERE ([o].[CustomerID] <> N'SAVEA') OR [o].[CustomerID] IS NULL
     ORDER BY [o].[OrderDate]
     OFFSET @__p_0 ROWS FETCH NEXT @__p_1 ROWS ONLY
 ) AS [t]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -3273,7 +3273,7 @@ CROSS APPLY (
     ) AS [t1] ON 1 = 1
 ) AS [t2]
 WHERE ([c].[City] = N'Seattle') AND ([t0].[OrderID] IS NOT NULL AND [t2].[OrderID] IS NOT NULL)
-ORDER BY [t0].[OrderID], [t2].[OrderDate]");
+ORDER BY [OrderID], [t2].[OrderDate]");
         }
 
         [SqlServerCondition(SqlServerCondition.SupportsOffset)]


### PR DESCRIPTION
Problem was that our expression comparison mechanism wasn't doing good job comparing extension nodes. Since the ExpressionEqualityComparer resides in Core it has no knowledge of custom expressions defined in Relational or providers. Those expressions should know how to compare themselves to one another, but in many cases they were using Equals method, rather than ExpressionEqualityComparer.Equals.

Fix is to use ExpressionEqualityComparer instead.
