### PR TITLE
fixing failing tests after recent package upgrade

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/TransactionTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/TransactionTestBase.cs
@@ -190,7 +190,7 @@ namespace Microsoft.EntityFrameworkCore
                 }
 
                 Assert.Equal(RelationalStrings.LogExplicitTransactionEnlisted.GenerateMessage("Serializable"),
-                    Fixture.ListLoggerFactory.Log.Single().Message);
+                    Fixture.ListLoggerFactory.Log.First().Message);
             }
 
             AssertStoreInitialState();
@@ -344,7 +344,7 @@ namespace Microsoft.EntityFrameworkCore
                 }
 
                 Assert.Equal(RelationalStrings.LogAmbientTransactionEnlisted.GenerateMessage("Serializable"),
-                    Fixture.ListLoggerFactory.Log.Single().Message);
+                    Fixture.ListLoggerFactory.Log.First().Message);
             }
 
             if (closeConnection)


### PR DESCRIPTION
Problem was that affected tests were expecting exactly one message in the log, but now we are seeing messages about disposing the reader. Presumably due to a bug fix in sql client, which now correctly disposes the reader which it previously did not.