### PR TITLE
Add model building support for collections of owned types.

### DIFF
--- a/EFCore.Runtime.sln.DotSettings
+++ b/EFCore.Runtime.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeInspection/CodeAnnotations/NamespacesWithAnnotations/=Microsoft_002EEntityFrameworkCore_002EAnnotations/@EntryIndexedValue">True</s:Boolean>
 	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=D44E9AA0167CE64B866A64486B319AB0/RelativePath/@EntryValue">..\EFCore.sln.DotSettings</s:String>
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=D44E9AA0167CE64B866A64486B319AB0/@KeyIndexDefined">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=FileD44E9AA0167CE64B866A64486B319AB0/@KeyIndexDefined">True</s:Boolean>

--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -137,13 +137,14 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             Check.NotNull(entityType, nameof(entityType));
             Check.NotNull(stringBuilder, nameof(stringBuilder));
 
-            var ownerNavigation = entityType.FindOwnership()?.PrincipalToDependent.Name;
+            var ownership = entityType.FindOwnership();
+            var ownerNavigation = ownership?.PrincipalToDependent.Name;
 
             stringBuilder
                 .Append(builderName)
                 .Append(
                     ownerNavigation != null
-                        ? ".OwnsOne("
+                        ? ownership.IsUnique ? ".OwnsOne(" : ".OwnsMany("
                         : ".Entity(")
                 .Append(Code.Literal(entityType.Name));
 
@@ -186,10 +187,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
 
                     GenerateProperties(builderName, entityType.GetDeclaredProperties(), stringBuilder);
 
-                    if (ownerNavigation == null)
-                    {
-                        GenerateKeys(builderName, entityType.GetDeclaredKeys(), entityType.FindDeclaredPrimaryKey(), stringBuilder);
-                    }
+                    GenerateKeys(builderName, entityType.GetDeclaredKeys(), entityType.FindDeclaredPrimaryKey(), stringBuilder);
 
                     GenerateIndexes(builderName, entityType.GetDeclaredIndexes(), stringBuilder);
 

--- a/src/EFCore.Relational/RelationalCollectionOwnershipBuilderExtensions.cs
+++ b/src/EFCore.Relational/RelationalCollectionOwnershipBuilderExtensions.cs
@@ -1,0 +1,129 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    ///     Relational database specific extension methods for <see cref="CollectionOwnershipBuilder" />.
+    /// </summary>
+    public static class RelationalCollectionOwnershipBuilderExtensions
+    {
+        /// <summary>
+        ///     Configures the view or table that the entity maps to when targeting a relational database.
+        /// </summary>
+        /// <param name="collectionOwnershipBuilder"> The builder for the entity type being configured. </param>
+        /// <param name="name"> The name of the view or table. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public static CollectionOwnershipBuilder ToTable(
+            [NotNull] this CollectionOwnershipBuilder collectionOwnershipBuilder,
+            [CanBeNull] string name)
+        {
+            Check.NotNull(collectionOwnershipBuilder, nameof(collectionOwnershipBuilder));
+            Check.NullButNotEmpty(name, nameof(name));
+
+            collectionOwnershipBuilder.GetInfrastructure<InternalEntityTypeBuilder>()
+                .Relational(ConfigurationSource.Explicit)
+                .ToTable(name);
+
+            return collectionOwnershipBuilder;
+        }
+
+        /// <summary>
+        ///     Configures the view or table that the entity maps to when targeting a relational database.
+        /// </summary>
+        /// <typeparam name="TEntity"> The entity type being configured. </typeparam>
+        /// <typeparam name="TDependentEntity"> The entity type that this relationship targets. </typeparam>
+        /// <param name="collectionOwnershipBuilder"> The builder for the entity type being configured. </param>
+        /// <param name="name"> The name of the view or table. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public static CollectionOwnershipBuilder<TEntity, TDependentEntity> ToTable<TEntity, TDependentEntity>(
+            [NotNull] this CollectionOwnershipBuilder<TEntity, TDependentEntity> collectionOwnershipBuilder,
+            [CanBeNull] string name)
+            where TEntity : class
+            where TDependentEntity : class
+            => (CollectionOwnershipBuilder<TEntity, TDependentEntity>)ToTable((CollectionOwnershipBuilder)collectionOwnershipBuilder, name);
+
+        /// <summary>
+        ///     Configures the view or table that the entity maps to when targeting a relational database.
+        /// </summary>
+        /// <param name="collectionOwnershipBuilder"> The builder for the entity type being configured. </param>
+        /// <param name="name"> The name of the view or table. </param>
+        /// <param name="schema"> The schema of the view or table. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public static CollectionOwnershipBuilder ToTable(
+            [NotNull] this CollectionOwnershipBuilder collectionOwnershipBuilder,
+            [CanBeNull] string name,
+            [CanBeNull] string schema)
+        {
+            Check.NotNull(collectionOwnershipBuilder, nameof(collectionOwnershipBuilder));
+            Check.NullButNotEmpty(name, nameof(name));
+            Check.NullButNotEmpty(schema, nameof(schema));
+
+            collectionOwnershipBuilder.GetInfrastructure<InternalEntityTypeBuilder>()
+                .Relational(ConfigurationSource.Explicit)
+                .ToTable(name, schema);
+
+            return collectionOwnershipBuilder;
+        }
+
+        /// <summary>
+        ///     Configures the view or table that the entity maps to when targeting a relational database.
+        /// </summary>
+        /// <typeparam name="TEntity"> The entity type being configured. </typeparam>
+        /// <typeparam name="TDependentEntity"> The entity type that this relationship targets. </typeparam>
+        /// <param name="collectionOwnershipBuilder"> The builder for the entity type being configured. </param>
+        /// <param name="name"> The name of the view or table. </param>
+        /// <param name="schema"> The schema of the view or table. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public static CollectionOwnershipBuilder<TEntity, TDependentEntity> ToTable<TEntity, TDependentEntity>(
+            [NotNull] this CollectionOwnershipBuilder<TEntity, TDependentEntity> collectionOwnershipBuilder,
+            [CanBeNull] string name,
+            [CanBeNull] string schema)
+            where TEntity : class
+            where TDependentEntity : class
+            => (CollectionOwnershipBuilder<TEntity, TDependentEntity>)ToTable((CollectionOwnershipBuilder)collectionOwnershipBuilder, name, schema);
+
+        /// <summary>
+        ///     Configures the foreign key constraint name for this relationship when targeting a relational database.
+        /// </summary>
+        /// <param name="referenceReferenceBuilder"> The builder being used to configure the relationship. </param>
+        /// <param name="name"> The name of the foreign key constraint. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public static CollectionOwnershipBuilder HasConstraintName(
+            [NotNull] this CollectionOwnershipBuilder referenceReferenceBuilder,
+            [CanBeNull] string name)
+        {
+            Check.NotNull(referenceReferenceBuilder, nameof(referenceReferenceBuilder));
+            Check.NullButNotEmpty(name, nameof(name));
+
+            referenceReferenceBuilder.GetInfrastructure<InternalRelationshipBuilder>()
+                .Relational(ConfigurationSource.Explicit)
+                .HasConstraintName(name);
+
+            return referenceReferenceBuilder;
+        }
+
+        /// <summary>
+        ///     Configures the foreign key constraint name for this relationship when targeting a relational database.
+        /// </summary>
+        /// <param name="referenceReferenceBuilder"> The builder being used to configure the relationship. </param>
+        /// <param name="name"> The name of the foreign key constraint. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        /// <typeparam name="TEntity"> The entity type on one end of the relationship. </typeparam>
+        /// <typeparam name="TDependentEntity"> The entity type on the other end of the relationship. </typeparam>
+        public static CollectionOwnershipBuilder<TEntity, TDependentEntity> HasConstraintName<TEntity, TDependentEntity>(
+            [NotNull] this CollectionOwnershipBuilder<TEntity, TDependentEntity> referenceReferenceBuilder,
+            [CanBeNull] string name)
+            where TEntity : class
+            where TDependentEntity : class
+            => (CollectionOwnershipBuilder<TEntity, TDependentEntity>)HasConstraintName(
+                (CollectionOwnershipBuilder)referenceReferenceBuilder, name);
+    }
+}

--- a/src/EFCore.Relational/Storage/Internal/RelationalCommand.cs
+++ b/src/EFCore.Relational/Storage/Internal/RelationalCommand.cs
@@ -352,7 +352,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
             command.CommandText = AdjustCommandText(CommandText);
 
             ConfigureCommand(command);
-            
+
             if (connection.CurrentTransaction != null)
             {
                 command.Transaction = connection.CurrentTransaction.GetDbTransaction();
@@ -388,7 +388,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         protected virtual void ConfigureCommand(DbCommand command)
         {
         }
-        
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore.SqlServer/Extensions/SqlServerCollectionOwnershipBuilderExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerCollectionOwnershipBuilderExtensions.cs
@@ -1,0 +1,46 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    ///     SQL Server specific extension methods for <see cref="CollectionOwnershipBuilder" />.
+    /// </summary>
+    public static class SqlServerCollectionOwnershipBuilderExtensions
+    {
+        /// <summary>
+        ///     Configures the table that the entity maps to when targeting SQL Server as memory-optimized.
+        /// </summary>
+        /// <param name="collectionOwnershipBuilder"> The builder for the entity type being configured. </param>
+        /// <param name="memoryOptimized"> A value indicating whether the table is memory-optimized. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public static CollectionOwnershipBuilder ForSqlServerIsMemoryOptimized(
+            [NotNull] this CollectionOwnershipBuilder collectionOwnershipBuilder, bool memoryOptimized = true)
+        {
+            Check.NotNull(collectionOwnershipBuilder, nameof(collectionOwnershipBuilder));
+
+            collectionOwnershipBuilder.OwnedEntityType.SqlServer().IsMemoryOptimized = memoryOptimized;
+
+            return collectionOwnershipBuilder;
+        }
+
+        /// <summary>
+        ///     Configures the table that the entity maps to when targeting SQL Server as memory-optimized.
+        /// </summary>
+        /// <typeparam name="TEntity"> The entity type being configured. </typeparam>
+        /// <typeparam name="TRelatedEntity"> The entity type that this relationship targets. </typeparam>
+        /// <param name="collectionOwnershipBuilder"> The builder for the entity type being configured. </param>
+        /// <param name="memoryOptimized"> A value indicating whether the table is memory-optimized. </param>
+        /// <returns> The same builder instance so that multiple calls can be chained. </returns>
+        public static CollectionOwnershipBuilder<TEntity, TRelatedEntity> ForSqlServerIsMemoryOptimized<TEntity, TRelatedEntity>(
+            [NotNull] this CollectionOwnershipBuilder<TEntity, TRelatedEntity> collectionOwnershipBuilder, bool memoryOptimized = true)
+            where TEntity : class
+            where TRelatedEntity : class
+            => (CollectionOwnershipBuilder<TEntity, TRelatedEntity>)ForSqlServerIsMemoryOptimized((CollectionOwnershipBuilder)collectionOwnershipBuilder, memoryOptimized);
+    }
+}

--- a/src/EFCore/Metadata/Builders/CollectionNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/CollectionNavigationBuilder.cs
@@ -155,13 +155,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             }
 
             return referenceName != null
-                && RelatedEntityType != foreignKey.DeclaringEntityType
+                   && RelatedEntityType != foreignKey.DeclaringEntityType
                 ? reference.Property == null && CollectionProperty == null
                     ? Builder.Navigations(reference.Name, CollectionName, DeclaringEntityType, RelatedEntityType, ConfigurationSource.Explicit)
                     : Builder.Navigations(reference.Property, CollectionProperty, DeclaringEntityType, RelatedEntityType, ConfigurationSource.Explicit)
                 : reference.Property == null
-                ? Builder.DependentToPrincipal(reference.Name, ConfigurationSource.Explicit)
-                : Builder.DependentToPrincipal(reference.Property, ConfigurationSource.Explicit);
+                    ? Builder.DependentToPrincipal(reference.Name, ConfigurationSource.Explicit)
+                    : Builder.DependentToPrincipal(reference.Property, ConfigurationSource.Explicit);
         }
 
         #region Hidden System.Object members

--- a/src/EFCore/Metadata/Builders/CollectionNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/CollectionNavigationBuilder`.cs
@@ -54,6 +54,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         }
 
         /// <summary>
+        ///     Configures this as a one-to-many relationship.
+        /// </summary>
+        /// <param name="navigationName">
+        ///     The name of the reference navigation property on the other end of this relationship.
+        ///     If null, there is no navigation property on the other end of the relationship.
+        /// </param>
+        /// <returns> An object to further configure the relationship. </returns>
+        public new virtual ReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne([CanBeNull] string navigationName = null)
+            => new ReferenceCollectionBuilder<TEntity, TRelatedEntity>(
+                DeclaringEntityType,
+                RelatedEntityType,
+                WithOneBuilder(Check.NullButNotEmpty(navigationName, nameof(navigationName))));
+
+        /// <summary>
         ///     <para>
         ///         Configures this as a one-to-many relationship.
         ///     </para>
@@ -75,19 +89,5 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 DeclaringEntityType,
                 RelatedEntityType,
                 WithOneBuilder(navigationExpression?.GetPropertyAccess()));
-
-        /// <summary>
-        ///     Configures this as a one-to-many relationship.
-        /// </summary>
-        /// <param name="navigationName">
-        ///     The name of the reference navigation property on the other end of this relationship.
-        ///     If null, there is no navigation property on the other end of the relationship.
-        /// </param>
-        /// <returns> An object to further configure the relationship. </returns>
-        public new virtual ReferenceCollectionBuilder<TEntity, TRelatedEntity> WithOne([CanBeNull] string navigationName = null)
-            => new ReferenceCollectionBuilder<TEntity, TRelatedEntity>(
-                DeclaringEntityType,
-                RelatedEntityType,
-                WithOneBuilder(Check.NullButNotEmpty(navigationName, nameof(navigationName))));
     }
 }

--- a/src/EFCore/Metadata/Builders/CollectionOwnershipBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/CollectionOwnershipBuilder`.cs
@@ -9,7 +9,6 @@ using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Internal;
-using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -20,15 +19,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
     ///         Provides a simple API for configuring a one-to-one ownership.
     ///     </para>
     /// </summary>
-    public class ReferenceOwnershipBuilder<TEntity, TRelatedEntity> : ReferenceOwnershipBuilder
+    public class CollectionOwnershipBuilder<TEntity, TDependentEntity> : CollectionOwnershipBuilder
         where TEntity : class
-        where TRelatedEntity : class
+        where TDependentEntity : class
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public ReferenceOwnershipBuilder(
+        public CollectionOwnershipBuilder(
             [NotNull] EntityType declaringEntityType,
             [NotNull] EntityType relatedEntityType,
             [NotNull] InternalRelationshipBuilder builder)
@@ -40,14 +39,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected ReferenceOwnershipBuilder(
+        protected CollectionOwnershipBuilder(
             InternalRelationshipBuilder builder,
-            ReferenceOwnershipBuilder oldBuilder,
-            bool inverted = false,
+            CollectionOwnershipBuilder<TEntity, TDependentEntity> oldBuilder,
             bool foreignKeySet = false,
             bool principalKeySet = false,
             bool requiredSet = false)
-            : base(builder, oldBuilder, inverted, foreignKeySet, principalKeySet, requiredSet)
+            : base(builder, oldBuilder, foreignKeySet, principalKeySet, requiredSet)
         {
         }
 
@@ -58,9 +56,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <param name="annotation"> The key of the annotation to be added or updated. </param>
         /// <param name="value"> The value to be stored in the annotation. </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public new virtual ReferenceOwnershipBuilder<TEntity, TRelatedEntity> HasForeignKeyAnnotation(
+        public new virtual CollectionOwnershipBuilder<TEntity, TDependentEntity> HasForeignKeyAnnotation(
             [NotNull] string annotation, [NotNull] object value)
-            => (ReferenceOwnershipBuilder<TEntity, TRelatedEntity>)base.HasForeignKeyAnnotation(annotation, value);
+            => (CollectionOwnershipBuilder<TEntity, TDependentEntity>)base.HasForeignKeyAnnotation(annotation, value);
 
         /// <summary>
         ///     <para>
@@ -84,14 +82,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     The name(s) of the foreign key property(s).
         /// </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public new virtual ReferenceOwnershipBuilder<TEntity, TRelatedEntity> HasForeignKey(
+        public new virtual CollectionOwnershipBuilder<TEntity, TDependentEntity> HasForeignKey(
             [NotNull] params string[] foreignKeyPropertyNames)
         {
             Builder = Builder.HasForeignKey(
                 Check.NotNull(foreignKeyPropertyNames, nameof(foreignKeyPropertyNames)),
-                RelatedEntityType,
+                DependentEntityType,
                 ConfigurationSource.Explicit);
-            return new ReferenceOwnershipBuilder<TEntity, TRelatedEntity>(
+            return new CollectionOwnershipBuilder<TEntity, TDependentEntity>(
                 Builder,
                 this,
                 foreignKeySet: foreignKeyPropertyNames.Any());
@@ -126,14 +124,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     </para>
         /// </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public virtual ReferenceOwnershipBuilder<TEntity, TRelatedEntity> HasForeignKey(
-            [NotNull] Expression<Func<TRelatedEntity, object>> foreignKeyExpression)
+        public virtual CollectionOwnershipBuilder<TEntity, TDependentEntity> HasForeignKey(
+            [NotNull] Expression<Func<TDependentEntity, object>> foreignKeyExpression)
         {
             Builder = Builder.HasForeignKey(
                 Check.NotNull(foreignKeyExpression, nameof(foreignKeyExpression)).GetPropertyAccessList(),
-                RelatedEntityType,
+                DependentEntityType,
                 ConfigurationSource.Explicit);
-            return new ReferenceOwnershipBuilder<TEntity, TRelatedEntity>(
+            return new CollectionOwnershipBuilder<TEntity, TDependentEntity>(
                 Builder,
                 this,
                 foreignKeySet: true);
@@ -147,13 +145,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </summary>
         /// <param name="keyPropertyNames"> The name(s) of the reference key property(s). </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public new virtual ReferenceOwnershipBuilder<TEntity, TRelatedEntity> HasPrincipalKey(
+        public new virtual CollectionOwnershipBuilder<TEntity, TDependentEntity> HasPrincipalKey(
             [NotNull] params string[] keyPropertyNames)
         {
             Builder = Builder.HasPrincipalKey(
                 Check.NotNull(keyPropertyNames, nameof(keyPropertyNames)),
                 ConfigurationSource.Explicit);
-            return new ReferenceOwnershipBuilder<TEntity, TRelatedEntity>(
+            return new CollectionOwnershipBuilder<TEntity, TDependentEntity>(
                 Builder,
                 this,
                 principalKeySet: keyPropertyNames.Any());
@@ -172,17 +170,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     <para>
         ///         If the principal key is made up of multiple properties then specify an anonymous type including the
         ///         properties (<c>t => new { t.Id1, t.Id2 }</c>). The order specified should match the order of
-        ///         corresponding properties in <see cref="HasForeignKey(Expression{Func{TRelatedEntity, object}})" />.
+        ///         corresponding properties in <see cref="HasForeignKey(Expression{Func{TDependentEntity, object}})" />.
         ///     </para>
         /// </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public virtual ReferenceOwnershipBuilder<TEntity, TRelatedEntity> HasPrincipalKey(
+        public virtual CollectionOwnershipBuilder<TEntity, TDependentEntity> HasPrincipalKey(
             [NotNull] Expression<Func<TEntity, object>> keyExpression)
         {
             Builder = Builder.HasPrincipalKey(
                 Check.NotNull(keyExpression, nameof(keyExpression)).GetPropertyAccessList(),
                 ConfigurationSource.Explicit);
-            return new ReferenceOwnershipBuilder<TEntity, TRelatedEntity>(
+            return new CollectionOwnershipBuilder<TEntity, TDependentEntity>(
                 Builder,
                 this,
                 principalKeySet: true);
@@ -194,7 +192,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </summary>
         /// <param name="deleteBehavior"> The action to perform. </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public new virtual ReferenceOwnershipBuilder<TEntity, TRelatedEntity> OnDelete(DeleteBehavior deleteBehavior)
+        public new virtual CollectionOwnershipBuilder<TEntity, TDependentEntity> OnDelete(DeleteBehavior deleteBehavior)
         {
             Builder = Builder.DeleteBehavior(deleteBehavior, ConfigurationSource.Explicit);
             return this;
@@ -207,9 +205,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <param name="annotation"> The key of the annotation to be added or updated. </param>
         /// <param name="value"> The value to be stored in the annotation. </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public new virtual ReferenceOwnershipBuilder<TEntity, TRelatedEntity> HasEntityTypeAnnotation(
+        public new virtual CollectionOwnershipBuilder<TEntity, TDependentEntity> HasEntityTypeAnnotation(
             [NotNull] string annotation, [NotNull] object value)
-            => (ReferenceOwnershipBuilder<TEntity, TRelatedEntity>)base.HasEntityTypeAnnotation(annotation, value);
+            => (CollectionOwnershipBuilder<TEntity, TDependentEntity>)base.HasEntityTypeAnnotation(annotation, value);
 
         /// <summary>
         ///     Sets the properties that make up the primary key for this owned entity type.
@@ -224,8 +222,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     </para>
         /// </param>
         /// <returns> An object that can be used to configure the primary key. </returns>
-        public virtual KeyBuilder HasKey([NotNull] Expression<Func<TRelatedEntity, object>> keyExpression)
-            => new KeyBuilder(RelatedEntityType.Builder.PrimaryKey(
+        public virtual KeyBuilder HasKey([NotNull] Expression<Func<TDependentEntity, object>> keyExpression)
+            => new KeyBuilder(DependentEntityType.Builder.PrimaryKey(
                 Check.NotNull(keyExpression, nameof(keyExpression)).GetPropertyAccessList(), ConfigurationSource.Explicit));
 
         /// <summary>
@@ -247,9 +245,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     <c>blog => blog.Url</c>).
         /// </param>
         /// <returns> An object that can be used to configure the property. </returns>
-        public virtual PropertyBuilder<TProperty> Property<TProperty>([NotNull] Expression<Func<TRelatedEntity, TProperty>> propertyExpression)
+        public virtual PropertyBuilder<TProperty> Property<TProperty>([NotNull] Expression<Func<TDependentEntity, TProperty>> propertyExpression)
             => new PropertyBuilder<TProperty>(
-                RelatedEntityType.Builder.Property(
+                DependentEntityType.Builder.Property(
                     Check.NotNull(propertyExpression, nameof(propertyExpression)).GetPropertyAccess(),
                     ConfigurationSource.Explicit));
 
@@ -258,8 +256,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     from the owned entity type that were added by convention.
         /// </summary>
         /// <param name="propertyName"> The name of then property to be removed from the entity type. </param>
-        public new virtual ReferenceOwnershipBuilder<TEntity, TRelatedEntity> Ignore([NotNull] string propertyName)
-            => (ReferenceOwnershipBuilder<TEntity, TRelatedEntity>)base.Ignore(propertyName);
+        public new virtual CollectionOwnershipBuilder<TEntity, TDependentEntity> Ignore([NotNull] string propertyName)
+            => (CollectionOwnershipBuilder<TEntity, TDependentEntity>)base.Ignore(propertyName);
 
         /// <summary>
         ///     Excludes the given property from the entity type. This method is typically used to remove properties
@@ -269,9 +267,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     A lambda expression representing the property to be ignored
         ///     (<c>blog => blog.Url</c>).
         /// </param>
-        public virtual ReferenceOwnershipBuilder<TEntity, TRelatedEntity> Ignore(
-            [NotNull] Expression<Func<TRelatedEntity, object>> propertyExpression)
-            => (ReferenceOwnershipBuilder<TEntity, TRelatedEntity>)
+        public virtual CollectionOwnershipBuilder<TEntity, TDependentEntity> Ignore(
+            [NotNull] Expression<Func<TDependentEntity, object>> propertyExpression)
+            => (CollectionOwnershipBuilder<TEntity, TDependentEntity>)
                 base.Ignore(Check.NotNull(propertyExpression, nameof(propertyExpression)).GetPropertyAccess().Name);
 
         /// <summary>
@@ -289,8 +287,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     </para>
         /// </param>
         /// <returns> An object that can be used to configure the index. </returns>
-        public virtual IndexBuilder HasIndex([NotNull] Expression<Func<TRelatedEntity, object>> indexExpression)
-            => new IndexBuilder(RelatedEntityType.Builder.HasIndex(
+        public virtual IndexBuilder HasIndex([NotNull] Expression<Func<TDependentEntity, object>> indexExpression)
+            => new IndexBuilder(DependentEntityType.Builder.HasIndex(
                 Check.NotNull(indexExpression, nameof(indexExpression)).GetPropertyAccessList(), ConfigurationSource.Explicit));
 
         /// <summary>
@@ -312,7 +310,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     The name of the reference navigation property on this entity type that represents the relationship.
         /// </param>
         /// <returns> An object that can be used to configure the entity type. </returns>
-        public virtual ReferenceOwnershipBuilder<TRelatedEntity, TNewRelatedEntity> OwnsOne<TNewRelatedEntity>(
+        public virtual ReferenceOwnershipBuilder<TDependentEntity, TNewRelatedEntity> OwnsOne<TNewRelatedEntity>(
             [NotNull] string navigationName)
             where TNewRelatedEntity : class
             => OwnsOneBuilder<TNewRelatedEntity>(new PropertyIdentity(Check.NotNull(navigationName, nameof(navigationName))));
@@ -331,16 +329,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///         Most operations on an owned entity require accessing it through the owner entity using the corresponding navigation.
         ///     </para>
         /// </summary>
-        /// <typeparam name="TNewRelatedEntity"> The entity type that this relationship targets. </typeparam>
+        /// <typeparam name="TRelatedEntity"> The entity type that this relationship targets. </typeparam>
         /// <param name="navigationExpression">
         ///     A lambda expression representing the reference navigation property on this entity type that represents
         ///     the relationship (<c>customer => customer.Address</c>).
         /// </param>
         /// <returns> An object that can be used to configure the entity type. </returns>
-        public virtual ReferenceOwnershipBuilder<TRelatedEntity, TNewRelatedEntity> OwnsOne<TNewRelatedEntity>(
-            [NotNull] Expression<Func<TRelatedEntity, TNewRelatedEntity>> navigationExpression)
-            where TNewRelatedEntity : class
-            => OwnsOneBuilder<TNewRelatedEntity>(new PropertyIdentity(
+        public virtual ReferenceOwnershipBuilder<TDependentEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(
+            [NotNull] Expression<Func<TDependentEntity, TRelatedEntity>> navigationExpression)
+            where TRelatedEntity : class
+            => OwnsOneBuilder<TRelatedEntity>(new PropertyIdentity(
                 Check.NotNull(navigationExpression, nameof(navigationExpression)).GetPropertyAccess()));
 
         /// <summary>
@@ -357,21 +355,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///         Most operations on an owned entity require accessing it through the owner entity using the corresponding navigation.
         ///     </para>
         /// </summary>
-        /// <typeparam name="TNewRelatedEntity"> The entity type that this relationship targets. </typeparam>
+        /// <typeparam name="TRelatedEntity"> The entity type that this relationship targets. </typeparam>
         /// <param name="navigationName">
         ///     The name of the reference navigation property on this entity type that represents the relationship.
         /// </param>
         /// <param name="buildAction"> An action that performs configuration of the relationship. </param>
         /// <returns> An object that can be used to configure the entity type. </returns>
-        public virtual ReferenceOwnershipBuilder<TEntity, TRelatedEntity> OwnsOne<TNewRelatedEntity>(
+        public virtual CollectionOwnershipBuilder<TEntity, TDependentEntity> OwnsOne<TRelatedEntity>(
             [NotNull] string navigationName,
-            [NotNull] Action<ReferenceOwnershipBuilder<TRelatedEntity, TNewRelatedEntity>> buildAction)
-            where TNewRelatedEntity : class
+            [NotNull] Action<ReferenceOwnershipBuilder<TDependentEntity, TRelatedEntity>> buildAction)
+            where TRelatedEntity : class
         {
             Check.NotNull(navigationName, nameof(navigationName));
             Check.NotNull(buildAction, nameof(buildAction));
 
-            buildAction.Invoke(OwnsOneBuilder<TNewRelatedEntity>(new PropertyIdentity(navigationName)));
+            buildAction.Invoke(OwnsOneBuilder<TRelatedEntity>(new PropertyIdentity(navigationName)));
             return this;
         }
 
@@ -389,39 +387,39 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///         Most operations on an owned entity require accessing it through the owner entity using the corresponding navigation.
         ///     </para>
         /// </summary>
-        /// <typeparam name="TNewRelatedEntity"> The entity type that this relationship targets. </typeparam>
+        /// <typeparam name="TRelatedEntity"> The entity type that this relationship targets. </typeparam>
         /// <param name="navigationExpression">
         ///     A lambda expression representing the reference navigation property on this entity type that represents
         ///     the relationship (<c>customer => customer.Address</c>).
         /// </param>
         /// <param name="buildAction"> An action that performs configuration of the relationship. </param>
         /// <returns> An object that can be used to configure the entity type. </returns>
-        public virtual ReferenceOwnershipBuilder<TEntity, TRelatedEntity> OwnsOne<TNewRelatedEntity>(
-            [NotNull] Expression<Func<TRelatedEntity, TNewRelatedEntity>> navigationExpression,
-            [NotNull] Action<ReferenceOwnershipBuilder<TRelatedEntity, TNewRelatedEntity>> buildAction)
-            where TNewRelatedEntity : class
+        public virtual CollectionOwnershipBuilder<TEntity, TDependentEntity> OwnsOne<TRelatedEntity>(
+            [NotNull] Expression<Func<TDependentEntity, TRelatedEntity>> navigationExpression,
+            [NotNull] Action<ReferenceOwnershipBuilder<TDependentEntity, TRelatedEntity>> buildAction)
+            where TRelatedEntity : class
         {
             Check.NotNull(navigationExpression, nameof(navigationExpression));
             Check.NotNull(buildAction, nameof(buildAction));
 
-            buildAction.Invoke(OwnsOneBuilder<TNewRelatedEntity>(new PropertyIdentity(navigationExpression.GetPropertyAccess())));
+            buildAction.Invoke(OwnsOneBuilder<TRelatedEntity>(new PropertyIdentity(navigationExpression.GetPropertyAccess())));
             return this;
         }
 
-        private ReferenceOwnershipBuilder<TRelatedEntity, TNewRelatedEntity> OwnsOneBuilder<TNewRelatedEntity>(PropertyIdentity navigation)
-            where TNewRelatedEntity : class
+        private ReferenceOwnershipBuilder<TDependentEntity, TRelatedEntity> OwnsOneBuilder<TRelatedEntity>(PropertyIdentity navigation)
+            where TRelatedEntity : class
         {
             InternalRelationshipBuilder relationship;
-            using (var batch = RelatedEntityType.Model.ConventionDispatcher.StartBatch())
+            using (var batch = DependentEntityType.Model.ConventionDispatcher.StartBatch())
             {
                 relationship = navigation.Property == null
-                    ? RelatedEntityType.Builder.Owns(typeof(TNewRelatedEntity), navigation.Name, ConfigurationSource.Explicit)
-                    : RelatedEntityType.Builder.Owns(typeof(TNewRelatedEntity), (PropertyInfo)navigation.Property, ConfigurationSource.Explicit);
+                    ? DependentEntityType.Builder.Owns(typeof(TRelatedEntity), navigation.Name, ConfigurationSource.Explicit)
+                    : DependentEntityType.Builder.Owns(typeof(TRelatedEntity), (PropertyInfo)navigation.Property, ConfigurationSource.Explicit);
                 relationship.IsUnique(true, ConfigurationSource.Explicit);
                 relationship = batch.Run(relationship.Metadata).Builder;
             }
 
-            return new ReferenceOwnershipBuilder<TRelatedEntity, TNewRelatedEntity>(
+            return new ReferenceOwnershipBuilder<TDependentEntity, TRelatedEntity>(
                 relationship.Metadata.PrincipalEntityType,
                 relationship.Metadata.DeclaringEntityType,
                 relationship);
@@ -440,15 +438,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///         Most operations on an owned entity require accessing it through the owner entity using the corresponding navigation.
         ///     </para>
         /// </summary>
-        /// <typeparam name="TDependentEntity"> The entity type that this relationship targets. </typeparam>
+        /// <typeparam name="TNewDependentEntity"> The entity type that this relationship targets. </typeparam>
         /// <param name="navigationName">
         ///     The name of the reference navigation property on this entity type that represents the relationship.
         /// </param>
         /// <returns> An object that can be used to configure the owned type and the relationship. </returns>
-        public virtual CollectionOwnershipBuilder<TRelatedEntity, TDependentEntity> OwnsMany<TDependentEntity>(
+        public virtual CollectionOwnershipBuilder<TDependentEntity, TNewDependentEntity> OwnsMany<TNewDependentEntity>(
             [NotNull] string navigationName)
-            where TDependentEntity : class
-            => OwnsManyBuilder<TDependentEntity>(new PropertyIdentity(Check.NotNull(navigationName, nameof(navigationName))));
+            where TNewDependentEntity : class
+            => OwnsManyBuilder<TNewDependentEntity>(new PropertyIdentity(Check.NotNull(navigationName, nameof(navigationName))));
 
         /// <summary>
         ///     <para>
@@ -463,16 +461,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///         Most operations on an owned entity require accessing it through the owner entity using the corresponding navigation.
         ///     </para>
         /// </summary>
-        /// <typeparam name="TDependentEntity"> The entity type that this relationship targets. </typeparam>
+        /// <typeparam name="TNewDependentEntity"> The entity type that this relationship targets. </typeparam>
         /// <param name="navigationExpression">
         ///     A lambda expression representing the reference navigation property on this entity type that represents
         ///     the relationship (<c>customer => customer.Address</c>).
         /// </param>
         /// <returns> An object that can be used to configure the owned type and the relationship. </returns>
-        public virtual CollectionOwnershipBuilder<TRelatedEntity, TDependentEntity> OwnsMany<TDependentEntity>(
-            [NotNull] Expression<Func<TRelatedEntity, IEnumerable<TDependentEntity>>> navigationExpression)
-            where TDependentEntity : class
-            => OwnsManyBuilder<TDependentEntity>(
+        public virtual CollectionOwnershipBuilder<TDependentEntity, TNewDependentEntity> OwnsMany<TNewDependentEntity>(
+            [NotNull] Expression<Func<TDependentEntity, IEnumerable<TNewDependentEntity>>> navigationExpression)
+            where TNewDependentEntity : class
+            => OwnsManyBuilder<TNewDependentEntity>(
                 new PropertyIdentity(Check.NotNull(navigationExpression, nameof(navigationExpression)).GetPropertyAccess()));
 
         /// <summary>
@@ -488,23 +486,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///         Most operations on an owned entity require accessing it through the owner entity using the corresponding navigation.
         ///     </para>
         /// </summary>
-        /// <typeparam name="TDependentEntity"> The entity type that this relationship targets. </typeparam>
+        /// <typeparam name="TNewDependentEntity"> The entity type that this relationship targets. </typeparam>
         /// <param name="navigationName">
         ///     The name of the reference navigation property on this entity type that represents the relationship.
         /// </param>
         /// <param name="buildAction"> An action that performs configuration of the owned type and the relationship. </param>
         /// <returns> An object that can be used to configure the entity type. </returns>
-        public virtual ReferenceOwnershipBuilder<TEntity, TRelatedEntity> OwnsMany<TDependentEntity>(
+        public virtual CollectionOwnershipBuilder<TEntity, TDependentEntity> OwnsMany<TNewDependentEntity>(
             [NotNull] string navigationName,
-            [NotNull] Action<CollectionOwnershipBuilder<TRelatedEntity, TDependentEntity>> buildAction)
-            where TDependentEntity : class
+            [NotNull] Action<CollectionOwnershipBuilder<TDependentEntity, TNewDependentEntity>> buildAction)
+            where TNewDependentEntity : class
         {
             Check.NotNull(navigationName, nameof(navigationName));
             Check.NotNull(buildAction, nameof(buildAction));
 
-            using (RelatedEntityType.Model.ConventionDispatcher.StartBatch())
+            using (DependentEntityType.Model.ConventionDispatcher.StartBatch())
             {
-                buildAction.Invoke(OwnsManyBuilder<TDependentEntity>(new PropertyIdentity(navigationName)));
+                buildAction.Invoke(OwnsManyBuilder<TNewDependentEntity>(new PropertyIdentity(navigationName)));
                 return this;
             }
         }
@@ -522,43 +520,43 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///         Most operations on an owned entity require accessing it through the owner entity using the corresponding navigation.
         ///     </para>
         /// </summary>
-        /// <typeparam name="TDependentEntity"> The entity type that this relationship targets. </typeparam>
+        /// <typeparam name="TNewDependentEntity"> The entity type that this relationship targets. </typeparam>
         /// <param name="navigationExpression">
         ///     A lambda expression representing the reference navigation property on this entity type that represents
         ///     the relationship (<c>customer => customer.Address</c>).
         /// </param>
         /// <param name="buildAction"> An action that performs configuration of the owned type and the relationship. </param>
         /// <returns> An object that can be used to configure the entity type. </returns>
-        public virtual ReferenceOwnershipBuilder<TEntity, TRelatedEntity> OwnsMany<TDependentEntity>(
-            [NotNull] Expression<Func<TRelatedEntity, IEnumerable<TDependentEntity>>> navigationExpression,
-            [NotNull] Action<CollectionOwnershipBuilder<TRelatedEntity, TDependentEntity>> buildAction)
-            where TDependentEntity : class
+        public virtual CollectionOwnershipBuilder<TEntity, TDependentEntity> OwnsMany<TNewDependentEntity>(
+            [NotNull] Expression<Func<TDependentEntity, IEnumerable<TNewDependentEntity>>> navigationExpression,
+            [NotNull] Action<CollectionOwnershipBuilder<TDependentEntity, TNewDependentEntity>> buildAction)
+            where TNewDependentEntity : class
         {
             Check.NotNull(navigationExpression, nameof(navigationExpression));
             Check.NotNull(buildAction, nameof(buildAction));
 
-            using (RelatedEntityType.Model.ConventionDispatcher.StartBatch())
+            using (DependentEntityType.Model.ConventionDispatcher.StartBatch())
             {
-                buildAction.Invoke(OwnsManyBuilder<TDependentEntity>(new PropertyIdentity(navigationExpression.GetPropertyAccess())));
+                buildAction.Invoke(OwnsManyBuilder<TNewDependentEntity>(new PropertyIdentity(navigationExpression.GetPropertyAccess())));
                 return this;
             }
         }
 
-        private CollectionOwnershipBuilder<TRelatedEntity, TDependentEntity> OwnsManyBuilder<TDependentEntity>(PropertyIdentity navigation)
-            where TDependentEntity : class
+        private CollectionOwnershipBuilder<TDependentEntity, TNewRelatedEntity> OwnsManyBuilder<TNewRelatedEntity>(PropertyIdentity navigation)
+            where TNewRelatedEntity : class
         {
             InternalRelationshipBuilder relationship;
-            using (var batch = RelatedEntityType.Model.ConventionDispatcher.StartBatch())
+            using (var batch = DependentEntityType.Model.ConventionDispatcher.StartBatch())
             {
                 relationship = navigation.Property == null
-                    ? RelatedEntityType.Builder.Owns(typeof(TDependentEntity), navigation.Name, ConfigurationSource.Explicit)
-                    : RelatedEntityType.Builder.Owns(typeof(TDependentEntity), (PropertyInfo)navigation.Property, ConfigurationSource.Explicit);
+                    ? DependentEntityType.Builder.Owns(typeof(TNewRelatedEntity), navigation.Name, ConfigurationSource.Explicit)
+                    : DependentEntityType.Builder.Owns(typeof(TNewRelatedEntity), (PropertyInfo)navigation.Property, ConfigurationSource.Explicit);
                 relationship.IsUnique(false, ConfigurationSource.Explicit);
                 relationship = batch.Run(relationship.Metadata).Builder;
             }
 
-            return new CollectionOwnershipBuilder<TRelatedEntity, TDependentEntity>(
-                RelatedEntityType,
+            return new CollectionOwnershipBuilder<TDependentEntity, TNewRelatedEntity>(
+                DependentEntityType,
                 relationship.Metadata.DeclaringEntityType,
                 relationship);
         }
@@ -589,19 +587,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     end.
         /// </param>
         /// <returns> An object that can be used to configure the relationship. </returns>
-        public virtual ReferenceNavigationBuilder<TRelatedEntity, TNewRelatedEntity> HasOne<TNewRelatedEntity>(
+        public virtual ReferenceNavigationBuilder<TDependentEntity, TNewRelatedEntity> HasOne<TNewRelatedEntity>(
             [CanBeNull] string navigationName)
             where TNewRelatedEntity : class
         {
             var relatedEntityType = FindRelatedEntityType(typeof(TNewRelatedEntity), navigationName);
 
-            return new ReferenceNavigationBuilder<TRelatedEntity, TNewRelatedEntity>(
-                RelatedEntityType,
+            return new ReferenceNavigationBuilder<TDependentEntity, TNewRelatedEntity>(
+                DependentEntityType,
                 relatedEntityType,
                 navigationName,
-                RelatedEntityType.Builder.Navigation(
+                DependentEntityType.Builder.Navigation(
                     relatedEntityType.Builder, navigationName, ConfigurationSource.Explicit,
-                    setTargetAsPrincipal: RelatedEntityType == relatedEntityType));
+                    setTargetAsPrincipal: DependentEntityType == relatedEntityType));
         }
 
         /// <summary>
@@ -632,70 +630,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     configured without a navigation property on this end.
         /// </param>
         /// <returns> An object that can be used to configure the relationship. </returns>
-        public virtual ReferenceNavigationBuilder<TRelatedEntity, TNewRelatedEntity> HasOne<TNewRelatedEntity>(
-            [CanBeNull] Expression<Func<TRelatedEntity, TNewRelatedEntity>> navigationExpression = null)
+        public virtual ReferenceNavigationBuilder<TDependentEntity, TNewRelatedEntity> HasOne<TNewRelatedEntity>(
+            [CanBeNull] Expression<Func<TDependentEntity, TNewRelatedEntity>> navigationExpression = null)
             where TNewRelatedEntity : class
         {
             var navigation = navigationExpression?.GetPropertyAccess();
             var relatedEntityType = FindRelatedEntityType(typeof(TNewRelatedEntity), navigation?.Name);
 
-            return new ReferenceNavigationBuilder<TRelatedEntity, TNewRelatedEntity>(
-                RelatedEntityType,
+            return new ReferenceNavigationBuilder<TDependentEntity, TNewRelatedEntity>(
+                DependentEntityType,
                 relatedEntityType,
                 navigation,
-                RelatedEntityType.Builder.Navigation(
+                DependentEntityType.Builder.Navigation(
                     relatedEntityType.Builder, navigation, ConfigurationSource.Explicit,
-                    setTargetAsPrincipal: RelatedEntityType == relatedEntityType));
-        }
-
-        /// <summary>
-        ///     <para>
-        ///         Configures a relationship where this entity type has a collection that contains
-        ///         instances of the other type in the relationship.
-        ///     </para>
-        ///     <para>
-        ///         Note that calling this method with no parameters will explicitly configure this side
-        ///         of the relationship to use no navigation property, even if such a property exists on the
-        ///         entity type. If the navigation property is to be used, then it must be specified.
-        ///     </para>
-        ///     <para>
-        ///         After calling this method, you should chain a call to
-        ///         <see cref="CollectionNavigationBuilder{TEntity,TRelatedEntity}
-        /// .WithOne(Expression{Func{TRelatedEntity,TEntity}})" />
-        ///         to fully configure the relationship. Calling just this method without the chained call will not
-        ///         produce a valid relationship.
-        ///     </para>
-        /// </summary>
-        /// <typeparam name="TNewRelatedEntity"> The entity type that this relationship targets. </typeparam>
-        /// <param name="navigationExpression">
-        ///     A lambda expression representing the collection navigation property on this entity type that represents
-        ///     the relationship (<c>blog => blog.Posts</c>). If no property is specified, the relationship will be
-        ///     configured without a navigation property on this end.
-        /// </param>
-        /// <returns> An object that can be used to configure the relationship. </returns>
-        public virtual CollectionNavigationBuilder<TRelatedEntity, TNewRelatedEntity> HasMany<TNewRelatedEntity>(
-            [CanBeNull] Expression<Func<TRelatedEntity, IEnumerable<TNewRelatedEntity>>> navigationExpression = null)
-            where TNewRelatedEntity : class
-        {
-            var navigation = navigationExpression?.GetPropertyAccess();
-            var relatedEntityType = FindRelatedEntityType(typeof(TNewRelatedEntity), navigation?.Name);
-
-            InternalRelationshipBuilder relationship;
-            using (var batch = RelatedEntityType.Model.ConventionDispatcher.StartBatch())
-            {
-                relationship = relatedEntityType.Builder
-                    .Relationship(RelatedEntityType.Builder, ConfigurationSource.Explicit)
-                    .IsUnique(false, ConfigurationSource.Explicit)
-                    .RelatedEntityTypes(RelatedEntityType, relatedEntityType, ConfigurationSource.Explicit)
-                    .PrincipalToDependent(navigation, ConfigurationSource.Explicit);
-                relationship = batch.Run(relationship);
-            }
-
-            return new CollectionNavigationBuilder<TRelatedEntity, TNewRelatedEntity>(
-                RelatedEntityType,
-                relatedEntityType,
-                navigation,
-                relationship);
+                    setTargetAsPrincipal: DependentEntityType == relatedEntityType));
         }
 
         /// <summary>
@@ -704,9 +652,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </summary>
         /// <param name="changeTrackingStrategy"> The change tracking strategy to be used. </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public new virtual ReferenceOwnershipBuilder<TEntity, TRelatedEntity> HasChangeTrackingStrategy(
+        public new virtual CollectionOwnershipBuilder<TEntity, TDependentEntity> HasChangeTrackingStrategy(
             ChangeTrackingStrategy changeTrackingStrategy)
-            => (ReferenceOwnershipBuilder<TEntity, TRelatedEntity>)base.HasChangeTrackingStrategy(changeTrackingStrategy);
+            => (CollectionOwnershipBuilder<TEntity, TDependentEntity>)base.HasChangeTrackingStrategy(changeTrackingStrategy);
 
         /// <summary>
         ///     <para>
@@ -725,8 +673,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </summary>
         /// <param name="propertyAccessMode"> The <see cref="PropertyAccessMode" /> to use for properties of this entity type. </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public new virtual ReferenceOwnershipBuilder<TEntity, TRelatedEntity> UsePropertyAccessMode(PropertyAccessMode propertyAccessMode)
-            => (ReferenceOwnershipBuilder<TEntity, TRelatedEntity>)base.UsePropertyAccessMode(propertyAccessMode);
+        public new virtual CollectionOwnershipBuilder<TEntity, TDependentEntity> UsePropertyAccessMode(PropertyAccessMode propertyAccessMode)
+            => (CollectionOwnershipBuilder<TEntity, TDependentEntity>)base.UsePropertyAccessMode(propertyAccessMode);
 
         /// <summary>
         ///     Configures this entity to have seed data. It is used to generate data motion migrations.
@@ -735,13 +683,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     An array of seed data.
         /// </param>
         /// <returns> An object that can be used to configure the model data. </returns>
-        public virtual DataBuilder<TRelatedEntity> HasData([NotNull] params TRelatedEntity[] data)
+        public virtual DataBuilder<TDependentEntity> HasData([NotNull] params TDependentEntity[] data)
         {
             Check.NotNull(data, nameof(data));
 
             OwnedEntityType.AddData(data);
 
-            return new DataBuilder<TRelatedEntity>();
+            return new DataBuilder<TDependentEntity>();
         }
 
         /// <summary>
@@ -751,11 +699,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     An array of seed data represented by anonymous types.
         /// </param>
         /// <returns> An object that can be used to configure the model data. </returns>
-        public new virtual DataBuilder<TRelatedEntity> HasData([NotNull] params object[] data)
+        public new virtual DataBuilder<TDependentEntity> HasData([NotNull] params object[] data)
         {
             base.HasData(data);
 
-            return new DataBuilder<TRelatedEntity>();
+            return new DataBuilder<TDependentEntity>();
         }
     }
 }

--- a/src/EFCore/Metadata/Builders/DataBuilder.cs
+++ b/src/EFCore/Metadata/Builders/DataBuilder.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.ComponentModel;
+
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders
 {
     /// <summary>
@@ -8,5 +10,30 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
     /// </summary>
     public class DataBuilder
     {
+        #region Hidden System.Object members
+
+        /// <summary>
+        ///     Returns a string that represents the current object.
+        /// </summary>
+        /// <returns> A string that represents the current object. </returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override string ToString() => base.ToString();
+
+        /// <summary>
+        ///     Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <param name="obj"> The object to compare with the current object. </param>
+        /// <returns> true if the specified object is equal to the current object; otherwise, false. </returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => base.Equals(obj);
+
+        /// <summary>
+        ///     Serves as the default hash function.
+        /// </summary>
+        /// <returns> A hash code for the current object. </returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => base.GetHashCode();
+
+        #endregion
     }
 }

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder.cs
@@ -117,6 +117,25 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///         If no property with the given name exists, then a new property will be added.
         ///     </para>
         ///     <para>
+        ///         When adding a new property with this overload the property name must match the
+        ///         name of a CLR property or field on the entity type. This overload cannot be used to
+        ///         add a new shadow state property.
+        ///     </para>
+        /// </summary>
+        /// <param name="propertyName"> The name of the property to be configured. </param>
+        /// <returns> An object that can be used to configure the property. </returns>
+        public virtual PropertyBuilder Property([NotNull] string propertyName)
+            => new PropertyBuilder(
+                Builder.Property(
+                    Check.NotEmpty(propertyName, nameof(propertyName)),
+                    ConfigurationSource.Explicit));
+
+        /// <summary>
+        ///     <para>
+        ///         Returns an object that can be used to configure a property of the entity type.
+        ///         If no property with the given name exists, then a new property will be added.
+        ///     </para>
+        ///     <para>
         ///         When adding a new property, if a property with the same name exists in the entity class
         ///         then it will be added to the model. If no property exists in the entity class, then
         ///         a new shadow state property will be added. A shadow state property is one that does not have a
@@ -158,25 +177,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                     ConfigurationSource.Explicit));
 
         /// <summary>
-        ///     <para>
-        ///         Returns an object that can be used to configure a property of the entity type.
-        ///         If no property with the given name exists, then a new property will be added.
-        ///     </para>
-        ///     <para>
-        ///         When adding a new property with this overload the property name must match the
-        ///         name of a CLR property or field on the entity type. This overload cannot be used to
-        ///         add a new shadow state property.
-        ///     </para>
-        /// </summary>
-        /// <param name="propertyName"> The name of the property to be configured. </param>
-        /// <returns> An object that can be used to configure the property. </returns>
-        public virtual PropertyBuilder Property([NotNull] string propertyName)
-            => new PropertyBuilder(
-                Builder.Property(
-                    Check.NotEmpty(propertyName, nameof(propertyName)),
-                    ConfigurationSource.Explicit));
-
-        /// <summary>
         ///     Excludes the given property from the entity type. This method is typically used to remove properties
         ///     from the entity type that were added by convention.
         /// </summary>
@@ -204,9 +204,42 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         }
 
         /// <summary>
+        ///     Configures an index on the specified properties. If there is an existing index on the given
+        ///     set of properties, then the existing index will be returned for configuration.
+        /// </summary>
+        /// <param name="propertyNames"> The names of the properties that make up the index. </param>
+        /// <returns> An object that can be used to configure the index. </returns>
+        public virtual IndexBuilder HasIndex([NotNull] params string[] propertyNames)
+            => new IndexBuilder(Builder.HasIndex(Check.NotEmpty(propertyNames, nameof(propertyNames)), ConfigurationSource.Explicit));
+
+        /// <summary>
         ///     <para>
         ///         Configures a relationship where the target entity is owned by (or part of) this entity.
-        ///         The target entity key value is always propagated from the entity it belongs to.
+        ///     </para>
+        ///     <para>
+        ///         The target entity type for each ownership relationship is treated as a different entity type
+        ///         even if the navigation is of the same type. Configuration of the target entity type
+        ///         isn't applied to the target entity type of other ownership relationships.
+        ///     </para>
+        ///     <para>
+        ///         Most operations on an owned entity require accessing it through the owner entity using the corresponding navigation.
+        ///     </para>
+        /// </summary>
+        /// <param name="ownedTypeName"> The name of the entity type that this relationship targets. </param>
+        /// <param name="navigationName">
+        ///     The name of the reference navigation property on this entity type that represents the relationship.
+        /// </param>
+        /// <returns> An object that can be used to configure the owned type and the relationship. </returns>
+        public virtual ReferenceOwnershipBuilder OwnsOne(
+            [NotNull] string ownedTypeName,
+            [NotNull] string navigationName)
+            => OwnsOneBuilder(
+                new TypeIdentity(Check.NotEmpty(ownedTypeName, nameof(ownedTypeName))),
+                Check.NotEmpty(navigationName, nameof(navigationName)));
+
+        /// <summary>
+        ///     <para>
+        ///         Configures a relationship where the target entity is owned by (or part of) this entity.
         ///     </para>
         ///     <para>
         ///         The target entity type for each ownership relationship is treated as a different entity type
@@ -221,7 +254,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <param name="navigationName">
         ///     The name of the reference navigation property on this entity type that represents the relationship.
         /// </param>
-        /// <returns> An object that can be used to configure the relationship. </returns>
+        /// <returns> An object that can be used to configure the owned type and the relationship. </returns>
         public virtual ReferenceOwnershipBuilder OwnsOne(
             [NotNull] Type ownedType,
             [NotNull] string navigationName)
@@ -232,7 +265,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <summary>
         ///     <para>
         ///         Configures a relationship where the target entity is owned by (or part of) this entity.
-        ///         The target entity key value is always propagated from the entity it belongs to.
         ///     </para>
         ///     <para>
         ///         The target entity type for each ownership relationship is treated as a different entity type
@@ -247,53 +279,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <param name="navigationName">
         ///     The name of the reference navigation property on this entity type that represents the relationship.
         /// </param>
-        /// <returns> An object that can be used to configure the relationship. </returns>
-        public virtual ReferenceOwnershipBuilder OwnsOne(
-            [NotNull] string ownedTypeName,
-            [NotNull] string navigationName)
-            => OwnsOneBuilder(
-                new TypeIdentity(Check.NotEmpty(ownedTypeName, nameof(ownedTypeName))),
-                Check.NotEmpty(navigationName, nameof(navigationName)));
-
-        /// <summary>
-        ///     <para>
-        ///         Configures a relationship where this entity type provides identity to
-        ///         the other type in the relationship.
-        ///     </para>
-        /// </summary>
-        /// <param name="ownedType"> The entity type that this relationship targets. </param>
-        /// <param name="navigationName">
-        ///     The name of the reference navigation property on this entity type that represents the relationship.
-        /// </param>
-        /// <param name="buildAction"> An action that performs configuration of the relationship. </param>
-        /// <returns> An object that can be used to configure the entity type. </returns>
-        public virtual EntityTypeBuilder OwnsOne(
-            [NotNull] Type ownedType,
-            [NotNull] string navigationName,
-            [NotNull] Action<ReferenceOwnershipBuilder> buildAction)
-        {
-            Check.NotNull(ownedType, nameof(ownedType));
-            Check.NotEmpty(navigationName, nameof(navigationName));
-            Check.NotNull(buildAction, nameof(buildAction));
-
-            using (Builder.Metadata.Model.ConventionDispatcher.StartBatch())
-            {
-                buildAction.Invoke(OwnsOneBuilder(new TypeIdentity(ownedType, (Model)Metadata.Model), navigationName));
-                return this;
-            }
-        }
-
-        /// <summary>
-        ///     <para>
-        ///         Configures a relationship where this entity type provides identity to
-        ///         the other type in the relationship.
-        ///     </para>
-        /// </summary>
-        /// <param name="ownedTypeName"> The name of the entity type that this relationship targets. </param>
-        /// <param name="navigationName">
-        ///     The name of the reference navigation property on this entity type that represents the relationship.
-        /// </param>
-        /// <param name="buildAction"> An action that performs configuration of the relationship. </param>
+        /// <param name="buildAction"> An action that performs configuration of the owned type and the relationship. </param>
         /// <returns> An object that can be used to configure the entity type. </returns>
         public virtual EntityTypeBuilder OwnsOne(
             [NotNull] string ownedTypeName,
@@ -307,6 +293,41 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             using (Builder.Metadata.Model.ConventionDispatcher.StartBatch())
             {
                 buildAction.Invoke(OwnsOneBuilder(new TypeIdentity(ownedTypeName), navigationName));
+                return this;
+            }
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Configures a relationship where the target entity is owned by (or part of) this entity.
+        ///     </para>
+        ///     <para>
+        ///         The target entity type for each ownership relationship is treated as a different entity type
+        ///         even if the navigation is of the same type. Configuration of the target entity type
+        ///         isn't applied to the target entity type of other ownership relationships.
+        ///     </para>
+        ///     <para>
+        ///         Most operations on an owned entity require accessing it through the owner entity using the corresponding navigation.
+        ///     </para>
+        /// </summary>
+        /// <param name="ownedType"> The entity type that this relationship targets. </param>
+        /// <param name="navigationName">
+        ///     The name of the reference navigation property on this entity type that represents the relationship.
+        /// </param>
+        /// <param name="buildAction"> An action that performs configuration of the owned type and the relationship. </param>
+        /// <returns> An object that can be used to configure the entity type. </returns>
+        public virtual EntityTypeBuilder OwnsOne(
+            [NotNull] Type ownedType,
+            [NotNull] string navigationName,
+            [NotNull] Action<ReferenceOwnershipBuilder> buildAction)
+        {
+            Check.NotNull(ownedType, nameof(ownedType));
+            Check.NotEmpty(navigationName, nameof(navigationName));
+            Check.NotNull(buildAction, nameof(buildAction));
+
+            using (Builder.Metadata.Model.ConventionDispatcher.StartBatch())
+            {
+                buildAction.Invoke(OwnsOneBuilder(new TypeIdentity(ownedType, (Model)Metadata.Model), navigationName));
                 return this;
             }
         }
@@ -329,57 +350,126 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         }
 
         /// <summary>
-        ///     Configures an index on the specified properties. If there is an existing index on the given
-        ///     set of properties, then the existing index will be returned for configuration.
+        ///     <para>
+        ///         Configures a relationship where the target entity is owned by (or part of) this entity.
+        ///     </para>
+        ///     <para>
+        ///         The target entity type for each ownership relationship is treated as a different entity type
+        ///         even if the navigation is of the same type. Configuration of the target entity type
+        ///         isn't applied to the target entity type of other ownership relationships.
+        ///     </para>
+        ///     <para>
+        ///         Most operations on an owned entity require accessing it through the owner entity using the corresponding navigation.
+        ///     </para>
         /// </summary>
-        /// <param name="propertyNames"> The names of the properties that make up the index. </param>
-        /// <returns> An object that can be used to configure the index. </returns>
-        public virtual IndexBuilder HasIndex([NotNull] params string[] propertyNames)
-            => new IndexBuilder(Builder.HasIndex(Check.NotEmpty(propertyNames, nameof(propertyNames)), ConfigurationSource.Explicit));
+        /// <param name="ownedTypeName"> The name of the entity type that this relationship targets. </param>
+        /// <param name="navigationName">
+        ///     The name of the reference navigation property on this entity type that represents the relationship.
+        /// </param>
+        /// <returns> An object that can be used to configure the owned type and the relationship. </returns>
+        public virtual CollectionOwnershipBuilder OwnsMany(
+            [NotNull] string ownedTypeName,
+            [NotNull] string navigationName)
+            => OwnsManyBuilder(
+                new TypeIdentity(Check.NotEmpty(ownedTypeName, nameof(ownedTypeName))),
+                Check.NotEmpty(navigationName, nameof(navigationName)));
 
         /// <summary>
         ///     <para>
-        ///         Configures a relationship where this entity type has a reference that points
-        ///         to a single instance of the other type in the relationship.
+        ///         Configures a relationship where the target entity is owned by (or part of) this entity.
         ///     </para>
         ///     <para>
-        ///         Note that calling this method with no parameters will explicitly configure this side
-        ///         of the relationship to use no navigation property, even if such a property exists on the
-        ///         entity type. If the navigation property is to be used, then it must be specified.
+        ///         The target entity type for each ownership relationship is treated as a different entity type
+        ///         even if the navigation is of the same type. Configuration of the target entity type
+        ///         isn't applied to the target entity type of other ownership relationships.
         ///     </para>
         ///     <para>
-        ///         After calling this method, you should chain a call to
-        ///         <see cref="ReferenceNavigationBuilder.WithMany" />
-        ///         or <see cref="ReferenceNavigationBuilder.WithOne" /> to fully configure
-        ///         the relationship. Calling just this method without the chained call will not
-        ///         produce a valid relationship.
+        ///         Most operations on an owned entity require accessing it through the owner entity using the corresponding navigation.
         ///     </para>
         /// </summary>
-        /// <param name="relatedType"> The entity type that this relationship targets. </param>
+        /// <param name="ownedType"> The entity type that this relationship targets. </param>
         /// <param name="navigationName">
-        ///     The name of the reference navigation property on this entity type that represents the relationship. If
-        ///     no property is specified, the relationship will be configured without a navigation property on this
-        ///     end.
+        ///     The name of the reference navigation property on this entity type that represents the relationship.
         /// </param>
-        /// <returns> An object that can be used to configure the relationship. </returns>
-        public virtual ReferenceNavigationBuilder HasOne(
-            [NotNull] Type relatedType,
-            [CanBeNull] string navigationName = null)
+        /// <returns> An object that can be used to configure the owned type and the relationship. </returns>
+        public virtual CollectionOwnershipBuilder OwnsMany(
+            [NotNull] Type ownedType,
+            [NotNull] string navigationName)
+            => OwnsManyBuilder(
+                new TypeIdentity(Check.NotNull(ownedType, nameof(ownedType)), (Model)Metadata.Model),
+                Check.NotEmpty(navigationName, nameof(navigationName)));
+
+        /// <summary>
+        ///     <para>
+        ///         Configures a relationship where this entity type provides identity to
+        ///         the other type in the relationship.
+        ///     </para>
+        /// </summary>
+        /// <param name="ownedTypeName"> The name of the entity type that this relationship targets. </param>
+        /// <param name="navigationName">
+        ///     The name of the reference navigation property on this entity type that represents the relationship.
+        /// </param>
+        /// <param name="buildAction"> An action that performs configuration of the owned type and the relationship. </param>
+        /// <returns> An object that can be used to configure the entity type. </returns>
+        public virtual EntityTypeBuilder OwnsMany(
+            [NotNull] string ownedTypeName,
+            [NotNull] string navigationName,
+            [NotNull] Action<CollectionOwnershipBuilder> buildAction)
         {
-            Check.NotNull(relatedType, nameof(relatedType));
-            Check.NullButNotEmpty(navigationName, nameof(navigationName));
+            Check.NotEmpty(ownedTypeName, nameof(ownedTypeName));
+            Check.NotEmpty(navigationName, nameof(navigationName));
+            Check.NotNull(buildAction, nameof(buildAction));
 
-            var relatedEntityType = Builder.Metadata.FindInDefinitionPath(relatedType) ??
-                                    Builder.ModelBuilder.Metadata.FindEntityType(relatedType, navigationName, Builder.Metadata) ??
-                                    Builder.ModelBuilder.Entity(relatedType, ConfigurationSource.Explicit).Metadata;
+            using (Builder.Metadata.Model.ConventionDispatcher.StartBatch())
+            {
+                buildAction.Invoke(OwnsManyBuilder(new TypeIdentity(ownedTypeName), navigationName));
+                return this;
+            }
+        }
 
-            return new ReferenceNavigationBuilder(
+        /// <summary>
+        ///     <para>
+        ///         Configures a relationship where this entity type provides identity to
+        ///         the other type in the relationship.
+        ///     </para>
+        /// </summary>
+        /// <param name="ownedType"> The entity type that this relationship targets. </param>
+        /// <param name="navigationName">
+        ///     The name of the reference navigation property on this entity type that represents the relationship.
+        /// </param>
+        /// <param name="buildAction"> An action that performs configuration of the owned type and the relationship. </param>
+        /// <returns> An object that can be used to configure the entity type. </returns>
+        public virtual EntityTypeBuilder OwnsMany(
+            [NotNull] Type ownedType,
+            [NotNull] string navigationName,
+            [NotNull] Action<CollectionOwnershipBuilder> buildAction)
+        {
+            Check.NotNull(ownedType, nameof(ownedType));
+            Check.NotEmpty(navigationName, nameof(navigationName));
+            Check.NotNull(buildAction, nameof(buildAction));
+
+            using (Builder.Metadata.Model.ConventionDispatcher.StartBatch())
+            {
+                buildAction.Invoke(OwnsManyBuilder(new TypeIdentity(ownedType, (Model)Metadata.Model), navigationName));
+                return this;
+            }
+        }
+
+        private CollectionOwnershipBuilder OwnsManyBuilder(in TypeIdentity ownedType, string navigationName)
+        {
+            InternalRelationshipBuilder relationship;
+            using (Builder.Metadata.Model.ConventionDispatcher.StartBatch())
+            {
+                relationship = ownedType.Type == null
+                    ? Builder.Owns(ownedType.Name, navigationName, ConfigurationSource.Explicit)
+                    : Builder.Owns(ownedType.Type, navigationName, ConfigurationSource.Explicit);
+                relationship.IsUnique(false, ConfigurationSource.Explicit);
+            }
+
+            return new CollectionOwnershipBuilder(
                 Builder.Metadata,
-                relatedEntityType,
-                navigationName,
-                Builder.Navigation(
-                    relatedEntityType.Builder, navigationName, ConfigurationSource.Explicit,
-                    setTargetAsPrincipal: Builder.Metadata == relatedEntityType));
+                relationship.Metadata.DeclaringEntityType,
+                relationship);
         }
 
         /// <summary>
@@ -414,9 +504,50 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             Check.NotEmpty(relatedTypeName, nameof(relatedTypeName));
             Check.NullButNotEmpty(navigationName, nameof(navigationName));
 
-            var relatedEntityType = Builder.Metadata.FindInDefinitionPath(relatedTypeName) ??
-                                    Builder.ModelBuilder.Metadata.FindEntityType(relatedTypeName, navigationName, Builder.Metadata) ??
-                                    Builder.ModelBuilder.Entity(relatedTypeName, ConfigurationSource.Explicit).Metadata;
+            var relatedEntityType = FindRelatedEntityType(relatedTypeName, navigationName);
+
+            return new ReferenceNavigationBuilder(
+                Builder.Metadata,
+                relatedEntityType,
+                navigationName,
+                Builder.Navigation(
+                    relatedEntityType.Builder, navigationName, ConfigurationSource.Explicit,
+                    setTargetAsPrincipal: Builder.Metadata == relatedEntityType));
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Configures a relationship where this entity type has a reference that points
+        ///         to a single instance of the other type in the relationship.
+        ///     </para>
+        ///     <para>
+        ///         Note that calling this method with no parameters will explicitly configure this side
+        ///         of the relationship to use no navigation property, even if such a property exists on the
+        ///         entity type. If the navigation property is to be used, then it must be specified.
+        ///     </para>
+        ///     <para>
+        ///         After calling this method, you should chain a call to
+        ///         <see cref="ReferenceNavigationBuilder.WithMany" />
+        ///         or <see cref="ReferenceNavigationBuilder.WithOne" /> to fully configure
+        ///         the relationship. Calling just this method without the chained call will not
+        ///         produce a valid relationship.
+        ///     </para>
+        /// </summary>
+        /// <param name="relatedType"> The entity type that this relationship targets. </param>
+        /// <param name="navigationName">
+        ///     The name of the reference navigation property on this entity type that represents the relationship. If
+        ///     no property is specified, the relationship will be configured without a navigation property on this
+        ///     end.
+        /// </param>
+        /// <returns> An object that can be used to configure the relationship. </returns>
+        public virtual ReferenceNavigationBuilder HasOne(
+            [NotNull] Type relatedType,
+            [CanBeNull] string navigationName = null)
+        {
+            Check.NotNull(relatedType, nameof(relatedType));
+            Check.NullButNotEmpty(navigationName, nameof(navigationName));
+
+            var relatedEntityType = FindRelatedEntityType(relatedType, navigationName);
 
             return new ReferenceNavigationBuilder(
                 Builder.Metadata,
@@ -444,7 +575,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///         produce a valid relationship.
         ///     </para>
         /// </summary>
-        /// <param name="relatedType"> The entity type that this relationship targets. </param>
+        /// <param name="relatedTypeName"> The name of the entity type that this relationship targets. </param>
         /// <param name="navigationName">
         ///     The name of the collection navigation property on this entity type that represents the relationship. If
         ///     no property is specified, the relationship will be configured without a navigation property on this
@@ -452,13 +583,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </param>
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual CollectionNavigationBuilder HasMany(
-            [NotNull] Type relatedType,
+            [NotNull] string relatedTypeName,
             [CanBeNull] string navigationName = null)
         {
-            Check.NotNull(relatedType, nameof(relatedType));
+            Check.NotEmpty(relatedTypeName, nameof(relatedTypeName));
             Check.NullButNotEmpty(navigationName, nameof(navigationName));
 
-            var relatedEntityType = Builder.ModelBuilder.Entity(relatedType, ConfigurationSource.Explicit).Metadata;
+            var relatedEntityType = FindRelatedEntityType(relatedTypeName, navigationName);
 
             InternalRelationshipBuilder relationship;
             using (var batch = Builder.Metadata.Model.ConventionDispatcher.StartBatch())
@@ -495,7 +626,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///         produce a valid relationship.
         ///     </para>
         /// </summary>
-        /// <param name="relatedTypeName"> The name of the entity type that this relationship targets. </param>
+        /// <param name="relatedType"> The entity type that this relationship targets. </param>
         /// <param name="navigationName">
         ///     The name of the collection navigation property on this entity type that represents the relationship. If
         ///     no property is specified, the relationship will be configured without a navigation property on this
@@ -503,13 +634,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </param>
         /// <returns> An object that can be used to configure the relationship. </returns>
         public virtual CollectionNavigationBuilder HasMany(
-            [NotNull] string relatedTypeName,
+            [NotNull] Type relatedType,
             [CanBeNull] string navigationName = null)
         {
-            Check.NotEmpty(relatedTypeName, nameof(relatedTypeName));
+            Check.NotNull(relatedType, nameof(relatedType));
             Check.NullButNotEmpty(navigationName, nameof(navigationName));
 
-            var relatedEntityType = Builder.ModelBuilder.Entity(relatedTypeName, ConfigurationSource.Explicit).Metadata;
+            var relatedEntityType = FindRelatedEntityType(relatedType, navigationName);
 
             InternalRelationshipBuilder relationship;
             using (var batch = Builder.Metadata.Model.ConventionDispatcher.StartBatch())
@@ -528,6 +659,26 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 navigationName,
                 relationship);
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual EntityType FindRelatedEntityType(string relatedTypeName, string navigationName)
+            => (navigationName == null
+                ? null
+                : Builder.ModelBuilder.Metadata.FindEntityType(relatedTypeName, navigationName, Builder.Metadata))
+               ?? Builder.ModelBuilder.Entity(relatedTypeName, ConfigurationSource.Explicit).Metadata;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual EntityType FindRelatedEntityType([NotNull] Type relatedType, [CanBeNull] string navigationName)
+            => (navigationName == null
+                ? null
+                : Builder.ModelBuilder.Metadata.FindEntityType(relatedType, navigationName, Builder.Metadata))
+               ?? Builder.ModelBuilder.Entity(relatedType, ConfigurationSource.Explicit).Metadata;
 
         /// <summary>
         ///     Configures the <see cref="ChangeTrackingStrategy" /> to be used for this entity type.
@@ -570,7 +721,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     Configures this entity to have seed data. It is used to generate data motion migrations.
         /// </summary>
         /// <param name="data">
-        ///     An array of seed data of the same type as the entity we're building.
+        ///     An array of seed data represented by anonymous types.
         /// </param>
         /// <returns> An object that can be used to configure the model data. </returns>
         public virtual DataBuilder HasData([NotNull] params object[] data)

--- a/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/EntityTypeBuilder`.cs
@@ -84,9 +84,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </param>
         /// <returns> An object that can be used to configure the primary key. </returns>
         public virtual KeyBuilder HasKey([NotNull] Expression<Func<TEntity, object>> keyExpression)
-            => new KeyBuilder(
-                Builder.PrimaryKey(
-                    Check.NotNull(keyExpression, nameof(keyExpression)).GetPropertyAccessList(), ConfigurationSource.Explicit));
+            => new KeyBuilder(Builder.PrimaryKey(
+                Check.NotNull(keyExpression, nameof(keyExpression)).GetPropertyAccessList(), ConfigurationSource.Explicit));
 
         /// <summary>
         ///     Creates an alternate key in the model for this entity type if one does not already exist over the specified
@@ -167,14 +166,35 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </param>
         /// <returns> An object that can be used to configure the index. </returns>
         public virtual IndexBuilder HasIndex([NotNull] Expression<Func<TEntity, object>> indexExpression)
-            => new IndexBuilder(
-                Builder.HasIndex(
-                    Check.NotNull(indexExpression, nameof(indexExpression)).GetPropertyAccessList(), ConfigurationSource.Explicit));
+            => new IndexBuilder(Builder.HasIndex(
+                Check.NotNull(indexExpression, nameof(indexExpression)).GetPropertyAccessList(), ConfigurationSource.Explicit));
 
         /// <summary>
         ///     <para>
         ///         Configures a relationship where the target entity is owned by (or part of) this entity.
-        ///         The target entity key value is always propagated from the entity it belongs to.
+        ///     </para>
+        ///     <para>
+        ///         The target entity type for each ownership relationship is treated as a different entity type
+        ///         even if the navigation is of the same type. Configuration of the target entity type
+        ///         isn't applied to the target entity type of other ownership relationships.
+        ///     </para>
+        ///     <para>
+        ///         Most operations on an owned entity require accessing it through the owner entity using the corresponding navigation.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TRelatedEntity"> The entity type that this relationship targets. </typeparam>
+        /// <param name="navigationName">
+        ///     The name of the reference navigation property on this entity type that represents the relationship.
+        /// </param>
+        /// <returns> An object that can be used to configure the owned type and the relationship. </returns>
+        public virtual ReferenceOwnershipBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(
+            [NotNull] string navigationName)
+            where TRelatedEntity : class
+            => OwnsOneBuilder<TRelatedEntity>(new PropertyIdentity(Check.NotNull(navigationName, nameof(navigationName))));
+
+        /// <summary>
+        ///     <para>
+        ///         Configures a relationship where the target entity is owned by (or part of) this entity.
         ///     </para>
         ///     <para>
         ///         The target entity type for each ownership relationship is treated as a different entity type
@@ -190,16 +210,50 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     A lambda expression representing the reference navigation property on this entity type that represents
         ///     the relationship (<c>customer => customer.Address</c>).
         /// </param>
-        /// <returns> An object that can be used to configure the relationship. </returns>
+        /// <returns> An object that can be used to configure the owned type and the relationship. </returns>
         public virtual ReferenceOwnershipBuilder<TEntity, TRelatedEntity> OwnsOne<TRelatedEntity>(
             [NotNull] Expression<Func<TEntity, TRelatedEntity>> navigationExpression)
             where TRelatedEntity : class
-            => OwnsOneBuilder<TRelatedEntity>(Check.NotNull(navigationExpression, nameof(navigationExpression)).GetPropertyAccess());
+            => OwnsOneBuilder<TRelatedEntity>(
+                new PropertyIdentity(Check.NotNull(navigationExpression, nameof(navigationExpression)).GetPropertyAccess()));
 
         /// <summary>
         ///     <para>
         ///         Configures a relationship where the target entity is owned by (or part of) this entity.
-        ///         The target entity key value is always propagated from the entity it belongs to.
+        ///     </para>
+        ///     <para>
+        ///         The target entity type for each ownership relationship is treated as a different entity type
+        ///         even if the navigation is of the same type. Configuration of the target entity type
+        ///         isn't applied to the target entity type of other ownership relationships.
+        ///     </para>
+        ///     <para>
+        ///         Most operations on an owned entity require accessing it through the owner entity using the corresponding navigation.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TRelatedEntity"> The entity type that this relationship targets. </typeparam>
+        /// <param name="navigationName">
+        ///     The name of the reference navigation property on this entity type that represents the relationship.
+        /// </param>
+        /// <param name="buildAction"> An action that performs configuration of the owned type and the relationship. </param>
+        /// <returns> An object that can be used to configure the entity type. </returns>
+        public virtual EntityTypeBuilder<TEntity> OwnsOne<TRelatedEntity>(
+            [NotNull] string navigationName,
+            [NotNull] Action<ReferenceOwnershipBuilder<TEntity, TRelatedEntity>> buildAction)
+            where TRelatedEntity : class
+        {
+            Check.NotNull(navigationName, nameof(navigationName));
+            Check.NotNull(buildAction, nameof(buildAction));
+
+            using (Builder.Metadata.Model.ConventionDispatcher.StartBatch())
+            {
+                buildAction.Invoke(OwnsOneBuilder<TRelatedEntity>(new PropertyIdentity(navigationName)));
+                return this;
+            }
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Configures a relationship where the target entity is owned by (or part of) this entity.
         ///     </para>
         ///     <para>
         ///         The target entity type for each ownership relationship is treated as a different entity type
@@ -215,7 +269,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     A lambda expression representing the reference navigation property on this entity type that represents
         ///     the relationship (<c>customer => customer.Address</c>).
         /// </param>
-        /// <param name="buildAction"> An action that performs configuration of the relationship. </param>
+        /// <param name="buildAction"> An action that performs configuration of the owned type and the relationship. </param>
         /// <returns> An object that can be used to configure the entity type. </returns>
         public virtual EntityTypeBuilder<TEntity> OwnsOne<TRelatedEntity>(
             [NotNull] Expression<Func<TEntity, TRelatedEntity>> navigationExpression,
@@ -227,25 +281,205 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
 
             using (Builder.Metadata.Model.ConventionDispatcher.StartBatch())
             {
-                buildAction.Invoke(OwnsOneBuilder<TRelatedEntity>(navigationExpression.GetPropertyAccess()));
+                buildAction.Invoke(OwnsOneBuilder<TRelatedEntity>(new PropertyIdentity(navigationExpression.GetPropertyAccess())));
                 return this;
             }
         }
 
-        private ReferenceOwnershipBuilder<TEntity, TRelatedEntity> OwnsOneBuilder<TRelatedEntity>(PropertyInfo navigation)
+        private ReferenceOwnershipBuilder<TEntity, TRelatedEntity> OwnsOneBuilder<TRelatedEntity>(PropertyIdentity navigation)
             where TRelatedEntity : class
         {
             InternalRelationshipBuilder relationship;
-            using (Builder.Metadata.Model.ConventionDispatcher.StartBatch())
+            using (var batch = Builder.Metadata.Model.ConventionDispatcher.StartBatch())
             {
-                relationship = Builder.Owns(typeof(TRelatedEntity), navigation, ConfigurationSource.Explicit);
+                relationship = navigation.Property == null
+                    ? Builder.Owns(typeof(TRelatedEntity), navigation.Name, ConfigurationSource.Explicit)
+                    : Builder.Owns(typeof(TRelatedEntity), (PropertyInfo)navigation.Property, ConfigurationSource.Explicit);
                 relationship.IsUnique(true, ConfigurationSource.Explicit);
+                relationship = batch.Run(relationship.Metadata).Builder;
             }
 
             return new ReferenceOwnershipBuilder<TEntity, TRelatedEntity>(
                 Builder.Metadata,
                 relationship.Metadata.DeclaringEntityType,
                 relationship);
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Configures a relationship where the target entity is owned by (or part of) this entity.
+        ///     </para>
+        ///     <para>
+        ///         The target entity type for each ownership relationship is treated as a different entity type
+        ///         even if the navigation is of the same type. Configuration of the target entity type
+        ///         isn't applied to the target entity type of other ownership relationships.
+        ///     </para>
+        ///     <para>
+        ///         Most operations on an owned entity require accessing it through the owner entity using the corresponding navigation.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TRelatedEntity"> The entity type that this relationship targets. </typeparam>
+        /// <param name="navigationName">
+        ///     The name of the reference navigation property on this entity type that represents the relationship.
+        /// </param>
+        /// <returns> An object that can be used to configure the owned type and the relationship. </returns>
+        public virtual CollectionOwnershipBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(
+            [NotNull] string navigationName)
+            where TRelatedEntity : class
+            => OwnsManyBuilder<TRelatedEntity>(new PropertyIdentity(Check.NotNull(navigationName, nameof(navigationName))));
+
+        /// <summary>
+        ///     <para>
+        ///         Configures a relationship where the target entity is owned by (or part of) this entity.
+        ///     </para>
+        ///     <para>
+        ///         The target entity type for each ownership relationship is treated as a different entity type
+        ///         even if the navigation is of the same type. Configuration of the target entity type
+        ///         isn't applied to the target entity type of other ownership relationships.
+        ///     </para>
+        ///     <para>
+        ///         Most operations on an owned entity require accessing it through the owner entity using the corresponding navigation.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TRelatedEntity"> The entity type that this relationship targets. </typeparam>
+        /// <param name="navigationExpression">
+        ///     A lambda expression representing the reference navigation property on this entity type that represents
+        ///     the relationship (<c>customer => customer.Address</c>).
+        /// </param>
+        /// <returns> An object that can be used to configure the owned type and the relationship. </returns>
+        public virtual CollectionOwnershipBuilder<TEntity, TRelatedEntity> OwnsMany<TRelatedEntity>(
+            [NotNull] Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression)
+            where TRelatedEntity : class
+            => OwnsManyBuilder<TRelatedEntity>(
+                new PropertyIdentity(Check.NotNull(navigationExpression, nameof(navigationExpression)).GetPropertyAccess()));
+
+        /// <summary>
+        ///     <para>
+        ///         Configures a relationship where the target entity is owned by (or part of) this entity.
+        ///     </para>
+        ///     <para>
+        ///         The target entity type for each ownership relationship is treated as a different entity type
+        ///         even if the navigation is of the same type. Configuration of the target entity type
+        ///         isn't applied to the target entity type of other ownership relationships.
+        ///     </para>
+        ///     <para>
+        ///         Most operations on an owned entity require accessing it through the owner entity using the corresponding navigation.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TRelatedEntity"> The entity type that this relationship targets. </typeparam>
+        /// <param name="navigationName">
+        ///     The name of the reference navigation property on this entity type that represents the relationship.
+        /// </param>
+        /// <param name="buildAction"> An action that performs configuration of the owned type and the relationship. </param>
+        /// <returns> An object that can be used to configure the entity type. </returns>
+        public virtual EntityTypeBuilder<TEntity> OwnsMany<TRelatedEntity>(
+            [NotNull] string navigationName,
+            [NotNull] Action<CollectionOwnershipBuilder<TEntity, TRelatedEntity>> buildAction)
+            where TRelatedEntity : class
+        {
+            Check.NotNull(navigationName, nameof(navigationName));
+            Check.NotNull(buildAction, nameof(buildAction));
+
+            using (Builder.Metadata.Model.ConventionDispatcher.StartBatch())
+            {
+                buildAction.Invoke(OwnsManyBuilder<TRelatedEntity>(new PropertyIdentity(navigationName)));
+                return this;
+            }
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Configures a relationship where the target entity is owned by (or part of) this entity.
+        ///     </para>
+        ///     <para>
+        ///         The target entity type for each ownership relationship is treated as a different entity type
+        ///         even if the navigation is of the same type. Configuration of the target entity type
+        ///         isn't applied to the target entity type of other ownership relationships.
+        ///     </para>
+        ///     <para>
+        ///         Most operations on an owned entity require accessing it through the owner entity using the corresponding navigation.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TRelatedEntity"> The entity type that this relationship targets. </typeparam>
+        /// <param name="navigationExpression">
+        ///     A lambda expression representing the reference navigation property on this entity type that represents
+        ///     the relationship (<c>customer => customer.Address</c>).
+        /// </param>
+        /// <param name="buildAction"> An action that performs configuration of the owned type and the relationship. </param>
+        /// <returns> An object that can be used to configure the entity type. </returns>
+        public virtual EntityTypeBuilder<TEntity> OwnsMany<TRelatedEntity>(
+            [NotNull] Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression,
+            [NotNull] Action<CollectionOwnershipBuilder<TEntity, TRelatedEntity>> buildAction)
+            where TRelatedEntity : class
+        {
+            Check.NotNull(navigationExpression, nameof(navigationExpression));
+            Check.NotNull(buildAction, nameof(buildAction));
+
+            using (Builder.Metadata.Model.ConventionDispatcher.StartBatch())
+            {
+                buildAction.Invoke(OwnsManyBuilder<TRelatedEntity>(new PropertyIdentity(navigationExpression.GetPropertyAccess())));
+                return this;
+            }
+        }
+
+        private CollectionOwnershipBuilder<TEntity, TRelatedEntity> OwnsManyBuilder<TRelatedEntity>(PropertyIdentity navigation)
+            where TRelatedEntity : class
+        {
+            InternalRelationshipBuilder relationship;
+            using (var batch = Builder.Metadata.Model.ConventionDispatcher.StartBatch())
+            {
+                relationship = navigation.Property == null
+                    ? Builder.Owns(typeof(TRelatedEntity), navigation.Name, ConfigurationSource.Explicit)
+                    : Builder.Owns(typeof(TRelatedEntity), (PropertyInfo)navigation.Property, ConfigurationSource.Explicit);
+                relationship.IsUnique(false, ConfigurationSource.Explicit);
+                relationship = batch.Run(relationship.Metadata).Builder;
+            }
+
+            return new CollectionOwnershipBuilder<TEntity, TRelatedEntity>(
+                Builder.Metadata,
+                relationship.Metadata.DeclaringEntityType,
+                relationship);
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Configures a relationship where this entity type has a reference that points
+        ///         to a single instance of the other type in the relationship.
+        ///     </para>
+        ///     <para>
+        ///         Note that calling this method with no parameters will explicitly configure this side
+        ///         of the relationship to use no navigation property, even if such a property exists on the
+        ///         entity type. If the navigation property is to be used, then it must be specified.
+        ///     </para>
+        ///     <para>
+        ///         After calling this method, you should chain a call to
+        ///         <see cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}.WithMany(string)" />
+        ///         or
+        ///         <see cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}.WithOne(string)" />
+        ///         to fully configure the relationship. Calling just this method without the chained call will not
+        ///         produce a valid relationship.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TRelatedEntity"> The entity type that this relationship targets. </typeparam>
+        /// <param name="navigationName">
+        ///     The name of the reference navigation property on this entity type that represents the relationship. If
+        ///     no property is specified, the relationship will be configured without a navigation property on this
+        ///     end.
+        /// </param>
+        /// <returns> An object that can be used to configure the relationship. </returns>
+        public virtual ReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(
+            [CanBeNull] string navigationName)
+            where TRelatedEntity : class
+        {
+            var relatedEntityType = FindRelatedEntityType(typeof(TRelatedEntity), navigationName);
+
+            return new ReferenceNavigationBuilder<TEntity, TRelatedEntity>(
+                Builder.Metadata,
+                relatedEntityType,
+                navigationName,
+                Builder.Navigation(
+                    relatedEntityType.Builder, navigationName, ConfigurationSource.Explicit,
+                    setTargetAsPrincipal: Builder.Metadata == relatedEntityType));
         }
 
         /// <summary>
@@ -281,7 +515,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             where TRelatedEntity : class
         {
             var navigation = navigationExpression?.GetPropertyAccess();
-            var relatedEntityType = FindRelatedEntityType<TRelatedEntity>(navigation?.Name);
+            var relatedEntityType = FindRelatedEntityType(typeof(TRelatedEntity), navigation?.Name);
 
             return new ReferenceNavigationBuilder<TEntity, TRelatedEntity>(
                 Builder.Metadata,
@@ -290,105 +524,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 Builder.Navigation(
                     relatedEntityType.Builder, navigation, ConfigurationSource.Explicit,
                     setTargetAsPrincipal: Builder.Metadata == relatedEntityType));
-        }
-
-        /// <summary>
-        ///     <para>
-        ///         Configures a relationship where this entity type has a reference that points
-        ///         to a single instance of the other type in the relationship.
-        ///     </para>
-        ///     <para>
-        ///         Note that calling this method with no parameters will explicitly configure this side
-        ///         of the relationship to use no navigation property, even if such a property exists on the
-        ///         entity type. If the navigation property is to be used, then it must be specified.
-        ///     </para>
-        ///     <para>
-        ///         After calling this method, you should chain a call to
-        ///         <see
-        ///             cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}.WithMany(Expression{Func{TRelatedEntity,IEnumerable{TEntity}}})" />
-        ///         or
-        ///         <see
-        ///             cref="ReferenceNavigationBuilder{TEntity,TRelatedEntity}.WithOne(Expression{Func{TRelatedEntity,TEntity}})" />
-        ///         to fully configure the relationship. Calling just this method without the chained call will not
-        ///         produce a valid relationship.
-        ///     </para>
-        /// </summary>
-        /// <typeparam name="TRelatedEntity"> The entity type that this relationship targets. </typeparam>
-        /// <param name="navigationName">
-        ///     The name of the reference navigation property on this entity type that represents the relationship. If
-        ///     no property is specified, the relationship will be configured without a navigation property on this
-        ///     end.
-        /// </param>
-        /// <returns> An object that can be used to configure the relationship. </returns>
-        public virtual ReferenceNavigationBuilder<TEntity, TRelatedEntity> HasOne<TRelatedEntity>(
-            [CanBeNull] string navigationName)
-            where TRelatedEntity : class
-        {
-            var relatedEntityType = FindRelatedEntityType<TRelatedEntity>(navigationName);
-
-            return new ReferenceNavigationBuilder<TEntity, TRelatedEntity>(
-                Builder.Metadata,
-                relatedEntityType,
-                navigationName,
-                Builder.Navigation(
-                    relatedEntityType.Builder, navigationName, ConfigurationSource.Explicit,
-                    setTargetAsPrincipal: Builder.Metadata == relatedEntityType));
-        }
-
-        private EntityType FindRelatedEntityType<TRelatedEntity>(string navigationName)
-            where TRelatedEntity : class
-            => Builder.Metadata.FindInDefinitionPath(typeof(TRelatedEntity)) ??
-               Builder.ModelBuilder.Metadata.FindEntityType(typeof(TRelatedEntity), navigationName, Builder.Metadata) ??
-               Builder.ModelBuilder.Entity(typeof(TRelatedEntity), ConfigurationSource.Explicit).Metadata;
-
-        /// <summary>
-        ///     <para>
-        ///         Configures a relationship where this entity type has a collection that contains
-        ///         instances of the other type in the relationship.
-        ///     </para>
-        ///     <para>
-        ///         Note that calling this method with no parameters will explicitly configure this side
-        ///         of the relationship to use no navigation property, even if such a property exists on the
-        ///         entity type. If the navigation property is to be used, then it must be specified.
-        ///     </para>
-        ///     <para>
-        ///         After calling this method, you should chain a call to
-        ///         <see
-        ///             cref="CollectionNavigationBuilder{TEntity,TRelatedEntity}.WithOne(Expression{Func{TRelatedEntity,TEntity}})" />
-        ///         to fully configure the relationship. Calling just this method without the chained call will not
-        ///         produce a valid relationship.
-        ///     </para>
-        /// </summary>
-        /// <typeparam name="TRelatedEntity"> The entity type that this relationship targets. </typeparam>
-        /// <param name="navigationExpression">
-        ///     A lambda expression representing the collection navigation property on this entity type that represents
-        ///     the relationship (<c>blog => blog.Posts</c>). If no property is specified, the relationship will be
-        ///     configured without a navigation property on this end.
-        /// </param>
-        /// <returns> An object that can be used to configure the relationship. </returns>
-        public virtual CollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
-            [CanBeNull] Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression = null)
-            where TRelatedEntity : class
-        {
-            var relatedEntityType = Builder.ModelBuilder.Entity(typeof(TRelatedEntity), ConfigurationSource.Explicit).Metadata;
-            var navigation = navigationExpression?.GetPropertyAccess();
-
-            InternalRelationshipBuilder relationship;
-            using (var batch = Builder.Metadata.Model.ConventionDispatcher.StartBatch())
-            {
-                relationship = relatedEntityType.Builder
-                    .Relationship(Builder, ConfigurationSource.Explicit)
-                    .IsUnique(false, ConfigurationSource.Explicit)
-                    .RelatedEntityTypes(Builder.Metadata, relatedEntityType, ConfigurationSource.Explicit)
-                    .PrincipalToDependent(navigation, ConfigurationSource.Explicit);
-                relationship = batch.Run(relationship);
-            }
-
-            return new CollectionNavigationBuilder<TEntity, TRelatedEntity>(
-                Builder.Metadata,
-                relatedEntityType,
-                navigation,
-                relationship);
         }
 
         /// <summary>
@@ -422,7 +557,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         {
             Check.NotEmpty(navigationName, nameof(navigationName));
 
-            var relatedEntityType = Builder.ModelBuilder.Entity(typeof(TRelatedEntity), ConfigurationSource.Explicit).Metadata;
+            var relatedEntityType = FindRelatedEntityType(typeof(TRelatedEntity), navigationName);
 
             InternalRelationshipBuilder relationship;
             using (var batch = Builder.Metadata.Model.ConventionDispatcher.StartBatch())
@@ -439,6 +574,56 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 Builder.Metadata,
                 relatedEntityType,
                 navigationName,
+                relationship);
+        }
+
+        /// <summary>
+        ///     <para>
+        ///         Configures a relationship where this entity type has a collection that contains
+        ///         instances of the other type in the relationship.
+        ///     </para>
+        ///     <para>
+        ///         Note that calling this method with no parameters will explicitly configure this side
+        ///         of the relationship to use no navigation property, even if such a property exists on the
+        ///         entity type. If the navigation property is to be used, then it must be specified.
+        ///     </para>
+        ///     <para>
+        ///         After calling this method, you should chain a call to
+        ///         <see
+        ///             cref="CollectionNavigationBuilder{TEntity,TRelatedEntity}.WithOne(Expression{Func{TRelatedEntity,TEntity}})" />
+        ///         to fully configure the relationship. Calling just this method without the chained call will not
+        ///         produce a valid relationship.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TRelatedEntity"> The entity type that this relationship targets. </typeparam>
+        /// <param name="navigationExpression">
+        ///     A lambda expression representing the collection navigation property on this entity type that represents
+        ///     the relationship (<c>blog => blog.Posts</c>). If no property is specified, the relationship will be
+        ///     configured without a navigation property on this end.
+        /// </param>
+        /// <returns> An object that can be used to configure the relationship. </returns>
+        public virtual CollectionNavigationBuilder<TEntity, TRelatedEntity> HasMany<TRelatedEntity>(
+            [CanBeNull] Expression<Func<TEntity, IEnumerable<TRelatedEntity>>> navigationExpression = null)
+            where TRelatedEntity : class
+        {
+            var navigation = navigationExpression?.GetPropertyAccess();
+            var relatedEntityType = FindRelatedEntityType(typeof(TRelatedEntity), navigation?.Name);
+
+            InternalRelationshipBuilder relationship;
+            using (var batch = Builder.Metadata.Model.ConventionDispatcher.StartBatch())
+            {
+                relationship = relatedEntityType.Builder
+                    .Relationship(Builder, ConfigurationSource.Explicit)
+                    .IsUnique(false, ConfigurationSource.Explicit)
+                    .RelatedEntityTypes(Builder.Metadata, relatedEntityType, ConfigurationSource.Explicit)
+                    .PrincipalToDependent(navigation, ConfigurationSource.Explicit);
+                relationship = batch.Run(relationship);
+            }
+
+            return new CollectionNavigationBuilder<TEntity, TRelatedEntity>(
+                Builder.Metadata,
+                relatedEntityType,
+                navigation,
                 relationship);
         }
 
@@ -475,10 +660,24 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     Configures this entity to have seed data. It is used to generate data motion migrations.
         /// </summary>
         /// <param name="data">
-        ///     An array of seed data.
+        ///     An array of seed data of the same type as the entity.
         /// </param>
         /// <returns> An object that can be used to configure the model data. </returns>
         public virtual DataBuilder<TEntity> HasData([NotNull] params TEntity[] data)
+        {
+            base.HasData(data);
+
+            return new DataBuilder<TEntity>();
+        }
+
+        /// <summary>
+        ///     Configures this entity to have seed data. It is used to generate data motion migrations.
+        /// </summary>
+        /// <param name="data">
+        ///     An array of seed data represented by anonymous types.
+        /// </param>
+        /// <returns> An object that can be used to configure the model data. </returns>
+        public new virtual DataBuilder<TEntity> HasData([NotNull] params object[] data)
         {
             base.HasData(data);
 

--- a/src/EFCore/Metadata/Builders/IndexBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/IndexBuilder`.cs
@@ -3,7 +3,6 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
-using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Builders
 {

--- a/src/EFCore/Metadata/Builders/QueryTypeBuilder.cs
+++ b/src/EFCore/Metadata/Builders/QueryTypeBuilder.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
@@ -74,9 +75,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <param name="name"> The name of the base type. </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public virtual QueryTypeBuilder HasBaseType([CanBeNull] string name)
-        {
-            return new QueryTypeBuilder(Builder.HasBaseType(name, ConfigurationSource.Explicit));
-        }
+            => new QueryTypeBuilder(Builder.HasBaseType(name, ConfigurationSource.Explicit));
 
         /// <summary>
         ///     Sets the base type of this query type in an inheritance hierarchy.
@@ -84,9 +83,26 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <param name="queryType"> The base type. </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public virtual QueryTypeBuilder HasBaseType([CanBeNull] Type queryType)
-        {
-            return new QueryTypeBuilder(Builder.HasBaseType(queryType, ConfigurationSource.Explicit));
-        }
+            => new QueryTypeBuilder(Builder.HasBaseType(queryType, ConfigurationSource.Explicit));
+
+        /// <summary>
+        ///     <para>
+        ///         Returns an object that can be used to configure a property of the query type.
+        ///         If no property with the given name exists, then a new property will be added.
+        ///     </para>
+        ///     <para>
+        ///         When adding a new property with this overload the property name must match the
+        ///         name of a CLR property or field on the query type. This overload cannot be used to
+        ///         add a new shadow state property.
+        ///     </para>
+        /// </summary>
+        /// <param name="propertyName"> The name of the property to be configured. </param>
+        /// <returns> An object that can be used to configure the property. </returns>
+        public virtual PropertyBuilder Property([NotNull] string propertyName)
+            => new PropertyBuilder(
+                Builder.Property(
+                    Check.NotEmpty(propertyName, nameof(propertyName)),
+                    ConfigurationSource.Explicit));
 
         /// <summary>
         ///     <para>
@@ -105,13 +121,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <param name="propertyName"> The name of the property to be configured. </param>
         /// <returns> An object that can be used to configure the property. </returns>
         public virtual PropertyBuilder<TProperty> Property<TProperty>([NotNull] string propertyName)
-        {
-            return new PropertyBuilder<TProperty>(
+            => new PropertyBuilder<TProperty>(
                 Builder.Property(
                     Check.NotEmpty(propertyName, nameof(propertyName)),
                     typeof(TProperty),
                     ConfigurationSource.Explicit));
-        }
 
         /// <summary>
         ///     <para>
@@ -130,34 +144,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <param name="propertyName"> The name of the property to be configured. </param>
         /// <returns> An object that can be used to configure the property. </returns>
         public virtual PropertyBuilder Property([NotNull] Type propertyType, [NotNull] string propertyName)
-        {
-            return new PropertyBuilder(
+            => new PropertyBuilder(
                 Builder.Property(
                     Check.NotEmpty(propertyName, nameof(propertyName)),
                     Check.NotNull(propertyType, nameof(propertyType)),
                     ConfigurationSource.Explicit));
-        }
-
-        /// <summary>
-        ///     <para>
-        ///         Returns an object that can be used to configure a property of the query type.
-        ///         If no property with the given name exists, then a new property will be added.
-        ///     </para>
-        ///     <para>
-        ///         When adding a new property with this overload the property name must match the
-        ///         name of a CLR property or field on the query type. This overload cannot be used to
-        ///         add a new shadow state property.
-        ///     </para>
-        /// </summary>
-        /// <param name="propertyName"> The name of the property to be configured. </param>
-        /// <returns> An object that can be used to configure the property. </returns>
-        public virtual PropertyBuilder Property([NotNull] string propertyName)
-        {
-            return new PropertyBuilder(
-                Builder.Property(
-                    Check.NotEmpty(propertyName, nameof(propertyName)),
-                    ConfigurationSource.Explicit));
-        }
 
         /// <summary>
         ///     Excludes the given property from the query type. This method is typically used to remove properties
@@ -184,44 +175,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             Builder.HasQueryFilter(filter);
 
             return this;
-        }
-
-        /// <summary>
-        ///     <para>
-        ///         Configures a relationship where this query type has a reference that points
-        ///         to a single instance of the other type in the relationship.
-        ///     </para>
-        ///     <para>
-        ///         After calling this method, you should chain a call to
-        ///         <see cref="ReferenceNavigationBuilder.WithMany" />
-        ///         or <see cref="ReferenceNavigationBuilder.WithOne" /> to fully configure
-        ///         the relationship. Calling just this method without the chained call will not
-        ///         produce a valid relationship.
-        ///     </para>
-        /// </summary>
-        /// <param name="relatedType"> The query type that this relationship targets. </param>
-        /// <param name="navigationName">
-        ///     The name of the reference navigation property on this query type that represents the relationship. If
-        ///     no property is specified, the relationship will be configured without a navigation property on this
-        ///     end.
-        /// </param>
-        /// <returns> An object that can be used to configure the relationship. </returns>
-        public virtual ReferenceNavigationBuilder HasOne(
-            [NotNull] Type relatedType,
-            [CanBeNull] string navigationName = null)
-        {
-            Check.NotNull(relatedType, nameof(relatedType));
-            Check.NullButNotEmpty(navigationName, nameof(navigationName));
-
-            var relatedEntityType = Builder.ModelBuilder.Entity(relatedType, ConfigurationSource.Explicit).Metadata;
-
-            return new ReferenceNavigationBuilder(
-                Builder.Metadata,
-                relatedEntityType,
-                navigationName,
-                Builder.Navigation(
-                    relatedEntityType.Builder, navigationName, ConfigurationSource.Explicit,
-                    Builder.Metadata == relatedEntityType));
         }
 
         /// <summary>
@@ -269,6 +222,44 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
 
         /// <summary>
         ///     <para>
+        ///         Configures a relationship where this query type has a reference that points
+        ///         to a single instance of the other type in the relationship.
+        ///     </para>
+        ///     <para>
+        ///         After calling this method, you should chain a call to
+        ///         <see cref="ReferenceNavigationBuilder.WithMany" />
+        ///         or <see cref="ReferenceNavigationBuilder.WithOne" /> to fully configure
+        ///         the relationship. Calling just this method without the chained call will not
+        ///         produce a valid relationship.
+        ///     </para>
+        /// </summary>
+        /// <param name="relatedType"> The query type that this relationship targets. </param>
+        /// <param name="navigationName">
+        ///     The name of the reference navigation property on this query type that represents the relationship. If
+        ///     no property is specified, the relationship will be configured without a navigation property on this
+        ///     end.
+        /// </param>
+        /// <returns> An object that can be used to configure the relationship. </returns>
+        public virtual ReferenceNavigationBuilder HasOne(
+            [NotNull] Type relatedType,
+            [CanBeNull] string navigationName = null)
+        {
+            Check.NotNull(relatedType, nameof(relatedType));
+            Check.NullButNotEmpty(navigationName, nameof(navigationName));
+
+            var relatedEntityType = Builder.ModelBuilder.Entity(relatedType, ConfigurationSource.Explicit).Metadata;
+
+            return new ReferenceNavigationBuilder(
+                Builder.Metadata,
+                relatedEntityType,
+                navigationName,
+                Builder.Navigation(
+                    relatedEntityType.Builder, navigationName, ConfigurationSource.Explicit,
+                    Builder.Metadata == relatedEntityType));
+        }
+
+        /// <summary>
+        ///     <para>
         ///         Sets the <see cref="PropertyAccessMode" /> to use for all properties of this query type.
         ///     </para>
         ///     <para>
@@ -290,5 +281,31 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
 
             return this;
         }
+
+        #region Hidden System.Object members
+
+        /// <summary>
+        ///     Returns a string that represents the current object.
+        /// </summary>
+        /// <returns> A string that represents the current object. </returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override string ToString() => base.ToString();
+
+        /// <summary>
+        ///     Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <param name="obj"> The object to compare with the current object. </param>
+        /// <returns> true if the specified object is equal to the current object; otherwise, false. </returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => base.Equals(obj);
+
+        /// <summary>
+        ///     Serves as the default hash function.
+        /// </summary>
+        /// <returns> A hash code for the current object. </returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => base.GetHashCode();
+
+        #endregion
     }
 }

--- a/src/EFCore/Metadata/Builders/QueryTypeBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/QueryTypeBuilder`.cs
@@ -81,9 +81,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <returns> An object that can be used to configure the property. </returns>
         public virtual PropertyBuilder<TProperty> Property<TProperty>(
             [NotNull] Expression<Func<TQuery, TProperty>> propertyExpression) => new PropertyBuilder<TProperty>(
-            Builder.Property(
-                Check.NotNull(propertyExpression, nameof(propertyExpression)).GetPropertyAccess(),
-                ConfigurationSource.Explicit));
+                Builder.Property(
+                    Check.NotNull(propertyExpression, nameof(propertyExpression)).GetPropertyAccess(),
+                    ConfigurationSource.Explicit));
 
         /// <summary>
         ///     Excludes the given property from the query type. This method is typically used to remove properties
@@ -93,8 +93,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     A lambda expression representing the property to be ignored
         ///     (<c>blog => blog.Url</c>).
         /// </param>
-        public virtual QueryTypeBuilder<TQuery> Ignore([NotNull] Expression<Func<TQuery, object>> propertyExpression) =>
-            (QueryTypeBuilder<TQuery>)base.Ignore(
+        public virtual QueryTypeBuilder<TQuery> Ignore([NotNull] Expression<Func<TQuery, object>> propertyExpression)
+            => (QueryTypeBuilder<TQuery>)base.Ignore(
                 Check.NotNull(propertyExpression, nameof(propertyExpression)).GetPropertyAccess().Name);
 
         /// <summary>
@@ -102,8 +102,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     from the query type that were added by convention.
         /// </summary>
         /// <param name="propertyName"> The name of then property to be removed from the query type. </param>
-        public new virtual QueryTypeBuilder<TQuery> Ignore([NotNull] string propertyName) =>
-            (QueryTypeBuilder<TQuery>)base.Ignore(propertyName);
+        public new virtual QueryTypeBuilder<TQuery> Ignore([NotNull] string propertyName)
+            => (QueryTypeBuilder<TQuery>)base.Ignore(propertyName);
 
         /// <summary>
         ///     Specifies a LINQ predicate expression that will automatically be applied to any queries targeting
@@ -111,8 +111,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// </summary>
         /// <param name="filter">The LINQ predicate expression.</param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public virtual QueryTypeBuilder<TQuery> HasQueryFilter([CanBeNull] Expression<Func<TQuery, bool>> filter) =>
-            (QueryTypeBuilder<TQuery>)base.HasQueryFilter(filter);
+        public virtual QueryTypeBuilder<TQuery> HasQueryFilter([CanBeNull] Expression<Func<TQuery, bool>> filter)
+            => (QueryTypeBuilder<TQuery>)base.HasQueryFilter(filter);
 
         /// <summary>
         ///     Configures a query used to provide data for a query type.

--- a/src/EFCore/Metadata/Builders/ReferenceCollectionBuilderBase.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceCollectionBuilderBase.cs
@@ -1,0 +1,143 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Builders
+{
+    /// <summary>
+    ///     <para>
+    ///         Provides a simple API for configuring a one-to-many relationship.
+    ///     </para>
+    ///     <para>
+    ///         Instances of this class are returned from methods when using the <see cref="ModelBuilder" /> API
+    ///         and it is not designed to be directly constructed in your application code.
+    ///     </para>
+    /// </summary>
+    public class ReferenceCollectionBuilderBase : IInfrastructure<IMutableModel>, IInfrastructure<InternalRelationshipBuilder>
+    {
+        private readonly IReadOnlyList<Property> _foreignKeyProperties;
+        private readonly IReadOnlyList<Property> _principalKeyProperties;
+        private readonly bool? _required;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public ReferenceCollectionBuilderBase(
+            [NotNull] EntityType principalEntityType,
+            [NotNull] EntityType dependentEntityType,
+            [NotNull] InternalRelationshipBuilder builder)
+            : this(builder, null)
+        {
+            Check.NotNull(builder, nameof(builder));
+
+            PrincipalEntityType = principalEntityType;
+            DependentEntityType = dependentEntityType;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected ReferenceCollectionBuilderBase(
+            InternalRelationshipBuilder builder,
+            ReferenceCollectionBuilderBase oldBuilder,
+            bool foreignKeySet = false,
+            bool principalKeySet = false,
+            bool requiredSet = false)
+        {
+            Check.NotNull(builder, nameof(builder));
+
+            Builder = builder;
+            if (oldBuilder != null)
+            {
+                PrincipalEntityType = oldBuilder.PrincipalEntityType;
+                DependentEntityType = oldBuilder.DependentEntityType;
+                _foreignKeyProperties = foreignKeySet
+                    ? builder.Metadata.Properties
+                    : oldBuilder._foreignKeyProperties;
+                _principalKeyProperties = principalKeySet
+                    ? builder.Metadata.PrincipalKey.Properties
+                    : oldBuilder._principalKeyProperties;
+                _required = requiredSet
+                    ? builder.Metadata.IsRequired
+                    : oldBuilder._required;
+
+                var foreignKey = builder.Metadata;
+                ForeignKey.AreCompatible(
+                    PrincipalEntityType,
+                    DependentEntityType,
+                    foreignKey.DependentToPrincipal?.GetIdentifyingMemberInfo(),
+                    foreignKey.PrincipalToDependent?.GetIdentifyingMemberInfo(),
+                    _foreignKeyProperties,
+                    _principalKeyProperties,
+                    foreignKey.IsUnique,
+                    _required,
+                    true);
+            }
+        }
+
+        /// <summary>
+        ///     Gets the principal entity type used to configure this relationship.
+        /// </summary>
+        protected virtual EntityType PrincipalEntityType { get; }
+
+        /// <summary>
+        ///     Gets the dependent entity type used to configure this relationship.
+        /// </summary>
+        protected virtual EntityType DependentEntityType { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected virtual InternalRelationshipBuilder Builder { get; [param: NotNull] set; }
+
+        /// <summary>
+        ///     The foreign key that represents this relationship.
+        /// </summary>
+        public virtual IMutableForeignKey Metadata => Builder.Metadata;
+
+        /// <summary>
+        ///     The model that this relationship belongs to.
+        /// </summary>
+        IMutableModel IInfrastructure<IMutableModel>.Instance => Builder.ModelBuilder.Metadata;
+
+        /// <summary>
+        ///     Gets the internal builder being used to configure this relationship.
+        /// </summary>
+        InternalRelationshipBuilder IInfrastructure<InternalRelationshipBuilder>.Instance => Builder;
+
+        #region Hidden System.Object members
+
+        /// <summary>
+        ///     Returns a string that represents the current object.
+        /// </summary>
+        /// <returns> A string that represents the current object. </returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override string ToString() => base.ToString();
+
+        /// <summary>
+        ///     Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <param name="obj"> The object to compare with the current object. </param>
+        /// <returns> true if the specified object is equal to the current object; otherwise, false. </returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => base.Equals(obj);
+
+        /// <summary>
+        ///     Serves as the default hash function.
+        /// </summary>
+        /// <returns> A hash code for the current object. </returns>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => base.GetHashCode();
+
+        #endregion
+    }
+}

--- a/src/EFCore/Metadata/Builders/ReferenceCollectionBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceCollectionBuilder`.cs
@@ -57,6 +57,35 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///         Configures the property(s) to use as the foreign key for this relationship.
         ///     </para>
         ///     <para>
+        ///         If the specified property name(s) do not exist on the entity type then a new shadow state
+        ///         property(s) will be added to serve as the foreign key. A shadow state property is one
+        ///         that does not have a corresponding property in the entity class. The current value for the
+        ///         property is stored in the <see cref="ChangeTracker" /> rather than being stored in instances
+        ///         of the entity class.
+        ///     </para>
+        ///     <para>
+        ///         If <see cref="HasPrincipalKey(Expression{Func{TPrincipalEntity, object}})" /> is not specified,
+        ///         then an attempt will be made to match the data type and order of foreign key properties against
+        ///         the primary key of the principal entity type. If they do not match, new shadow state properties
+        ///         that form a unique index will be added to the principal entity type to serve as the reference key.
+        ///     </para>
+        /// </summary>
+        /// <param name="foreignKeyPropertyNames">
+        ///     The name(s) of the foreign key property(s).
+        /// </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public new virtual ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity> HasForeignKey(
+            [NotNull] params string[] foreignKeyPropertyNames)
+            => new ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity>(
+                HasForeignKeyBuilder(Check.NotEmpty(foreignKeyPropertyNames, nameof(foreignKeyPropertyNames))),
+                this,
+                foreignKeySet: true);
+
+        /// <summary>
+        ///     <para>
+        ///         Configures the property(s) to use as the foreign key for this relationship.
+        ///     </para>
+        ///     <para>
         ///         If <see cref="HasPrincipalKey(Expression{Func{TPrincipalEntity, object}})" /> is not specified, then
         ///         an attempt will be made to match the data type and order of foreign key properties against the
         ///         primary key of the principal entity type. If they do not match, new shadow state properties that
@@ -73,7 +102,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     <para>
         ///         If the foreign key is made up of multiple properties then specify an anonymous type including the
         ///         properties (<c>comment => new { comment.BlogId, comment.PostTitle }</c>). The order specified should match the order of
-        ///         corresponding keys in <see cref="HasPrincipalKey(Expression{Func{TPrincipalEntity,object}})" />.
+        ///         corresponding properties in <see cref="HasPrincipalKey(Expression{Func{TPrincipalEntity,object}})" />.
         ///     </para>
         /// </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
@@ -90,13 +119,28 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     the specified property(s) is not already a unique constraint (or the primary key) then a new unique
         ///     constraint will be introduced.
         /// </summary>
+        /// <param name="keyPropertyNames"> The name(s) of the reference key property(s). </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public new virtual ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity> HasPrincipalKey([NotNull] params string[] keyPropertyNames)
+            => new ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity>(
+                HasPrincipalKeyBuilder(Check.NotEmpty(keyPropertyNames, nameof(keyPropertyNames))),
+                this,
+                principalKeySet: true);
+
+        /// <summary>
+        ///     Configures the unique property(s) that this relationship targets. Typically you would only call this
+        ///     method if you want to use a property(s) other than the primary key as the principal property(s). If
+        ///     the specified property(s) is not already a unique constraint (or the primary key) then a new unique
+        ///     constraint will be introduced.
+        /// </summary>
         /// <param name="keyExpression">
         ///     <para>
         ///         A lambda expression representing the reference key property(s) (<c>blog => blog.BlogId</c>).
         ///     </para>
         ///     <para>
-        ///         If the principal key is made up of multiple properties then specify an anonymous type including
-        ///         the properties (<c>post => new { post.BlogId, post.PostTitle }</c>).
+        ///         If the principal key is made up of multiple properties then specify an anonymous type including the
+        ///         properties (<c>t => new { t.Id1, t.Id2 }</c>). The order specified should match the order of
+        ///         corresponding properties in <see cref="HasForeignKey(Expression{Func{TDependentEntity,object}})" />.
         ///     </para>
         /// </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
@@ -114,53 +158,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         /// <param name="annotation"> The key of the annotation to be added or updated. </param>
         /// <param name="value"> The value to be stored in the annotation. </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public new virtual ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity> HasAnnotation([NotNull] string annotation, [NotNull] object value)
+        public new virtual ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity> HasAnnotation(
+            [NotNull] string annotation,
+            [NotNull] object value)
             => (ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity>)base.HasAnnotation(
                 Check.NotEmpty(annotation, nameof(annotation)),
                 Check.NotNull(value, nameof(value)));
-
-        /// <summary>
-        ///     <para>
-        ///         Configures the property(s) to use as the foreign key for this relationship.
-        ///     </para>
-        ///     <para>
-        ///         If the specified property name(s) do not exist on the entity type then a new shadow state
-        ///         property(s) will be added to serve as the foreign key. A shadow state property is one
-        ///         that does not have a corresponding property in the entity class. The current value for the
-        ///         property is stored in the <see cref="ChangeTracker" /> rather than being stored in instances
-        ///         of the entity class.
-        ///     </para>
-        ///     <para>
-        ///         If <see cref="HasPrincipalKey(Expression{Func{TPrincipalEntity,object}})" /> is not specified, then an attempt will be made to
-        ///         match
-        ///         the data type and order of foreign key properties against the primary key of the principal
-        ///         entity type. If they do not match, new shadow state properties that form a unique index will be
-        ///         added to the principal entity type to serve as the reference key.
-        ///     </para>
-        /// </summary>
-        /// <param name="foreignKeyPropertyNames">
-        ///     The name(s) of the foreign key property(s).
-        /// </param>
-        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public new virtual ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity> HasForeignKey([NotNull] params string[] foreignKeyPropertyNames)
-            => new ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity>(
-                HasForeignKeyBuilder(Check.NotEmpty(foreignKeyPropertyNames, nameof(foreignKeyPropertyNames))),
-                this,
-                foreignKeySet: true);
-
-        /// <summary>
-        ///     Configures the unique property(s) that this relationship targets. Typically you would only call this
-        ///     method if you want to use a property(s) other than the primary key as the principal property(s). If
-        ///     the specified property(s) is not already a unique constraint (or the primary key) then a new unique
-        ///     constraint will be introduced.
-        /// </summary>
-        /// <param name="keyPropertyNames"> The name(s) of the reference key property(s). </param>
-        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public new virtual ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity> HasPrincipalKey([NotNull] params string[] keyPropertyNames)
-            => new ReferenceCollectionBuilder<TPrincipalEntity, TDependentEntity>(
-                HasPrincipalKeyBuilder(Check.NotEmpty(keyPropertyNames, nameof(keyPropertyNames))),
-                this,
-                principalKeySet: true);
 
         /// <summary>
         ///     Configures whether this is a required relationship (i.e. whether the foreign key property(s) can

--- a/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder.cs
@@ -158,8 +158,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                     ? builder.Navigations(ReferenceName, collection.Name, RelatedEntityType, DeclaringEntityType, ConfigurationSource.Explicit)
                     : builder.Navigations(ReferenceProperty, collection.Property, RelatedEntityType, DeclaringEntityType, ConfigurationSource.Explicit)
                 : collection.Property != null
-                ? builder.PrincipalToDependent(collection.Property, ConfigurationSource.Explicit)
-                : builder.PrincipalToDependent(collection.Name, ConfigurationSource.Explicit);
+                    ? builder.PrincipalToDependent(collection.Property, ConfigurationSource.Explicit)
+                    : builder.PrincipalToDependent(collection.Name, ConfigurationSource.Explicit);
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceNavigationBuilder`.cs
@@ -64,6 +64,27 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///         entity type. If the navigation property is to be used, then it must be specified.
         ///     </para>
         /// </summary>
+        /// <param name="navigationName">
+        ///     The name of the collection navigation property on the other end of this relationship.
+        ///     If null or not specified, there is no navigation property on the other end of the relationship.
+        /// </param>
+        /// <returns> An object to further configure the relationship. </returns>
+        public new virtual ReferenceCollectionBuilder<TRelatedEntity, TEntity> WithMany([CanBeNull] string navigationName = null)
+            => new ReferenceCollectionBuilder<TRelatedEntity, TEntity>(
+                RelatedEntityType,
+                DeclaringEntityType,
+                WithManyBuilder(Check.NullButNotEmpty(navigationName, nameof(navigationName))));
+
+        /// <summary>
+        ///     <para>
+        ///         Configures this as a one-to-many relationship.
+        ///     </para>
+        ///     <para>
+        ///         Note that calling this method with no parameters will explicitly configure this side
+        ///         of the relationship to use no navigation property, even if such a property exists on the
+        ///         entity type. If the navigation property is to be used, then it must be specified.
+        ///     </para>
+        /// </summary>
         /// <param name="navigationExpression">
         ///     A lambda expression representing the collection navigation property on the other end of this
         ///     relationship (<c>blog => blog.Posts</c>). If no property is specified, the relationship will be
@@ -76,6 +97,27 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 RelatedEntityType,
                 DeclaringEntityType,
                 WithManyBuilder(navigationExpression?.GetPropertyAccess()));
+
+        /// <summary>
+        ///     <para>
+        ///         Configures this as a one-to-many relationship.
+        ///     </para>
+        ///     <para>
+        ///         Note that calling this method with no parameters will explicitly configure this side
+        ///         of the relationship to use no navigation property, even if such a property exists on the
+        ///         entity type. If the navigation property is to be used, then it must be specified.
+        ///     </para>
+        /// </summary>
+        /// <param name="navigationName">
+        ///     The name of the reference navigation property on the other end of this relationship.
+        ///     If null or not specified, there is no navigation property on the other end of the relationship.
+        /// </param>
+        /// <returns> An object to further configure the relationship. </returns>
+        public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne([CanBeNull] string navigationName = null)
+            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
+                DeclaringEntityType,
+                RelatedEntityType,
+                WithOneBuilder(Check.NullButNotEmpty(navigationName, nameof(navigationName))));
 
         /// <summary>
         ///     <para>
@@ -99,47 +141,5 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                 DeclaringEntityType,
                 RelatedEntityType,
                 WithOneBuilder(navigationExpression?.GetPropertyAccess()));
-
-        /// <summary>
-        ///     <para>
-        ///         Configures this as a one-to-many relationship.
-        ///     </para>
-        ///     <para>
-        ///         Note that calling this method with no parameters will explicitly configure this side
-        ///         of the relationship to use no navigation property, even if such a property exists on the
-        ///         entity type. If the navigation property is to be used, then it must be specified.
-        ///     </para>
-        /// </summary>
-        /// <param name="navigationName">
-        ///     The name of the collection navigation property on the other end of this relationship.
-        ///     If null or not specified, there is no navigation property on the other end of the relationship.
-        /// </param>
-        /// <returns> An object to further configure the relationship. </returns>
-        public new virtual ReferenceCollectionBuilder<TRelatedEntity, TEntity> WithMany([CanBeNull] string navigationName = null)
-            => new ReferenceCollectionBuilder<TRelatedEntity, TEntity>(
-                RelatedEntityType,
-                DeclaringEntityType,
-                WithManyBuilder(Check.NullButNotEmpty(navigationName, nameof(navigationName))));
-
-        /// <summary>
-        ///     <para>
-        ///         Configures this as a one-to-many relationship.
-        ///     </para>
-        ///     <para>
-        ///         Note that calling this method with no parameters will explicitly configure this side
-        ///         of the relationship to use no navigation property, even if such a property exists on the
-        ///         entity type. If the navigation property is to be used, then it must be specified.
-        ///     </para>
-        /// </summary>
-        /// <param name="navigationName">
-        ///     The name of the reference navigation property on the other end of this relationship.
-        ///     If null or not specified, there is no navigation property on the other end of the relationship.
-        /// </param>
-        /// <returns> An object to further configure the relationship. </returns>
-        public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> WithOne([CanBeNull] string navigationName = null)
-            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
-                DeclaringEntityType,
-                RelatedEntityType,
-                WithOneBuilder(Check.NullButNotEmpty(navigationName, nameof(navigationName))));
     }
 }

--- a/src/EFCore/Metadata/Builders/ReferenceReferenceBuilder.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceReferenceBuilder.cs
@@ -83,24 +83,24 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///         added to the principal entity type to serve as the reference key.
         ///     </para>
         /// </summary>
-        /// <param name="dependentEntityType">
-        ///     The entity type that is the dependent in this relationship (the type that has the foreign key
-        ///     properties).
+        /// <param name="dependentEntityTypeName">
+        ///     The name of the entity type that is the dependent in this relationship (the type that has the foreign
+        ///     key properties).
         /// </param>
         /// <param name="foreignKeyPropertyNames">
         ///     The name(s) of the foreign key property(s).
         /// </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public virtual ReferenceReferenceBuilder HasForeignKey(
-            [NotNull] Type dependentEntityType,
+            [NotNull] string dependentEntityTypeName,
             [NotNull] params string[] foreignKeyPropertyNames)
             => new ReferenceReferenceBuilder(
                 HasForeignKeyBuilder(
-                    ResolveEntityType(Check.NotNull(dependentEntityType, nameof(dependentEntityType))),
-                    dependentEntityType.ShortDisplayName(),
+                    ResolveEntityType(Check.NotNull(dependentEntityTypeName, nameof(dependentEntityTypeName))),
+                    dependentEntityTypeName,
                     Check.NotNull(foreignKeyPropertyNames, nameof(foreignKeyPropertyNames))),
                 this,
-                Builder.Metadata.DeclaringEntityType.ClrType != dependentEntityType,
+                Builder.Metadata.DeclaringEntityType.Name != ResolveEntityType(dependentEntityTypeName).Name,
                 foreignKeySet: foreignKeyPropertyNames.Any());
 
         /// <summary>
@@ -121,24 +121,24 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///         added to the principal entity type to serve as the reference key.
         ///     </para>
         /// </summary>
-        /// <param name="dependentEntityTypeName">
-        ///     The name of the entity type that is the dependent in this relationship (the type that has the foreign
-        ///     key properties).
+        /// <param name="dependentEntityType">
+        ///     The entity type that is the dependent in this relationship (the type that has the foreign key
+        ///     properties).
         /// </param>
         /// <param name="foreignKeyPropertyNames">
         ///     The name(s) of the foreign key property(s).
         /// </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
         public virtual ReferenceReferenceBuilder HasForeignKey(
-            [NotNull] string dependentEntityTypeName,
+            [NotNull] Type dependentEntityType,
             [NotNull] params string[] foreignKeyPropertyNames)
             => new ReferenceReferenceBuilder(
                 HasForeignKeyBuilder(
-                    ResolveEntityType(Check.NotNull(dependentEntityTypeName, nameof(dependentEntityTypeName))),
-                    dependentEntityTypeName,
+                    ResolveEntityType(Check.NotNull(dependentEntityType, nameof(dependentEntityType))),
+                    dependentEntityType.ShortDisplayName(),
                     Check.NotNull(foreignKeyPropertyNames, nameof(foreignKeyPropertyNames))),
                 this,
-                Builder.Metadata.DeclaringEntityType.Name != ResolveEntityType(dependentEntityTypeName).Name,
+                Builder.Metadata.DeclaringEntityType.ClrType != dependentEntityType,
                 foreignKeySet: foreignKeyPropertyNames.Any());
 
         /// <summary>
@@ -200,35 +200,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///     match the order that the primary key or unique constraint properties were configured on the principal
         ///     entity type.
         /// </remarks>
-        /// <param name="principalEntityType">
-        ///     The entity type that is the principal in this relationship (the type
-        ///     that has the reference key properties).
-        /// </param>
-        /// <param name="keyPropertyNames"> The name(s) of the reference key property(s). </param>
-        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public virtual ReferenceReferenceBuilder HasPrincipalKey(
-            [NotNull] Type principalEntityType,
-            [NotNull] params string[] keyPropertyNames)
-            => new ReferenceReferenceBuilder(
-                HasPrincipalKeyBuilder(
-                    ResolveEntityType(Check.NotNull(principalEntityType, nameof(principalEntityType))),
-                    principalEntityType.ShortDisplayName(),
-                    Check.NotNull(keyPropertyNames, nameof(keyPropertyNames))),
-                this,
-                inverted: Builder.Metadata.PrincipalEntityType.ClrType != principalEntityType,
-                principalKeySet: keyPropertyNames.Any());
-
-        /// <summary>
-        ///     Configures the unique property(s) that this relationship targets. Typically you would only call this
-        ///     method if you want to use a property(s) other than the primary key as the principal property(s). If
-        ///     the specified property(s) is not already a unique constraint (or the primary key) then a new unique
-        ///     constraint will be introduced.
-        /// </summary>
-        /// <remarks>
-        ///     If multiple principal key properties are specified, the order of principal key properties should
-        ///     match the order that the primary key or unique constraint properties were configured on the principal
-        ///     entity type.
-        /// </remarks>
         /// <param name="principalEntityTypeName">
         ///     The name of the entity type that is the principal in this relationship (the type
         ///     that has the reference key properties).
@@ -245,6 +216,35 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
                     Check.NotNull(keyPropertyNames, nameof(keyPropertyNames))),
                 this,
                 inverted: Builder.Metadata.PrincipalEntityType.Name != ResolveEntityType(principalEntityTypeName).Name,
+                principalKeySet: keyPropertyNames.Any());
+
+        /// <summary>
+        ///     Configures the unique property(s) that this relationship targets. Typically you would only call this
+        ///     method if you want to use a property(s) other than the primary key as the principal property(s). If
+        ///     the specified property(s) is not already a unique constraint (or the primary key) then a new unique
+        ///     constraint will be introduced.
+        /// </summary>
+        /// <remarks>
+        ///     If multiple principal key properties are specified, the order of principal key properties should
+        ///     match the order that the primary key or unique constraint properties were configured on the principal
+        ///     entity type.
+        /// </remarks>
+        /// <param name="principalEntityType">
+        ///     The entity type that is the principal in this relationship (the type
+        ///     that has the reference key properties).
+        /// </param>
+        /// <param name="keyPropertyNames"> The name(s) of the reference key property(s). </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public virtual ReferenceReferenceBuilder HasPrincipalKey(
+            [NotNull] Type principalEntityType,
+            [NotNull] params string[] keyPropertyNames)
+            => new ReferenceReferenceBuilder(
+                HasPrincipalKeyBuilder(
+                    ResolveEntityType(Check.NotNull(principalEntityType, nameof(principalEntityType))),
+                    principalEntityType.ShortDisplayName(),
+                    Check.NotNull(keyPropertyNames, nameof(keyPropertyNames))),
+                this,
+                inverted: Builder.Metadata.PrincipalEntityType.ClrType != principalEntityType,
                 principalKeySet: keyPropertyNames.Any());
 
         /// <summary>

--- a/src/EFCore/Metadata/Builders/ReferenceReferenceBuilder`.cs
+++ b/src/EFCore/Metadata/Builders/ReferenceReferenceBuilder`.cs
@@ -70,6 +70,44 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///         of the entity class.
         ///     </para>
         ///     <para>
+        ///         If <see cref="HasPrincipalKey(string, string[])" /> is not specified, then an attempt will be made to
+        ///         match the data type and order of foreign key properties against the primary key of the principal
+        ///         entity type. If they do not match, new shadow state properties that form a unique index will be
+        ///         added to the principal entity type to serve as the reference key.
+        ///     </para>
+        /// </summary>
+        /// <param name="dependentEntityTypeName">
+        ///     The name of entity type that is the dependent in this relationship (the type that has the foreign key
+        ///     properties).
+        /// </param>
+        /// <param name="foreignKeyPropertyNames">
+        ///     The name(s) of the foreign key property(s).
+        /// </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> HasForeignKey(
+            [NotNull] string dependentEntityTypeName,
+            [NotNull] params string[] foreignKeyPropertyNames)
+            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
+                HasForeignKeyBuilder(
+                    ResolveEntityType(Check.NotNull(dependentEntityTypeName, nameof(dependentEntityTypeName))),
+                    dependentEntityTypeName,
+                    Check.NotNull(foreignKeyPropertyNames, nameof(foreignKeyPropertyNames))),
+                this,
+                inverted: Builder.Metadata.DeclaringEntityType.Name != ResolveEntityType(dependentEntityTypeName).Name,
+                foreignKeySet: foreignKeyPropertyNames.Any());
+
+        /// <summary>
+        ///     <para>
+        ///         Configures the property(s) to use as the foreign key for this relationship.
+        ///     </para>
+        ///     <para>
+        ///         If the specified property name(s) do not exist on the entity type then a new shadow state
+        ///         property(s) will be added to serve as the foreign key. A shadow state property is one
+        ///         that does not have a corresponding property in the entity class. The current value for the
+        ///         property is stored in the <see cref="ChangeTracker" /> rather than being stored in instances
+        ///         of the entity class.
+        ///     </para>
+        ///     <para>
         ///         If <see cref="HasPrincipalKey(Type,string[])" /> is not specified, then an attempt will be made to
         ///         match the data type and order of foreign key properties against the primary key of the principal
         ///         entity type. If they do not match, new shadow state properties that form a unique index will be
@@ -108,10 +146,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///         of the entity class.
         ///     </para>
         ///     <para>
-        ///         If <see cref="HasPrincipalKey(Type, string[])" /> is not specified, then an attempt will be made to
+        ///         If <see cref="HasPrincipalKey{T}(string[])" /> is not specified, then an attempt will be made to
         ///         match the data type and order of foreign key properties against the primary key of the principal
         ///         entity type. If they do not match, new shadow state properties that form a unique index will be
-        ///         added to the principal entity type to serve as the reference key.
+        ///         added to the principal entity type to serve as the referenced key.
         ///     </para>
         /// </summary>
         /// <typeparam name="TDependentEntity">
@@ -128,16 +166,80 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             => HasForeignKey(typeof(TDependentEntity), foreignKeyPropertyNames);
 
         /// <summary>
+        ///     <para>
+        ///         Configures the property(s) to use as the foreign key for this relationship.
+        ///     </para>
+        ///     <para>
+        ///         If the specified property name(s) do not exist on the entity type then a new shadow state
+        ///         property(s) will be added to serve as the foreign key. A shadow state property is one
+        ///         that does not have a corresponding property in the entity class. The current value for the
+        ///         property is stored in the <see cref="ChangeTracker" /> rather than being stored in instances
+        ///         of the entity class.
+        ///     </para>
+        ///     <para>
+        ///         If <see cref="HasPrincipalKey{T}(Expression{Func{T, object}})" /> is not specified, then an attempt
+        ///         will be made to match the data type and order of foreign key properties against the primary key of
+        ///         the principal entity type. If they do not match, new shadow state properties that form a unique
+        ///         index will be added to the principal entity type to serve as the reference key.
+        ///     </para>
+        /// </summary>
+        /// <typeparam name="TDependentEntity">
+        ///     The entity type that is the dependent in this relationship. That is, the type
+        ///     that has the foreign key properties.
+        /// </typeparam>
+        /// <param name="foreignKeyExpression">
+        ///     <para>
+        ///         A lambda expression representing the foreign key property(s) (<c>t => t.Id1</c>).
+        ///     </para>
+        ///     <para>
+        ///         If the foreign key is made up of multiple properties then specify an anonymous type including the
+        ///         properties (<c>t => new { t.Id1, t.Id2 }</c>). The order specified should match the order of
+        ///         corresponding keys in <see cref="HasPrincipalKey{TPrincipalEntity}(Expression{Func{TPrincipalEntity, object}})" />.
+        ///     </para>
+        /// </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> HasForeignKey<TDependentEntity>(
+            [NotNull] Expression<Func<TDependentEntity, object>> foreignKeyExpression)
+            where TDependentEntity : class
+            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
+                HasForeignKeyBuilder(
+                    ResolveEntityType(typeof(TDependentEntity)),
+                    typeof(TDependentEntity).ShortDisplayName(),
+                    Check.NotNull(foreignKeyExpression, nameof(foreignKeyExpression)).GetPropertyAccessList()),
+                this,
+                inverted: Builder.Metadata.DeclaringEntityType.ClrType != typeof(TDependentEntity),
+                foreignKeySet: true);
+
+        /// <summary>
         ///     Configures the unique property(s) that this relationship targets. Typically you would only call this
         ///     method if you want to use a property(s) other than the primary key as the principal property(s). If
         ///     the specified property(s) is not already a unique constraint (or the primary key) then a new unique
         ///     constraint will be introduced.
         /// </summary>
-        /// <remarks>
-        ///     If multiple principal key properties are specified, the order of principal key properties should
-        ///     match the order that the primary key or unique constraint properties were configured on the principal
-        ///     entity type.
-        /// </remarks>
+        /// <param name="principalEntityTypeName">
+        ///     The name of entity type that is the principal in this relationship (the type
+        ///     that has the reference key properties).
+        /// </param>
+        /// <param name="keyPropertyNames"> The name(s) of the reference key property(s). </param>
+        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
+        public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> HasPrincipalKey(
+            [NotNull] string principalEntityTypeName,
+            [NotNull] params string[] keyPropertyNames)
+            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
+                HasPrincipalKeyBuilder(
+                    ResolveEntityType(Check.NotEmpty(principalEntityTypeName, nameof(principalEntityTypeName))),
+                    principalEntityTypeName,
+                    Check.NotNull(keyPropertyNames, nameof(keyPropertyNames))),
+                this,
+                inverted: Builder.Metadata.PrincipalEntityType.Name != principalEntityTypeName,
+                principalKeySet: keyPropertyNames.Any());
+
+        /// <summary>
+        ///     Configures the unique property(s) that this relationship targets. Typically you would only call this
+        ///     method if you want to use a property(s) other than the primary key as the principal property(s). If
+        ///     the specified property(s) is not already a unique constraint (or the primary key) then a new unique
+        ///     constraint will be introduced.
+        /// </summary>
         /// <param name="principalEntityType">
         ///     The entity type that is the principal in this relationship (the type
         ///     that has the reference key properties).
@@ -174,119 +276,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
             => HasPrincipalKey(typeof(TPrincipalEntity), keyPropertyNames);
 
         /// <summary>
-        ///     <para>
-        ///         Configures the property(s) to use as the foreign key for this relationship.
-        ///     </para>
-        ///     <para>
-        ///         If the specified property name(s) do not exist on the entity type then a new shadow state
-        ///         property(s) will be added to serve as the foreign key. A shadow state property is one
-        ///         that does not have a corresponding property in the entity class. The current value for the
-        ///         property is stored in the <see cref="ChangeTracker" /> rather than being stored in instances
-        ///         of the entity class.
-        ///     </para>
-        ///     <para>
-        ///         If <see cref="HasPrincipalKey(string, string[])" /> is not specified, then an attempt will be made to
-        ///         match the data type and order of foreign key properties against the primary key of the principal
-        ///         entity type. If they do not match, new shadow state properties that form a unique index will be
-        ///         added to the principal entity type to serve as the reference key.
-        ///     </para>
-        /// </summary>
-        /// <param name="dependentEntityTypeName">
-        ///     The name of entity type that is the dependent in this relationship (the type that has the foreign key
-        ///     properties).
-        /// </param>
-        /// <param name="foreignKeyPropertyNames">
-        ///     The name(s) of the foreign key property(s).
-        /// </param>
-        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> HasForeignKey(
-            [NotNull] string dependentEntityTypeName,
-            [NotNull] params string[] foreignKeyPropertyNames)
-            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
-                HasForeignKeyBuilder(
-                    ResolveEntityType(Check.NotNull(dependentEntityTypeName, nameof(dependentEntityTypeName))),
-                    dependentEntityTypeName,
-                    Check.NotNull(foreignKeyPropertyNames, nameof(foreignKeyPropertyNames))),
-                this,
-                inverted: Builder.Metadata.DeclaringEntityType.Name != ResolveEntityType(dependentEntityTypeName).Name,
-                foreignKeySet: foreignKeyPropertyNames.Any());
-
-        /// <summary>
-        ///     Configures the unique property(s) that this relationship targets. Typically you would only call this
-        ///     method if you want to use a property(s) other than the primary key as the principal property(s). If
-        ///     the specified property(s) is not already a unique constraint (or the primary key) then a new unique
-        ///     constraint
-        ///     will be introduced.
-        /// </summary>
-        /// <remarks>
-        ///     If multiple principal key properties are specified, the order of principal key properties should
-        ///     match the order that the primary key or unique constraint properties were configured on the principal
-        ///     entity type.
-        /// </remarks>
-        /// <param name="principalEntityTypeName">
-        ///     The name of entity type that is the principal in this relationship (the type
-        ///     that has the reference key properties).
-        /// </param>
-        /// <param name="keyPropertyNames"> The name(s) of the reference key property(s). </param>
-        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public new virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> HasPrincipalKey(
-            [NotNull] string principalEntityTypeName,
-            [NotNull] params string[] keyPropertyNames)
-            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
-                HasPrincipalKeyBuilder(
-                    ResolveEntityType(Check.NotEmpty(principalEntityTypeName, nameof(principalEntityTypeName))),
-                    principalEntityTypeName,
-                    Check.NotNull(keyPropertyNames, nameof(keyPropertyNames))),
-                this,
-                inverted: Builder.Metadata.PrincipalEntityType.Name != principalEntityTypeName,
-                principalKeySet: keyPropertyNames.Any());
-
-        /// <summary>
-        ///     <para>
-        ///         Configures the property(s) to use as the foreign key for this relationship.
-        ///     </para>
-        ///     <para>
-        ///         If the specified property name(s) do not exist on the entity type then a new shadow state
-        ///         property(s) will be added to serve as the foreign key. A shadow state property is one
-        ///         that does not have a corresponding property in the entity class. The current value for the
-        ///         property is stored in the <see cref="ChangeTracker" /> rather than being stored in instances
-        ///         of the entity class.
-        ///     </para>
-        ///     <para>
-        ///         If <see cref="HasPrincipalKey{T}(string[])" /> is not specified, then an attempt will be made to
-        ///         match the data type and order of foreign key properties against the primary key of the principal
-        ///         entity type. If they do not match, new shadow state properties that form a unique index will be
-        ///         added to the principal entity type to serve as the reference key.
-        ///     </para>
-        /// </summary>
-        /// <typeparam name="TDependentEntity">
-        ///     The entity type that is the dependent in this relationship. That is, the type
-        ///     that has the foreign key properties.
-        /// </typeparam>
-        /// <param name="foreignKeyExpression">
-        ///     <para>
-        ///         A lambda expression representing the foreign key property(s) (<c>t => t.Id1</c>).
-        ///     </para>
-        ///     <para>
-        ///         If the foreign key is made up of multiple properties then specify an anonymous type including the
-        ///         properties (<c>t => new { t.Id1, t.Id2 }</c>). The order specified should match the order of
-        ///         corresponding keys in <see cref="HasPrincipalKey(Type,string[])" />.
-        ///     </para>
-        /// </param>
-        /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>
-        public virtual ReferenceReferenceBuilder<TEntity, TRelatedEntity> HasForeignKey<TDependentEntity>(
-            [NotNull] Expression<Func<TDependentEntity, object>> foreignKeyExpression)
-            where TDependentEntity : class
-            => new ReferenceReferenceBuilder<TEntity, TRelatedEntity>(
-                HasForeignKeyBuilder(
-                    ResolveEntityType(typeof(TDependentEntity)),
-                    typeof(TDependentEntity).ShortDisplayName(),
-                    Check.NotNull(foreignKeyExpression, nameof(foreignKeyExpression)).GetPropertyAccessList()),
-                this,
-                inverted: Builder.Metadata.DeclaringEntityType.ClrType != typeof(TDependentEntity),
-                foreignKeySet: true);
-
-        /// <summary>
         ///     Configures the unique property(s) that this relationship targets. Typically you would only call this
         ///     method if you want to use a property(s) other than the primary key as the principal property(s). If
         ///     the specified property(s) is not already a unique constraint (or the primary key) then a new unique
@@ -306,8 +295,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Builders
         ///         A lambda expression representing the reference key property(s) (<c>t => t.Id</c>).
         ///     </para>
         ///     <para>
-        ///         If the principal key is made up of multiple properties then specify an anonymous type including
-        ///         the properties (<c>t => new { t.Id1, t.Id2 }</c>).
+        ///         If the principal key is made up of multiple properties then specify an anonymous type including the
+        ///         properties (<c>t => new { t.Id1, t.Id2 }</c>). The order specified should match the order of
+        ///         corresponding properties in <see cref="HasForeignKey{TDependentEntity}(Expression{Func{TDependentEntity, object}})" />.
         ///     </para>
         /// </param>
         /// <returns> The same builder instance so that multiple configuration calls can be chained. </returns>

--- a/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
@@ -130,9 +130,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             conventionSet.ForeignKeyRemovedConventions.Add(foreignKeyIndexConvention);
 
             conventionSet.ForeignKeyUniquenessChangedConventions.Add(foreignKeyPropertyDiscoveryConvention);
+            conventionSet.ForeignKeyUniquenessChangedConventions.Add(keyDiscoveryConvention);
             conventionSet.ForeignKeyUniquenessChangedConventions.Add(foreignKeyIndexConvention);
 
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(new NavigationEagerLoadingConvention());
+            conventionSet.ForeignKeyOwnershipChangedConventions.Add(keyDiscoveryConvention);
+            conventionSet.ForeignKeyOwnershipChangedConventions.Add(relationshipDiscoveryConvention);
 
             conventionSet.ModelBuiltConventions.Add(new ModelCleanupConvention());
             conventionSet.ModelBuiltConventions.Add(keyAttributeConvention);

--- a/src/EFCore/Metadata/Conventions/Internal/InversePropertyAttributeConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/InversePropertyAttributeConvention.cs
@@ -325,7 +325,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             foreach (var inverseNavigation in inverseNavigations)
             {
-                if (IsAmbiguousInverse(navigation, entityType.ClrType, entityType.Model, inverseNavigation.Value))
+                if (inverseNavigation.Key.GetMemberType().IsAssignableFrom(entityType.ClrType)
+                    && IsAmbiguousInverse(navigation, entityType.ClrType, entityType.Model, inverseNavigation.Value))
                 {
                     return true;
                 }

--- a/src/EFCore/Metadata/Conventions/Internal/KeyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/KeyDiscoveryConvention.cs
@@ -24,7 +24,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         IBaseTypeChangedConvention,
         IPropertyFieldChangedConvention,
         IForeignKeyAddedConvention,
-        IForeignKeyRemovedConvention
+        IForeignKeyRemovedConvention,
+        IForeignKeyUniquenessChangedConvention,
+        IForeignKeyOwnershipChangedConvention
     {
         private const string KeySuffix = "Id";
         private readonly IDiagnosticsLogger<DbLoggerCategory.Model> _logger;
@@ -154,11 +156,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         /// </summary>
         public virtual InternalRelationshipBuilder Apply(InternalRelationshipBuilder relationshipBuilder)
         {
-            var entityType = relationshipBuilder.Metadata.DeclaringEntityType;
-            if (entityType.HasDefiningNavigation())
+            if (relationshipBuilder.Metadata.IsOwnership)
             {
-                Apply(entityType.Builder);
+                Apply(relationshipBuilder.Metadata.DeclaringEntityType.Builder);
             }
+
+            return relationshipBuilder;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        InternalRelationshipBuilder IForeignKeyOwnershipChangedConvention.Apply(InternalRelationshipBuilder relationshipBuilder)
+        {
+            Apply(relationshipBuilder.Metadata.DeclaringEntityType.Builder);
 
             return relationshipBuilder;
         }
@@ -169,7 +181,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         /// </summary>
         public virtual void Apply(InternalEntityTypeBuilder entityTypeBuilder, ForeignKey foreignKey)
         {
-            if (entityTypeBuilder.Metadata.HasDefiningNavigation())
+            if (foreignKey.IsOwnership)
             {
                 Apply(entityTypeBuilder);
             }

--- a/src/EFCore/Metadata/Conventions/Internal/NavigationEagerLoadingConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/NavigationEagerLoadingConvention.cs
@@ -17,7 +17,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         /// </summary>
         public virtual InternalRelationshipBuilder Apply(InternalRelationshipBuilder relationshipBuilder)
         {
-            relationshipBuilder.Metadata.PrincipalToDependent.IsEagerLoaded = relationshipBuilder.Metadata.IsOwnership;
+            if (relationshipBuilder.Metadata.PrincipalToDependent != null)
+            {
+                relationshipBuilder.Metadata.PrincipalToDependent.IsEagerLoaded = relationshipBuilder.Metadata.IsOwnership;
+            }
 
             return relationshipBuilder;
         }

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -2055,24 +2055,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 var type = rawSeed.GetType();
                 foreach (var memberInfo in type.GetMembersInHierarchy())
                 {
-                    ValueConverter valueConverter = null;
-                    if (providerValues)
+                    if (!properties.TryGetValue(memberInfo.Name, out var propertyBase))
                     {
-                        if (!properties.TryGetValue(memberInfo.Name, out var propertyBase))
+                        continue;
+                    }
+
+                    ValueConverter valueConverter = null;
+                    if (providerValues
+                        && !valueConverters.TryGetValue(memberInfo.Name, out valueConverter))
+                    {
+                        if (propertyBase is IProperty property)
                         {
-                            continue;
+                            valueConverter = property.FindMapping()?.Converter
+                                             ?? property.GetValueConverter();
                         }
 
-                        if (!valueConverters.TryGetValue(memberInfo.Name, out valueConverter))
-                        {
-                            if (propertyBase is IProperty property)
-                            {
-                                valueConverter = property.FindMapping()?.Converter
-                                                 ?? property.GetValueConverter();
-                            }
-
-                            valueConverters[memberInfo.Name] = valueConverter;
-                        }
+                        valueConverters[memberInfo.Name] = valueConverter;
                     }
 
                     object value = null;

--- a/src/EFCore/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -924,12 +924,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         newRelationshipBuilder.Metadata.DeclaringEntityType.Builder.HasBaseType((Type)null, configurationSource);
                     }
 
-                    if (newRelationshipBuilder.Metadata.IsUnique)
-                    {
-                        newRelationshipBuilder.Metadata.DeclaringEntityType.Builder.PrimaryKey(
-                            newRelationshipBuilder.Metadata.Properties.Select(p => p.Name).ToList(), ConfigurationSource.Convention);
-                    }
-
                     newRelationshipBuilder.Metadata.DeclaringEntityType.Builder.RemoveNonOwnershipRelationships(configurationSource);
                 }
                 else
@@ -1014,10 +1008,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 return true;
             }
 
-            return !configurationSource.HasValue
-                || !configurationSource.Value.Overrides(Metadata.GetDeleteBehaviorConfigurationSource())
-                ? false
-                : true;
+            return configurationSource.HasValue && configurationSource.Value.Overrides(Metadata.GetDeleteBehaviorConfigurationSource());
         }
 
         /// <summary>
@@ -1054,12 +1045,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 if (builder == null)
                 {
                     return null;
-                }
-
-                if (unique && builder.Metadata.IsOwnership)
-                {
-                    builder.Metadata.DeclaringEntityType.Builder.PrimaryKey(
-                        builder.Metadata.Properties.Select(p => p.Name).ToList(), ConfigurationSource.Convention);
                 }
 
                 return batch.Run(builder);

--- a/test/EFCore.Design.Tests/Migrations/Design/SnapshotModelProcessorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/SnapshotModelProcessorTest.cs
@@ -1,17 +1,18 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
 
+// ReSharper disable ClassNeverInstantiated.Local
+// ReSharper disable UnusedAutoPropertyAccessor.Local
 // ReSharper disable InconsistentNaming
 namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 {
@@ -75,7 +76,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
             new SnapshotModelProcessor(reporter).Process(model);
 
-            Assert.Equal(DesignStrings.MultipleAnnotationConflict("DefaultSchema"), reporter.Messages.Single());
+            Assert.Equal("warn: " + DesignStrings.MultipleAnnotationConflict("DefaultSchema"), reporter.Messages.Single());
             Assert.Equal(2, model.GetAnnotations().Count());
 
             var actual = (string)model["Relational:DefaultSchema"];
@@ -96,7 +97,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
             new SnapshotModelProcessor(reporter).Process(model);
 
-            Assert.Equal(DesignStrings.MultipleAnnotationConflict("DefaultSchema"), reporter.Messages.Single());
+            Assert.Equal("warn: " + DesignStrings.MultipleAnnotationConflict("DefaultSchema"), reporter.Messages.Single());
             Assert.Equal(2, model.GetAnnotations().Count());
 
             var actual = (string)model["Relational:DefaultSchema"];
@@ -142,15 +143,31 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             Assert.Equal("Value", (string)model["Unicorn:DefaultSchema"]);
         }
 
-        private class TestOperationReporter : IOperationReporter
+        [Fact]
+        public void Sets_owned_type_keys()
         {
-            public IList<string> Messages { get; } = new List<string>();
+            var builder = new ModelBuilder(new ConventionSet());
 
-            public void WriteWarning(string message) => Messages.Add(message);
+            var model = builder.Model;
+            ((Model)model).SetProductVersion("2.1.0");
 
-            public void WriteError(string message) => throw new NotImplementedException();
-            public void WriteInformation(string message) => throw new NotImplementedException();
-            public void WriteVerbose(string message) => throw new NotImplementedException();
+            builder.Entity<Blog>(b =>
+            {
+                b.Property(e => e.Id);
+                b.HasKey(e => e.Id);
+
+                b.OwnsOne(e => e.Details, d =>
+                {
+                    d.HasForeignKey(e => e.BlogId);
+                });
+            });
+
+            var reporter = new TestOperationReporter();
+            new SnapshotModelProcessor(reporter).Process(model);
+
+            Assert.Empty(reporter.Messages);
+            Assert.Equal(nameof(BlogDetails.BlogId),
+                model.FindEntityType(typeof(Blog)).FindNavigation(nameof(Blog.Details)).GetTargetType().FindPrimaryKey().Properties.Single().Name);
         }
 
         private void AddAnnotations(IMutableAnnotatable element)
@@ -182,12 +199,20 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             public int Id { get; set; }
 
             public ICollection<Post> Posts { get; set; }
+            public BlogDetails Details { get; set; }
         }
 
         private class Post
         {
             public int BlogId { get; set; }
             public Blog Blog { get; set; }
+        }
+
+        private class BlogDetails
+        {
+            public int BlogId { get; set; }
+
+            public ICollection<Post> Posts { get; set; }
         }
     }
 }

--- a/test/EFCore.Relational.Tests/ModelBuilding/RelationalTestModelBuilderExtensions.cs
+++ b/test/EFCore.Relational.Tests/ModelBuilding/RelationalTestModelBuilderExtensions.cs
@@ -11,14 +11,30 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         public static ModelBuilderTest.TestPropertyBuilder<TProperty> HasColumnName<TProperty>(
             this ModelBuilderTest.TestPropertyBuilder<TProperty> builder, string name)
         {
-            var genericBuilder = (builder as IInfrastructure<PropertyBuilder<TProperty>>)?.Instance;
-            if (genericBuilder != null)
+            switch (builder)
             {
-                genericBuilder.HasColumnName(name);
+                case IInfrastructure<PropertyBuilder<TProperty>> genericBuilder:
+                    genericBuilder.Instance.HasColumnName(name);
+                    break;
+                case IInfrastructure<PropertyBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.HasColumnName(name);
+                    break;
             }
-            else
+
+            return builder;
+        }
+
+        public static ModelBuilderTest.TestPropertyBuilder<TProperty> HasColumnType<TProperty>(
+            this ModelBuilderTest.TestPropertyBuilder<TProperty> builder, string typeName)
+        {
+            switch (builder)
             {
-                (builder as IInfrastructure<PropertyBuilder>).Instance.HasColumnName(name);
+                case IInfrastructure<PropertyBuilder<TProperty>> genericBuilder:
+                    genericBuilder.Instance.HasColumnType(typeName);
+                    break;
+                case IInfrastructure<PropertyBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.HasColumnType(typeName);
+                    break;
             }
 
             return builder;
@@ -27,14 +43,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         public static ModelBuilderTest.TestPropertyBuilder<TProperty> HasDefaultValueSql<TProperty>(
             this ModelBuilderTest.TestPropertyBuilder<TProperty> builder, string sql)
         {
-            var genericBuilder = (builder as IInfrastructure<PropertyBuilder<TProperty>>)?.Instance;
-            if (genericBuilder != null)
+            switch (builder)
             {
-                genericBuilder.HasDefaultValueSql(sql);
-            }
-            else
-            {
-                (builder as IInfrastructure<PropertyBuilder>).Instance.HasDefaultValueSql(sql);
+                case IInfrastructure<PropertyBuilder<TProperty>> genericBuilder:
+                    genericBuilder.Instance.HasDefaultValueSql(sql);
+                    break;
+                case IInfrastructure<PropertyBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.HasDefaultValueSql(sql);
+                    break;
             }
 
             return builder;
@@ -43,14 +59,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         public static ModelBuilderTest.TestPropertyBuilder<TProperty> HasComputedColumnSql<TProperty>(
             this ModelBuilderTest.TestPropertyBuilder<TProperty> builder, string sql)
         {
-            var genericBuilder = (builder as IInfrastructure<PropertyBuilder<TProperty>>)?.Instance;
-            if (genericBuilder != null)
+            switch (builder)
             {
-                genericBuilder.HasComputedColumnSql(sql);
-            }
-            else
-            {
-                (builder as IInfrastructure<PropertyBuilder>).Instance.HasComputedColumnSql(sql);
+                case IInfrastructure<PropertyBuilder<TProperty>> genericBuilder:
+                    genericBuilder.Instance.HasComputedColumnSql(sql);
+                    break;
+                case IInfrastructure<PropertyBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.HasComputedColumnSql(sql);
+                    break;
             }
 
             return builder;
@@ -59,14 +75,30 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         public static ModelBuilderTest.TestPropertyBuilder<TProperty> HasDefaultValue<TProperty>(
             this ModelBuilderTest.TestPropertyBuilder<TProperty> builder, object value)
         {
-            var genericBuilder = (builder as IInfrastructure<PropertyBuilder<TProperty>>)?.Instance;
-            if (genericBuilder != null)
+            switch (builder)
             {
-                genericBuilder.HasDefaultValue(value);
+                case IInfrastructure<PropertyBuilder<TProperty>> genericBuilder:
+                    genericBuilder.Instance.HasDefaultValue(value);
+                    break;
+                case IInfrastructure<PropertyBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.HasDefaultValue(value);
+                    break;
             }
-            else
+
+            return builder;
+        }
+
+        public static ModelBuilderTest.TestPropertyBuilder<TProperty> IsFixedLength<TProperty>(
+            this ModelBuilderTest.TestPropertyBuilder<TProperty> builder, bool fixedLength = true)
+        {
+            switch (builder)
             {
-                (builder as IInfrastructure<PropertyBuilder>).Instance.HasDefaultValue(value);
+                case IInfrastructure<PropertyBuilder<TProperty>> genericBuilder:
+                    genericBuilder.Instance.IsFixedLength(fixedLength);
+                    break;
+                case IInfrastructure<PropertyBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.IsFixedLength(fixedLength);
+                    break;
             }
 
             return builder;
@@ -76,14 +108,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             this ModelBuilderTest.TestEntityTypeBuilder<TEntity> builder, string name)
             where TEntity : class
         {
-            var genericBuilder = (builder as IInfrastructure<EntityTypeBuilder<TEntity>>)?.Instance;
-            if (genericBuilder != null)
+            switch (builder)
             {
-                genericBuilder.ToTable(name);
-            }
-            else
-            {
-                (builder as IInfrastructure<EntityTypeBuilder>).Instance.ToTable(name);
+                case IInfrastructure<EntityTypeBuilder<TEntity>> genericBuilder:
+                    genericBuilder.Instance.ToTable(name);
+                    break;
+                case IInfrastructure<EntityTypeBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.ToTable(name);
+                    break;
             }
 
             return builder;
@@ -93,14 +125,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             this ModelBuilderTest.TestEntityTypeBuilder<TEntity> builder, string name, string schema)
             where TEntity : class
         {
-            var genericBuilder = (builder as IInfrastructure<EntityTypeBuilder<TEntity>>)?.Instance;
-            if (genericBuilder != null)
+            switch (builder)
             {
-                genericBuilder.ToTable(name, schema);
-            }
-            else
-            {
-                (builder as IInfrastructure<EntityTypeBuilder>).Instance.ToTable(name, schema);
+                case IInfrastructure<EntityTypeBuilder<TEntity>> genericBuilder:
+                    genericBuilder.Instance.ToTable(name, schema);
+                    break;
+                case IInfrastructure<EntityTypeBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.ToTable(name, schema);
+                    break;
             }
 
             return builder;
@@ -111,14 +143,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             where TEntity : class
             where TRelatedEntity : class
         {
-            var genericBuilder = (builder as IInfrastructure<ReferenceOwnershipBuilder<TEntity, TRelatedEntity>>)?.Instance;
-            if (genericBuilder != null)
+            switch (builder)
             {
-                genericBuilder.ToTable(name);
-            }
-            else
-            {
-                (builder as IInfrastructure<ReferenceOwnershipBuilder>).Instance.ToTable(name);
+                case IInfrastructure<ReferenceOwnershipBuilder<TEntity, TRelatedEntity>> genericBuilder:
+                    genericBuilder.Instance.ToTable(name);
+                    break;
+                case IInfrastructure<ReferenceOwnershipBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.ToTable(name);
+                    break;
             }
 
             return builder;
@@ -129,14 +161,127 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             where TEntity : class
             where TRelatedEntity : class
         {
-            var genericBuilder = (builder as IInfrastructure<ReferenceOwnershipBuilder<TEntity, TRelatedEntity>>)?.Instance;
-            if (genericBuilder != null)
+            switch (builder)
             {
-                genericBuilder.ToTable(name, schema);
+                case IInfrastructure<ReferenceOwnershipBuilder<TEntity, TRelatedEntity>> genericBuilder:
+                    genericBuilder.Instance.ToTable(name, schema);
+                    break;
+                case IInfrastructure<ReferenceOwnershipBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.ToTable(name, schema);
+                    break;
             }
-            else
+
+            return builder;
+        }
+
+        public static ModelBuilderTest.TestCollectionOwnershipBuilder<TEntity, TDependentEntity> ToTable<TEntity, TDependentEntity>(
+            this ModelBuilderTest.TestCollectionOwnershipBuilder<TEntity, TDependentEntity> builder, string name)
+            where TEntity : class
+            where TDependentEntity : class
+        {
+            switch (builder)
             {
-                (builder as IInfrastructure<ReferenceOwnershipBuilder>).Instance.ToTable(name, schema);
+                case IInfrastructure<CollectionOwnershipBuilder<TEntity, TDependentEntity>> genericBuilder:
+                    genericBuilder.Instance.ToTable(name);
+                    break;
+                case IInfrastructure<CollectionOwnershipBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.ToTable(name);
+                    break;
+            }
+
+            return builder;
+        }
+
+        public static ModelBuilderTest.TestCollectionOwnershipBuilder<TEntity, TDependentEntity> ToTable<TEntity, TDependentEntity>(
+            this ModelBuilderTest.TestCollectionOwnershipBuilder<TEntity, TDependentEntity> builder, string name, string schema)
+            where TEntity : class
+            where TDependentEntity : class
+        {
+            switch (builder)
+            {
+                case IInfrastructure<CollectionOwnershipBuilder<TEntity, TDependentEntity>> genericBuilder:
+                    genericBuilder.Instance.ToTable(name, schema);
+                    break;
+                case IInfrastructure<CollectionOwnershipBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.ToTable(name, schema);
+                    break;
+            }
+
+            return builder;
+        }
+
+        public static ModelBuilderTest.TestReferenceOwnershipBuilder<TEntity, TRelatedEntity> HasConstraintName<TEntity, TRelatedEntity>(
+            this ModelBuilderTest.TestReferenceOwnershipBuilder<TEntity, TRelatedEntity> builder,
+            string name)
+            where TEntity : class
+            where TRelatedEntity : class
+        {
+            switch (builder)
+            {
+                case IInfrastructure<ReferenceOwnershipBuilder<TEntity, TRelatedEntity>> genericBuilder:
+                    genericBuilder.Instance.HasConstraintName(name);
+                    break;
+                case IInfrastructure<ReferenceOwnershipBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.HasConstraintName(name);
+                    break;
+            }
+
+            return builder;
+        }
+
+        public static ModelBuilderTest.TestCollectionOwnershipBuilder<TEntity, TDependentEntity> HasConstraintName<TEntity, TDependentEntity>(
+            this ModelBuilderTest.TestCollectionOwnershipBuilder<TEntity, TDependentEntity> builder,
+            string name)
+            where TEntity : class
+            where TDependentEntity : class
+        {
+            switch (builder)
+            {
+                case IInfrastructure<CollectionOwnershipBuilder<TEntity, TDependentEntity>> genericBuilder:
+                    genericBuilder.Instance.HasConstraintName(name);
+                    break;
+                case IInfrastructure<CollectionOwnershipBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.HasConstraintName(name);
+                    break;
+            }
+
+            return builder;
+        }
+
+
+        public static ModelBuilderTest.TestReferenceReferenceBuilder<TEntity, TRelatedEntity> HasConstraintName<TEntity, TRelatedEntity>(
+            this ModelBuilderTest.TestReferenceReferenceBuilder<TEntity, TRelatedEntity> builder,
+            string name)
+            where TEntity : class
+            where TRelatedEntity : class
+        {
+            switch (builder)
+            {
+                case IInfrastructure<ReferenceReferenceBuilder<TEntity, TRelatedEntity>> genericBuilder:
+                    genericBuilder.Instance.HasConstraintName(name);
+                    break;
+                case IInfrastructure<ReferenceReferenceBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.HasConstraintName(name);
+                    break;
+            }
+
+            return builder;
+        }
+
+        public static ModelBuilderTest.TestReferenceCollectionBuilder<TEntity, TRelatedEntity> HasConstraintName<TEntity, TRelatedEntity>(
+            this ModelBuilderTest.TestReferenceCollectionBuilder<TEntity, TRelatedEntity> builder,
+            string name)
+            where TEntity : class
+            where TRelatedEntity : class
+        {
+            switch (builder)
+            {
+                case IInfrastructure<ReferenceCollectionBuilder<TEntity, TRelatedEntity>> genericBuilder:
+                    genericBuilder.Instance.HasConstraintName(name);
+                    break;
+                case IInfrastructure<ReferenceCollectionBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.HasConstraintName(name);
+                    break;
             }
 
             return builder;
@@ -147,6 +292,22 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         {
             var indexBuilder = builder.GetInfrastructure();
             indexBuilder.HasFilter(filterExpression);
+            return builder;
+        }
+
+        public static ModelBuilderTest.TestIndexBuilder HasName(
+            this ModelBuilderTest.TestIndexBuilder builder, string name)
+        {
+            var indexBuilder = builder.GetInfrastructure();
+            indexBuilder.HasName(name);
+            return builder;
+        }
+
+        public static ModelBuilderTest.TestKeyBuilder HasName(
+            this ModelBuilderTest.TestKeyBuilder builder, string name)
+        {
+            var keyBuilder = builder.GetInfrastructure();
+            keyBuilder.HasName(name);
             return builder;
         }
     }

--- a/test/EFCore.SqlServer.Tests/ModelBuilding/SqlServerModelBuilderGenericTest.cs
+++ b/test/EFCore.SqlServer.Tests/ModelBuilding/SqlServerModelBuilderGenericTest.cs
@@ -251,7 +251,9 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                         bb.OwnsOne(
                             b => b.AlternateLabel, tb =>
                             {
+                                tb.HasConstraintName("AlternateLabelFK");
                                 tb.ToTable("TT", "TS");
+                                tb.ForSqlServerIsMemoryOptimized();
                                 tb.OwnsOne(
                                     l => l.AnotherBookLabel, ab =>
                                     {
@@ -303,12 +305,16 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var bookLabel2Ownership11 = bookLabel2Ownership1.DeclaringEntityType.FindNavigation(nameof(BookLabel.SpecialBookLabel)).ForeignKey;
                 var bookLabel2Ownership21 = bookLabel2Ownership2.DeclaringEntityType.FindNavigation(nameof(BookLabel.AnotherBookLabel)).ForeignKey;
 
+                Assert.Equal("AlternateLabelFK", bookOwnership2.Relational().Name);
+
                 Assert.Equal("BS", book.SqlServer().Schema);
                 Assert.Equal("BT", book.SqlServer().TableName);
                 Assert.Equal("LS", bookOwnership1.DeclaringEntityType.SqlServer().Schema);
                 Assert.Equal("LT", bookOwnership1.DeclaringEntityType.SqlServer().TableName);
+                Assert.False(bookOwnership1.DeclaringEntityType.SqlServer().IsMemoryOptimized);
                 Assert.Equal("TS", bookOwnership2.DeclaringEntityType.SqlServer().Schema);
                 Assert.Equal("TT", bookOwnership2.DeclaringEntityType.SqlServer().TableName);
+                Assert.True(bookOwnership2.DeclaringEntityType.SqlServer().IsMemoryOptimized);
                 Assert.Equal("AS2", bookLabel1Ownership1.DeclaringEntityType.SqlServer().Schema);
                 Assert.Equal("AT2", bookLabel1Ownership1.DeclaringEntityType.SqlServer().TableName);
                 Assert.Equal("SS1", bookLabel1Ownership2.DeclaringEntityType.SqlServer().Schema);
@@ -346,6 +352,60 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Equal(2, model.GetEntityTypes().Count(e => e.ClrType == typeof(BookLabel)));
                 Assert.Equal(4, model.GetEntityTypes().Count(e => e.ClrType == typeof(AnotherBookLabel)));
                 Assert.Equal(4, model.GetEntityTypes().Count(e => e.ClrType == typeof(SpecialBookLabel)));
+            }
+
+            [Fact]
+            public virtual void Owned_type_collections_can_be_mapped_to_different_tables()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<Customer>().OwnsMany(
+                    c => c.Orders,
+                    r =>
+                    {
+                        r.ForSqlServerIsMemoryOptimized();
+                        r.Ignore(o => o.OrderCombination);
+                        r.Ignore(o => o.Details);
+                    });
+
+                modelBuilder.Validate();
+
+                var ownership = model.FindEntityType(typeof(Customer)).FindNavigation(nameof(Customer.Orders)).ForeignKey;
+                var owned = ownership.DeclaringEntityType;
+                Assert.True(ownership.IsOwnership);
+                Assert.Equal(nameof(Order.Customer), ownership.DependentToPrincipal.Name);
+                Assert.Equal("FK_Order_Customer_CustomerId", ownership.Relational().Name);
+
+                Assert.Equal(1, owned.GetForeignKeys().Count());
+                Assert.Equal(1, owned.GetIndexes().Count());
+                Assert.Equal(new[] { nameof(Order.OrderId), nameof(Order.AnotherCustomerId), nameof(Order.CustomerId) },
+                    owned.GetProperties().Select(p => p.SqlServer().ColumnName));
+                Assert.Equal(nameof(Order), owned.SqlServer().TableName);
+                Assert.Null(owned.SqlServer().Schema);
+                Assert.True(owned.SqlServer().IsMemoryOptimized);
+
+                modelBuilder.Entity<Customer>().OwnsMany(
+                    c => c.Orders,
+                    r =>
+                    {
+                        r.HasConstraintName("Owned");
+                        r.ToTable("bar", "foo");
+                    });
+
+                Assert.Equal("bar", owned.SqlServer().TableName);
+                Assert.Equal("foo", owned.SqlServer().Schema);
+                Assert.Equal("Owned", ownership.Relational().Name);
+
+                modelBuilder.Entity<Customer>().OwnsMany(
+                    c => c.Orders,
+                    r =>
+                    {
+                        r.ToTable("blah");
+                    });
+
+                Assert.Equal("blah", owned.SqlServer().TableName);
+                Assert.Equal("foo", owned.SqlServer().Schema);
             }
 
             protected override TestModelBuilder CreateModelBuilder()

--- a/test/EFCore.SqlServer.Tests/ModelBuilding/SqlServerTestModelBuilderExtensions.cs
+++ b/test/EFCore.SqlServer.Tests/ModelBuilding/SqlServerTestModelBuilderExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Microsoft.EntityFrameworkCore.ModelBuilding
 {
@@ -12,6 +13,42 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         {
             var indexBuilder = builder.GetInfrastructure();
             indexBuilder.ForSqlServerIsClustered(clustered);
+            return builder;
+        }
+
+        public static ModelBuilderTest.TestReferenceOwnershipBuilder<TEntity, TRelatedEntity> ForSqlServerIsMemoryOptimized<TEntity, TRelatedEntity>(
+            this ModelBuilderTest.TestReferenceOwnershipBuilder<TEntity, TRelatedEntity> builder, bool memoryOptimized = true)
+            where TEntity : class
+            where TRelatedEntity : class
+        {
+            switch (builder)
+            {
+                case IInfrastructure<ReferenceOwnershipBuilder<TEntity, TRelatedEntity>> genericBuilder:
+                    genericBuilder.Instance.ForSqlServerIsMemoryOptimized(memoryOptimized);
+                    break;
+                case IInfrastructure<ReferenceOwnershipBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.ForSqlServerIsMemoryOptimized(memoryOptimized);
+                    break;
+            }
+
+            return builder;
+        }
+
+        public static ModelBuilderTest.TestCollectionOwnershipBuilder<TEntity, TDependentEntity> ForSqlServerIsMemoryOptimized<TEntity, TDependentEntity>(
+            this ModelBuilderTest.TestCollectionOwnershipBuilder<TEntity, TDependentEntity> builder, bool memoryOptimized = true)
+            where TEntity : class
+            where TDependentEntity : class
+        {
+            switch (builder)
+            {
+                case IInfrastructure<CollectionOwnershipBuilder<TEntity, TDependentEntity>> genericBuilder:
+                    genericBuilder.Instance.ForSqlServerIsMemoryOptimized(memoryOptimized);
+                    break;
+                case IInfrastructure<CollectionOwnershipBuilder> nongenericBuilder:
+                    nongenericBuilder.Instance.ForSqlServerIsMemoryOptimized(memoryOptimized);
+                    break;
+            }
+
             return builder;
         }
     }

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalEntityEntryTestBase.cs
@@ -1591,7 +1591,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 {
                     eb.HasKey(e => e.Id);
                     var owned = eb.OwnsOne(e => e.Owned).HasForeignKey("Id");
-                    owned.OwnedEntityType.SetPrimaryKey(new[] { owned.OwnedEntityType.FindProperty("Id") });
+                    owned.HasKey("Id");
                     owned.Property(e => e.Value);
                 });
 

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalMixedEntityEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalMixedEntityEntryTest.cs
@@ -185,7 +185,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 {
                     eb.HasKey(e => e.Id);
                     var owned = eb.OwnsOne(e => e.Owned).HasForeignKey("Id");
-                    owned.OwnedEntityType.SetPrimaryKey(new[] { owned.OwnedEntityType.FindProperty("Id") });
+                    owned.HasKey("Id");
                     owned.Property(e => e.Value);
                 });
 

--- a/test/EFCore.Tests/ChangeTracking/Internal/InternalShadowEntityEntryTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/InternalShadowEntityEntryTest.cs
@@ -83,7 +83,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     eb.Property<int>(nameof(OwnerClass.Id));
                     eb.HasKey(nameof(OwnerClass.Id));
                     var owned = eb.OwnsOne(typeof(OwnedClass).FullName, nameof(OwnerClass.Owned)).HasForeignKey("Id");
-                    owned.OwnedEntityType.SetPrimaryKey(new[] { owned.OwnedEntityType.FindProperty("Id") });
+                    owned.HasKey("Id");
                     owned.Property<string>(nameof(OwnedClass.Value));
                 });
 

--- a/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
@@ -642,6 +642,8 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Equal(-1, entityType.FindProperty("Strange").GetOriginalValueIndex());
                 Assert.Equal(2, entityType.FindProperty("Top").GetOriginalValueIndex());
                 Assert.Equal(-1, entityType.FindProperty("Bottom").GetOriginalValueIndex());
+
+                Assert.Equal(ChangeTrackingStrategy.ChangingAndChangedNotifications, entityType.GetChangeTrackingStrategy());
             }
 
             [Fact]

--- a/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Xunit;
@@ -17,29 +16,39 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         public abstract class OwnedTypesTestBase : ModelBuilderTestBase
         {
             [Fact]
-            public virtual void Can_declare_owned_type()
+            public virtual void Can_configure_owned_type()
             {
                 var modelBuilder = CreateModelBuilder();
                 var model = modelBuilder.Model;
 
-                var entityBuilder = modelBuilder.Entity<Customer>().OwnsOne(c => c.Details);
+                var entityBuilder = modelBuilder.Entity<Customer>().OwnsOne(c => c.Details)
+                    .OnDelete(DeleteBehavior.SetNull)
+                    .HasPrincipalKey(c => c.AlternateKey);
                 entityBuilder.Property(d => d.CustomerId);
+                entityBuilder.HasIndex(d => d.CustomerId);
 
                 modelBuilder.Validate();
 
                 var owner = model.FindEntityType(typeof(Customer));
+                Assert.Equal(typeof(Customer).FullName, owner.Name);
                 var ownership = owner.FindNavigation(nameof(Customer.Details)).ForeignKey;
                 Assert.True(ownership.IsOwnership);
-                Assert.Equal(typeof(Customer).FullName, owner.Name);
-                Assert.Same(entityBuilder.OwnedEntityType, ownership.DeclaringEntityType);
+                Assert.Equal(DeleteBehavior.SetNull, ownership.DeleteBehavior);
                 Assert.Equal(nameof(Customer.Details), ownership.PrincipalToDependent.Name);
+                Assert.Equal("CustomerAlternateKey", ownership.Properties.Single().Name);
+                Assert.Equal(nameof(Customer.AlternateKey), ownership.PrincipalKey.Properties.Single().Name);
+                var owned = ownership.DeclaringEntityType;
+                Assert.Same(entityBuilder.OwnedEntityType, owned);
+                Assert.Equal(1, owned.GetForeignKeys().Count());
+                Assert.Equal(nameof(CustomerDetails.CustomerId), owned.GetIndexes().Single().Properties.Single().Name);
+                Assert.Equal(new[] { "CustomerAlternateKey", nameof(CustomerDetails.CustomerId), nameof(CustomerDetails.Id) },
+                    owned.GetProperties().Select(p => p.Name));
                 Assert.NotNull(model.FindEntityType(typeof(CustomerDetails)));
                 Assert.Equal(1, model.GetEntityTypes().Count(e => e.ClrType == typeof(CustomerDetails)));
-                Assert.Equal(1, ownership.DeclaringEntityType.GetForeignKeys().Count());
             }
 
             [Fact]
-            public virtual void Can_use_nested_closure()
+            public virtual void Can_configure_owned_type_using_nested_closure()
             {
                 var modelBuilder = CreateModelBuilder();
                 var model = modelBuilder.Model;
@@ -50,13 +59,14 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                         .HasForeignKeyAnnotation("bar", "foo"));
 
                 var ownership = model.FindEntityType(typeof(Customer)).FindNavigation(nameof(Customer.Details)).ForeignKey;
+                var owned = ownership.DeclaringEntityType;
                 Assert.True(ownership.IsOwnership);
-                Assert.Equal("bar", ownership.DeclaringEntityType.FindAnnotation("foo").Value);
-                Assert.Equal(1, ownership.DeclaringEntityType.GetForeignKeys().Count());
+                Assert.Equal("bar", owned.FindAnnotation("foo").Value);
+                Assert.Equal(1, owned.GetForeignKeys().Count());
             }
 
             [Fact]
-            public virtual void Can_configure_inverse()
+            public virtual void Can_configure_owned_type_inverse()
             {
                 var modelBuilder = CreateModelBuilder();
                 var model = modelBuilder.Model;
@@ -89,31 +99,37 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 var model = modelBuilder.Model;
 
                 modelBuilder.Entity<Customer>().OwnsOne(c => c.Details)
+                    .UsePropertyAccessMode(PropertyAccessMode.FieldDuringConstruction)
+                    .HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangedNotifications)
                     .Ignore(d => d.Id)
                     .Property<int>("foo");
 
                 modelBuilder.Validate();
 
                 var owner = model.FindEntityType(typeof(Customer));
-                var ownee = owner.FindNavigation(nameof(Customer.Details)).ForeignKey.DeclaringEntityType;
+                var owned = owner.FindNavigation(nameof(Customer.Details)).ForeignKey.DeclaringEntityType;
                 Assert.Null(owner.FindProperty("foo"));
-                Assert.Equal(new[] { nameof(CustomerDetails.CustomerId), "foo" }, ownee.GetProperties().Select(p => p.Name).ToArray());
+                Assert.Equal(new[] { nameof(CustomerDetails.CustomerId), "foo" }, owned.GetProperties().Select(p => p.Name).ToArray());
+                Assert.Equal(PropertyAccessMode.FieldDuringConstruction, owned.GetPropertyAccessMode());
+                Assert.Equal(ChangeTrackingStrategy.ChangedNotifications, owned.GetChangeTrackingStrategy());
             }
 
             [Fact]
-            public virtual void Can_configure_single_owned_type_using_attribute()
+            public virtual void Can_configure_owned_type_key()
             {
                 var modelBuilder = CreateModelBuilder();
                 var model = modelBuilder.Model;
 
-                modelBuilder.Entity<SpecialOrder>();
+                modelBuilder.Entity<Customer>().OwnsOne(c => c.Details)
+                    .HasKey(c => c.Id);
 
                 modelBuilder.Validate();
 
-                var owner = model.FindEntityType(typeof(SpecialOrder));
-                var ownership = owner.FindNavigation(nameof(SpecialOrder.ShippingAddress)).ForeignKey;
-                Assert.True(ownership.IsOwnership);
-                Assert.NotNull(ownership.DeclaringEntityType.FindProperty(nameof(StreetAddress.Street)));
+                var owner = model.FindEntityType(typeof(Customer));
+                var owned = owner.FindNavigation(nameof(Customer.Details)).ForeignKey.DeclaringEntityType;
+                Assert.Equal(new[] { nameof(CustomerDetails.Id), nameof(CustomerDetails.CustomerId) },
+                    owned.GetProperties().Select(p => p.Name).ToArray());
+                Assert.Equal(nameof(CustomerDetails.Id), owned.FindPrimaryKey().Properties.Single().Name);
             }
 
             [Fact]
@@ -179,13 +195,297 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 var ownership = model.FindEntityType(typeof(OtherCustomer)).FindNavigation(nameof(Customer.Details)).ForeignKey;
                 var foreignKey = model.FindEntityType(typeof(SpecialCustomer)).GetReferencingForeignKeys()
-                    .Single(
-                        fk => fk.DeclaringEntityType.ClrType == typeof(CustomerDetails)
-                              && fk.PrincipalToDependent == null);
+                    .Single(fk => fk.DeclaringEntityType.ClrType == typeof(CustomerDetails)
+                                  && fk.PrincipalToDependent == null);
                 Assert.Same(ownership.DeclaringEntityType, foreignKey.DeclaringEntityType);
                 Assert.NotEqual(ownership.Properties.Single().Name, foreignKey.Properties.Single().Name);
                 Assert.Equal(2, model.GetEntityTypes().Count(e => e.ClrType == typeof(CustomerDetails)));
                 Assert.Equal(2, ownership.DeclaringEntityType.GetForeignKeys().Count());
+            }
+
+            [Fact]
+            public virtual void Can_configure_owned_type_collection_from_an_owned_type()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Ignore<OrderDetails>();
+                var entityBuilder = modelBuilder.Entity<CustomerDetails>().OwnsOne(o => o.Customer)
+                    .OwnsMany(c => c.Orders);
+
+                modelBuilder.Validate();
+
+                var ownership = model.FindEntityType(typeof(CustomerDetails)).FindNavigation(nameof(CustomerDetails.Customer)).ForeignKey;
+                var owned = ownership.DeclaringEntityType;
+                Assert.True(ownership.IsOwnership);
+                Assert.True(ownership.IsUnique);
+                Assert.Equal(nameof(Customer.Details), ownership.DependentToPrincipal.Name);
+                Assert.Equal(nameof(Customer.Id), ownership.Properties.Single().Name);
+                Assert.Equal(nameof(Customer.Id), owned.FindPrimaryKey().Properties.Single().Name);
+                Assert.Empty(owned.GetIndexes());
+                var chainedOwnership = owned.FindNavigation(nameof(Customer.Orders)).ForeignKey;
+                var chainedOwned = chainedOwnership.DeclaringEntityType;
+                Assert.True(chainedOwnership.IsOwnership);
+                Assert.False(chainedOwnership.IsUnique);
+                Assert.Equal(nameof(Order.Customer), chainedOwnership.DependentToPrincipal.Name);
+                Assert.Equal(nameof(Order.CustomerId), chainedOwnership.Properties.Single().Name);
+                Assert.Equal(nameof(Order.OrderId), chainedOwned.FindPrimaryKey().Properties.Single().Name);
+                Assert.Equal(1, chainedOwned.GetForeignKeys().Count());
+                Assert.Equal(nameof(Order.CustomerId), chainedOwned.GetIndexes().Single().Properties.Single().Name);
+                Assert.Same(entityBuilder.OwnedEntityType, chainedOwned);
+
+                Assert.Equal(3, model.GetEntityTypes().Count());
+            }
+
+            [Fact]
+            public virtual void Can_configure_owned_type_collection()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                var entityBuilder = modelBuilder.Entity<Customer>().OwnsMany(c => c.Orders)
+                    .UsePropertyAccessMode(PropertyAccessMode.FieldDuringConstruction)
+                    .HasChangeTrackingStrategy(ChangeTrackingStrategy.ChangedNotifications)
+                    .Ignore(nameof(Order.OrderId))
+                    .Ignore(o => o.OrderCombination)
+                    .Ignore(o => o.Details)
+                    .OnDelete(DeleteBehavior.SetNull);
+                entityBuilder.Property<int>("foo");
+                entityBuilder.HasIndex("foo");
+                entityBuilder.HasKey(o => o.AnotherCustomerId);
+                entityBuilder.HasPrincipalKey(c => c.AlternateKey);
+
+                modelBuilder.Validate();
+
+                var owner = model.FindEntityType(typeof(Customer));
+                var ownership = owner.FindNavigation(nameof(Customer.Orders)).ForeignKey;
+                var owned = ownership.DeclaringEntityType;
+                Assert.Same(entityBuilder.OwnedEntityType, owned);
+                Assert.True(ownership.IsOwnership);
+                Assert.Equal(DeleteBehavior.SetNull, ownership.DeleteBehavior);
+                Assert.Equal("CustomerAlternateKey", ownership.Properties.Single().Name);
+                Assert.Equal(nameof(Customer.AlternateKey), ownership.PrincipalKey.Properties.Single().Name);
+                Assert.Equal(nameof(Order.Customer), ownership.DependentToPrincipal.Name);
+
+                Assert.Null(owner.FindProperty("foo"));
+                Assert.Equal(nameof(Order.AnotherCustomerId), owned.FindPrimaryKey().Properties.Single().Name);
+                Assert.Equal(2, owned.GetIndexes().Count());
+                Assert.Equal("CustomerAlternateKey", owned.GetIndexes().First().Properties.Single().Name);
+                Assert.Equal("foo", owned.GetIndexes().Last().Properties.Single().Name);
+                Assert.Equal(new[] { nameof(Order.AnotherCustomerId), "CustomerAlternateKey", nameof(Order.CustomerId), "foo" },
+                    owned.GetProperties().Select(p => p.Name).ToArray());
+                Assert.Equal(PropertyAccessMode.FieldDuringConstruction, owned.GetPropertyAccessMode());
+                Assert.Equal(ChangeTrackingStrategy.ChangedNotifications, owned.GetChangeTrackingStrategy());
+
+                Assert.NotNull(model.FindEntityType(typeof(Order)));
+                Assert.Equal(1, model.GetEntityTypes().Count(e => e.ClrType == typeof(Order)));
+                Assert.Equal(1, owned.GetForeignKeys().Count());
+                Assert.Equal(1, owned.GetNavigations().Count());
+            }
+
+            [Fact]
+            public virtual void Can_configure_owned_type_collection_using_nested_closure()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<Customer>().OwnsMany(
+                    c => c.Orders,
+                    r =>
+                    {
+                        r.HasEntityTypeAnnotation("foo", "bar")
+                            .HasForeignKeyAnnotation("bar", "foo");
+                        r.Property<uint>("Id");
+                        r.HasKey("Id");
+                        r.HasForeignKey("DifferentCustomerId");
+                        r.HasIndex(o => o.AnotherCustomerId);
+                        r.Property(o => o.AnotherCustomerId).IsRequired();
+                        r.HasOne(o => o.Customer).WithMany(c => c.Orders);
+                        r.Ignore(o => o.OrderCombination);
+                        r.Ignore(o => o.Details);
+                    });
+
+                modelBuilder.Validate();
+
+                var ownership = model.FindEntityType(typeof(Customer)).FindNavigation(nameof(Customer.Orders)).ForeignKey;
+                var owned = ownership.DeclaringEntityType;
+                Assert.True(ownership.IsOwnership);
+                Assert.Equal("DifferentCustomerId", ownership.Properties.Single().Name);
+                Assert.Equal("bar", owned.FindAnnotation("foo").Value);
+                Assert.Equal(1, owned.GetForeignKeys().Count());
+                Assert.Equal("Id", owned.FindPrimaryKey().Properties.Single().Name);
+                Assert.Equal(2, owned.GetIndexes().Count());
+                Assert.Equal(nameof(Order.AnotherCustomerId), owned.GetIndexes().First().Properties.Single().Name);
+                Assert.Equal("DifferentCustomerId", owned.GetIndexes().Last().Properties.Single().Name);
+                Assert.False(owned.FindProperty(nameof(Order.AnotherCustomerId)).IsNullable);
+                Assert.Equal(nameof(Order.Customer), ownership.DependentToPrincipal.Name);
+            }
+
+            [Fact]
+            public virtual void Can_configure_one_to_one_relationship_from_an_owned_type_collection()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Ignore<Customer>();
+                modelBuilder.Ignore<OrderDetails>();
+                modelBuilder.Entity<OtherCustomer>().OwnsMany(c => c.Orders)
+                    .HasOne<SpecialCustomer>()
+                    .WithOne()
+                    .HasPrincipalKey<SpecialCustomer>();
+
+                Assert.NotNull(model.FindEntityType(typeof(Order)));
+
+                modelBuilder.Entity<SpecialCustomer>().OwnsMany(c => c.Orders);
+
+                modelBuilder.Validate();
+
+                Assert.Null(model.FindEntityType(typeof(Order)));
+                var ownership1 = model.FindEntityType(typeof(OtherCustomer)).FindNavigation(nameof(Customer.Orders)).ForeignKey;
+                var ownership2 = model.FindEntityType(typeof(SpecialCustomer)).FindNavigation(nameof(Customer.Orders)).ForeignKey;
+                Assert.Equal(typeof(Order), ownership1.DeclaringEntityType.ClrType);
+                Assert.Equal(typeof(Order), ownership2.DeclaringEntityType.ClrType);
+                Assert.NotSame(ownership1.DeclaringEntityType, ownership2.DeclaringEntityType);
+                Assert.Equal("OtherCustomerId", ownership1.Properties.Single().Name);
+                Assert.Equal("SpecialCustomerId", ownership2.Properties.Single().Name);
+
+                var foreignKey = model.FindEntityType(typeof(SpecialCustomer)).GetReferencingForeignKeys()
+                    .Single(fk => fk.DeclaringEntityType.ClrType == typeof(Order)
+                                  && fk.PrincipalToDependent == null);
+                Assert.Same(ownership1.DeclaringEntityType, foreignKey.DeclaringEntityType);
+                Assert.Null(foreignKey.PrincipalToDependent);
+                Assert.NotEqual(ownership1.Properties.Single().Name, foreignKey.Properties.Single().Name);
+                Assert.Equal(5, model.GetEntityTypes().Count());
+                Assert.Equal(2, model.GetEntityTypes(typeof(Order)).Count);
+                Assert.Equal(2, ownership1.DeclaringEntityType.GetForeignKeys().Count());
+
+                Assert.Equal(2, model.GetEntityTypes().Count(e => e.ClrType == typeof(Order)));
+                Assert.Equal(2, ownership1.DeclaringEntityType.GetForeignKeys().Count());
+                Assert.Equal(1, ownership2.DeclaringEntityType.GetForeignKeys().Count());
+                Assert.Null(model.FindEntityType(typeof(SpecialOrder)));
+            }
+
+            [Fact]
+            public virtual void Can_configure_owned_type_from_an_owned_type_collection()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Ignore<OrderDetails>();
+                var entityBuilder = modelBuilder.Entity<Customer>().OwnsMany(c => c.Orders)
+                    .OwnsOne(o => o.Details);
+                entityBuilder.HasData(new OrderDetails
+                {
+                    OrderId = -1
+                });
+
+                modelBuilder.Validate();
+
+                var ownership = model.FindEntityType(typeof(Customer)).FindNavigation(nameof(Customer.Orders)).ForeignKey;
+                var owned = ownership.DeclaringEntityType;
+                Assert.Equal(nameof(Order.CustomerId), ownership.Properties.Single().Name);
+                Assert.Equal(1, ownership.DeclaringEntityType.GetForeignKeys().Count());
+                var chainedOwnership = owned.FindNavigation(nameof(Order.Details)).ForeignKey;
+                var chainedOwned = chainedOwnership.DeclaringEntityType;
+                Assert.Same(entityBuilder.OwnedEntityType, chainedOwned);
+                Assert.True(chainedOwnership.IsOwnership);
+                Assert.True(chainedOwnership.IsUnique);
+                Assert.Equal(nameof(OrderDetails.OrderId), chainedOwned.FindPrimaryKey().Properties.Single().Name);
+                Assert.Empty(chainedOwned.GetIndexes());
+                Assert.Equal(-1, chainedOwned.GetData().Single()[nameof(OrderDetails.OrderId)]);
+                Assert.Equal(nameof(OrderDetails.OrderId), chainedOwnership.Properties.Single().Name);
+                Assert.Equal(nameof(OrderDetails.Order), chainedOwnership.DependentToPrincipal.Name);
+
+                Assert.Equal(4, model.GetEntityTypes().Count());
+            }
+
+            [Fact]
+            public virtual void Can_chain_owned_type_collection_configurations()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Ignore<OrderDetails>();
+                modelBuilder.Entity<Customer>().OwnsMany(c => c.Orders, ob =>
+                {
+                    ob.HasData(new Order
+                    {
+                        OrderId = -2,
+                        CustomerId = -1
+                    });
+                    ob.OwnsMany(o => o.Products);
+                });
+
+                modelBuilder.Validate();
+
+                var ownership = model.FindEntityType(typeof(Customer)).FindNavigation(nameof(Customer.Orders)).ForeignKey;
+                var owned = ownership.DeclaringEntityType;
+                Assert.Equal(1, ownership.DeclaringEntityType.GetForeignKeys().Count());
+                var seedData = owned.GetData().Single();
+                Assert.Equal(-2, seedData[nameof(Order.OrderId)]);
+                Assert.Equal(-1, seedData[nameof(Order.CustomerId)]);
+                var chainedOwnership = owned.FindNavigation(nameof(Order.Products)).ForeignKey;
+                var chainedOwned = chainedOwnership.DeclaringEntityType;
+                Assert.True(chainedOwnership.IsOwnership);
+                Assert.False(chainedOwnership.IsUnique);
+                Assert.Equal("OrderId", chainedOwnership.Properties.Single().Name);
+                Assert.Equal(nameof(Product.Id), chainedOwned.FindPrimaryKey().Properties.Single().Name);
+                Assert.Equal("OrderId",
+                    chainedOwned.GetIndexes().Single().Properties.Single().Name);
+                Assert.Equal(nameof(Product.Order), chainedOwnership.DependentToPrincipal.Name);
+
+                Assert.Equal(4, model.GetEntityTypes().Count());
+            }
+
+            [Fact]
+            public virtual void Can_configure_owned_type_collection_with_one_call()
+            {
+                var modelBuilder = CreateModelBuilder();
+
+                modelBuilder.Owned<Order>();
+                modelBuilder.Owned<SpecialOrder>();
+                modelBuilder.Ignore<SpecialOrder>();
+                var specialCustomer = modelBuilder.Entity<SpecialCustomer>().Metadata;
+
+                modelBuilder.Validate();
+
+                var model = (Model)modelBuilder.Model;
+                var customer = model.FindEntityType(typeof(Customer));
+
+                var ownership = customer.FindNavigation(nameof(Customer.Orders)).ForeignKey;
+                Assert.True(ownership.IsOwnership);
+                Assert.False(ownership.IsUnique);
+                Assert.Equal(nameof(Order.OrderId), ownership.DeclaringEntityType.FindPrimaryKey().Properties.Single().Name);
+                var specialOwnership = specialCustomer.FindNavigation(nameof(SpecialCustomer.SpecialOrders)).ForeignKey;
+                Assert.True(specialOwnership.IsOwnership);
+                Assert.False(specialOwnership.IsUnique);
+                Assert.Equal(nameof(SpecialOrder.SpecialOrderId), specialOwnership.DeclaringEntityType.FindPrimaryKey().Properties.Single().Name);
+
+                Assert.Equal(9, modelBuilder.Model.GetEntityTypes().Count());
+                Assert.Equal(2, modelBuilder.Model.GetEntityTypes(typeof(Order)).Count);
+                Assert.Equal(7, modelBuilder.Model.GetEntityTypes().Count(e => !e.HasDefiningNavigation()));
+                Assert.Equal(5, modelBuilder.Model.GetEntityTypes().Count(e => e.IsOwned()));
+
+                Assert.Null(model.FindIgnoredTypeConfigurationSource(typeof(Order)));
+                Assert.Null(model.FindIgnoredTypeConfigurationSource(typeof(SpecialOrder)));
+                Assert.Null(model.FindIgnoredTypeConfigurationSource(typeof(Customer)));
+                Assert.Null(model.FindIgnoredTypeConfigurationSource(typeof(SpecialCustomer)));
+            }
+
+            [Fact]
+            public virtual void Can_configure_single_owned_type_using_attribute()
+            {
+                var modelBuilder = CreateModelBuilder();
+                var model = modelBuilder.Model;
+
+                modelBuilder.Entity<SpecialOrder>();
+
+                modelBuilder.Validate();
+
+                var owner = model.FindEntityType(typeof(SpecialOrder));
+                var ownership = owner.FindNavigation(nameof(SpecialOrder.ShippingAddress)).ForeignKey;
+                Assert.True(ownership.IsOwnership);
+                Assert.NotNull(ownership.DeclaringEntityType.FindProperty(nameof(StreetAddress.Street)));
             }
 
             [Fact]
@@ -346,13 +646,17 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             {
                 var modelBuilder = CreateModelBuilder();
 
-                modelBuilder.Entity<Book>().OwnsOne(b => b.Label, bb => { bb.OwnsOne(l => l.AnotherBookLabel, ab => { ab.OwnsOne(l => l.SpecialBookLabel); }); });
+                modelBuilder.Entity<Book>().OwnsOne(b => b.Label, bb =>
+                { bb.OwnsOne(l => l.AnotherBookLabel, ab => { ab.OwnsOne(l => l.SpecialBookLabel); }); });
 
-                modelBuilder.Entity<Book>().OwnsOne(b => b.AlternateLabel, bb => { bb.OwnsOne(l => l.AnotherBookLabel, ab => { ab.OwnsOne(l => l.SpecialBookLabel); }); });
+                modelBuilder.Entity<Book>().OwnsOne(b => b.AlternateLabel, bb =>
+                { bb.OwnsOne(l => l.AnotherBookLabel, ab => { ab.OwnsOne(l => l.SpecialBookLabel); }); });
 
-                modelBuilder.Entity<Book>().OwnsOne(b => b.Label, bb => { bb.OwnsOne(l => l.SpecialBookLabel, sb => { sb.OwnsOne(l => l.AnotherBookLabel); }); });
+                modelBuilder.Entity<Book>().OwnsOne(b => b.Label, bb =>
+                { bb.OwnsOne(l => l.SpecialBookLabel, sb => { sb.OwnsOne(l => l.AnotherBookLabel); }); });
 
-                modelBuilder.Entity<Book>().OwnsOne(b => b.AlternateLabel, bb => { bb.OwnsOne(l => l.SpecialBookLabel, sb => { sb.OwnsOne(l => l.AnotherBookLabel); }); });
+                modelBuilder.Entity<Book>().OwnsOne(b => b.AlternateLabel, bb =>
+                { bb.OwnsOne(l => l.SpecialBookLabel, sb => { sb.OwnsOne(l => l.AnotherBookLabel); }); });
 
                 modelBuilder.Validate();
 
@@ -386,27 +690,6 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 modelBuilder.Validate();
 
                 VerifyOwnedBookLabelModel(modelBuilder.Model);
-            }
-
-            [Fact]
-            public virtual void Collection_navigation_to_owned_entity_type_is_ignored()
-            {
-                var modelBuilder = CreateModelBuilder();
-
-                modelBuilder.Owned<Order>();
-                modelBuilder.Owned<SpecialOrder>();
-                var customerBuilder = modelBuilder.Entity<SpecialCustomer>();
-
-                Assert.Equal(
-                    CoreStrings.NavigationNotAdded(
-                        nameof(Customer), nameof(Customer.Orders), "IEnumerable<Order>"),
-                    Assert.Throws<InvalidOperationException>(() => modelBuilder.Validate()).Message);
-
-                Assert.Null(customerBuilder.Metadata.FindNavigation(nameof(SpecialCustomer.Orders)));
-                Assert.Null(customerBuilder.Metadata.FindNavigation(nameof(SpecialCustomer.SpecialOrders)));
-                Assert.Equal(0, modelBuilder.Model.GetEntityTypes(typeof(Order)).Count);
-                Assert.Null(((Model)modelBuilder.Model).FindIgnoredTypeConfigurationSource(typeof(Order)));
-                Assert.Null(((Model)modelBuilder.Model).FindIgnoredTypeConfigurationSource(typeof(SpecialOrder)));
             }
 
             protected virtual void VerifyOwnedBookLabelModel(IMutableModel model)

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+﻿﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -7,6 +7,7 @@ using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Newtonsoft.Json.Linq;
 
 // ReSharper disable UnusedAutoPropertyAccessor.Local
@@ -111,14 +112,23 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public int Id { get; set; }
         }
 
-        protected class CustomerDetails : DetailsBase
+        protected class CustomerDetails : DetailsBase, INotifyPropertyChanged
         {
             public int CustomerId { get; set; }
 
             public Customer Customer { get; set; }
+
+            public event PropertyChangedEventHandler PropertyChanged;
+            protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+            {
+                if (PropertyChanged == null)
+                {
+                    throw new NotImplementedException();
+                }
+            }
         }
 
-        protected class Order
+        protected class Order : INotifyPropertyChanged
         {
             public static readonly PropertyInfo DetailsProperty = typeof(Order).GetProperty(nameof(Details));
 
@@ -131,6 +141,23 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public OrderCombination OrderCombination { get; set; }
 
             public OrderDetails Details { get; set; }
+            public ICollection<Product> Products { get; set; }
+
+            public event PropertyChangedEventHandler PropertyChanged;
+            protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+            {
+                if (PropertyChanged == null)
+                {
+                    throw new NotImplementedException();
+                }
+            }
+        }
+
+        [NotMapped]
+        protected class Product
+        {
+            public int Id { get; set; }
+            public Order Order { get; set; }
         }
 
         [Owned]
@@ -143,6 +170,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         [NotMapped]
         protected class SpecialOrder : Order
         {
+            public int SpecialOrderId { get; set; }
             public int? SpecialCustomerId { get; set; }
             public SpecialCustomer SpecialCustomer { get; set; }
             public BackOrder BackOrder { get; set; }


### PR DESCRIPTION
Add HasKey() to ReferenceOwnershipBuilder
Add missing string overloads of OwnsOne() and HasOne()
Add hiding overloads of HasData()
Sort methods and fix some comments
Move owned type primary key configuration to KeyDiscoveryConvention
Update model snapshot accordingly.

Part of #8172
