### PR TITLE
Fix to #12173 - Query: Include annotation is not ignored for group by aggregate causing client eval

### DIFF
--- a/src/EFCore/Query/ExpressionVisitors/Internal/QuerySourceTracingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/QuerySourceTracingExpressionVisitor.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
@@ -100,6 +102,16 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             return expression;
         }
 
+        private static readonly ISet<Type> _aggregateResultOperators = new HashSet<Type>
+        {
+            typeof(AverageResultOperator),
+            typeof(CountResultOperator),
+            typeof(LongCountResultOperator),
+            typeof(MaxResultOperator),
+            typeof(MinResultOperator),
+            typeof(SumResultOperator)
+        };
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
@@ -107,6 +119,11 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         protected override Expression VisitSubQuery(SubQueryExpression subQueryExpression)
         {
             if (_reachable)
+            {
+                return subQueryExpression;
+            }
+
+            if (subQueryExpression.QueryModel.ResultOperators.Any(ro => _aggregateResultOperators.Contains(ro.GetType())))
             {
                 return subQueryExpression;
             }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7614,6 +7614,124 @@ ORDER BY [w.SynergyWith].[Name] + N'Marcus'' Lancer'");
 FROM [Missions] AS [m]");
         }
 
+        public override void GroupBy_Property_Include_Select_Average()
+        {
+            base.GroupBy_Property_Include_Select_Average();
+
+            AssertSql(
+                @"SELECT AVG(CAST([g].[SquadId] AS float))
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+GROUP BY [g].[Rank]");
+        }
+
+        public override void GroupBy_Property_Include_Select_Sum()
+        {
+            base.GroupBy_Property_Include_Select_Sum();
+
+            AssertSql(
+                @"SELECT SUM([g].[SquadId])
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+GROUP BY [g].[Rank]");
+        }
+
+        public override void GroupBy_Property_Include_Select_Count()
+        {
+            base.GroupBy_Property_Include_Select_Count();
+
+            AssertSql(
+                @"SELECT COUNT(*)
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+GROUP BY [g].[Rank]");
+        }
+
+        public override void GroupBy_Property_Include_Select_LongCount()
+        {
+            base.GroupBy_Property_Include_Select_LongCount();
+
+            AssertSql(
+                @"SELECT COUNT_BIG(*)
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+GROUP BY [g].[Rank]");
+        }
+
+        public override void GroupBy_Property_Include_Select_Min()
+        {
+            base.GroupBy_Property_Include_Select_Min();
+
+            AssertSql(
+                @"SELECT MIN([g].[SquadId])
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+GROUP BY [g].[Rank]");
+        }
+
+        public override void GroupBy_Property_Include_Aggregate_with_anonymous_selector()
+        {
+            base.GroupBy_Property_Include_Aggregate_with_anonymous_selector();
+
+            AssertSql(
+                @"SELECT [g].[Nickname] AS [Key], COUNT(*) AS [c]
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+GROUP BY [g].[Nickname]
+ORDER BY [Key]");
+        }
+
+        public override void Group_by_entity_key_with_include_on_that_entity_with_key_in_result_selector()
+        {
+            base.Group_by_entity_key_with_include_on_that_entity_with_key_in_result_selector();
+
+            AssertSql(
+                @"");
+        }
+
+        public override void Group_by_entity_key_with_include_on_that_entity_with_key_in_result_selector_using_EF_Property()
+        {
+            base.Group_by_entity_key_with_include_on_that_entity_with_key_in_result_selector_using_EF_Property();
+
+            AssertSql(
+                @"");
+        }
+
+        public override void Group_by_with_include_with_entity_in_result_selector()
+        {
+            base.Group_by_with_include_with_entity_in_result_selector();
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.CityOfBirth].[Name], [g.CityOfBirth].[Location]
+FROM [Gears] AS [g]
+INNER JOIN [Cities] AS [g.CityOfBirth] ON [g].[CityOrBirthName] = [g.CityOfBirth].[Name]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [g].[Rank]");
+        }
+
+        public override void GroupBy_Property_Include_Select_Max()
+        {
+            base.GroupBy_Property_Include_Select_Max();
+
+            AssertSql(
+                @"SELECT MAX([g].[SquadId])
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+GROUP BY [g].[Rank]");
+        }
+
+        public override void Include_with_group_by_and_FirstOrDefault_gets_properly_applied()
+        {
+            base.Include_with_group_by_and_FirstOrDefault_gets_properly_applied();
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.CityOfBirth].[Name], [g.CityOfBirth].[Location]
+FROM [Gears] AS [g]
+INNER JOIN [Cities] AS [g.CityOfBirth] ON [g].[CityOrBirthName] = [g.CityOfBirth].[Name]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY [g].[Rank]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Problem was that when looking for query source on which the include should be applied we were not short-circuiting on subqueries with aggregate result operators that returns a scalar value (count, sum, etc).

Fix is to jump out of the QuerySourceTracingExpressionVisitor when we encounter such a case.