### PR TITLE
SqlServer Migrations: Quote schema identifier in TRANSFER statement

### DIFF
--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -1528,10 +1528,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                 builder
                     .AppendLine("DECLARE @defaultSchema sysname = SCHEMA_NAME();")
                     .Append("EXEC(")
-                    .Append("N'ALTER SCHEMA ' + @defaultSchema + ")
+                    .Append("N'ALTER SCHEMA [' + @defaultSchema + ")
                     .Append(
                         stringTypeMapping.GenerateSqlLiteral(
-                            " TRANSFER " + Dependencies.SqlGenerationHelper.DelimitIdentifier(name, schema) + ";"))
+                            "] TRANSFER " + Dependencies.SqlGenerationHelper.DelimitIdentifier(name, schema) + ";"))
                     .AppendLine(");");
             }
             else

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
@@ -1185,7 +1185,7 @@ namespace Microsoft.EntityFrameworkCore
 
             Assert.Equal(
                 "DECLARE @defaultSchema sysname = SCHEMA_NAME();" + EOL +
-                "EXEC(N'ALTER SCHEMA ' + @defaultSchema + N' TRANSFER [dbo].[EntityFrameworkHiLoSequence];');" + EOL,
+                "EXEC(N'ALTER SCHEMA [' + @defaultSchema + N'] TRANSFER [dbo].[EntityFrameworkHiLoSequence];');" + EOL,
                 Sql);
         }
 
@@ -1237,7 +1237,7 @@ namespace Microsoft.EntityFrameworkCore
 
             Assert.Equal(
                 "DECLARE @defaultSchema sysname = SCHEMA_NAME();" + EOL +
-                "EXEC(N'ALTER SCHEMA ' + @defaultSchema + N' TRANSFER [dbo].[People];');" + EOL,
+                "EXEC(N'ALTER SCHEMA [' + @defaultSchema + N'] TRANSFER [dbo].[People];');" + EOL,
                 Sql);
         }
 


### PR DESCRIPTION
Fixes #12559