### PR TITLE
Remove quirk tests due to global race condition

### DIFF
--- a/test/EFCore.InMemory.FunctionalTests/UpdatesInMemoryTestBase.cs
+++ b/test/EFCore.InMemory.FunctionalTests/UpdatesInMemoryTestBase.cs
@@ -3,13 +3,8 @@
 
 using System;
 using System.Threading.Tasks;
-#if Test20
-using Microsoft.EntityFrameworkCore.Internal;
-#else
 using Microsoft.EntityFrameworkCore.InMemory.Internal;
-#endif
 using Microsoft.EntityFrameworkCore.TestModels.UpdatesModel;
-using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -20,106 +15,6 @@ namespace Microsoft.EntityFrameworkCore
             : base(fixture)
         {
         }
-
-#if !Test20
-        [Fact]
-        public virtual void Update_on_bytes_concurrency_token_original_value_matches_throws_with_quirk()
-        {
-            var productId = Guid.NewGuid();
-
-            try
-            {
-                AppContext.SetSwitch("Microsoft.EntityFrameworkCore.Issue12214", true);
-
-                ExecuteWithStrategyInTransaction(
-                    context =>
-                    {
-                        context.Add(
-                            new ProductWithBytes
-                            {
-                                Id = productId,
-                                Name = "MegaChips",
-                                Bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }
-                            });
-
-                            context.SaveChanges();
-                    },
-                    context =>
-                    {
-                        var entry = context.ProductWithBytes.Attach(
-                            new ProductWithBytes
-                            {
-                                Id = productId,
-                                Name = "MegaChips",
-                                Bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }
-                            });
-
-                        entry.Entity.Name = "GigaChips";
-
-                        Assert.Throws<DbUpdateConcurrencyException>(
-                            () => context.SaveChanges());
-                    },
-                    context =>
-                    {
-                        Assert.Equal("MegaChips", context.ProductWithBytes.Find(productId).Name);
-                    });
-
-            }
-            finally
-            {
-                AppContext.SetSwitch("Microsoft.EntityFrameworkCore.Issue12214", false);
-            }
-        }
-
-        [Fact]
-        public virtual void Remove_on_bytes_concurrency_token_original_value_matches_throws_with_quirk()
-        {
-            var productId = Guid.NewGuid();
-
-            try
-            {
-                AppContext.SetSwitch("Microsoft.EntityFrameworkCore.Issue12214", true);
-
-                ExecuteWithStrategyInTransaction(
-                    context =>
-                    {
-                        context.Add(
-                            new ProductWithBytes
-                            {
-                                Id = productId,
-                                Name = "MegaChips",
-                                Bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }
-                            });
-
-                        context.SaveChanges();
-                    },
-                    context =>
-                    {
-                        var entry = context.ProductWithBytes.Attach(
-                            new ProductWithBytes
-                            {
-                                Id = productId,
-                                Name = "MegaChips",
-                                Bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }
-                            });
-
-                        entry.State = EntityState.Deleted;
-
-                        Assert.Throws<DbUpdateConcurrencyException>(
-                            () => context.SaveChanges());
-                    },
-                    context =>
-                    {
-                        Assert.Equal("MegaChips", context.ProductWithBytes.Find(productId).Name);
-                    });
-
-            }
-            finally
-            {
-                AppContext.SetSwitch("Microsoft.EntityFrameworkCore.Issue12214", false);
-            }
-        }
-#endif
 
         protected override string UpdateConcurrencyMessage
             => InMemoryStrings.UpdateConcurrencyException;


### PR DESCRIPTION
Fixes #13262

Since two test suites both switch the quirk on and off, but the quirk is global, it results in a race condition where one test is expecting it to be off, but it then gets switched off while that test is running. Fix is to remove these tests since they have little value going forward.
