### PR TITLE
Fix to #12575 - Query: compilation error for query with SelectMany optional navigation followed by a Select optional navigation

### DIFF
--- a/src/EFCore.Specification.Tests/Query/ComplexNavigationsWeakQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/ComplexNavigationsWeakQueryTestBase.cs
@@ -441,6 +441,18 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
         }
 
+        public override void SelectMany_navigation_property_followed_by_select_collection_navigation()
+        {
+        }
+
+        public override void Multiple_SelectMany_navigation_property_followed_by_select_collection_navigation()
+        {
+        }
+
+        public override void SelectMany_navigation_property_with_include_and_followed_by_select_collection_navigation()
+        {
+        }
+
         #endregion
     }
 }

--- a/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
@@ -1208,7 +1208,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                     ReferenceReplacingExpressionVisitor
                         .ReplaceClauseReferences(e, querySourceMapping, throwOnUnmappedReferences: false));
 
-            AdjustIncludeAnnotations(querySourceMapping, additionalFromClauseBeingProcessed, querySourceReferenceExpression.ReferencedQuerySource);
+            AdjustQueryCompilationContextStateAfterSelectMany(
+                querySourceMapping,
+                additionalFromClauseBeingProcessed,
+                querySourceReferenceExpression.ReferencedQuerySource);
 
             return querySourceReferenceExpression;
         }
@@ -1263,7 +1266,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                         e => ReferenceReplacingExpressionVisitor
                             .ReplaceClauseReferences(e, querySourceMapping, throwOnUnmappedReferences: false));
 
-                    AdjustIncludeAnnotations(querySourceMapping, additionalFromClauseBeingProcessed, navigationJoin.QuerySourceReferenceExpression.ReferencedQuerySource);
+                    AdjustQueryCompilationContextStateAfterSelectMany(
+                        querySourceMapping,
+                        additionalFromClauseBeingProcessed,
+                        navigationJoin.QuerySourceReferenceExpression.ReferencedQuerySource);
 
                     return navigationJoin.QuerySourceReferenceExpression;
                 }
@@ -1276,7 +1282,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             return outerQuerySourceReferenceExpression;
         }
 
-        private void AdjustIncludeAnnotations(QuerySourceMapping querySourceMapping, IQuerySource querySourceBeingProcessed, IQuerySource resultQuerySource)
+        private void AdjustQueryCompilationContextStateAfterSelectMany(QuerySourceMapping querySourceMapping, IQuerySource querySourceBeingProcessed, IQuerySource resultQuerySource)
         {
             foreach (var includeResultOperator in _queryModelVisitor.QueryCompilationContext.QueryAnnotations.OfType<IncludeResultOperator>())
             {
@@ -1289,6 +1295,17 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 if (includeResultOperator.QuerySource == querySourceBeingProcessed)
                 {
                     includeResultOperator.QuerySource = resultQuerySource;
+                }
+            }
+
+            if (_queryModelVisitor.QueryCompilationContext.CorrelatedSubqueryMetadataMap != null)
+            {
+                foreach (var mapping in _queryModelVisitor.QueryCompilationContext.CorrelatedSubqueryMetadataMap)
+                {
+                    if (mapping.Value.ParentQuerySource == querySourceBeingProcessed)
+                    {
+                        mapping.Value.ParentQuerySource = resultQuerySource;
+                    }
                 }
             }
         }

--- a/src/EFCore/Query/Internal/CorrelatedSubqueryMetadata.cs
+++ b/src/EFCore/Query/Internal/CorrelatedSubqueryMetadata.cs
@@ -57,6 +57,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         /// <summary>
         ///     Query source that is origin of the collection navigation.
         /// </summary>
-        public virtual IQuerySource ParentQuerySource { get; }
+        public virtual IQuerySource ParentQuerySource { get; internal set; }
     }
 }

--- a/src/EFCore/Query/QueryCompilationContext.cs
+++ b/src/EFCore/Query/QueryCompilationContext.cs
@@ -120,6 +120,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        internal virtual IDictionary<MainFromClause, CorrelatedSubqueryMetadata> CorrelatedSubqueryMetadataMap => _correlatedSubqueryMetadataMap;
+
+        /// <summary>
         ///     Gets the model.
         /// </summary>
         /// <value>

--- a/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/ComplexNavigationsQuerySqlServerTest.cs
@@ -3741,6 +3741,77 @@ INNER JOIN (
 ORDER BY [t].[Id]");
         }
 
+        public override void SelectMany_navigation_property_followed_by_select_collection_navigation()
+        {
+            base.SelectMany_navigation_property_followed_by_select_collection_navigation();
+
+            AssertSql(
+                @"SELECT [l1.OneToMany_Optional].[Id]
+FROM [LevelOne] AS [l1]
+INNER JOIN [LevelTwo] AS [l1.OneToMany_Optional] ON [l1].[Id] = [l1.OneToMany_Optional].[OneToMany_Optional_InverseId]
+ORDER BY [l1.OneToMany_Optional].[Id]",
+                //
+                @"SELECT [l1.OneToMany_Optional.OneToMany_Optional].[Id], [l1.OneToMany_Optional.OneToMany_Optional].[Level2_Optional_Id], [l1.OneToMany_Optional.OneToMany_Optional].[Level2_Required_Id], [l1.OneToMany_Optional.OneToMany_Optional].[Name], [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToOne_Optional_SelfId], [t].[Id]
+FROM [LevelThree] AS [l1.OneToMany_Optional.OneToMany_Optional]
+INNER JOIN (
+    SELECT [l1.OneToMany_Optional0].[Id]
+    FROM [LevelOne] AS [l10]
+    INNER JOIN [LevelTwo] AS [l1.OneToMany_Optional0] ON [l10].[Id] = [l1.OneToMany_Optional0].[OneToMany_Optional_InverseId]
+) AS [t] ON [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
+ORDER BY [t].[Id]");
+        }
+
+        public override void Multiple_SelectMany_navigation_property_followed_by_select_collection_navigation()
+        {
+            base.Multiple_SelectMany_navigation_property_followed_by_select_collection_navigation();
+
+            AssertSql(
+                @"SELECT [l1.OneToMany_Optional.OneToMany_Optional].[Id]
+FROM [LevelOne] AS [l1]
+INNER JOIN [LevelTwo] AS [l1.OneToMany_Optional] ON [l1].[Id] = [l1.OneToMany_Optional].[OneToMany_Optional_InverseId]
+INNER JOIN [LevelThree] AS [l1.OneToMany_Optional.OneToMany_Optional] ON [l1.OneToMany_Optional].[Id] = [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_InverseId]
+ORDER BY [l1.OneToMany_Optional.OneToMany_Optional].[Id]",
+                //
+                @"SELECT [l1.OneToMany_Optional.OneToMany_Optional.OneToMany_Optional].[Id], [l1.OneToMany_Optional.OneToMany_Optional.OneToMany_Optional].[Level3_Optional_Id], [l1.OneToMany_Optional.OneToMany_Optional.OneToMany_Optional].[Level3_Required_Id], [l1.OneToMany_Optional.OneToMany_Optional.OneToMany_Optional].[Name], [l1.OneToMany_Optional.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToMany_Optional.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToMany_Optional.OneToMany_Optional.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToMany_Optional.OneToMany_Optional.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToMany_Optional.OneToMany_Optional.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToMany_Optional.OneToMany_Optional.OneToMany_Optional].[OneToOne_Optional_SelfId], [t].[Id]
+FROM [LevelFour] AS [l1.OneToMany_Optional.OneToMany_Optional.OneToMany_Optional]
+INNER JOIN (
+    SELECT [l1.OneToMany_Optional.OneToMany_Optional0].[Id]
+    FROM [LevelOne] AS [l10]
+    INNER JOIN [LevelTwo] AS [l1.OneToMany_Optional0] ON [l10].[Id] = [l1.OneToMany_Optional0].[OneToMany_Optional_InverseId]
+    INNER JOIN [LevelThree] AS [l1.OneToMany_Optional.OneToMany_Optional0] ON [l1.OneToMany_Optional0].[Id] = [l1.OneToMany_Optional.OneToMany_Optional0].[OneToMany_Optional_InverseId]
+) AS [t] ON [l1.OneToMany_Optional.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t].[Id]
+ORDER BY [t].[Id]");
+        }
+
+        public override void SelectMany_navigation_property_with_include_and_followed_by_select_collection_navigation()
+        {
+            base.SelectMany_navigation_property_with_include_and_followed_by_select_collection_navigation();
+
+            AssertSql(
+                @"SELECT [l1.OneToMany_Optional].[Id], [l1.OneToMany_Optional].[Date], [l1.OneToMany_Optional].[Level1_Optional_Id], [l1.OneToMany_Optional].[Level1_Required_Id], [l1.OneToMany_Optional].[Name], [l1.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToMany_Optional].[OneToOne_Optional_SelfId]
+FROM [LevelOne] AS [l1]
+INNER JOIN [LevelTwo] AS [l1.OneToMany_Optional] ON [l1].[Id] = [l1.OneToMany_Optional].[OneToMany_Optional_InverseId]
+ORDER BY [l1.OneToMany_Optional].[Id]",
+                //
+                @"SELECT [l1.OneToMany_Optional.OneToMany_Required].[Id], [l1.OneToMany_Optional.OneToMany_Required].[Level2_Optional_Id], [l1.OneToMany_Optional.OneToMany_Required].[Level2_Required_Id], [l1.OneToMany_Optional.OneToMany_Required].[Name], [l1.OneToMany_Optional.OneToMany_Required].[OneToMany_Optional_InverseId], [l1.OneToMany_Optional.OneToMany_Required].[OneToMany_Optional_Self_InverseId], [l1.OneToMany_Optional.OneToMany_Required].[OneToMany_Required_InverseId], [l1.OneToMany_Optional.OneToMany_Required].[OneToMany_Required_Self_InverseId], [l1.OneToMany_Optional.OneToMany_Required].[OneToOne_Optional_PK_InverseId], [l1.OneToMany_Optional.OneToMany_Required].[OneToOne_Optional_SelfId]
+FROM [LevelThree] AS [l1.OneToMany_Optional.OneToMany_Required]
+INNER JOIN (
+    SELECT DISTINCT [l1.OneToMany_Optional0].[Id]
+    FROM [LevelOne] AS [l10]
+    INNER JOIN [LevelTwo] AS [l1.OneToMany_Optional0] ON [l10].[Id] = [l1.OneToMany_Optional0].[OneToMany_Optional_InverseId]
+) AS [t] ON [l1.OneToMany_Optional.OneToMany_Required].[OneToMany_Required_InverseId] = [t].[Id]
+ORDER BY [t].[Id]",
+                //
+                @"SELECT [l1.OneToMany_Optional.OneToMany_Optional].[Id], [l1.OneToMany_Optional.OneToMany_Optional].[Level2_Optional_Id], [l1.OneToMany_Optional.OneToMany_Optional].[Level2_Required_Id], [l1.OneToMany_Optional.OneToMany_Optional].[Name], [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_Self_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Required_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Required_Self_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToOne_Optional_PK_InverseId], [l1.OneToMany_Optional.OneToMany_Optional].[OneToOne_Optional_SelfId], [t0].[Id]
+FROM [LevelThree] AS [l1.OneToMany_Optional.OneToMany_Optional]
+INNER JOIN (
+    SELECT [l1.OneToMany_Optional1].[Id]
+    FROM [LevelOne] AS [l11]
+    INNER JOIN [LevelTwo] AS [l1.OneToMany_Optional1] ON [l11].[Id] = [l1.OneToMany_Optional1].[OneToMany_Optional_InverseId]
+) AS [t0] ON [l1.OneToMany_Optional.OneToMany_Optional].[OneToMany_Optional_InverseId] = [t0].[Id]
+ORDER BY [t0].[Id]");
+        }
+
         private void AssertSql(params string[] expected)
         {
             Fixture.TestSqlLoggerFactory.AssertBaseline(expected);


### PR DESCRIPTION
Problem was that when we rewrite SelectMany, query sources get changed and need to be updated. We do that already for Include query annotations, but we were not doing it for query sources stored in CorrelatedSubqueryMetadata.

Fix is to update CorrelatedSubqueryMetadata query sources after we rewrite SelectMany, just like we do for Include annotations.