### PR TITLE
Include Expression could not handle extra join

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -1,4 +1,4 @@
-// Copyright (c) .NET Foundation. All rights reserved.
+﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -1614,11 +1614,18 @@ namespace Microsoft.EntityFrameworkCore.Query
                     ? innerSelectExpression.Projection
                     : Enumerable.Empty<Expression>();
 
-            var joinExpression
-                = outerSelectExpression.AddInnerJoin(
-                    innerSelectExpression.Tables.Single(),
+            var joinExpression = outerSelectExpression.AddInnerJoin(
+                    innerSelectExpression.Tables.First(),
                     projection,
                     innerSelectExpression.Predicate);
+
+            if (innerSelectExpression.Tables.Count > 1)
+            {
+                foreach (var otherTableExpression in innerSelectExpression.Tables.Skip(1))
+                {
+                    outerSelectExpression.AddTable(otherTableExpression);
+                }
+            }
 
             joinExpression.Predicate = predicate;
             joinExpression.QuerySource = joinClause;


### PR DESCRIPTION
- [X] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format

    Summary of the changes
    If you look into following issues, #12965 and #12668, you can see i want to create an extra join on
    properties that i marked for it. Everytime i do a query i want to **Coalesce** these column with a
    **Joined Table.** When i did this i ran into multiple issues, as example when you have a **Navigation
    Property** it was always filled in, EFCore saw this as an object when you use **Expression.New** and not
    anymore as an **EntityType**. The reason for this is explained in the issues and that's because they 
    make use of **Tracking**.
    As you can see in the issue #12668 i asked if it is a good idea to keep creating an **EntityType** if
    **AsNoTracking** Expression is added. While i am waiting i created a work around in my code that make
    this work on **EFCore.Relational** level, i made an overwrite of the **SelectExpression** class. While i was 
    creating this work around i bumped into a problem and that problem is when i add an `Include` 
    Expression **EFCore** first creates a **SelectExpression** and than convert it to an **InnerJoin**. My 
    modification adds to the **SelectExpression** of the **Include** Expression also a **LeftOuterJoin**. Because
    of this the **innerSelectExpression** had 2 tables instead of 1. So what i did is use the **First** table for the
    **InnerJoin** and add my **LeftOuterJoin** also as a **Table** to the **outerSelectExpression**.

    This solved my issue, so now i hope this could be implemented in **EFCore** so i can keep working with
    this final work around until there comes a better solution.

- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Code meets the expectations our engineering guidelines.