### PR TITLE
Implements #11486: Contains support for SQL server FTS.

### DIFF
--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -345,6 +345,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
                 GetString("IncludePropertyNotFound", nameof(entityType), nameof(property)),
                 entityType, property);
 
+        /// <summary>
+        ///     The 'Contains' method is not supported because the query has switched to client-evaluation. Inspect the log to determine which query expressions are triggering client-evaluation.
+        /// </summary>
+        public static string ContainsFunctionOnClient
+            => GetString("ContainsFunctionOnClient");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -234,4 +234,7 @@
   <data name="IncludePropertyNotFound" xml:space="preserve">
     <value>Include property '{entityType}.{property}' not found</value>
   </data>
+  <data name="ContainsFunctionOnClient" xml:space="preserve">
+    <value>The 'Contains' method is not supported because the query has switched to client-evaluation. Inspect the log to determine which query expressions are triggering client-evaluation.</value>
+  </data>
 </root>

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerCompositeMethodCallTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerCompositeMethodCallTranslator.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
             new SqlServerDateAddTranslator(),
             new SqlServerDateDiffTranslator(),
             new SqlServerEndsWithOptimizedTranslator(),
-            new SqlServerFreeTextMethodCallTranslator(),
+            new SqlServerFullTextSearchMethodCallTranslator(),
             new SqlServerMathTranslator(),
             new SqlServerNewGuidTranslator(),
             new SqlServerObjectToStringTranslator(),

--- a/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerFullTextSearchMethodCallTranslator.cs
+++ b/src/EFCore.SqlServer/Query/ExpressionTranslators/Internal/SqlServerFullTextSearchMethodCallTranslator.cs
@@ -16,18 +16,29 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class SqlServerFreeTextMethodCallTranslator : IMethodCallTranslator
+    public class SqlServerFullTextSearchMethodCallTranslator : IMethodCallTranslator
     {
-        private const string FunctionName = "FREETEXT";
+        private const string FreeTextFunctionName = "FREETEXT";
+        private const string ContainsFunctionName = "CONTAINS";
 
-        private static readonly MethodInfo _methodInfo
+        private static readonly MethodInfo _freeTextMethodInfo
             = typeof(SqlServerDbFunctionsExtensions).GetRuntimeMethod(
                 nameof(SqlServerDbFunctionsExtensions.FreeText),
                 new[] { typeof(DbFunctions), typeof(string), typeof(string) });
 
-        private static readonly MethodInfo _methodInfoWithLanguage
+        private static readonly MethodInfo _freeTextMethodInfoWithLanguage
             = typeof(SqlServerDbFunctionsExtensions).GetRuntimeMethod(
                 nameof(SqlServerDbFunctionsExtensions.FreeText),
+                new[] { typeof(DbFunctions), typeof(string), typeof(string), typeof(int) });
+
+        private static readonly MethodInfo _containsMethodInfo
+            = typeof(SqlServerDbFunctionsExtensions).GetRuntimeMethod(
+                nameof(SqlServerDbFunctionsExtensions.Contains),
+                new[] { typeof(DbFunctions), typeof(string), typeof(string) });
+
+        private static readonly MethodInfo _containsMethodInfoWithLanguage
+            = typeof(SqlServerDbFunctionsExtensions).GetRuntimeMethod(
+                nameof(SqlServerDbFunctionsExtensions.Contains),
                 new[] { typeof(DbFunctions), typeof(string), typeof(string), typeof(int) });
 
         /// <summary>
@@ -38,12 +49,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         {
             Check.NotNull(methodCallExpression, nameof(methodCallExpression));
 
-            if (Equals(methodCallExpression.Method, _methodInfo))
+            if (Equals(methodCallExpression.Method, _freeTextMethodInfo))
             {
                 ValidatePropertyReference(methodCallExpression.Arguments[1]);
 
                 return new SqlFunctionExpression(
-                    FunctionName,
+                    FreeTextFunctionName,
                     typeof(bool),
                     new[]
                     {
@@ -52,12 +63,42 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
                     });
             }
 
-            if (Equals(methodCallExpression.Method, _methodInfoWithLanguage))
+            if (Equals(methodCallExpression.Method, _freeTextMethodInfoWithLanguage))
             {
                 ValidatePropertyReference(methodCallExpression.Arguments[1]);
 
                 return new SqlFunctionExpression(
-                    FunctionName,
+                    FreeTextFunctionName,
+                    typeof(bool),
+                    new[]
+                    {
+                        methodCallExpression.Arguments[1],
+                        methodCallExpression.Arguments[2],
+                        new SqlFragmentExpression(
+                            $"LANGUAGE {((ConstantExpression)methodCallExpression.Arguments[3]).Value}")
+                    });
+            }
+
+            if (Equals(methodCallExpression.Method, _containsMethodInfo))
+            {
+                ValidatePropertyReference(methodCallExpression.Arguments[1]);
+
+                return new SqlFunctionExpression(
+                    ContainsFunctionName,
+                    typeof(bool),
+                    new[]
+                    {
+                        methodCallExpression.Arguments[1],
+                        methodCallExpression.Arguments[2]
+                    });
+            }
+
+            if (Equals(methodCallExpression.Method, _containsMethodInfoWithLanguage))
+            {
+                ValidatePropertyReference(methodCallExpression.Arguments[1]);
+
+                return new SqlFunctionExpression(
+                    ContainsFunctionName,
                     typeof(bool),
                     new[]
                     {

--- a/src/EFCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
+++ b/src/EFCore.SqlServer/Query/Sql/Internal/SqlServerQuerySqlGenerator.cs
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.Sql.Internal
         protected override Expression VisitBinary(BinaryExpression binaryExpression)
         {
             if (binaryExpression.Left is SqlFunctionExpression sqlFunctionExpression
-                && sqlFunctionExpression.FunctionName == "FREETEXT")
+                && (sqlFunctionExpression.FunctionName == "FREETEXT" || sqlFunctionExpression.FunctionName == "CONTAINS"))
             {
                 Visit(binaryExpression.Left);
 

--- a/src/EFCore.SqlServer/SqlServerDbFunctionsExtensions.cs
+++ b/src/EFCore.SqlServer/SqlServerDbFunctionsExtensions.cs
@@ -57,6 +57,49 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
+        ///     <para>
+        ///         A DbFunction method stub that can be used in LINQ queries to target the SQL Server CONTAINS store function.
+        ///     </para>
+        /// </summary>
+        /// <remarks>
+        ///     This DbFunction method has no in-memory implementation and will throw if the query switches to client-evaluation.
+        ///     This can happen if the query contains one or more expressions that could not be translated to the store.
+        /// </remarks>
+        /// <param name="_">DbFunctions instance</param>
+        /// <param name="propertyReference">The property on which the search will be performed.</param>
+        /// <param name="searchCondition">The text that will be searched for in the property and the condition for a match.</param>
+        /// <param name="languageTerm">A Language ID from the sys.syslanguages table.</param>
+        public static bool Contains(
+            [CanBeNull] this DbFunctions _,
+            [NotNull] string propertyReference,
+            [NotNull] string searchCondition,
+            int languageTerm)
+            => ContainsCore(propertyReference, searchCondition, languageTerm);
+
+        /// <summary>
+        ///     <para>
+        ///         A DbFunction method stub that can be used in LINQ queries to target the SQL Server CONTAINS store function.
+        ///     </para>
+        /// </summary>
+        /// <remarks>
+        ///     This DbFunction method has no in-memory implementation and will throw if the query switches to client-evaluation.
+        ///     This can happen if the query contains one or more expressions that could not be translated to the store.
+        /// </remarks>
+        /// <param name="_">DbFunctions instance</param>
+        /// <param name="propertyReference">The property on which the search will be performed.</param>
+        /// <param name="searchCondition">The text that will be searched for in the property and the condition for a match.</param>
+        public static bool Contains(
+            [CanBeNull] this DbFunctions _,
+            [NotNull] string propertyReference,
+            [NotNull] string searchCondition)
+            => ContainsCore(propertyReference, searchCondition, null);
+
+        private static bool ContainsCore(string propertyName, string searchCondition, int? languageTerm)
+        {
+            throw new InvalidOperationException(SqlServerStrings.ContainsFunctionOnClient);
+        }
+
+        /// <summary>
         ///     Counts the number of year boundaries crossed between the startDate and endDate.
         ///     Corresponds to SQL Server's DATEDIFF(YEAR,startDate,endDate).
         /// </summary>


### PR DESCRIPTION
```
    Summary of the changes
    - Added Contains function mapping to SqlServerDbFunctionsExtensions.cs
    - Added translator logic for Contains to SqlServerFreeTextMethodCallTranslator, renamed to SqlServerFullTextSearchMethodCallTranslator.
    - Updated query generator
    - Added tests
```
 Fixes #11486