### PR TITLE
Fix to #12830 - Query: invalid sql for query projecting a sql function (e.g ROUND) and ordering by it twice

### DIFF
--- a/src/EFCore.Relational/Query/Expressions/InExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/InExpression.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Query.Sql;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -170,7 +171,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             => Operand.Equals(other.Operand)
                && (Values == null
                    ? other.Values == null
-                   : Values.SequenceEqual(other.Values))
+                    : ExpressionEqualityComparer.Instance.SequenceEquals(Values, other.Values))
                && (SubQuery == null
                    ? other.SubQuery == null
                    : SubQuery.Equals(other.SubQuery));

--- a/src/EFCore.Relational/Query/Expressions/SqlFunctionExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SqlFunctionExpression.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Query.Sql;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -257,7 +258,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
                && string.Equals(FunctionName, other.FunctionName)
                && string.Equals(Schema, other.Schema)
                && IsNiladic == other.IsNiladic
-               && _arguments.SequenceEqual(other._arguments)
+               && ExpressionEqualityComparer.Instance.SequenceEquals(_arguments, other._arguments)
                && (Instance == null && other.Instance == null
                    || Instance?.Equals(other.Instance) == true);
 

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Functions.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Functions.cs
@@ -1268,5 +1268,32 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 os => os.Where(o => Equals(o.OrderID, arg)));
         }
+
+        [Theory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Projecting_Math_Truncate_and_ordering_by_it_twice(bool isAsync)
+        {
+            return AssertQuery<Order>(
+                isAsync,
+                os => os.Where(o => o.OrderID < 10250).Select(o => new { A = Math.Truncate((double)o.OrderID) }).OrderBy(r => r.A).OrderBy(r => r.A));
+        }
+
+        [Theory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Projecting_Math_Truncate_and_ordering_by_it_twice2(bool isAsync)
+        {
+            return AssertQuery<Order>(
+                isAsync,
+                os => os.Where(o => o.OrderID < 10250).Select(o => new { A = Math.Truncate((double)o.OrderID) }).OrderBy(r => r.A).OrderByDescending(r => r.A));
+        }
+
+        [Theory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Projecting_Math_Truncate_and_ordering_by_it_twice3(bool isAsync)
+        {
+            return AssertQuery<Order>(
+                isAsync,
+                os => os.Where(o => o.OrderID < 10250).Select(o => new { A = Math.Truncate((double)o.OrderID) }).OrderByDescending(r => r.A).ThenBy(r => r.A));
+        }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Functions.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Functions.cs
@@ -1305,5 +1305,38 @@ WHERE [o].[OrderDate] = @__arg_0");
 FROM [Orders] AS [o]
 WHERE 0 = 1");
         }
+
+        public override async Task Projecting_Math_Truncate_and_ordering_by_it_twice(bool isAsync)
+        {
+            await base.Projecting_Math_Truncate_and_ordering_by_it_twice(isAsync);
+
+            AssertSql(
+                @"SELECT ROUND(CAST([o].[OrderID] AS float), 0, 1) AS [A]
+FROM [Orders] AS [o]
+WHERE [o].[OrderID] < 10250
+ORDER BY [A]");
+        }
+
+        public override async Task Projecting_Math_Truncate_and_ordering_by_it_twice2(bool isAsync)
+        {
+            await base.Projecting_Math_Truncate_and_ordering_by_it_twice2(isAsync);
+
+            AssertSql(
+                @"SELECT ROUND(CAST([o].[OrderID] AS float), 0, 1) AS [A]
+FROM [Orders] AS [o]
+WHERE [o].[OrderID] < 10250
+ORDER BY [A] DESC");
+        }
+
+        public override async Task Projecting_Math_Truncate_and_ordering_by_it_twice3(bool isAsync)
+        {
+            await base.Projecting_Math_Truncate_and_ordering_by_it_twice3(isAsync);
+
+            AssertSql(
+                @"SELECT ROUND(CAST([o].[OrderID] AS float), 0, 1) AS [A]
+FROM [Orders] AS [o]
+WHERE [o].[OrderID] < 10250
+ORDER BY [A] DESC");
+        }
     }
 }


### PR DESCRIPTION
Problem was that when performing Expression comparison using ExpressionEqualityComparer, the constituent sequences were compared using default comparer (via SequenceEquals method), which doesn't know how to properly handle some Expressions (e.g. ConstantExpression).
Fix is to add SequenceEquals method to out ExpressionEqualityComparer, that will perform the sequence comparison using its own logic.