### PR TITLE
[2.1.3] Handle properties with same name from multiple explicit interface implementations.

### DIFF
--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -190,12 +190,15 @@ namespace System
             do
             {
                 var typeInfo = type.GetTypeInfo();
-                var propertyInfo = typeInfo.GetDeclaredProperty(name);
-                if (propertyInfo != null
-                    && !(propertyInfo.GetMethod ?? propertyInfo.SetMethod).IsStatic)
+                foreach (var propertyInfo in typeInfo.DeclaredProperties)
                 {
-                    yield return propertyInfo;
+                    if (propertyInfo.Name.Equals(name, StringComparison.Ordinal)
+                        && !(propertyInfo.GetMethod ?? propertyInfo.SetMethod).IsStatic)
+                    {
+                        yield return propertyInfo;
+                    }
                 }
+
                 type = typeInfo.BaseType;
             }
             while (type != null);

--- a/test/EFCore.Tests/EFCore.Tests.csproj
+++ b/test/EFCore.Tests/EFCore.Tests.csproj
@@ -18,6 +18,10 @@
     <ProjectReference Include="..\..\src\EFCore.Specification.Tests\EFCore.Specification.Tests.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
+  </ItemGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
     <Reference Include="System.Transactions" />
   </ItemGroup>

--- a/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
@@ -11,6 +11,7 @@ using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 // ReSharper disable InconsistentNaming
@@ -760,7 +761,6 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Null(entityType.FindProperty("Strange").GetValueConverter());
             }
 
-
             [Fact]
             public virtual void Properties_can_have_value_converter_set_inline()
             {
@@ -780,6 +780,24 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Null(entityType.FindProperty("Up").GetValueConverter());
                 Assert.NotNull(entityType.FindProperty("Down").GetValueConverter());
                 Assert.NotNull(entityType.FindProperty("Charm").GetValueConverter());
+            }
+
+            [Fact]
+            public virtual void IEnumerable_properties_with_value_converter_set_are_not_discovered_as_navigations()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<JsonProperty>(
+                    b =>
+                    {
+                        b.Property(e => e.JObject).HasConversion(v => v.ToString(), v => new JObject(v));
+                    });
+
+                modelBuilder.Validate();
+
+                var entityType = (IEntityType)model.GetEntityTypes().Single();
+                Assert.NotNull(entityType.FindProperty(nameof(JsonProperty.JObject)).GetValueConverter());
             }
 
             [Fact]

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -7,6 +7,8 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Reflection;
+using Newtonsoft.Json.Linq;
+
 // ReSharper disable UnusedAutoPropertyAccessor.Local
 
 namespace Microsoft.EntityFrameworkCore.ModelBuilding
@@ -424,6 +426,13 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public int KappaId { get; set; }
 
             public Kappa Kappa { get; set; }
+        }
+
+        protected class JsonProperty
+        {
+            public int Id { get; set; }
+
+            public JObject JObject { get; set; }
         }
 
         protected interface IEntityBase


### PR DESCRIPTION
Fixes #12203
