### PR TITLE
Fix to #12463 - Query: compilation error (bad cancellation token) for async query projecting collection navigation and include

### DIFF
--- a/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/ComplexNavigationsQueryTestBase.cs
@@ -4659,7 +4659,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [Theory]
         [InlineData(false)]
-        //[InlineData(true)] issue #12463
+        [InlineData(true)]
         public virtual Task Project_collection_and_include(bool isAsync)
         {
             return AssertQuery<Level1>(

--- a/src/EFCore/Query/ExpressionVisitors/Internal/CorrelatedCollectionOptimizingVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/CorrelatedCollectionOptimizingVisitor.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Threading;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Extensions.Internal;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -49,9 +48,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             = typeof(Enumerable).GetTypeInfo().GetDeclaredMethod(nameof(Enumerable.ToList));
 
         private List<Ordering> _parentOrderings { get; } = new List<Ordering>();
-
-        private static readonly ParameterExpression _cancellationTokenParameter
-            = Expression.Parameter(typeof(CancellationToken), name: "ct");
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -387,7 +383,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
             if (_queryCompilationContext.IsAsyncQuery)
             {
-                arguments.Add(_cancellationTokenParameter);
+                arguments.Add(QueryCompilationContext.CancellationTokenParameter);
             }
 
             var result = Expression.Call(

--- a/src/EFCore/Query/ExpressionVisitors/Internal/TaskLiftingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/TaskLiftingExpressionVisitor.cs
@@ -22,9 +22,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         private static readonly ParameterExpression _resultsParameter
             = Expression.Parameter(typeof(object[]), name: "results");
 
-        private static readonly ParameterExpression _dummyCancellationToken
-            = Expression.Parameter(typeof(CancellationToken), name: "ct");
-
         private readonly List<Expression> _taskExpressions = new List<Expression>();
 
         /// <summary>
@@ -51,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                 if (CancellationTokenParameter == null)
                 {
-                    CancellationTokenParameter = _dummyCancellationToken;
+                    CancellationTokenParameter = QueryCompilationContext.CancellationTokenParameter;
                 }
             }
 
@@ -143,11 +140,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                                 memberExpressionType.GenericTypeArguments[0]),
                             memberExpression.Expression)));
 
-                if (CancellationTokenParameter == null)
-                {
-                    Visit(memberExpression.Expression);
-                }
-
                 return
                     Expression.Convert(
                         Expression.ArrayAccess(
@@ -174,11 +166,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                             _toObjectTask.MakeGenericMethod(
                                 methodCallExpression.Method.ReturnType),
                             methodCallExpression.Arguments[0])));
-
-                if (CancellationTokenParameter == null)
-                {
-                    Visit(methodCallExpression.Arguments[0]);
-                }
 
                 return
                     Expression.Convert(

--- a/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTreeNode.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTreeNode.cs
@@ -139,7 +139,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                             typeof(Func<>).MakeGenericType(asyncEnumerableType));
 
                     includeCollectionMethodInfo = _queryBufferIncludeCollectionAsyncMethodInfo;
-                    cancellationTokenExpression = _cancellationTokenParameter;
+                    cancellationTokenExpression = QueryCompilationContext.CancellationTokenParameter;
                 }
 
                 return

--- a/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTreeNodeBase.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTreeNodeBase.cs
@@ -128,8 +128,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                                             EntityQueryModelVisitor.QueryContextParameter,
                                             entityParameter,
                                             _includedParameter,
-                                            _cancellationTokenParameter),
-                                        _cancellationTokenParameter))
+                                            QueryCompilationContext.CancellationTokenParameter),
+                                        QueryCompilationContext.CancellationTokenParameter))
                             : Expression.Call(
                                 _includeMethodInfo.MakeGenericMethod(targetQuerySourceReferenceExpression.Type),
                                 EntityQueryModelVisitor.QueryContextParameter,

--- a/src/EFCore/Query/Internal/IncludeCompiler.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.cs
@@ -37,9 +37,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private static readonly ParameterExpression _includedParameter
             = Expression.Parameter(typeof(object[]), name: "included");
 
-        private static readonly ParameterExpression _cancellationTokenParameter
-            = Expression.Parameter(typeof(CancellationToken), name: "ct");
-
         private readonly QueryCompilationContext _queryCompilationContext;
         private readonly IQuerySourceTracingExpressionVisitorFactory _querySourceTracingExpressionVisitorFactory;
         private readonly List<IncludeResultOperator> _includeResultOperators;

--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Threading;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Extensions.Internal;
@@ -66,6 +67,13 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         internal ISet<QueryModel> DuplicateQueryModels = new HashSet<QueryModel>();
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static readonly ParameterExpression CancellationTokenParameter
+            = Expression.Parameter(typeof(CancellationToken), name: "ct");
 
         /// <summary>
         ///     Registers a mapping between correlated collection query models and metadata needed to process them.


### PR DESCRIPTION
Also fixes #12358 - The use of the ToListAsync method leads to missing data in version 2.1.0 of Microsoft.AspNetCore.All

Problem was that we were using multiple instances of cancellation token parameter when constructing a query plan. Fix is to unify it into one instance that is located on QueryCompilationContext instead.