### PR TITLE
[2.1.5] Query: Improve logic to find underlying property for projection

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalExpressionExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalExpressionExtensions.cs
@@ -89,6 +89,9 @@ namespace Microsoft.EntityFrameworkCore.Internal
                     return columnReferenceExpression.Expression.FindProperty(targetType);
                 case AliasExpression aliasExpression:
                     return aliasExpression.Expression.FindProperty(targetType);
+                case NullableExpression nullableExpression
+                when !AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue13025", out var isEnabled) || !isEnabled:
+                    return nullableExpression.Operand.FindProperty(targetType);
                 case UnaryExpression unaryExpression:
                     return unaryExpression.Operand.FindProperty(targetType);
                 case SqlFunctionExpression functionExpression:


### PR DESCRIPTION
Issue: GroupJoin-DefaultIfEmpty aka left outer join introduced NullableExpression around the property which we fail to find hence we use wrong type mapping which expect int32 but we get back int16 from database

Resolves #13025
