### PR TITLE
[2.1.3] Use structural equality for concurrency check in in-memory database

### DIFF
--- a/src/EFCore.InMemory/Storage/Internal/InMemoryTable.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryTable.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -103,7 +104,9 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
                 for (var index = 0; index < valueBuffer.Length; index++)
                 {
                     if (properties[index].IsConcurrencyToken
-                        && !Equals(_rows[key][index], entry.GetOriginalValue(properties[index])))
+                        && !StructuralComparisons.StructuralEqualityComparer.Equals(
+                            _rows[key][index],
+                            entry.GetOriginalValue(properties[index])))
                     {
                         concurrencyConflicts.Add(properties[index], _rows[key][index]);
                         continue;

--- a/src/EFCore.Specification.Tests/TestModels/UpdatesModel/Product.cs
+++ b/src/EFCore.Specification.Tests/TestModels/UpdatesModel/Product.cs
@@ -15,4 +15,13 @@ namespace Microsoft.EntityFrameworkCore.TestModels.UpdatesModel
         [ConcurrencyCheck]
         public decimal Price { get; set; }
     }
+
+    public class ProductWithBytes
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+
+        [ConcurrencyCheck]
+        public byte[] Bytes { get; set; }
+    }
 }

--- a/src/EFCore.Specification.Tests/TestModels/UpdatesModel/UpdatesContext.cs
+++ b/src/EFCore.Specification.Tests/TestModels/UpdatesModel/UpdatesContext.cs
@@ -10,6 +10,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.UpdatesModel
     {
         public DbSet<Category> Categories { get; set; }
         public DbSet<Product> Products { get; set; }
+        public DbSet<ProductWithBytes> ProductWithBytes { get; set; }
 
         public UpdatesContext(DbContextOptions options)
             : base(options)
@@ -27,6 +28,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.UpdatesModel
                     Id = 78,
                     PrincipalId = 778
                 });
+
             context.Add(
                 new Product
                 {
@@ -35,6 +37,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.UpdatesModel
                     Price = 1.49M,
                     DependentId = 778
                 });
+
             context.Add(
                 new Product
                 {
@@ -42,6 +45,14 @@ namespace Microsoft.EntityFrameworkCore.TestModels.UpdatesModel
                     Name = "Apple Cobler",
                     Price = 2.49M,
                     DependentId = 778
+                });
+
+            context.Add(
+                new ProductWithBytes
+                {
+                    Id = productId1,
+                    Name = "MegaChips",
+                    Bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }
                 });
 
             context.SaveChanges();

--- a/src/EFCore.Specification.Tests/UpdatesFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/UpdatesFixtureBase.cs
@@ -19,6 +19,10 @@ namespace Microsoft.EntityFrameworkCore
                 .Property(e => e.Id)
                 .ValueGeneratedNever();
 
+            modelBuilder.Entity<ProductWithBytes>()
+                .Property(e => e.Id)
+                .ValueGeneratedNever();
+
             modelBuilder.Entity<Category>()
                 .Property(e => e.Id)
                 .ValueGeneratedNever();

--- a/src/EFCore.Specification.Tests/UpdatesTestBase.cs
+++ b/src/EFCore.Specification.Tests/UpdatesTestBase.cs
@@ -100,6 +100,51 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [Fact]
+        public virtual void Update_on_bytes_concurrency_token_original_value_mismatch_throws()
+        {
+            var productId = new Guid("984ade3c-2f7b-4651-a351-642e92ab7146");
+
+            ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    var entry = context.ProductWithBytes.Attach(
+                        new ProductWithBytes
+                        {
+                            Id = productId,
+                            Name = "MegaChips",
+                            Bytes = new byte[] { 8, 7, 6, 5, 4, 3, 2, 1 }
+                        });
+
+                    entry.Property(c => c.Name).IsModified = true;
+
+                    Assert.Throws<DbUpdateConcurrencyException>(
+                        () => context.SaveChanges());
+                });
+        }
+
+        [Fact]
+        public virtual void Update_on_bytes_concurrency_token_original_value_matches_does_not_throw()
+        {
+            var productId = new Guid("984ade3c-2f7b-4651-a351-642e92ab7146");
+
+            ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    var entry = context.ProductWithBytes.Attach(
+                        new ProductWithBytes
+                        {
+                            Id = productId,
+                            Name = "MegaChips",
+                            Bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }
+                        });
+
+                    entry.Property(c => c.Name).IsModified = true;
+
+                    Assert.Equal(1, context.SaveChanges());
+                });
+        }
+
+        [Fact]
         public virtual void Can_remove_partial()
         {
             var productId = new Guid("984ade3c-2f7b-4651-a351-642e92ab7146");


### PR DESCRIPTION
Fixes #12214

Fix is to use structural equality all the time for concurrency checks. This matches more closely the way the check works on real database systems.
