### PR TITLE
Query: Fix entity equality on navigation accessed on subquery

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -4708,6 +4708,56 @@ FROM [Orders] AS [c.Orders0]",
 FROM [Customers] AS [c0]");
         }
 
+        public override async Task Collection_navigation_equal_to_null_for_subquery(bool isAsync)
+        {
+            await base.Collection_navigation_equal_to_null_for_subquery(isAsync);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE (
+    SELECT TOP(1) [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+    ORDER BY [o].[OrderID]
+) IS NULL");
+        }
+
+        public override async Task Dependent_to_principal_navigation_equal_to_null_for_subquery(bool isAsync)
+        {
+            await base.Dependent_to_principal_navigation_equal_to_null_for_subquery(isAsync);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE (
+    SELECT TOP(1) [o].[CustomerID]
+    FROM [Orders] AS [o]
+    WHERE [c].[CustomerID] = [o].[CustomerID]
+    ORDER BY [o].[OrderID]
+) IS NULL");
+        }
+
+        public override async Task Collection_navigation_equality_rewrite_for_subquery(bool isAsync)
+        {
+            await base.Collection_navigation_equality_rewrite_for_subquery(isAsync);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE ([c].[CustomerID] LIKE N'A' + N'%' AND (LEFT([c].[CustomerID], LEN(N'A')) = N'A')) AND ((
+    SELECT TOP(1) [o].[OrderID]
+    FROM [Orders] AS [o]
+    WHERE [o].[OrderID] < 10300
+    ORDER BY [o].[OrderID]
+) = (
+    SELECT TOP(1) [o0].[OrderID]
+    FROM [Orders] AS [o0]
+    WHERE [o0].[OrderID] > 10500
+    ORDER BY [o0].[OrderID]
+))");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 


### PR DESCRIPTION
Issue:
We have certain optimizations running when comparing navigations with null or other navigations
- collection nav == collection nav converts to their parent equality
- collection nav == null converts to parent == null
- dependent to principal nav == null converts to parent.FK == null

For all above cases, we have to create parent expression. We used to create it through a method which assumed the navigation chain will always start from QSRE.
This all worked correctly upto 2.0 where we did not convert equalities after subquery.
In 2.1 we enabled equality rewrites involving subquery, which ultimately broke above assumption. The navigation chain can start from a subquery too.
Which means that for any of above optimization, we would through NRE (or equivalent).

Fix:
Instead of using function which would assume the root of chain is QSRE always, we moved to unwrapping last navigation, exactly same way we discover it in first place.

Resolves #12738
