### PR TITLE
Allow type mappings and member translators outside of the provider

### DIFF
--- a/src/EFCore.InMemory/Storage/Internal/InMemoryTypeMappingSource.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryTypeMappingSource.cs
@@ -38,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
                 return new InMemoryTypeMapping(clrType);
             }
 
-            return null;
+            return base.FindMapping(mappingInfo);
         }
     }
 }

--- a/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
+++ b/src/EFCore.Relational/Infrastructure/EntityFrameworkRelationalServicesBuilder.cs
@@ -93,7 +93,10 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(IRelationalConnection), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IRelationalDatabaseCreator), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IHistoryRepository), new ServiceCharacteristics(ServiceLifetime.Scoped) },
-                { typeof(INamedConnectionStringResolver), new ServiceCharacteristics(ServiceLifetime.Scoped) }
+                { typeof(INamedConnectionStringResolver), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+                { typeof(IRelationalTypeMappingSourcePlugin), new ServiceCharacteristics(ServiceLifetime.Singleton, multipleRegistrations: true) },
+                { typeof(IMethodCallTranslatorPlugin), new ServiceCharacteristics(ServiceLifetime.Singleton, multipleRegistrations: true) },
+                { typeof(IMemberTranslatorPlugin), new ServiceCharacteristics(ServiceLifetime.Singleton, multipleRegistrations: true) }
             };
 
         /// <summary>

--- a/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalConventionSetBuilderDependencies.cs
+++ b/src/EFCore.Relational/Metadata/Conventions/Internal/RelationalConventionSetBuilderDependencies.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -64,8 +65,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 new FallbackRelationalTypeMappingSource(
                     new TypeMappingSourceDependencies(
                         new ValueConverterSelector(
-                            new ValueConverterSelectorDependencies())),
-                    new RelationalTypeMappingSourceDependencies(),
+                            new ValueConverterSelectorDependencies()),
+                        Enumerable.Empty<ITypeMappingSourcePlugin>()),
+                    new RelationalTypeMappingSourceDependencies(
+                        Enumerable.Empty<IRelationalTypeMappingSourcePlugin>()),
                     typeMapper),
                 null,
                 currentContext,
@@ -153,8 +156,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 new FallbackRelationalTypeMappingSource(
                     new TypeMappingSourceDependencies(
                         new ValueConverterSelector(
-                            new ValueConverterSelectorDependencies())),
-                    new RelationalTypeMappingSourceDependencies(),
+                            new ValueConverterSelectorDependencies()),
+                        Enumerable.Empty<ITypeMappingSourcePlugin>()),
+                    new RelationalTypeMappingSourceDependencies(
+                        Enumerable.Empty<IRelationalTypeMappingSourcePlugin>()),
                     typeMapper),
                 Logger, Context, SetFinder, typeMapper);
 

--- a/src/EFCore.Relational/Query/ExpressionTranslators/IMemberTranslatorPlugin.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/IMemberTranslatorPlugin.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
+{
+    /// <summary>
+    ///     Represents plugin member translators.
+    /// </summary>
+    public interface IMemberTranslatorPlugin
+    {
+        /// <summary>
+        ///     Gets the member translators.
+        /// </summary>
+        IEnumerable<IMemberTranslator> Translators { get; }
+    }
+}

--- a/src/EFCore.Relational/Query/ExpressionTranslators/IMethodCallTranslatorPlugin.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/IMethodCallTranslatorPlugin.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
+{
+    /// <summary>
+    ///     Represents plugin method call translators.
+    /// </summary>
+    public interface IMethodCallTranslatorPlugin
+    {
+        /// <summary>
+        ///     Gets the method call translators.
+        /// </summary>
+        IEnumerable<IMethodCallTranslator> Translators { get; }
+    }
+}

--- a/src/EFCore.Relational/Query/ExpressionTranslators/RelationalCompositeMemberTranslatorDependencies.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/RelationalCompositeMemberTranslatorDependencies.cs
@@ -1,6 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
+
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
 {
     /// <summary>
@@ -35,9 +39,26 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
         ///         the constructor at any point in this process.
         ///     </para>
         /// </summary>
-        // ReSharper disable once EmptyConstructor
-        public RelationalCompositeMemberTranslatorDependencies()
+        /// <param name="plugins"> The plugins. </param>
+        public RelationalCompositeMemberTranslatorDependencies([NotNull] IEnumerable<IMemberTranslatorPlugin> plugins)
         {
+            Check.NotNull(plugins, nameof(plugins));
+
+            Plugins = plugins;
         }
+
+        /// <summary>
+        ///     Gets the plugins.
+        /// </summary>
+        public IEnumerable<IMemberTranslatorPlugin> Plugins { get; }
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="plugins"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public RelationalCompositeMemberTranslatorDependencies With(
+                [NotNull] IEnumerable<IMemberTranslatorPlugin> plugins)
+            => new RelationalCompositeMemberTranslatorDependencies(plugins);
     }
 }

--- a/src/EFCore.Relational/Query/ExpressionTranslators/RelationalCompositeMethodCallTranslatorDependencies.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/RelationalCompositeMethodCallTranslatorDependencies.cs
@@ -1,8 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
 {
@@ -39,9 +41,16 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
         ///     </para>
         /// </summary>
         /// <param name="logger"> A logger. </param>
-        public RelationalCompositeMethodCallTranslatorDependencies([NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger)
+        /// <param name="plugins"> The plugins. </param>
+        public RelationalCompositeMethodCallTranslatorDependencies(
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger,
+            [NotNull] IEnumerable<IMethodCallTranslatorPlugin> plugins)
         {
+            Check.NotNull(logger, nameof(logger));
+            Check.NotNull(plugins, nameof(plugins));
+
             Logger = logger;
+            Plugins = plugins;
         }
 
         /// <summary>
@@ -50,11 +59,25 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
         public IDiagnosticsLogger<DbLoggerCategory.Query> Logger { get; }
 
         /// <summary>
+        ///     Gets the plugins.
+        /// </summary>
+        public IEnumerable<IMethodCallTranslatorPlugin> Plugins { get; }
+
+        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="logger"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public RelationalCompositeMethodCallTranslatorDependencies With([NotNull] IDiagnosticsLogger<DbLoggerCategory.Query> logger)
-            => new RelationalCompositeMethodCallTranslatorDependencies(logger);
+            => new RelationalCompositeMethodCallTranslatorDependencies(logger, Plugins);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="plugins"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public RelationalCompositeMethodCallTranslatorDependencies With(
+                [NotNull] IEnumerable<IMethodCallTranslatorPlugin> plugins)
+            => new RelationalCompositeMethodCallTranslatorDependencies(Logger, plugins);
     }
 }

--- a/src/EFCore.Relational/Storage/IRelationalTypeMappingSourcePlugin.cs
+++ b/src/EFCore.Relational/Storage/IRelationalTypeMappingSourcePlugin.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    /// <summary>
+    ///     Represents a plugin relational type mapping source.
+    /// </summary>
+    public interface IRelationalTypeMappingSourcePlugin
+    {
+        /// <summary>
+        ///     Finds a type mapping for the given info.
+        /// </summary>
+        /// <param name="mappingInfo"> The mapping info to use to create the mapping. </param>
+        /// <returns> The type mapping, or <c>null</c> if none could be found. </returns>
+        RelationalTypeMapping FindMapping(in RelationalTypeMappingInfo mappingInfo);
+    }
+}

--- a/src/EFCore.Relational/Storage/Internal/FallbackRelationalTypeMappingSource.cs
+++ b/src/EFCore.Relational/Storage/Internal/FallbackRelationalTypeMappingSource.cs
@@ -78,7 +78,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                 mapping = mapping.Clone(newStoreName, mapping.Size);
             }
 
-            return mapping;
+            return mapping ?? base.FindMapping(mappingInfo);
         }
 
         private RelationalTypeMapping FindMappingForProperty(in RelationalTypeMappingInfo mappingInfo)

--- a/src/EFCore.Relational/Storage/RelationalTypeMapperExtensions.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapperExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
@@ -30,8 +31,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 : new FallbackRelationalTypeMappingSource(
                         new TypeMappingSourceDependencies(
                             new ValueConverterSelector(
-                                new ValueConverterSelectorDependencies())),
-                        new RelationalTypeMappingSourceDependencies(),
+                                new ValueConverterSelectorDependencies()),
+                            Enumerable.Empty<ITypeMappingSourcePlugin>()),
+                        new RelationalTypeMappingSourceDependencies(
+                            Enumerable.Empty<IRelationalTypeMappingSourcePlugin>()),
                         typeMapper)
                     .GetMappingForValue(value);
 
@@ -48,8 +51,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
             => new FallbackRelationalTypeMappingSource(
                     new TypeMappingSourceDependencies(
                         new ValueConverterSelector(
-                            new ValueConverterSelectorDependencies())),
-                    new RelationalTypeMappingSourceDependencies(),
+                            new ValueConverterSelectorDependencies()),
+                        Enumerable.Empty<ITypeMappingSourcePlugin>()),
+                    new RelationalTypeMappingSourceDependencies(
+                        Enumerable.Empty<IRelationalTypeMappingSourcePlugin>()),
                     typeMapper)
                 .GetMapping(property);
 
@@ -66,8 +71,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
             => new FallbackRelationalTypeMappingSource(
                     new TypeMappingSourceDependencies(
                         new ValueConverterSelector(
-                            new ValueConverterSelectorDependencies())),
-                    new RelationalTypeMappingSourceDependencies(),
+                            new ValueConverterSelectorDependencies()),
+                        Enumerable.Empty<ITypeMappingSourcePlugin>()),
+                    new RelationalTypeMappingSourceDependencies(
+                        Enumerable.Empty<IRelationalTypeMappingSourcePlugin>()),
                     typeMapper)
                 .GetMapping(clrType);
 
@@ -89,8 +96,10 @@ namespace Microsoft.EntityFrameworkCore.Storage
             => new FallbackRelationalTypeMappingSource(
                     new TypeMappingSourceDependencies(
                         new ValueConverterSelector(
-                            new ValueConverterSelectorDependencies())),
-                    new RelationalTypeMappingSourceDependencies(),
+                            new ValueConverterSelectorDependencies()),
+                        Enumerable.Empty<ITypeMappingSourcePlugin>()),
+                    new RelationalTypeMappingSourceDependencies(
+                        Enumerable.Empty<IRelationalTypeMappingSourcePlugin>()),
                     typeMapper)
                 .GetMapping(typeName);
     }

--- a/src/EFCore.Relational/Storage/RelationalTypeMappingSource.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMappingSource.cs
@@ -58,7 +58,19 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="mappingInfo"> The mapping info to use to create the mapping. </param>
         /// <returns> The type mapping, or <c>null</c> if none could be found. </returns>
-        protected abstract RelationalTypeMapping FindMapping(in RelationalTypeMappingInfo mappingInfo);
+        protected virtual RelationalTypeMapping FindMapping(in RelationalTypeMappingInfo mappingInfo)
+        {
+            foreach (var plugin in RelationalDependencies.Plugins)
+            {
+                var typeMapping = plugin.FindMapping(mappingInfo);
+                if (typeMapping != null)
+                {
+                    return typeMapping;
+                }
+            }
+
+            return null;
+        }
 
         /// <summary>
         ///     Dependencies used to create this <see cref="RelationalTypeMappingSource" />

--- a/src/EFCore.Relational/Storage/RelationalTypeMappingSourceDependencies.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMappingSourceDependencies.cs
@@ -1,6 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
+
 namespace Microsoft.EntityFrameworkCore.Storage
 {
     /// <summary>
@@ -35,9 +39,27 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///         the constructor at any point in this process.
         ///     </para>
         /// </summary>
-        // ReSharper disable once EmptyConstructor
-        public RelationalTypeMappingSourceDependencies()
+        /// <param name="plugins"> The plugins. </param>
+        public RelationalTypeMappingSourceDependencies(
+            [NotNull] IEnumerable<IRelationalTypeMappingSourcePlugin> plugins)
         {
+            Check.NotNull(plugins, nameof(plugins));
+
+            Plugins = plugins;
         }
+
+        /// <summary>
+        ///     Gets the plugins.
+        /// </summary>
+        public IEnumerable<IRelationalTypeMappingSourcePlugin> Plugins { get; }
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="plugins"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public RelationalTypeMappingSourceDependencies With(
+                [NotNull] IEnumerable<IRelationalTypeMappingSourcePlugin> plugins)
+            => new RelationalTypeMappingSourceDependencies(plugins);
     }
 }

--- a/src/EFCore.Relational/breakingchanges.netcore.json
+++ b/src/EFCore.Relational/breakingchanges.netcore.json
@@ -218,5 +218,15 @@
       "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.ISqlGenerationHelper",
       "MemberId": "System.Void GenerateParameterNamePlaceholder(System.Text.StringBuilder builder, System.String name)",
       "Kind": "Addition"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.RelationalCompositeMemberTranslatorDependencies",
+      "MemberId": "public .ctor()",
+      "Kind": "Removal"
+    },
+    {
+      "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.RelationalCompositeMethodCallTranslatorDependencies",
+      "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Diagnostics.IDiagnosticsLogger<Microsoft.EntityFrameworkCore.DbLoggerCategory+Query> logger)",
+      "Kind": "Removal"
     }
 ]

--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerTypeMappingSource.cs
@@ -239,7 +239,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected override RelationalTypeMapping FindMapping(in RelationalTypeMappingInfo mappingInfo)
-            => FindRawMapping(mappingInfo)?.Clone(mappingInfo);
+            => FindRawMapping(mappingInfo)?.Clone(mappingInfo)
+                ?? base.FindMapping(mappingInfo);
 
         private RelationalTypeMapping FindRawMapping(RelationalTypeMappingInfo mappingInfo)
         {

--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -145,7 +145,8 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(IPropertyListener), new ServiceCharacteristics(ServiceLifetime.Scoped, multipleRegistrations: true) },
                 { typeof(IResettableService), new ServiceCharacteristics(ServiceLifetime.Scoped, multipleRegistrations: true) },
                 { typeof(ISingletonOptions), new ServiceCharacteristics(ServiceLifetime.Singleton, multipleRegistrations: true) },
-                { typeof(IEvaluatableExpressionFilter), new ServiceCharacteristics(ServiceLifetime.Scoped) }
+                { typeof(IEvaluatableExpressionFilter), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+                { typeof(ITypeMappingSourcePlugin), new ServiceCharacteristics(ServiceLifetime.Singleton, multipleRegistrations: true) }
             };
 
         /// <summary>

--- a/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilderDependencies.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/CoreConventionSetBuilderDependencies.cs
@@ -63,7 +63,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 new FallbackTypeMappingSource(
                     new TypeMappingSourceDependencies(
                         new ValueConverterSelector(
-                            new ValueConverterSelectorDependencies())),
+                            new ValueConverterSelectorDependencies()),
+                        Enumerable.Empty<ITypeMappingSourcePlugin>()),
                     typeMapper),
                 null,
                 null,
@@ -175,7 +176,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 new FallbackTypeMappingSource(
                     new TypeMappingSourceDependencies(
                         new ValueConverterSelector(
-                            new ValueConverterSelectorDependencies())),
+                            new ValueConverterSelectorDependencies()),
+                        Enumerable.Empty<ITypeMappingSourcePlugin>()),
                     typeMapper),
                 ConstructorBindingFactory,
                 ParameterBindingFactories,

--- a/src/EFCore/Storage/ITypeMappingSourcePlugin.cs
+++ b/src/EFCore/Storage/ITypeMappingSourcePlugin.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    /// <summary>
+    ///     Represents a plugin type mapping source.
+    /// </summary>
+    public interface ITypeMappingSourcePlugin
+    {
+        /// <summary>
+        ///     Finds a type mapping for the given info.
+        /// </summary>
+        /// <param name="mappingInfo"> The mapping info to use to create the mapping. </param>
+        /// <returns> The type mapping, or <c>null</c> if none could be found. </returns>
+        CoreTypeMapping FindMapping(in TypeMappingInfo mappingInfo);
+    }
+}

--- a/src/EFCore/Storage/Internal/FallbackTypeMappingSource.cs
+++ b/src/EFCore/Storage/Internal/FallbackTypeMappingSource.cs
@@ -45,7 +45,7 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
         protected override CoreTypeMapping FindMapping(in TypeMappingInfo mappingInfo)
             => _typeMapper.IsTypeMapped(mappingInfo.ClrType)
                 ? new ConcreteTypeMapping(mappingInfo.ClrType)
-                : null;
+                : base.FindMapping(mappingInfo);
 
         private class ConcreteTypeMapping : CoreTypeMapping
         {

--- a/src/EFCore/Storage/TypeMappingSourceBase.cs
+++ b/src/EFCore/Storage/TypeMappingSourceBase.cs
@@ -51,7 +51,19 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// </summary>
         /// <param name="mappingInfo"> The mapping info to use to create the mapping. </param>
         /// <returns> The type mapping, or <c>null</c> if none could be found. </returns>
-        protected abstract CoreTypeMapping FindMapping(in TypeMappingInfo mappingInfo);
+        protected virtual CoreTypeMapping FindMapping(in TypeMappingInfo mappingInfo)
+        {
+            foreach (var plugin in Dependencies.Plugins)
+            {
+                var typeMapping = plugin.FindMapping(mappingInfo);
+                if (typeMapping != null)
+                {
+                    return typeMapping;
+                }
+            }
+
+            return null;
+        }
 
         /// <summary>
         ///     Called after a mapping has been found so that it can be validated for the given property.

--- a/src/EFCore/Storage/TypeMappingSourceDependencies.cs
+++ b/src/EFCore/Storage/TypeMappingSourceDependencies.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -40,11 +41,16 @@ namespace Microsoft.EntityFrameworkCore.Storage
         ///     </para>
         /// </summary>
         /// <param name="valueConverterSelector"> The registry of known <see cref="ValueConverter" />s. </param>
-        public TypeMappingSourceDependencies([NotNull] IValueConverterSelector valueConverterSelector)
+        /// <param name="plugins"> The plugins. </param>
+        public TypeMappingSourceDependencies(
+            [NotNull] IValueConverterSelector valueConverterSelector,
+            [NotNull] IEnumerable<ITypeMappingSourcePlugin> plugins)
         {
             Check.NotNull(valueConverterSelector, nameof(valueConverterSelector));
+            Check.NotNull(plugins, nameof(plugins));
 
             ValueConverterSelector = valueConverterSelector;
+            Plugins = plugins;
         }
 
         /// <summary>
@@ -53,11 +59,25 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public IValueConverterSelector ValueConverterSelector { get; }
 
         /// <summary>
+        ///     Gets the plugins.
+        /// </summary>
+        public IEnumerable<ITypeMappingSourcePlugin> Plugins { get; }
+
+        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="valueConverterSelector"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public TypeMappingSourceDependencies With([NotNull] IValueConverterSelector valueConverterSelector)
-            => new TypeMappingSourceDependencies(valueConverterSelector);
+            => new TypeMappingSourceDependencies(valueConverterSelector, Plugins);
+
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="plugins"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public TypeMappingSourceDependencies With([NotNull] IEnumerable<ITypeMappingSourcePlugin> plugins)
+            => new TypeMappingSourceDependencies(ValueConverterSelector, plugins);
     }
 }


### PR DESCRIPTION
This brings some of the functionality added by @roji in the Npgsql provider into EF Core. We'll use this as part of #1100 to allow NTS types to be mapped and have their members translated.

**Note to providers:** Call `base.FindMapping()` in your type mapping source to enable this functionality.