### PR TITLE
Fix to #12298 - Query: function call with argument that has null protection applied on can be unnecessarily complex leading to client eval

### DIFF
--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -5811,11 +5811,35 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
-        public virtual void Order_by_with_complex_ordering_function_and_null_compensated_argument()
+        public virtual void String_compare_with_null_conditional_argument()
         {
             AssertQuery<Weapon>(
                 ws => ws.Select(w => w.SynergyWith).OrderBy(w => w.Name.CompareTo("Marcus' Lancer") == 0),
                 ws => ws.Select(w => w.SynergyWith).OrderBy(w => w != null ? w.Name.CompareTo("Marcus' Lancer") == 0 : false));
+        }
+
+        [ConditionalFact]
+        public virtual void String_compare_with_null_conditional_argument2()
+        {
+            AssertQuery<Weapon>(
+                ws => ws.Select(w => w.SynergyWith).OrderBy(w => "Marcus' Lancer".CompareTo(w.Name) == 0),
+                ws => ws.Select(w => w.SynergyWith).OrderBy(w => w != null ? "Marcus' Lancer".CompareTo(w.Name) == 0 : false));
+        }
+
+        [ConditionalFact]
+        public virtual void String_concat_with_null_conditional_argument()
+        {
+            AssertQuery<Weapon>(
+                ws => ws.Select(w => w.SynergyWith).OrderBy(w => w.Name + 5),
+                ws => ws.Select(w => w.SynergyWith).OrderBy(w => w != null ? w.Name + 5 : null));
+        }
+
+        [ConditionalFact]
+        public virtual void String_concat_with_null_conditional_argument2()
+        {
+            AssertQuery<Weapon>(
+                ws => ws.Select(w => w.SynergyWith).OrderBy(w => string.Concat(w.Name, "Marcus' Lancer")),
+                ws => ws.Select(w => w.SynergyWith).OrderBy(w => w != null ? string.Concat(w.Name, "Marcus' Lancer") : null));
         }
 
         // Remember to add any new tests to Async version of this test class

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerCompositeMethodCallTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerCompositeMethodCallTranslator.cs
@@ -32,7 +32,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
             new SqlServerStringTrimEndTranslator(),
             new SqlServerStringTrimStartTranslator(),
             new SqlServerStringTrimTranslator(),
-            new SqlServerStringIndexOfTranslator()
+            new SqlServerStringIndexOfTranslator(),
+            new SqlServerStringConcatMethodCallTranslator()
         };
 
         /// <summary>

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringConcatMethodCallTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerStringConcatMethodCallTranslator.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class SqlServerStringConcatMethodCallTranslator : IMethodCallTranslator
+    {
+        private static readonly MethodInfo _stringConcatMethodInfo
+            = typeof(string).GetRuntimeMethod(
+                nameof(string.Concat),
+                new[] { typeof(string), typeof(string) });
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+            => _stringConcatMethodInfo.Equals(methodCallExpression.Method)
+            ? Expression.Add(methodCallExpression.Arguments[0], methodCallExpression.Arguments[1], _stringConcatMethodInfo)
+            : null;
+    }
+}

--- a/src/EFCore/Query/Expressions/Internal/NullConditionalExpression.cs
+++ b/src/EFCore/Query/Expressions/Internal/NullConditionalExpression.cs
@@ -119,7 +119,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions.Internal
 
             if (newCaller != Caller
                 || newAccessOperation != AccessOperation
-                && (newAccessOperation as NullConditionalExpression)?.AccessOperation != AccessOperation)
+                && !(ExpressionEqualityComparer.Instance.Equals((newAccessOperation as NullConditionalExpression)?.AccessOperation, AccessOperation)))
             {
                 return new NullConditionalExpression(newCaller, newAccessOperation);
             }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7554,14 +7554,54 @@ FROM [Weapons] AS [w]
 ORDER BY [Binary]");
         }
 
-        public override void Order_by_with_complex_ordering_function_and_null_compensated_argument()
+        public override void String_compare_with_null_conditional_argument()
         {
-            base.Order_by_with_complex_ordering_function_and_null_compensated_argument();
+            base.String_compare_with_null_conditional_argument();
 
             AssertSql(
                 @"SELECT [w.SynergyWith].[Id], [w.SynergyWith].[AmmunitionType], [w.SynergyWith].[IsAutomatic], [w.SynergyWith].[Name], [w.SynergyWith].[OwnerFullName], [w.SynergyWith].[SynergyWithId]
 FROM [Weapons] AS [w]
-LEFT JOIN [Weapons] AS [w.SynergyWith] ON [w].[SynergyWithId] = [w.SynergyWith].[Id]");
+LEFT JOIN [Weapons] AS [w.SynergyWith] ON [w].[SynergyWithId] = [w.SynergyWith].[Id]
+ORDER BY CASE
+    WHEN [w.SynergyWith].[Name] = N'Marcus'' Lancer'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END");
+        }
+
+        public override void String_compare_with_null_conditional_argument2()
+        {
+            base.String_compare_with_null_conditional_argument2();
+
+            AssertSql(
+                @"SELECT [w.SynergyWith].[Id], [w.SynergyWith].[AmmunitionType], [w.SynergyWith].[IsAutomatic], [w.SynergyWith].[Name], [w.SynergyWith].[OwnerFullName], [w.SynergyWith].[SynergyWithId]
+FROM [Weapons] AS [w]
+LEFT JOIN [Weapons] AS [w.SynergyWith] ON [w].[SynergyWithId] = [w.SynergyWith].[Id]
+ORDER BY CASE
+    WHEN N'Marcus'' Lancer' = [w.SynergyWith].[Name]
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END");
+        }
+
+        public override void String_concat_with_null_conditional_argument()
+        {
+            base.String_concat_with_null_conditional_argument();
+
+            AssertSql(
+                @"SELECT [w.SynergyWith].[Id], [w.SynergyWith].[AmmunitionType], [w.SynergyWith].[IsAutomatic], [w.SynergyWith].[Name], [w.SynergyWith].[OwnerFullName], [w.SynergyWith].[SynergyWithId]
+FROM [Weapons] AS [w]
+LEFT JOIN [Weapons] AS [w.SynergyWith] ON [w].[SynergyWithId] = [w.SynergyWith].[Id]
+ORDER BY [w.SynergyWith].[Name] + CAST(5 AS nvarchar(max))");
+        }
+
+        public override void String_concat_with_null_conditional_argument2()
+        {
+            base.String_concat_with_null_conditional_argument2();
+
+            AssertSql(
+                @"SELECT [w.SynergyWith].[Id], [w.SynergyWith].[AmmunitionType], [w.SynergyWith].[IsAutomatic], [w.SynergyWith].[Name], [w.SynergyWith].[OwnerFullName], [w.SynergyWith].[SynergyWithId]
+FROM [Weapons] AS [w]
+LEFT JOIN [Weapons] AS [w.SynergyWith] ON [w].[SynergyWithId] = [w.SynergyWith].[Id]
+ORDER BY [w.SynergyWith].[Name] + N'Marcus'' Lancer'");
         }
 
         private void AssertSql(params string[] expected)


### PR DESCRIPTION
Problem was that when deciding whether new NullConditional expression was needed we were not correctly comparing the access expressions. Fix is to use ExpressionComparer instead to correctly identify equivalent expressions.
Moreover, when it comes to translation of SqlFragments (e.g. string compare) we are passing the expressions without stripping them from NCEs, and string compare was not accounting for presence of NCEs (or convert nodes). Fix is to improve the translator to correctly match expressions wrapped in NCE.

Also added translator for string.Compare(string, string) which we missed before.