### PR TITLE
Format HasData in snapshot to multiple lines

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -1113,36 +1113,42 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                         firstDatum = false;
                     }
 
-                    stringBuilder.Append("new { ");
+                    stringBuilder
+                        .AppendLine("new")
+                        .AppendLine("{");
 
-                    var firstProperty = true;
-                    foreach (var property in propertiesToOutput)
+                    using (stringBuilder.Indent())
                     {
-                        if (o.TryGetValue(property.Name, out var value)
-                            && value != null)
+                        var firstProperty = true;
+                        foreach (var property in propertiesToOutput)
                         {
-                            if (!firstProperty)
+                            if (o.TryGetValue(property.Name, out var value)
+                                && value != null)
                             {
-                                stringBuilder.Append(", ");
-                            }
-                            else
-                            {
-                                firstProperty = false;
-                            }
+                                if (!firstProperty)
+                                {
+                                    stringBuilder.AppendLine(",");
+                                }
+                                else
+                                {
+                                    firstProperty = false;
+                                }
 
-                            stringBuilder
-                                .Append(Code.Identifier(property.Name))
-                                .Append(" = ")
-                                .Append(Code.UnknownLiteral(value));
+                                stringBuilder
+                                    .Append(Code.Identifier(property.Name))
+                                    .Append(" = ")
+                                    .Append(Code.UnknownLiteral(value));
+                            }
                         }
+
+                        stringBuilder.AppendLine();
                     }
 
-                    stringBuilder.Append(" }");
+                    stringBuilder.Append("}");
                 }
             }
 
             stringBuilder
-                .AppendLine()
                 .AppendLine(");");
         }
     }

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -835,8 +835,10 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
         b.ToTable(""EntityWithOneProperty"");
 
         b.HasData(
-            new { Id = 1 }
-        );
+            new
+            {
+                Id = 1
+            });
     });
 
 builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"", b =>
@@ -883,8 +885,11 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""EntityWithStringKeyId"");
 
                 b1.HasData(
-                    new { AlternateId = 1, Id = -1 }
-                );
+                    new
+                    {
+                        AlternateId = 1,
+                        Id = -1
+                    });
             });
     });
 
@@ -1604,8 +1609,11 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
         b.ToTable(""EntityWithEnumType"");
 
         b.HasData(
-            new { Id = 1, Day = ""Fri"" }
-        );
+            new
+            {
+                Id = 1,
+                Day = ""Fri""
+            });
     });
 ",
                 o =>
@@ -2652,9 +2660,15 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
         b.ToTable(""EntityWithOneProperty"");
 
         b.HasData(
-            new { Id = 42 },
-            new { Id = 43, OptionalProperty = 4.3m }
-        );
+            new
+            {
+                Id = 42
+            },
+            new
+            {
+                Id = 43,
+                OptionalProperty = 4.3m
+            });
     });
 ",
                 o => Assert.Collection(
@@ -2701,8 +2715,10 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
         b.ToTable(""EntityWithOneProperty"");
 
         b.HasData(
-            new { Id = 27 }
-        );
+            new
+            {
+                Id = 27
+            });
     });
 
 builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
@@ -2718,8 +2734,11 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
         b.ToTable(""EntityWithTwoProperties"");
 
         b.HasData(
-            new { Id = 42, AlternateId = 43 }
-        );
+            new
+            {
+                Id = 42,
+                AlternateId = 43
+            });
     });
 ",
                 o => Assert.Collection(


### PR DESCRIPTION
In the snapshot code HasData will now output as following

```
b.HasData(
    new
    {
        Id = 42
    },
    new
    {
        Id = 43,
        OptionalProperty = 4.3m
    });
```

I also updated all the unit tests to the new format. 

Fixes #12367

