### PR TITLE
[2.1] Query: Null checking with anonymous projection produces invalid SQL

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -436,6 +436,12 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                 return base.VisitMethodCall(node);
             }
 
+            // We skip these nodes because test ? null : new { ... } cannot remove null check
+            protected override Expression VisitNew(NewExpression newExpression) => newExpression;
+
+            protected override Expression VisitMemberInit(MemberInitExpression memberInitExpression)
+                => memberInitExpression;
+
             protected override Expression VisitBinary(BinaryExpression node)
             {
                 // not safe to make the optimization due to null semantics

--- a/src/EFCore.Specification.Tests/Query/ComplexNavigationsWeakQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/ComplexNavigationsWeakQueryTestBase.cs
@@ -433,6 +433,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
         }
 
+        public override void Null_check_in_anonymous_type_projection_should_not_be_removed()
+        {
+        }
+
+        public override void Null_check_in_Dto_projection_should_not_be_removed()
+        {
+        }
+
         #endregion
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -3697,6 +3697,50 @@ CROSS APPLY (
 ORDER BY [l1].[Id]");
         }
 
+        public override void Null_check_in_anonymous_type_projection_should_not_be_removed()
+        {
+            base.Null_check_in_anonymous_type_projection_should_not_be_removed();
+
+            AssertSql(
+                @"SELECT [l1].[Id]
+FROM [LevelOne] AS [l1]
+ORDER BY [l1].[Id]",
+                //
+                @"SELECT [t].[Id], CASE
+    WHEN [l2.OneToOne_Required_FK].[Id] IS NULL
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END, [l2.OneToOne_Required_FK].[Name], [l1.OneToMany_Optional].[OneToMany_Optional_InverseId]
+FROM [LevelTwo] AS [l1.OneToMany_Optional]
+LEFT JOIN [LevelThree] AS [l2.OneToOne_Required_FK] ON [l1.OneToMany_Optional].[Id] = [l2.OneToOne_Required_FK].[Level2_Required_Id]
+INNER JOIN (
+    SELECT [l10].[Id]
+    FROM [LevelOne] AS [l10]
+) AS [t] ON [l1.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
+ORDER BY [t].[Id]");
+        }
+
+        public override void Null_check_in_Dto_projection_should_not_be_removed()
+        {
+            base.Null_check_in_Dto_projection_should_not_be_removed();
+
+            AssertSql(
+                @"SELECT [l1].[Id]
+FROM [LevelOne] AS [l1]
+ORDER BY [l1].[Id]",
+                //
+                @"SELECT [t].[Id], CASE
+    WHEN [l2.OneToOne_Required_FK].[Id] IS NULL
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END, [l2.OneToOne_Required_FK].[Name] AS [Value], [l1.OneToMany_Optional].[OneToMany_Optional_InverseId]
+FROM [LevelTwo] AS [l1.OneToMany_Optional]
+LEFT JOIN [LevelThree] AS [l2.OneToOne_Required_FK] ON [l1.OneToMany_Optional].[Id] = [l2.OneToOne_Required_FK].[Level2_Required_Id]
+INNER JOIN (
+    SELECT [l10].[Id]
+    FROM [LevelOne] AS [l10]
+) AS [t] ON [l1.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
+ORDER BY [t].[Id]");
+        }
+
         private void AssertSql(params string[] expected)
         {
             Fixture.TestSqlLoggerFactory.AssertBaseline(expected);


### PR DESCRIPTION


Issue:
The issue here is, we had projection of kind `nav.Id == null ? null : new { nav.Property }`
When it is single property access, we can remove null check since SQL is null safe.
Same is not true for anonymous type since it has no SQL equivalent.
Anonyous type produces Expression[] in sql translation and we tried to print it out in SQL causing exception.

Fix:
Fix is to skip over NewExpression/MemberInitExpression so that if we encounter those, we don't go inside of them.

Resolves #12412
