### PR TITLE
[2.1.3] Query: Do not rewrite entity equality to key equality for com…

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/Query/InheritanceRelationshipsQueryRelationalFixture.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/InheritanceRelationshipsQueryRelationalFixture.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -9,6 +10,10 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public abstract class InheritanceRelationshipsQueryRelationalFixture : InheritanceRelationshipsQueryFixtureBase
     {
-        public TestSqlLoggerFactory TestSqlLoggerFactory => (TestSqlLoggerFactory)ServiceProvider.GetRequiredService<ILoggerFactory>();
+        public TestSqlLoggerFactory TestSqlLoggerFactory
+            => (TestSqlLoggerFactory)ServiceProvider.GetRequiredService<ILoggerFactory>();
+
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+            => base.AddOptions(builder).ConfigureWarnings(w => w.Log(RelationalEventId.QueryClientEvaluationWarning));
     }
 }

--- a/src/EFCore.Specification.Tests/Query/InheritanceRelationshipsQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/InheritanceRelationshipsQueryTestBase.cs
@@ -609,6 +609,21 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
+        [Fact]
+        public virtual void Derived_dependent_to_principal_navigation_null_equality()
+        {
+            using (var context = CreateContext())
+            {
+                var query = context.BaseEntities
+                    .Where(b => b is DerivedInheritanceRelationshipEntity
+                                    ? (b as DerivedInheritanceRelationshipEntity).BaseSelfRerefenceOnDerived == null
+                                    : false)
+                    .ToList();
+
+                Assert.Equal(3, query.Count);
+            }
+        }
+
         protected InheritanceRelationshipsContext CreateContext() => Fixture.CreateContext();
 
         protected virtual void ClearLog()

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
@@ -1455,8 +1455,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         public virtual void Where_subquery_FirstOrDefault_is_null()
         {
             AssertQuery<Customer>(
-                cs => cs.Where(c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault() == null),
-                entryCount: 2);
+                cs => cs.Where(c => c.CustomerID.StartsWith("P"))
+                        .Where(c => c.Orders.OrderBy(o => o.OrderID).FirstOrDefault() == null),
+                entryCount: 1);
         }
 
         [ConditionalFact]

--- a/src/EFCore/Query/ExpressionVisitors/Internal/EntityEqualityRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/EntityEqualityRewritingExpressionVisitor.cs
@@ -150,6 +150,11 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             var properties = MemberAccessBindingExpressionVisitor
                 .GetPropertyPath(nonNullExpression, _queryCompilationContext, out var qsre);
 
+            if (qsre == null)
+            {
+                return null;
+            }
+
             if (properties.Count > 0
                 && properties[properties.Count - 1] is INavigation lastNavigation
                 && lastNavigation.IsCollection())

--- a/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceRelationshipsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/InheritanceRelationshipsQuerySqlServerTest.cs
@@ -11,7 +11,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public InheritanceRelationshipsQuerySqlServerTest(InheritanceRelationshipsQuerySqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
+            Fixture.TestSqlLoggerFactory.Clear();
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         public override void Include_reference_with_inheritance1()
@@ -791,6 +792,16 @@ INNER JOIN (
     FROM [ReferencedEntities] AS [e0]
 ) AS [t] ON [e.Principals].[ReferencedEntityId] = [t].[Id]
 ORDER BY [t].[Id]");
+        }
+
+        public override void Derived_dependent_to_principal_navigation_null_equality()
+        {
+            base.Derived_dependent_to_principal_navigation_null_equality();
+
+            AssertSql(
+                @"SELECT [b].[Id], [b].[Discriminator], [b].[Name], [b].[BaseId]
+FROM [BaseEntities] AS [b]
+WHERE [b].[Discriminator] IN (N'DerivedInheritanceRelationshipEntity', N'BaseInheritanceRelationshipEntity')");
         }
 
         private void AssertSql(params string[] expected)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
@@ -1602,12 +1602,35 @@ WHERE EXISTS (
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
 FROM [Customers] AS [c]
-WHERE (
-    SELECT TOP(1) [o].[OrderID]
-    FROM [Orders] AS [o]
-    WHERE [c].[CustomerID] = [o].[CustomerID]
-    ORDER BY [o].[OrderID]
-) IS NULL");
+WHERE [c].[CustomerID] LIKE N'P' + N'%' AND (LEFT([c].[CustomerID], LEN(N'P')) = N'P')",
+                //
+                @"@_outer_CustomerID='PARIS' (Size = 5)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+ORDER BY [o].[OrderID]",
+                //
+                @"@_outer_CustomerID='PERIC' (Size = 5)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+ORDER BY [o].[OrderID]",
+                //
+                @"@_outer_CustomerID='PICCO' (Size = 5)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+ORDER BY [o].[OrderID]",
+                //
+                @"@_outer_CustomerID='PRINI' (Size = 5)
+
+SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+FROM [Orders] AS [o]
+WHERE @_outer_CustomerID = [o].[CustomerID]
+ORDER BY [o].[OrderID]");
         }
 
         public override void Where_subquery_FirstOrDefault_compared_to_entity()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -293,19 +293,19 @@ FROM (
                 //
                 @"@_outer_ReportsTo='2' (Nullable = true)
 
-SELECT TOP(2) [e20].[EmployeeID]
-FROM [Employees] AS [e20]
-WHERE [e20].[EmployeeID] = @_outer_ReportsTo",
+SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
+FROM [Employees] AS [e2]
+WHERE [e2].[EmployeeID] = @_outer_ReportsTo",
                 //
-                @"SELECT TOP(2) [e20].[EmployeeID]
-FROM [Employees] AS [e20]
-WHERE [e20].[EmployeeID] IS NULL",
+                @"SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
+FROM [Employees] AS [e2]
+WHERE [e2].[EmployeeID] IS NULL",
                 //
                 @"@_outer_ReportsTo='2' (Nullable = true)
 
-SELECT TOP(2) [e20].[EmployeeID]
-FROM [Employees] AS [e20]
-WHERE [e20].[EmployeeID] = @_outer_ReportsTo");
+SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
+FROM [Employees] AS [e2]
+WHERE [e2].[EmployeeID] = @_outer_ReportsTo");
         }
 
         public override void Where_query_composition_is_not_null()
@@ -324,19 +324,19 @@ FROM (
                 //
                 @"@_outer_ReportsTo='2' (Nullable = true)
 
-SELECT TOP(2) [e20].[EmployeeID]
-FROM [Employees] AS [e20]
-WHERE [e20].[EmployeeID] = @_outer_ReportsTo",
+SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
+FROM [Employees] AS [e2]
+WHERE [e2].[EmployeeID] = @_outer_ReportsTo",
                 //
-                @"SELECT TOP(2) [e20].[EmployeeID]
-FROM [Employees] AS [e20]
-WHERE [e20].[EmployeeID] IS NULL",
+                @"SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
+FROM [Employees] AS [e2]
+WHERE [e2].[EmployeeID] IS NULL",
                 //
                 @"@_outer_ReportsTo='2' (Nullable = true)
 
-SELECT TOP(2) [e20].[EmployeeID]
-FROM [Employees] AS [e20]
-WHERE [e20].[EmployeeID] = @_outer_ReportsTo");
+SELECT TOP(2) [e2].[EmployeeID], [e2].[City], [e2].[Country], [e2].[FirstName], [e2].[ReportsTo], [e2].[Title]
+FROM [Employees] AS [e2]
+WHERE [e2].[EmployeeID] = @_outer_ReportsTo");
         }
 
 #if !Test20


### PR DESCRIPTION
…plex expression

Issue: In 2.1 we started rewriting entity equality to key equality for complex cases like FirstOrDefault. But when we do Navigation.PK to FK conversion, we actually proper member access path rather than complex expression. Further even if we optimize it to normal key equality, it would still fail if don't translate it to server.
Solution: Do not convert entity equality when its not member access path defined in EF.

Resolves #12256
