### PR TITLE
WIP: Add eviction to query cache

### DIFF
--- a/src/EFCore/Query/Internal/ICompiledQueryCache.cs
+++ b/src/EFCore/Query/Internal/ICompiledQueryCache.cs
@@ -28,5 +28,17 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         Func<QueryContext, IAsyncEnumerable<TResult>> GetOrAddAsyncQuery<TResult>(
             [NotNull] object cacheKey,
             [NotNull] Func<Func<QueryContext, IAsyncEnumerable<TResult>>> compiler);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        void Clear();
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        int Count { get; }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -9,14 +9,12 @@ using System.Data;
 using System.Data.SqlClient;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Xunit;
 using Xunit.Abstractions;
@@ -750,7 +748,7 @@ LEFT JOIN [Customer] AS [o.Customer] ON ([o].[CustomerFirstName] = [o.Customer].
                     };
                     var details = new Details
                     {
-                        FullName = @"Daenerys Stormborn of the House Targaryen, the First of Her Name, the Unburnt, Queen of Meereen, 
+                        FullName = @"Daenerys Stormborn of the House Targaryen, the First of Her Name, the Unburnt, Queen of Meereen,
 Queen of the Andals and the Rhoynar and the First Men, Khaleesi of the Great Grass Sea, Breaker of Chains, and Mother of Dragons"
                     };
 
@@ -2265,7 +2263,7 @@ WHERE ([e].[PermissionShort] & CAST(4 AS smallint)) = CAST(4 AS smallint)");
             {
                 using (var context = new MyContext8909(_options))
                 {
-                    context.Cache.Compact(1);
+                    context.Cache.Clear();
 
                     var id = 1;
                     context.Entities.Where(c => c.Id == id).ToList();
@@ -2298,7 +2296,7 @@ WHERE [c].[Id] = @__id_0");
             {
                 using (var context = new MyContext8909(_options))
                 {
-                    context.Cache.Compact(1);
+                    context.Cache.Clear();
 
                     var id = 0;
                     // ReSharper disable once AccessToModifiedClosure
@@ -2335,7 +2333,7 @@ WHERE [c].[Id] = @__id_0");
             {
                 using (var context = new MyContext8909(_options))
                 {
-                    context.Cache.Compact(1);
+                    context.Cache.Clear();
 
                     var id = 0;
                     // ReSharper disable once AccessToModifiedClosure
@@ -2390,17 +2388,7 @@ WHERE [c].[Id] IN (
 
             public DbSet<Entity8909> Entities { get; set; }
 
-            public MemoryCache Cache
-            {
-                get
-                {
-                    var compiledQueryCache = this.GetService<ICompiledQueryCache>();
-
-                    return (MemoryCache)typeof(CompiledQueryCache).GetTypeInfo()
-                        .GetField("_memoryCache", BindingFlags.Instance | BindingFlags.NonPublic)
-                        ?.GetValue(compiledQueryCache);
-                }
-            }
+            public ICompiledQueryCache Cache => this.GetService<ICompiledQueryCache>();
         }
 
         public class Entity8909
@@ -2634,7 +2622,7 @@ WHERE [w].[Val] = 1");
                         @"CREATE FUNCTION foo.AddOne (@num int)
                                                             RETURNS int
                                                                 AS
-                                                            BEGIN  
+                                                            BEGIN
                                                                 return @num + 1 ;
                                                             END");
 
@@ -2642,7 +2630,7 @@ WHERE [w].[Val] = 1");
                         @"CREATE FUNCTION dbo.AddTwo (@num int)
                                                             RETURNS int
                                                                 AS
-                                                            BEGIN  
+                                                            BEGIN
                                                                 return @num + 2 ;
                                                             END");
 

--- a/test/EFCore.Tests/Query/CompiledQueryCacheTest.cs
+++ b/test/EFCore.Tests/Query/CompiledQueryCacheTest.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Query
+{
+    public class CompiledQueryCacheTest
+    {
+        [Fact]
+        public void Least_used_queries_are_evicted_from_cache()
+        {
+            const int threadCount = 10;
+            const int compilersCount = 1000;
+
+            var compilers = new (int Frequency, int HitCount, Func<Func<QueryContext, int>> Compiler)[compilersCount];
+
+            for (var i = 0; i < compilersCount; i++)
+            {
+                var index = i;
+
+                compilers[i] = (0, 0, (Func<Func<QueryContext, int>>)(() =>
+                {
+                    compilers[index].HitCount++;
+
+                    return q => -1;
+                }));
+            }
+
+            var used = new ConcurrentStack<int>();
+
+            ICompiledQueryCache cache = new CompiledQueryCache();
+
+            Parallel.For(
+                0, threadCount,
+                _ =>
+                {
+                    var mod = 1;
+                    for (var i = 0; i < 2000; i++)
+                    {
+                        for (var j = 0; j < compilersCount; j += mod)
+                        {
+                            compilers[j].Frequency++;
+                            cache.GetOrAddQuery(j, compilers[j].Compiler);
+                            used.Push(j);
+                        }
+
+                        mod = (mod * 2) % 256;
+                        mod = mod == 0 ? 1 : mod;
+                    }
+                });
+
+            for (var i = 0; i < 300; i++)
+            {
+                used.TryPop(out var index);
+                var compiledCount = compilers[index].HitCount;
+
+                // Should be in the cache, so this should not trigger re-compiling.
+                cache.GetOrAddQuery(index, compilers[index].Compiler);
+                Assert.Equal(compiledCount, compilers[index].HitCount);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Issue #12905

I started this with the intention of leaving IMemoryCache in place and adding eviction around it. However, I could not see that IMemoryCache was providing any value other than overhead, so I removed it here.

We have #12157 open to consider changing the way we use IMemoryCache in 3.0, which means that even if we stop using it now, we may want to start using it again in the future.

Therefore, open questions:
* Is it okay to stop using IMemoryCache?
* Should we obsolete the UseMemoryCache methods? After this change they do nothing, but we may want them back in 3.0.
  * Instead of obsoleting, we could update the API doc comments to reflect the current situation
* At the moment, the query limit and number queries to evict is hard-coded. I think it should be possible to configure these in case this change kills perf for some app using a huge number of queries. But then if the implementation changes in 3.0, any configuration we add here may not apply. So ideas:
  * Make them protected properties in the internal service, so people can set them if needed, but only as a workaround to hitting issues.
  * Add proper config and obsolete if needed in 3.0.
