### PR TITLE
Fix to #10153 - Query: add translator for Nullable<>.GetValueOrDefault()

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionTranslators/Internal/GetValueOrDefaultTranslator.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/Internal/GetValueOrDefaultTranslator.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class GetValueOrDefaultTranslator : IMethodCallTranslator
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        {
+            if (methodCallExpression.Method.Name == nameof(Nullable<int>.GetValueOrDefault))
+            {
+                if (methodCallExpression.Arguments.Count == 0)
+                {
+                    return Expression.Coalesce(
+                        methodCallExpression.Object,
+                        methodCallExpression.Type.GenerateDefaultValueConstantExpression());
+                }
+                else if (methodCallExpression.Arguments.Count == 1)
+                {
+                    return Expression.Coalesce(
+                        methodCallExpression.Object,
+                        methodCallExpression.Arguments[0]);
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/EFCore.Relational/Query/ExpressionTranslators/RelationalCompositeMethodCallTranslator.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/RelationalCompositeMethodCallTranslator.cs
@@ -35,8 +35,9 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
                 {
                     new EnumHasFlagTranslator(),
                     new EqualsTranslator(dependencies.Logger),
+                    new GetValueOrDefaultTranslator(),
                     new IsNullOrEmptyTranslator(),
-                    new LikeTranslator()
+                    new LikeTranslator(),
                 };
         }
 

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -6906,6 +6906,8 @@ namespace Microsoft.EntityFrameworkCore.Query
             return Task.CompletedTask;
         }
 
+        public  TEntity Client<TEntity>(TEntity entity) => entity;
+
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OrderBy_same_expression_containing_IsNull_correctly_deduplicates_the_ordering(bool isAsync)
@@ -6915,7 +6917,72 @@ namespace Microsoft.EntityFrameworkCore.Query
                 gs => gs.Select(g => g.LeaderNickname != null ? (bool?)(g.Nickname.Length == 5) : (bool?)null).OrderBy(e => e.HasValue).ThenBy(e => e.HasValue));
         }
 
-        public  TEntity Client<TEntity>(TEntity entity) => entity;
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GetValueOrDefault_in_projection(bool isAsync)
+        {
+            return AssertQueryScalar<Weapon>(
+                isAsync,
+                ws => ws.Select(w => w.SynergyWithId.GetValueOrDefault()));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GetValueOrDefault_in_filter(bool isAsync)
+        {
+            return AssertQuery<Weapon>(
+                isAsync,
+                ws => ws.Where(w => w.SynergyWithId.GetValueOrDefault() == 0));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GetValueOrDefault_in_filter_non_nullable_column(bool isAsync)
+        {
+            return AssertQuery<Weapon>(
+                isAsync,
+                ws => ws.Where(w => ((int?)w.Id).GetValueOrDefault() == 0));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GetValueOrDefault_on_DateTimeOffset(bool isAsync)
+        {
+            var defaultValue = default(DateTimeOffset);
+
+            return AssertQuery<Mission>(
+                isAsync,
+                ms => ms.Where(m => ((DateTimeOffset?)m.Timeline).GetValueOrDefault() == defaultValue));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GetValueOrDefault_in_order_by(bool isAsync)
+        {
+            return AssertQuery<Weapon>(
+                isAsync,
+                ws => ws.OrderBy(w => w.SynergyWithId.GetValueOrDefault()).ThenBy(w => w.Id),
+                assertOrder: true);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GetValueOrDefault_with_argument(bool isAsync)
+        {
+            return AssertQuery<Weapon>(
+                isAsync,
+                ws => ws.Where(w => w.SynergyWithId.GetValueOrDefault(w.Id) == 1));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task GetValueOrDefault_with_argument_complex(bool isAsync)
+        {
+            return AssertQuery<Weapon>(
+                isAsync,
+                ws => ws.Where(w => w.SynergyWithId.GetValueOrDefault(w.Name.Length + 42) > 10),
+                ws => ws.Where(w => (w.SynergyWithId == null ? w.Name.Length + 42 : w.SynergyWithId) > 10));
+        }
 
         protected GearsOfWarContext CreateContext() => Fixture.CreateContext();
 

--- a/src/EFCore.Specification.Tests/Query/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/QueryTestBase.cs
@@ -1125,6 +1125,13 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         public Task AssertQueryScalar<TItem1>(
             bool isAsync,
+            Func<IQueryable<TItem1>, IQueryable<DateTime>> query,
+            bool assertOrder = false)
+            where TItem1 : class
+            => AssertQueryScalar(isAsync, query, query, assertOrder);
+
+        public Task AssertQueryScalar<TItem1>(
+            bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<DateTimeOffset>> query,
             bool assertOrder = false)
             where TItem1 : class
@@ -1187,6 +1194,23 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             where TItem2 : class
             => AssertQueryScalar<TItem1, TItem2, bool>(isAsync, actualQuery, expectedQuery, assertOrder);
+
+        public Task AssertQueryScalar<TItem1, TItem2>(
+            bool isAsync,
+            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<DateTime>> query,
+            bool assertOrder = false)
+            where TItem1 : class
+            where TItem2 : class
+            => AssertQueryScalar<TItem1, TItem2, DateTime>(isAsync, query, query, assertOrder);
+
+        public Task AssertQueryScalar<TItem1, TItem2>(
+            bool isAsync,
+            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<DateTime>> actualQuery,
+            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<DateTime>> expectedQuery,
+            bool assertOrder = false)
+            where TItem1 : class
+            where TItem2 : class
+            => AssertQueryScalar<TItem1, TItem2, DateTime>(isAsync, actualQuery, expectedQuery, assertOrder);
 
         public Task AssertQueryScalar<TItem1, TItem2, TResult>(
             bool isAsync,

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -1111,5 +1111,26 @@ namespace Microsoft.EntityFrameworkCore.Query
                           B = o.CustomerID
                       });
         }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_GetValueOrDefault_on_DateTime(bool isAsync)
+        {
+            return AssertQueryScalar<Order>(
+                isAsync,
+                os => os.Select(o => o.OrderDate.GetValueOrDefault()));
+        }
+
+        [ConditionalTheory(Skip = "issue #12797")]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Select_GetValueOrDefault_on_DateTime_with_null_values(bool isAsync)
+        {
+            return AssertQueryScalar<Customer, Order>(
+                isAsync,
+                (cs, os) => from c in cs
+                            join o in os on c.CustomerID equals o.CustomerID into grouping
+                            from o in grouping.DefaultIfEmpty()
+                            select o.OrderDate.GetValueOrDefault());
+        }
     }
 }

--- a/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
+++ b/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
@@ -406,5 +406,22 @@ namespace Microsoft.EntityFrameworkCore.Internal
                             .Cast<Expression>()
                             .ToArray()));
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static ConstantExpression GenerateDefaultValueConstantExpression(this Type type)
+        {
+            Check.NotNull(type, nameof(type));
+
+            return (ConstantExpression)_generateDefaultValueConstantExpressionInternalMethod.MakeGenericMethod(type).Invoke(null, new object[] { });
+        }
+
+        private static readonly MethodInfo _generateDefaultValueConstantExpressionInternalMethod =
+            typeof(ExpressionExtensions).GetTypeInfo().GetDeclaredMethod(nameof(GenerateDefaultValueConstantExpressionInternal));
+
+        private static ConstantExpression GenerateDefaultValueConstantExpressionInternal<TDefault>()
+            => Expression.Constant(default(TDefault));
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7964,6 +7964,77 @@ ORDER BY CASE
 END");
         }
 
+        public override async Task GetValueOrDefault_in_projection(bool isAsync)
+        {
+            await base.GetValueOrDefault_in_projection(isAsync);
+
+            AssertSql(
+                @"SELECT COALESCE([w].[SynergyWithId], 0)
+FROM [Weapons] AS [w]");
+        }
+
+        public override async Task GetValueOrDefault_in_filter(bool isAsync)
+        {
+            await base.GetValueOrDefault_in_filter(isAsync);
+
+            AssertSql(
+                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapons] AS [w]
+WHERE COALESCE([w].[SynergyWithId], 0) = 0");
+        }
+
+        public override async Task GetValueOrDefault_in_filter_non_nullable_column(bool isAsync)
+        {
+            await base.GetValueOrDefault_in_filter_non_nullable_column(isAsync);
+
+            AssertSql(
+                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapons] AS [w]
+WHERE COALESCE([w].[Id], 0) = 0");
+        }
+
+        public override async Task GetValueOrDefault_on_DateTimeOffset(bool isAsync)
+        {
+            await base.GetValueOrDefault_on_DateTimeOffset(isAsync);
+
+            AssertSql(
+                @"@__defaultValue_0='0001-01-01T00:00:00.0000000+00:00'
+
+SELECT [m].[Id], [m].[CodeName], [m].[Rating], [m].[Timeline]
+FROM [Missions] AS [m]
+WHERE COALESCE([m].[Timeline], '0001-01-01T00:00:00.000+00:00') = @__defaultValue_0");
+        }
+
+        public override async Task GetValueOrDefault_in_order_by(bool isAsync)
+        {
+            await base.GetValueOrDefault_in_order_by(isAsync);
+
+            AssertSql(
+                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapons] AS [w]
+ORDER BY COALESCE([w].[SynergyWithId], 0), [w].[Id]");
+        }
+
+        public override async Task GetValueOrDefault_with_argument(bool isAsync)
+        {
+            await base.GetValueOrDefault_with_argument(isAsync);
+
+            AssertSql(
+                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapons] AS [w]
+WHERE COALESCE([w].[SynergyWithId], [w].[Id]) = 1");
+        }
+
+        public override async Task GetValueOrDefault_with_argument_complex(bool isAsync)
+        {
+            await base.GetValueOrDefault_with_argument_complex(isAsync);
+
+            AssertSql(
+                @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapons] AS [w]
+WHERE COALESCE([w].[SynergyWithId], CAST(LEN([w].[Name]) AS int) + 42) > 10");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
@@ -952,5 +952,22 @@ ORDER BY [B]");
 FROM [Orders] AS [o]
 ORDER BY [B]");
         }
+
+        public override async Task Select_GetValueOrDefault_on_DateTime(bool isAsync)
+        {
+            await base.Select_GetValueOrDefault_on_DateTime(isAsync);
+
+            AssertSql(
+                @"SELECT COALESCE([o].[OrderDate], '0001-01-01T00:00:00.0000000')
+FROM [Orders] AS [o]");
+        }
+
+        public override async Task Select_GetValueOrDefault_on_DateTime_with_null_values(bool isAsync)
+        {
+            await base.Select_GetValueOrDefault_on_DateTime_with_null_values(isAsync);
+
+            AssertSql(
+                @"");
+        }
     }
 }


### PR DESCRIPTION
Adding translation on a relational level - translates to COALESCE