### PR TITLE
Ensure each in-memory test fixture uses a different named database

### DIFF
--- a/test/EFCore.InMemory.FunctionalTests/UpdatesInMemoryWithSensitiveDataLoggingFixture.cs
+++ b/test/EFCore.InMemory.FunctionalTests/UpdatesInMemoryWithSensitiveDataLoggingFixture.cs
@@ -7,6 +7,8 @@ namespace Microsoft.EntityFrameworkCore
 {
     public class UpdatesInMemoryWithSensitiveDataLoggingFixture : UpdatesInMemoryFixtureBase
     {
+        protected override string StoreName { get; } = "UpdateTestSensitive";
+
         protected override ITestStoreFactory TestStoreFactory => InMemoryTestStoreFactory.Instance;
 
         public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)

--- a/test/EFCore.InMemory.FunctionalTests/UpdatesInMemoryWithoutSensitiveDataLoggingFixture.cs
+++ b/test/EFCore.InMemory.FunctionalTests/UpdatesInMemoryWithoutSensitiveDataLoggingFixture.cs
@@ -7,6 +7,8 @@ namespace Microsoft.EntityFrameworkCore
 {
     public class UpdatesInMemoryWithoutSensitiveDataLoggingFixture : UpdatesInMemoryFixtureBase
     {
+        protected override string StoreName { get; } = "UpdateTestInsensitive";
+
         protected override ITestStoreFactory TestStoreFactory => InMemoryTestStoreFactory.Instance;
 
         public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)


### PR DESCRIPTION
Hopefully fixes #12859

(cherry picked from commit 4f65388bf68312e16fe07e62f79d8fad4e242f2a)
