### PR TITLE
Automatically flow version into tests and powershell definitions

### DIFF
--- a/src/EFCore.Tools/EFCore.Tools.csproj
+++ b/src/EFCore.Tools/EFCore.Tools.csproj
@@ -27,11 +27,17 @@ Update-Database
     <ProjectReference Include="..\ef\ef.csproj" />
   </ItemGroup>
 
-  <Target Name="SetPackageProperties" BeforeTargets="GenerateNuspec">
+  <ItemGroup>
+    <GeneratedContent Include="*.psd1.in">
+      <Properties>VersionPrefix=$(VersionPrefix)</Properties>
+    </GeneratedContent>
+  </ItemGroup>
+
+  <Target Name="SetPackageProperties" BeforeTargets="GenerateNuspec" DependsOnTargets="ResolveCommitHash">
     <PropertyGroup>
       <!-- Make sure we create a symbols.nupkg -->
       <IncludeSymbols>true</IncludeSymbols>
-      
+
       <NuspecProperties>
         id=$(PackageId);
         version=$(PackageVersion);
@@ -46,13 +52,19 @@ Update-Database
         author=$(Authors);
         copyright=$(Copyright);
         description=$(Description);
+        targetDir=$(TargetDir);
       </NuspecProperties>
     </PropertyGroup>
   </Target>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
-  <Target Name="Compile" />
+  <Target Name="Compile"
+    Inputs="$(MSBuildAllProjects);@(GeneratedContent)"
+    Outputs="@(GeneratedContent->'$(TargetDir)%(FileName)'">
+    <Sdk_GenerateFileFromTemplate TemplateFile="%(GeneratedContent.Identity)" OutputPath="$(TargetDir)%(FileName)" Properties="%(Properties)" />
+  </Target>
+
   <Target Name="CopyFilesToOutputDirectory" />
 
 </Project>

--- a/src/EFCore.Tools/EFCore.Tools.nuspec
+++ b/src/EFCore.Tools/EFCore.Tools.nuspec
@@ -24,6 +24,7 @@
   <files>
     <file src="lib/**/*" target="" />
     <file src="tools/**/*" target=""/>
+    <file src="$targetDir$*.psd1" target="tools/"/>
     <file src="../ef/bin/$configuration$/net461/ef.exe" target="tools/net461/any/" />
     <file src="../ef/bin/$configuration$/net461/ef.pdb" target="tools/net461/any/" />
     <file src="../ef/bin/x86/$configuration$/net461/ef.exe" target="tools/net461/win-x86/" />

--- a/src/EFCore.Tools/EntityFrameworkCore.PowerShell2.psd1.in
+++ b/src/EFCore.Tools/EntityFrameworkCore.PowerShell2.psd1.in
@@ -3,7 +3,7 @@
     ModuleToProcess = 'EntityFrameworkCore.PowerShell2.psm1'
 
     # Version number of this module.
-    ModuleVersion = '2.1.2'
+    ModuleVersion = '${VersionPrefix}'
 
     # ID used to uniquely identify this module
     GUID = '2de7c7fd-c848-41d7-8634-37fed4d3bb36'

--- a/src/EFCore.Tools/EntityFrameworkCore.psd1.in
+++ b/src/EFCore.Tools/EntityFrameworkCore.psd1.in
@@ -3,7 +3,7 @@
     RootModule = 'EntityFrameworkCore.psm1'
 
     # Version number of this module.
-    ModuleVersion = '2.1.2'
+    ModuleVersion = '${VersionPrefix}'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/test/EFCore.Tests/EFCore.Tests.csproj
+++ b/test/EFCore.Tests/EFCore.Tests.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>PackageVersion</_Parameter1>
+      <_Parameter2>$(PackageVersion)</_Parameter2>
+    </AssemblyAttribute>
     <None Include="..\xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/test/EFCore.Tests/ModelSourceTest.cs
+++ b/test/EFCore.Tests/ModelSourceTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -129,8 +130,9 @@ namespace Microsoft.EntityFrameworkCore
             var modelSource = CreateDefaultModelSource(new DbSetFinder());
 
             var model = modelSource.GetModel(new Context1(), _nullConventionSetBuilder, _coreModelValidator);
+            var packageVersion = typeof(Context1).Assembly.GetCustomAttributes<AssemblyMetadataAttribute>().Single(m => m.Key == "PackageVersion").Value;
 
-            Assert.StartsWith("2.1.2", model.GetProductVersion(), StringComparison.OrdinalIgnoreCase);
+            Assert.StartsWith(packageVersion, model.GetProductVersion(), StringComparison.OrdinalIgnoreCase);
         }
 
         private class Context1 : DbContext


### PR DESCRIPTION
Follow-up to https://github.com/aspnet/EntityFrameworkCore/pull/12484#issuecomment-400828972

Remove the hard-coded versions from .psd1 files and tests. Instead, this flows the version automatically into test runs and the .psd1 definitions.