### PR TITLE
[2.1] Fix to #12175 - OrderBy with contains and mapping fails duplicate Query source - expression association

### DIFF
--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -517,7 +517,27 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         /// </summary>
         /// <param name="projection"> The projection expression. </param>
         protected virtual void GenerateProjection([NotNull] Expression projection)
-            => Visit(ApplyOptimizations(projection, searchCondition: false));
+        {
+            if (AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue12175", out var isEnabled) && isEnabled)
+            {
+                Visit(
+                    ApplyOptimizations(
+                        ApplyExplicitCastToBoolInProjectionOptimization(projection),
+                        searchCondition: false));
+            }
+            else
+            {
+                Visit(
+                    ApplyExplicitCastToBoolInProjectionOptimization(
+                        ApplyOptimizations(projection, searchCondition: false)));
+            }
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual Expression ApplyExplicitCastToBoolInProjectionOptimization(Expression expression) => expression;
 
         /// <summary>
         ///     Visit the predicate in SQL WHERE clause

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -5053,6 +5053,22 @@ namespace Microsoft.EntityFrameworkCore.Query
                 elementAsserter: CollectionAsserter<Gear>(e => e.Nickname, (e, a) => Assert.Equal(e.Nickname, a.Nickname)));
         }
 
+        [ConditionalFact]
+        public virtual void Correlated_collection_with_complex_order_by_funcletized_to_constant_bool()
+        {
+            var nicknames = new List<string>();
+            AssertQuery<Gear>(
+                gs => from g in gs
+                      orderby nicknames.Contains(g.Nickname) descending
+                      select new { g.Nickname, Weapons = g.Weapons.Select(w => w.Name).ToList() },
+                elementSorter: e => e.Nickname,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.Nickname, a.Nickname);
+                    CollectionAsserter<string>(ee => ee)(e.Weapons, a.Weapons);
+                });
+        }
+
         // Remember to add any new tests to Async version of this test class
 
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();

--- a/src/EFCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
+++ b/src/EFCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
@@ -132,17 +132,16 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Sql.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected override void GenerateProjection(Expression projection)
+        protected override Expression ApplyExplicitCastToBoolInProjectionOptimization(Expression expression)
         {
-            var aliasedProjection = projection as AliasExpression;
-            var expressionToProcess = aliasedProjection?.Expression ?? projection;
+            var aliasedProjection = expression as AliasExpression;
+            var expressionToProcess = aliasedProjection?.Expression ?? expression;
+
             var updatedExpression = ExplicitCastToBool(expressionToProcess);
 
-            expressionToProcess = aliasedProjection != null
+            return aliasedProjection != null
                 ? new AliasExpression(aliasedProjection.Alias, updatedExpression)
                 : updatedExpression;
-
-            base.GenerateProjection(expressionToProcess);
         }
 
         private static Expression ExplicitCastToBool(Expression expression)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/IncludeSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/IncludeSqlServerTest.cs
@@ -1495,7 +1495,7 @@ OFFSET @__p_1 ROWS",
 SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
 FROM [Orders] AS [c.Orders]
 INNER JOIN (
-    SELECT [c0].[CustomerID], 0 AS [c]
+    SELECT [c0].[CustomerID], CAST(0 AS bit) AS [c]
     FROM [Customers] AS [c0]
     WHERE [c0].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c0].[CustomerID], LEN(N'A')) = N'A')
     ORDER BY [c], [c0].[CustomerID]
@@ -1522,7 +1522,7 @@ OFFSET @__p_1 ROWS",
 SELECT [c.Orders].[OrderID], [c.Orders].[CustomerID], [c.Orders].[EmployeeID], [c.Orders].[OrderDate]
 FROM [Orders] AS [c.Orders]
 INNER JOIN (
-    SELECT [c0].[CustomerID], 1 AS [c]
+    SELECT [c0].[CustomerID], CAST(1 AS bit) AS [c]
     FROM [Customers] AS [c0]
     WHERE [c0].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c0].[CustomerID], LEN(N'A')) = N'A')
     ORDER BY [c], [c0].[CustomerID]


### PR DESCRIPTION
Problem was that for queries that project constant bool which gets produced as a result of optimization (e.g. Contains on empty collection) we would not add explicit cast to bool, which resulted in value coming back as int.

Fix is to apply optimizations before we perform the check that determines whether the explicit cast is needed - this way the value is already collapsed into constant at this point and explicit cast is correctly applied.