### PR TITLE
Query: GroupBy Count with predicate translation to server (#11711)

### DIFF
--- a/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GroupByQueryTestBase.cs
@@ -1901,6 +1901,22 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual Task GroupBy_count_with_predicate()
+        {
+            return AssertQueryScalarAsync<Order>(
+                os => os.GroupBy(o => o.CustomerID)
+                    .Select(g => g.Count(o => o.OrderDate != null)));
+        }
+
+        [ConditionalFact]
+        public virtual Task GroupBy_long_count_with_predicate()
+        {
+            return AssertQueryScalarAsync<Order>(
+                os => os.GroupBy(o => o.CustomerID)
+                    .Select(g => g.LongCount(o => o.OrderDate != null)));
+        }
+
+        [ConditionalFact]
         public virtual Task GroupBy_Key_as_part_of_element_selector()
         {
             return AssertQueryAsync<Order>(

--- a/src/EFCore/Query/ExpressionVisitors/Internal/RequiresMaterializationExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/RequiresMaterializationExpressionVisitor.cs
@@ -257,6 +257,17 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     }
                 }
             }
+            else if ((expression.QueryModel.ResultOperators[0] is CountResultOperator
+                     || expression.QueryModel.ResultOperators[0] is LongCountResultOperator)
+                     && expression.QueryModel.BodyClauses.OfType<WhereClause>().FirstOrDefault() is WhereClause whereClause)
+            {
+                expression.QueryModel.SelectClause.Selector = Expression.Condition(
+                    whereClause.Predicate,
+                    Expression.Constant(1, typeof(int?)),
+                    Expression.Constant(null, typeof(int?)));
+
+                expression.QueryModel.BodyClauses.Remove(whereClause);
+            }
 
             return expression;
         }
@@ -264,7 +275,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         private bool IsGroupByAggregateSubQuery(QueryModel queryModel)
         {
             if (queryModel.MainFromClause.FromExpression.Type.IsGrouping()
-                && queryModel.BodyClauses.Count == 0
                 && queryModel.ResultOperators.Count == 1
                 && _aggregateResultOperators.Contains(queryModel.ResultOperators[0].GetType())
                 && _queryModelStack.Count > 0

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GroupByQuerySqlServerTest.cs
@@ -619,7 +619,7 @@ GROUP BY [o].[CustomerID]");
             await base.GroupBy_Property_scalar_element_selector_Count();
 
             AssertSql(
-                @"SELECT COUNT(*)
+                @"SELECT COUNT([o].[OrderID])
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
         }
@@ -629,7 +629,7 @@ GROUP BY [o].[CustomerID]");
             await base.GroupBy_Property_scalar_element_selector_LongCount();
 
             AssertSql(
-                @"SELECT COUNT_BIG(*)
+                @"SELECT COUNT_BIG([o].[OrderID])
 FROM [Orders] AS [o]
 GROUP BY [o].[CustomerID]");
         }
@@ -1420,9 +1420,38 @@ ORDER BY [o].[CustomerID]");
             await base.GroupBy_Where_in_aggregate();
 
             AssertSql(
-                @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
+                @"SELECT COUNT(CASE
+    WHEN [o].[OrderID] < 10300
+    THEN 1 ELSE NULL
+END)
 FROM [Orders] AS [o]
-ORDER BY [o].[CustomerID]");
+GROUP BY [o].[CustomerID]");
+        }
+
+        public override async Task GroupBy_count_with_predicate()
+        {
+            await base.GroupBy_count_with_predicate();
+
+            AssertSql(
+                @"SELECT COUNT(CASE
+    WHEN [o].[OrderDate] IS NOT NULL
+    THEN 1 ELSE NULL
+END)
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]");
+        }
+
+        public override async Task GroupBy_long_count_with_predicate()
+        {
+            await base.GroupBy_long_count_with_predicate();
+
+            AssertSql(
+                @"SELECT COUNT_BIG(CASE
+    WHEN [o].[OrderDate] IS NOT NULL
+    THEN 1 ELSE NULL
+END)
+FROM [Orders] AS [o]
+GROUP BY [o].[CustomerID]");
         }
 
         public override async Task GroupBy_Key_as_part_of_element_selector()


### PR DESCRIPTION
Fixes #11711 

This PR introduces SQL translation of GroupBy with Count aggregation on predicate as follows:
```
COUNT(CASE
    WHEN predicate
    THEN 1 ELSE NULL
END)
```

The code checks for presence of `Count` or `LongCount` result operators with a predicate in GroupBy aggregate subquery and then creates a conditional expression as a selector. Then when handling those result operators we put that selector as an argument of `COUNT` function.

The only problem is `GroupBy_Where_in_aggregate` test, that fails for InMemory provider. I will soon investigate more or possibly someone from the team will have an ideas.