### PR TITLE
Cosmos.Sql: basic query client evaluation

### DIFF
--- a/src/EFCore.Cosmos.Sql/Query/ExpressionVisitors/Internal/CosmosSqlEntityQueryableExpressionVisitor.cs
+++ b/src/EFCore.Cosmos.Sql/Query/ExpressionVisitors/Internal/CosmosSqlEntityQueryableExpressionVisitor.cs
@@ -47,7 +47,12 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.ExpressionVisitors.Inte
                     entityType.CosmosSql().CollectionName,
                     new SelectExpression(entityType, _querySource),
                     _cosmosClient),
-                new EntityShaper(entityType, _entityMaterializerSource));
+                new EntityShaper(entityType,
+                    trackingQuery: QueryModelVisitor.QueryCompilationContext.IsTrackingQuery
+                        && !entityType.IsQueryType,
+                    useQueryBuffer: QueryModelVisitor.QueryCompilationContext.IsQueryBufferRequired
+                        && !entityType.IsQueryType,
+                    _entityMaterializerSource));
         }
     }
 }

--- a/src/EFCore.Cosmos.Sql/Query/ExpressionVisitors/Internal/CosmosSqlGenerator.cs
+++ b/src/EFCore.Cosmos.Sql/Query/ExpressionVisitors/Internal/CosmosSqlGenerator.cs
@@ -46,17 +46,13 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.ExpressionVisitors.Inte
             { ExpressionType.LessThanOrEqual, " <= " },
 
             // Unary
-            { ExpressionType.UnaryPlus, "+" }, // TODO: Regression test pending
+            { ExpressionType.UnaryPlus, "+" },
             { ExpressionType.Negate, "-" },
             { ExpressionType.Not, "~" },
 
             // Others
             { ExpressionType.Coalesce, " ?? " },
         };
-
-        public CosmosSqlGenerator()
-        {
-        }
 
         public SqlQuerySpec GenerateSqlQuerySpec(
             SelectExpression selectExpression,
@@ -119,7 +115,11 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.ExpressionVisitors.Inte
             }
             else if (value.GetType().IsInteger() || value.GetType() == typeof(decimal))
             {
-                _sqlBuilder.Append($"{value}");
+                _sqlBuilder.Append(value.ToString());
+            }
+            else if (value.GetType() == typeof(bool))
+            {
+                _sqlBuilder.Append(((bool)value) ? "true" : "false");
             }
             else
             {
@@ -163,6 +163,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.ExpressionVisitors.Inte
 
             return base.VisitExtension(extensionExpression);
         }
+
 
         protected override Expression VisitParameter(ParameterExpression parameterExpression)
         {

--- a/src/EFCore.Cosmos.Sql/Query/ExpressionVisitors/Internal/SqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Cosmos.Sql/Query/ExpressionVisitors/Internal/SqlTranslatingExpressionVisitor.cs
@@ -1,14 +1,22 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 using Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.Expressions.Internal;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Query;
+using Microsoft.EntityFrameworkCore.Query.Expressions.Internal;
+using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors;
 using Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+using Remotion.Linq.Clauses.Expressions;
 
 namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.ExpressionVisitors.Internal
 {
-    public class SqlTranslatingExpressionVisitor : ExpressionVisitor
+    public class SqlTranslatingExpressionVisitor : ExpressionVisitorBase
     {
         private readonly SelectExpression _selectExpression;
         private readonly QueryCompilationContext _queryCompilationContext;
@@ -20,12 +28,21 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.ExpressionVisitors.Inte
             _queryCompilationContext = queryCompilationContext;
         }
 
+        public virtual bool Translated { get; private set; } = true;
+
         protected override Expression VisitMember(MemberExpression memberExpression)
         {
             var properties = MemberAccessBindingExpressionVisitor.GetPropertyPath(memberExpression,
                 _queryCompilationContext, out var qsre);
 
-            return _selectExpression.BindPropertyPath(qsre, properties);
+            var newExpression = _selectExpression.BindPropertyPath(qsre, properties);
+            if (newExpression == null)
+            {
+                Translated = false;
+                return memberExpression;
+            }
+
+            return newExpression;
         }
 
         protected override Expression VisitMethodCall(MethodCallExpression methodCallExpression)
@@ -33,7 +50,110 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.ExpressionVisitors.Inte
             var properties = MemberAccessBindingExpressionVisitor.GetPropertyPath(methodCallExpression,
                 _queryCompilationContext, out var qsre);
 
-            return _selectExpression.BindPropertyPath(qsre, properties);
+            var newExpression = _selectExpression.BindPropertyPath(qsre, properties);
+            if (newExpression == null)
+            {
+                Translated = false;
+                return methodCallExpression;
+            }
+
+            return newExpression;
+        }
+
+        protected override Expression VisitTypeBinary(TypeBinaryExpression node)
+        {
+            var newExpression = Visit(node.Expression);
+            if (!Translated)
+            {
+                return node;
+            }
+
+            var castEntityType = _queryCompilationContext.Model.FindEntityType(node.TypeOperand);
+            if (castEntityType == null)
+            {
+                Translated = false;
+                return node;
+            }
+
+            var discriminatorPredicate = _selectExpression.GetDiscriminatorPredicate(castEntityType);
+            if (discriminatorPredicate == null)
+            {
+                Translated = false;
+                return node;
+            }
+
+            return discriminatorPredicate;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override Expression VisitExtension(Expression node)
+        {
+            if (node is NullConditionalExpression nullConditionalExpression)
+            {
+                var newExpression = Visit(nullConditionalExpression.AccessOperation);
+                if (newExpression.Type != node.Type)
+                {
+                    newExpression = Expression.Convert(newExpression, node.Type);
+                }
+
+                return newExpression;
+            }
+
+            if (node is NullSafeEqualExpression nullConditionalEqualExpression)
+            {
+                return Visit(nullConditionalEqualExpression.EqualExpression);
+            }
+
+            return base.VisitExtension(node);
+        }
+
+        protected override Expression VisitNew(NewExpression expression)
+        {
+            if (expression.Type == typeof(AnonymousObject)
+                || expression.Type == typeof(MaterializedAnonymousObject)
+                || expression.Type.IsAnonymousType()
+                || expression.Type.IsTupleType())
+            {
+                Translated = false;
+                return expression;
+            }
+
+            return base.VisitNew(expression);
+        }
+
+        protected override Expression VisitConstant(ConstantExpression expression)
+        {
+            if (expression.Type == typeof(AnonymousObject)
+                || expression.Type == typeof(MaterializedAnonymousObject)
+                || expression.Type.IsAnonymousType()
+                || expression.Type.IsTupleType())
+            {
+                Translated = false;
+                return expression;
+            }
+
+            return base.VisitConstant(expression);
+        }
+
+        protected override Expression VisitSubQuery(SubQueryExpression subQueryExpression)
+        {
+            Translated = false;
+            return subQueryExpression;
+        }
+
+        protected override Expression VisitQuerySourceReference(QuerySourceReferenceExpression expression)
+        {
+            var newExpression = _selectExpression.BindPropertyPath(expression, new List<IPropertyBase>());
+            if (newExpression == null)
+            {
+                Translated = false;
+                return expression;
+            }
+
+            return newExpression;
         }
     }
 }

--- a/src/EFCore.Cosmos.Sql/Query/Expressions/Internal/DocumentQueryExpression.cs
+++ b/src/EFCore.Cosmos.Sql/Query/Expressions/Internal/DocumentQueryExpression.cs
@@ -89,7 +89,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.Expressions.Internal
 
                 public void Dispose()
                 {
-                    _underlyingEnumerator.Dispose();
+                    _underlyingEnumerator?.Dispose();
                 }
 
                 public bool MoveNext()

--- a/src/EFCore.Cosmos.Sql/Query/Expressions/Internal/QueryShaperExpression.cs
+++ b/src/EFCore.Cosmos.Sql/Query/Expressions/Internal/QueryShaperExpression.cs
@@ -24,12 +24,10 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.Expressions.Internal
         }
 
         public override Expression Reduce()
-        {
-            return Call(
+            => Call(
                 typeof(QueryShaperExpression).GetTypeInfo().GetDeclaredMethod(nameof(_Shape)).MakeGenericMethod(Shaper.Type),
                 QueryExpression,
                 Shaper.CreateShaperLambda());
-        }
 
         public Expression QueryExpression { get; }
 
@@ -50,7 +48,5 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.Expressions.Internal
         protected override Expression VisitChildren(ExpressionVisitor visitor) => this;
         public override Type Type => typeof(IEnumerable<>).MakeGenericType(Shaper.Type);
         public override ExpressionType NodeType => ExpressionType.Extension;
-
-
     }
 }

--- a/src/EFCore.Cosmos.Sql/Query/Internal/EntityShaper.cs
+++ b/src/EFCore.Cosmos.Sql/Query/Internal/EntityShaper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query;
@@ -15,12 +16,20 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.Internal
     public class EntityShaper : IShaper
     {
         private readonly IEntityType _entityType;
+        private readonly bool _trackingQuery;
+        private readonly bool _useQueryBuffer;
         private readonly IEntityMaterializerSource _entityMaterializerSource;
 
-        public EntityShaper(IEntityType entityType, IEntityMaterializerSource entityMaterializerSource)
+        public EntityShaper(
+            IEntityType entityType,
+            bool trackingQuery,
+            bool useQueryBuffer,
+            IEntityMaterializerSource entityMaterializerSource)
         {
             _entityType = entityType;
             _entityMaterializerSource = entityMaterializerSource;
+            _trackingQuery = trackingQuery;
+            _useQueryBuffer = useQueryBuffer;
         }
 
         public virtual LambdaExpression CreateShaperLambda()
@@ -34,33 +43,69 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.Internal
                         _entityType, materializationContextParameter), materializationContextParameter);
 
             var jObjectParameter = Expression.Parameter(typeof(JObject), "jObject");
+            var shapeMethodInfo = _useQueryBuffer ? _bufferedShapeMethodInfo : _shapeMethodInfo;
 
             return Expression.Lambda(
                 Expression.Call(
-                    typeof(EntityShaper).GetTypeInfo().GetDeclaredMethod(nameof(_Shape))
-                       .MakeGenericMethod(_entityType.ClrType),
+                    shapeMethodInfo.MakeGenericMethod(_entityType.ClrType),
                     jObjectParameter,
                     EntityQueryModelVisitor.QueryContextParameter,
-                    Expression.Constant(_entityType),
+                    Expression.Constant(_entityType.FindPrimaryKey()),
+                    Expression.Constant(_trackingQuery),
                     valueBufferFactory,
                     materializer),
                 jObjectParameter);
         }
 
-        private static T _Shape<T>(
+        private static readonly MethodInfo _shapeMethodInfo
+            = typeof(EntityShaper).GetTypeInfo().GetDeclaredMethod(nameof(Shape));
+
+        [UsedImplicitly]
+        private static T Shape<T>(
             JObject innerObject,
             QueryContext queryContext,
-            IEntityType entityType,
+            IKey key,
+            bool trackingQuery,
             Func<JObject, object[]> valueBufferFactory,
-            Func<MaterializationContext, T> materializer)
+            Func<MaterializationContext, object> materializer)
         {
             var valueBuffer = new ValueBuffer(valueBufferFactory(innerObject));
 
-            var entity = materializer(new MaterializationContext(valueBuffer, queryContext.Context));
+            if (trackingQuery)
+            {
+                var entry = queryContext.StateManager.TryGetEntry(key, valueBuffer, throwOnNullKey: true);
 
-            queryContext.StateManager.StartTrackingFromQuery(entityType, entity, valueBuffer, handledForeignKeys: null);
+                if (entry != null)
+                {
+                    return (T)entry.Entity;
+                }
+            }
 
-            return entity;
+            return (T)materializer(new MaterializationContext(valueBuffer, queryContext.Context));
+        }
+
+        private static readonly MethodInfo _bufferedShapeMethodInfo
+            = typeof(EntityShaper).GetTypeInfo().GetDeclaredMethod(nameof(BufferedShape));
+
+        [UsedImplicitly]
+        private static T BufferedShape<T>(
+            JObject innerObject,
+            QueryContext queryContext,
+            IKey key,
+            bool trackingQuery,
+            Func<JObject, object[]> valueBufferFactory,
+            Func<MaterializationContext, object> materializer)
+        {
+            var valueBuffer = new ValueBuffer(valueBufferFactory(innerObject));
+
+            return (T)queryContext.QueryBuffer
+                    .GetEntity(
+                        key,
+                        new EntityLoadInfo(
+                            new MaterializationContext(valueBuffer, queryContext.Context),
+                            materializer),
+                        queryStateManager: trackingQuery,
+                        throwOnNullKey: true);
         }
 
         public virtual Type Type => _entityType.ClrType;

--- a/src/EFCore.Cosmos.Sql/Query/Internal/ValueBufferFactoryFactory.cs
+++ b/src/EFCore.Cosmos.Sql/Query/Internal/ValueBufferFactoryFactory.cs
@@ -37,9 +37,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.Internal
             Expression jObjectExpression,
             IPropertyBase property)
         {
-            // TODO : Converters
-            // TODO : TryCatch for invalid values
-
             var expression = Expression.Convert(
                 Expression.Call(
                     jObjectExpression,

--- a/src/EFCore.Cosmos.Sql/Storage/Internal/DocumentCollection.cs
+++ b/src/EFCore.Cosmos.Sql/Storage/Internal/DocumentCollection.cs
@@ -35,7 +35,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Storage.Internal
         {
             var key = _principalKeyValueFactory.CreateFromCurrentValues((InternalEntityEntry)entry);
 
-            // TODO: Escape | Bar|string.Empty
             return key is object[] array ? string.Join("|", array) : key.ToString();
         }
 

--- a/src/EFCore.Relational/Query/ExpressionVisitors/Internal/BufferedEntityShaper`.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/Internal/BufferedEntityShaper`.cs
@@ -49,8 +49,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         {
             Debug.Assert(queryContext != null);
 
-            var entity
-                = (TEntity)queryContext.QueryBuffer
+            return (TEntity)queryContext.QueryBuffer
                     .GetEntity(
                         Key,
                         new EntityLoadInfo(
@@ -59,8 +58,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                             _typeIndexMap),
                         queryStateManager: IsTrackingQuery,
                         throwOnNullKey: !AllowNullResult);
-
-            return entity;
         }
 
         /// <summary>

--- a/src/EFCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/RelationalEntityQueryableExpressionVisitor.cs
@@ -195,13 +195,11 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
 
                 var requiresClientEval = !useQueryComposition;
 
-                if (!useQueryComposition)
+                if (!useQueryComposition
+                    && relationalQueryCompilationContext.IsIncludeQuery)
                 {
-                    if (relationalQueryCompilationContext.IsIncludeQuery)
-                    {
-                        throw new InvalidOperationException(
-                            RelationalStrings.StoredProcedureIncludeNotSupported);
-                    }
+                    throw new InvalidOperationException(
+                        RelationalStrings.StoredProcedureIncludeNotSupported);
                 }
 
                 if (useQueryComposition

--- a/src/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
+++ b/src/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
@@ -11,7 +11,7 @@
     <EnableApiCheck>false</EnableApiCheck>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(FunctionalTests_PackageVersion)' == '2.1.0'">
    <DefineConstants>$(DefineConstants);Test21</DefineConstants>
   </PropertyGroup>

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.Where.cs
@@ -517,6 +517,35 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_bitwise_or(bool isAsync)
+        {
+            return AssertQuery<Customer>(
+                isAsync,
+                cs => cs.Where(c => c.CustomerID == "ALFKI" | c.CustomerID == "ANATR"),
+                entryCount: 2);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Where_bitwise_and(bool isAsync)
+        {
+            return AssertQuery<Customer>(
+                isAsync,
+                cs => cs.Where(c => c.CustomerID == "ALFKI" & c.CustomerID == "ANATR"));
+        }
+
+        [ConditionalTheory]
+        [InlineData(false)]
+        public virtual Task Where_bitwise_xor(bool isAsync)
+        {
+            return AssertQuery<Customer>(
+                isAsync,
+                cs => cs.Where(c => (c.CustomerID == "ALFKI") ^ true),
+                entryCount: 90);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task Where_simple_shadow(bool isAsync)
         {
             return AssertQuery<Employee>(

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -3627,25 +3627,6 @@ namespace Microsoft.EntityFrameworkCore.Query
                 os => os.Select(o => o.Customer.City + " " + o.Customer.City));
         }
 
-        [ConditionalTheory]
-        [MemberData(nameof(IsAsyncData))]
-        public virtual Task Where_bitwise_or(bool isAsync)
-        {
-            return AssertQuery<Customer>(
-                isAsync,
-                cs => cs.Where(c => c.CustomerID == "ALFKI" | c.CustomerID == "ANATR"),
-                entryCount: 2);
-        }
-
-        [ConditionalTheory]
-        [MemberData(nameof(IsAsyncData))]
-        public virtual Task Where_bitwise_and(bool isAsync)
-        {
-            return AssertQuery<Customer>(
-                isAsync,
-                cs => cs.Where(c => c.CustomerID == "ALFKI" & c.CustomerID == "ANATR"));
-        }
-
         [ConditionalFact]
         public virtual void Select_bitwise_or()
         {

--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -291,14 +291,14 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             }
 
             var clrType = entity.GetType();
-
-            var newEntry = _internalEntityEntryFactory.Create(
-                this,
-                baseEntityType.ClrType == clrType
+            var entityType = baseEntityType.ClrType == clrType
                 || baseEntityType.HasDefiningNavigation()
                     ? baseEntityType
-                    : _model.FindRuntimeEntityType(clrType),
-                entity, valueBuffer);
+                    : _model.FindRuntimeEntityType(clrType);
+
+            var newEntry = valueBuffer.IsEmpty
+                ? _internalEntityEntryFactory.Create(this, entityType, entity)
+                : _internalEntityEntryFactory.Create(this, entityType, entity, valueBuffer);
 
             foreach (var key in baseEntityType.GetKeys())
             {

--- a/src/EFCore/Query/ExpressionVisitors/Internal/CorrelatedCollectionOptimizingVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/CorrelatedCollectionOptimizingVisitor.cs
@@ -228,7 +228,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
             var parentItemName
                 = parentQuerySource.HasGeneratedItemName()
-                    ? navigation.DeclaringEntityType.DisplayName()[0].ToString().ToLowerInvariant()
+                    ? navigation.DeclaringEntityType.ShortName()[0].ToString().ToLowerInvariant()
                     : parentQuerySource.ItemName;
 
             collectionQueryModel.MainFromClause.ItemName = $"{parentItemName}.{navigation.Name}";

--- a/src/EFCore/Query/ExpressionVisitors/Internal/MemberAccessBindingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/MemberAccessBindingExpressionVisitor.cs
@@ -58,9 +58,8 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
                 {
                     if (newArguments[i].Type == typeof(ValueBuffer))
                     {
-                        newArguments[i]
-                            = _queryModelVisitor
-                                .BindReadValueMethod(expression.Arguments[i].Type, newArguments[i], 0);
+                        newArguments[i] = _queryModelVisitor
+                            .BindReadValueMethod(expression.Arguments[i].Type, newArguments[i], 0);
                     }
                 }
             }
@@ -267,8 +266,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             {
                 if (newExpression.Type == typeof(ValueBuffer))
                 {
-                    return _queryModelVisitor
-                               .BindMemberToValueBuffer(node, newExpression)
+                    return _queryModelVisitor.BindMemberToValueBuffer(node, newExpression)
                            ?? node;
                 }
 
@@ -323,53 +321,15 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
             if (newExpression == null)
             {
-                newExpression
-                    = (MethodCallExpression)base.VisitMethodCall(methodCallExpression);
+                newExpression = (MethodCallExpression)base.VisitMethodCall(methodCallExpression);
             }
 
             firstArgument = firstArgument ?? newExpression.Arguments.FirstOrDefault();
 
             return newExpression != methodCallExpression
                 && firstArgument?.Type == typeof(ValueBuffer)
-                ? _queryModelVisitor
-                        .BindMethodCallToValueBuffer(methodCallExpression, firstArgument)
-                    ?? newExpression
-                : _queryModelVisitor
-                       .BindMethodCallExpression<Expression>(
-                           methodCallExpression,
-                           (property, _) =>
-                           {
-                               var propertyType = newExpression.Method.GetGenericArguments()[0];
-
-                               if (newExpression.Arguments[0] is ConstantExpression maybeConstantExpression)
-                               {
-                                   return Expression.Constant(
-                                       property.GetGetter().GetClrValue(maybeConstantExpression.Value),
-                                       propertyType);
-                               }
-
-                               if (newExpression.Arguments[0] is MethodCallExpression maybeMethodCallExpression
-                                   && maybeMethodCallExpression.Method.IsGenericMethod
-                                   && maybeMethodCallExpression.Method.GetGenericMethodDefinition()
-                                       .Equals(DefaultQueryExpressionVisitor.GetParameterValueMethodInfo)
-                                   || newExpression.Arguments[0].NodeType == ExpressionType.Parameter
-                                   && !property.IsShadowProperty)
-                               {
-                                   // The target is a parameter, try and get the value from it directly.
-                                   return Expression.Call(
-                                       _getValueFromEntityMethodInfo
-                                           .MakeGenericMethod(propertyType),
-                                       Expression.Constant(property.GetGetter()),
-                                       newExpression.Arguments[0]);
-                               }
-
-                               return Expression.Call(
-                                   _getValueMethodInfo.MakeGenericMethod(propertyType),
-                                   EntityQueryModelVisitor.QueryContextParameter,
-                                   newExpression.Arguments[0],
-                                   Expression.Constant(property));
-                           })
-                   ?? newExpression;
+                ? _queryModelVisitor.BindMethodCallToValueBuffer(methodCallExpression, firstArgument) ?? newExpression
+                : _queryModelVisitor.BindMethodCallToEntity(methodCallExpression, newExpression) ?? newExpression;
         }
 
         /// <summary>
@@ -477,26 +437,6 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             }
 
             return entityType;
-        }
-
-        private static readonly MethodInfo _getValueMethodInfo
-            = typeof(MemberAccessBindingExpressionVisitor)
-                .GetTypeInfo().GetDeclaredMethod(nameof(GetValue));
-
-        [UsedImplicitly]
-        private static T GetValue<T>(QueryContext queryContext, object entity, IProperty property)
-        {
-            return entity == null ? (default) : (T)queryContext.QueryBuffer.GetPropertyValue(entity, property);
-        }
-
-        private static readonly MethodInfo _getValueFromEntityMethodInfo
-            = typeof(MemberAccessBindingExpressionVisitor)
-                .GetTypeInfo().GetDeclaredMethod(nameof(GetValueFromEntity));
-
-        [UsedImplicitly]
-        private static T GetValueFromEntity<T>(IClrPropertyGetter clrPropertyGetter, object entity)
-        {
-            return entity == null ? (default) : (T)clrPropertyGetter.GetClrValue(entity);
         }
     }
 }

--- a/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/NavigationRewritingExpressionVisitor.cs
@@ -729,12 +729,10 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
                 if (_insideInnerKeySelector && !_insideMaterializeCollectionNavigation)
                 {
-                    var translated = CreateSubqueryForNavigations(
+                    return CreateSubqueryForNavigations(
                         outerQuerySourceReferenceExpression,
                         properties,
                         propertyCreator);
-
-                    return translated;
                 }
 
                 var navigationResultExpression = RewriteNavigationsIntoJoins(
@@ -1359,7 +1357,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
 
             var itemName = sourceExpression is QuerySourceReferenceExpression qsre && !qsre.ReferencedQuerySource.HasGeneratedItemName()
                 ? qsre.ReferencedQuerySource.ItemName
-                : navigation.DeclaringEntityType.DisplayName()[0].ToString().ToLowerInvariant();
+                : navigation.DeclaringEntityType.ShortName()[0].ToString().ToLowerInvariant();
 
             var joinClause
                 = new JoinClause(

--- a/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
@@ -347,13 +347,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected override Expression VisitNew(NewExpression node)
-        {
-            var arguments = Visit(node.Arguments);
-
-            var newNode = node.Update(arguments);
-
-            return newNode;
-        }
+            => node.Update(Visit(node.Arguments));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Query/Expressions/Internal/NullConditionalExpression.cs
+++ b/src/EFCore/Query/Expressions/Internal/NullConditionalExpression.cs
@@ -90,8 +90,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions.Internal
                 operation = Convert(operation, _type);
             }
 
-            var resultExpression
-                = Block(
+            return Block(
                     new[] { nullableCaller, result },
                     Assign(nullableCaller, Caller),
                     Assign(result, Default(_type)),
@@ -99,8 +98,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions.Internal
                         NotEqual(nullableCaller, Default(nullableCallerType)),
                         Assign(result, operation)),
                     result);
-
-            return resultExpression;
         }
 
         /// <summary>

--- a/src/EFCore/Query/Internal/ExpressionPrinter.cs
+++ b/src/EFCore/Query/Internal/ExpressionPrinter.cs
@@ -694,11 +694,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             return methodCallExpression;
         }
 
-        private static bool IsAnonymousType(Type type)
-            => type.Name.StartsWith("<>")
-               && type.GetCustomAttributes(typeof(CompilerGeneratedAttribute), inherit: false).Length > 0
-               && type.Name.Contains("AnonymousType");
-
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
@@ -710,7 +705,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
             var isComplex = newExpression.Arguments.Count > 1;
             var appendAction = isComplex ? (Action<string>)AppendLine : Append;
 
-            var isAnonymousType = IsAnonymousType(newExpression.Type);
+            var isAnonymousType = newExpression.Type.IsAnonymousType();
             if (!isAnonymousType)
             {
                 _stringBuilder.Append(newExpression.Type.ShortDisplayName());

--- a/src/EFCore/Query/Internal/IncludeCompiler.CollectionQueryModelRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/Internal/IncludeCompiler.CollectionQueryModelRewritingExpressionVisitor.cs
@@ -136,7 +136,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 var parentItemName
                     = parentQuerySource.HasGeneratedItemName()
-                        ? navigation.DeclaringEntityType.DisplayName()[0].ToString().ToLowerInvariant()
+                        ? navigation.DeclaringEntityType.ShortName()[0].ToString().ToLowerInvariant()
                         : parentQuerySource.ItemName;
 
                 collectionQueryModel.MainFromClause.ItemName = $"{parentItemName}.{navigation.Name}";

--- a/src/Shared/SharedTypeExtensions.cs
+++ b/src/Shared/SharedTypeExtensions.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 // ReSharper disable once CheckNamespace
 namespace System
@@ -59,11 +60,41 @@ namespace System
         }
 
         public static bool IsSignedInteger(this Type type)
-        {
-            return type == typeof(int)
+            => type == typeof(int)
                    || type == typeof(long)
                    || type == typeof(short)
                    || type == typeof(sbyte);
+
+        public static bool IsAnonymousType(this Type type)
+            => type.Name.StartsWith("<>")
+               && type.GetCustomAttributes(typeof(CompilerGeneratedAttribute), inherit: false).Length > 0
+               && type.Name.Contains("AnonymousType");
+
+        public static bool IsTupleType(this Type type)
+        {
+            if (type == typeof(Tuple))
+            {
+                return true;
+            }
+
+            if (type.IsGenericType)
+            {
+                var genericDefinition = type.GetGenericTypeDefinition();
+                if (genericDefinition == typeof(Tuple<>)
+                    || genericDefinition == typeof(Tuple<,>)
+                    || genericDefinition == typeof(Tuple<,,>)
+                    || genericDefinition == typeof(Tuple<,,,>)
+                    || genericDefinition == typeof(Tuple<,,,,>)
+                    || genericDefinition == typeof(Tuple<,,,,,>)
+                    || genericDefinition == typeof(Tuple<,,,,,,>)
+                    || genericDefinition == typeof(Tuple<,,,,,,,>)
+                    || genericDefinition == typeof(Tuple<,,,,,,,>))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         public static PropertyInfo GetAnyProperty(this Type type, string name)

--- a/test/EFCore.Cosmos.Sql.FunctionalTests/CosmosSqlEndToEndTest.cs
+++ b/test/EFCore.Cosmos.Sql.FunctionalTests/CosmosSqlEndToEndTest.cs
@@ -22,7 +22,6 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql
         }
 
         [ConditionalFact]
-        // TODO: Remove ToList when Single/Count works
         public async Task Can_add_update_delete_end_to_end()
         {
             using (var testDatabase = CosmosSqlTestStore.CreateInitialized(DatabaseName))
@@ -42,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql
 
                 using (var context = new CustomerContext(options))
                 {
-                    var customerFromStore = context.Set<Customer>().ToList().Single();
+                    var customerFromStore = context.Set<Customer>().Single();
 
                     Assert.Equal(42, customerFromStore.Id);
                     Assert.Equal("Theon", customerFromStore.Name);
@@ -58,7 +57,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql
 
                 using (var context = new CustomerContext(options))
                 {
-                    var customerFromStore = context.Set<Customer>().ToList().Single();
+                    var customerFromStore = context.Set<Customer>().Single();
 
                     Assert.Equal(42, customerFromStore.Id);
                     Assert.Equal("Theon Greyjoy", customerFromStore.Name);
@@ -73,7 +72,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql
 
                 using (var context = new CustomerContext(options))
                 {
-                    Assert.Equal(0, context.Set<Customer>().ToList().Count());
+                    Assert.Equal(0, context.Set<Customer>().Count());
                 }
             }
         }

--- a/test/EFCore.Cosmos.Sql.FunctionalTests/Query/SimpleQueryCosmosSqlTest.Functions.cs
+++ b/test/EFCore.Cosmos.Sql.FunctionalTests/Query/SimpleQueryCosmosSqlTest.Functions.cs
@@ -1,0 +1,919 @@
+﻿using System.Threading.Tasks;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query
+{
+    public partial class SimpleQueryCosmosSqlTest
+    {
+        public override async Task String_StartsWith_Literal(bool isAsync)
+        {
+            await base.String_StartsWith_Literal(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task String_StartsWith_Identity(bool isAsync)
+        {
+            await base.String_StartsWith_Identity(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task String_StartsWith_Column(bool isAsync)
+        {
+            await base.String_StartsWith_Column(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task String_StartsWith_MethodCall(bool isAsync)
+        {
+            await base.String_StartsWith_MethodCall(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task String_EndsWith_Literal(bool isAsync)
+        {
+            await base.String_EndsWith_Literal(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task String_EndsWith_Identity(bool isAsync)
+        {
+            await base.String_EndsWith_Identity(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task String_EndsWith_Column(bool isAsync)
+        {
+            await base.String_EndsWith_Column(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task String_EndsWith_MethodCall(bool isAsync)
+        {
+            await base.String_EndsWith_MethodCall(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task String_Contains_Literal(bool isAsync)
+        {
+            await base.String_Contains_Literal(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task String_Contains_Identity(bool isAsync)
+        {
+            await base.String_Contains_Identity(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task String_Contains_Column(bool isAsync)
+        {
+            await base.String_Contains_Column(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task String_Contains_MethodCall(bool isAsync)
+        {
+            await base.String_Contains_MethodCall(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task String_Compare_simple_zero(bool isAsync)
+        {
+            await base.String_Compare_simple_zero(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task String_Compare_simple_one(bool isAsync)
+        {
+            await base.String_Compare_simple_one(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task String_compare_with_parameter(bool isAsync)
+        {
+            await base.String_compare_with_parameter(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task String_Compare_simple_client(bool isAsync)
+        {
+            await base.String_Compare_simple_client(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task String_Compare_nested(bool isAsync)
+        {
+            await base.String_Compare_nested(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task String_Compare_multi_predicate(bool isAsync)
+        {
+            await base.String_Compare_multi_predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task String_Compare_to_simple_zero(bool isAsync)
+        {
+            await base.String_Compare_to_simple_zero(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task String_Compare_to_simple_one(bool isAsync)
+        {
+            await base.String_Compare_to_simple_one(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task String_compare_to_with_parameter(bool isAsync)
+        {
+            await base.String_compare_to_with_parameter(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task String_Compare_to_simple_client(bool isAsync)
+        {
+            await base.String_Compare_to_simple_client(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task String_Compare_to_nested(bool isAsync)
+        {
+            await base.String_Compare_to_nested(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task String_Compare_to_multi_predicate(bool isAsync)
+        {
+            await base.String_Compare_to_multi_predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_math_abs1(bool isAsync)
+        {
+            await base.Where_math_abs1(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        }
+
+        public override async Task Where_math_abs2(bool isAsync)
+        {
+            await base.Where_math_abs2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        }
+
+        public override async Task Where_math_abs3(bool isAsync)
+        {
+            await base.Where_math_abs3(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        }
+
+        public override async Task Where_math_abs_uncorrelated(bool isAsync)
+        {
+            await base.Where_math_abs_uncorrelated(isAsync);
+
+            AssertSql(
+                @"@__Abs_0='10'
+
+SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (@__Abs_0 < c[""ProductID""]))");
+        }
+
+        public override async Task Where_math_ceiling1(bool isAsync)
+        {
+            await base.Where_math_ceiling1(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_math_ceiling2(bool isAsync)
+        {
+            await base.Where_math_ceiling2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        }
+
+        public override async Task Where_math_floor(bool isAsync)
+        {
+            await base.Where_math_floor(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        }
+
+        public override async Task Where_math_power(bool isAsync)
+        {
+            await base.Where_math_power(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        }
+
+        public override async Task Where_math_round(bool isAsync)
+        {
+            await base.Where_math_round(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        }
+
+        public override async Task Select_math_round_int(bool isAsync)
+        {
+            await base.Select_math_round_int(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10250))");
+        }
+
+        public override async Task Select_math_truncate_int(bool isAsync)
+        {
+            await base.Select_math_truncate_int(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10250))");
+        }
+
+        public override async Task Where_math_round2(bool isAsync)
+        {
+            await base.Where_math_round2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        }
+
+        public override async Task Where_math_truncate(bool isAsync)
+        {
+            await base.Where_math_truncate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        }
+
+        public override async Task Where_math_exp(bool isAsync)
+        {
+            await base.Where_math_exp(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        }
+
+        public override async Task Where_math_log10(bool isAsync)
+        {
+            await base.Where_math_log10(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        }
+
+        public override async Task Where_math_log(bool isAsync)
+        {
+            await base.Where_math_log(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        }
+
+        public override async Task Where_math_log_new_base(bool isAsync)
+        {
+            await base.Where_math_log_new_base(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        }
+
+        public override async Task Where_math_sqrt(bool isAsync)
+        {
+            await base.Where_math_sqrt(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        }
+
+        public override async Task Where_math_acos(bool isAsync)
+        {
+            await base.Where_math_acos(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        }
+
+        public override async Task Where_math_asin(bool isAsync)
+        {
+            await base.Where_math_asin(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        }
+
+        public override async Task Where_math_atan(bool isAsync)
+        {
+            await base.Where_math_atan(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        }
+
+        public override async Task Where_math_atan2(bool isAsync)
+        {
+            await base.Where_math_atan2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        }
+
+        public override async Task Where_math_cos(bool isAsync)
+        {
+            await base.Where_math_cos(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        }
+
+        public override async Task Where_math_sin(bool isAsync)
+        {
+            await base.Where_math_sin(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        }
+
+        public override async Task Where_math_tan(bool isAsync)
+        {
+            await base.Where_math_tan(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        }
+
+        public override async Task Where_math_sign(bool isAsync)
+        {
+            await base.Where_math_sign(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        }
+
+        public override async Task Where_math_min(bool isAsync)
+        {
+            await base.Where_math_min(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        }
+
+        public override async Task Where_math_max(bool isAsync)
+        {
+            await base.Where_math_max(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 11077))");
+        }
+
+        public override async Task Where_guid_newguid(bool isAsync)
+        {
+            await base.Where_guid_newguid(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        }
+
+        public override async Task Where_string_to_upper(bool isAsync)
+        {
+            await base.Where_string_to_upper(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_string_to_lower(bool isAsync)
+        {
+            await base.Where_string_to_lower(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_functions_nested(bool isAsync)
+        {
+            await base.Where_functions_nested(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Convert_ToByte(bool isAsync)
+        {
+            await base.Convert_ToByte(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Convert_ToDecimal(bool isAsync)
+        {
+            await base.Convert_ToDecimal(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Convert_ToDouble(bool isAsync)
+        {
+            await base.Convert_ToDouble(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Convert_ToInt16(bool isAsync)
+        {
+            await base.Convert_ToInt16(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Convert_ToInt32(bool isAsync)
+        {
+            await base.Convert_ToInt32(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Convert_ToInt64(bool isAsync)
+        {
+            await base.Convert_ToInt64(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Convert_ToString(bool isAsync)
+        {
+            await base.Convert_ToString(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Indexof_with_emptystring(bool isAsync)
+        {
+            await base.Indexof_with_emptystring(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Replace_with_emptystring(bool isAsync)
+        {
+            await base.Replace_with_emptystring(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Substring_with_zero_startindex(bool isAsync)
+        {
+            await base.Substring_with_zero_startindex(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Substring_with_zero_length(bool isAsync)
+        {
+            await base.Substring_with_zero_length(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Substring_with_constant(bool isAsync)
+        {
+            await base.Substring_with_constant(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Substring_with_closure(bool isAsync)
+        {
+            await base.Substring_with_closure(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Substring_with_client_eval(bool isAsync)
+        {
+            await base.Substring_with_client_eval(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task IsNullOrEmpty_in_predicate(bool isAsync)
+        {
+            await base.IsNullOrEmpty_in_predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override void IsNullOrEmpty_in_projection()
+        {
+            base.IsNullOrEmpty_in_projection();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override void IsNullOrEmpty_negated_in_projection()
+        {
+            base.IsNullOrEmpty_negated_in_projection();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task IsNullOrWhiteSpace_in_predicate(bool isAsync)
+        {
+            await base.IsNullOrWhiteSpace_in_predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task TrimStart_without_arguments_in_predicate(bool isAsync)
+        {
+            await base.TrimStart_without_arguments_in_predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task TrimStart_with_char_argument_in_predicate(bool isAsync)
+        {
+            await base.TrimStart_with_char_argument_in_predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task TrimStart_with_char_array_argument_in_predicate(bool isAsync)
+        {
+            await base.TrimStart_with_char_array_argument_in_predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task TrimEnd_without_arguments_in_predicate(bool isAsync)
+        {
+            await base.TrimEnd_without_arguments_in_predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task TrimEnd_with_char_argument_in_predicate(bool isAsync)
+        {
+            await base.TrimEnd_with_char_argument_in_predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task TrimEnd_with_char_array_argument_in_predicate(bool isAsync)
+        {
+            await base.TrimEnd_with_char_array_argument_in_predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Trim_without_argument_in_predicate(bool isAsync)
+        {
+            await base.Trim_without_argument_in_predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Trim_with_char_argument_in_predicate(bool isAsync)
+        {
+            await base.Trim_with_char_argument_in_predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Trim_with_char_array_argument_in_predicate(bool isAsync)
+        {
+            await base.Trim_with_char_array_argument_in_predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Order_by_length_twice(bool isAsync)
+        {
+            await base.Order_by_length_twice(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Order_by_length_twice_followed_by_projection_of_naked_collection_navigation(bool isAsync)
+        {
+            await base.Order_by_length_twice_followed_by_projection_of_naked_collection_navigation(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Static_string_equals_in_predicate(bool isAsync)
+        {
+            await base.Static_string_equals_in_predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Static_equals_nullable_datetime_compared_to_non_nullable(bool isAsync)
+        {
+            await base.Static_equals_nullable_datetime_compared_to_non_nullable(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Static_equals_int_compared_to_long(bool isAsync)
+        {
+            await base.Static_equals_int_compared_to_long(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Projecting_Math_Truncate_and_ordering_by_it_twice(bool isAsync)
+        {
+            await base.Projecting_Math_Truncate_and_ordering_by_it_twice(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10250))");
+        }
+
+        public override async Task Projecting_Math_Truncate_and_ordering_by_it_twice2(bool isAsync)
+        {
+            await base.Projecting_Math_Truncate_and_ordering_by_it_twice2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10250))");
+        }
+
+        public override async Task Projecting_Math_Truncate_and_ordering_by_it_twice3(bool isAsync)
+        {
+            await base.Projecting_Math_Truncate_and_ordering_by_it_twice3(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10250))");
+        }
+    }
+}

--- a/test/EFCore.Cosmos.Sql.FunctionalTests/Query/SimpleQueryCosmosSqlTest.JoinGroupJoin.cs
+++ b/test/EFCore.Cosmos.Sql.FunctionalTests/Query/SimpleQueryCosmosSqlTest.JoinGroupJoin.cs
@@ -1,0 +1,427 @@
+﻿using System.Threading.Tasks;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query
+{
+    public partial class SimpleQueryCosmosSqlTest
+    {
+        public override async Task Join_customers_orders_projection(bool isAsync)
+        {
+            await base.Join_customers_orders_projection(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Join_customers_orders_entities(bool isAsync)
+        {
+            await base.Join_customers_orders_entities(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Join_select_many(bool isAsync)
+        {
+            await base.Join_select_many(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Client_Join_select_many(bool isAsync)
+        {
+            await base.Client_Join_select_many(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task Join_customers_orders_select(bool isAsync)
+        {
+            await base.Join_customers_orders_select(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Join_customers_orders_with_subquery(bool isAsync)
+        {
+            await base.Join_customers_orders_with_subquery(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Join_customers_orders_with_subquery_with_take(bool isAsync)
+        {
+            await base.Join_customers_orders_with_subquery_with_take(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Join_customers_orders_with_subquery_anonymous_property_method(bool isAsync)
+        {
+            await base.Join_customers_orders_with_subquery_anonymous_property_method(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Join_customers_orders_with_subquery_anonymous_property_method_with_take(bool isAsync)
+        {
+            await base.Join_customers_orders_with_subquery_anonymous_property_method_with_take(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Join_customers_orders_with_subquery_predicate(bool isAsync)
+        {
+            await base.Join_customers_orders_with_subquery_predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Join_customers_orders_with_subquery_predicate_with_take(bool isAsync)
+        {
+            await base.Join_customers_orders_with_subquery_predicate_with_take(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Join_composite_key(bool isAsync)
+        {
+            await base.Join_composite_key(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Join_complex_condition(bool isAsync)
+        {
+            await base.Join_complex_condition(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Join_client_new_expression(bool isAsync)
+        {
+            await base.Join_client_new_expression(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Join_same_collection_multiple(bool isAsync)
+        {
+            await base.Join_same_collection_multiple(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Join_same_collection_force_alias_uniquefication(bool isAsync)
+        {
+            await base.Join_same_collection_force_alias_uniquefication(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task GroupJoin_customers_orders_count(bool isAsync)
+        {
+            await base.GroupJoin_customers_orders_count(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task GroupJoin_customers_orders_count_preserves_ordering(bool isAsync)
+        {
+            await base.GroupJoin_customers_orders_count_preserves_ordering(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CustomerID""] != ""VAFFE"") AND (c[""CustomerID""] != ""DRACD"")))");
+        }
+
+        public override async Task GroupJoin_simple(bool isAsync)
+        {
+            await base.GroupJoin_simple(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task GroupJoin_simple2(bool isAsync)
+        {
+            await base.GroupJoin_simple2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task GroupJoin_simple3(bool isAsync)
+        {
+            await base.GroupJoin_simple3(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task GroupJoin_tracking_groups(bool isAsync)
+        {
+            await base.GroupJoin_tracking_groups(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task GroupJoin_simple_ordering(bool isAsync)
+        {
+            await base.GroupJoin_simple_ordering(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task GroupJoin_simple_subquery(bool isAsync)
+        {
+            await base.GroupJoin_simple_subquery(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task GroupJoin_DefaultIfEmpty(bool isAsync)
+        {
+            await base.GroupJoin_DefaultIfEmpty(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task GroupJoin_DefaultIfEmpty_multiple(bool isAsync)
+        {
+            await base.GroupJoin_DefaultIfEmpty_multiple(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task GroupJoin_DefaultIfEmpty2(bool isAsync)
+        {
+            await base.GroupJoin_DefaultIfEmpty2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task GroupJoin_DefaultIfEmpty3(bool isAsync)
+        {
+            await base.GroupJoin_DefaultIfEmpty3(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task GroupJoin_Where(bool isAsync)
+        {
+            await base.GroupJoin_Where(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task GroupJoin_Where_OrderBy(bool isAsync)
+        {
+            await base.GroupJoin_Where_OrderBy(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task GroupJoin_DefaultIfEmpty_Where(bool isAsync)
+        {
+            await base.GroupJoin_DefaultIfEmpty_Where(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Join_GroupJoin_DefaultIfEmpty_Where(bool isAsync)
+        {
+            await base.Join_GroupJoin_DefaultIfEmpty_Where(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task GroupJoin_DefaultIfEmpty_Project(bool isAsync)
+        {
+            await base.GroupJoin_DefaultIfEmpty_Project(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task GroupJoin_with_different_outer_elements_with_same_key(bool isAsync)
+        {
+            await base.GroupJoin_with_different_outer_elements_with_same_key(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task GroupJoin_with_different_outer_elements_with_same_key_with_predicate(bool isAsync)
+        {
+            await base.GroupJoin_with_different_outer_elements_with_same_key_with_predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] > 11500))");
+        }
+
+        public override async Task GroupJoin_with_different_outer_elements_with_same_key_projected_from_another_entity(bool isAsync)
+        {
+            await base.GroupJoin_with_different_outer_elements_with_same_key_projected_from_another_entity(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        }
+
+        public override async Task GroupJoin_SelectMany_subquery_with_filter(bool isAsync)
+        {
+            await base.GroupJoin_SelectMany_subquery_with_filter(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task GroupJoin_SelectMany_subquery_with_filter_orderby(bool isAsync)
+        {
+            await base.GroupJoin_SelectMany_subquery_with_filter_orderby(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task GroupJoin_SelectMany_subquery_with_filter_and_DefaultIfEmpty(bool isAsync)
+        {
+            await base.GroupJoin_SelectMany_subquery_with_filter_and_DefaultIfEmpty(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task GroupJoin_SelectMany_subquery_with_filter_orderby_and_DefaultIfEmpty(bool isAsync)
+        {
+            await base.GroupJoin_SelectMany_subquery_with_filter_orderby_and_DefaultIfEmpty(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task GroupJoin_with_order_by_key_descending1(bool isAsync)
+        {
+            await base.GroupJoin_with_order_by_key_descending1(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task GroupJoin_with_order_by_key_descending2(bool isAsync)
+        {
+            await base.GroupJoin_with_order_by_key_descending2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+    }
+}

--- a/test/EFCore.Cosmos.Sql.FunctionalTests/Query/SimpleQueryCosmosSqlTest.QueryTypes.cs
+++ b/test/EFCore.Cosmos.Sql.FunctionalTests/Query/SimpleQueryCosmosSqlTest.QueryTypes.cs
@@ -1,0 +1,117 @@
+﻿using System.Threading.Tasks;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query
+{
+    public partial class SimpleQueryCosmosSqlTest
+    {
+        public override async Task QueryType_simple(bool isAsync)
+        {
+            await base.QueryType_simple(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task QueryType_where_simple(bool isAsync)
+        {
+            await base.QueryType_where_simple(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override void Query_backed_by_database_view()
+        {
+            base.Query_backed_by_database_view();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND NOT(c[""Discontinued""]))");
+        }
+
+        public override void QueryType_with_nav_defining_query()
+        {
+            base.QueryType_with_nav_defining_query();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task QueryType_with_mixed_tracking(bool isAsync)
+        {
+            await base.QueryType_with_mixed_tracking(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task QueryType_with_defining_query(bool isAsync)
+        {
+            await base.QueryType_with_defining_query(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task QueryType_with_defining_query_and_correlated_collection(bool isAsync)
+        {
+            await base.QueryType_with_defining_query_and_correlated_collection(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task QueryType_with_included_nav(bool isAsync)
+        {
+            await base.QueryType_with_included_nav(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task QueryType_with_included_navs_multi_level(bool isAsync)
+        {
+            await base.QueryType_with_included_navs_multi_level(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task QueryType_select_where_navigation(bool isAsync)
+        {
+            await base.QueryType_select_where_navigation(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task QueryType_select_where_navigation_multi_level(bool isAsync)
+        {
+            await base.QueryType_select_where_navigation_multi_level(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+    }
+}

--- a/test/EFCore.Cosmos.Sql.FunctionalTests/Query/SimpleQueryCosmosSqlTest.ResultOperators.cs
+++ b/test/EFCore.Cosmos.Sql.FunctionalTests/Query/SimpleQueryCosmosSqlTest.ResultOperators.cs
@@ -1,0 +1,1051 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Internal;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query
+{
+    public partial class SimpleQueryCosmosSqlTest
+    {
+        public override async Task Union_with_custom_projection(bool isAsync)
+        {
+            await base.Union_with_custom_projection(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override void Select_All()
+        {
+            base.Select_All();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Sum_with_no_arg(bool isAsync)
+        {
+            await base.Sum_with_no_arg(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Sum_with_binary_expression(bool isAsync)
+        {
+            await base.Sum_with_binary_expression(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Sum_with_arg(bool isAsync)
+        {
+            await base.Sum_with_arg(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Sum_with_arg_expression(bool isAsync)
+        {
+            await base.Sum_with_arg_expression(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Sum_with_division_on_decimal(bool isAsync)
+        {
+            await base.Sum_with_division_on_decimal(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        }
+
+        public override async Task Sum_with_division_on_decimal_no_significant_digits(bool isAsync)
+        {
+            await base.Sum_with_division_on_decimal_no_significant_digits(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        }
+
+        public override async Task Sum_with_coalesce(bool isAsync)
+        {
+            await base.Sum_with_coalesce(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND (c[""ProductID""] < 40))");
+        }
+
+        public override async Task Sum_over_subquery_is_client_eval(bool isAsync)
+        {
+            await base.Sum_over_subquery_is_client_eval(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Sum_on_float_column(bool isAsync)
+        {
+            await base.Sum_on_float_column(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""ProductID""] = 1))");
+        }
+
+        public override async Task Sum_on_float_column_in_subquery(bool isAsync)
+        {
+            await base.Sum_on_float_column_in_subquery(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))");
+        }
+
+        public override async Task Average_with_no_arg(bool isAsync)
+        {
+            await base.Average_with_no_arg(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Average_with_binary_expression(bool isAsync)
+        {
+            await base.Average_with_binary_expression(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Average_with_arg(bool isAsync)
+        {
+            await base.Average_with_arg(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Average_with_arg_expression(bool isAsync)
+        {
+            await base.Average_with_arg_expression(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Average_with_division_on_decimal(bool isAsync)
+        {
+            await base.Average_with_division_on_decimal(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        }
+
+        public override async Task Average_with_division_on_decimal_no_significant_digits(bool isAsync)
+        {
+            await base.Average_with_division_on_decimal_no_significant_digits(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        }
+
+        public override async Task Average_with_coalesce(bool isAsync)
+        {
+            await base.Average_with_coalesce(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND (c[""ProductID""] < 40))");
+        }
+
+        public override async Task Average_over_subquery_is_client_eval(bool isAsync)
+        {
+            await base.Average_over_subquery_is_client_eval(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Average_on_float_column(bool isAsync)
+        {
+            await base.Average_on_float_column(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""ProductID""] = 1))");
+        }
+
+        public override async Task Average_on_float_column_in_subquery(bool isAsync)
+        {
+            await base.Average_on_float_column_in_subquery(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))");
+        }
+
+        public override async Task Average_on_float_column_in_subquery_with_cast(bool isAsync)
+        {
+            await base.Average_on_float_column_in_subquery_with_cast(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))");
+        }
+
+        public override async Task Min_with_no_arg(bool isAsync)
+        {
+            await base.Min_with_no_arg(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Min_with_arg(bool isAsync)
+        {
+            await base.Min_with_arg(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Min_with_coalesce(bool isAsync)
+        {
+            await base.Min_with_coalesce(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND (c[""ProductID""] < 40))");
+        }
+
+        public override async Task Min_over_subquery_is_client_eval(bool isAsync)
+        {
+            await base.Min_over_subquery_is_client_eval(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Max_with_no_arg(bool isAsync)
+        {
+            await base.Max_with_no_arg(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Max_with_arg(bool isAsync)
+        {
+            await base.Max_with_arg(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Max_with_coalesce(bool isAsync)
+        {
+            await base.Max_with_coalesce(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND (c[""ProductID""] < 40))");
+        }
+
+        public override async Task Max_over_subquery_is_client_eval(bool isAsync)
+        {
+            await base.Max_over_subquery_is_client_eval(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Count_with_predicate(bool isAsync)
+        {
+            await base.Count_with_predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Where_OrderBy_Count(bool isAsync)
+        {
+            await base.Where_OrderBy_Count(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task OrderBy_Where_Count(bool isAsync)
+        {
+            await base.OrderBy_Where_Count(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task OrderBy_Count_with_predicate(bool isAsync)
+        {
+            await base.OrderBy_Count_with_predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task OrderBy_Where_Count_with_predicate(bool isAsync)
+        {
+            await base.OrderBy_Where_Count_with_predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] > 10)) AND (c[""CustomerID""] != ""ALFKI""))");
+        }
+
+        public override async Task Where_OrderBy_Count_client_eval(bool isAsync)
+        {
+            await base.Where_OrderBy_Count_client_eval(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Where_OrderBy_Count_client_eval_mixed(bool isAsync)
+        {
+            await base.Where_OrderBy_Count_client_eval_mixed(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] > 10))");
+        }
+
+        public override async Task OrderBy_Where_Count_client_eval(bool isAsync)
+        {
+            await base.OrderBy_Where_Count_client_eval(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task OrderBy_Where_Count_client_eval_mixed(bool isAsync)
+        {
+            await base.OrderBy_Where_Count_client_eval_mixed(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task OrderBy_Count_with_predicate_client_eval(bool isAsync)
+        {
+            await base.OrderBy_Count_with_predicate_client_eval(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task OrderBy_Count_with_predicate_client_eval_mixed(bool isAsync)
+        {
+            await base.OrderBy_Count_with_predicate_client_eval_mixed(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task OrderBy_Where_Count_with_predicate_client_eval(bool isAsync)
+        {
+            await base.OrderBy_Where_Count_with_predicate_client_eval(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task OrderBy_Where_Count_with_predicate_client_eval_mixed(bool isAsync)
+        {
+            await base.OrderBy_Where_Count_with_predicate_client_eval_mixed(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task OrderBy_client_Take(bool isAsync)
+        {
+            await base.OrderBy_client_Take(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task Distinct(bool isAsync)
+        {
+            await base.Distinct(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Distinct_Scalar(bool isAsync)
+        {
+            await base.Distinct_Scalar(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_Distinct(bool isAsync)
+        {
+            await base.OrderBy_Distinct(isAsync);
+
+            // Ordering not preserved by distinct when ordering columns not projected.
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Distinct_OrderBy(bool isAsync)
+        {
+            await base.Distinct_OrderBy(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Distinct_OrderBy2(bool isAsync)
+        {
+            await base.Distinct_OrderBy2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Distinct_OrderBy3(bool isAsync)
+        {
+            await base.Distinct_OrderBy3(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Distinct_Count(bool isAsync)
+        {
+            await base.Distinct_Count(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_Select_Distinct_Count(bool isAsync)
+        {
+            await base.Select_Select_Distinct_Count(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Single_Predicate(bool isAsync)
+        {
+            await base.Single_Predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task FirstOrDefault_inside_subquery_gets_server_evaluated(bool isAsync)
+        {
+            await base.FirstOrDefault_inside_subquery_gets_server_evaluated(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task First_inside_subquery_gets_client_evaluated(bool isAsync)
+        {
+            await base.First_inside_subquery_gets_client_evaluated(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Last(bool isAsync)
+        {
+            await base.Last(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Last_when_no_order_by(bool isAsync)
+        {
+            await base.Last_when_no_order_by(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Last_Predicate(bool isAsync)
+        {
+            await base.Last_Predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_Last(bool isAsync)
+        {
+            await base.Where_Last(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task LastOrDefault(bool isAsync)
+        {
+            await base.LastOrDefault(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task LastOrDefault_Predicate(bool isAsync)
+        {
+            await base.LastOrDefault_Predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_LastOrDefault(bool isAsync)
+        {
+            await base.Where_LastOrDefault(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Contains_with_subquery(bool isAsync)
+        {
+            await base.Contains_with_subquery(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Contains_with_local_array_closure(bool isAsync)
+        {
+            await base.Contains_with_local_array_closure(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Contains_with_subquery_and_local_array_closure(bool isAsync)
+        {
+            await base.Contains_with_subquery_and_local_array_closure(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Contains_with_local_int_array_closure(bool isAsync)
+        {
+            await base.Contains_with_local_int_array_closure(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task Contains_with_local_nullable_int_array_closure(bool isAsync)
+        {
+            await base.Contains_with_local_nullable_int_array_closure(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task Contains_with_local_array_inline(bool isAsync)
+        {
+            await base.Contains_with_local_array_inline(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Contains_with_local_list_closure(bool isAsync)
+        {
+            await base.Contains_with_local_list_closure(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Contains_with_local_list_closure_all_null(bool isAsync)
+        {
+            await base.Contains_with_local_list_closure_all_null(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Contains_with_local_list_inline(bool isAsync)
+        {
+            await base.Contains_with_local_list_inline(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Contains_with_local_list_inline_closure_mix(bool isAsync)
+        {
+            await base.Contains_with_local_list_inline_closure_mix(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Contains_with_local_collection_false(bool isAsync)
+        {
+            await base.Contains_with_local_collection_false(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Contains_with_local_collection_complex_predicate_and(bool isAsync)
+        {
+            await base.Contains_with_local_collection_complex_predicate_and(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Contains_with_local_collection_complex_predicate_or(bool isAsync)
+        {
+            await base.Contains_with_local_collection_complex_predicate_or(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Contains_with_local_collection_complex_predicate_not_matching_ins1(bool isAsync)
+        {
+            await base.Contains_with_local_collection_complex_predicate_not_matching_ins1(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Contains_with_local_collection_complex_predicate_not_matching_ins2(bool isAsync)
+        {
+            await base.Contains_with_local_collection_complex_predicate_not_matching_ins2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Contains_with_local_collection_sql_injection(bool isAsync)
+        {
+            await base.Contains_with_local_collection_sql_injection(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Contains_with_local_collection_empty_closure(bool isAsync)
+        {
+            await base.Contains_with_local_collection_empty_closure(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Contains_with_local_collection_empty_inline(bool isAsync)
+        {
+            await base.Contains_with_local_collection_empty_inline(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Contains_top_level(bool isAsync)
+        {
+            await base.Contains_top_level(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Contains_with_local_tuple_array_closure(bool isAsync)
+        {
+            await base.Contains_with_local_tuple_array_closure(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        }
+
+        public override async Task Contains_with_local_anonymous_type_array_closure(bool isAsync)
+        {
+            await base.Contains_with_local_anonymous_type_array_closure(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        }
+
+        public override void OfType_Select()
+        {
+            base.OfType_Select();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override void OfType_Select_OfType_Select()
+        {
+            base.OfType_Select_OfType_Select();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Average_with_non_matching_types_in_projection_doesnt_produce_second_explicit_cast(bool isAsync)
+        {
+            await base.Average_with_non_matching_types_in_projection_doesnt_produce_second_explicit_cast(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Max_with_non_matching_types_in_projection_introduces_explicit_cast(bool isAsync)
+        {
+            await base.Max_with_non_matching_types_in_projection_introduces_explicit_cast(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Min_with_non_matching_types_in_projection_introduces_explicit_cast(bool isAsync)
+        {
+            await base.Min_with_non_matching_types_in_projection_introduces_explicit_cast(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task OrderBy_Take_Last_gives_correct_result(bool isAsync)
+        {
+            await base.OrderBy_Take_Last_gives_correct_result(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_Skip_Last_gives_correct_result(bool isAsync)
+        {
+            await base.OrderBy_Skip_Last_gives_correct_result(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override void Contains_over_entityType_should_rewrite_to_identity_equality()
+        {
+            base.Contains_over_entityType_should_rewrite_to_identity_equality();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10248))");
+        }
+
+        public override void Contains_over_entityType_should_materialize_when_composite()
+        {
+            base.Contains_over_entityType_should_materialize_when_composite();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND ((c[""OrderID""] = 10248) AND (c[""ProductID""] = 42)))");
+        }
+
+        public override void Paging_operation_on_string_doesnt_issue_warning()
+        {
+            base.Paging_operation_on_string_doesnt_issue_warning();
+
+            Assert.DoesNotContain(
+                CoreStrings.LogFirstWithoutOrderByAndFilter.GenerateMessage(
+                    @"(from char <generated>_1 in [c].CustomerID select [<generated>_1]).FirstOrDefault()"),
+                Fixture.TestSqlLoggerFactory.Log.Select(l => l.Message));
+        }
+
+        public override async Task Project_constant_Sum(bool isAsync)
+        {
+            await base.Project_constant_Sum(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task Where_subquery_any_equals_operator(bool isAsync)
+        {
+            await base.Where_subquery_any_equals_operator(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_subquery_any_equals(bool isAsync)
+        {
+            await base.Where_subquery_any_equals(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_subquery_any_equals_static(bool isAsync)
+        {
+            await base.Where_subquery_any_equals_static(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_subquery_where_any(bool isAsync)
+        {
+            await base.Where_subquery_where_any(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""México D.F.""))");
+        }
+
+        public override async Task Where_subquery_all_not_equals_operator(bool isAsync)
+        {
+            await base.Where_subquery_all_not_equals_operator(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_subquery_all_not_equals(bool isAsync)
+        {
+            await base.Where_subquery_all_not_equals(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_subquery_all_not_equals_static(bool isAsync)
+        {
+            await base.Where_subquery_all_not_equals_static(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_subquery_where_all(bool isAsync)
+        {
+            await base.Where_subquery_where_all(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""México D.F.""))");
+        }
+
+        public override async Task Cast_to_same_Type_Count_works(bool isAsync)
+        {
+            await base.Cast_to_same_Type_Count_works(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+    }
+}

--- a/test/EFCore.Cosmos.Sql.FunctionalTests/Query/SimpleQueryCosmosSqlTest.Select.cs
+++ b/test/EFCore.Cosmos.Sql.FunctionalTests/Query/SimpleQueryCosmosSqlTest.Select.cs
@@ -1,0 +1,737 @@
+﻿using System.Threading.Tasks;
+
+namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query
+{
+    public partial class SimpleQueryCosmosSqlTest
+    {
+        public override async Task Projection_when_arithmetic_expression_precendence(bool isAsync)
+        {
+            await base.Projection_when_arithmetic_expression_precendence(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Projection_when_arithmetic_expressions(bool isAsync)
+        {
+            await base.Projection_when_arithmetic_expressions(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Projection_when_arithmetic_mixed(bool isAsync)
+        {
+            await base.Projection_when_arithmetic_mixed(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Projection_when_arithmetic_mixed_subqueries(bool isAsync)
+        {
+            await base.Projection_when_arithmetic_mixed_subqueries(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Projection_when_null_value(bool isAsync)
+        {
+            await base.Projection_when_null_value(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Projection_when_client_evald_subquery(bool isAsync)
+        {
+            await base.Projection_when_client_evald_subquery(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Project_to_object_array(bool isAsync)
+        {
+            await base.Project_to_object_array(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""EmployeeID""] = 1))");
+        }
+
+        public override async Task Project_to_int_array(bool isAsync)
+        {
+            await base.Project_to_int_array(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""EmployeeID""] = 1))");
+        }
+
+        public override async Task Select_bool_closure_with_order_by_property_with_cast_to_nullable(bool isAsync)
+        {
+            await base.Select_bool_closure_with_order_by_property_with_cast_to_nullable(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_bool_closure_with_order_parameter_with_cast_to_nullable(bool isAsync)
+        {
+            await base.Select_bool_closure_with_order_parameter_with_cast_to_nullable(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_scalar(bool isAsync)
+        {
+            await base.Select_scalar(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_anonymous_one(bool isAsync)
+        {
+            await base.Select_anonymous_one(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_anonymous_two(bool isAsync)
+        {
+            await base.Select_anonymous_two(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_anonymous_three(bool isAsync)
+        {
+            await base.Select_anonymous_three(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_anonymous_bool_constant_true(bool isAsync)
+        {
+            await base.Select_anonymous_bool_constant_true(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_anonymous_constant_in_expression(bool isAsync)
+        {
+            await base.Select_anonymous_constant_in_expression(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_anonymous_conditional_expression(bool isAsync)
+        {
+            await base.Select_anonymous_conditional_expression(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Product"")");
+        }
+
+        public override async Task Select_constant_int(bool isAsync)
+        {
+            await base.Select_constant_int(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_constant_null_string(bool isAsync)
+        {
+            await base.Select_constant_null_string(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_local(bool isAsync)
+        {
+            await base.Select_local(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_scalar_primitive_after_take(bool isAsync)
+        {
+            await base.Select_scalar_primitive_after_take(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task Select_project_filter(bool isAsync)
+        {
+            await base.Select_project_filter(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
+        }
+
+        public override async Task Select_project_filter2(bool isAsync)
+        {
+            await base.Select_project_filter2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
+        }
+
+        public override async Task Select_nested_collection(bool isAsync)
+        {
+            await base.Select_nested_collection(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
+        }
+
+        public override void Select_nested_collection_multi_level()
+        {
+            base.Select_nested_collection_multi_level();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override void Select_nested_collection_multi_level2()
+        {
+            base.Select_nested_collection_multi_level2();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override void Select_nested_collection_multi_level3()
+        {
+            base.Select_nested_collection_multi_level3();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override void Select_nested_collection_multi_level4()
+        {
+            base.Select_nested_collection_multi_level4();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override void Select_nested_collection_multi_level5()
+        {
+            base.Select_nested_collection_multi_level5();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override void Select_nested_collection_multi_level6()
+        {
+            base.Select_nested_collection_multi_level6();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_nested_collection_count_using_anonymous_type(bool isAsync)
+        {
+            await base.Select_nested_collection_count_using_anonymous_type(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task New_date_time_in_anonymous_type_works(bool isAsync)
+        {
+            await base.New_date_time_in_anonymous_type_works(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_non_matching_value_types_int_to_long_introduces_explicit_cast(bool isAsync)
+        {
+            await base.Select_non_matching_value_types_int_to_long_introduces_explicit_cast(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Select_non_matching_value_types_nullable_int_to_long_introduces_explicit_cast(bool isAsync)
+        {
+            await base.Select_non_matching_value_types_nullable_int_to_long_introduces_explicit_cast(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Select_non_matching_value_types_nullable_int_to_int_doesnt_introduce_explicit_cast(bool isAsync)
+        {
+            await base.Select_non_matching_value_types_nullable_int_to_int_doesnt_introduce_explicit_cast(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Select_non_matching_value_types_int_to_nullable_int_doesnt_introduce_explicit_cast(bool isAsync)
+        {
+            await base.Select_non_matching_value_types_int_to_nullable_int_doesnt_introduce_explicit_cast(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Select_non_matching_value_types_from_binary_expression_introduces_explicit_cast(bool isAsync)
+        {
+            await base.Select_non_matching_value_types_from_binary_expression_introduces_explicit_cast(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Select_non_matching_value_types_from_binary_expression_nested_introduces_top_level_explicit_cast(bool isAsync)
+        {
+            await base.Select_non_matching_value_types_from_binary_expression_nested_introduces_top_level_explicit_cast(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Select_non_matching_value_types_from_unary_expression_introduces_explicit_cast1(bool isAsync)
+        {
+            await base.Select_non_matching_value_types_from_unary_expression_introduces_explicit_cast1(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Select_non_matching_value_types_from_unary_expression_introduces_explicit_cast2(bool isAsync)
+        {
+            await base.Select_non_matching_value_types_from_unary_expression_introduces_explicit_cast2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Select_non_matching_value_types_from_length_introduces_explicit_cast(bool isAsync)
+        {
+            await base.Select_non_matching_value_types_from_length_introduces_explicit_cast(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Select_non_matching_value_types_from_method_call_introduces_explicit_cast(bool isAsync)
+        {
+            await base.Select_non_matching_value_types_from_method_call_introduces_explicit_cast(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Select_non_matching_value_types_from_anonymous_type_introduces_explicit_cast(bool isAsync)
+        {
+            await base.Select_non_matching_value_types_from_anonymous_type_introduces_explicit_cast(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Select_conditional_with_null_comparison_in_test(bool isAsync)
+        {
+            await base.Select_conditional_with_null_comparison_in_test(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Projection_in_a_subquery_should_be_liftable(bool isAsync)
+        {
+            await base.Projection_in_a_subquery_should_be_liftable(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task Projection_containing_DateTime_subtraction(bool isAsync)
+        {
+            await base.Projection_containing_DateTime_subtraction(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))");
+        }
+
+        public override async Task Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault(bool isAsync)
+        {
+            await base.Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Project_single_element_from_collection_with_OrderBy_Skip_and_FirstOrDefault(bool isAsync)
+        {
+            await base.Project_single_element_from_collection_with_OrderBy_Skip_and_FirstOrDefault(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault(bool isAsync)
+        {
+            await base.Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault_followed_by_projecting_length(bool isAsync)
+        {
+            await base.Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault_followed_by_projecting_length(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Project_single_element_from_collection_with_OrderBy_Take_and_SingleOrDefault(bool isAsync)
+        {
+            await base.Project_single_element_from_collection_with_OrderBy_Take_and_SingleOrDefault(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault_with_parameter(bool isAsync)
+        {
+            await base.Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault_with_parameter(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault(bool isAsync)
+        {
+            await base.Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_followed_by_projection_of_length_property(bool isAsync)
+        {
+            await base.Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_followed_by_projection_of_length_property(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_2(bool isAsync)
+        {
+            await base.Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault(bool isAsync)
+        {
+            await base.Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))");
+        }
+
+        public override async Task Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault_2(bool isAsync)
+        {
+            await base.Project_single_element_from_collection_with_OrderBy_over_navigation_Take_and_FirstOrDefault_2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10250))");
+        }
+
+        public override async Task Select_datetime_year_component(bool isAsync)
+        {
+            await base.Select_datetime_year_component(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Select_datetime_month_component(bool isAsync)
+        {
+            await base.Select_datetime_month_component(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Select_datetime_day_of_year_component(bool isAsync)
+        {
+            await base.Select_datetime_day_of_year_component(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Select_datetime_day_component(bool isAsync)
+        {
+            await base.Select_datetime_day_component(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Select_datetime_hour_component(bool isAsync)
+        {
+            await base.Select_datetime_hour_component(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Select_datetime_minute_component(bool isAsync)
+        {
+            await base.Select_datetime_minute_component(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Select_datetime_second_component(bool isAsync)
+        {
+            await base.Select_datetime_second_component(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Select_datetime_millisecond_component(bool isAsync)
+        {
+            await base.Select_datetime_millisecond_component(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Select_byte_constant(bool isAsync)
+        {
+            await base.Select_byte_constant(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_short_constant(bool isAsync)
+        {
+            await base.Select_short_constant(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_bool_constant(bool isAsync)
+        {
+            await base.Select_bool_constant(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Anonymous_projection_AsNoTracking_Selector(bool isAsync)
+        {
+            await base.Anonymous_projection_AsNoTracking_Selector(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Anonymous_projection_with_repeated_property_being_ordered(bool isAsync)
+        {
+            await base.Anonymous_projection_with_repeated_property_being_ordered(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Anonymous_projection_with_repeated_property_being_ordered_2(bool isAsync)
+        {
+            await base.Anonymous_projection_with_repeated_property_being_ordered_2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Select_GetValueOrDefault_on_DateTime(bool isAsync)
+        {
+            await base.Select_GetValueOrDefault_on_DateTime(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Select_GetValueOrDefault_on_DateTime_with_null_values(bool isAsync)
+        {
+            await base.Select_GetValueOrDefault_on_DateTime_with_null_values(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+    }
+}

--- a/test/EFCore.Cosmos.Sql.FunctionalTests/Query/SimpleQueryCosmosSqlTest.Where.cs
+++ b/test/EFCore.Cosmos.Sql.FunctionalTests/Query/SimpleQueryCosmosSqlTest.Where.cs
@@ -2,21 +2,20 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
-using Microsoft.EntityFrameworkCore.Query;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
-using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query
 {
-    public partial class SimpleQueryCosmosSqlTest : QueryTestBase<NorthwindQueryCosmosSqlFixture<NoopModelCustomizer>>
+    public partial class SimpleQueryCosmosSqlTest
     {
         [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_add(bool isAsync)
+        [MemberData(nameof(IsAsyncData))]
+        public async virtual Task Where_add(bool isAsync)
         {
-            AssertQuery<Order>(
+            await AssertQuery<Order>(
                 isAsync,
                 os => os.Where(o => o.OrderID + 10 == 10258),
                 entryCount: 1);
@@ -28,10 +27,10 @@ WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] + 10) = 10258))")
         }
 
         [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_subtract(bool isAsync)
+        [MemberData(nameof(IsAsyncData))]
+        public async virtual Task Where_subtract(bool isAsync)
         {
-            AssertQuery<Order>(
+            await AssertQuery<Order>(
                 isAsync,
                 os => os.Where(o => o.OrderID - 10 == 10238),
                 entryCount: 1);
@@ -43,10 +42,10 @@ WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] - 10) = 10238))")
         }
 
         [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_multiply(bool isAsync)
+        [MemberData(nameof(IsAsyncData))]
+        public async virtual Task Where_multiply(bool isAsync)
         {
-            AssertQuery<Order>(
+            await AssertQuery<Order>(
                 isAsync,
                 os => os.Where(o => o.OrderID * 1 == 10248),
                 entryCount: 1);
@@ -58,10 +57,10 @@ WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] * 1) = 10248))");
         }
 
         [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_divide(bool isAsync)
+        [MemberData(nameof(IsAsyncData))]
+        public async virtual Task Where_divide(bool isAsync)
         {
-            AssertQuery<Order>(
+            await AssertQuery<Order>(
                 isAsync,
                 os => os.Where(o => o.OrderID / 1 == 10248),
                 entryCount: 1);
@@ -73,10 +72,10 @@ WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] / 1) = 10248))");
         }
 
         [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_modulo(bool isAsync)
+        [MemberData(nameof(IsAsyncData))]
+        public async virtual Task Where_modulo(bool isAsync)
         {
-            AssertQuery<Order>(
+            await AssertQuery<Order>(
                 isAsync,
                 os => os.Where(o => o.OrderID % 10248 == 0),
                 entryCount: 1);
@@ -87,56 +86,37 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] % 10248) = 0))");
         }
 
-        [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_bitwise_or(bool isAsync)
+        public override Task Where_bitwise_or(bool isAsync)
         {
-            AssertQuery<Order>(
-                isAsync,
-                os => os.Where(o => (o.OrderID | 10248) == 10248),
-                entryCount: 1);
+            // #13168
+            //await base.Where_bitwise_or(isAsync);
+
+            return Task.CompletedTask;
+        }
+
+        public override async Task Where_bitwise_and(bool isAsync)
+        {
+            await base.Where_bitwise_and(isAsync);
 
             AssertSql(
                 @"SELECT c AS query
 FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] | 10248) = 10248))");
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CustomerID""] = ""ALFKI"") & (c[""CustomerID""] = ""ANATR"")))");
+        }
+
+        public override Task Where_bitwise_xor(bool isAsync)
+        {
+            // #13168
+            // await base.Where_bitwise_xor(isAsync);
+
+            return Task.CompletedTask;
         }
 
         [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_bitwise_and(bool isAsync)
+        [MemberData(nameof(IsAsyncData))]
+        public async virtual Task Where_bitwise_leftshift(bool isAsync)
         {
-            AssertQuery<Order>(
-                isAsync,
-                os => os.Where(o => (o.OrderID & 11067) == 11067),
-                entryCount: 2);
-
-            AssertSql(
-                @"SELECT c AS query
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] & 11067) = 11067))");
-        }
-
-        [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_bitwise_xor(bool isAsync)
-        {
-            AssertQuery<Order>(
-                isAsync,
-                os => os.Where(o => (o.OrderID ^ 10248) == 0),
-                entryCount: 1);
-
-            AssertSql(
-                @"SELECT c AS query
-FROM root c
-WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] ^ 10248) = 0))");
-        }
-
-        [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_bitwise_leftshift(bool isAsync)
-        {
-            AssertQuery<Order>(
+            await AssertQuery<Order>(
                 isAsync,
                 os => os.Where(o => (o.OrderID << 1) == 20496),
                 entryCount: 1);
@@ -148,10 +128,10 @@ WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] << 1) = 20496))")
         }
 
         [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_bitwise_rightshift(bool isAsync)
+        [MemberData(nameof(IsAsyncData))]
+        public async virtual Task Where_bitwise_rightshift(bool isAsync)
         {
-            AssertQuery<Order>(
+            await AssertQuery<Order>(
                 isAsync,
                 os => os.Where(o => (o.OrderID >> 1) == 5124),
                 entryCount: 2);
@@ -163,10 +143,10 @@ WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] >> 1) = 5124))");
         }
 
         [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_logical_and(bool isAsync)
+        [MemberData(nameof(IsAsyncData))]
+        public async virtual Task Where_logical_and(bool isAsync)
         {
-            AssertQuery<Customer>(
+            await AssertQuery<Customer>(
                 isAsync,
                 cs => cs.Where(c => c.City == "Seattle" && c.ContactTitle == "Owner"),
                 entryCount: 1);
@@ -178,10 +158,10 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""City""] = ""Seattle"") AN
         }
 
         [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_logical_or(bool isAsync)
+        [MemberData(nameof(IsAsyncData))]
+        public async virtual Task Where_logical_or(bool isAsync)
         {
-            AssertQuery<Customer>(
+            await AssertQuery<Customer>(
                 isAsync,
                 cs => cs.Where(c => c.CustomerID == "ALFKI" || c.CustomerID == "ANATR"),
                 entryCount: 2);
@@ -193,10 +173,10 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CustomerID""] = ""ALFKI""
         }
 
         [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_logical_not(bool isAsync)
+        [MemberData(nameof(IsAsyncData))]
+        public async virtual Task Where_logical_not(bool isAsync)
         {
-            AssertQuery<Customer>(
+            await AssertQuery<Customer>(
                 isAsync,
                 cs => cs.Where(c => !(c.City != "Seattle")),
                 entryCount: 1);
@@ -208,10 +188,10 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND NOT((c[""City""] != ""Seattle""
         }
 
         [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_equality(bool isAsync)
+        [MemberData(nameof(IsAsyncData))]
+        public async virtual Task Where_equality(bool isAsync)
         {
-            AssertQuery<Employee>(
+            await AssertQuery<Employee>(
                 isAsync,
                 es => es.Where(e => e.ReportsTo == 2),
                 entryCount: 5);
@@ -223,10 +203,10 @@ WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""ReportsTo""] = 2))");
         }
 
         [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_inequality(bool isAsync)
+        [MemberData(nameof(IsAsyncData))]
+        public async virtual Task Where_inequality(bool isAsync)
         {
-            AssertQuery<Employee>(
+            await AssertQuery<Employee>(
                 isAsync,
                 es => es.Where(e => e.ReportsTo != 2),
                 entryCount: 4);
@@ -238,10 +218,10 @@ WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""ReportsTo""] != 2))");
         }
 
         [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_greaterthan(bool isAsync)
+        [MemberData(nameof(IsAsyncData))]
+        public async virtual Task Where_greaterthan(bool isAsync)
         {
-            AssertQuery<Employee>(
+            await AssertQuery<Employee>(
                 isAsync,
                 es => es.Where(e => e.ReportsTo > 2),
                 entryCount: 3);
@@ -253,10 +233,10 @@ WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""ReportsTo""] > 2))");
         }
 
         [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_greaterthanorequal(bool isAsync)
+        [MemberData(nameof(IsAsyncData))]
+        public async virtual Task Where_greaterthanorequal(bool isAsync)
         {
-            AssertQuery<Employee>(
+            await AssertQuery<Employee>(
                 isAsync,
                 es => es.Where(e => e.ReportsTo >= 2),
                 entryCount: 8);
@@ -268,10 +248,10 @@ WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""ReportsTo""] >= 2))");
         }
 
         [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_lessthan(bool isAsync)
+        [MemberData(nameof(IsAsyncData))]
+        public async virtual Task Where_lessthan(bool isAsync)
         {
-            AssertQuery<Employee>(
+            await AssertQuery<Employee>(
                 isAsync,
                 es => es.Where(e => e.ReportsTo < 2),
                 entryCount: 0);
@@ -283,10 +263,10 @@ WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""ReportsTo""] < 2))");
         }
 
         [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_lessthanorequal(bool isAsync)
+        [MemberData(nameof(IsAsyncData))]
+        public async virtual Task Where_lessthanorequal(bool isAsync)
         {
-            AssertQuery<Employee>(
+            await AssertQuery<Employee>(
                 isAsync,
                 es => es.Where(e => e.ReportsTo <= 2),
                 entryCount: 5);
@@ -298,10 +278,10 @@ WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""ReportsTo""] <= 2))");
         }
 
         [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_string_concat(bool isAsync)
+        [MemberData(nameof(IsAsyncData))]
+        public async virtual Task Where_string_concat(bool isAsync)
         {
-            AssertQuery<Customer>(
+            await AssertQuery<Customer>(
                 isAsync,
                 cs => cs.Where(c => c.CustomerID + "END" == "ALFKIEND"),
                 entryCount: 1);
@@ -313,10 +293,10 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CustomerID""] || ""END"")
         }
 
         [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_unary_minus(bool isAsync)
+        [MemberData(nameof(IsAsyncData))]
+        public async virtual Task Where_unary_minus(bool isAsync)
         {
-            AssertQuery<Order>(
+            await AssertQuery<Order>(
                 isAsync,
                 os => os.Where(o => -o.OrderID == -10248),
                 entryCount: 1);
@@ -328,10 +308,10 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (-(c[""OrderID""]) = -10248))");
         }
 
         [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_bitwise_not(bool isAsync)
+        [MemberData(nameof(IsAsyncData))]
+        public async virtual Task Where_bitwise_not(bool isAsync)
         {
-            AssertQuery<Order>(
+            await AssertQuery<Order>(
                 isAsync,
                 os => os.Where(o => ~o.OrderID == -10249),
                 entryCount: 1);
@@ -343,10 +323,10 @@ WHERE ((c[""Discriminator""] = ""Order"") AND (~(c[""OrderID""]) = -10249))");
         }
 
         [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_ternary(bool isAsync)
+        [MemberData(nameof(IsAsyncData))]
+        public async virtual Task Where_ternary(bool isAsync)
         {
-            AssertQuery<Customer>(
+            await AssertQuery<Customer>(
                 isAsync,
 #pragma warning disable IDE0029 // Use coalesce expression
                 cs => cs.Where(c => (c.Region != null ? c.Region : "SP") == "BC"),
@@ -360,10 +340,10 @@ WHERE ((c[""Discriminator""] = ""Customer"") AND (((c[""Region""] != null) ? c["
         }
 
         [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_coalesce(bool isAsync)
+        [MemberData(nameof(IsAsyncData))]
+        public async virtual Task Where_coalesce(bool isAsync)
         {
-            AssertQuery<Customer>(
+            await AssertQuery<Customer>(
                 isAsync,
                 cs => cs.Where(c => (c.Region ?? "SP") == "BC"),
                 entryCount: 2);
@@ -374,78 +354,249 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""Region""] ?? ""SP"") = ""BC""))");
         }
 
-        [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_simple_closure(bool isAsync)
+        public override async Task Where_simple(bool isAsync)
         {
-            var city = "London";
-
-            AssertQuery<Customer>(
-                isAsync,
-                cs => cs.Where(c => c.City == city),
-                entryCount: 6);
+            await base.Where_simple(isAsync);
 
             AssertSql(
-                @"@__city_0='London'
-
-SELECT c AS query
+                @"SELECT c AS query
 FROM root c
-WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = @__city_0))");
+WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
-        [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_simple_closure_nullable_type(bool isAsync)
+        public override async Task Where_as_queryable_expression(bool isAsync)
         {
-            int? reportsTo = 2;
-
-            AssertQuery<Employee>(
-                isAsync,
-                es => es.Where(e => e.ReportsTo == reportsTo),
-                entryCount: 5);
-
-            reportsTo = 5;
-
-            AssertQuery<Employee>(
-                isAsync,
-                es => es.Where(e => e.ReportsTo == reportsTo),
-                entryCount: 3);
-
-            reportsTo = null;
-
-            AssertQuery<Employee>(
-                isAsync,
-                es => es.Where(e => e.ReportsTo == reportsTo),
-                entryCount: 1);
+            await base.Where_as_queryable_expression(isAsync);
 
             AssertSql(
-                @"@__reportsTo_0='2'
-
-SELECT c AS query
+                @"SELECT c AS query
 FROM root c
-WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""ReportsTo""] = @__reportsTo_0))",
-                //
-                @"@__reportsTo_0='5'
-
-SELECT c AS query
-FROM root c
-WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""ReportsTo""] = @__reportsTo_0))",
-                //
-                @"@__reportsTo_0=null
-
-SELECT c AS query
-FROM root c
-WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""ReportsTo""] = @__reportsTo_0))");
+WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
-        [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_simple_shadow(bool isAsync)
+        public override async Task Where_simple_closure(bool isAsync)
         {
-            AssertQuery<Employee>(
-                isAsync,
-                es => es.Where(e => EF.Property<string>(e, "Title") == "Sales Representative"),
-                entryCount: 6);
+            await base.Where_simple_closure(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_indexer_closure(bool isAsync)
+        {
+            await base.Where_indexer_closure(isAsync);
+
+            AssertSql(
+                @"@__p_0='London'
+
+SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = @__p_0))");
+        }
+
+        public override async Task Where_dictionary_key_access_closure(bool isAsync)
+        {
+            await base.Where_dictionary_key_access_closure(isAsync);
+
+            AssertSql(
+                @"@__get_Item_0='London'
+
+SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = @__get_Item_0))");
+        }
+
+        public override async Task Where_tuple_item_closure(bool isAsync)
+        {
+            await base.Where_tuple_item_closure(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_named_tuple_item_closure(bool isAsync)
+        {
+            await base.Where_named_tuple_item_closure(isAsync);
+
+            AssertSql(
+                @"@__predicateTuple_Item2_0='London'
+
+SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = @__predicateTuple_Item2_0))");
+        }
+
+        public override async Task Where_simple_closure_constant(bool isAsync)
+        {
+            await base.Where_simple_closure_constant(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_simple_closure_via_query_cache(bool isAsync)
+        {
+            await base.Where_simple_closure_via_query_cache(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_method_call_nullable_type_closure_via_query_cache(bool isAsync)
+        {
+            await base.Where_method_call_nullable_type_closure_via_query_cache(isAsync);
+
+            AssertSql(
+                @"@__city_Int_0='2'
+
+SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""ReportsTo""] = @__city_Int_0))");
+        }
+
+        public override async Task Where_method_call_nullable_type_reverse_closure_via_query_cache(bool isAsync)
+        {
+            await base.Where_method_call_nullable_type_reverse_closure_via_query_cache(isAsync);
+
+            AssertSql(
+                @"@__city_NullableInt_0='1'
+
+SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""EmployeeID""] > @__city_NullableInt_0))");
+        }
+
+        public override async Task Where_method_call_closure_via_query_cache(bool isAsync)
+        {
+            await base.Where_method_call_closure_via_query_cache(isAsync);
+
+            AssertSql(
+                @"@__GetCity_0='London'
+
+SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = @__GetCity_0))");
+        }
+
+        public override async Task Where_field_access_closure_via_query_cache(bool isAsync)
+        {
+            await base.Where_field_access_closure_via_query_cache(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_property_access_closure_via_query_cache(bool isAsync)
+        {
+            await base.Where_property_access_closure_via_query_cache(isAsync);
+
+            AssertSql(
+                @"@__city_InstancePropertyValue_0='London'
+
+SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = @__city_InstancePropertyValue_0))");
+        }
+
+        public override async Task Where_static_field_access_closure_via_query_cache(bool isAsync)
+        {
+            await base.Where_static_field_access_closure_via_query_cache(isAsync);
+
+            AssertSql(
+                @"@__StaticFieldValue_0='London'
+
+SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = @__StaticFieldValue_0))");
+        }
+
+        public override async Task Where_static_property_access_closure_via_query_cache(bool isAsync)
+        {
+            await base.Where_static_property_access_closure_via_query_cache(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_nested_field_access_closure_via_query_cache(bool isAsync)
+        {
+            await base.Where_nested_field_access_closure_via_query_cache(isAsync);
+
+            AssertSql(
+                @"@__city_Nested_InstanceFieldValue_0='London'
+
+SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = @__city_Nested_InstanceFieldValue_0))");
+        }
+
+        public override async Task Where_nested_property_access_closure_via_query_cache(bool isAsync)
+        {
+            await base.Where_nested_property_access_closure_via_query_cache(isAsync);
+
+            AssertSql(
+                @"@__city_Nested_InstancePropertyValue_0='London'
+
+SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = @__city_Nested_InstancePropertyValue_0))");
+        }
+
+        public override async Task Where_new_instance_field_access_closure_via_query_cache(bool isAsync)
+        {
+            await base.Where_new_instance_field_access_closure_via_query_cache(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_simple_closure_via_query_cache_nullable_type(bool isAsync)
+        {
+            await base.Where_simple_closure_via_query_cache_nullable_type(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_simple_closure_via_query_cache_nullable_type_reverse(bool isAsync)
+        {
+            await base.Where_simple_closure_via_query_cache_nullable_type_reverse(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override void Where_subquery_closure_via_query_cache()
+        {
+            base.Where_subquery_closure_via_query_cache();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""Discriminator""] = ""Employee""))");
+        }
+
+        public override async Task Where_simple_shadow(bool isAsync)
+        {
+            await base.Where_simple_shadow(isAsync);
 
             AssertSql(
                 @"SELECT c AS query
@@ -453,14 +604,9 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""Title""] = ""Sales Representative""))");
         }
 
-        [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_client_property(bool isAsync)
+        public override async Task Where_simple_shadow_projection(bool isAsync)
         {
-            AssertQuery<Employee>(
-                isAsync,
-                es => es.Where(e => ClientMethod(e.ReportsTo)),
-                entryCount: 1);
+            await base.Where_simple_shadow_projection(isAsync);
 
             AssertSql(
                 @"SELECT c AS query
@@ -468,14 +614,9 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Employee"")");
         }
 
-        [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Where_client_ef_property(bool isAsync)
+        public override async Task Where_shadow_subquery_FirstOrDefault(bool isAsync)
         {
-            AssertQuery<Employee>(
-                isAsync,
-                es => es.Where(e => ClientMethod(EF.Property<uint?>(e, "ReportsTo"))),
-                entryCount: 1);
+            await base.Where_shadow_subquery_FirstOrDefault(isAsync);
 
             AssertSql(
                 @"SELECT c AS query
@@ -483,6 +624,1095 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Employee"")");
         }
 
-        private static bool ClientMethod(uint? value) => value == null;
+        public override async Task Where_client(bool isAsync)
+        {
+            await base.Where_client(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_subquery_correlated(bool isAsync)
+        {
+            await base.Where_subquery_correlated(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_subquery_correlated_client_eval(bool isAsync)
+        {
+            await base.Where_subquery_correlated_client_eval(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_client_and_server_top_level(bool isAsync)
+        {
+            await base.Where_client_and_server_top_level(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_client_or_server_top_level(bool isAsync)
+        {
+            await base.Where_client_or_server_top_level(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_client_and_server_non_top_level(bool isAsync)
+        {
+            await base.Where_client_and_server_non_top_level(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_client_deep_inside_predicate_and_server_top_level(bool isAsync)
+        {
+            await base.Where_client_deep_inside_predicate_and_server_top_level(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_equals_method_string(bool isAsync)
+        {
+            await base.Where_equals_method_string(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_equals_method_int(bool isAsync)
+        {
+            await base.Where_equals_method_int(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task Where_equals_using_object_overload_on_mismatched_types(bool isAsync)
+        {
+            await base.Where_equals_using_object_overload_on_mismatched_types(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_equals_using_int_overload_on_mismatched_types(bool isAsync)
+        {
+            await base.Where_equals_using_int_overload_on_mismatched_types(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task Where_equals_on_mismatched_types_nullable_int_long(bool isAsync)
+        {
+            await base.Where_equals_on_mismatched_types_nullable_int_long(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task Where_equals_on_mismatched_types_nullable_long_nullable_int(bool isAsync)
+        {
+            await base.Where_equals_on_mismatched_types_nullable_long_nullable_int(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task Where_equals_on_mismatched_types_int_nullable_int(bool isAsync)
+        {
+            await base.Where_equals_on_mismatched_types_int_nullable_int(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task Where_equals_on_matched_nullable_int_types(bool isAsync)
+        {
+            await base.Where_equals_on_matched_nullable_int_types(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task Where_equals_on_null_nullable_int_types(bool isAsync)
+        {
+            await base.Where_equals_on_null_nullable_int_types(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task Where_comparison_nullable_type_not_null(bool isAsync)
+        {
+            await base.Where_comparison_nullable_type_not_null(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""ReportsTo""] = 2))");
+        }
+
+        public override async Task Where_comparison_nullable_type_null(bool isAsync)
+        {
+            await base.Where_comparison_nullable_type_null(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""ReportsTo""] = null))");
+        }
+
+        public override async Task Where_string_length(bool isAsync)
+        {
+            await base.Where_string_length(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_string_indexof(bool isAsync)
+        {
+            await base.Where_string_indexof(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_string_replace(bool isAsync)
+        {
+            await base.Where_string_replace(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_string_substring(bool isAsync)
+        {
+            await base.Where_string_substring(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_datetime_now(bool isAsync)
+        {
+            await base.Where_datetime_now(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_datetime_utcnow(bool isAsync)
+        {
+            await base.Where_datetime_utcnow(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_datetime_today(bool isAsync)
+        {
+            await base.Where_datetime_today(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task Where_datetime_date_component(bool isAsync)
+        {
+            await base.Where_datetime_date_component(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Where_date_add_year_constant_component(bool isAsync)
+        {
+            await base.Where_date_add_year_constant_component(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Where_datetime_year_component(bool isAsync)
+        {
+            await base.Where_datetime_year_component(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Where_datetime_month_component(bool isAsync)
+        {
+            await base.Where_datetime_month_component(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Where_datetime_dayOfYear_component(bool isAsync)
+        {
+            await base.Where_datetime_dayOfYear_component(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Where_datetime_day_component(bool isAsync)
+        {
+            await base.Where_datetime_day_component(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Where_datetime_hour_component(bool isAsync)
+        {
+            await base.Where_datetime_hour_component(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Where_datetime_minute_component(bool isAsync)
+        {
+            await base.Where_datetime_minute_component(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Where_datetime_second_component(bool isAsync)
+        {
+            await base.Where_datetime_second_component(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Where_datetime_millisecond_component(bool isAsync)
+        {
+            await base.Where_datetime_millisecond_component(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Where_datetimeoffset_now_component(bool isAsync)
+        {
+            await base.Where_datetimeoffset_now_component(isAsync);
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Where_datetimeoffset_utcnow_component(bool isAsync)
+        {
+            await base.Where_datetimeoffset_utcnow_component(isAsync);
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_simple_reversed(bool isAsync)
+        {
+            await base.Where_simple_reversed(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (""London"" = c[""City""]))");
+        }
+
+        public override async Task Where_is_null(bool isAsync)
+        {
+            await base.Where_is_null(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = null))");
+        }
+
+        public override async Task Where_null_is_null(bool isAsync)
+        {
+            await base.Where_null_is_null(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND true)");
+        }
+
+        public override async Task Where_constant_is_null(bool isAsync)
+        {
+            await base.Where_constant_is_null(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND false)");
+        }
+
+        public override async Task Where_is_not_null(bool isAsync)
+        {
+            await base.Where_is_not_null(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] != null))");
+        }
+
+        public override async Task Where_null_is_not_null(bool isAsync)
+        {
+            await base.Where_null_is_not_null(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND false)");
+        }
+
+        public override async Task Where_constant_is_not_null(bool isAsync)
+        {
+            await base.Where_constant_is_not_null(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND true)");
+        }
+
+        public override async Task Where_identity_comparison(bool isAsync)
+        {
+            await base.Where_identity_comparison(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_in_optimization_multiple(bool isAsync)
+        {
+            await base.Where_in_optimization_multiple(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_not_in_optimization1(bool isAsync)
+        {
+            await base.Where_not_in_optimization1(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_not_in_optimization2(bool isAsync)
+        {
+            await base.Where_not_in_optimization2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_not_in_optimization3(bool isAsync)
+        {
+            await base.Where_not_in_optimization3(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_not_in_optimization4(bool isAsync)
+        {
+            await base.Where_not_in_optimization4(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_select_many_and(bool isAsync)
+        {
+            await base.Where_select_many_and(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_primitive(bool isAsync)
+        {
+            await base.Where_primitive(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task Where_bool_member(bool isAsync)
+        {
+            await base.Where_bool_member(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND c[""Discontinued""])");
+        }
+
+        public override async Task Where_bool_member_false(bool isAsync)
+        {
+            await base.Where_bool_member_false(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND NOT(c[""Discontinued""]))");
+        }
+
+        public override async Task Where_bool_client_side_negated(bool isAsync)
+        {
+            await base.Where_bool_client_side_negated(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Product"")");
+        }
+
+        public override async Task Where_bool_member_negated_twice(bool isAsync)
+        {
+            await base.Where_bool_member_negated_twice(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND NOT(NOT((c[""Discontinued""] = true))))");
+        }
+
+        public override async Task Where_bool_member_shadow(bool isAsync)
+        {
+            await base.Where_bool_member_shadow(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_bool_member_false_shadow(bool isAsync)
+        {
+            await base.Where_bool_member_false_shadow(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND NOT(c[""Discontinued""]))");
+        }
+
+        public override async Task Where_bool_member_equals_constant(bool isAsync)
+        {
+            await base.Where_bool_member_equals_constant(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Product"")");
+        }
+
+        public override async Task Where_bool_member_in_complex_predicate(bool isAsync)
+        {
+            await base.Where_bool_member_in_complex_predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND (((c[""ProductID""] > 100) AND c[""Discontinued""]) OR (c[""Discontinued""] = true)))");
+        }
+
+        public override async Task Where_bool_member_compared_to_binary_expression(bool isAsync)
+        {
+            await base.Where_bool_member_compared_to_binary_expression(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND (c[""Discontinued""] = (c[""ProductID""] > 50)))");
+        }
+
+        public override async Task Where_not_bool_member_compared_to_not_bool_member(bool isAsync)
+        {
+            await base.Where_not_bool_member_compared_to_not_bool_member(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_negated_boolean_expression_compared_to_another_negated_boolean_expression(bool isAsync)
+        {
+            await base.Where_negated_boolean_expression_compared_to_another_negated_boolean_expression(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND (NOT((c[""ProductID""] > 50)) = NOT((c[""ProductID""] > 20))))");
+        }
+
+        public override async Task Where_not_bool_member_compared_to_binary_expression(bool isAsync)
+        {
+            await base.Where_not_bool_member_compared_to_binary_expression(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND (NOT(c[""Discontinued""]) = (c[""ProductID""] > 50)))");
+        }
+
+        public override async Task Where_bool_parameter(bool isAsync)
+        {
+            await base.Where_bool_parameter(isAsync);
+
+            AssertSql(
+                @"@__prm_0='True'
+
+SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND @__prm_0)");
+        }
+
+        public override async Task Where_bool_parameter_compared_to_binary_expression(bool isAsync)
+        {
+            await base.Where_bool_parameter_compared_to_binary_expression(isAsync);
+
+            AssertSql(
+                @"@__prm_0='True'
+
+SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND ((c[""ProductID""] > 50) != @__prm_0))");
+        }
+
+        public override async Task Where_bool_member_and_parameter_compared_to_binary_expression_nested(bool isAsync)
+        {
+            await base.Where_bool_member_and_parameter_compared_to_binary_expression_nested(isAsync);
+
+            AssertSql(
+                @"@__prm_0='True'
+
+SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND (c[""Discontinued""] = ((c[""ProductID""] > 50) != @__prm_0)))");
+        }
+
+        public override async Task Where_de_morgan_or_optimizated(bool isAsync)
+        {
+            await base.Where_de_morgan_or_optimizated(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND NOT((c[""Discontinued""] OR (c[""ProductID""] < 20))))");
+        }
+
+        public override async Task Where_de_morgan_and_optimizated(bool isAsync)
+        {
+            await base.Where_de_morgan_and_optimizated(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND NOT((c[""Discontinued""] AND (c[""ProductID""] < 20))))");
+        }
+
+        public override async Task Where_complex_negated_expression_optimized(bool isAsync)
+        {
+            await base.Where_complex_negated_expression_optimized(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_short_member_comparison(bool isAsync)
+        {
+            await base.Where_short_member_comparison(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND (c[""UnitsInStock""] > 10))");
+        }
+
+        public override async Task Where_comparison_to_nullable_bool(bool isAsync)
+        {
+            await base.Where_comparison_to_nullable_bool(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_true(bool isAsync)
+        {
+            await base.Where_true(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND true)");
+        }
+
+        public override async Task Where_false(bool isAsync)
+        {
+            await base.Where_false(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND false)");
+        }
+
+        public override async Task Where_bool_closure(bool isAsync)
+        {
+            await base.Where_bool_closure(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND false)");
+        }
+
+        public override async Task Where_default(bool isAsync)
+        {
+            await base.Where_default(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""Fax""] = null))");
+        }
+
+        public override async Task Where_expression_invoke(bool isAsync)
+        {
+            await base.Where_expression_invoke(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_concat_string_int_comparison1(bool isAsync)
+        {
+            await base.Where_concat_string_int_comparison1(isAsync);
+
+            AssertSql(
+                @"@__i_0='10'
+
+SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CustomerID""] || @__i_0) = c[""CompanyName""]))");
+        }
+
+        public override async Task Where_concat_string_int_comparison2(bool isAsync)
+        {
+            await base.Where_concat_string_int_comparison2(isAsync);
+
+            AssertSql(
+                @"@__i_0='10'
+
+SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((@__i_0 + c[""CustomerID""]) = c[""CompanyName""]))");
+        }
+
+        public override async Task Where_concat_string_int_comparison3(bool isAsync)
+        {
+            await base.Where_concat_string_int_comparison3(isAsync);
+
+            AssertSql(
+                @"@__i_0='10'
+@__j_1='21'
+
+SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (((((@__i_0 + 20) + c[""CustomerID""]) || @__j_1) || 42) = c[""CompanyName""]))");
+        }
+
+        public override async Task Where_ternary_boolean_condition_true(bool isAsync)
+        {
+            await base.Where_ternary_boolean_condition_true(isAsync);
+
+            AssertSql(
+                @"@__flag_0='True'
+
+SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND (@__flag_0 ? (c[""UnitsInStock""] >= 20) : (c[""UnitsInStock""] < 20)))");
+        }
+
+        public override async Task Where_ternary_boolean_condition_false(bool isAsync)
+        {
+            await base.Where_ternary_boolean_condition_false(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_ternary_boolean_condition_with_another_condition(bool isAsync)
+        {
+            await base.Where_ternary_boolean_condition_with_another_condition(isAsync);
+
+            AssertSql(
+                @"@__productId_0='15'
+@__flag_1='True'
+
+SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND ((c[""ProductID""] < @__productId_0) AND (@__flag_1 ? (c[""UnitsInStock""] >= 20) : (c[""UnitsInStock""] < 20))))");
+        }
+
+        public override async Task Where_ternary_boolean_condition_with_false_as_result_true(bool isAsync)
+        {
+            await base.Where_ternary_boolean_condition_with_false_as_result_true(isAsync);
+
+            AssertSql(
+                @"@__flag_0='True'
+
+SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND (@__flag_0 ? (c[""UnitsInStock""] >= 20) : false))");
+        }
+
+        public override async Task Where_ternary_boolean_condition_with_false_as_result_false(bool isAsync)
+        {
+            await base.Where_ternary_boolean_condition_with_false_as_result_false(isAsync);
+
+            AssertSql(
+                @"@__flag_0='False'
+
+SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Product"") AND (@__flag_0 ? (c[""UnitsInStock""] >= 20) : false))");
+        }
+
+        public override async Task Where_compare_constructed_equal(bool isAsync)
+        {
+            await base.Where_compare_constructed_equal(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_compare_constructed_multi_value_equal(bool isAsync)
+        {
+            await base.Where_compare_constructed_multi_value_equal(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_compare_constructed_multi_value_not_equal(bool isAsync)
+        {
+            await base.Where_compare_constructed_multi_value_not_equal(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_compare_tuple_constructed_equal(bool isAsync)
+        {
+            await base.Where_compare_tuple_constructed_equal(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_compare_tuple_constructed_multi_value_equal(bool isAsync)
+        {
+            await base.Where_compare_tuple_constructed_multi_value_equal(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_compare_tuple_constructed_multi_value_not_equal(bool isAsync)
+        {
+            await base.Where_compare_tuple_constructed_multi_value_not_equal(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_compare_tuple_create_constructed_equal(bool isAsync)
+        {
+            await base.Where_compare_tuple_create_constructed_equal(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_compare_tuple_create_constructed_multi_value_equal(bool isAsync)
+        {
+            await base.Where_compare_tuple_create_constructed_multi_value_equal(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_compare_tuple_create_constructed_multi_value_not_equal(bool isAsync)
+        {
+            await base.Where_compare_tuple_create_constructed_multi_value_not_equal(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_compare_null(bool isAsync)
+        {
+            await base.Where_compare_null(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_Is_on_same_type(bool isAsync)
+        {
+            await base.Where_Is_on_same_type(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""Discriminator""] = ""Customer""))");
+        }
+
+        public override async Task Where_chain(bool isAsync)
+        {
+            await base.Where_chain(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override void Where_navigation_contains()
+        {
+            base.Where_navigation_contains();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_array_index(bool isAsync)
+        {
+            await base.Where_array_index(isAsync);
+
+            AssertSql(
+                @"@__p_0='ALFKI'
+
+SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = @__p_0))");
+        }
+
+        public override async Task Where_multiple_contains_in_subquery_with_or(bool isAsync)
+        {
+            await AssertQuery<OrderDetail, Product, Order>(
+                isAsync,
+                (ods, ps, os) =>
+                    ods.Where(od => od.OrderID < 10250).Where(
+                        od =>
+                            ps.OrderBy(p => p.ProductID).Take(1).Select(p => p.ProductID).Contains(od.ProductID)
+                            || os.OrderBy(o => o.OrderID).Take(1).Select(o => o.OrderID).Contains(od.OrderID)),
+                entryCount: 3);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] < 10250))");
+        }
+
+        public override async Task Where_multiple_contains_in_subquery_with_and(bool isAsync)
+        {
+            await AssertQuery<OrderDetail, Product, Order>(
+                isAsync,
+                (ods, ps, os) =>
+                    ods.Where(od => od.OrderID < 10260).Where(
+                        od =>
+                            ps.OrderBy(p => p.ProductID).Take(20).Select(p => p.ProductID).Contains(od.ProductID)
+                            && os.OrderBy(o => o.OrderID).Take(10).Select(o => o.OrderID).Contains(od.OrderID)),
+                entryCount: 5);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] < 10260))");
+        }
+
+        public override async Task Where_contains_on_navigation(bool isAsync)
+        {
+            await AssertQuery<Order, Customer>(
+                isAsync,
+                (os, cs) => os.Where(o => o.OrderID > 10354 && o.OrderID < 10360)
+                .Where(o => cs.Where(c => c.City == "London")
+                .Any(c => c.Orders.Contains(o))),
+                entryCount: 2);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] > 10354) AND (c[""OrderID""] < 10360)))");
+        }
+
+        public override async Task Where_subquery_FirstOrDefault_is_null(bool isAsync)
+        {
+            await base.Where_subquery_FirstOrDefault_is_null(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_subquery_FirstOrDefault_compared_to_entity(bool isAsync)
+        {
+            await base.Where_subquery_FirstOrDefault_compared_to_entity(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Time_of_day_datetime(bool isAsync)
+        {
+            await base.Time_of_day_datetime(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
     }
 }

--- a/test/EFCore.Cosmos.Sql.FunctionalTests/Query/SimpleQueryCosmosSqlTest.cs
+++ b/test/EFCore.Cosmos.Sql.FunctionalTests/Query/SimpleQueryCosmosSqlTest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -10,7 +12,7 @@ using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query
 {
-    public partial class SimpleQueryCosmosSqlTest : QueryTestBase<NorthwindQueryCosmosSqlFixture<NoopModelCustomizer>>
+    public partial class SimpleQueryCosmosSqlTest : SimpleQueryTestBase<NorthwindQueryCosmosSqlFixture<NoopModelCustomizer>>
     {
         public SimpleQueryCosmosSqlTest(NorthwindQueryCosmosSqlFixture<NoopModelCustomizer> fixture,
             ITestOutputHelper testOutputHelper)
@@ -20,13 +22,11 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
-        protected NorthwindContext CreateContext() => Fixture.CreateContext();
-
         [ConditionalTheory]
-        [InlineData(false)]
-        public virtual void Simple_IQuaryable(bool isAsync)
+        [MemberData(nameof(IsAsyncData))]
+        public async virtual Task Simple_IQueryable(bool isAsync)
         {
-            AssertQuery<Customer>(isAsync, cs => cs, entryCount: 91);
+            await AssertQuery<Customer>(isAsync, cs => cs, entryCount: 91);
 
             AssertSql(
                 @"SELECT c AS query
@@ -34,8 +34,3042 @@ FROM root c
 WHERE (c[""Discriminator""] = ""Customer"")");
         }
 
-        protected virtual void ClearLog() => Fixture.TestSqlLoggerFactory.Clear();
+        public override void Shaper_command_caching_when_parameter_names_different()
+        {
+            base.Shaper_command_caching_when_parameter_names_different();
 
-        private void AssertSql(params string[] expected) => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+            AssertSql(
+    @"SELECT c AS query
+FROM root c
+WHERE (((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")) AND ""True"")",
+    //
+    @"SELECT c AS query
+FROM root c
+WHERE (((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI"")) AND ""True"")");
+        }
+
+        public override void Lifting_when_subquery_nested_order_by_anonymous()
+        {
+            base.Lifting_when_subquery_nested_order_by_anonymous();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override void Lifting_when_subquery_nested_order_by_simple()
+        {
+            base.Lifting_when_subquery_nested_order_by_simple();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Local_array(bool isAsync)
+        {
+            await base.Local_array(isAsync);
+
+            AssertSql(
+                @"@__get_Item_0='ALFKI'
+
+SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = @__get_Item_0))");
+        }
+
+        public override void Method_with_constant_queryable_arg()
+        {
+            base.Method_with_constant_queryable_arg();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Entity_equality_self(bool isAsync)
+        {
+            await base.Entity_equality_self(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = c[""CustomerID""]))");
+        }
+
+        public override async Task Entity_equality_local(bool isAsync)
+        {
+            await base.Entity_equality_local(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Join_with_entity_equality_local_on_both_sources(bool isAsync)
+        {
+            await base.Join_with_entity_equality_local_on_both_sources(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Entity_equality_local_inline(bool isAsync)
+        {
+            await base.Entity_equality_local_inline(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Entity_equality_null(bool isAsync)
+        {
+            await base.Entity_equality_null(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = null))");
+        }
+
+        public override async Task Entity_equality_not_null(bool isAsync)
+        {
+            await base.Entity_equality_not_null(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] != null))");
+        }
+
+        public override async Task Queryable_reprojection(bool isAsync)
+        {
+            await base.Queryable_reprojection(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Default_if_empty_top_level(bool isAsync)
+        {
+            await base.Default_if_empty_top_level(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""EmployeeID""] = 4294967295))");
+        }
+
+        public override async Task Join_with_default_if_empty_on_both_sources(bool isAsync)
+        {
+            await base.Join_with_default_if_empty_on_both_sources(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Default_if_empty_top_level_followed_by_projecting_constant(bool isAsync)
+        {
+            await base.Default_if_empty_top_level_followed_by_projecting_constant(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Default_if_empty_top_level_positive(bool isAsync)
+        {
+            await base.Default_if_empty_top_level_positive(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""EmployeeID""] > 0))");
+        }
+
+        public override async Task Default_if_empty_top_level_arg(bool isAsync)
+        {
+            await base.Default_if_empty_top_level_arg(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""EmployeeID""] = 4294967295))");
+        }
+
+
+        public override async Task Default_if_empty_top_level_arg_followed_by_projecting_constant(bool isAsync)
+        {
+            await base.Default_if_empty_top_level_arg_followed_by_projecting_constant(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Default_if_empty_top_level_projection(bool isAsync)
+        {
+            await base.Default_if_empty_top_level_projection(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Employee"") AND (c[""EmployeeID""] = 4294967295))");
+        }
+
+        public override async Task Where_query_composition(bool isAsync)
+        {
+            await base.Where_query_composition(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_query_composition_is_null(bool isAsync)
+        {
+            await base.Where_query_composition_is_null(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_query_composition_is_not_null(bool isAsync)
+        {
+            await base.Where_query_composition_is_null(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_query_composition_entity_equality_one_element_SingleOrDefault(bool isAsync)
+        {
+            await base.Where_query_composition_entity_equality_one_element_SingleOrDefault(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task Where_query_composition_entity_equality_one_element_FirstOrDefault(bool isAsync)
+        {
+            await base.Where_query_composition_entity_equality_one_element_FirstOrDefault(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_query_composition_entity_equality_no_elements_SingleOrDefault(bool isAsync)
+        {
+            await base.Where_query_composition_entity_equality_no_elements_SingleOrDefault(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task Where_query_composition_entity_equality_no_elements_FirstOrDefault(bool isAsync)
+        {
+            await base.Where_query_composition_entity_equality_no_elements_FirstOrDefault(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_query_composition_entity_equality_multiple_elements_FirstOrDefault(bool isAsync)
+        {
+            await base.Where_query_composition_entity_equality_multiple_elements_FirstOrDefault(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task Where_query_composition2(bool isAsync)
+        {
+            await base.Where_query_composition2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task Where_query_composition2_FirstOrDefault(bool isAsync)
+        {
+            await base.Where_query_composition2_FirstOrDefault(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_query_composition2_FirstOrDefault_with_anonymous(bool isAsync)
+        {
+            await base.Where_query_composition2_FirstOrDefault_with_anonymous(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override void Select_Subquery_Single()
+        {
+            base.Select_Subquery_Single();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        }
+
+        public override void Select_Where_Subquery_Deep_Single()
+        {
+            base.Select_Where_Subquery_Deep_Single();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""OrderDetail"") AND (c[""OrderID""] = 10344))");
+        }
+
+        public override void Select_Where_Subquery_Deep_First()
+        {
+            base.Select_Where_Subquery_Deep_First();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        }
+
+        public override void Select_Where_Subquery_Equality()
+        {
+            base.Select_Where_Subquery_Equality();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Where_subquery_anon(bool isAsync)
+        {
+            await base.Where_subquery_anon(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_subquery_anon_nested(bool isAsync)
+        {
+            await base.Where_subquery_anon_nested(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_SelectMany(bool isAsync)
+        {
+            await base.OrderBy_SelectMany(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Let_any_subquery_anonymous(bool isAsync)
+        {
+            await base.Let_any_subquery_anonymous(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_arithmetic(bool isAsync)
+        {
+            await base.OrderBy_arithmetic(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task OrderBy_condition_comparison(bool isAsync)
+        {
+            await base.OrderBy_condition_comparison(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Product"")");
+        }
+
+        public override async Task OrderBy_ternary_conditions(bool isAsync)
+        {
+            await base.OrderBy_ternary_conditions(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Product"")");
+        }
+
+        public override void OrderBy_any()
+        {
+            base.OrderBy_any();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Skip(bool isAsync)
+        {
+            await base.Skip(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Skip_no_orderby(bool isAsync)
+        {
+            await base.Skip_no_orderby(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Skip_Take(bool isAsync)
+        {
+            await base.Skip_Take(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Join_Customers_Orders_Skip_Take(bool isAsync)
+        {
+            await base.Join_Customers_Orders_Skip_Take(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Join_Customers_Orders_Skip_Take_followed_by_constant_projection(bool isAsync)
+        {
+            await base.Join_Customers_Orders_Skip_Take_followed_by_constant_projection(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Join_Customers_Orders_Projection_With_String_Concat_Skip_Take(bool isAsync)
+        {
+            await base.Join_Customers_Orders_Projection_With_String_Concat_Skip_Take(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Join_Customers_Orders_Orders_Skip_Take_Same_Properties(bool isAsync)
+        {
+            await base.Join_Customers_Orders_Orders_Skip_Take_Same_Properties(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Take_Skip(bool isAsync)
+        {
+            await base.Take_Skip(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Take_Skip_Distinct(bool isAsync)
+        {
+            await base.Take_Skip_Distinct(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Take_Skip_Distinct_Caching(bool isAsync)
+        {
+            await base.Take_Skip_Distinct_Caching(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Take_Distinct_Count(bool isAsync)
+        {
+            await base.Take_Distinct_Count(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Take_Where_Distinct_Count(bool isAsync)
+        {
+            await base.Take_Where_Distinct_Count(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""FRANK""))");
+        }
+
+        public override async Task Null_conditional_simple(bool isAsync)
+        {
+            await base.Null_conditional_simple(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Null_conditional_deep(bool isAsync)
+        {
+            await base.Null_conditional_deep(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Queryable_simple(bool isAsync)
+        {
+            await base.Queryable_simple(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Queryable_simple_anonymous(bool isAsync)
+        {
+            await base.Queryable_simple_anonymous(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Queryable_nested_simple(bool isAsync)
+        {
+            await base.Queryable_nested_simple(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Queryable_simple_anonymous_projection_subquery(bool isAsync)
+        {
+            await base.Queryable_simple_anonymous_projection_subquery(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Queryable_simple_anonymous_subquery(bool isAsync)
+        {
+            await base.Queryable_simple_anonymous_subquery(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Take_simple(bool isAsync)
+        {
+            await base.Take_simple(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Take_simple_parameterized(bool isAsync)
+        {
+            await base.Take_simple_parameterized(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Take_simple_projection(bool isAsync)
+        {
+            await base.Take_simple_projection(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Take_subquery_projection(bool isAsync)
+        {
+            await base.Take_subquery_projection(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_Take_Count(bool isAsync)
+        {
+            await base.OrderBy_Take_Count(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Take_OrderBy_Count(bool isAsync)
+        {
+            await base.Take_OrderBy_Count(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Any_simple(bool isAsync)
+        {
+            await base.Any_simple(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Any_predicate(bool isAsync)
+        {
+            await base.Any_predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Any_nested_negated(bool isAsync)
+        {
+            await base.Any_nested_negated(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Any_nested_negated2(bool isAsync)
+        {
+            await base.Any_nested_negated2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Any_nested_negated3(bool isAsync)
+        {
+            await base.Any_nested_negated3(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Any_nested(bool isAsync)
+        {
+            await base.Any_nested(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Any_nested2(bool isAsync)
+        {
+            await base.Any_nested2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Any_nested3(bool isAsync)
+        {
+            await base.Any_nested3(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override void Any_with_multiple_conditions_still_uses_exists()
+        {
+            base.Any_with_multiple_conditions_still_uses_exists();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task All_top_level(bool isAsync)
+        {
+            await base.All_top_level(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task All_top_level_column(bool isAsync)
+        {
+            await base.All_top_level_column(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task All_top_level_subquery(bool isAsync)
+        {
+            await base.All_top_level_subquery(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task All_top_level_subquery_ef_property(bool isAsync)
+        {
+            await base.All_top_level_subquery_ef_property(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task First_client_predicate(bool isAsync)
+        {
+            await base.First_client_predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_select_many_or(bool isAsync)
+        {
+            await base.Where_select_many_or(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_select_many_or2(bool isAsync)
+        {
+            await base.Where_select_many_or2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_select_many_or3(bool isAsync)
+        {
+            await base.Where_select_many_or3(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_select_many_or4(bool isAsync)
+        {
+            await base.Where_select_many_or4(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_select_many_or_with_parameter(bool isAsync)
+        {
+            await base.Where_select_many_or_with_parameter(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task SelectMany_mixed(bool isAsync)
+        {
+            await base.SelectMany_mixed(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task SelectMany_simple_subquery(bool isAsync)
+        {
+            await base.SelectMany_simple_subquery(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task SelectMany_simple1(bool isAsync)
+        {
+            await base.SelectMany_simple1(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task SelectMany_simple2(bool isAsync)
+        {
+            await base.SelectMany_simple2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task SelectMany_entity_deep(bool isAsync)
+        {
+            await base.SelectMany_entity_deep(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task SelectMany_projection1(bool isAsync)
+        {
+            await base.SelectMany_projection1(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task SelectMany_projection2(bool isAsync)
+        {
+            await base.SelectMany_projection2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task SelectMany_Count(bool isAsync)
+        {
+            await base.SelectMany_Count(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task SelectMany_LongCount(bool isAsync)
+        {
+            await base.SelectMany_LongCount(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task SelectMany_OrderBy_ThenBy_Any(bool isAsync)
+        {
+            await base.SelectMany_OrderBy_ThenBy_Any(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Join_Where_Count(bool isAsync)
+        {
+            await base.Join_Where_Count(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_Join_Any(bool isAsync)
+        {
+            await base.Where_Join_Any(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_Join_Exists(bool isAsync)
+        {
+            await base.Where_Join_Exists(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_Join_Exists_Inequality(bool isAsync)
+        {
+            await base.Where_Join_Exists_Inequality(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_Join_Exists_Constant(bool isAsync)
+        {
+            await base.Where_Join_Exists_Constant(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_Join_Not_Exists(bool isAsync)
+        {
+            await base.Where_Join_Not_Exists(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Join_OrderBy_Count(bool isAsync)
+        {
+            await base.Join_OrderBy_Count(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Multiple_joins_Where_Order_Any(bool isAsync)
+        {
+            await base.Multiple_joins_Where_Order_Any(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_join_select(bool isAsync)
+        {
+            await base.Where_join_select(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Where_orderby_join_select(bool isAsync)
+        {
+            await base.Where_orderby_join_select(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_join_orderby_join_select(bool isAsync)
+        {
+            await base.Where_join_orderby_join_select(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] != ""ALFKI""))");
+        }
+
+        public override async Task Where_select_many(bool isAsync)
+        {
+            await base.Where_select_many(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_orderby_select_many(bool isAsync)
+        {
+            await base.Where_orderby_select_many(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task SelectMany_cartesian_product_with_ordering(bool isAsync)
+        {
+            await base.SelectMany_cartesian_product_with_ordering(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task SelectMany_Joined_DefaultIfEmpty(bool isAsync)
+        {
+            await base.SelectMany_Joined_DefaultIfEmpty(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task SelectMany_Joined_DefaultIfEmpty2(bool isAsync)
+        {
+            await base.SelectMany_Joined_DefaultIfEmpty2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task SelectMany_Joined_Take(bool isAsync)
+        {
+            await base.SelectMany_Joined_Take(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Take_with_single(bool isAsync)
+        {
+            await base.Take_with_single(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Take_with_single_select_many(bool isAsync)
+        {
+            await base.Take_with_single_select_many(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Distinct_Skip(bool isAsync)
+        {
+            await base.Distinct_Skip(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Distinct_Skip_Take(bool isAsync)
+        {
+            await base.Distinct_Skip_Take(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Skip_Distinct(bool isAsync)
+        {
+            await base.Skip_Distinct(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Skip_Take_Distinct(bool isAsync)
+        {
+            await base.Skip_Take_Distinct(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Skip_Take_Any(bool isAsync)
+        {
+            await base.Skip_Take_Any(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Skip_Take_All(bool isAsync)
+        {
+            await base.Skip_Take_All(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Take_All(bool isAsync)
+        {
+            await base.Take_All(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Skip_Take_Any_with_predicate(bool isAsync)
+        {
+            await base.Skip_Take_Any_with_predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Take_Any_with_predicate(bool isAsync)
+        {
+            await base.Take_Any_with_predicate(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy(bool isAsync)
+        {
+            await base.OrderBy(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_true(bool isAsync)
+        {
+            await base.OrderBy_true(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_integer(bool isAsync)
+        {
+            await base.OrderBy_integer(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_parameter(bool isAsync)
+        {
+            await base.OrderBy_parameter(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_anon(bool isAsync)
+        {
+            await base.OrderBy_anon(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_anon2(bool isAsync)
+        {
+            await base.OrderBy_anon2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_client_mixed(bool isAsync)
+        {
+            await base.OrderBy_client_mixed(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_multiple_queries(bool isAsync)
+        {
+            await base.OrderBy_multiple_queries(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Take_Distinct(bool isAsync)
+        {
+            await base.Take_Distinct(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Distinct_Take(bool isAsync)
+        {
+            await base.Distinct_Take(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Distinct_Take_Count(bool isAsync)
+        {
+            await base.Distinct_Take_Count(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task OrderBy_shadow(bool isAsync)
+        {
+            await base.OrderBy_shadow(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task OrderBy_multiple(bool isAsync)
+        {
+            await base.OrderBy_multiple(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_ThenBy_Any(bool isAsync)
+        {
+            await base.OrderBy_ThenBy_Any(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_correlated_subquery1(bool isAsync)
+        {
+            await base.OrderBy_correlated_subquery1(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_correlated_subquery2(bool isAsync)
+        {
+            await base.OrderBy_correlated_subquery2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Where_subquery_recursive_trivial(bool isAsync)
+        {
+            await base.Where_subquery_recursive_trivial(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task Where_query_composition4(bool isAsync)
+        {
+            await base.Where_query_composition4(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override void Select_DTO_distinct_translated_to_server()
+        {
+            base.Select_DTO_distinct_translated_to_server();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))");
+        }
+
+        public override void Select_DTO_constructor_distinct_translated_to_server()
+        {
+            base.Select_DTO_constructor_distinct_translated_to_server();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))");
+        }
+
+        public override void Select_DTO_with_member_init_distinct_translated_to_server()
+        {
+            base.Select_DTO_with_member_init_distinct_translated_to_server();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))");
+        }
+
+        public override void Select_nested_collection_count_using_DTO()
+        {
+            base.Select_nested_collection_count_using_DTO();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_DTO_with_member_init_distinct_in_subquery_translated_to_server(bool isAsync)
+        {
+            await base.Select_DTO_with_member_init_distinct_in_subquery_translated_to_server(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] < 10300))");
+        }
+
+        public override void Select_DTO_with_member_init_distinct_in_subquery_used_in_projection_translated_to_server()
+        {
+            base.Select_DTO_with_member_init_distinct_in_subquery_used_in_projection_translated_to_server();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_correlated_subquery_projection(bool isAsync)
+        {
+            await base.Select_correlated_subquery_projection(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_correlated_subquery_filtered(bool isAsync)
+        {
+            await base.Select_correlated_subquery_filtered(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_correlated_subquery_ordered(bool isAsync)
+        {
+            await base.Select_correlated_subquery_ordered(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Where_subquery_on_bool(bool isAsync)
+        {
+            await base.Where_subquery_on_bool(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Product"")");
+        }
+
+        public override async Task Where_subquery_on_collection(bool isAsync)
+        {
+            await AssertQuery<Product, OrderDetail>(
+                isAsync,
+                (pr, od) =>
+                    pr.Where(p => p.ProductID < 10250)
+                      .Where(
+                        p => od
+                            .Where(o => o.ProductID == p.ProductID)
+                            .Select(odd => odd.Quantity).Contains<short>(5)),
+                entryCount: 43);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Product"")");
+        }
+
+        public override async Task Select_many_cross_join_same_collection(bool isAsync)
+        {
+            await base.Select_many_cross_join_same_collection(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_null_coalesce_operator(bool isAsync)
+        {
+            await base.OrderBy_null_coalesce_operator(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_null_coalesce_operator(bool isAsync)
+        {
+            await base.Select_null_coalesce_operator(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_conditional_operator(bool isAsync)
+        {
+            await base.OrderBy_conditional_operator(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_conditional_operator_where_condition_null(bool isAsync)
+        {
+            await base.OrderBy_conditional_operator_where_condition_null(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_comparison_operator(bool isAsync)
+        {
+            await base.OrderBy_comparison_operator(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Projection_null_coalesce_operator(bool isAsync)
+        {
+            await base.Projection_null_coalesce_operator(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Filter_coalesce_operator(bool isAsync)
+        {
+            await base.Filter_coalesce_operator(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CompanyName""] ?? c[""ContactName""]) = ""The Big Cheese""))");
+        }
+
+        public override async Task Take_skip_null_coalesce_operator(bool isAsync)
+        {
+            await base.Take_skip_null_coalesce_operator(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_take_null_coalesce_operator(bool isAsync)
+        {
+            await base.Select_take_null_coalesce_operator(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_take_skip_null_coalesce_operator(bool isAsync)
+        {
+            await base.Select_take_skip_null_coalesce_operator(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_take_skip_null_coalesce_operator2(bool isAsync)
+        {
+            await base.Select_take_skip_null_coalesce_operator2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_take_skip_null_coalesce_operator3(bool isAsync)
+        {
+            await base.Select_take_skip_null_coalesce_operator3(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override void Selected_column_can_coalesce()
+        {
+            base.Selected_column_can_coalesce();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task DateTime_parse_is_parameterized(bool isAsync)
+        {
+            await base.DateTime_parse_is_parameterized(isAsync);
+
+            AssertSql(
+                @"@__Parse_0='1998-01-01T12:00:00'
+
+SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] > @__Parse_0))");
+        }
+
+        public override void Random_next_is_not_funcletized_1()
+        {
+            base.Random_next_is_not_funcletized_1();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override void Random_next_is_not_funcletized_2()
+        {
+            base.Random_next_is_not_funcletized_2();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override void Random_next_is_not_funcletized_3()
+        {
+            base.Random_next_is_not_funcletized_3();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override void Random_next_is_not_funcletized_4()
+        {
+            base.Random_next_is_not_funcletized_4();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override void Random_next_is_not_funcletized_5()
+        {
+            base.Random_next_is_not_funcletized_5();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override void Random_next_is_not_funcletized_6()
+        {
+            base.Random_next_is_not_funcletized_6();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Environment_newline_is_funcletized(bool isAsync)
+        {
+            await base.Environment_newline_is_funcletized(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task String_concat_with_navigation1(bool isAsync)
+        {
+            await base.String_concat_with_navigation1(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task String_concat_with_navigation2(bool isAsync)
+        {
+            await base.String_concat_with_navigation2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override void Select_bitwise_or()
+        {
+            base.Select_bitwise_or();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override void Select_bitwise_or_multiple()
+        {
+            base.Select_bitwise_or_multiple();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override void Select_bitwise_and()
+        {
+            base.Select_bitwise_and();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override void Select_bitwise_and_or()
+        {
+            base.Select_bitwise_and_or();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override Task Where_bitwise_or_with_logical_or(bool isAsync)
+        {
+            // #13168
+            //await base.Where_bitwise_or_with_logical_or(isAsync);
+
+            return Task.CompletedTask;
+        }
+
+        public override async Task Where_bitwise_and_with_logical_and(bool isAsync)
+        {
+            await base.Where_bitwise_and_with_logical_and(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (((c[""CustomerID""] = ""ALFKI"") & (c[""CustomerID""] = ""ANATR"")) AND (c[""CustomerID""] = ""ANTON"")))");
+        }
+
+        public override Task Where_bitwise_or_with_logical_and(bool isAsync)
+        {
+            // #13168
+            //await base.Where_bitwise_or_with_logical_and(isAsync);
+
+            return Task.CompletedTask;
+        }
+
+        public override async Task Where_bitwise_and_with_logical_or(bool isAsync)
+        {
+            await base.Where_bitwise_and_with_logical_or(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (((c[""CustomerID""] = ""ALFKI"") & (c[""CustomerID""] = ""ANATR"")) OR (c[""CustomerID""] = ""ANTON"")))");
+        }
+
+        public override void Select_bitwise_or_with_logical_or()
+        {
+            base.Select_bitwise_or_with_logical_or();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override void Select_bitwise_and_with_logical_and()
+        {
+            base.Select_bitwise_and_with_logical_and();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Handle_materialization_properly_when_more_than_two_query_sources_are_involved(bool isAsync)
+        {
+            await base.Handle_materialization_properly_when_more_than_two_query_sources_are_involved(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override Task Parameter_extraction_short_circuits_1(bool isAsync)
+        {
+            // #13159
+            //await base.Parameter_extraction_short_circuits_1(isAsync);
+
+            return Task.CompletedTask;
+        }
+
+        public override async Task Parameter_extraction_short_circuits_2(bool isAsync)
+        {
+            await base.Parameter_extraction_short_circuits_2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override Task Parameter_extraction_short_circuits_3(bool isAsync)
+        {
+            // #13159
+            //await base.Parameter_extraction_short_circuits_3(isAsync);
+
+            return Task.CompletedTask;
+        }
+
+        public override async Task Subquery_member_pushdown_does_not_change_original_subquery_model(bool isAsync)
+        {
+            await base.Subquery_member_pushdown_does_not_change_original_subquery_model(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Query_expression_with_to_string_and_contains(bool isAsync)
+        {
+            await base.Query_expression_with_to_string_and_contains(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Select_expression_long_to_string(bool isAsync)
+        {
+            await base.Select_expression_long_to_string(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+        }
+
+        public override async Task Select_expression_int_to_string(bool isAsync)
+        {
+            await base.Select_expression_int_to_string(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+        }
+
+        public override async Task ToString_with_formatter_is_evaluated_on_the_client(bool isAsync)
+        {
+            await base.ToString_with_formatter_is_evaluated_on_the_client(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+        }
+
+        public override async Task Select_expression_other_to_string(bool isAsync)
+        {
+            await base.Select_expression_other_to_string(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+        }
+
+        public override async Task Select_expression_date_add_year(bool isAsync)
+        {
+            await base.Select_expression_date_add_year(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+        }
+
+        public override async Task Select_expression_datetime_add_month(bool isAsync)
+        {
+            await base.Select_expression_datetime_add_month(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+        }
+
+        public override async Task Select_expression_datetime_add_hour(bool isAsync)
+        {
+            await base.Select_expression_datetime_add_hour(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+        }
+
+        public override async Task Select_expression_datetime_add_minute(bool isAsync)
+        {
+            await base.Select_expression_datetime_add_minute(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+        }
+
+        public override async Task Select_expression_datetime_add_second(bool isAsync)
+        {
+            await base.Select_expression_datetime_add_second(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+        }
+
+        public override async Task Select_expression_date_add_milliseconds_above_the_range(bool isAsync)
+        {
+            await base.Select_expression_date_add_milliseconds_above_the_range(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+        }
+
+        public override async Task Select_expression_date_add_milliseconds_below_the_range(bool isAsync)
+        {
+            await base.Select_expression_date_add_milliseconds_below_the_range(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+        }
+
+        public override async Task Select_expression_date_add_milliseconds_large_number_divided(bool isAsync)
+        {
+            await base.Select_expression_date_add_milliseconds_large_number_divided(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+        }
+
+        public override async Task Select_expression_references_are_updated_correctly_with_subquery(bool isAsync)
+        {
+            await base.Select_expression_references_are_updated_correctly_with_subquery(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderDate""] != null))");
+        }
+
+        public override void DefaultIfEmpty_without_group_join()
+        {
+            base.DefaultIfEmpty_without_group_join();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""London""))");
+        }
+
+        public override async Task DefaultIfEmpty_in_subquery(bool isAsync)
+        {
+            await base.DefaultIfEmpty_in_subquery(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task DefaultIfEmpty_in_subquery_nested(bool isAsync)
+        {
+            await base.DefaultIfEmpty_in_subquery_nested(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""City""] = ""Seattle""))");
+        }
+
+        public override async Task OrderBy_skip_take(bool isAsync)
+        {
+            await base.OrderBy_skip_take(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_skip_skip_take(bool isAsync)
+        {
+            await base.OrderBy_skip_skip_take(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_skip_take_take(bool isAsync)
+        {
+            await base.OrderBy_skip_take_take(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_skip_take_take_take_take(bool isAsync)
+        {
+            await base.OrderBy_skip_take_take_take_take(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_skip_take_skip_take_skip(bool isAsync)
+        {
+            await base.OrderBy_skip_take_skip_take_skip(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_skip_take_distinct(bool isAsync)
+        {
+            await base.OrderBy_skip_take_distinct(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_coalesce_take_distinct(bool isAsync)
+        {
+            await base.OrderBy_coalesce_take_distinct(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Product"")");
+        }
+
+        public override async Task OrderBy_coalesce_skip_take_distinct(bool isAsync)
+        {
+            await base.OrderBy_coalesce_skip_take_distinct(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Product"")");
+        }
+
+        public override async Task OrderBy_coalesce_skip_take_distinct_take(bool isAsync)
+        {
+            await base.OrderBy_coalesce_skip_take_distinct_take(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Product"")");
+        }
+
+        public override async Task OrderBy_skip_take_distinct_orderby_take(bool isAsync)
+        {
+            await base.OrderBy_skip_take_distinct_orderby_take(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task No_orderby_added_for_fully_translated_manually_constructed_LOJ(bool isAsync)
+        {
+            await base.No_orderby_added_for_fully_translated_manually_constructed_LOJ(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ(bool isAsync)
+        {
+            await base.No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ_with_additional_join_condition1(bool isAsync)
+        {
+            await base.No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ_with_additional_join_condition1(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ_with_additional_join_condition2(bool isAsync)
+        {
+            await base.No_orderby_added_for_client_side_GroupJoin_dependent_to_principal_LOJ_with_additional_join_condition2(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Orderby_added_for_client_side_GroupJoin_principal_to_dependent_LOJ(bool isAsync)
+        {
+            await base.Orderby_added_for_client_side_GroupJoin_principal_to_dependent_LOJ(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Employee"")");
+        }
+
+        public override async Task Contains_with_DateTime_Date(bool isAsync)
+        {
+            await base.Contains_with_DateTime_Date(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Contains_with_subquery_involving_join_binds_to_correct_table(bool isAsync)
+        {
+            await base.Contains_with_subquery_involving_join_binds_to_correct_table(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Complex_query_with_repeated_query_model_compiles_correctly(bool isAsync)
+        {
+            await base.Complex_query_with_repeated_query_model_compiles_correctly(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Complex_query_with_repeated_nested_query_model_compiles_correctly(bool isAsync)
+        {
+            await base.Complex_query_with_repeated_nested_query_model_compiles_correctly(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Anonymous_member_distinct_where(bool isAsync)
+        {
+            await base.Anonymous_member_distinct_where(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Anonymous_member_distinct_orderby(bool isAsync)
+        {
+            await base.Anonymous_member_distinct_orderby(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Anonymous_member_distinct_result(bool isAsync)
+        {
+            await base.Anonymous_member_distinct_result(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Anonymous_complex_distinct_where(bool isAsync)
+        {
+            await base.Anonymous_complex_distinct_where(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Anonymous_complex_distinct_orderby(bool isAsync)
+        {
+            await base.Anonymous_complex_distinct_orderby(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Anonymous_complex_distinct_result(bool isAsync)
+        {
+            await base.Anonymous_complex_distinct_result(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Anonymous_complex_orderby(bool isAsync)
+        {
+            await base.Anonymous_complex_orderby(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Anonymous_subquery_orderby(bool isAsync)
+        {
+            await base.Anonymous_subquery_orderby(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task DTO_member_distinct_where(bool isAsync)
+        {
+            await base.DTO_member_distinct_where(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task DTO_member_distinct_orderby(bool isAsync)
+        {
+            await base.DTO_member_distinct_orderby(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task DTO_member_distinct_result(bool isAsync)
+        {
+            await base.DTO_member_distinct_result(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task DTO_complex_distinct_where(bool isAsync)
+        {
+            await base.DTO_complex_distinct_where(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task DTO_complex_distinct_orderby(bool isAsync)
+        {
+            await base.DTO_complex_distinct_orderby(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task DTO_complex_distinct_result(bool isAsync)
+        {
+            await base.DTO_complex_distinct_result(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task DTO_complex_orderby(bool isAsync)
+        {
+            await base.DTO_complex_orderby(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task DTO_subquery_orderby(bool isAsync)
+        {
+            await base.DTO_subquery_orderby(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Include_with_orderby_skip_preserves_ordering(bool isAsync)
+        {
+            await base.Include_with_orderby_skip_preserves_ordering(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND ((c[""CustomerID""] != ""VAFFE"") AND (c[""CustomerID""] != ""DRACD"")))");
+        }
+
+        public override async Task Int16_parameter_can_be_used_for_int_column(bool isAsync)
+        {
+            await base.Int16_parameter_can_be_used_for_int_column(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND (c[""OrderID""] = 10300))");
+        }
+
+        public override async Task Subquery_is_null_translated_correctly(bool isAsync)
+        {
+            await base.Subquery_is_null_translated_correctly(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Subquery_is_not_null_translated_correctly(bool isAsync)
+        {
+            await base.Subquery_is_not_null_translated_correctly(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_take_average(bool isAsync)
+        {
+            await base.Select_take_average(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Select_take_count(bool isAsync)
+        {
+            await base.Select_take_count(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_orderBy_take_count(bool isAsync)
+        {
+            await base.Select_orderBy_take_count(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_take_long_count(bool isAsync)
+        {
+            await base.Select_take_long_count(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_orderBy_take_long_count(bool isAsync)
+        {
+            await base.Select_orderBy_take_long_count(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_take_max(bool isAsync)
+        {
+            await base.Select_take_max(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Select_take_min(bool isAsync)
+        {
+            await base.Select_take_min(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Select_take_sum(bool isAsync)
+        {
+            await base.Select_take_sum(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Select_skip_average(bool isAsync)
+        {
+            await base.Select_skip_average(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Select_skip_count(bool isAsync)
+        {
+            await base.Select_skip_count(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_orderBy_skip_count(bool isAsync)
+        {
+            await base.Select_orderBy_skip_count(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_skip_long_count(bool isAsync)
+        {
+            await base.Select_skip_long_count(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_orderBy_skip_long_count(bool isAsync)
+        {
+            await base.Select_orderBy_skip_long_count(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_skip_max(bool isAsync)
+        {
+            await base.Select_skip_max(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Select_skip_min(bool isAsync)
+        {
+            await base.Select_skip_min(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Select_skip_sum(bool isAsync)
+        {
+            await base.Select_skip_sum(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Select_distinct_average(bool isAsync)
+        {
+            await base.Select_distinct_average(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Select_distinct_count(bool isAsync)
+        {
+            await base.Select_distinct_count(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_distinct_long_count(bool isAsync)
+        {
+            await base.Select_distinct_long_count(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Select_distinct_max(bool isAsync)
+        {
+            await base.Select_distinct_max(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Select_distinct_min(bool isAsync)
+        {
+            await base.Select_distinct_min(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Select_distinct_sum(bool isAsync)
+        {
+            await base.Select_distinct_sum(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Comparing_to_fixed_string_parameter(bool isAsync)
+        {
+            await base.Comparing_to_fixed_string_parameter(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Comparing_entities_using_Equals(bool isAsync)
+        {
+            await base.Comparing_entities_using_Equals(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Comparing_different_entity_types_using_Equals(bool isAsync)
+        {
+            await base.Comparing_different_entity_types_using_Equals(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Comparing_entity_to_null_using_Equals(bool isAsync)
+        {
+            await base.Comparing_entity_to_null_using_Equals(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Comparing_navigations_using_Equals(bool isAsync)
+        {
+            await base.Comparing_navigations_using_Equals(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Comparing_navigations_using_static_Equals(bool isAsync)
+        {
+            await base.Comparing_navigations_using_static_Equals(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Comparing_non_matching_entities_using_Equals(bool isAsync)
+        {
+            await base.Comparing_non_matching_entities_using_Equals(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Comparing_non_matching_collection_navigations_using_Equals(bool isAsync)
+        {
+            await base.Comparing_non_matching_collection_navigations_using_Equals(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Comparing_collection_navigation_to_null(bool isAsync)
+        {
+            await base.Comparing_collection_navigation_to_null(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = null))");
+        }
+
+        public override async Task Comparing_collection_navigation_to_null_complex(bool isAsync)
+        {
+            await base.Comparing_collection_navigation_to_null_complex(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""OrderDetail"")");
+        }
+
+        public override async Task Compare_collection_navigation_with_itself(bool isAsync)
+        {
+            await base.Compare_collection_navigation_with_itself(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Compare_two_collection_navigations_with_different_query_sources(bool isAsync)
+        {
+            await base.Compare_two_collection_navigations_with_different_query_sources(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Compare_two_collection_navigations_using_equals(bool isAsync)
+        {
+            await base.Compare_two_collection_navigations_using_equals(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Compare_two_collection_navigations_with_different_property_chains(bool isAsync)
+        {
+            await base.Compare_two_collection_navigations_with_different_property_chains(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_ThenBy_same_column_different_direction(bool isAsync)
+        {
+            await base.OrderBy_ThenBy_same_column_different_direction(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_OrderBy_same_column_different_direction(bool isAsync)
+        {
+            await base.OrderBy_OrderBy_same_column_different_direction(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Complex_nested_query_doesnt_try_binding_to_grandparent_when_parent_returns_complex_result(bool isAsync)
+        {
+            await base.Complex_nested_query_doesnt_try_binding_to_grandparent_when_parent_returns_complex_result(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task Complex_nested_query_properly_binds_to_grandparent_when_parent_returns_scalar_result(bool isAsync)
+        {
+            await base.Complex_nested_query_properly_binds_to_grandparent_when_parent_returns_scalar_result(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""CustomerID""] = ""ALFKI""))");
+        }
+
+        public override async Task OrderBy_Dto_projection_skip_take(bool isAsync)
+        {
+            await base.OrderBy_Dto_projection_skip_take(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override void Streaming_chained_sync_query()
+        {
+            base.Streaming_chained_sync_query();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Join_take_count_works(bool isAsync)
+        {
+            await base.Join_take_count_works(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE ((c[""Discriminator""] = ""Order"") AND ((c[""OrderID""] > 690) AND (c[""OrderID""] < 710)))");
+        }
+
+        public override async Task OrderBy_empty_list_contains(bool isAsync)
+        {
+            await base.OrderBy_empty_list_contains(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task OrderBy_empty_list_does_not_contains(bool isAsync)
+        {
+            await base.OrderBy_empty_list_does_not_contains(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override void Manual_expression_tree_typed_null_equality()
+        {
+            base.Manual_expression_tree_typed_null_equality();
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Let_subquery_with_multiple_occurences(bool isAsync)
+        {
+            await base.Let_subquery_with_multiple_occurences(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Order"")");
+        }
+
+        public override async Task Let_entity_equality_to_null(bool isAsync)
+        {
+            await base.Let_entity_equality_to_null(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Let_entity_equality_to_other_entity(bool isAsync)
+        {
+            await base.Let_entity_equality_to_other_entity(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task SelectMany_after_client_method(bool isAsync)
+        {
+            await base.SelectMany_after_client_method(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Collection_navigation_equal_to_null_for_subquery(bool isAsync)
+        {
+            await base.Collection_navigation_equal_to_null_for_subquery(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Dependent_to_principal_navigation_equal_to_null_for_subquery(bool isAsync)
+        {
+            await base.Dependent_to_principal_navigation_equal_to_null_for_subquery(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override async Task Collection_navigation_equality_rewrite_for_subquery(bool isAsync)
+        {
+            await base.Collection_navigation_equality_rewrite_for_subquery(isAsync);
+
+            AssertSql(
+                @"SELECT c AS query
+FROM root c
+WHERE (c[""Discriminator""] = ""Customer"")");
+        }
+
+        public override void Throws_on_concurrent_query_first()
+        {
+            // #13160
+        }
+
+        public override void Throws_on_concurrent_query_list()
+        {
+            // #13160
+        }
+
+        private void AssertSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected);
+
+        private void AssertContainsSql(params string[] expected)
+            => Fixture.TestSqlLoggerFactory.AssertBaseline(expected, assertOrder: false);
+
+        protected override void ClearLog()
+            => Fixture.TestSqlLoggerFactory.Clear();
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Where.cs
@@ -1,11 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Internal;
-using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -384,6 +382,47 @@ WHERE EXISTS (
     SELECT 1
     FROM [Orders] AS [o]
     WHERE ([o].[CustomerID] = @__customerID_0) AND ([o].[CustomerID] = [c].[CustomerID]))");
+        }
+
+        public override async Task Where_bitwise_or(bool isAsync)
+        {
+            await base.Where_bitwise_or(isAsync);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE (CASE
+    WHEN [c].[CustomerID] = N'ALFKI'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END | CASE
+    WHEN [c].[CustomerID] = N'ANATR'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END) = 1");
+        }
+
+        public override async Task Where_bitwise_and(bool isAsync)
+        {
+            await base.Where_bitwise_and(isAsync);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+WHERE (CASE
+    WHEN [c].[CustomerID] = N'ALFKI'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END & CASE
+    WHEN [c].[CustomerID] = N'ANATR'
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END) = 1");
+        }
+
+        public override async Task Where_bitwise_xor(bool isAsync)
+        {
+            await base.Where_bitwise_xor(isAsync);
+
+            AssertSql(
+                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]");
         }
 
         public override async Task Where_simple_shadow(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
-using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -19,7 +18,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         public SimpleQuerySqlServerTest(NorthwindQuerySqlServerFixture<NoopModelCustomizer> fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            Fixture.TestSqlLoggerFactory.Clear();
+            ClearLog();
             //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
@@ -2763,38 +2762,6 @@ LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[Custom
                 @"SELECT ([o.Customer].[City] + N' ') + [o.Customer].[City]
 FROM [Orders] AS [o]
 LEFT JOIN [Customers] AS [o.Customer] ON [o].[CustomerID] = [o.Customer].[CustomerID]");
-        }
-
-        public override async Task Where_bitwise_or(bool isAsync)
-        {
-            await base.Where_bitwise_or(isAsync);
-
-            AssertSql(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-WHERE (CASE
-    WHEN [c].[CustomerID] = N'ALFKI'
-    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END | CASE
-    WHEN [c].[CustomerID] = N'ANATR'
-    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END) = 1");
-        }
-
-        public override async Task Where_bitwise_and(bool isAsync)
-        {
-            await base.Where_bitwise_and(isAsync);
-
-            AssertSql(
-                @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-WHERE (CASE
-    WHEN [c].[CustomerID] = N'ALFKI'
-    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END & CASE
-    WHEN [c].[CustomerID] = N'ANATR'
-    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
-END) = 1");
         }
 
         public override void Select_bitwise_or()


### PR DESCRIPTION
Enable unmapped members in queries
Enable materializing entities with shadow properties
Only track entities in the final projection
Implement SimpleQueryTest
