### PR TITLE
[TINY ]Fix to #12697 - Query: client method around qsre followed by projecting collection navigation throws during compilation

### DIFF
--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -631,8 +631,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
             else
             {
                 var processedExperssion = ApplyOptimizations(orderingExpression, searchCondition: false);
-                if (processedExperssion is ConstantExpression
-                    || processedExperssion is ParameterExpression)
+                if (processedExperssion.RemoveConvert() is ConstantExpression
+                    || processedExperssion.RemoveConvert() is ParameterExpression)
                 {
                     _relationalCommandBuilder.Append("(SELECT 1)");
                 }

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -128,6 +128,33 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [Theory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Select_bool_closure_with_order_by_property_with_cast_to_nullable(bool isAsync)
+        {
+            var boolean = false;
+
+            await AssertQuery<Customer>(
+                isAsync,
+                cs => cs.Select(
+                    c => new
+                    {
+                        f = boolean
+                    }).OrderBy(e => (bool?)e.f),
+                e => e.f);
+        }
+
+        [Theory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual async Task Select_bool_closure_with_order_parameter_with_cast_to_nullable(bool isAsync)
+        {
+            var boolean = false;
+
+            await AssertQueryScalar<Customer>(
+                isAsync,
+                cs => cs.Select(c => boolean).OrderBy(e => (bool?)e));
+        }
+
+        [Theory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task Select_scalar(bool isAsync)
         {
             return AssertQuery<Customer>(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
@@ -119,6 +119,30 @@ FROM [Employees] AS [e]
 WHERE [e].[EmployeeID] = 1");
         }
 
+        public override async Task Select_bool_closure_with_order_by_property_with_cast_to_nullable(bool isAsync)
+        {
+            await base.Select_bool_closure_with_order_by_property_with_cast_to_nullable(isAsync);
+
+            AssertSql(
+                @"@__boolean_0='False'
+
+SELECT @__boolean_0 AS [f]
+FROM [Customers] AS [c]
+ORDER BY (SELECT 1)");
+        }
+
+        public override async Task Select_bool_closure_with_order_parameter_with_cast_to_nullable(bool isAsync)
+        {
+            await base.Select_bool_closure_with_order_parameter_with_cast_to_nullable(isAsync);
+
+            AssertSql(
+                @"@__boolean_0='False'
+
+SELECT @__boolean_0
+FROM [Customers] AS [c]
+ORDER BY (SELECT 1)");
+        }
+
         public override async Task Select_scalar(bool isAsync)
         {
             await base.Select_scalar(isAsync);


### PR DESCRIPTION
Problem was that when we were producing ORDER BY (SELECT 1) in case of ordering by constant or a variable, we didn't take into account possibility of those being wrapped around converts. Fix is to strip possible Convert nodes before testing for the expression types that should be converted to SELECT 1