### PR TITLE
Query: Rewrite to key equality for owned navigation being compared to null

### DIFF
--- a/src/EFCore/Query/ExpressionVisitors/Internal/EntityEqualityRewritingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/EntityEqualityRewritingExpressionVisitor.cs
@@ -176,7 +176,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
             var entityType = _model.FindEntityType(nonNullExpression.Type)
                              ?? GetEntityType(properties, qsre);
 
-            if (entityType?.IsOwned() != false)
+            if (entityType == null)
             {
                 return null;
             }


### PR DESCRIPTION
It is safe because @AndriySvyryd said so

Resolves #13157