### PR TITLE
Separate fk requiredness and add a convention type that runs when it changes

### DIFF
--- a/src/EFCore/Metadata/Conventions/ConventionSet.cs
+++ b/src/EFCore/Metadata/Conventions/ConventionSet.cs
@@ -127,6 +127,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         public virtual IList<IForeignKeyUniquenessChangedConvention> ForeignKeyUniquenessChangedConventions { get; } = new List<IForeignKeyUniquenessChangedConvention>();
 
         /// <summary>
+        ///     Conventions to run when the uniqueness of a foreign key is changed.
+        /// </summary>
+        public virtual IList<IForeignKeyRequirednessChangedConvention> ForeignKeyRequirednessChangedConventions { get; } = new List<IForeignKeyRequirednessChangedConvention>();
+
+        /// <summary>
         ///     Conventions to run when the ownership of a foreign key is changed.
         /// </summary>
         public virtual IList<IForeignKeyOwnershipChangedConvention> ForeignKeyOwnershipChangedConventions { get; } = new List<IForeignKeyOwnershipChangedConvention>();

--- a/src/EFCore/Metadata/Conventions/Internal/CascadeDeleteConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/CascadeDeleteConvention.cs
@@ -10,22 +10,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class CascadeDeleteConvention : IForeignKeyAddedConvention, IPropertyNullabilityChangedConvention
+    public class CascadeDeleteConvention : IForeignKeyAddedConvention, IForeignKeyRequirednessChangedConvention
     {
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public virtual bool Apply(InternalPropertyBuilder propertyBuilder)
-        {
-            foreach (var foreignKey in propertyBuilder.Metadata.GetContainingForeignKeys())
-            {
-                Apply(foreignKey.Builder);
-            }
-
-            return true;
-        }
-
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionDispatcher.cs
@@ -221,6 +221,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public virtual InternalRelationshipBuilder OnForeignKeyRequirednessChanged([NotNull] InternalRelationshipBuilder relationshipBuilder)
+            => _scope.OnForeignKeyRequirednessChanged(Check.NotNull(relationshipBuilder, nameof(relationshipBuilder)));
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual InternalRelationshipBuilder OnForeignKeyOwnershipChanged([NotNull] InternalRelationshipBuilder relationshipBuilder)
             => _scope.OnForeignKeyOwnershipChanged(Check.NotNull(relationshipBuilder, nameof(relationshipBuilder)));
 

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionNode.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionNode.cs
@@ -216,6 +216,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 return relationshipBuilder;
             }
 
+            public virtual InternalRelationshipBuilder OnForeignKeyRequirednessChanged([NotNull] InternalRelationshipBuilder relationshipBuilder)
+            {
+                Add(new OnForeignKeyRequirednessChangedNode(relationshipBuilder));
+                return relationshipBuilder;
+            }
+
             public virtual InternalRelationshipBuilder OnForeignKeyOwnershipChanged([NotNull] InternalRelationshipBuilder relationshipBuilder)
             {
                 Add(new OnForeignKeyOwnershipChangedNode(relationshipBuilder));
@@ -604,6 +610,25 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 foreach (var uniquenessConvention in _conventionSet.ForeignKeyUniquenessChangedConventions)
                 {
                     relationshipBuilder = uniquenessConvention.Apply(relationshipBuilder);
+                    if (relationshipBuilder?.Metadata.Builder == null)
+                    {
+                        return null;
+                    }
+                }
+
+                return relationshipBuilder;
+            }
+
+            public override InternalRelationshipBuilder OnForeignKeyRequirednessChanged(InternalRelationshipBuilder relationshipBuilder)
+            {
+                if (relationshipBuilder.Metadata.Builder == null)
+                {
+                    return null;
+                }
+
+                foreach (var requirednessConvention in _conventionSet.ForeignKeyRequirednessChangedConventions)
+                {
+                    relationshipBuilder = requirednessConvention.Apply(relationshipBuilder);
                     if (relationshipBuilder?.Metadata.Builder == null)
                     {
                         return null;
@@ -1045,6 +1070,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public InternalRelationshipBuilder RelationshipBuilder { get; }
 
             public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnForeignKeyUniquenessChanged(this);
+        }
+
+        private class OnForeignKeyRequirednessChangedNode : ConventionNode
+        {
+            public OnForeignKeyRequirednessChangedNode(InternalRelationshipBuilder relationshipBuilder)
+            {
+                RelationshipBuilder = relationshipBuilder;
+            }
+
+            public InternalRelationshipBuilder RelationshipBuilder { get; }
+
+            public override ConventionNode Accept(ConventionVisitor visitor) => visitor.VisitOnForeignKeyRequirednessChanged(this);
         }
 
         private class OnForeignKeyOwnershipChangedNode : ConventionNode

--- a/src/EFCore/Metadata/Conventions/Internal/ConventionVisitor.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ConventionVisitor.cs
@@ -57,6 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public virtual OnNavigationAddedNode VisitOnNavigationAdded(OnNavigationAddedNode node) => node;
             public virtual OnNavigationRemovedNode VisitOnNavigationRemoved(OnNavigationRemovedNode node) => node;
             public virtual OnForeignKeyUniquenessChangedNode VisitOnForeignKeyUniquenessChanged(OnForeignKeyUniquenessChangedNode node) => node;
+            public virtual OnForeignKeyRequirednessChangedNode VisitOnForeignKeyRequirednessChanged(OnForeignKeyRequirednessChangedNode node) => node;
             public virtual OnForeignKeyOwnershipChangedNode VisitOnForeignKeyOwnershipChanged(OnForeignKeyOwnershipChangedNode node) => node;
             public virtual OnPrincipalEndChangedNode VisitOnPrincipalEndChanged(OnPrincipalEndChangedNode node) => node;
             public virtual OnPropertyAddedNode VisitOnPropertyAdded(OnPropertyAddedNode node) => node;
@@ -184,6 +185,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             public override OnForeignKeyUniquenessChangedNode VisitOnForeignKeyUniquenessChanged(OnForeignKeyUniquenessChangedNode node)
             {
                 Dispatcher._immediateConventionScope.OnForeignKeyUniquenessChanged(node.RelationshipBuilder);
+                return null;
+            }
+
+            public override OnForeignKeyRequirednessChangedNode VisitOnForeignKeyRequirednessChanged(OnForeignKeyRequirednessChangedNode node)
+            {
+                Dispatcher._immediateConventionScope.OnForeignKeyRequirednessChanged(node.RelationshipBuilder);
                 return null;
             }
 

--- a/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilder.cs
@@ -133,6 +133,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             conventionSet.ForeignKeyUniquenessChangedConventions.Add(keyDiscoveryConvention);
             conventionSet.ForeignKeyUniquenessChangedConventions.Add(foreignKeyIndexConvention);
 
+            conventionSet.ForeignKeyRequirednessChangedConventions.Add(cascadeDeleteConvention);
+
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(new NavigationEagerLoadingConvention());
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(keyDiscoveryConvention);
             conventionSet.ForeignKeyOwnershipChangedConventions.Add(relationshipDiscoveryConvention);
@@ -168,8 +170,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             conventionSet.IndexRemovedConventions.Add(foreignKeyIndexConvention);
 
             conventionSet.IndexUniquenessChangedConventions.Add(foreignKeyIndexConvention);
-
-            conventionSet.PropertyNullabilityChangedConventions.Add(cascadeDeleteConvention);
 
             conventionSet.PrincipalEndChangedConventions.Add(foreignKeyPropertyDiscoveryConvention);
 

--- a/src/EFCore/Metadata/Conventions/Internal/IForeignKeyRequirednessChangedConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/IForeignKeyRequirednessChangedConvention.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public interface IForeignKeyRequirednessChangedConvention
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        InternalRelationshipBuilder Apply([NotNull] InternalRelationshipBuilder relationshipBuilder);
+    }
+}

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -2302,11 +2302,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             ///     directly from your code. This API may change or be removed in future releases.
             /// </summary>
             public Snapshot(
-                [CanBeNull] EntityType entityType,
+                [NotNull] EntityType entityType,
                 [CanBeNull] PropertiesSnapshot properties,
                 [CanBeNull] List<InternalIndexBuilder> indexes,
                 [CanBeNull] List<(InternalKeyBuilder, ConfigurationSource?)> keys,
-                [CanBeNull] List<(InternalRelationshipBuilder, Snapshot)> relationships)
+                [CanBeNull] List<RelationshipSnapshot> relationships)
             {
                 EntityType = entityType;
                 Properties = properties ?? new PropertiesSnapshot(null, null, null, null);

--- a/src/EFCore/Metadata/Internal/ForeignKey.cs
+++ b/src/EFCore/Metadata/Internal/ForeignKey.cs
@@ -21,6 +21,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     {
         private DeleteBehavior? _deleteBehavior;
         private bool? _isUnique;
+        private bool? _isRequired;
         private bool? _isOwnership;
 
         private ConfigurationSource _configurationSource;
@@ -408,7 +409,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual bool IsRequired
         {
-            get => !Properties.Any(p => p.IsNullable);
+            get => _isRequired ?? !Properties.Any(p => p.IsNullable);
             set => SetIsRequired(value, ConfigurationSource.Explicit);
         }
 
@@ -420,9 +421,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             if (required == IsRequired)
             {
+                _isRequired = required;
                 UpdateIsRequiredConfigurationSource(configurationSource);
                 return;
             }
+
+            _isRequired = required;
 
             var properties = Properties;
             if (!required)
@@ -441,6 +445,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 property.SetIsNullable(!required, configurationSource);
             }
 
+            DeclaringEntityType.Model.ConventionDispatcher.OnForeignKeyRequirednessChanged(Builder);
             UpdateIsRequiredConfigurationSource(configurationSource);
         }
 

--- a/src/EFCore/Metadata/Internal/Key.cs
+++ b/src/EFCore/Metadata/Internal/Key.cs
@@ -73,6 +73,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        [DebuggerStepThrough]
         public virtual ConfigurationSource GetConfigurationSource() => _configurationSource;
 
         /// <summary>

--- a/src/EFCore/Metadata/Internal/PropertiesSnapshot.cs
+++ b/src/EFCore/Metadata/Internal/PropertiesSnapshot.cs
@@ -22,7 +22,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [CanBeNull] List<InternalPropertyBuilder> properties,
             [CanBeNull] List<InternalIndexBuilder> indexes,
             [CanBeNull] List<(InternalKeyBuilder, ConfigurationSource?)> keys,
-            [CanBeNull] List<(InternalRelationshipBuilder, EntityType.Snapshot)> relationships)
+            [CanBeNull] List<RelationshipSnapshot> relationships)
         {
             Properties = properties;
             Indexes = indexes;
@@ -31,7 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         }
 
         private List<InternalPropertyBuilder> Properties { [DebuggerStepThrough] get; }
-        private List<(InternalRelationshipBuilder, EntityType.Snapshot)> Relationships { [DebuggerStepThrough] get; set; }
+        private List<RelationshipSnapshot> Relationships { [DebuggerStepThrough] get; set; }
         private List<InternalIndexBuilder> Indexes { [DebuggerStepThrough] get; set; }
         private List<(InternalKeyBuilder, ConfigurationSource?)> Keys { [DebuggerStepThrough] get; set; }
 
@@ -39,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual void Add([NotNull] List<(InternalRelationshipBuilder, EntityType.Snapshot)> relationships)
+        public virtual void Add([NotNull] List<RelationshipSnapshot> relationships)
         {
             if (Relationships == null)
             {
@@ -119,19 +119,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             if (Relationships != null)
             {
-                foreach (var detachedRelationshipTuple in Relationships.Where(r => r.Item2 != null))
+                foreach (var detachedRelationshipTuple in Relationships)
                 {
-                    var newRelationship = detachedRelationshipTuple.Item1.Attach(entityTypeBuilder);
-                    if (newRelationship != null)
-                    {
-                        detachedRelationshipTuple.Item2.Attach(
-                            newRelationship.Metadata.ResolveOtherEntityType(entityTypeBuilder.Metadata).Builder);
-                    }
-                }
-
-                foreach (var detachedRelationshipTuple in Relationships.Where(r => r.Item2 == null))
-                {
-                    detachedRelationshipTuple.Item1.Attach(entityTypeBuilder);
+                    detachedRelationshipTuple.Attach(entityTypeBuilder);
                 }
             }
         }

--- a/src/EFCore/Metadata/Internal/RelationshipSnapshot.cs
+++ b/src/EFCore/Metadata/Internal/RelationshipSnapshot.cs
@@ -1,0 +1,54 @@
+using System.Diagnostics;
+using JetBrains.Annotations;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class RelationshipSnapshot
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public RelationshipSnapshot(
+            [NotNull] InternalRelationshipBuilder relationship,
+            [CanBeNull] EntityType.Snapshot weakEntityTypeSnapshot)
+        {
+            Relationship = relationship;
+            WeakEntityTypeSnapshot = weakEntityTypeSnapshot;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual InternalRelationshipBuilder Relationship { [DebuggerStepThrough] get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual EntityType.Snapshot WeakEntityTypeSnapshot { [DebuggerStepThrough] get; set; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual InternalRelationshipBuilder Attach([CanBeNull] InternalEntityTypeBuilder entityTypeBuilder = null)
+        {
+            entityTypeBuilder = entityTypeBuilder ?? Relationship.Metadata.DeclaringEntityType.Builder;
+            var newRelationship = Relationship.Attach(entityTypeBuilder);
+
+            if (newRelationship != null)
+            {
+                WeakEntityTypeSnapshot?.Attach(
+                    newRelationship.Metadata.ResolveOtherEntityType(entityTypeBuilder.Metadata).Builder);
+            }
+
+            return newRelationship;
+        }
+    }
+}

--- a/src/Shared/MemberInfoExtensions.cs
+++ b/src/Shared/MemberInfoExtensions.cs
@@ -11,21 +11,16 @@ namespace System.Reflection
             => (memberInfo as PropertyInfo)?.PropertyType ?? ((FieldInfo)memberInfo)?.FieldType;
 
         public static bool IsSameAs(this MemberInfo propertyInfo, MemberInfo otherPropertyInfo)
-        {
-            if (propertyInfo == null)
-            {
-                return otherPropertyInfo == null;
-            }
-
-            return otherPropertyInfo == null
-                ? false
-                : Equals(propertyInfo, otherPropertyInfo)
-                   || (propertyInfo.Name == otherPropertyInfo.Name
-                       && (propertyInfo.DeclaringType == otherPropertyInfo.DeclaringType
-                           || propertyInfo.DeclaringType.GetTypeInfo().IsSubclassOf(otherPropertyInfo.DeclaringType)
-                           || otherPropertyInfo.DeclaringType.GetTypeInfo().IsSubclassOf(propertyInfo.DeclaringType)
-                           || propertyInfo.DeclaringType.GetTypeInfo().ImplementedInterfaces.Contains(otherPropertyInfo.DeclaringType)
-                           || otherPropertyInfo.DeclaringType.GetTypeInfo().ImplementedInterfaces.Contains(propertyInfo.DeclaringType)));
-        }
+            => propertyInfo == null
+                ? otherPropertyInfo == null
+                : (otherPropertyInfo == null
+                    ? false
+                    : Equals(propertyInfo, otherPropertyInfo)
+                      || (propertyInfo.Name == otherPropertyInfo.Name
+                          && (propertyInfo.DeclaringType == otherPropertyInfo.DeclaringType
+                              || propertyInfo.DeclaringType.GetTypeInfo().IsSubclassOf(otherPropertyInfo.DeclaringType)
+                              || otherPropertyInfo.DeclaringType.GetTypeInfo().IsSubclassOf(propertyInfo.DeclaringType)
+                              || propertyInfo.DeclaringType.GetTypeInfo().ImplementedInterfaces.Contains(otherPropertyInfo.DeclaringType)
+                              || otherPropertyInfo.DeclaringType.GetTypeInfo().ImplementedInterfaces.Contains(propertyInfo.DeclaringType))));
     }
 }

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -801,10 +801,11 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
 
                             eb.HasOne(e => e.EntityWithStringKey).WithOne();
 
-                            eb.HasData(new EntityWithTwoProperties
+                            eb.HasData(new
                             {
                                 AlternateId = 1,
-                                Id = -1
+                                Id = -1,
+                                EntityWithStringKeyId = "1"
                             });
                         });
 
@@ -857,7 +858,8 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     .ValueGeneratedOnAdd()
                     .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-                b1.Property<string>(""EntityWithStringKeyId"");
+                b1.Property<string>(""EntityWithStringKeyId"")
+                    .IsRequired();
 
                 b1.Property<int>(""Id"");
 
@@ -865,8 +867,7 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     .HasName(""PK_Custom"");
 
                 b1.HasIndex(""EntityWithStringKeyId"")
-                    .IsUnique()
-                    .HasFilter(""[EntityWithTwoProperties_EntityWithStringKeyId] IS NOT NULL"");
+                    .IsUnique();
 
                 b1.HasIndex(""Id"")
                     .IsUnique();
@@ -881,10 +882,11 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
 
                 b1.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"", ""EntityWithStringKey"")
                     .WithOne()
-                    .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""EntityWithStringKeyId"");
+                    .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""EntityWithStringKeyId"")
+                    .OnDelete(DeleteBehavior.Cascade);
 
                 b1.HasData(
-                    new { AlternateId = 1, Id = -1 }
+                    new { AlternateId = 1, EntityWithStringKeyId = ""1"", Id = -1 }
                 );
             });
     });
@@ -945,12 +947,11 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     var owned1index1 = ownedType1.GetIndexes().First();
                     Assert.Equal("EntityWithStringKeyId", owned1index1.Properties[0].Name);
                     Assert.True(owned1index1.IsUnique);
-                    Assert.Equal("[EntityWithTwoProperties_EntityWithStringKeyId] IS NOT NULL", owned1index1.Relational().Filter);
                     var owned1index2 = ownedType1.GetIndexes().Last();
                     Assert.Equal("Id", owned1index2.Properties[0].Name);
                     Assert.True(owned1index2.IsUnique);
                     Assert.Null(owned1index2.Relational().Filter);
-                    Assert.Equal(new object[] { 1, -1 }, ownedType1.GetData().Single().Values);
+                    Assert.Equal(new object[] { 1, "1", -1 }, ownedType1.GetData().Single().Values);
                     Assert.Equal(nameof(EntityWithOneProperty), ownedType1.Relational().TableName);
 
                     var entityWithStringKey = o.FindEntityType(typeof(EntityWithStringKey));


### PR DESCRIPTION
This preserves the correct value for detached FKs and is part of a larger change