### PR TITLE
[2.1] Fix to #12351 - Incorrect SQL generated for Count over Group By (EFCore 2.1)

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -840,6 +840,8 @@ namespace Microsoft.EntityFrameworkCore.Query
                 var subSelectExpression = subQueryModelVisitor.Queries.First();
                 AddQuery(querySource, subSelectExpression);
 
+                RequiresStreamingGroupResultOperator = true;
+
                 return subQueryModelVisitor.Expression;
             }
 

--- a/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/AsyncGroupByQueryTestBase.cs
@@ -1990,5 +1990,24 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         #endregion
 
+        #region ResultOperatorsAfterGroupBy
+
+        [ConditionalFact]
+        public virtual async Task Count_after_GroupBy()
+        {
+            await AssertSingleResult<Order>(
+                os => os.GroupBy(o => o.CustomerID).Select(g => g.Sum(gg => gg.OrderID)).CountAsync());
+        }
+
+        [ConditionalFact]
+        public virtual async Task LongCount_after_client_GroupBy()
+        {
+            await AssertSingleResult<Order>(
+                os => (from o in os
+                       group o by new { o.CustomerID } into g
+                       select g.Where(e => e.OrderID < 10300).Count()).LongCountAsync());
+        }
+
+        #endregion
     }
 }

--- a/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -1994,5 +1994,45 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         #endregion
+
+        #region ResultOperatorsAfterGroupBy
+
+        [ConditionalFact]
+        public virtual void Count_after_GroupBy_aggregate()
+        {
+            AssertSingleResult<Order>(
+                os =>os.GroupBy(o => o.CustomerID).Select(g => g.Sum(gg => gg.OrderID)).Count());
+        }
+
+        [ConditionalFact]
+        public virtual void LongCount_after_client_GroupBy()
+        {
+            AssertSingleResult<Order>(
+                os => (from o in os
+                      group o by new { o.CustomerID } into g
+                      select g.Where(e => e.OrderID < 10300).Count()).LongCount());
+        }
+
+        [ConditionalFact]
+        public virtual void MinMax_after_GroupBy_aggregate()
+        {
+            AssertSingleResult<Order>(
+                os => os.GroupBy(o => o.CustomerID).Select(g => g.Sum(gg => gg.OrderID)).Min());
+
+            AssertSingleResult<Order>(
+                os => os.GroupBy(o => o.CustomerID).Select(g => g.Sum(gg => gg.OrderID)).Max());
+        }
+
+        [ConditionalFact]
+        public virtual void AllAny_after_GroupBy_aggregate()
+        {
+            AssertSingleResult<Order>(
+                os => os.GroupBy(o => o.CustomerID).Select(g => g.Sum(gg => gg.OrderID)).All(ee => true));
+
+            AssertSingleResult<Order>(
+                os => os.GroupBy(o => o.CustomerID).Select(g => g.Sum(gg => gg.OrderID)).Any());
+        }
+
+        #endregion
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7437,25 +7437,6 @@ INNER JOIN (
 ORDER BY [t].[c] DESC, [t].[Nickname], [t].[SquadId], [t].[FullName]");
         }
 
-        [ConditionalFact]
-        public virtual void Correlated_collection_with_complex_order_by_funcletized_to_constant_bool_legacy_behavior()
-        {
-            var nicknames = new List<string>();
-            AppContext.SetSwitch("Microsoft.EntityFrameworkCore.Issue12175", true);
-            try
-            {
-                Assert.Throws<InvalidOperationException>(
-                    () => AssertQuery<Gear>(
-                        gs => from g in gs
-                                orderby nicknames.Contains(g.Nickname) descending
-                                select new { g.Nickname, Weapons = g.Weapons.Select(w => w.Name).ToList() }));
-            }
-            finally
-            {
-                AppContext.SetSwitch("Microsoft.EntityFrameworkCore.Issue12175", false);
-            }
-        }
-
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
There was two problems here:
- we were not lifting a select expression that had a GroupBy-Aggregate pattern, and another result operator was composed on top,
- we were not propagating RequiresStreamingGroupBy flag to a parent QM, when we lifted a client group by subquery, which could result in the client methods being wiped out if Count/LongCount was composed on top.