### PR TITLE
Query: Use ProjectionExpressionVisitor when no SelectExpression

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/Query/AsyncIncludeSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AsyncIncludeSqlServerTest.cs
@@ -12,8 +12,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public AsyncIncludeSqlServerTest(IncludeSqlServerFixture fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
-            //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            Fixture.TestSqlLoggerFactory.Clear();
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         public override async Task Include_collection_order_by_subquery()


### PR DESCRIPTION
Issue:
The issue here was, when we get no select expression in RelationalProjectionEV, we returned expression as is. That made the expression to be visited through EntityQueryableEV.
ProjectionEV has special code (since it is projection side) to insert adapters from async to sync to match types. Because of above issue, we did not insert adapter and hit type mismatch.

Solution:
If there is no SelectExpression in RelationalProjectionEV then call base instead of returning expression.

Resolves #12374
