### PR TITLE
Better exception message when query encounters a missing type mapping

### DIFF
--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -1744,7 +1744,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
 
                 if (typeMapping == null
                     || (typeMapping.ClrType.UnwrapNullableType() != parameterType
-                        && parameterType.IsEnum))
+                        && (parameterType.IsEnum
+                        || !typeof(IConvertible).IsAssignableFrom(parameterType))))
                 {
                     typeMapping = Dependencies.TypeMappingSource.GetMapping(parameterType);
                 }


### PR DESCRIPTION
Issue #12732

Note that this PR does not fix the issue, but does provide a better message for the failure.
