### PR TITLE
Deep copy byte arrays into the in-memory store

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -508,7 +508,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 CoreAnnotationNames.PropertyAccessModeAnnotation,
                 CoreAnnotationNames.TypeMapping,
                 CoreAnnotationNames.ValueComparer,
-                CoreAnnotationNames.KeyValueComparer);
+                CoreAnnotationNames.KeyValueComparer,
+                CoreAnnotationNames.DeepValueComparer);
 
             GenerateAnnotations(annotations, stringBuilder);
         }

--- a/src/EFCore.Design/Migrations/Design/MigrationsCodeGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsCodeGenerator.cs
@@ -227,6 +227,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 CoreAnnotationNames.TypeMapping,
                 CoreAnnotationNames.ValueComparer,
                 CoreAnnotationNames.KeyValueComparer,
+                CoreAnnotationNames.DeepValueComparer,
                 CoreAnnotationNames.ConstructorBinding,
                 CoreAnnotationNames.NavigationAccessModeAnnotation,
                 CoreAnnotationNames.OwnedTypesAnnotation,

--- a/src/EFCore.InMemory/Query/Internal/InMemoryQueryModelVisitor.cs
+++ b/src/EFCore.InMemory/Query/Internal/InMemoryQueryModelVisitor.cs
@@ -6,7 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.Storage;
 
@@ -37,14 +39,6 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
             = typeof(InMemoryQueryModelVisitor).GetTypeInfo()
                 .GetDeclaredMethod(nameof(EntityQuery));
 
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public static readonly MethodInfo OfTypeMethodInfo
-            = typeof(Enumerable).GetTypeInfo()
-                .GetDeclaredMethod(nameof(Enumerable.OfType));
-
         [UsedImplicitly]
         private static IEnumerable<TEntity> EntityQuery<TEntity>(
             QueryContext queryContext,
@@ -70,10 +64,31 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Query.Internal
                                             new MaterializationContext(
                                                 valueBuffer,
                                                 queryContext.Context),
-                                            c => materializer(t.EntityType, c)),
+                                            c => materializer(t.EntityType, SnapshotValueBuffer(t.EntityType, c))),
                                         queryStateManager,
                                         throwOnNullKey: false);
                             }));
+
+        private static MaterializationContext SnapshotValueBuffer(
+            IEntityType entityType,
+            MaterializationContext c)
+        {
+            var comparers = GetDeepComparers(entityType.GetProperties());
+
+            var copy = new object[comparers.Count];
+            for (var index = 0; index < comparers.Count; index++)
+            {
+                copy[index] = SnapshotValue(comparers[index], c.ValueBuffer[index]);
+            }
+
+            return new MaterializationContext(new ValueBuffer(copy), c.Context);
+        }
+
+        private static object SnapshotValue(ValueComparer comparer, object value)
+            => comparer == null ? value : comparer.Snapshot(value);
+
+        private static List<ValueComparer> GetDeepComparers(IEnumerable<IProperty> properties)
+            => properties.Select(p => p.GetDeepValueComparer() ?? p.FindMapping()?.DeepComparer).ToList();
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryTypeMapping.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryTypeMapping.cs
@@ -19,8 +19,17 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public InMemoryTypeMapping([NotNull] Type clrType, [CanBeNull] ValueComparer comparer = null)
-            : base(new CoreTypeMappingParameters(clrType, comparer: comparer))
+        public InMemoryTypeMapping(
+            [NotNull] Type clrType,
+            [CanBeNull] ValueComparer comparer = null,
+            [CanBeNull] ValueComparer deepComparer = null)
+            : base(new CoreTypeMappingParameters(
+                clrType,
+                converter: null,
+                comparer,
+                keyComparer: null,
+                deepComparer,
+                valueGeneratorFactory: null))
         {
         }
 

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryTypeMappingSource.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryTypeMappingSource.cs
@@ -33,11 +33,16 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
             Debug.Assert(clrType != null);
 
             if (clrType.IsValueType
-                || clrType == typeof(string)
-                || clrType == typeof(byte[]))
+                || clrType == typeof(string))
             {
                 return new InMemoryTypeMapping(clrType);
             }
+
+            if (clrType == typeof(byte[]))
+            {
+                return new InMemoryTypeMapping(clrType, deepComparer: new ArrayDeepComparer<byte>());
+            }
+
             if (clrType.Name == "GeoAPI.Geometries.IGeometry"
                 || clrType.GetInterface("GeoAPI.Geometries.IGeometry") != null)
             {

--- a/src/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
+++ b/src/EFCore.Specification.Tests/BuiltInDataTypesTestBase.cs
@@ -54,10 +54,10 @@ namespace Microsoft.EntityFrameworkCore
             using (var context = CreateContext())
             {
                 Assert.NotNull(context.Set<MaxLengthDataTypes>().Where(e => e.Id == 799 && e.String3 == shortString).ToList().SingleOrDefault());
-                Assert.NotNull(context.Set<MaxLengthDataTypes>().Where(e => e.Id == 799 && e.ByteArray5 == shortBinary).ToList().SingleOrDefault());
+                Assert.NotNull(context.Set<MaxLengthDataTypes>().Where(e => e.Id == 799 && e.ByteArray5.SequenceEqual(shortBinary)).ToList().SingleOrDefault());
 
                 Assert.NotNull(context.Set<MaxLengthDataTypes>().Where(e => e.Id == 799 && e.String9000 == longString).ToList().SingleOrDefault());
-                Assert.NotNull(context.Set<MaxLengthDataTypes>().Where(e => e.Id == 799 && e.ByteArray9000 == longBinary).ToList().SingleOrDefault());
+                Assert.NotNull(context.Set<MaxLengthDataTypes>().Where(e => e.Id == 799 && e.ByteArray9000.SequenceEqual(longBinary)).ToList().SingleOrDefault());
             }
         }
 

--- a/src/EFCore.Specification.Tests/TestModels/UpdatesModel/AFewBytes.cs
+++ b/src/EFCore.Specification.Tests/TestModels/UpdatesModel/AFewBytes.cs
@@ -2,17 +2,12 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.UpdatesModel
 {
-    public class Product
+    public class AFewBytes
     {
         public Guid Id { get; set; }
-        public int? DependentId { get; set; }
-        public string Name { get; set; }
-
-        [ConcurrencyCheck]
-        public decimal Price { get; set; }
+        public byte[] Bytes { get; set; }
     }
 }

--- a/src/EFCore.Specification.Tests/TestModels/UpdatesModel/ProductWithBytes.cs
+++ b/src/EFCore.Specification.Tests/TestModels/UpdatesModel/ProductWithBytes.cs
@@ -6,13 +6,12 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.UpdatesModel
 {
-    public class Product
+    public class ProductWithBytes
     {
         public Guid Id { get; set; }
-        public int? DependentId { get; set; }
         public string Name { get; set; }
 
         [ConcurrencyCheck]
-        public decimal Price { get; set; }
+        public byte[] Bytes { get; set; }
     }
 }

--- a/src/EFCore.Specification.Tests/TestModels/UpdatesModel/UpdatesContext.cs
+++ b/src/EFCore.Specification.Tests/TestModels/UpdatesModel/UpdatesContext.cs
@@ -11,6 +11,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.UpdatesModel
         public DbSet<Category> Categories { get; set; }
         public DbSet<Product> Products { get; set; }
         public DbSet<ProductWithBytes> ProductWithBytes { get; set; }
+        public DbSet<AFewBytes> AFewBytes { get; set; }
 
         public UpdatesContext(DbContextOptions options)
             : base(options)

--- a/src/EFCore.Specification.Tests/UpdatesFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/UpdatesFixtureBase.cs
@@ -27,7 +27,11 @@ namespace Microsoft.EntityFrameworkCore
                 .Property(e => e.Id)
                 .ValueGeneratedNever();
 
-                modelBuilder.Entity<LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCorrectly>(
+            modelBuilder.Entity<AFewBytes>()
+                .Property(e => e.Id)
+                .ValueGeneratedNever();
+
+            modelBuilder.Entity<LoginEntityTypeWithAnExtremelyLongAndOverlyConvolutedNameThatIsUsedToVerifyThatTheStoreIdentifierGenerationLengthLimitIsWorkingCorrectly>(
                 eb =>
                 {
                     eb.HasKey(

--- a/src/EFCore/ChangeTracking/ArrayDeepComparer.cs
+++ b/src/EFCore/ChangeTracking/ArrayDeepComparer.cs
@@ -1,0 +1,28 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Linq;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking
+{
+    /// <summary>
+    ///     <para>
+    ///         Specifies value snapshotting and comparison for arrays where each element is compared
+    ///         a new array is constructed when snapshotting.
+    ///     </para>
+    /// </summary>
+    /// <typeparam name="TElement"> The array element type. </typeparam>
+    public class ArrayDeepComparer<TElement> : ValueComparer<TElement[]>
+    {
+        /// <summary>
+        ///     Creates a comparer instance.
+        /// </summary>
+        public ArrayDeepComparer()
+            : base(
+                CreateDefaultEqualsExpression(favorStructuralComparisons: true),
+                CreateDefaultHashCodeExpression(favorStructuralComparisons: true),
+                v => v == null ? null : v.ToArray())
+        {
+        }
+    }
+}

--- a/src/EFCore/ChangeTracking/ValueComparer`.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer`.cs
@@ -84,7 +84,14 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         {
         }
 
-        private static Expression<Func<T, T, bool>> CreateDefaultEqualsExpression(bool favorStructuralComparisons)
+        /// <summary>
+        ///     Creates an expression for equality.
+        /// </summary>
+        /// <param name="favorStructuralComparisons">
+        ///     If <c>true</c>, then <see cref="IStructuralEquatable" /> is used if the type implements it.
+        /// </param>
+        /// <returns> The equality expression. </returns>
+        protected static Expression<Func<T, T, bool>> CreateDefaultEqualsExpression(bool favorStructuralComparisons)
         {
             var type = typeof(T);
             var param1 = Expression.Parameter(type, "v1");
@@ -153,7 +160,14 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
                 param1, param2);
         }
 
-        private static Expression<Func<T, int>> CreateDefaultHashCodeExpression(bool favorStructuralComparisons)
+        /// <summary>
+        ///     Creates an expression for generated a hash code.
+        /// </summary>
+        /// <param name="favorStructuralComparisons">
+        ///     If <c>true</c>, then <see cref="IStructuralEquatable" /> is used if the type implements it.
+        /// </param>
+        /// <returns> The hash code expression. </returns>
+        protected static Expression<Func<T, int>> CreateDefaultHashCodeExpression(bool favorStructuralComparisons)
         {
             var type = typeof(T);
             var unwrappedType = type.UnwrapNullableType();
@@ -243,7 +257,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// <param name="instance"> The instance. </param>
         /// <returns> The snapshot. </returns>
         public override object Snapshot(object instance)
-            => Snapshot((T)instance);
+            => instance == null ? null : (object)Snapshot((T)instance);
 
         /// <summary>
         ///     <para>

--- a/src/EFCore/Extensions/MutablePropertyExtensions.cs
+++ b/src/EFCore/Extensions/MutablePropertyExtensions.cs
@@ -151,7 +151,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         /// <summary>
-        ///     Sets the custom <see cref="ValueComparer" /> for this property when performing key comparisons..
+        ///     Sets the custom <see cref="ValueComparer" /> for this property when performing key comparisons.
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <param name="comparer"> The comparer, or <c>null</c> to remove any previously set comparer. </param>
@@ -160,6 +160,18 @@ namespace Microsoft.EntityFrameworkCore
             CheckComparerType(property, comparer);
 
             property[CoreAnnotationNames.KeyValueComparer] = comparer;
+        }
+
+        /// <summary>
+        ///     Sets the custom <see cref="ValueComparer" /> for deep copies for this property.
+        /// </summary>
+        /// <param name="property"> The property. </param>
+        /// <param name="comparer"> The comparer, or <c>null</c> to remove any previously set comparer. </param>
+        public static void SetDeepValueComparer([NotNull] this IMutableProperty property, [CanBeNull] ValueComparer comparer)
+        {
+            CheckComparerType(property, comparer);
+
+            property[CoreAnnotationNames.DeepValueComparer] = comparer;
         }
 
         private static void CheckComparerType(IMutableProperty property, ValueComparer comparer)

--- a/src/EFCore/Extensions/PropertyExtensions.cs
+++ b/src/EFCore/Extensions/PropertyExtensions.cs
@@ -170,11 +170,19 @@ namespace Microsoft.EntityFrameworkCore
             => (ValueComparer)Check.NotNull(property, nameof(property))[CoreAnnotationNames.ValueComparer];
 
         /// <summary>
-        ///     Gets the <see cref="ValueComparer" /> for this property, or null if none is set.
+        ///     Gets the <see cref="ValueComparer" /> to use with keys for this property, or null if none is set.
         /// </summary>
         /// <param name="property"> The property. </param>
         /// <returns> The comparer, or <c>null</c> if none has been set. </returns>
         public static ValueComparer GetKeyValueComparer([NotNull] this IProperty property)
+            => (ValueComparer)Check.NotNull(property, nameof(property))[CoreAnnotationNames.KeyValueComparer];
+
+        /// <summary>
+        ///     Gets the <see cref="ValueComparer" /> to use for deep copies for this property, or null if none is set.
+        /// </summary>
+        /// <param name="property"> The property. </param>
+        /// <returns> The comparer, or <c>null</c> if none has been set. </returns>
+        public static ValueComparer GetDeepValueComparer([NotNull] this IProperty property)
             => (ValueComparer)Check.NotNull(property, nameof(property))[CoreAnnotationNames.KeyValueComparer];
     }
 }

--- a/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
+++ b/src/EFCore/Metadata/Internal/CoreAnnotationNames.cs
@@ -86,6 +86,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public const string DeepValueComparer = "DeepValueComparer";
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public const string ProviderClrType = "ProviderClrType";
     }
 }

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -53,6 +53,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 CoreAnnotationNames.ValueConverter,
                 CoreAnnotationNames.ValueComparer,
                 CoreAnnotationNames.KeyValueComparer,
+                CoreAnnotationNames.DeepValueComparer,
                 CoreAnnotationNames.ProviderClrType,
                 RelationalAnnotationNames.ColumnName,
                 RelationalAnnotationNames.ColumnType,


### PR DESCRIPTION
Fixes #13254

This change introduces a new ValueComparer type that can be used when deep copies are needed. Neither the regular or the key comparer can be relied on to work this way, hence the need for a new one. There is no reliable way to know if such a comparer is needed, so it's up to the application/provider setting up the type mapping to provide one if needed.