### PR TITLE
SqlServer RevEng: Skip reflexive foreign key constraints

### DIFF
--- a/src/EFCore.SqlServer/Diagnostics/SqlServerEventId.cs
+++ b/src/EFCore.SqlServer/Diagnostics/SqlServerEventId.cs
@@ -57,7 +57,8 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
             UniqueConstraintFound,
             IndexFound,
             ForeignKeyFound,
-            ForeignKeyPrincipalColumnMissingWarning
+            ForeignKeyPrincipalColumnMissingWarning,
+            ReflexiveConstraintIgnored
         }
 
         private static readonly string _validationPrefix = DbLoggerCategory.Model.Validation.Name + ".";
@@ -281,5 +282,11 @@ namespace Microsoft.EntityFrameworkCore.Diagnostics
         ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
         /// </summary>
         public static readonly EventId ForeignKeyPrincipalColumnMissingWarning = MakeScaffoldingId(Id.ForeignKeyPrincipalColumnMissingWarning);
+
+        /// <summary>
+        ///     A reflexive foreign key constraint was skipped.
+        ///     This event is in the <see cref="DbLoggerCategory.Scaffolding" /> category.
+        /// </summary>
+        public static readonly EventId ReflexiveConstraintIgnored = MakeScaffoldingId(Id.ReflexiveConstraintIgnored);
     }
 }

--- a/src/EFCore.SqlServer/Internal/SqlServerLoggerExtensions.cs
+++ b/src/EFCore.SqlServer/Internal/SqlServerLoggerExtensions.cs
@@ -431,5 +431,28 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
             // No DiagnosticsSource events because these are purely design-time messages
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static void ReflexiveConstraintIgnored(
+            [NotNull] this IDiagnosticsLogger<DbLoggerCategory.Scaffolding> diagnostics,
+            [NotNull] string foreignKeyName,
+            [NotNull] string tableName)
+        {
+            var definition = SqlServerStrings.LogReflexiveConstraintIgnored;
+
+            var warningBehavior = definition.GetLogBehavior(diagnostics);
+            if (warningBehavior != WarningBehavior.Ignore)
+            {
+                definition.Log(
+                    diagnostics,
+                    warningBehavior,
+                    foreignKeyName, tableName);
+            }
+
+            // No DiagnosticsSource events because these are purely design-time messages
+        }
     }
 }

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.Designer.cs
@@ -351,6 +351,19 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Internal
         public static string ContainsFunctionOnClient
             => GetString("ContainsFunctionOnClient");
 
+        /// <summary>
+        ///     Skipping foreign key '{foreignKeyName}' on table '{tableName}' since all of its columns reference themselves.
+        /// </summary>
+        public static readonly EventDefinition<string, string> LogReflexiveConstraintIgnored
+            = new EventDefinition<string, string>(
+                SqlServerEventId.ReflexiveConstraintIgnored,
+                LogLevel.Debug,
+                "SqlServerEventId.ReflexiveConstraintIgnored",
+                LoggerMessage.Define<string, string>(
+                    LogLevel.Debug,
+                    SqlServerEventId.ReflexiveConstraintIgnored,
+                    _resourceManager.GetString("LogReflexiveConstraintIgnored")));
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
+++ b/src/EFCore.SqlServer/Properties/SqlServerStrings.resx
@@ -237,4 +237,8 @@
   <data name="ContainsFunctionOnClient" xml:space="preserve">
     <value>The 'Contains' method is not supported because the query has switched to client-evaluation. Inspect the log to determine which query expressions are triggering client-evaluation.</value>
   </data>
+  <data name="LogReflexiveConstraintIgnored" xml:space="preserve">
+    <value>Skipping foreign key '{foreignKeyName}' on table '{tableName}' since all of its columns reference themselves.</value>
+    <comment>Debug SqlServerEventId.ReflexiveConstraintIgnored string string</comment>
+  </data>
 </root>

--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerDatabaseModelFactory.cs
@@ -1000,7 +1000,16 @@ ORDER BY [table_schema], [table_name], [f].[name], [fc].[constraint_column_id]";
 
                             if (!invalid)
                             {
-                                table.ForeignKeys.Add(foreignKey);
+                                if (foreignKey.Columns.SequenceEqual(foreignKey.PrincipalColumns))
+                                {
+                                    _logger.ReflexiveConstraintIgnored(
+                                        foreignKey.Name,
+                                        DisplayName(table.Schema, table.Name));
+                                }
+                                else
+                                {
+                                    table.ForeignKeys.Add(foreignKey);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Part of #9543