### PR TITLE
Relational Query: Support niladic functions

### DIFF
--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -1523,20 +1523,21 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
         /// </returns>
         public virtual Expression VisitSqlFunction(SqlFunctionExpression sqlFunctionExpression)
         {
-            var parentTypeMapping = _typeMapping;
-
-            _typeMapping = null;
-
             GenerateSqlFunctionName(sqlFunctionExpression);
 
-            _relationalCommandBuilder.Append("(");
+            if (!sqlFunctionExpression.IsNiladic)
+            {
+                _relationalCommandBuilder.Append("(");
 
-            _typeMapping = null;
+                var parentTypeMapping = _typeMapping;
+                _typeMapping = null;
 
-            GenerateList(sqlFunctionExpression.Arguments);
+                GenerateList(sqlFunctionExpression.Arguments);
 
-            _relationalCommandBuilder.Append(")");
-            _typeMapping = parentTypeMapping;
+                _typeMapping = parentTypeMapping;
+
+                _relationalCommandBuilder.Append(")");
+            }
 
             return sqlFunctionExpression;
         }


### PR DESCRIPTION
I need support for things like `[t].[GeometryColumn].STX` in SQL as part of #1100. Can also be used for `CURRENT_TIMESTAMP`, etc.

I tried to write some unit tests, but the cost of unit testing `DefaultQuerySqlGenerator` is much higher than I'm willing to pay right now considering I have functional tests that use this already passing in my spatial branch.

Part of #9022

cc @pmiddleton