### PR TITLE
Update double literal to not append .0 when it is not needed

### DIFF
--- a/src/EFCore.Design/Design/Internal/CSharpHelper.cs
+++ b/src/EFCore.Design/Design/Internal/CSharpHelper.cs
@@ -376,9 +376,20 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual string Literal(double value) => EnsureDecimalPlaces(value.ToString("R", CultureInfo.InvariantCulture));
+        public virtual string Literal(double value) => EnsureDecimalPlaces(value);
 
-        private static string EnsureDecimalPlaces(string number) => number.IndexOf('.') >= 0 ? number : number + ".0";
+        private static string EnsureDecimalPlaces(double number)
+        {
+            var literal = number.ToString("G17", CultureInfo.InvariantCulture);
+
+            return !literal.Contains("E")
+                && !literal.Contains("e")
+                && !literal.Contains(".")
+                && !double.IsNaN(number)
+                && !double.IsInfinity(number)
+                ? literal + ".0"
+                : literal;
+        }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.Design/Design/Internal/CSharpHelper.cs
+++ b/src/EFCore.Design/Design/Internal/CSharpHelper.cs
@@ -382,13 +382,26 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
         {
             var literal = number.ToString("G17", CultureInfo.InvariantCulture);
 
-            return !literal.Contains("E")
-                && !literal.Contains("e")
-                && !literal.Contains(".")
-                && !double.IsNaN(number)
-                && !double.IsInfinity(number)
-                ? literal + ".0"
-                : literal;
+            if (double.IsNaN(number))
+            {
+                return $"double.{nameof(double.NaN)}";
+            }
+            else if (double.IsNegativeInfinity(number))
+            {
+                return $"double.{nameof(double.NegativeInfinity)}";
+            }
+            else if (double.IsPositiveInfinity(number))
+            {
+                return $"double.{nameof(double.PositiveInfinity)}";
+            }
+            else
+            {
+                return !literal.Contains("E")
+                    && !literal.Contains("e")
+                    && !literal.Contains(".")
+                    ? literal + ".0"
+                    : literal;
+            }
         }
 
         /// <summary>

--- a/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
@@ -36,13 +36,13 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             "4.2000000000000002")]
         [InlineData(
             double.NegativeInfinity,
-            "-Infinity")]
+            "double.NegativeInfinity")]
         [InlineData(
             double.PositiveInfinity,
-            "Infinity")]
+            "double.PositiveInfinity")]
         [InlineData(
             double.NaN,
-            "NaN")]
+            "double.NaN")]
         [InlineData(
             0.84551240822557006,
             "0.84551240822557006")]

--- a/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
@@ -41,9 +41,6 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             6E-14,
             "5.9999999999999997E-14")]
         [InlineData(
-            6E-14,
-            "6E-14")]
-        [InlineData(
             -1.7976931348623157E+308, // Double MinValue
             "-1.7976931348623157E+308")]
         [InlineData(

--- a/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
@@ -35,6 +35,15 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             4.2,
             "4.2000000000000002")]
         [InlineData(
+            double.NegativeInfinity,
+            "-Infinity")]
+        [InlineData(
+            double.PositiveInfinity,
+            "Infinity")]
+        [InlineData(
+            double.NaN,
+            "NaN")]
+        [InlineData(
             0.84551240822557006,
             "0.84551240822557006")]
         [InlineData(

--- a/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
@@ -41,6 +41,9 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             6E-14,
             "5.9999999999999997E-14")]
         [InlineData(
+            6E-14,
+            "6E-14")]
+        [InlineData(
             -1.7976931348623157E+308, // Double MinValue
             "-1.7976931348623157E+308")]
         [InlineData(

--- a/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
@@ -33,7 +33,13 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             @"'\''")]
         [InlineData(
             4.2,
-            "4.2")]
+            "4.2000000000000002")]
+        [InlineData(
+            0.84551240822557006,
+            "0.84551240822557006")]
+        [InlineData(
+            6E-14,
+            "5.9999999999999997E-14")]
         [InlineData(
             -1.7976931348623157E+308, // Double MinValue
             "-1.7976931348623157E+308")]


### PR DESCRIPTION
When providing values in exponential form it would append .0 where it was not needed.
6E-14 => 6E-14.0

Fixes #13089 

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Code meets the expectations our engineering guidelines. 

However wouldn't it be better to use the G17 format instead of R format? 

For example

Original | G17 | R   
---------|------|-----
6E-14    | 5.9999999999999997E-14 | 6E-14
0.84551240822557006 | 0.84551240822557006 | 0.84551240822557

