### PR TITLE
[2.1.3] Use structural equality for concurrency check in in-memory database

### DIFF
--- a/src/EFCore.Specification.Tests/TestModels/UpdatesModel/Product.cs
+++ b/src/EFCore.Specification.Tests/TestModels/UpdatesModel/Product.cs
@@ -11,7 +11,17 @@ namespace Microsoft.EntityFrameworkCore.TestModels.UpdatesModel
         public Guid Id { get; set; }
         public int? DependentId { get; set; }
         public string Name { get; set; }
+
         [ConcurrencyCheck]
         public decimal Price { get; set; }
+    }
+
+    public class ProductWithBytes
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; }
+
+        [ConcurrencyCheck]
+        public byte[] Bytes { get; set; }
     }
 }

--- a/src/EFCore.Specification.Tests/TestModels/UpdatesModel/UpdatesContext.cs
+++ b/src/EFCore.Specification.Tests/TestModels/UpdatesModel/UpdatesContext.cs
@@ -9,6 +9,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.UpdatesModel
     {
         public DbSet<Category> Categories { get; set; }
         public DbSet<Product> Products { get; set; }
+        public DbSet<ProductWithBytes> ProductWithBytes { get; set; }
 
         public UpdatesContext(DbContextOptions options)
             : base(options)
@@ -23,6 +24,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.UpdatesModel
             context.Add(new Category { Id = 78, PrincipalId = 778 });
             context.Add(new Product { Id = productId1, Name = "Apple Cider", Price = 1.49M, DependentId = 778 });
             context.Add(new Product { Id = productId2, Name = "Apple Cobler", Price = 2.49M, DependentId = 778 });
+            context.Add(new ProductWithBytes { Id = productId1, Name = "MegaChips", Bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 } });
 
             context.SaveChanges();
         }

--- a/src/EFCore.Specification.Tests/UpdatesFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/UpdatesFixtureBase.cs
@@ -22,6 +22,11 @@ namespace Microsoft.EntityFrameworkCore
             modelBuilder.Entity<Category>()
                 .Property(e => e.Id)
                 .ValueGeneratedNever();
+
+            modelBuilder.Entity<ProductWithBytes>()
+                .Property(e => e.Id)
+                .ValueGeneratedNever();
+
 #if !Test20
             modelBuilder.Entity<LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCorrectly>(eb =>
             {

--- a/src/EFCore.Specification.Tests/UpdatesTestBase.cs
+++ b/src/EFCore.Specification.Tests/UpdatesTestBase.cs
@@ -99,6 +99,112 @@ namespace Microsoft.EntityFrameworkCore
                                 () => context.SaveChanges()).Message);
                     });
         }
+
+        [Fact]
+        public virtual void Update_on_bytes_concurrency_token_original_value_mismatch_throws()
+        {
+            var productId = new Guid("984ade3c-2f7b-4651-a351-642e92ab7146");
+
+            ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    var entry = context.ProductWithBytes.Attach(
+                        new ProductWithBytes
+                        {
+                            Id = productId,
+                            Name = "MegaChips",
+                            Bytes = new byte[] { 8, 7, 6, 5, 4, 3, 2, 1 }
+                        });
+
+                    entry.Entity.Name = "GigaChips";
+
+                    Assert.Throws<DbUpdateConcurrencyException>(
+                        () => context.SaveChanges());
+                },
+                context =>
+                {
+                    Assert.Equal("MegaChips", context.ProductWithBytes.Find(productId).Name);
+                });
+        }
+
+        [Fact]
+        public virtual void Update_on_bytes_concurrency_token_original_value_matches_does_not_throw()
+        {
+            var productId = new Guid("984ade3c-2f7b-4651-a351-642e92ab7146");
+
+            ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    var entry = context.ProductWithBytes.Attach(
+                        new ProductWithBytes
+                        {
+                            Id = productId,
+                            Name = "MegaChips",
+                            Bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }
+                        });
+
+                    entry.Entity.Name = "GigaChips";
+
+                    Assert.Equal(1, context.SaveChanges());
+                },
+                context =>
+                {
+                    Assert.Equal("GigaChips", context.ProductWithBytes.Find(productId).Name);
+                });
+        }
+
+        [Fact]
+        public virtual void Remove_on_bytes_concurrency_token_original_value_mismatch_throws()
+        {
+            var productId = new Guid("984ade3c-2f7b-4651-a351-642e92ab7146");
+
+            ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    var entry = context.ProductWithBytes.Attach(
+                        new ProductWithBytes
+                        {
+                            Id = productId,
+                            Name = "MegaChips",
+                            Bytes = new byte[] { 8, 7, 6, 5, 4, 3, 2, 1 }
+                        });
+
+                    entry.State = EntityState.Deleted;
+
+                    Assert.Throws<DbUpdateConcurrencyException>(
+                        () => context.SaveChanges());
+                },
+                context =>
+                {
+                    Assert.Equal("MegaChips", context.ProductWithBytes.Find(productId).Name);
+                });
+        }
+
+        [Fact]
+        public virtual void Remove_on_bytes_concurrency_token_original_value_matches_does_not_throw()
+        {
+            var productId = new Guid("984ade3c-2f7b-4651-a351-642e92ab7146");
+
+            ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    var entry = context.ProductWithBytes.Attach(
+                        new ProductWithBytes
+                        {
+                            Id = productId,
+                            Name = "MegaChips",
+                            Bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }
+                        });
+
+                    entry.State = EntityState.Deleted;
+
+                    Assert.Equal(1, context.SaveChanges());
+                },
+                context =>
+                {
+                    Assert.Null(context.ProductWithBytes.Find(productId));
+                });
+        }
 #endif
 
         [Fact]


### PR DESCRIPTION
Fixes #12214

Fix is to use structural equality all the time for concurrency checks. This matches more closely the way the check works on real database systems.