### PR TITLE
[2.1.3] Allow dependents that can match a principal through multiple relationships

### DIFF
--- a/src/EFCore.Specification.Tests/GraphUpdatesFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/GraphUpdatesFixtureBase.cs
@@ -328,6 +328,20 @@ namespace Microsoft.EntityFrameworkCore
 
                 modelBuilder.Entity<BadCustomer>();
                 modelBuilder.Entity<BadOrder>();
+
+                modelBuilder.Entity<QuestTask>();
+
+                modelBuilder.Entity<QuizTask>()
+                    .HasMany(qt => qt.Choices)
+                    .WithOne()
+                    .HasForeignKey(tc => tc.QuestTaskId);
+
+                modelBuilder.Entity<HiddenAreaTask>()
+                    .HasMany(hat => hat.Choices)
+                    .WithOne()
+                    .HasForeignKey(tc => tc.QuestTaskId);
+
+                modelBuilder.Entity<TaskChoice>();
             }
 
             protected virtual object CreateFullGraph()
@@ -2545,6 +2559,54 @@ namespace Microsoft.EntityFrameworkCore
             {
                 get => _badCustomer;
                 set => SetWithNotify(value, ref _badCustomer);
+            }
+        }
+
+        protected class HiddenAreaTask : TaskWithChoices
+        {
+        }
+
+        protected abstract class QuestTask : NotifyingEntity
+        {
+            private int _id;
+
+            public int Id
+            {
+                get => _id;
+                set => SetWithNotify(value, ref _id);
+            }
+        }
+
+        protected class QuizTask : TaskWithChoices
+        {
+        }
+
+        protected class TaskChoice : NotifyingEntity
+        {
+            private int _id;
+            private int _questTaskId;
+
+            public int Id
+            {
+                get => _id;
+                set => SetWithNotify(value, ref _id);
+            }
+
+            public int QuestTaskId
+            {
+                get => _questTaskId;
+                set => SetWithNotify(value, ref _questTaskId);
+            }
+        }
+
+        protected abstract class TaskWithChoices : QuestTask
+        {
+            private ICollection<TaskChoice> _choices = new ObservableHashSet<TaskChoice>(ReferenceEqualityComparer.Instance);
+
+            public ICollection<TaskChoice> Choices
+            {
+                get => _choices;
+                set => SetWithNotify(value, ref _choices);
             }
         }
 

--- a/src/EFCore.Specification.Tests/GraphUpdatesTestBase.cs
+++ b/src/EFCore.Specification.Tests/GraphUpdatesTestBase.cs
@@ -5733,5 +5733,102 @@ namespace Microsoft.EntityFrameworkCore
                         Assert.Empty(principal.BadOrders);
                     });
         }
+
+        [ConditionalFact]
+        public virtual void Can_add_valid_first_depedent_when_multiple_possible_principal_sides()
+        {
+            ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    var quizTask = new QuizTask();
+                    quizTask.Choices.Add(new TaskChoice());
+
+                    context.Add(quizTask);
+
+                    context.SaveChanges();
+                },
+                context =>
+                {
+                    var quizTask = context.Set<QuizTask>().Include(e => e.Choices).Single();
+
+                    Assert.Equal(quizTask.Id, quizTask.Choices.Single().QuestTaskId);
+
+                    Assert.Same(quizTask.Choices.Single(), context.Set<TaskChoice>().Single());
+
+                    Assert.Empty(context.Set<HiddenAreaTask>().Include(e => e.Choices));
+                });
+        }
+
+        [ConditionalFact]
+        public virtual void Can_add_valid_second_depedent_when_multiple_possible_principal_sides()
+        {
+            ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    var hiddenAreaTask = new HiddenAreaTask();
+                    hiddenAreaTask.Choices.Add(new TaskChoice());
+
+                    context.Add(hiddenAreaTask);
+
+                    context.SaveChanges();
+                },
+                context =>
+                {
+                    var hiddenAreaTask = context.Set<HiddenAreaTask>().Include(e => e.Choices).Single();
+
+                    Assert.Equal(hiddenAreaTask.Id, hiddenAreaTask.Choices.Single().QuestTaskId);
+
+                    Assert.Same(hiddenAreaTask.Choices.Single(), context.Set<TaskChoice>().Single());
+
+                    Assert.Empty(context.Set<QuizTask>().Include(e => e.Choices));
+                });
+        }
+
+        [ConditionalFact]
+        public virtual void Can_add_multiple_depedents_when_multiple_possible_principal_sides()
+        {
+            ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    var quizTask = new QuizTask();
+                    quizTask.Choices.Add(new TaskChoice());
+                    quizTask.Choices.Add(new TaskChoice());
+
+                    context.Add(quizTask);
+
+                    var hiddenAreaTask = new HiddenAreaTask();
+                    hiddenAreaTask.Choices.Add(new TaskChoice());
+                    hiddenAreaTask.Choices.Add(new TaskChoice());
+
+                    context.Add(hiddenAreaTask);
+
+                    context.SaveChanges();
+                },
+                context =>
+                {
+                    var quizTask = context.Set<QuizTask>().Include(e => e.Choices).Single();
+                    var hiddenAreaTask = context.Set<HiddenAreaTask>().Include(e => e.Choices).Single();
+
+                    Assert.Equal(2, quizTask.Choices.Count);
+                    foreach (var quizTaskChoice in quizTask.Choices)
+                    {
+                        Assert.Equal(quizTask.Id, quizTaskChoice.QuestTaskId);
+                    }
+
+                    Assert.Equal(2, hiddenAreaTask.Choices.Count);
+                    foreach (var hiddenAreaTaskChoice in hiddenAreaTask.Choices)
+                    {
+                        Assert.Equal(hiddenAreaTask.Id, hiddenAreaTaskChoice.QuestTaskId);
+                    }
+
+                    foreach (var taskChoice in context.Set<TaskChoice>())
+                    {
+                        Assert.Equal(
+                            1,
+                            quizTask.Choices.Count(e => e.Id == taskChoice.Id)
+                            + hiddenAreaTask.Choices.Count(e => e.Id == taskChoice.Id));
+                    }
+                });
+        }
     }
 }


### PR DESCRIPTION
Fixes #12227

This issues happens when the principal side of multiple relationships is using inheritance and the relationships share and FK property and principal key definition. In this case, the FK value may match instances that are not of the correct type for the given relationship. This would normally be an error and we started throwing for it in 2.1. But it is not an error if the principal is correct for some other relationship sharing the same FK property. So the fix here is to check all the FKs to see if any one can be used. If so, then no problem. If not, then still an error to catch the common case. No matches is also okay, since we don't know whether the principal is loaded or not.

Note that technically, GetPrincipal is broken and should be fixed with new API surface to get all possible principals, but not doing this here because it would be new API in a patch.
