### PR TITLE
Make database creation resilient in tests

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/Query/SqlExecutorTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/SqlExecutorTestBase.cs
@@ -57,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureCreatedResiliently();
 
                 using (var synchronizationEvent = new ManualResetEventSlim(false))
                 {
@@ -224,7 +224,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureCreatedResiliently();
 
                 using (var synchronizationEvent = new ManualResetEventSlim(false))
                 {

--- a/src/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
@@ -248,7 +248,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             protected override void Seed(DbContext context)
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureCreatedResiliently();
 
                 var order11 = new Order
                 {

--- a/src/EFCore.Specification.Tests/CompositeKeyEndToEndTestBase.cs
+++ b/src/EFCore.Specification.Tests/CompositeKeyEndToEndTestBase.cs
@@ -70,7 +70,7 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = CreateContext())
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureCreatedResiliently();
 
                 var added = context.Add(
                     new Unicorn

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -3449,7 +3449,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureCreatedResiliently();
 
                 using (var synchronizationEvent = new ManualResetEventSlim(false))
                 {
@@ -3485,7 +3485,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             using (var context = CreateContext())
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureCreatedResiliently();
 
                 using (var synchronizationEvent = new ManualResetEventSlim(false))
                 {

--- a/src/EFCore.Specification.Tests/TestUtilities/DatabaseFacadeExtensions.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/DatabaseFacadeExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities
+{
+    public static class DatabaseFacadeExtensions
+    {
+        public static bool EnsureCreatedResiliently(this DatabaseFacade facade)
+            => facade.CreateExecutionStrategy().Execute(facade, f => f.EnsureCreated());
+
+        public static Task<bool> EnsureCreatedResilientlyAsync(this DatabaseFacade façade, CancellationToken cancellationToken = default)
+            => façade.CreateExecutionStrategy().ExecuteAsync(façade, (f, ct) => f.EnsureCreatedAsync(ct), cancellationToken);
+    }
+}

--- a/test/EFCore.SqlServer.FunctionalTests/BatchingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/BatchingTest.cs
@@ -266,7 +266,7 @@ namespace Microsoft.EntityFrameworkCore
 
             protected override void Seed(PoolableDbContext context)
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureCreatedResiliently();
                 context.Database.ExecuteSqlCommand(
                     @"
 ALTER TABLE dbo.Owners

--- a/test/EFCore.SqlServer.FunctionalTests/ComputedColumnTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/ComputedColumnTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new Context(serviceProvider, TestStore.Name))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureCreatedResiliently();
 
                 var entity = context.Add(new Entity { P1 = 20, P2 = 30, P3 = 80 }).Entity;
 
@@ -39,7 +39,7 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new Context(serviceProvider, TestStore.Name))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureCreatedResiliently();
 
                 var entity = context.Add(new Entity { P1 = 20, P2 = 30 }).Entity;
 
@@ -139,7 +139,7 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new NullableContext(serviceProvider, TestStore.Name))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureCreatedResiliently();
 
                 var entity = context.EnumItems.Add(new EnumItem { FlagEnum = FlagEnum.AValue, OptionalFlagEnum = FlagEnum.BValue }).Entity;
                 context.SaveChanges();

--- a/test/EFCore.SqlServer.FunctionalTests/DefaultValuesTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DefaultValuesTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.EntityFrameworkCore
         {
             using (var context = new ChipsContext(_serviceProvider, TestStore.Name))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureCreatedResiliently();
 
                 context.Chippers.Add(
                     new Chipper

--- a/test/EFCore.SqlServer.FunctionalTests/MemoryOptimizedTablesTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/MemoryOptimizedTablesTest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore
                 };
                 using (var context = CreateContext())
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     // ReSharper disable once CoVariantArrayConversion
                     context.AddRange(fastUns);

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -139,7 +139,7 @@ INSERT [dbo].[Postcodes] ([PostcodeID], [PostcodeValue], [TownName]) VALUES (5, 
             {
                 using (var context = new DeadlockContext(Fixture.CreateOptions(testStore)))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
                     context.EnsureSeeded();
 
                     var count
@@ -4733,7 +4733,7 @@ FROM [Prices] AS [e]");
 
             using (var context = contextCreator())
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureCreatedResiliently();
                 contextInitializer?.Invoke(context);
             }
 

--- a/test/EFCore.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SequenceEndToEndTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new BronieContext(serviceProvider, TestStore.Name))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureCreatedResiliently();
             }
 
             AddEntities(serviceProvider, TestStore.Name);
@@ -82,7 +82,7 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new BronieContext(serviceProvider, TestStore.Name))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureCreatedResiliently();
             }
 
             await AddEntitiesAsync(serviceProvider, TestStore.Name);
@@ -140,7 +140,7 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new BronieContext(serviceProvider, TestStore.Name))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureCreatedResiliently();
             }
 
             const int threadCount = 50;
@@ -180,7 +180,7 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new BronieContext(serviceProvider, TestStore.Name))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureCreatedResiliently();
             }
 
             AddEntitiesWithIds(serviceProvider, 0, TestStore.Name);
@@ -279,7 +279,7 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new NullableBronieContext(serviceProvider, TestStore.Name, true))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureCreatedResiliently();
             }
 
             AddEntitiesNullable(serviceProvider, TestStore.Name, true);
@@ -307,7 +307,7 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new NullableBronieContext(serviceProvider, TestStore.Name, false))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureCreatedResiliently();
             }
 
             AddEntitiesNullable(serviceProvider, TestStore.Name, false);

--- a/test/EFCore.SqlServer.FunctionalTests/SequentialGuidEndToEndTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SequentialGuidEndToEndTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new BronieContext(serviceProvider, TestStore.Name))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureCreatedResiliently();
 
                 for (var i = 0; i < 50; i++)
                 {
@@ -59,7 +59,7 @@ namespace Microsoft.EntityFrameworkCore
 
             using (var context = new BronieContext(serviceProvider, TestStore.Name))
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureCreatedResiliently();
 
                 for (var i = 0; i < 50; i++)
                 {

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerConfigPatternsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerConfigPatternsTest.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 // ReSharper disable InconsistentNaming
 // ReSharper disable UnusedAutoPropertyAccessor.Local
+#pragma warning disable RCS1102 // Make class static.
 namespace Microsoft.EntityFrameworkCore
 {
     public class SqlServerConfigPatternsTest

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerDatabaseCreatorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerDatabaseCreatorTest.cs
@@ -352,15 +352,15 @@ namespace Microsoft.EntityFrameworkCore
             {
                 using (var context = new BloggingContext(testDatabase))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     if (async)
                     {
-                        Assert.False(await context.Database.EnsureCreatedAsync());
+                        Assert.False(await context.Database.EnsureCreatedResilientlyAsync());
                     }
                     else
                     {
-                        Assert.False(context.Database.EnsureCreated());
+                        Assert.False(context.Database.EnsureCreatedResiliently());
                     }
 
                     Assert.Equal(ConnectionState.Closed, context.Database.GetDbConnection().State);
@@ -673,6 +673,7 @@ namespace Microsoft.EntityFrameworkCore
         }
     }
 
+    #pragma warning disable RCS1102 // Make class static.
     [SqlServerCondition(SqlServerCondition.IsNotSqlAzure | SqlServerCondition.IsNotTeamCity)]
     public class SqlServerDatabaseCreatorTest
     {

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerDbFunctionMetadataTests.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerDbFunctionMetadataTests.cs
@@ -12,7 +12,7 @@ namespace Microsoft.EntityFrameworkCore
 {
     public class SqlServerDbFunctionMetadataTests
     {
-        public class TestMethods
+        public static class TestMethods
         {
             public static int Foo()
             {

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -119,7 +119,7 @@ namespace Microsoft.EntityFrameworkCore
                 var options = Fixture.CreateOptions(testDatabase);
                 using (var context = new NumNumContext(options))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     context.AddRange(
                         nownNum1, nownNum2, numNum1, numNum2, adNum1, adNum2, anNum1, anNum2,
@@ -334,7 +334,7 @@ namespace Microsoft.EntityFrameworkCore
                 var options = Fixture.CreateOptions(testDatabase);
                 using (var context = new ENumContext(options))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     context.AddRange(sNum1, sNum2, enNum1, enNum2, bNum1, bNum2);
 
@@ -608,7 +608,7 @@ namespace Microsoft.EntityFrameworkCore
                 var options = Fixture.CreateOptions(testDatabase);
                 using (var context = new GameDbContext(options))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     context.Characters.Add(
                         new PlayerCharacter(
@@ -643,7 +643,7 @@ namespace Microsoft.EntityFrameworkCore
 
                 using (var context = new GameDbContext(options))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     var player = new PlayerCharacter(
                         new Level
@@ -679,7 +679,7 @@ namespace Microsoft.EntityFrameworkCore
 
                 using (var context = new GameDbContext(options))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     var player = new PlayerCharacter(
                         new Level
@@ -728,7 +728,7 @@ namespace Microsoft.EntityFrameworkCore
 
                 using (var context = new GameDbContext(options))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     var player = new PlayerCharacter(
                         new Level
@@ -1149,7 +1149,7 @@ namespace Microsoft.EntityFrameworkCore
         private static async Task<TBlog[]> CreateBlogDatabaseAsync<TBlog>(DbContext context)
             where TBlog : class, IBlog, new()
         {
-            context.Database.EnsureCreated();
+            context.Database.EnsureCreatedResiliently();
 
             var blog1 = context.Add(
                 new TBlog

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerQueryTriggersTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerQueryTriggersTest.cs
@@ -143,7 +143,7 @@ namespace Microsoft.EntityFrameworkCore
 
             protected override void Seed(DbContext context)
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureCreatedResiliently();
 
                 context.Database.ExecuteSqlCommand(
                     @"

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerTriggersTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerTriggersTest.cs
@@ -167,7 +167,7 @@ namespace Microsoft.EntityFrameworkCore
 
             protected override void Seed(PoolableDbContext context)
             {
-                context.Database.EnsureCreated();
+                context.Database.EnsureCreatedResiliently();
 
                 context.Database.ExecuteSqlCommand(
                     @"

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerValueGenerationScenariosTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 using (var context = new BlogContextIdentity(testStore.Name))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     context.AddRange(
                         new Blog
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 using (var context = new BlogContextHiLo(testStore.Name))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     context.AddRange(
                         new Blog
@@ -126,7 +126,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 using (var context = new BlogContextDefaultValue(testStore.Name))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     context.AddRange(
                         new Blog
@@ -218,7 +218,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 using (var context = new BlogContextStringDefaultValue(testStore.Name))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     context.AddRange(
                         new BlogWithStringKey
@@ -280,7 +280,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 using (var context = new BlogContextKeyColumnWithDefaultValue(testStore.Name))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     context.AddRange(
                         new Blog
@@ -332,7 +332,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 using (var context = new BlogContextNoKeyGeneration(testStore.Name))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     context.AddRange(
                         new Blog
@@ -381,7 +381,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 using (var context = new BlogContextNoKeyGenerationNullableKey(testStore.Name))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     context.AddRange(
                         new NullableKeyBlog
@@ -431,7 +431,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 using (var context = new BlogContextNonKeyDefaultValue(testStore.Name))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     var blogs = new List<Blog>
                     {
@@ -507,7 +507,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 using (var context = new BlogContextNonKeyReadOnlyDefaultValue(testStore.Name))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     context.AddRange(
                         new Blog
@@ -574,7 +574,7 @@ namespace Microsoft.EntityFrameworkCore
             {
                 using (var context = new BlogContextComputedColumn(testStore.Name))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     var blog = context.Add(
                         new FullNameBlog
@@ -777,7 +777,7 @@ END");
                 Guid afterSave;
                 using (var context = new BlogContextClientGuidKey(testStore.Name))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     var blog = context.Add(
                         new GuidBlog
@@ -831,7 +831,7 @@ END");
             {
                 using (var context = new BlogContextClientGuidNonKey(testStore.Name))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     var blog = context.Add(
                         new GuidBlog
@@ -866,7 +866,7 @@ END");
                 Guid afterSave;
                 using (var context = new BlogContextServerGuidKey(testStore.Name))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     var blog = context.Add(
                         new GuidBlog
@@ -927,7 +927,7 @@ END");
             {
                 using (var context = new BlogContext(testStore.Name))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     context.AddRange(
                         new Blog
@@ -958,7 +958,7 @@ END");
             {
                 using (var context = new BlogContext(testStore.Name))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     context.AddRange(
                         new Blog
@@ -995,7 +995,7 @@ END");
             {
                 using (var context = new BlogContextSpecifyKeysUsingDefault(testStore.Name))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     context.AddRange(
                         new Blog
@@ -1045,7 +1045,7 @@ END");
             {
                 using (var context = new BlogContextReadOnlySequenceKeyColumnWithDefaultValue(testStore.Name))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     context.AddRange(
                         new Blog
@@ -1092,7 +1092,7 @@ END");
             {
                 using (var context = new BlogContextNonKeyReadOnlyDefaultValue(testStore.Name))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     context.AddRange(
                         new Blog
@@ -1121,7 +1121,7 @@ END");
             {
                 using (var context = new BlogContextComputedColumn(testStore.Name))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     context.Add(
                         new FullNameBlog
@@ -1147,7 +1147,7 @@ END");
             {
                 using (var context = new BlogContextComputedColumn(testStore.Name))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     context.Add(
                         new FullNameBlog
@@ -1182,7 +1182,7 @@ END");
             {
                 using (var context = new BlogContextConcurrencyWithRowversion(testStore.Name))
                 {
-                    context.Database.EnsureCreated();
+                    context.Database.EnsureCreatedResiliently();
 
                     var blog = context.Add(
                         new ConcurrentBlog

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
@@ -87,7 +87,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 {
                     using (var context = createContext())
                     {
-                        context.Database.EnsureCreated();
+                        context.Database.EnsureCreatedResiliently();
                         seed(context);
                     }
                 }

--- a/test/EFCore.SqlServer.Tests/CommandConfigurationTests.cs
+++ b/test/EFCore.SqlServer.Tests/CommandConfigurationTests.cs
@@ -5,6 +5,7 @@ using System;
 using Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider;
 using Xunit;
 
+#pragma warning disable RCS1102 // Make class static.
 namespace Microsoft.EntityFrameworkCore
 {
     public class CommandConfigurationTests


### PR DESCRIPTION
Tests using `SharedStoreFixture` already have resilient database creation

Fixes #13037 

