### PR TITLE
Fix to #11944 - Query: Include for derived types fails when navigation property is defined in an intermediate type

### DIFF
--- a/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTreeNode.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.IncludeLoadTreeNode.cs
@@ -102,7 +102,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     = new MainFromClause(
                         targetType.Name.Substring(0, 1).ToLowerInvariant(),
                         targetType,
-                        targetExpression.CreateEFPropertyExpression(Navigation.GetIdentifyingMemberInfo()));
+                        targetExpression.CreateEFPropertyExpression(Navigation));
 
                 queryCompilationContext.AddQuerySourceRequiringMaterialization(mainFromClause);
 


### PR DESCRIPTION
Problem was that when we were constructing collection subquery for the included entities we were using a MemberInfo to determine on which type the navigation is declared. This was incorrect when navigation from EF perspective is defined in a different place than the CLR classes would indicate. We should be using information contained on IPropertyBase instead.