### PR TITLE
SqlServer: Scaffold sysname data type columns

### DIFF
--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
@@ -319,7 +319,7 @@ SELECT
     CAST([t].[scale] AS int) AS [scale]
 FROM [sys].[types] AS [t]
 JOIN [sys].[types] AS [t2] ON [t].[system_type_id] = [t2].[user_type_id]
-WHERE [t].[is_user_defined] = 1";
+WHERE [t].[is_user_defined] = 1 OR [t].[system_type_id] <> [t].[user_type_id]";
 
                 using (var reader = command.ExecuteReader())
                 {

--- a/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Scaffolding/SqlServerDatabaseModelFactoryTest.cs
@@ -847,6 +847,30 @@ DROP TYPE db2.TestTypeAlias;");
         }
 
         [Fact]
+        public void Column_with_sysname_assigns_underlying_store_type_and_nullability()
+        {
+            Test(
+                @"
+CREATE TABLE TypeAlias (
+    Id int,
+    typeAliasColumn sysname
+);",
+                Enumerable.Empty<string>(),
+                Enumerable.Empty<string>(),
+                dbModel =>
+                {
+                    var column = Assert.Single(dbModel.Tables.Single().Columns.Where(c => c.Name == "typeAliasColumn"));
+
+                    // ReSharper disable once PossibleNullReferenceException
+                    Assert.Equal("sysname", column.StoreType);
+                    Assert.Equal("nvarchar(128)", column.GetUnderlyingStoreType());
+                    Assert.False(column.IsNullable);
+                },
+                @"
+DROP TABLE TypeAlias;");
+        }
+
+        [Fact]
         public void Decimal_numeric_types_have_precision_scale()
         {
             Test(


### PR DESCRIPTION
Recognize system defined type aliases

Resolves #12595
