### PR TITLE
Query: Allow to inline DbParameter in FromSql

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
@@ -874,6 +874,19 @@ AND ((]UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
             }
         }
 
+        [Fact]
+        public virtual void From_sql_with_inlined_db_parameter()
+        {
+            using (var context = CreateContext())
+            {
+                var parameter = CreateDbParameter("@somename", "ALFKI");
+
+                var query = context.Customers
+                    .FromSql(NormalizeDelimeters($"SELECT * FROM [Customers] WHERE [CustomerID] = {parameter}"))
+                    .ToList();
+            }
+        }
+
         private RawSqlString NormalizeDelimeters(RawSqlString sql)
             => Fixture.TestStore.NormalizeDelimeters(sql);
 


### PR DESCRIPTION
Issue: Since interpolated string is used for SQL, we capture the argument array as parameter expression in funcletization.
When we print SQL, we did not check that inner values coming out of parameters could be DbParameter too.

Resolves #12067
