### PR TITLE
[2.1.5] Fix to #10153 - Query: add translator for Nullable<>.GetValueOrDefault()

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionTranslators/Internal/GetValueOrDefaultTranslator.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/Internal/GetValueOrDefaultTranslator.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class GetValueOrDefaultTranslator : IMethodCallTranslator
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Expression Translate(MethodCallExpression methodCallExpression)
+        {
+            if (methodCallExpression.Method.Name == nameof(Nullable<int>.GetValueOrDefault)
+                && methodCallExpression.Type.IsNumeric())
+            {
+                if (methodCallExpression.Arguments.Count == 0)
+                {
+                    return Expression.Coalesce(
+                        methodCallExpression.Object,
+                        methodCallExpression.Type.GenerateDefaultValueConstantExpression());
+                }
+                else if (methodCallExpression.Arguments.Count == 1)
+                {
+                    return Expression.Coalesce(
+                        methodCallExpression.Object,
+                        methodCallExpression.Arguments[0]);
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/EFCore.Relational/Query/ExpressionTranslators/RelationalCompositeMethodCallTranslator.cs
+++ b/src/EFCore.Relational/Query/ExpressionTranslators/RelationalCompositeMethodCallTranslator.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -38,6 +39,11 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionTranslators
                     new IsNullOrEmptyTranslator(),
                     new LikeTranslator()
                 };
+
+            if (!AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue10153", out var isEnabled) || !isEnabled)
+            {
+                _methodCallTranslators.Add(new GetValueOrDefaultTranslator());
+            }
         }
 
         /// <summary>

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -5068,6 +5068,59 @@ namespace Microsoft.EntityFrameworkCore.Query
                     CollectionAsserter<string>(ee => ee)(e.Weapons, a.Weapons);
                 });
         }
+        
+        [ConditionalFact]
+        public virtual void GetValueOrDefault_in_projection()
+        {
+            AssertQueryScalar<Weapon>(
+                ws => ws.Select(w => w.SynergyWithId.GetValueOrDefault()));
+        }
+
+        [ConditionalFact]
+        public virtual void GetValueOrDefault_in_filter()
+        {
+            AssertQuery<Weapon>(
+                ws => ws.Where(w => w.SynergyWithId.GetValueOrDefault() == 0));
+        }
+
+        [ConditionalFact]
+        public virtual void GetValueOrDefault_in_filter_non_nullable_column()
+        {
+            AssertQuery<Weapon>(
+                ws => ws.Where(w => ((int?)w.Id).GetValueOrDefault() == 0));
+        }
+
+        [ConditionalFact]
+        public virtual void GetValueOrDefault_on_DateTimeOffset()
+        {
+            var defaultValue = default(DateTimeOffset);
+
+            AssertQuery<Mission>(
+               ms => ms.Where(m => ((DateTimeOffset?)m.Timeline).GetValueOrDefault() == defaultValue));
+        }
+
+        [ConditionalFact]
+        public virtual void GetValueOrDefault_in_order_by()
+        {
+            AssertQuery<Weapon>(
+                ws => ws.OrderBy(w => w.SynergyWithId.GetValueOrDefault()).ThenBy(w => w.Id),
+                assertOrder: true);
+        }
+
+        [ConditionalFact]
+        public virtual void GetValueOrDefault_with_argument()
+        {
+            AssertQuery<Weapon>(
+                ws => ws.Where(w => w.SynergyWithId.GetValueOrDefault(w.Id) == 1));
+        }
+
+        [ConditionalFact]
+        public virtual void GetValueOrDefault_with_argument_complex()
+        {
+            AssertQuery<Weapon>(
+                ws => ws.Where(w => w.SynergyWithId.GetValueOrDefault(w.Name.Length + 42) > 10),
+                ws => ws.Where(w => (w.SynergyWithId == null ? w.Name.Length + 42 : w.SynergyWithId) > 10));
+        }
 
         // Remember to add any new tests to Async version of this test class
 

--- a/src/EFCore.Specification.Tests/Query/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/QueryTestBase.cs
@@ -198,6 +198,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             => AssertQueryScalar<TItem1, bool>(actualQuery, expectedQuery, assertOrder);
 
         public void AssertQueryScalar<TItem1>(
+            Func<IQueryable<TItem1>, IQueryable<DateTime>> query,
+            bool assertOrder = false)
+            where TItem1 : class
+            => AssertQueryScalar(query, query, assertOrder);
+
+        public void AssertQueryScalar<TItem1>(
             Func<IQueryable<TItem1>, IQueryable<DateTimeOffset>> query,
             bool assertOrder = false)
             where TItem1 : class
@@ -253,6 +259,21 @@ namespace Microsoft.EntityFrameworkCore.Query
             where TItem1 : class
             where TItem2 : class
             => AssertQueryScalar<TItem1, TItem2, bool>(actualQuery, expectedQuery, assertOrder);
+
+        public void AssertQueryScalar<TItem1, TItem2>(
+            Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<DateTime>> query,
+            bool assertOrder = false)
+            where TItem1 : class
+            where TItem2 : class
+            => AssertQueryScalar<TItem1, TItem2, DateTime>(query, query, assertOrder);
+
+        public void AssertQueryScalar<TItem1, TItem2>(
+           Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<DateTime>> actualQuery,
+           Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<DateTime>> expectedQuery,
+           bool assertOrder = false)
+           where TItem1 : class
+           where TItem2 : class
+           => AssertQueryScalar<TItem1, TItem2, DateTime>(actualQuery, expectedQuery, assertOrder);
 
         public void AssertQueryScalar<TItem1, TItem2, TResult>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TResult>> actualQuery,

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Select.cs
@@ -793,5 +793,22 @@ namespace Microsoft.EntityFrameworkCore.Query
                           B = c.CustomerID
                       });
         }
+
+        [ConditionalFact]
+        public virtual void Select_GetValueOrDefault_on_DateTime()
+        {
+            AssertQueryScalar<Order>(
+                os => os.Select(o => o.OrderDate.GetValueOrDefault()));
+        }
+
+        [ConditionalFact(Skip = "issue #12797")]
+        public virtual void Select_GetValueOrDefault_on_DateTime_with_null_values()
+        {
+            AssertQueryScalar<Customer, Order>(
+                (cs, os) => from c in cs
+                            join o in os on c.CustomerID equals o.CustomerID into grouping
+                            from o in grouping.DefaultIfEmpty()
+                            select o.OrderDate.GetValueOrDefault());
+        }
     }
 }

--- a/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
+++ b/src/EFCore/Extensions/Internal/ExpressionExtensions.cs
@@ -395,5 +395,22 @@ namespace Microsoft.EntityFrameworkCore.Internal
                             .Cast<Expression>()
                             .ToArray()));
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static ConstantExpression GenerateDefaultValueConstantExpression(this Type type)
+        {
+            Check.NotNull(type, nameof(type));
+
+            return (ConstantExpression)_generateDefaultValueConstantExpressionInternalMethod.MakeGenericMethod(type).Invoke(null, new object[] { });
+        }
+
+        private static readonly MethodInfo _generateDefaultValueConstantExpressionInternalMethod =
+           typeof(ExpressionExtensions).GetTypeInfo().GetDeclaredMethod(nameof(GenerateDefaultValueConstantExpressionInternal));
+
+        private static ConstantExpression GenerateDefaultValueConstantExpressionInternal<TDefault>()
+           => Expression.Constant(default(TDefault));
     }
 }

--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -33,6 +33,16 @@ namespace System
                     ? typeof(Nullable<>).MakeGenericType(type)
                     : type.UnwrapNullableType();
 
+        public static bool IsNumeric(this Type type)
+        {
+            type = type.UnwrapNullableType();
+
+            return type.IsInteger()
+               || type == typeof(decimal)
+               || type == typeof(float)
+               || type == typeof(double);
+        }
+
         public static bool IsInteger(this Type type)
         {
             type = type.UnwrapNullableType();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7437,6 +7437,74 @@ INNER JOIN (
 ORDER BY [t].[c] DESC, [t].[Nickname], [t].[SquadId], [t].[FullName]");
         }
 
+        public override void GetValueOrDefault_in_projection()
+        {
+            base.GetValueOrDefault_in_projection();
+
+            AssertSql(
+               @"SELECT COALESCE([w].[SynergyWithId], 0)
+FROM [Weapons] AS [w]");
+        }
+
+        public override void GetValueOrDefault_in_filter()
+        {
+            base.GetValueOrDefault_in_filter();
+
+            AssertSql(
+               @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapons] AS [w]
+WHERE COALESCE([w].[SynergyWithId], 0) = 0");
+        }
+
+        public override void GetValueOrDefault_in_filter_non_nullable_column()
+        {
+            base.GetValueOrDefault_in_filter_non_nullable_column();
+
+            AssertSql(
+               @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapons] AS [w]
+WHERE COALESCE([w].[Id], 0) = 0");
+        }
+
+        public override void GetValueOrDefault_on_DateTimeOffset()
+        {
+            base.GetValueOrDefault_on_DateTimeOffset();
+
+            AssertSql(
+                @"SELECT [m].[Id], [m].[CodeName], [m].[Rating], [m].[Timeline]
+FROM [Missions] AS [m]");
+        }
+
+        public override void GetValueOrDefault_in_order_by()
+        {
+            base.GetValueOrDefault_in_order_by();
+
+            AssertSql(
+               @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapons] AS [w]
+ORDER BY COALESCE([w].[SynergyWithId], 0), [w].[Id]");
+        }
+
+        public override void GetValueOrDefault_with_argument()
+        {
+            base.GetValueOrDefault_with_argument();
+
+            AssertSql(
+               @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapons] AS [w]
+WHERE COALESCE([w].[SynergyWithId], [w].[Id]) = 1");
+        }
+
+        public override void GetValueOrDefault_with_argument_complex()
+        {
+            base.GetValueOrDefault_with_argument_complex();
+
+            AssertSql(
+               @"SELECT [w].[Id], [w].[AmmunitionType], [w].[IsAutomatic], [w].[Name], [w].[OwnerFullName], [w].[SynergyWithId]
+FROM [Weapons] AS [w]
+WHERE COALESCE([w].[SynergyWithId], CAST(LEN([w].[Name]) AS int) + 42) > 10");
+        }
+
         private void AssertSql(params string[] expected)
             => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
@@ -906,5 +906,22 @@ FROM [Orders] AS [o]");
 FROM [Customers] AS [c]
 ORDER BY [B]");
         }
+
+        public override void Select_GetValueOrDefault_on_DateTime()
+        {
+            base.Select_GetValueOrDefault_on_DateTime();
+
+            AssertSql(
+                @"SELECT [o].[OrderDate]
+FROM [Orders] AS [o]");
+        }
+
+        public override void Select_GetValueOrDefault_on_DateTime_with_null_values()
+        {
+            base.Select_GetValueOrDefault_on_DateTime_with_null_values();
+
+            AssertSql(
+               @"");
+        }
     }
 }


### PR DESCRIPTION
Adding translation on a relational level - translates to COALESCE