### PR TITLE
Some help for resolution of problem #12169

### DIFF
--- a/src/EFCore.Relational/Storage/RelationalDataReader.cs
+++ b/src/EFCore.Relational/Storage/RelationalDataReader.cs
@@ -106,6 +106,11 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public virtual DbDataReader DbDataReader => _reader;
 
         /// <summary>
+        ///     Gets the underlying command for the result set.
+        /// </summary>
+        public virtual DbCommand DbCommand => _command;
+
+        /// <summary>
         ///     Calls Read on the underlying DbDataReader.
         /// </summary>
         /// <returns>true if there are more rows; otherwise false.</returns>


### PR DESCRIPTION
New property RelationalDataReader::DbCommand allow to read OUTPUT-parameters of modification commands (INSERT, UPDATE).

It used from ConsumeResultSetWithPropagation method.

Need for resolution of problem #12169

---------
Additional information:

My ADO.NET provider (lcpi.data.oledb) does not return OUTPUT-parameters of modification commands (INSERT,UPDATE) through DataReader.