### PR TITLE
Relational extensions: add time unit to XML docs

### DIFF
--- a/src/EFCore.Relational/RelationalDatabaseFacadeExtensions.cs
+++ b/src/EFCore.Relational/RelationalDatabaseFacadeExtensions.cs
@@ -429,7 +429,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     <para>
-        ///         Sets the timeout to use for commands executed with this <see cref="DbContext" />.
+        ///         Sets the timeout (in seconds) to use for commands executed with this <see cref="DbContext" />.
         ///     </para>
         ///     <para>
         ///         Note that the command timeout is distinct from the connection timeout, which is commonly
@@ -469,7 +469,7 @@ namespace Microsoft.EntityFrameworkCore
 
         /// <summary>
         ///     <para>
-        ///         Returns the timeout set for commands executed with this <see cref="DbContext" />.
+        ///         Returns the timeout (in seconds) set for commands executed with this <see cref="DbContext" />.
         ///     </para>
         ///     <para>
         ///         Note that the command timeout is distinct from the connection timeout, which is commonly


### PR DESCRIPTION
Adds time unit details to Get/SetCommandTimeout() extension methods:
 - Adds `"(in seconds)"` to `GetCommandTimeout()`
 - Adds `"(in seconds)"` to `SetCommandTimeout()` (`int` overload only)

Currently, a user sees this:

![image](https://user-images.githubusercontent.com/454813/44435040-24feb480-a57c-11e8-94e8-b8eb5ee81425.png)

After a tweet, others seemed to agree a quick time unit addition here would save some headaches, so...here it is!