### PR TITLE
Fix to #12748 - Inner-query with byte[] FK produces wrong result with EFCore 2.1.x

### DIFF
--- a/src/EFCore/Query/ExpressionVisitors/Internal/CorrelatedCollectionOptimizingVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/CorrelatedCollectionOptimizingVisitor.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -475,7 +476,15 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                                 }
                             }
 
-                            equalityExpression = Expression.Equal(typedOuterKeyAccess, typedInnerKeyAccess);
+                            if (typeof(IStructuralEquatable).GetTypeInfo()
+                                .IsAssignableFrom(typedOuterKeyAccess.Type.GetTypeInfo()))
+                            {
+                                equalityExpression = Expression.Call(_structuralEqualsMethod, typedOuterKeyAccess, typedInnerKeyAccess);
+                            }
+                            else
+                            {
+                                equalityExpression = Expression.Equal(typedOuterKeyAccess, typedInnerKeyAccess);
+                            }
 
                             return
                                 (Expression)Expression.Condition(
@@ -488,6 +497,15 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     .Aggregate((e1, e2) => Expression.AndAlso(e1, e2)),
                 outerKeyParameter,
                 innerKeyParameter);
+        }
+
+        private static readonly MethodInfo _structuralEqualsMethod
+            = typeof(CorrelatedCollectionOptimizingVisitor).GetTypeInfo()
+                .GetDeclaredMethod(nameof(StructuralEquals));
+
+        private static bool StructuralEquals(object x, object y)
+        {
+            return StructuralComparisons.StructuralEqualityComparer.Equals(x, y);
         }
 
         private static void TryAddPropertyToOrderings(


### PR DESCRIPTION
Problem was that correlated subquery did not perform structural comparison between outer and inner key values when needed (e.g. for byte[] keys). We already do this for Include queries.