### PR TITLE
Allow property accessor delegates to use fields that need casting

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/SnapshotFactoryFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/SnapshotFactoryFactory.cs
@@ -116,9 +116,15 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 }
                 else
                 {
-                    var memberAccess = Expression.MakeMemberAccess(
+                    var memberAccess = (Expression)Expression.MakeMemberAccess(
                         entityVariable,
                         propertyBase.GetMemberInfo(forConstruction: false, forSet: false));
+
+                    if (memberAccess.Type != propertyBase.ClrType)
+                    {
+                        memberAccess = Expression.Convert(memberAccess, propertyBase.ClrType);
+                    }
+
                     arguments[i] = (propertyBase as INavigation)?.IsCollection() ?? false
                         ? Expression.Call(
                             null,

--- a/src/EFCore/Metadata/Internal/ClrCollectionAccessorFactory.cs
+++ b/src/EFCore/Metadata/Internal/ClrCollectionAccessorFactory.cs
@@ -76,10 +76,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var entityParameter = Expression.Parameter(typeof(TEntity), "entity");
             var valueParameter = Expression.Parameter(typeof(TCollection), "collection");
 
+            var memberAccess = (Expression)Expression.MakeMemberAccess(entityParameter, memberInfo);
+            if (memberAccess.Type != typeof(TCollection))
+            {
+                memberAccess = Expression.Convert(memberAccess, typeof(TCollection));
+            }
+
             var getterDelegate = Expression.Lambda<Func<TEntity, TCollection>>(
-                Expression.MakeMemberAccess(
-                    entityParameter,
-                    memberInfo),
+                memberAccess,
                 entityParameter).Compile();
 
             Action<TEntity, TCollection> setterDelegate = null;

--- a/src/EFCore/Metadata/Internal/ClrPropertySetterFactory.cs
+++ b/src/EFCore/Metadata/Internal/ClrPropertySetterFactory.cs
@@ -33,13 +33,17 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             var entityParameter = Expression.Parameter(typeof(TEntity), "entity");
             var valueParameter = Expression.Parameter(typeof(TValue), "value");
+            var memberType = memberInfo.GetMemberType();
+            var convertedParameter = memberType == typeof(TValue)
+                ? (Expression)valueParameter
+                : Expression.Convert(valueParameter, memberType);
 
             Expression writeExpression;
             if (memberInfo.DeclaringType.GetTypeInfo().IsAssignableFrom(typeof(TEntity).GetTypeInfo()))
             {
                 writeExpression = Expression.Assign(
                     Expression.MakeMemberAccess(entityParameter, memberInfo),
-                    valueParameter);
+                    convertedParameter);
             }
             else
             {
@@ -57,7 +61,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                             Expression.ReferenceNotEqual(converted, Expression.Constant(null)),
                             Expression.Assign(
                                 Expression.MakeMemberAccess(converted, memberInfo),
-                                valueParameter))
+                                convertedParameter))
                     });
             }
 

--- a/src/EFCore/Metadata/Internal/PropertyAccessorsFactory.cs
+++ b/src/EFCore/Metadata/Internal/PropertyAccessorsFactory.cs
@@ -65,6 +65,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 currentValueExpression = Expression.MakeMemberAccess(
                     convertedExpression,
                     propertyBase.GetMemberInfo(forConstruction: false, forSet: false));
+
+                if (currentValueExpression.Type != typeof(TProperty))
+                {
+                    currentValueExpression = Expression.Convert(currentValueExpression, typeof(TProperty));
+                }
             }
 
             var storeGeneratedIndex = propertyBase.GetStoreGeneratedIndex();


### PR DESCRIPTION
Fixes #12490

Note that in #12490, the wrong backing field is found. This is not fixed here--issue #12523 covers that.
