### PR TITLE
Fix to #12582 - Includes With Cast Throws Exception

### DIFF
--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -6695,6 +6695,16 @@ namespace Microsoft.EntityFrameworkCore.Query
                 expectedIncludes);
         }
 
+        [Theory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Include_collection_with_Cast_to_base(bool isAsync)
+        {
+            return AssertIncludeQuery<Gear>(
+                isAsync,
+                gs => gs.OfType<Officer>().Include(o => o.Weapons).Cast<Gear>(),
+                new List<IExpectedInclude> { new ExpectedInclude<Gear>(e => e.Weapons, "Weapons") });
+        }
+
         // Remember to add any new tests to Async version of this test class
 
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();

--- a/src/EFCore/Query/Internal/IncludeCompiler.CollectionQueryModelRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.CollectionQueryModelRewritingExpressionVisitor.cs
@@ -363,11 +363,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     lastResultOperator = choiceResultOperator is LastResultOperator;
                 }
 
-                foreach (var groupResultOperator
-                    in queryModel.ResultOperators.OfType<GroupResultOperator>()
-                        .ToArray())
+                foreach (var typeChangingResultOperator
+                    in queryModel.ResultOperators.Where(ro => ro is GroupResultOperator || ro is CastResultOperator || ro is OfTypeResultOperator).ToList())
                 {
-                    queryModel.ResultOperators.Remove(groupResultOperator);
+                    queryModel.ResultOperators.Remove(typeChangingResultOperator);
                 }
 
                 if (queryModel.BodyClauses

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7732,6 +7732,26 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
 ORDER BY [g].[Rank]");
         }
 
+        public override async Task Include_collection_with_Cast_to_base(bool isAsync)
+        {
+            await base.Include_collection_with_Cast_to_base(isAsync);
+
+            AssertSql(
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank]
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] = N'Officer'
+ORDER BY [g].[FullName]",
+                //
+                @"SELECT [g.Weapons].[Id], [g.Weapons].[AmmunitionType], [g.Weapons].[IsAutomatic], [g.Weapons].[Name], [g.Weapons].[OwnerFullName], [g.Weapons].[SynergyWithId]
+FROM [Weapons] AS [g.Weapons]
+INNER JOIN (
+    SELECT [g0].[FullName]
+    FROM [Gears] AS [g0]
+    WHERE [g0].[Discriminator] = N'Officer'
+) AS [t] ON [g.Weapons].[OwnerFullName] = [t].[FullName]
+ORDER BY [t].[FullName]");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Problem was that when we rewrite collection query during the include compilation we are supposed to prune the result operators that change the result type (e.g. GroupBy). However we missed Cast and OfType, which would lead to discrepancy between the selector and the QM result type.
Fix is to remove the missing operators from the collection query - we only need it to select all the elements of the included collection, we don't need to preserve the original type.