### PR TITLE
[2.1.3] Compare structs correctly in ClrPropertyGetter delegate

### DIFF
--- a/src/EFCore/Metadata/Internal/ClrPropertyGetterFactory.cs
+++ b/src/EFCore/Metadata/Internal/ClrPropertyGetterFactory.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
@@ -32,6 +33,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             var entityParameter = Expression.Parameter(typeof(TEntity), "entity");
+            var memberType = memberInfo.GetMemberType();
+            var defaultExpression = Expression.Default(memberType);
 
             Expression readExpression;
             if (memberInfo.DeclaringType.GetTypeInfo().IsAssignableFrom(typeof(TEntity).GetTypeInfo()))
@@ -52,12 +55,28 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                             Expression.TypeAs(entityParameter, memberInfo.DeclaringType)),
                         Expression.Condition(
                             Expression.ReferenceEqual(converted, Expression.Constant(null)),
-                            Expression.Default(memberInfo.GetMemberType()),
+                            defaultExpression,
                             Expression.MakeMemberAccess(converted, memberInfo))
                     });
             }
 
-            var hasDefaultValueExpression = Expression.Equal(readExpression, Expression.Default(memberInfo.GetMemberType()));
+            var useRtmBehaviour = AppContext.TryGetSwitch(
+                                      "Microsoft.EntityFrameworkCore.Issue112290",
+                                      out var isEnabled)
+                                  && isEnabled;
+
+            var property = propertyBase as IProperty;
+            var comparer = memberType.IsNullableType() || useRtmBehaviour
+                ? null
+                : property?.GetValueComparer()
+                  ?? property?.FindMapping()?.Comparer
+                  ?? (ValueComparer)Activator.CreateInstance(
+                      typeof(ValueComparer<>).MakeGenericType(memberType),
+                      new object[] { false });
+
+            var hasDefaultValueExpression = comparer == null
+                ? Expression.Equal(readExpression, defaultExpression)
+                : comparer.ExtractEqualsBody(readExpression, defaultExpression);
 
             return new ClrPropertyGetter<TEntity, TValue>(
                 Expression.Lambda<Func<TEntity, TValue>>(readExpression, entityParameter).Compile(),

--- a/test/EFCore.SqlServer.FunctionalTests/CustomConvertersSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/CustomConvertersSqlServerTest.cs
@@ -135,6 +135,8 @@ BuiltInNullableDataTypesShadow.TestNullableUnsignedInt16 ---> [nullable int] [Pr
 BuiltInNullableDataTypesShadow.TestNullableUnsignedInt32 ---> [nullable bigint] [Precision = 19 Scale = 0]
 BuiltInNullableDataTypesShadow.TestNullableUnsignedInt64 ---> [nullable decimal] [Precision = 20 Scale = 0]
 BuiltInNullableDataTypesShadow.TestString ---> [nullable nvarchar] [MaxLength = -1]
+Load.Fuel ---> [float] [Precision = 53]
+Load.LoadId ---> [int] [Precision = 10 Scale = 0]
 MaxLengthDataTypes.ByteArray5 ---> [nullable varbinary] [MaxLength = 7]
 MaxLengthDataTypes.ByteArray9000 ---> [nullable nvarchar] [MaxLength = -1]
 MaxLengthDataTypes.Id ---> [int] [Precision = 10 Scale = 0]

--- a/test/EFCore.Tests/Metadata/Internal/ClrPropertyGetterFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ClrPropertyGetterFactoryTest.cs
@@ -69,9 +69,45 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     }));
         }
 
+        [Fact]
+        public void Delegate_getter_is_returned_for_IProperty_struct_property()
+        {
+            var entityType = new Model().AddEntityType(typeof(Customer));
+            var fuelProperty = entityType.AddProperty("Fuel", typeof(Fuel));
+
+            Assert.Equal(
+                new Fuel(1.0),
+                new ClrPropertyGetterFactory().Create(fuelProperty).GetClrValue(
+                    new Customer
+                    {
+                        Id = 7,
+                        Fuel = new Fuel(1.0)
+                    }));
+        }
+
+        [Fact]
+        public void Delegate_getter_is_returned_for_struct_property_info()
+        {
+            Assert.Equal(
+                new Fuel(1.0),
+                new ClrPropertyGetterFactory().Create(typeof(Customer).GetAnyProperty("Fuel")).GetClrValue(
+                    new Customer
+                    {
+                        Id = 7,
+                        Fuel = new Fuel(1.0)
+                    }));
+        }
+
         private class Customer
         {
             internal int Id { get; set; }
+            internal Fuel Fuel { get; set; }
+        }
+
+        private struct Fuel
+        {
+            public Fuel(double volume) => Volume = volume;
+            public double Volume { get; }
         }
     }
 }


### PR DESCRIPTION
Fixes #12290

The issue here is that a ValueComparer was not being used when it should have been.

PR is on dev, but I will move to release/2.1 before merging.