### PR TITLE
WIP: Cosmos.Sql: Basic MemberAccess binding on client side

### DIFF
--- a/src/EFCore.Cosmos.Sql/Extensions/CosmosSqlServiceCollectionExtensions.cs
+++ b/src/EFCore.Cosmos.Sql/Extensions/CosmosSqlServiceCollectionExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
+using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
@@ -30,6 +31,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 .TryAdd<IDatabaseCreator, CosmosSqlDatabaseCreator>()
                 .TryAdd<IEntityQueryModelVisitorFactory, CosmosSqlEntityQueryModelVisitorFactory>()
                 .TryAdd<IEntityQueryableExpressionVisitorFactory, CosmosSqlEntityQueryableExpressionVisitorFactory>()
+                .TryAdd<IMemberAccessBindingExpressionVisitorFactory, CosmosSqlMemberAccessBindingExpressionVisitorFactory>()
                 .TryAddProviderSpecificServices(
                     b => b
                         .TryAddScoped<CosmosClient, CosmosClient>()

--- a/src/EFCore.Cosmos.Sql/Query/ExpressionVisitors/Internal/CosmosSqlEntityQueryableExpressionVisitor.cs
+++ b/src/EFCore.Cosmos.Sql/Query/ExpressionVisitors/Internal/CosmosSqlEntityQueryableExpressionVisitor.cs
@@ -47,7 +47,12 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.ExpressionVisitors.Inte
                     entityType.CosmosSql().CollectionName,
                     new SelectExpression(entityType, _querySource),
                     _cosmosClient),
-                new EntityShaper(entityType, _entityMaterializerSource));
+                new EntityShaper(entityType,
+                    trackingQuery: QueryModelVisitor.QueryCompilationContext.IsTrackingQuery
+                        && !entityType.IsQueryType,
+                    useQueryBuffer: QueryModelVisitor.QueryCompilationContext.IsQueryBufferRequired
+                        && !entityType.IsQueryType,
+                    _entityMaterializerSource));
         }
     }
 }

--- a/src/EFCore.Cosmos.Sql/Query/ExpressionVisitors/Internal/CosmosSqlMemberAccessBindingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos.Sql/Query/ExpressionVisitors/Internal/CosmosSqlMemberAccessBindingExpressionVisitor.cs
@@ -1,0 +1,121 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Extensions.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
+using Newtonsoft.Json.Linq;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.Expressions;
+using Remotion.Linq.Parsing;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.ExpressionVisitors.Internal
+{
+    public class CosmosSqlMemberAccessBindingExpressionVisitor : RelinqExpressionVisitor
+    {
+        private readonly QuerySourceMapping _querySourceMapping;
+        private readonly EntityQueryModelVisitor _queryModelVisitor;
+        private readonly bool _inProjection;
+        private static readonly MethodInfo _getItemMethodInfo
+            = typeof(JObject).GetTypeInfo().GetRuntimeProperties()
+                .Single(pi => pi.Name == "Item" && pi.GetIndexParameters()[0].ParameterType == typeof(string))
+                .GetMethod;
+
+        public CosmosSqlMemberAccessBindingExpressionVisitor(
+            QuerySourceMapping querySourceMapping,
+            EntityQueryModelVisitor queryModelVisitor,
+            bool inProjection)
+        {
+            _querySourceMapping = querySourceMapping;
+            _queryModelVisitor = queryModelVisitor;
+            _inProjection = inProjection;
+        }
+
+        protected override Expression VisitMember(MemberExpression memberExpression)
+        {
+            var newExpression = Visit(memberExpression.Expression);
+
+            if (newExpression != memberExpression.Expression)
+            {
+                if (newExpression.Type == typeof(JObject))
+                {
+                    var properties = MemberAccessBindingExpressionVisitor.GetPropertyPath(
+                        memberExpression, _queryModelVisitor.QueryCompilationContext, out var qsre);
+
+                    if (qsre != null)
+                    {
+                        foreach (var property in properties)
+                        {
+                            newExpression = CreateGetValueExpression(
+                                newExpression, property);
+                        }
+
+                        return newExpression;
+                    }
+                }
+
+                return Expression.MakeMemberAccess(newExpression, memberExpression.Member);
+            }
+
+            return memberExpression;
+        }
+
+        protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
+        {
+            if (methodCallExpression.Method.IsEFPropertyMethod())
+            {
+                var source = methodCallExpression.Arguments[0];
+                var newSource = Visit(source);
+
+                if (source != newSource)
+                {
+                    if (newSource.Type == typeof(JObject))
+                    {
+                        var properties = MemberAccessBindingExpressionVisitor.GetPropertyPath(
+                        methodCallExpression, _queryModelVisitor.QueryCompilationContext, out var qsre);
+
+                        if (qsre != null)
+                        {
+                            foreach (var property in properties)
+                            {
+                                newSource = CreateGetValueExpression(
+                                    newSource, property);
+                            }
+
+                            return newSource;
+                        }
+                    }
+                }
+            }
+
+            return base.VisitMethodCall(methodCallExpression);
+        }
+
+        protected override Expression VisitQuerySourceReference(QuerySourceReferenceExpression querySourceReferenceExpression)
+        {
+            return _querySourceMapping.ContainsMapping(querySourceReferenceExpression.ReferencedQuerySource)
+                ? _querySourceMapping.GetExpression(querySourceReferenceExpression.ReferencedQuerySource)
+                : querySourceReferenceExpression;
+        }
+
+        private static Expression CreateGetValueExpression(
+            Expression jObjectExpression,
+            IPropertyBase property)
+        {
+            // TODO : Converters
+            // TODO : TryCatch for invalid values
+
+            return Expression.Convert(
+                Expression.Call(
+                    jObjectExpression,
+                    _getItemMethodInfo,
+                    Expression.Constant(property.Name)),
+                property.ClrType);
+        }
+    }
+}

--- a/src/EFCore.Cosmos.Sql/Query/ExpressionVisitors/Internal/CosmosSqlMemberAccessBindingExpressionVisitorFactory.cs
+++ b/src/EFCore.Cosmos.Sql/Query/ExpressionVisitors/Internal/CosmosSqlMemberAccessBindingExpressionVisitorFactory.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
+using Remotion.Linq.Clauses;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.ExpressionVisitors.Internal
+{
+    public class CosmosSqlMemberAccessBindingExpressionVisitorFactory : MemberAccessBindingExpressionVisitorFactory
+    {
+        public override ExpressionVisitor Create(
+            QuerySourceMapping querySourceMapping,
+            EntityQueryModelVisitor queryModelVisitor,
+            bool inProjection)
+            => new CosmosSqlMemberAccessBindingExpressionVisitor(querySourceMapping, queryModelVisitor, inProjection);
+    }
+}

--- a/src/EFCore.Cosmos.Sql/Query/ExpressionVisitors/Internal/SqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos.Sql/Query/ExpressionVisitors/Internal/SqlTranslatingExpressionVisitor.cs
@@ -25,7 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.ExpressionVisitors.Inte
             var properties = MemberAccessBindingExpressionVisitor.GetPropertyPath(memberExpression,
                 _queryCompilationContext, out var qsre);
 
-            return _selectExpression.BindPropertyPath(qsre, properties) ?? base.VisitMember(memberExpression);
+            return _selectExpression.BindPropertyPath(qsre, properties);
         }
 
         protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.ExpressionVisitors.Inte
             var properties = MemberAccessBindingExpressionVisitor.GetPropertyPath(methodCallExpression,
                 _queryCompilationContext, out var qsre);
 
-            return _selectExpression.BindPropertyPath(qsre, properties) ?? base.VisitMethodCall(methodCallExpression);
+            return _selectExpression.BindPropertyPath(qsre, properties);
         }
     }
 }

--- a/src/EFCore.Cosmos.Sql/Query/Expressions/Internal/DocumentQueryExpression.cs
+++ b/src/EFCore.Cosmos.Sql/Query/Expressions/Internal/DocumentQueryExpression.cs
@@ -17,18 +17,17 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.Expressions.Internal
     {
         private readonly bool _async;
         private readonly string _collectionId;
-        private readonly SelectExpression _selectExpression;
         private readonly CosmosClient _cosmosClient;
 
         public DocumentQueryExpression(bool async, string collectionId, SelectExpression selectExpression, CosmosClient cosmosClient)
         {
             _async = async;
             _collectionId = collectionId;
-            _selectExpression = selectExpression;
+            SelectExpression = selectExpression;
             _cosmosClient = cosmosClient;
         }
 
-        public SelectExpression SelectExpression => _selectExpression;
+        public SelectExpression SelectExpression { get; }
 
         public override bool CanReduce => true;
 
@@ -39,7 +38,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.Expressions.Internal
                 Constant(_cosmosClient),
                 EntityQueryModelVisitor.QueryContextParameter,
                 Constant(_collectionId),
-                Constant(_selectExpression));
+                Constant(SelectExpression));
 
         private static IEnumerable<JObject> _Query(
             CosmosClient cosmosClient,

--- a/src/EFCore.Cosmos.Sql/Query/Expressions/Internal/QueryShaperExpression.cs
+++ b/src/EFCore.Cosmos.Sql/Query/Expressions/Internal/QueryShaperExpression.cs
@@ -12,24 +12,28 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.Expressions.Internal
 {
     public class QueryShaperExpression : Expression
     {
-        private readonly Expression _queryExpression;
-        private readonly IShaper _shaper;
-
         public QueryShaperExpression(Expression queryExpression, IShaper shaper)
         {
-            _queryExpression = queryExpression;
-            _shaper = shaper;
+            if (queryExpression.Type.TryGetSequenceType() != typeof(JObject))
+            {
+                throw new InvalidOperationException("Invalid type");
+            }
+
+            QueryExpression = queryExpression;
+            Shaper = shaper;
         }
 
         public override Expression Reduce()
         {
             return Call(
-                typeof(QueryShaperExpression).GetTypeInfo().GetDeclaredMethod(nameof(_Shape)).MakeGenericMethod(_shaper.Type),
-                _queryExpression,
-                _shaper.CreateShaperLambda());
+                typeof(QueryShaperExpression).GetTypeInfo().GetDeclaredMethod(nameof(_Shape)).MakeGenericMethod(Shaper.Type),
+                QueryExpression,
+                Shaper.CreateShaperLambda());
         }
 
-        public Expression QueryExpression => _queryExpression;
+        public Expression QueryExpression { get; }
+
+        public IShaper Shaper { get; }
 
         private static IEnumerable<T> _Shape<T>(
             IEnumerable<JObject> innerEnumerable,
@@ -44,7 +48,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.Expressions.Internal
         public override bool CanReduce => true;
 
         protected override Expression VisitChildren(ExpressionVisitor visitor) => this;
-        public override Type Type => typeof(IEnumerable<>).MakeGenericType(_shaper.Type);
+        public override Type Type => typeof(IEnumerable<>).MakeGenericType(Shaper.Type);
         public override ExpressionType NodeType => ExpressionType.Extension;
+
+
     }
 }

--- a/src/EFCore.Cosmos.Sql/Query/Expressions/Internal/QueryShaperExpression.cs
+++ b/src/EFCore.Cosmos.Sql/Query/Expressions/Internal/QueryShaperExpression.cs
@@ -24,12 +24,10 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.Expressions.Internal
         }
 
         public override Expression Reduce()
-        {
-            return Call(
+            => Call(
                 typeof(QueryShaperExpression).GetTypeInfo().GetDeclaredMethod(nameof(_Shape)).MakeGenericMethod(Shaper.Type),
                 QueryExpression,
                 Shaper.CreateShaperLambda());
-        }
 
         public Expression QueryExpression { get; }
 
@@ -50,7 +48,5 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.Expressions.Internal
         protected override Expression VisitChildren(ExpressionVisitor visitor) => this;
         public override Type Type => typeof(IEnumerable<>).MakeGenericType(Shaper.Type);
         public override ExpressionType NodeType => ExpressionType.Extension;
-
-
     }
 }

--- a/src/EFCore.Cosmos.Sql/Query/Expressions/Internal/SelectExpression.cs
+++ b/src/EFCore.Cosmos.Sql/Query/Expressions/Internal/SelectExpression.cs
@@ -43,7 +43,8 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.Expressions.Internal
         public Expression BindPropertyPath(
             QuerySourceReferenceExpression querySourceReferenceExpression, List<IPropertyBase> properties)
         {
-            if (querySourceReferenceExpression.ReferencedQuerySource != _querySource)
+            if (querySourceReferenceExpression == null
+                || querySourceReferenceExpression.ReferencedQuerySource != _querySource)
             {
                 return null;
             }

--- a/src/EFCore.Cosmos.Sql/Query/Internal/CosmosSqlQueryModelVisitor.cs
+++ b/src/EFCore.Cosmos.Sql/Query/Internal/CosmosSqlQueryModelVisitor.cs
@@ -1,10 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Diagnostics;
+using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.Expressions.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.ExpressionVisitors.Internal;
 using Microsoft.EntityFrameworkCore.Query;
+using Newtonsoft.Json.Linq;
 using Remotion.Linq;
 using Remotion.Linq.Clauses;
 
@@ -26,8 +30,11 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.Internal
 
         public override void VisitWhereClause(WhereClause whereClause, QueryModel queryModel, int index)
         {
-            if (Expression is QueryShaperExpression queryShaperExpression
-                && queryShaperExpression.QueryExpression is DocumentQueryExpression documentQueryExpression)
+            Debug.Assert(Expression is QueryShaperExpression, "Invalid Expression encountered");
+
+            var queryShaperExpression = (QueryShaperExpression)Expression;
+
+            if (queryShaperExpression.QueryExpression is DocumentQueryExpression documentQueryExpression)
             {
                 var selectExpression = documentQueryExpression.SelectExpression;
                 var sqlTranslatingExpressionVisitor = new SqlTranslatingExpressionVisitor(
@@ -42,7 +49,29 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.Internal
                 }
             }
 
-            base.VisitWhereClause(whereClause, queryModel, index);
+            var fromClause = queryModel.MainFromClause;
+
+            // Change current parameter to JObject
+            UpdateCurrentParameter(fromClause, typeof(JObject));
+
+            var predicate = ReplaceClauseReferences(whereClause.Predicate);
+
+            Expression = new QueryShaperExpression(
+                Expression.Call(LinqOperatorProvider.Where.MakeGenericMethod(CurrentParameter.Type),
+                queryShaperExpression.QueryExpression,
+                Expression.Lambda(predicate, CurrentParameter)),
+                queryShaperExpression.Shaper);
+
+            UpdateCurrentParameter(fromClause, Expression.Type.TryGetSequenceType());
+
+            //base.VisitWhereClause(whereClause, queryModel, index);
+        }
+
+        private void UpdateCurrentParameter(IQuerySource querySource, Type type)
+        {
+            CurrentParameter = Expression.Parameter(type, querySource.ItemName);
+
+            QueryCompilationContext.AddOrUpdateMapping(querySource, CurrentParameter);
         }
     }
 }

--- a/src/EFCore.Cosmos.Sql/Query/Internal/EntityShaper.cs
+++ b/src/EFCore.Cosmos.Sql/Query/Internal/EntityShaper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query;
@@ -15,12 +16,20 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.Internal
     public class EntityShaper : IShaper
     {
         private readonly IEntityType _entityType;
+        private readonly bool _trackingQuery;
+        private readonly bool _useQueryBuffer;
         private readonly IEntityMaterializerSource _entityMaterializerSource;
 
-        public EntityShaper(IEntityType entityType, IEntityMaterializerSource entityMaterializerSource)
+        public EntityShaper(
+            IEntityType entityType,
+            bool trackingQuery,
+            bool useQueryBuffer,
+            IEntityMaterializerSource entityMaterializerSource)
         {
             _entityType = entityType;
             _entityMaterializerSource = entityMaterializerSource;
+            _trackingQuery = trackingQuery;
+            _useQueryBuffer = useQueryBuffer;
         }
 
         public virtual LambdaExpression CreateShaperLambda()
@@ -34,33 +43,69 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.Internal
                         _entityType, materializationContextParameter), materializationContextParameter);
 
             var jObjectParameter = Expression.Parameter(typeof(JObject), "jObject");
+            var shapeMethodInfo = _useQueryBuffer ? _bufferedShapeMethodInfo : _shapeMethodInfo;
 
             return Expression.Lambda(
                 Expression.Call(
-                    typeof(EntityShaper).GetTypeInfo().GetDeclaredMethod(nameof(_Shape))
-                       .MakeGenericMethod(_entityType.ClrType),
+                    shapeMethodInfo.MakeGenericMethod(_entityType.ClrType),
                     jObjectParameter,
                     EntityQueryModelVisitor.QueryContextParameter,
-                    Expression.Constant(_entityType),
+                    Expression.Constant(_entityType.FindPrimaryKey()),
+                    Expression.Constant(_trackingQuery),
                     valueBufferFactory,
                     materializer),
                 jObjectParameter);
         }
 
-        private static T _Shape<T>(
+        private static readonly MethodInfo _shapeMethodInfo
+            = typeof(EntityShaper).GetTypeInfo().GetDeclaredMethod(nameof(Shape));
+
+        [UsedImplicitly]
+        private static T Shape<T>(
             JObject innerObject,
             QueryContext queryContext,
-            IEntityType entityType,
+            IKey key,
+            bool trackingQuery,
             Func<JObject, object[]> valueBufferFactory,
-            Func<MaterializationContext, T> materializer)
+            Func<MaterializationContext, object> materializer)
         {
             var valueBuffer = new ValueBuffer(valueBufferFactory(innerObject));
 
-            var entity = materializer(new MaterializationContext(valueBuffer, queryContext.Context));
+            if (trackingQuery)
+            {
+                var entry = queryContext.StateManager.TryGetEntry(key, valueBuffer, throwOnNullKey: true);
 
-            queryContext.StateManager.StartTrackingFromQuery(entityType, entity, valueBuffer, handledForeignKeys: null);
+                if (entry != null)
+                {
+                    return (T)entry.Entity;
+                }
+            }
 
-            return entity;
+            return (T)materializer(new MaterializationContext(valueBuffer, queryContext.Context));
+        }
+
+        private static readonly MethodInfo _bufferedShapeMethodInfo
+            = typeof(EntityShaper).GetTypeInfo().GetDeclaredMethod(nameof(BufferedShape));
+
+        [UsedImplicitly]
+        private static T BufferedShape<T>(
+            JObject innerObject,
+            QueryContext queryContext,
+            IKey key,
+            bool trackingQuery,
+            Func<JObject, object[]> valueBufferFactory,
+            Func<MaterializationContext, object> materializer)
+        {
+            var valueBuffer = new ValueBuffer(valueBufferFactory(innerObject));
+
+            return (T)queryContext.QueryBuffer
+                    .GetEntity(
+                        key,
+                        new EntityLoadInfo(
+                            new MaterializationContext(valueBuffer, queryContext.Context),
+                            materializer),
+                        queryStateManager: trackingQuery,
+                        throwOnNullKey: true);
         }
 
         public virtual Type Type => _entityType.ClrType;

--- a/src/EFCore.Cosmos.Sql/Query/Internal/ValueBufferFactoryFactory.cs
+++ b/src/EFCore.Cosmos.Sql/Query/Internal/ValueBufferFactoryFactory.cs
@@ -35,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.Internal
 
         private static Expression CreateGetValueExpression(
             Expression jObjectExpression,
-            IProperty property)
+            IPropertyBase property)
         {
             // TODO : Converters
             // TODO : TryCatch for invalid values

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/BufferedEntityShaper`.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/BufferedEntityShaper`.cs
@@ -49,8 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         {
             Debug.Assert(queryContext != null);
 
-            var entity
-                = (TEntity)queryContext.QueryBuffer
+            return (TEntity)queryContext.QueryBuffer
                     .GetEntity(
                         Key,
                         new EntityLoadInfo(
@@ -59,8 +58,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                             _typeIndexMap),
                         queryStateManager: IsTrackingQuery,
                         throwOnNullKey: !AllowNullResult);
-
-            return entity;
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
@@ -195,13 +195,11 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
 
                 var requiresClientEval = !useQueryComposition;
 
-                if (!useQueryComposition)
+                if (!useQueryComposition
+                    && relationalQueryCompilationContext.IsIncludeQuery)
                 {
-                    if (relationalQueryCompilationContext.IsIncludeQuery)
-                    {
-                        throw new InvalidOperationException(
-                            RelationalStrings.StoredProcedureIncludeNotSupported);
-                    }
+                    throw new InvalidOperationException(
+                        RelationalStrings.StoredProcedureIncludeNotSupported);
                 }
 
                 if (useQueryComposition

--- a/src/EFCore/Query/EntityQueryModelVisitor.cs
+++ b/src/EFCore/Query/EntityQueryModelVisitor.cs
@@ -1619,17 +1619,14 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 var elementType = expression.Type.TryGetElementType(typeof(IEnumerable<>));
 
-                if (elementType != null)
+                if (elementType != null
+                    && LinqOperatorProvider is AsyncLinqOperatorProvider asyncLinqOperatorProvider)
                 {
-                    if (LinqOperatorProvider is AsyncLinqOperatorProvider asyncLinqOperatorProvider)
-                    {
-                        return
-                            Expression.Call(
-                                asyncLinqOperatorProvider
-                                    .ToAsyncEnumerable
-                                    .MakeGenericMethod(elementType),
-                                expression);
-                    }
+                    return Expression.Call(
+                            asyncLinqOperatorProvider
+                                .ToAsyncEnumerable
+                                .MakeGenericMethod(elementType),
+                            expression);
                 }
             }
 

--- a/test/EFCore.Cosmos.Sql.FunctionalTests/CosmosSqlEndToEndTest.cs
+++ b/test/EFCore.Cosmos.Sql.FunctionalTests/CosmosSqlEndToEndTest.cs
@@ -22,7 +22,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql
         }
 
         [ConditionalFact]
-        // TODO: Remove ToList when Single/Count works
         public async Task Can_add_update_delete_end_to_end()
         {
             using (var testDatabase = CosmosSqlTestStore.CreateInitialized(DatabaseName))
@@ -42,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql
 
                 using (var context = new CustomerContext(options))
                 {
-                    var customerFromStore = context.Set<Customer>().ToList().Single();
+                    var customerFromStore = context.Set<Customer>().Single();
 
                     Assert.Equal(42, customerFromStore.Id);
                     Assert.Equal("Theon", customerFromStore.Name);
@@ -58,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql
 
                 using (var context = new CustomerContext(options))
                 {
-                    var customerFromStore = context.Set<Customer>().ToList().Single();
+                    var customerFromStore = context.Set<Customer>().Single();
 
                     Assert.Equal(42, customerFromStore.Id);
                     Assert.Equal("Theon Greyjoy", customerFromStore.Name);
@@ -73,7 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql
 
                 using (var context = new CustomerContext(options))
                 {
-                    Assert.Equal(0, context.Set<Customer>().ToList().Count());
+                    Assert.Equal(0, context.Set<Customer>().Count());
                 }
             }
         }

--- a/test/EFCore.Cosmos.Sql.FunctionalTests/Query/SimpleQueryCosmosSqlTest.Where.cs
+++ b/test/EFCore.Cosmos.Sql.FunctionalTests/Query/SimpleQueryCosmosSqlTest.Where.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -14,9 +15,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query
     {
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_add(bool isAsync)
+        public async virtual Task Where_add(bool isAsync)
         {
-            AssertQuery<Order>(
+            await AssertQuery<Order>(
                 isAsync,
                 os => os.Where(o => o.OrderID + 10 == 10258),
                 entryCount: 1);
@@ -29,9 +30,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] + 10) = 10258))")
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_subtract(bool isAsync)
+        public async virtual Task Where_subtract(bool isAsync)
         {
-            AssertQuery<Order>(
+            await AssertQuery<Order>(
                 isAsync,
                 os => os.Where(o => o.OrderID - 10 == 10238),
                 entryCount: 1);
@@ -44,9 +45,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] - 10) = 10238))")
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_multiply(bool isAsync)
+        public async virtual Task Where_multiply(bool isAsync)
         {
-            AssertQuery<Order>(
+            await AssertQuery<Order>(
                 isAsync,
                 os => os.Where(o => o.OrderID * 1 == 10248),
                 entryCount: 1);
@@ -59,9 +60,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] * 1) = 10248))");
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_divide(bool isAsync)
+        public async virtual Task Where_divide(bool isAsync)
         {
-            AssertQuery<Order>(
+            await AssertQuery<Order>(
                 isAsync,
                 os => os.Where(o => o.OrderID / 1 == 10248),
                 entryCount: 1);
@@ -74,9 +75,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] / 1) = 10248))");
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_modulo(bool isAsync)
+        public async virtual Task Where_modulo(bool isAsync)
         {
-            AssertQuery<Order>(
+            await AssertQuery<Order>(
                 isAsync,
                 os => os.Where(o => o.OrderID % 10248 == 0),
                 entryCount: 1);
@@ -89,9 +90,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] % 10248) = 0))");
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_bitwise_or(bool isAsync)
+        public async virtual Task Where_bitwise_or(bool isAsync)
         {
-            AssertQuery<Order>(
+            await AssertQuery<Order>(
                 isAsync,
                 os => os.Where(o => (o.OrderID | 10248) == 10248),
                 entryCount: 1);
@@ -104,9 +105,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] | 10248) = 10248)
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_bitwise_and(bool isAsync)
+        public async virtual Task Where_bitwise_and(bool isAsync)
         {
-            AssertQuery<Order>(
+            await AssertQuery<Order>(
                 isAsync,
                 os => os.Where(o => (o.OrderID & 11067) == 11067),
                 entryCount: 2);
@@ -119,9 +120,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] & 11067) = 11067)
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_bitwise_xor(bool isAsync)
+        public async virtual Task Where_bitwise_xor(bool isAsync)
         {
-            AssertQuery<Order>(
+            await AssertQuery<Order>(
                 isAsync,
                 os => os.Where(o => (o.OrderID ^ 10248) == 0),
                 entryCount: 1);
@@ -134,9 +135,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] ^ 10248) = 0))");
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_bitwise_leftshift(bool isAsync)
+        public async virtual Task Where_bitwise_leftshift(bool isAsync)
         {
-            AssertQuery<Order>(
+            await AssertQuery<Order>(
                 isAsync,
                 os => os.Where(o => (o.OrderID << 1) == 20496),
                 entryCount: 1);
@@ -149,9 +150,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] << 1) = 20496))")
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_bitwise_rightshift(bool isAsync)
+        public async virtual Task Where_bitwise_rightshift(bool isAsync)
         {
-            AssertQuery<Order>(
+            await AssertQuery<Order>(
                 isAsync,
                 os => os.Where(o => (o.OrderID >> 1) == 5124),
                 entryCount: 2);
@@ -164,9 +165,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] >> 1) = 5124))");
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_logical_and(bool isAsync)
+        public async virtual Task Where_logical_and(bool isAsync)
         {
-            AssertQuery<Customer>(
+            await AssertQuery<Customer>(
                 isAsync,
                 cs => cs.Where(c => c.City == "Seattle" && c.ContactTitle == "Owner"),
                 entryCount: 1);
@@ -179,9 +180,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""City""] = ""Seattle"") AN
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_logical_or(bool isAsync)
+        public async virtual Task Where_logical_or(bool isAsync)
         {
-            AssertQuery<Customer>(
+            await AssertQuery<Customer>(
                 isAsync,
                 cs => cs.Where(c => c.CustomerID == "ALFKI" || c.CustomerID == "ANATR"),
                 entryCount: 2);
@@ -194,9 +195,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CustomerID""] = ""ALFKI""
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_logical_not(bool isAsync)
+        public async virtual Task Where_logical_not(bool isAsync)
         {
-            AssertQuery<Customer>(
+            await AssertQuery<Customer>(
                 isAsync,
                 cs => cs.Where(c => !(c.City != "Seattle")),
                 entryCount: 1);
@@ -209,9 +210,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND NOT((c[""City""] != ""Seattle""
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_equality(bool isAsync)
+        public async virtual Task Where_equality(bool isAsync)
         {
-            AssertQuery<Employee>(
+            await AssertQuery<Employee>(
                 isAsync,
                 es => es.Where(e => e.ReportsTo == 2),
                 entryCount: 5);
@@ -224,9 +225,9 @@ WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""ReportsTo""] = 2))");
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_inequality(bool isAsync)
+        public async virtual Task Where_inequality(bool isAsync)
         {
-            AssertQuery<Employee>(
+            await AssertQuery<Employee>(
                 isAsync,
                 es => es.Where(e => e.ReportsTo != 2),
                 entryCount: 4);
@@ -239,9 +240,9 @@ WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""ReportsTo""] != 2))");
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_greaterthan(bool isAsync)
+        public async virtual Task Where_greaterthan(bool isAsync)
         {
-            AssertQuery<Employee>(
+            await AssertQuery<Employee>(
                 isAsync,
                 es => es.Where(e => e.ReportsTo > 2),
                 entryCount: 3);
@@ -254,9 +255,9 @@ WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""ReportsTo""] > 2))");
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_greaterthanorequal(bool isAsync)
+        public async virtual Task Where_greaterthanorequal(bool isAsync)
         {
-            AssertQuery<Employee>(
+            await AssertQuery<Employee>(
                 isAsync,
                 es => es.Where(e => e.ReportsTo >= 2),
                 entryCount: 8);
@@ -269,9 +270,9 @@ WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""ReportsTo""] >= 2))");
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_lessthan(bool isAsync)
+        public async virtual Task Where_lessthan(bool isAsync)
         {
-            AssertQuery<Employee>(
+            await AssertQuery<Employee>(
                 isAsync,
                 es => es.Where(e => e.ReportsTo < 2),
                 entryCount: 0);
@@ -284,9 +285,9 @@ WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""ReportsTo""] < 2))");
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_lessthanorequal(bool isAsync)
+        public async virtual Task Where_lessthanorequal(bool isAsync)
         {
-            AssertQuery<Employee>(
+            await AssertQuery<Employee>(
                 isAsync,
                 es => es.Where(e => e.ReportsTo <= 2),
                 entryCount: 5);
@@ -299,9 +300,9 @@ WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""ReportsTo""] <= 2))");
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_string_concat(bool isAsync)
+        public async virtual Task Where_string_concat(bool isAsync)
         {
-            AssertQuery<Customer>(
+            await AssertQuery<Customer>(
                 isAsync,
                 cs => cs.Where(c => c.CustomerID + "END" == "ALFKIEND"),
                 entryCount: 1);
@@ -314,9 +315,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CustomerID""] || ""END"")
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_unary_minus(bool isAsync)
+        public async virtual Task Where_unary_minus(bool isAsync)
         {
-            AssertQuery<Order>(
+            await AssertQuery<Order>(
                 isAsync,
                 os => os.Where(o => -o.OrderID == -10248),
                 entryCount: 1);
@@ -329,9 +330,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (-(c[""OrderID""]) = -10248))");
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_bitwise_not(bool isAsync)
+        public async virtual Task Where_bitwise_not(bool isAsync)
         {
-            AssertQuery<Order>(
+            await AssertQuery<Order>(
                 isAsync,
                 os => os.Where(o => ~o.OrderID == -10249),
                 entryCount: 1);
@@ -344,9 +345,9 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (~(c[""OrderID""]) = -10249))");
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_ternary(bool isAsync)
+        public async virtual Task Where_ternary(bool isAsync)
         {
-            AssertQuery<Customer>(
+            await AssertQuery<Customer>(
                 isAsync,
 #pragma warning disable IDE0029 // Use coalesce expression
                 cs => cs.Where(c => (c.Region != null ? c.Region : "SP") == "BC"),
@@ -361,9 +362,9 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (((c[""Region""] != null) ? c["
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_coalesce(bool isAsync)
+        public async virtual Task Where_coalesce(bool isAsync)
         {
-            AssertQuery<Customer>(
+            await AssertQuery<Customer>(
                 isAsync,
                 cs => cs.Where(c => (c.Region ?? "SP") == "BC"),
                 entryCount: 2);
@@ -376,11 +377,11 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""Region""] ?? ""SP"") = ""
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_simple_closure(bool isAsync)
+        public async virtual Task Where_simple_closure(bool isAsync)
         {
             var city = "London";
 
-            AssertQuery<Customer>(
+            await AssertQuery<Customer>(
                 isAsync,
                 cs => cs.Where(c => c.City == city),
                 entryCount: 6);
@@ -395,25 +396,25 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = @__city_0))");
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_simple_closure_nullable_type(bool isAsync)
+        public async virtual Task Where_simple_closure_nullable_type(bool isAsync)
         {
             int? reportsTo = 2;
 
-            AssertQuery<Employee>(
+            await AssertQuery<Employee>(
                 isAsync,
                 es => es.Where(e => e.ReportsTo == reportsTo),
                 entryCount: 5);
 
             reportsTo = 5;
 
-            AssertQuery<Employee>(
+            await AssertQuery<Employee>(
                 isAsync,
                 es => es.Where(e => e.ReportsTo == reportsTo),
                 entryCount: 3);
 
             reportsTo = null;
 
-            AssertQuery<Employee>(
+            await AssertQuery<Employee>(
                 isAsync,
                 es => es.Where(e => e.ReportsTo == reportsTo),
                 entryCount: 1);
@@ -440,9 +441,9 @@ WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""ReportsTo""] = @__reportsT
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_simple_shadow(bool isAsync)
+        public async virtual Task Where_simple_shadow(bool isAsync)
         {
-            AssertQuery<Employee>(
+            await AssertQuery<Employee>(
                 isAsync,
                 es => es.Where(e => EF.Property<string>(e, "Title") == "Sales Representative"),
                 entryCount: 6);
@@ -455,9 +456,9 @@ WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""Title""] = ""Sales Represe
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_client_property(bool isAsync)
+        public async virtual Task Where_client_property(bool isAsync)
         {
-            AssertQuery<Employee>(
+            await AssertQuery<Employee>(
                 isAsync,
                 es => es.Where(e => ClientMethod(e.ReportsTo)),
                 entryCount: 1);
@@ -470,9 +471,9 @@ WHERE (c[""Discriminator""] = ""Employee"")");
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Where_client_ef_property(bool isAsync)
+        public async virtual Task Where_client_ef_property(bool isAsync)
         {
-            AssertQuery<Employee>(
+            await AssertQuery<Employee>(
                 isAsync,
                 es => es.Where(e => ClientMethod(EF.Property<uint?>(e, "ReportsTo"))),
                 entryCount: 1);
@@ -484,5 +485,15 @@ WHERE (c[""Discriminator""] = ""Employee"")");
         }
 
         private static bool ClientMethod(uint? value) => value == null;
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        public virtual Task Where_client(bool isAsync)
+        {
+            return AssertQuery<Customer>(
+                isAsync,
+                cs => cs.Where(c => c.IsLondon),
+                entryCount: 6);
+        }
     }
 }

--- a/test/EFCore.Cosmos.Sql.FunctionalTests/Query/SimpleQueryCosmosSqlTest.Where.cs
+++ b/test/EFCore.Cosmos.Sql.FunctionalTests/Query/SimpleQueryCosmosSqlTest.Where.cs
@@ -452,5 +452,37 @@ WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""ReportsTo""] = @__reportsT
 FROM root c
 WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""Title""] = ""Sales Representative""))");
         }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        public virtual void Where_client_property(bool isAsync)
+        {
+            AssertQuery<Employee>(
+                isAsync,
+                es => es.Where(e => ClientMethod(e.ReportsTo)),
+                entryCount: 1);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        public virtual void Where_client_ef_property(bool isAsync)
+        {
+            AssertQuery<Employee>(
+                isAsync,
+                es => es.Where(e => ClientMethod(EF.Property<uint?>(e, "ReportsTo"))),
+                entryCount: 1);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        private static bool ClientMethod(uint? value) => value == null;
     }
 }

--- a/test/EFCore.Cosmos.Sql.FunctionalTests/Query/SimpleQueryCosmosSqlTest.cs
+++ b/test/EFCore.Cosmos.Sql.FunctionalTests/Query/SimpleQueryCosmosSqlTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -24,9 +25,9 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query
 
         [ConditionalTheory]
         [InlineData(false)]
-        public virtual void Simple_IQuaryable(bool isAsync)
+        public async virtual Task Simple_IQuaryable(bool isAsync)
         {
-            AssertQuery<Customer>(isAsync, cs => cs, entryCount: 91);
+            await AssertQuery<Customer>(isAsync, cs => cs, entryCount: 91);
 
             AssertSql(
                 @"SELECT c AS query


### PR DESCRIPTION
Enable shadow properties in queries
Enable unmapped members in queries
Enable materializing entities with shadow properties
Only track entities in the final projection