### PR TITLE
Add ClientEvaluationNotSupportedException

### DIFF
--- a/src/EFCore/ClientEvaluationNotSupportedException.cs
+++ b/src/EFCore/ClientEvaluationNotSupportedException.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.EntityFrameworkCore
+{
+    /// <summary>
+    /// An exception that is thrown when a method intended for SQL translation by EF Core is evaluated by the client.
+    /// </summary>
+    public class ClientEvaluationNotSupportedException : NotSupportedException
+    {
+        private readonly string _callerMemberName;
+
+        /// <inheritdoc />
+        public override string Message
+            => $"'{_callerMemberName}' is only intended for SQL translation by EF Core, but was evaluated by the client.";
+
+        /// <inheritdoc />
+        public ClientEvaluationNotSupportedException([CallerMemberName] string method = default)
+            => _callerMemberName = method;
+    }
+}


### PR DESCRIPTION
Currently, we throw a `NotSupportedException` when database functions are mapped to extension methods on `DbFunctions` without client implementations. 

A `ClientEvaluationNotSupportedException` supports providers by offering an explicit exception that uses the `CallerMemberNameAttribute` to include the name of the evaluated method (decreasing the amount of exception messages to maintain).

We're working with something like this in https://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL/pull/407, but it was [suggested](https://github.com/npgsql/Npgsql.EntityFrameworkCore.PostgreSQL/pull/407#discussion_r191078236) that this exception may be better suited for the main EF Core project.

cc: @roji 