### PR TITLE
PMC Tools: Handle absolute paths better

### DIFF
--- a/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
+++ b/src/EFCore.Tools/tools/EntityFrameworkCore.psm1
@@ -431,7 +431,7 @@ function Script-Migration
     if (!$Output)
     {
         $intermediatePath = GetIntermediatePath $dteProject
-        if (!(Split-Path $intermediatePath -IsAbsolute))
+        if (![IO.Path]::IsPathRooted($intermediatePath))
         {
             $projectDir = GetProperty $dteProject.Properties 'FullPath'
             $intermediatePath = Join-Path $projectDir $intermediatePath -Resolve | Convert-Path
@@ -440,7 +440,7 @@ function Script-Migration
         $scriptFileName = [IO.Path]::ChangeExtension([IO.Path]::GetRandomFileName(), '.sql')
         $Output = Join-Path $intermediatePath $scriptFileName
     }
-    elseif (!(Split-Path $Output -IsAbsolute))
+    elseif (![IO.Path]::IsPathRooted($Output))
     {
         $Output = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($Output)
     }
@@ -608,7 +608,7 @@ function GetStartupProject($name, $fallbackProject)
         if ($startupProjectPaths.Length -eq 1)
         {
             $startupProjectPath = $startupProjectPaths[0]
-            if (!(Split-Path -IsAbsolute $startupProjectPath))
+            if (![IO.Path]::IsPathRooted($startupProjectPath))
             {
                 $solutionPath = Split-Path (GetProperty $DTE.Solution.Properties 'Path')
                 $startupProjectPath = Join-Path $solutionPath $startupProjectPath -Resolve | Convert-Path
@@ -756,7 +756,7 @@ function EF($project, $startupProject, $params, [switch] $skipBuild)
 
     $startupProjectDir = GetProperty $startupProject.Properties 'FullPath'
     $outputPath = GetProperty $startupProject.ConfigurationManager.ActiveConfiguration.Properties 'OutputPath'
-    $targetDir = Join-Path $startupProjectDir $outputPath -Resolve | Convert-Path
+    $targetDir = [IO.Path]::GetFullPath([IO.Path]::Combine($startupProjectDir, $outputPath))
     $startupTargetFileName = GetOutputFileName $startupProject
     $startupTargetPath = Join-Path $targetDir $startupTargetFileName
     $targetFrameworkMoniker = GetProperty $startupProject.Properties 'TargetFrameworkMoniker'
@@ -1076,7 +1076,7 @@ function GetProjectItem($project, $path)
 {
     $fullPath = GetProperty $project.Properties 'FullPath'
 
-    if (Split-Path $path -IsAbsolute)
+    if ([IO.Path]::IsPathRooted($path))
     {
         $path = $path.Substring($fullPath.Length)
     }


### PR DESCRIPTION
I manually verified that absolute paths are handled in these paths and the issue is fixed.

For context, `Split-Path -IsAbsolute` doesn't work for network paths, and `Join-Path` doesn't handle absolute child paths.

Fixes #11781 