### PR TITLE
Prevent ILazyLoader property in proxy from being serialized by JSON.NET

### DIFF
--- a/src/EFCore.Proxies/Proxies/Internal/IProxyLazyLoader.cs
+++ b/src/EFCore.Proxies/Proxies/Internal/IProxyLazyLoader.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Runtime.Serialization;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
@@ -16,6 +17,7 @@ namespace Microsoft.EntityFrameworkCore.Proxies.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        [IgnoreDataMember]
         ILazyLoader LazyLoader { get; [param: CanBeNull] set; }
     }
 }

--- a/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
+++ b/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
@@ -10,12 +10,27 @@ using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore
 {
     public class LazyLoadingProxyTests
     {
+        [Fact]
+        public void Serialization_is_disabled_for_ILazyLoader_property()
+        {
+            using (var context = new NeweyContext(nameof(Serialization_is_disabled_for_ILazyLoader_property)))
+            {
+                var proxy = context.Set<March82GGtp>().CreateProxy();
+
+                var output = JsonConvert.SerializeObject(proxy);
+                Assert.Equal(
+                    "{\"Id\":0}",
+                    output);
+            }
+        }
+
         [Fact]
         public void Materialization_uses_parameterless_constructor()
         {

--- a/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
+++ b/test/EFCore.Proxies.Tests/LazyLoadingProxyTests.cs
@@ -18,20 +18,6 @@ namespace Microsoft.EntityFrameworkCore
     public class LazyLoadingProxyTests
     {
         [Fact]
-        public void Serialization_is_disabled_for_ILazyLoader_property()
-        {
-            using (var context = new NeweyContext(nameof(Serialization_is_disabled_for_ILazyLoader_property)))
-            {
-                var proxy = context.Set<March82GGtp>().CreateProxy();
-
-                var output = JsonConvert.SerializeObject(proxy);
-                Assert.Equal(
-                    "{\"Id\":0}",
-                    output);
-            }
-        }
-
-        [Fact]
         public void Materialization_uses_parameterless_constructor()
         {
             using (var context = new NeweyContext(nameof(Materialization_uses_parameterless_constructor)))


### PR DESCRIPTION
Fixes #12772

Using `IgnoreDataMember` for this since it doesn't bring in any new dependencies and is honored by JSON.NET.
