### PR TITLE
Benchmarks: Compile for AnyCpu

### DIFF
--- a/benchmarks/src/EFCore.Benchmarks/JobExtensions.cs
+++ b/benchmarks/src/EFCore.Benchmarks/JobExtensions.cs
@@ -3,6 +3,7 @@
 
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
 
 namespace Microsoft.EntityFrameworkCore.Benchmarks
@@ -11,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore.Benchmarks
     {
         public static Job ConfigureJob(this Job job, bool singleRun = false)
         {
-            job.WithGcForce(true).WithUnrollFactor(1).WithInvocationCount(1);
+            job.WithGcForce(true).WithUnrollFactor(1).WithInvocationCount(1).With(Platform.AnyCpu);
 
             if (singleRun)
             {

--- a/benchmarks/test/EFCore.Benchmarks.Sqlite.Version20/EFCore.Benchmarks.Sqlite.Version20.csproj
+++ b/benchmarks/test/EFCore.Benchmarks.Sqlite.Version20/EFCore.Benchmarks.Sqlite.Version20.csproj
@@ -29,7 +29,9 @@
 
   <ItemGroup>
     <Compile Include="..\EFCore.Benchmarks.Sqlite.Version22\**\*.cs"
-             Exclude="..\EFCore.Benchmarks.Sqlite.Version22\obj\**\*;..\EFCore.Benchmarks.Sqlite.Version22\bin\**\*" />
+             Exclude="..\EFCore.Benchmarks.Sqlite.Version22\obj\**\*;
+                      ..\EFCore.Benchmarks.Sqlite.Version22\bin\**\*;
+                      ..\EFCore.Benchmarks.Sqlite.Version22\Models\AdventureWorks\AdventureWorksContext.cs" />
   </ItemGroup>
 
 </Project>

--- a/benchmarks/test/EFCore.Benchmarks.Sqlite.Version20/Models/AdventureWorks/AdventureWorksContext.cs
+++ b/benchmarks/test/EFCore.Benchmarks.Sqlite.Version20/Models/AdventureWorks/AdventureWorksContext.cs
@@ -1,0 +1,32 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+
+namespace Microsoft.EntityFrameworkCore.Benchmarks.Models.AdventureWorks
+{
+    public class AdventureWorksContext : AdventureWorksContextBase
+    {
+        private readonly string _connectionString;
+
+        public AdventureWorksContext(string connectionString)
+        {
+            _connectionString = connectionString;
+        }
+
+        protected override void ConfigureProvider(DbContextOptionsBuilder optionsBuilder)
+        {
+            optionsBuilder.UseSqlite(_connectionString);
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            foreach (var entityType in modelBuilder.Model.GetEntityTypes())
+            {
+                // Work around issue #9560
+                entityType.Relational().Schema = null;
+            }
+        }
+    }
+}

--- a/benchmarks/test/EFCore.Benchmarks.Sqlite.Version21/EFCore.Benchmarks.Sqlite.Version21.csproj
+++ b/benchmarks/test/EFCore.Benchmarks.Sqlite.Version21/EFCore.Benchmarks.Sqlite.Version21.csproj
@@ -29,7 +29,8 @@
 
   <ItemGroup>
     <Compile Include="..\EFCore.Benchmarks.Sqlite.Version22\**\*.cs"
-             Exclude="..\EFCore.Benchmarks.Sqlite.Version22\obj\**\*;..\EFCore.Benchmarks.Sqlite.Version22\bin\**\*" />
+             Exclude="..\EFCore.Benchmarks.Sqlite.Version22\obj\**\*;
+                      ..\EFCore.Benchmarks.Sqlite.Version22\bin\**\*" />
   </ItemGroup>
 
 </Project>

--- a/benchmarks/test/EFCore.Benchmarks.Sqlite.Version22/EFCore.Benchmarks.Sqlite.Version22.csproj
+++ b/benchmarks/test/EFCore.Benchmarks.Sqlite.Version22/EFCore.Benchmarks.Sqlite.Version22.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="$(SQLitePCLRawBundleGreenPackageVersion)" />
+    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="$(SQLitePCLRawBundleGreenPackageVersion)" PrivateAssets="None"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
BDN compiles .NET framework benchmarks with x64 platform which does not work for sqlite.dll
