### PR TITLE
[Test] Update in-memory tests to use a different entity instance for concurrency checks

### DIFF
--- a/src/EFCore.Specification.Tests/TestModels/UpdatesModel/UpdatesContext.cs
+++ b/src/EFCore.Specification.Tests/TestModels/UpdatesModel/UpdatesContext.cs
@@ -24,7 +24,6 @@ namespace Microsoft.EntityFrameworkCore.TestModels.UpdatesModel
             context.Add(new Category { Id = 78, PrincipalId = 778 });
             context.Add(new Product { Id = productId1, Name = "Apple Cider", Price = 1.49M, DependentId = 778 });
             context.Add(new Product { Id = productId2, Name = "Apple Cobler", Price = 2.49M, DependentId = 778 });
-            context.Add(new ProductWithBytes { Id = productId1, Name = "MegaChips", Bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 } });
 
             context.SaveChanges();
         }

--- a/src/EFCore.Specification.Tests/UpdatesTestBase.cs
+++ b/src/EFCore.Specification.Tests/UpdatesTestBase.cs
@@ -103,9 +103,21 @@ namespace Microsoft.EntityFrameworkCore
         [Fact]
         public virtual void Update_on_bytes_concurrency_token_original_value_mismatch_throws()
         {
-            var productId = new Guid("984ade3c-2f7b-4651-a351-642e92ab7146");
+            var productId = Guid.NewGuid();
 
             ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    context.Add(
+                        new ProductWithBytes
+                        {
+                            Id = productId,
+                            Name = "MegaChips",
+                            Bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }
+                        });
+
+                    context.SaveChanges();
+                },
                 context =>
                 {
                     var entry = context.ProductWithBytes.Attach(
@@ -130,9 +142,21 @@ namespace Microsoft.EntityFrameworkCore
         [Fact]
         public virtual void Update_on_bytes_concurrency_token_original_value_matches_does_not_throw()
         {
-            var productId = new Guid("984ade3c-2f7b-4651-a351-642e92ab7146");
+            var productId = Guid.NewGuid();
 
             ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    context.Add(
+                        new ProductWithBytes
+                        {
+                            Id = productId,
+                            Name = "MegaChips",
+                            Bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }
+                        });
+
+                    context.SaveChanges();
+                },
                 context =>
                 {
                     var entry = context.ProductWithBytes.Attach(
@@ -156,9 +180,21 @@ namespace Microsoft.EntityFrameworkCore
         [Fact]
         public virtual void Remove_on_bytes_concurrency_token_original_value_mismatch_throws()
         {
-            var productId = new Guid("984ade3c-2f7b-4651-a351-642e92ab7146");
+            var productId = Guid.NewGuid();
 
             ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    context.Add(
+                        new ProductWithBytes
+                        {
+                            Id = productId,
+                            Name = "MegaChips",
+                            Bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }
+                        });
+
+                    context.SaveChanges();
+                },
                 context =>
                 {
                     var entry = context.ProductWithBytes.Attach(
@@ -183,9 +219,21 @@ namespace Microsoft.EntityFrameworkCore
         [Fact]
         public virtual void Remove_on_bytes_concurrency_token_original_value_matches_does_not_throw()
         {
-            var productId = new Guid("984ade3c-2f7b-4651-a351-642e92ab7146");
+            var productId = Guid.NewGuid();
 
             ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    context.Add(
+                        new ProductWithBytes
+                        {
+                            Id = productId,
+                            Name = "MegaChips",
+                            Bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }
+                        });
+
+                    context.SaveChanges();
+                },
                 context =>
                 {
                     var entry = context.ProductWithBytes.Attach(
@@ -454,17 +502,19 @@ namespace Microsoft.EntityFrameworkCore
 
         protected virtual void ExecuteWithStrategyInTransaction(
             Action<UpdatesContext> testOperation,
-            Action<UpdatesContext> nestedTestOperation1 = null)
+            Action<UpdatesContext> nestedTestOperation1 = null,
+            Action<UpdatesContext> nestedTestOperation2 = null)
             => TestHelpers.ExecuteWithStrategyInTransaction(
                 CreateContext, UseTransaction,
-                testOperation, nestedTestOperation1);
+                testOperation, nestedTestOperation1, nestedTestOperation2);
 
         protected virtual Task ExecuteWithStrategyInTransactionAsync(
             Func<UpdatesContext, Task> testOperation,
-            Func<UpdatesContext, Task> nestedTestOperation1 = null)
+            Func<UpdatesContext, Task> nestedTestOperation1 = null,
+            Func<UpdatesContext, Task> nestedTestOperation2 = null)
             => TestHelpers.ExecuteWithStrategyInTransactionAsync(
                 CreateContext, UseTransaction,
-                testOperation, nestedTestOperation1);
+                testOperation, nestedTestOperation1, nestedTestOperation2);
 
         protected virtual void UseTransaction(DatabaseFacade facade, IDbContextTransaction transaction)
         {

--- a/test/EFCore.InMemory.FunctionalTests/UpdatesInMemoryTestBase.cs
+++ b/test/EFCore.InMemory.FunctionalTests/UpdatesInMemoryTestBase.cs
@@ -25,13 +25,25 @@ namespace Microsoft.EntityFrameworkCore
         [Fact]
         public virtual void Update_on_bytes_concurrency_token_original_value_matches_throws_with_quirk()
         {
-            var productId = new Guid("984ade3c-2f7b-4651-a351-642e92ab7146");
+            var productId = Guid.NewGuid();
 
             try
             {
                 AppContext.SetSwitch("Microsoft.EntityFrameworkCore.Issue12214", true);
 
                 ExecuteWithStrategyInTransaction(
+                    context =>
+                    {
+                        context.Add(
+                            new ProductWithBytes
+                            {
+                                Id = productId,
+                                Name = "MegaChips",
+                                Bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }
+                            });
+
+                            context.SaveChanges();
+                    },
                     context =>
                     {
                         var entry = context.ProductWithBytes.Attach(
@@ -62,13 +74,25 @@ namespace Microsoft.EntityFrameworkCore
         [Fact]
         public virtual void Remove_on_bytes_concurrency_token_original_value_matches_throws_with_quirk()
         {
-            var productId = new Guid("984ade3c-2f7b-4651-a351-642e92ab7146");
+            var productId = Guid.NewGuid();
 
             try
             {
                 AppContext.SetSwitch("Microsoft.EntityFrameworkCore.Issue12214", true);
 
                 ExecuteWithStrategyInTransaction(
+                    context =>
+                    {
+                        context.Add(
+                            new ProductWithBytes
+                            {
+                                Id = productId,
+                                Name = "MegaChips",
+                                Bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }
+                            });
+
+                        context.SaveChanges();
+                    },
                     context =>
                     {
                         var entry = context.ProductWithBytes.Attach(
@@ -101,16 +125,20 @@ namespace Microsoft.EntityFrameworkCore
             => InMemoryStrings.UpdateConcurrencyException;
 
         protected override void ExecuteWithStrategyInTransaction(
-            Action<UpdatesContext> testOperation, Action<UpdatesContext> nestedTestOperation1 = null)
+            Action<UpdatesContext> testOperation,
+            Action<UpdatesContext> nestedTestOperation1 = null,
+            Action<UpdatesContext> nestedTestOperation2 = null)
         {
-            base.ExecuteWithStrategyInTransaction(testOperation, nestedTestOperation1);
+            base.ExecuteWithStrategyInTransaction(testOperation, nestedTestOperation1, nestedTestOperation2);
             Fixture.Reseed();
         }
 
         protected override async Task ExecuteWithStrategyInTransactionAsync(
-            Func<UpdatesContext, Task> testOperation, Func<UpdatesContext, Task> nestedTestOperation1 = null)
+            Func<UpdatesContext, Task> testOperation,
+            Func<UpdatesContext, Task> nestedTestOperation1 = null,
+            Func<UpdatesContext, Task> nestedTestOperation2 = null)
         {
-            await base.ExecuteWithStrategyInTransactionAsync(testOperation, nestedTestOperation1);
+            await base.ExecuteWithStrategyInTransactionAsync(testOperation, nestedTestOperation1, nestedTestOperation2);
             Fixture.Reseed();
         }
     }


### PR DESCRIPTION
Due to #13098
Fixes #13053
