### PR TITLE
[2.1] Fix to #12314 - SumAsync throw Exception when used over float?

### DIFF
--- a/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -963,6 +963,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             return handlerContext.EvalOnClient();
         }
 
+        private static readonly MethodInfo _castToNullableMethodInfo
+            = typeof(RelationalTaskExtensions).GetRuntimeMethods().Where(m => m.Name == nameof(RelationalTaskExtensions.CastToNullable)).Single();
+
         private static Expression HandleSum(HandlerContext handlerContext)
         {
             if (!handlerContext.QueryModelVisitor.RequiresClientProjection
@@ -990,10 +993,21 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                             .MakeGenericMethod(sumExpression.Type.UnwrapNullableType())
                             .Invoke(null, new object[] { handlerContext, /*throwOnNullResult:*/ false });
 
-                    return
-                        sumExpression.Type.IsNullableType()
+                    if (handlerContext.QueryModelVisitor.QueryCompilationContext.IsAsyncQuery
+                        && !(AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue12314", out var isEnabled) && isEnabled))
+                    {
+                        return sumExpression.Type.IsNullableType()
+                            ? Expression.Call(
+                                _castToNullableMethodInfo.MakeGenericMethod(sumExpression.Type.UnwrapNullableType()),
+                                clientExpression)
+                            : clientExpression;
+                    }
+                    else
+                    {
+                        return sumExpression.Type.IsNullableType()
                             ? Expression.Convert(clientExpression, sumExpression.Type)
                             : clientExpression;
+                    }
                 }
             }
 

--- a/src/EFCore.Specification.Tests/Query/AsyncGearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncGearsOfWarQueryTestBase.cs
@@ -1691,5 +1691,15 @@ namespace Microsoft.EntityFrameworkCore.Query
                 assertOrder: true,
                 elementAsserter: CollectionAsserter<Gear>(e => e.Nickname, (e, a) => Assert.Equal(e.Nickname, a.Nickname)));
         }
+
+        [ConditionalFact]
+        public virtual async Task Sum_with_no_data_nullable_double()
+        {
+            using (var ctx = CreateContext())
+            {
+                var result = await ctx.Missions.Where(m => m.CodeName == "Operation Foobar").Select(m => m.Rating).SumAsync();
+                Assert.Equal(0, result);
+            }
+        }
     }
 }

--- a/src/EFCore.Specification.Tests/Query/AsyncQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncQueryTestBase.cs
@@ -21,219 +21,249 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         // one argument
 
-        protected virtual async Task AssertSingleResult<TItem1>(
+        protected virtual Task AssertSingleResult<TItem1>(
             Func<IQueryable<TItem1>, Task<object>> query,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
-            => await AssertSingleResult(query, query, asserter, entryCount);
+            => AssertSingleResult(query, query, asserter, entryCount);
 
-        protected virtual async Task AssertSingleResult<TItem1>(
+        protected virtual Task AssertSingleResult<TItem1>(
             Func<IQueryable<TItem1>, Task<object>> actualQuery,
             Func<IQueryable<TItem1>, Task<object>> expectedQuery,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
-            => await Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
+            => Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
 
-        protected virtual async Task AssertSingleResult<TItem1>(
+        protected virtual Task AssertSingleResult<TItem1>(
             Func<IQueryable<TItem1>, Task<int>> query,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
-            => await AssertSingleResult(query, query, asserter, entryCount);
+            => AssertSingleResult(query, query, asserter, entryCount);
 
-        protected virtual async Task AssertSingleResult<TItem1>(
+        protected virtual Task AssertSingleResult<TItem1>(
             Func<IQueryable<TItem1>, Task<int>> actualQuery,
             Func<IQueryable<TItem1>, Task<int>> expectedQuery,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
-            => await Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
+            => Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
 
-        protected virtual async Task AssertSingleResult<TItem1>(
+        protected virtual Task AssertSingleResult<TItem1>(
+            Func<IQueryable<TItem1>, Task<int?>> query,
+            Action<object, object> asserter = null,
+            int entryCount = 0)
+            where TItem1 : class
+            => AssertSingleResult(query, query, asserter, entryCount);
+
+        protected virtual Task AssertSingleResult<TItem1>(
+            Func<IQueryable<TItem1>, Task<int?>> actualQuery,
+            Func<IQueryable<TItem1>, Task<int?>> expectedQuery,
+            Action<object, object> asserter = null,
+            int entryCount = 0)
+            where TItem1 : class
+            => Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
+
+        protected virtual Task AssertSingleResult<TItem1>(
             Func<IQueryable<TItem1>, Task<long>> query,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
-            => await AssertSingleResult(query, query, asserter, entryCount);
+            => AssertSingleResult(query, query, asserter, entryCount);
 
-        protected virtual async Task AssertSingleResult<TItem1>(
+        protected virtual Task AssertSingleResult<TItem1>(
             Func<IQueryable<TItem1>, Task<long>> actualQuery,
             Func<IQueryable<TItem1>, Task<long>> expectedQuery,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
-            => await Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
+            => Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
 
-        protected virtual async Task AssertSingleResult<TItem1>(
+        protected virtual Task AssertSingleResult<TItem1>(
             Func<IQueryable<TItem1>, Task<bool>> query,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
-            => await AssertSingleResult(query, query, asserter, entryCount);
+            => AssertSingleResult(query, query, asserter, entryCount);
 
-        protected virtual async Task AssertSingleResult<TItem1>(
+        protected virtual Task AssertSingleResult<TItem1>(
             Func<IQueryable<TItem1>, Task<bool>> actualQuery,
             Func<IQueryable<TItem1>, Task<bool>> expectedQuery,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
-            => await Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
+            => Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
 
-        protected virtual async Task AssertSingleResult<TItem1>(
+        protected virtual Task AssertSingleResult<TItem1>(
             Func<IQueryable<TItem1>, Task<decimal>> query,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
-            => await AssertSingleResult(query, query, asserter, entryCount);
+            => AssertSingleResult(query, query, asserter, entryCount);
 
-        protected virtual async Task AssertSingleResult<TItem1>(
+        protected virtual Task AssertSingleResult<TItem1>(
             Func<IQueryable<TItem1>, Task<decimal>> actualQuery,
             Func<IQueryable<TItem1>, Task<decimal>> expectedQuery,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
-            => await Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
+            => Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
 
-        protected virtual async Task AssertSingleResult<TItem1>(
+        protected virtual Task AssertSingleResult<TItem1>(
             Func<IQueryable<TItem1>, Task<double>> query,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
-            => await AssertSingleResult(query, query, asserter, entryCount);
+            => AssertSingleResult(query, query, asserter, entryCount);
 
-        protected virtual async Task AssertSingleResult<TItem1>(
+        protected virtual Task AssertSingleResult<TItem1>(
             Func<IQueryable<TItem1>, Task<double>> actualQuery,
             Func<IQueryable<TItem1>, Task<double>> expectedQuery,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
-            => await Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
+            => Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
 
-        protected virtual async Task AssertSingleResult<TItem1, TResult>(
+        protected virtual Task AssertSingleResult<TItem1>(
+            Func<IQueryable<TItem1>, Task<double?>> query,
+            Action<object, object> asserter = null,
+            int entryCount = 0)
+            where TItem1 : class
+            => AssertSingleResult(query, query, asserter, entryCount);
+
+        protected virtual Task AssertSingleResult<TItem1>(
+            Func<IQueryable<TItem1>, Task<double?>> actualQuery,
+            Func<IQueryable<TItem1>, Task<double?>> expectedQuery,
+            Action<object, object> asserter = null,
+            int entryCount = 0)
+            where TItem1 : class
+            => Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
+
+        protected virtual Task AssertSingleResult<TItem1, TResult>(
             Func<IQueryable<TItem1>, Task<TResult>> query,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
-            => await AssertSingleResult(query, query, asserter, entryCount);
+            => AssertSingleResult(query, query, asserter, entryCount);
 
-        protected virtual async Task AssertSingleResult<TItem1, TResult>(
+        protected virtual Task AssertSingleResult<TItem1, TResult>(
             Func<IQueryable<TItem1>, Task<TResult>> actualQuery,
             Func<IQueryable<TItem1>, Task<TResult>> expectedQuery,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
-            => await Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
+            => Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
 
         // two arguments
 
-        public virtual async Task AssertSingleResult<TItem1, TItem2>(
+        public virtual Task AssertSingleResult<TItem1, TItem2>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, Task<object>> query,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
             where TItem2 : class
-            => await AssertSingleResult(query, query, asserter, entryCount);
+            => AssertSingleResult(query, query, asserter, entryCount);
 
-        public virtual async Task AssertSingleResult<TItem1, TItem2>(
+        public virtual Task AssertSingleResult<TItem1, TItem2>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, Task<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, Task<object>> expectedQuery,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
             where TItem2 : class
-            => await Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
+            => Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
 
-        public virtual async Task AssertSingleResult<TItem1, TItem2>(
+        public virtual Task AssertSingleResult<TItem1, TItem2>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, Task<int>> query,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
             where TItem2 : class
-            => await AssertSingleResult(query, query, asserter, entryCount);
+            => AssertSingleResult(query, query, asserter, entryCount);
 
-        public virtual async Task AssertSingleResult<TItem1, TItem2>(
+        public virtual Task AssertSingleResult<TItem1, TItem2>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, Task<int>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, Task<int>> expectedQuery,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
             where TItem2 : class
-            => await Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
+            => Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
 
-        public virtual async Task AssertSingleResult<TItem1, TItem2>(
+        public virtual Task AssertSingleResult<TItem1, TItem2>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, Task<long>> query,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
             where TItem2 : class
-            => await AssertSingleResult(query, query, asserter, entryCount);
+            => AssertSingleResult(query, query, asserter, entryCount);
 
-        public virtual async Task AssertSingleResult<TItem1, TItem2>(
+        public virtual Task AssertSingleResult<TItem1, TItem2>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, Task<long>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, Task<long>> expectedQuery,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
             where TItem2 : class
-            => await Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
+            => Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
 
-        public virtual async Task AssertSingleResult<TItem1, TItem2>(
+        public virtual Task AssertSingleResult<TItem1, TItem2>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, Task<bool>> query,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
             where TItem2 : class
-            => await AssertSingleResult(query, query, asserter, entryCount);
+            => AssertSingleResult(query, query, asserter, entryCount);
 
-        public virtual async Task AssertSingleResult<TItem1, TItem2>(
+        public virtual Task AssertSingleResult<TItem1, TItem2>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, Task<bool>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, Task<bool>> expectedQuery,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
             where TItem2 : class
-            => await Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
+            => Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
 
-        protected virtual async Task AssertSingleResult<TItem1, TItem2, TResult>(
+        protected virtual Task AssertSingleResult<TItem1, TItem2, TResult>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, Task<TResult>> query,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
             where TItem2 : class
-            => await AssertSingleResult(query, query, asserter, entryCount);
+            => AssertSingleResult(query, query, asserter, entryCount);
 
-        protected virtual async Task AssertSingleResult<TItem1, TItem2, TResult>(
+        protected virtual Task AssertSingleResult<TItem1, TItem2, TResult>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, Task<TResult>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, Task<TResult>> expectedQuery,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
             where TItem2 : class
-            => await Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
+            => Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
 
         // three arguments
 
-        public virtual async Task AssertSingleResult<TItem1, TItem2, TItem3>(
+        public virtual Task AssertSingleResult<TItem1, TItem2, TItem3>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, Task<bool>> query,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
             where TItem2 : class
             where TItem3 : class
-            => await AssertSingleResult(query, query, asserter, entryCount);
+            => AssertSingleResult(query, query, asserter, entryCount);
 
-        public virtual async Task AssertSingleResult<TItem1, TItem2, TItem3, TResult>(
+        public virtual Task AssertSingleResult<TItem1, TItem2, TItem3, TResult>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, Task<TResult>> query,
             Action<object, object> asserter = null,
             int entryCount = 0)
             where TItem1 : class
             where TItem2 : class
             where TItem3 : class
-            => await AssertSingleResult(query, query, asserter, entryCount);
+            => AssertSingleResult(query, query, asserter, entryCount);
 
-        public virtual async Task AssertSingleResult<TItem1, TItem2, TItem3, TResult>(
+        public virtual Task AssertSingleResult<TItem1, TItem2, TItem3, TResult>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, Task<TResult>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, Task<TResult>> expectedQuery,
             Action<object, object> asserter = null,
@@ -241,22 +271,22 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             where TItem2 : class
             where TItem3 : class
-            => await Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
+            => Fixture.QueryAsserter.AssertSingleResult(actualQuery, expectedQuery, asserter, entryCount);
 
         #endregion
 
         #region AssertQuery
 
-        public virtual async Task AssertQuery<TItem1>(
+        public virtual Task AssertQuery<TItem1>(
             Func<IQueryable<TItem1>, IQueryable<object>> query,
             Func<dynamic, object> elementSorter = null,
             Action<dynamic, dynamic> elementAsserter = null,
             bool assertOrder = false,
             int entryCount = 0)
             where TItem1 : class
-            => await Fixture.QueryAsserter.AssertQuery(query, query, elementSorter, elementAsserter, assertOrder, entryCount, isAsync: true);
+            => Fixture.QueryAsserter.AssertQuery(query, query, elementSorter, elementAsserter, assertOrder, entryCount, isAsync: true);
 
-        public virtual async Task AssertQuery<TItem1>(
+        public virtual Task AssertQuery<TItem1>(
             Func<IQueryable<TItem1>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<object>> expectedQuery,
             Func<dynamic, object> elementSorter = null,
@@ -264,9 +294,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             bool assertOrder = false,
             int entryCount = 0)
             where TItem1 : class
-            => await Fixture.QueryAsserter.AssertQuery(actualQuery, expectedQuery, elementSorter, elementAsserter, assertOrder, entryCount, isAsync: true);
+            => Fixture.QueryAsserter.AssertQuery(actualQuery, expectedQuery, elementSorter, elementAsserter, assertOrder, entryCount, isAsync: true);
 
-        public virtual async Task AssertQuery<TItem1, TItem2>(
+        public virtual Task AssertQuery<TItem1, TItem2>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> query,
             Func<dynamic, object> elementSorter = null,
             Action<dynamic, dynamic> elementAsserter = null,
@@ -274,9 +304,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             int entryCount = 0)
             where TItem1 : class
             where TItem2 : class
-            => await Fixture.QueryAsserter.AssertQuery(query, query, elementSorter, elementAsserter, assertOrder, entryCount, isAsync: true);
+            => Fixture.QueryAsserter.AssertQuery(query, query, elementSorter, elementAsserter, assertOrder, entryCount, isAsync: true);
 
-        public virtual async Task AssertQuery<TItem1, TItem2>(
+        public virtual Task AssertQuery<TItem1, TItem2>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> expectedQuery,
             Func<dynamic, object> elementSorter = null,
@@ -285,9 +315,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             int entryCount = 0)
             where TItem1 : class
             where TItem2 : class
-            => await Fixture.QueryAsserter.AssertQuery(actualQuery, expectedQuery, elementSorter, elementAsserter, assertOrder, entryCount, isAsync: true);
+            => Fixture.QueryAsserter.AssertQuery(actualQuery, expectedQuery, elementSorter, elementAsserter, assertOrder, entryCount, isAsync: true);
 
-        public virtual async Task AssertQuery<TItem1, TItem2, TItem3>(
+        public virtual Task AssertQuery<TItem1, TItem2, TItem3>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<object>> query,
             Func<dynamic, object> elementSorter = null,
             Action<dynamic, dynamic> elementAsserter = null,
@@ -296,9 +326,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             where TItem2 : class
             where TItem3 : class
-            => await Fixture.QueryAsserter.AssertQuery(query, query, elementSorter, elementAsserter, assertOrder, entryCount, isAsync: true);
+            => Fixture.QueryAsserter.AssertQuery(query, query, elementSorter, elementAsserter, assertOrder, entryCount, isAsync: true);
 
-        public virtual async Task AssertQuery<TItem1, TItem2, TItem3>(
+        public virtual Task AssertQuery<TItem1, TItem2, TItem3>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<object>> expectedQuery,
             Func<dynamic, object> elementSorter = null,
@@ -308,89 +338,89 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             where TItem2 : class
             where TItem3 : class
-            => await Fixture.QueryAsserter.AssertQuery(actualQuery, expectedQuery, elementSorter, elementAsserter, assertOrder, entryCount, isAsync: true);
+            => Fixture.QueryAsserter.AssertQuery(actualQuery, expectedQuery, elementSorter, elementAsserter, assertOrder, entryCount, isAsync: true);
 
         #endregion
 
         #region AssertQueryScalar
 
-        public virtual async Task AssertQueryScalar<TItem1>(
+        public virtual Task AssertQueryScalar<TItem1>(
             Func<IQueryable<TItem1>, IQueryable<int>> query,
             bool assertOrder = false)
             where TItem1 : class
-            => await AssertQueryScalar(query, query, assertOrder);
+            => AssertQueryScalar(query, query, assertOrder);
 
-        public virtual async Task AssertQueryScalar<TItem1>(
+        public virtual Task AssertQueryScalar<TItem1>(
             Func<IQueryable<TItem1>, IQueryable<int>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<int>> expectedQuery,
             bool assertOrder = false)
             where TItem1 : class
-            => await AssertQueryScalar<TItem1, int>(actualQuery, expectedQuery, assertOrder);
+            => AssertQueryScalar<TItem1, int>(actualQuery, expectedQuery, assertOrder);
 
-        public virtual async Task AssertQueryScalar<TItem1>(
+        public virtual Task AssertQueryScalar<TItem1>(
             Func<IQueryable<TItem1>, IQueryable<uint>> query,
             bool assertOrder = false)
             where TItem1 : class
-            => await AssertQueryScalar(query, query, assertOrder);
+            => AssertQueryScalar(query, query, assertOrder);
 
-        public virtual async Task AssertQueryScalar<TItem1>(
+        public virtual Task AssertQueryScalar<TItem1>(
             Func<IQueryable<TItem1>, IQueryable<uint>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<uint>> expectedQuery,
             bool assertOrder = false)
             where TItem1 : class
-            => await AssertQueryScalar<TItem1, uint>(actualQuery, expectedQuery, assertOrder);
+            => AssertQueryScalar<TItem1, uint>(actualQuery, expectedQuery, assertOrder);
 
-        public virtual async Task AssertQueryScalar<TItem1>(
+        public virtual Task AssertQueryScalar<TItem1>(
             Func<IQueryable<TItem1>, IQueryable<long>> query,
             bool assertOrder = false)
             where TItem1 : class
-            => await AssertQueryScalar(query, query, assertOrder);
+            => AssertQueryScalar(query, query, assertOrder);
 
-        public virtual async Task AssertQueryScalar<TItem1>(
+        public virtual Task AssertQueryScalar<TItem1>(
             Func<IQueryable<TItem1>, IQueryable<short>> query,
             bool assertOrder = false)
             where TItem1 : class
-            => await AssertQueryScalar(query, query, assertOrder);
+            => AssertQueryScalar(query, query, assertOrder);
 
-        public virtual async Task AssertQueryScalar<TItem1>(
+        public virtual Task AssertQueryScalar<TItem1>(
             Func<IQueryable<TItem1>, IQueryable<double>> query,
             bool assertOrder = false)
             where TItem1 : class
-            => await AssertQueryScalar(query, query, assertOrder);
+            => AssertQueryScalar(query, query, assertOrder);
 
-        public virtual async Task AssertQueryScalar<TItem1>(
+        public virtual Task AssertQueryScalar<TItem1>(
             Func<IQueryable<TItem1>, IQueryable<bool>> query,
             bool assertOrder = false)
             where TItem1 : class
-            => await AssertQueryScalar(query, query, assertOrder);
+            => AssertQueryScalar(query, query, assertOrder);
 
-        public virtual async Task AssertQueryScalar<TItem1>(
+        public virtual Task AssertQueryScalar<TItem1>(
             Func<IQueryable<TItem1>, IQueryable<bool>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<bool>> expectedQuery,
             bool assertOrder = false)
             where TItem1 : class
-            => await AssertQueryScalar<TItem1, bool>(actualQuery, expectedQuery, assertOrder);
+            => AssertQueryScalar<TItem1, bool>(actualQuery, expectedQuery, assertOrder);
 
-        public virtual async Task AssertQueryScalar<TItem1>(
+        public virtual Task AssertQueryScalar<TItem1>(
             Func<IQueryable<TItem1>, IQueryable<DateTimeOffset>> query,
             bool assertOrder = false)
             where TItem1 : class
-            => await AssertQueryScalar(query, query, assertOrder);
+            => AssertQueryScalar(query, query, assertOrder);
 
-        public virtual async Task AssertQueryScalar<TItem1, TResult>(
+        public virtual Task AssertQueryScalar<TItem1, TResult>(
             Func<IQueryable<TItem1>, IQueryable<TResult>> query,
             bool assertOrder = false)
             where TItem1 : class
             where TResult : struct
-            => await Fixture.QueryAsserter.AssertQueryScalar(query, query, assertOrder, isAsync: true);
+            => Fixture.QueryAsserter.AssertQueryScalar(query, query, assertOrder, isAsync: true);
 
-        public virtual async Task AssertQueryScalar<TItem1, TResult>(
+        public virtual Task AssertQueryScalar<TItem1, TResult>(
             Func<IQueryable<TItem1>, IQueryable<TResult>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TResult>> expectedQuery,
             bool assertOrder = false)
             where TItem1 : class
             where TResult : struct
-            => await Fixture.QueryAsserter.AssertQueryScalar(actualQuery, expectedQuery, assertOrder, isAsync: true);
+            => Fixture.QueryAsserter.AssertQueryScalar(actualQuery, expectedQuery, assertOrder, isAsync: true);
 
         public virtual void AssertQueryScalar<TItem1, TItem2>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<int>> query,

--- a/src/EFCore.Specification.Tests/Query/AsyncSimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncSimpleQueryTestBase.cs
@@ -3808,5 +3808,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             await AssertSingleResult<Customer>(cs => cs.Cast<Customer>().CountAsync());
         }
+
+        [ConditionalFact]
+        public virtual async Task Sum_with_no_data_nullable()
+        {
+            await AssertSingleResult<Order>(os => os.Where(o => o.OrderID < 0).Select(o => (int?)o.OrderID).SumAsync());
+        }
     }
 }

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryFixtureBase.cs
@@ -150,6 +150,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                             {
                                 Assert.Equal(e.Id, a.Id);
                                 Assert.Equal(e.CodeName, a.CodeName);
+                                Assert.Equal(e.Rating, a.Rating);
                                 Assert.Equal(e.Timeline, a.Timeline);
                             }
                         }

--- a/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarData.cs
+++ b/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarData.cs
@@ -104,9 +104,9 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
         public static IReadOnlyList<Mission> CreateMissions()
             => new List<Mission>
             {
-                new Mission { Id = 1, CodeName = "Lightmass Offensive", Timeline = new DateTimeOffset(2, 1, 2, 10, 0, 0, new TimeSpan(1, 30, 0)) },
-                new Mission { Id = 2, CodeName = "Hollow Storm", Timeline = new DateTimeOffset(2, 3, 1, 8, 0, 0, new TimeSpan(-5, 0, 0)) },
-                new Mission { Id = 3, CodeName = "Halvo Bay defense", Timeline = new DateTimeOffset(10, 5, 3, 12, 0, 0, new TimeSpan()) }
+                new Mission { Id = 1, CodeName = "Lightmass Offensive", Rating = 2.1, Timeline = new DateTimeOffset(2, 1, 2, 10, 0, 0, new TimeSpan(1, 30, 0)) },
+                new Mission { Id = 2, CodeName = "Hollow Storm", Rating = 4.2, Timeline = new DateTimeOffset(2, 3, 1, 8, 0, 0, new TimeSpan(-5, 0, 0)) },
+                new Mission { Id = 3, CodeName = "Halvo Bay defense", Rating = null, Timeline = new DateTimeOffset(10, 5, 3, 12, 0, 0, new TimeSpan()) }
             };
 
         public static IReadOnlyList<SquadMission> CreateSquadMissions()

--- a/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/Mission.cs
+++ b/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/Mission.cs
@@ -11,6 +11,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
         public int Id { get; set; }
 
         public string CodeName { get; set; }
+        public double? Rating { get; set; }
         public DateTimeOffset Timeline { get; set; }
 
         public virtual ICollection<SquadMission> ParticipatingSquads { get; set; }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/AsyncSimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/AsyncSimpleQuerySqlServerTest.cs
@@ -214,5 +214,21 @@ namespace Microsoft.EntityFrameworkCore.Query
                 os => os.Select(o => new { o.Customer.City, Count = o.OrderDetails.Count() }),
                 elementSorter: e => e.City + " " + e.Count);
         }
+
+        [Fact]
+        public async Task Sum_with_no_data_nullable_legacy_behavior()
+        {
+            AppContext.SetSwitch("Microsoft.EntityFrameworkCore.Issue12314", true);
+
+            try
+            {
+                await Assert.ThrowsAsync<InvalidOperationException>(
+                    async () => await AssertSingleResult<Order>(os => os.Where(o => o.OrderID < 0).Select(o => (int?)o.OrderID).SumAsync()));
+            }
+            finally
+            {
+                AppContext.SetSwitch("Microsoft.EntityFrameworkCore.Issue12314", false);
+            }
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -3037,7 +3037,7 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
             base.Where_datetimeoffset_now();
 
             AssertSql(
-                @"SELECT [m].[Id], [m].[CodeName], [m].[Timeline]
+                @"SELECT [m].[Id], [m].[CodeName], [m].[Rating], [m].[Timeline]
 FROM [Missions] AS [m]
 WHERE [m].[Timeline] <> SYSDATETIMEOFFSET()");
         }
@@ -3047,7 +3047,7 @@ WHERE [m].[Timeline] <> SYSDATETIMEOFFSET()");
             base.Where_datetimeoffset_utcnow();
 
             AssertSql(
-                @"SELECT [m].[Id], [m].[CodeName], [m].[Timeline]
+                @"SELECT [m].[Id], [m].[CodeName], [m].[Rating], [m].[Timeline]
 FROM [Missions] AS [m]
 WHERE [m].[Timeline] <> CAST(SYSUTCDATETIME() AS datetimeoffset)");
         }
@@ -3060,7 +3060,7 @@ WHERE [m].[Timeline] <> CAST(SYSUTCDATETIME() AS datetimeoffset)");
             AssertSql(
                 @"@__Date_0='0001-01-01T00:00:00'
 
-SELECT [m].[Id], [m].[CodeName], [m].[Timeline]
+SELECT [m].[Id], [m].[CodeName], [m].[Rating], [m].[Timeline]
 FROM [Missions] AS [m]
 WHERE CONVERT(date, [m].[Timeline]) > @__Date_0");
         }
@@ -3070,7 +3070,7 @@ WHERE CONVERT(date, [m].[Timeline]) > @__Date_0");
             base.Where_datetimeoffset_year_component();
 
             AssertSql(
-                @"SELECT [m].[Id], [m].[CodeName], [m].[Timeline]
+                @"SELECT [m].[Id], [m].[CodeName], [m].[Rating], [m].[Timeline]
 FROM [Missions] AS [m]
 WHERE DATEPART(year, [m].[Timeline]) = 2");
         }
@@ -3080,7 +3080,7 @@ WHERE DATEPART(year, [m].[Timeline]) = 2");
             base.Where_datetimeoffset_month_component();
 
             AssertSql(
-                @"SELECT [m].[Id], [m].[CodeName], [m].[Timeline]
+                @"SELECT [m].[Id], [m].[CodeName], [m].[Rating], [m].[Timeline]
 FROM [Missions] AS [m]
 WHERE DATEPART(month, [m].[Timeline]) = 1");
         }
@@ -3090,7 +3090,7 @@ WHERE DATEPART(month, [m].[Timeline]) = 1");
             base.Where_datetimeoffset_dayofyear_component();
 
             AssertSql(
-                @"SELECT [m].[Id], [m].[CodeName], [m].[Timeline]
+                @"SELECT [m].[Id], [m].[CodeName], [m].[Rating], [m].[Timeline]
 FROM [Missions] AS [m]
 WHERE DATEPART(dayofyear, [m].[Timeline]) = 2");
         }
@@ -3100,7 +3100,7 @@ WHERE DATEPART(dayofyear, [m].[Timeline]) = 2");
             base.Where_datetimeoffset_day_component();
 
             AssertSql(
-                @"SELECT [m].[Id], [m].[CodeName], [m].[Timeline]
+                @"SELECT [m].[Id], [m].[CodeName], [m].[Rating], [m].[Timeline]
 FROM [Missions] AS [m]
 WHERE DATEPART(day, [m].[Timeline]) = 2");
         }
@@ -3110,7 +3110,7 @@ WHERE DATEPART(day, [m].[Timeline]) = 2");
             base.Where_datetimeoffset_hour_component();
 
             AssertSql(
-                @"SELECT [m].[Id], [m].[CodeName], [m].[Timeline]
+                @"SELECT [m].[Id], [m].[CodeName], [m].[Rating], [m].[Timeline]
 FROM [Missions] AS [m]
 WHERE DATEPART(hour, [m].[Timeline]) = 10");
         }
@@ -3120,7 +3120,7 @@ WHERE DATEPART(hour, [m].[Timeline]) = 10");
             base.Where_datetimeoffset_minute_component();
 
             AssertSql(
-                @"SELECT [m].[Id], [m].[CodeName], [m].[Timeline]
+                @"SELECT [m].[Id], [m].[CodeName], [m].[Rating], [m].[Timeline]
 FROM [Missions] AS [m]
 WHERE DATEPART(minute, [m].[Timeline]) = 0");
         }
@@ -3130,7 +3130,7 @@ WHERE DATEPART(minute, [m].[Timeline]) = 0");
             base.Where_datetimeoffset_second_component();
 
             AssertSql(
-                @"SELECT [m].[Id], [m].[CodeName], [m].[Timeline]
+                @"SELECT [m].[Id], [m].[CodeName], [m].[Rating], [m].[Timeline]
 FROM [Missions] AS [m]
 WHERE DATEPART(second, [m].[Timeline]) = 0");
         }
@@ -3140,7 +3140,7 @@ WHERE DATEPART(second, [m].[Timeline]) = 0");
             base.Where_datetimeoffset_millisecond_component();
 
             AssertSql(
-                @"SELECT [m].[Id], [m].[CodeName], [m].[Timeline]
+                @"SELECT [m].[Id], [m].[CodeName], [m].[Rating], [m].[Timeline]
 FROM [Missions] AS [m]
 WHERE DATEPART(millisecond, [m].[Timeline]) = 0");
         }


### PR DESCRIPTION
Problem was that in order to return 0 from empty Sum of nullable values, we convert them to non-nullable (to produce 0) and then convert back to nullable type. This works without issue for sync path, but in async simple casting like that doesn't work.

Fix is to call method that adds Task.ContinueWith() call that casts the result to the correct type in the async scenario.