### PR TITLE
Query: Generate correct SQL literal for smalldatetime

### DIFF
--- a/src/EFCore.SqlServer/Storage/Internal/SqlServerDateTimeTypeMapping.cs
+++ b/src/EFCore.SqlServer/Storage/Internal/SqlServerDateTimeTypeMapping.cs
@@ -69,7 +69,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         protected override string SqlLiteralFormatString
             => StoreType == "date"
                 ? "'" + DateFormatConst + "'"
-                : (StoreType == "datetime"
+                : (StoreType == "datetime" || StoreType == "smalldatetime"
                     ? "'" + DateTimeFormatConst + "'"
                     : "'" + DateTime2FormatConst + "'");
     }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -4393,7 +4393,8 @@ FROM [Prices] AS [e]");
                 context =>
                 {
                     context.AddRange(
-                        new Price11885 {
+                        new Price11885
+                        {
                             IntColumn = 1,
                             NullableIntColumn = 1,
                             LongColumn = 1000,
@@ -4794,6 +4795,74 @@ FROM [Prices] AS [e]");
             public virtual ICollection<DefinitionHistory12170> HistoryEntries { get; set; }
             public virtual DefinitionHistory12170 LatestHistoryEntry { get; set; }
             public int? LatestHistoryEntryID { get; set; }
+        }
+
+        #endregion
+
+        #region Bug13118
+
+        [Fact]
+        public virtual void DateTime_Contains_with_smalldatetime_generates_correct_literal()
+        {
+            using (CreateDatabase13118())
+            {
+                using (var context = new MyContext13118(_options))
+                {
+                    var testDateList = new List<DateTime>() { new DateTime(2018, 10, 07) };
+                    var findRecordsWithDateInList = context.ReproEntity
+                        .Where(a => testDateList.Contains(a.MyTime))
+                        .ToList();
+
+                    Assert.Single(findRecordsWithDateInList);
+
+                    AssertSql(
+                        @"SELECT [a].[Id], [a].[MyTime]
+FROM [ReproEntity] AS [a]
+WHERE [a].[MyTime] IN ('2018-10-07T00:00:00.000')");
+                }
+            }
+        }
+
+        private SqlServerTestStore CreateDatabase13118()
+        {
+            return CreateTestStore(
+                () => new MyContext13118(_options),
+                context =>
+                {
+                    context.AddRange(
+                        new ReproEntity13118
+                        {
+                            MyTime = new DateTime(2018, 10, 07)
+                        },
+                        new ReproEntity13118
+                        {
+                            MyTime = new DateTime(2018, 10, 08)
+                        });
+
+                    context.SaveChanges();
+                    ClearLog();
+                });
+        }
+
+        public class MyContext13118 : DbContext
+        {
+            public virtual DbSet<ReproEntity13118> ReproEntity { get; set; }
+
+            public MyContext13118(DbContextOptions options)
+               : base(options)
+            {
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<ReproEntity13118>(e => e.Property("MyTime").HasColumnType("smalldatetime"));
+            }
+        }
+
+        public class ReproEntity13118
+        {
+            public Guid Id { get; set; }
+            public DateTime MyTime { get; set; }
         }
 
         #endregion


### PR DESCRIPTION
Issue: smalldatetime literal should be same as datetime literal. Conditions missed it hence we were printing literal for datetime2 which failed at parsing.

Resolves #13118
