### PR TITLE
Fix to #12856 - Query: IsNullExpression doesn't use ExpressionEqualityComparer to compare its arguments which may lead to invalid sql

### DIFF
--- a/src/EFCore.Relational/Query/Expressions/IsNullExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/IsNullExpression.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq.Expressions;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.Query.Sql;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -93,7 +94,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
             return ReferenceEquals(this, obj) ? true : obj.GetType() == GetType() && Equals((IsNullExpression)obj);
         }
 
-        private bool Equals(IsNullExpression other) => Equals(_operand, other._operand);
+        private bool Equals(IsNullExpression other) => ExpressionEqualityComparer.Instance.Equals(_operand, other._operand);
 
         /// <summary>
         ///     Returns a hash code for this object.

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -6821,6 +6821,15 @@ namespace Microsoft.EntityFrameworkCore.Query
             return Task.CompletedTask;
         }
 
+        [Theory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task OrderBy_same_expression_containing_IsNull_correctly_deduplicates_the_ordering(bool isAsync)
+        {
+            return AssertQueryScalar<Gear>(
+                isAsync,
+                gs => gs.Select(g => g.LeaderNickname != null ? (bool?)(g.Nickname.Length == 5) : (bool?)null).OrderBy(e => e.HasValue).ThenBy(e => e.HasValue));
+        }
+
         public  TEntity Client<TEntity>(TEntity entity) => entity;
 
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7899,6 +7899,32 @@ INNER JOIN (
 ORDER BY [t1].[Id], [t1].[FullName]");
         }
 
+        public override async Task OrderBy_same_expression_containing_IsNull_correctly_deduplicates_the_ordering(bool isAsync)
+        {
+            await base.OrderBy_same_expression_containing_IsNull_correctly_deduplicates_the_ordering(isAsync);
+
+            AssertSql(
+                @"SELECT CASE
+    WHEN [g].[LeaderNickname] IS NOT NULL
+    THEN CASE
+        WHEN CAST(LEN([g].[Nickname]) AS int) = 5
+        THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+    END ELSE NULL
+END
+FROM [Gears] AS [g]
+WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
+ORDER BY CASE
+    WHEN CASE
+        WHEN [g].[LeaderNickname] IS NOT NULL
+        THEN CASE
+            WHEN CAST(LEN([g].[Nickname]) AS int) = 5
+            THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+        END ELSE NULL
+    END IS NOT NULL
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
We were using regular comparer, fix is to use ExpressionEqualityComparer instead.