### PR TITLE
Fix "leaked" connection open count in test

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/Query/AsyncFromSqlQueryTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/AsyncFromSqlQueryTestBase.cs
@@ -357,13 +357,20 @@ FROM [Customers]"))
             {
                 ctx.Database.OpenConnection();
 
-                var query = await ctx.Customers
-                    .Include(v => v.Orders)
-                    .Where(v => v.CustomerID == "MAMRFC")
-                    .ToListAsync();
+                try
+                {
+                    var query = await ctx.Customers
+                        .Include(v => v.Orders)
+                        .Where(v => v.CustomerID == "MAMRFC")
+                        .ToListAsync();
 
-                Assert.Empty(query);
-                Assert.Equal(ConnectionState.Open, ctx.Database.GetDbConnection().State);
+                    Assert.Empty(query);
+                    Assert.Equal(ConnectionState.Open, ctx.Database.GetDbConnection().State);
+                }
+                finally
+                {
+                    ctx.Database.CloseConnection();
+                }
             }
         }
 


### PR DESCRIPTION
While porting the Npgsql EF Core provider to work against release/2.2, `Include_closed_connection_opened_by_it_when_buffering` started failing. After some investigation I tracked it to `Include_does_not_close_user_opened_connection_for_empty_result` running before it, and that test called `IRelationalConnection.OpenConnection()` without a corresponding `CloseConnection()`. Since the context is pooled, the next test to be executed (the failing one) has an `IRelationalConnection` with `_openCount` equal to one.

Interestingly, `Include_closed_connection_opened_by_it_when_buffering` starts by doing `Fixture.TestStore.CloseConnection()`, which closes the `DbConnection` but doesn't increment the `IRelationalConnection`'s open count. The test then proceeds to open the relational connection and then close it, but since the open count is still one the underlying `DbConnection` never gets closed.

This can be reproduced by dropping the following test into `AsyncFromSqlQuerySqliteTest`:

```c#
[Fact]
public virtual void User_opened_connection_leaks_across_pooled_contexts()
{
    using (var ctx = CreateContext())
    {
        ctx.Database.OpenConnection();
    }

    Fixture.TestStore.CloseConnection();

    using (var ctx = CreateContext())
    {
        var connection = ctx.Database.GetDbConnection();
        var relationalConn = ctx.GetService<IRelationalConnection>();

        Assert.Equal(ConnectionState.Closed, connection.State);

        relationalConn.Open();
        relationalConn.Close();

        Assert.Equal(ConnectionState.Closed, connection.State);
    }
}
```

I'm not sure why you're not running into this now (test ordering happens to be different than mine?), or what changes happened in 2.2 to make this start failing (not enough time to dive in at the moment...). The decision to not reset `RelationalConnection` if the connection isn't "owned" may be problematic; if it's the desired behavior then the test needs to be modified to close the connection (this PR does that).