### PR TITLE
Remove extra "see" in RawSqlString documentation

### DIFF
--- a/src/EFCore.Relational/RawSqlString.cs
+++ b/src/EFCore.Relational/RawSqlString.cs
@@ -27,7 +27,7 @@ namespace Microsoft.EntityFrameworkCore
         public static implicit operator RawSqlString([NotNull] FormattableString fs) => default;
 
         /// <summary>
-        ///     Constructs a <see cref="RawSqlString" /> from a see <see cref="string" />
+        ///     Constructs a <see cref="RawSqlString" /> from a <see cref="string" />
         /// </summary>
         /// <param name="s"> The string. </param>
         public RawSqlString([NotNull] string s) => Format = s;


### PR DESCRIPTION
Fixes an extra "see" in [the documentation](https://docs.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.rawsqlstring.-ctor?view=efcore-2.1).

![image](https://user-images.githubusercontent.com/188129/43171784-9c0ed898-8f60-11e8-99fc-89e43e07ca62.png)
