### PR TITLE
Use appropriate ValueComparer when setting original values

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/EmptyShadowValuesFactoryFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/EmptyShadowValuesFactoryFactory.cs
@@ -31,6 +31,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        protected override ValueComparer GetValueComparer(IProperty property)
+            => null;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         protected override bool UseEntityVariable => false;
 
         /// <summary>

--- a/src/EFCore/ChangeTracking/Internal/OriginalValues.cs
+++ b/src/EFCore/ChangeTracking/Internal/OriginalValues.cs
@@ -67,7 +67,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                             property.Name, property.DeclaringEntityType.DisplayName(), property.ClrType.DisplayName()));
                 }
 
-                _values[index] = value;
+                _values[index] = SnapshotValue(property, value);;
             }
 
             public void RejectChanges(InternalEntityEntry entry)
@@ -82,7 +82,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     var index = property.GetOriginalValueIndex();
                     if (index >= 0)
                     {
-                        entry[property] = _values[index];
+                        entry[property] = SnapshotValue(property, _values[index]);
                     }
                 }
             }
@@ -99,9 +99,16 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                     var index = property.GetOriginalValueIndex();
                     if (index >= 0)
                     {
-                        _values[index] = entry[property];
+                        _values[index] = SnapshotValue(property, entry[property]);
                     }
                 }
+            }
+
+            private static object SnapshotValue(IProperty property, object value)
+            {
+                var comparer = property.GetValueComparer() ?? property.FindMapping()?.Comparer;
+
+                return comparer == null ? value : comparer.Snapshot(value);
             }
 
             public bool IsEmpty => _values == null;

--- a/src/EFCore/ChangeTracking/Internal/OriginalValuesFactoryFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/OriginalValuesFactoryFactory.cs
@@ -25,5 +25,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         /// </summary>
         protected override int GetPropertyCount(IEntityType entityType)
             => entityType.OriginalValueCount();
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override ValueComparer GetValueComparer(IProperty property)
+            => property.GetValueComparer() ?? property.FindMapping()?.Comparer;
     }
 }

--- a/src/EFCore/ChangeTracking/Internal/RelationshipSnapshotFactoryFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/RelationshipSnapshotFactoryFactory.cs
@@ -25,5 +25,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         /// </summary>
         protected override int GetPropertyCount(IEntityType entityType)
             => entityType.RelationshipPropertyCount();
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override ValueComparer GetValueComparer(IProperty property)
+            => property.GetKeyValueComparer() ?? property.FindMapping()?.KeyComparer;
     }
 }

--- a/src/EFCore/ChangeTracking/Internal/RelationshipsSnapshot.cs
+++ b/src/EFCore/ChangeTracking/Internal/RelationshipsSnapshot.cs
@@ -42,7 +42,23 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 Debug.Assert(!IsEmpty);
                 Debug.Assert(!(propertyBase is INavigation) || !((INavigation)propertyBase).IsCollection());
 
-                _values[propertyBase.GetRelationshipIndex()] = value;
+                _values[propertyBase.GetRelationshipIndex()] = SnapshotValue(propertyBase, value);
+            }
+
+
+            private static object SnapshotValue(IPropertyBase propertyBase, object value)
+            {
+                if (propertyBase is IProperty property)
+                {
+                    var comparer = property.GetKeyValueComparer() ?? property.FindMapping()?.KeyComparer;
+
+                    if (comparer != null)
+                    {
+                        return comparer.Snapshot(value);
+                    }
+                }
+
+                return value;
             }
 
             public void RemoveFromCollection(IPropertyBase propertyBase, object removedEntity)

--- a/src/EFCore/ChangeTracking/Internal/ShadowValuesFactoryFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/ShadowValuesFactoryFactory.cs
@@ -33,6 +33,13 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        protected override ValueComparer GetValueComparer(IProperty property)
+            => null;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         protected override bool UseEntityVariable => false;
 
         /// <summary>

--- a/src/EFCore/ChangeTracking/Internal/SnapshotFactoryFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/SnapshotFactoryFactory.cs
@@ -159,11 +159,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 : constructorExpression;
         }
 
-        private static Expression CreateSnapshotValueExpression(Expression expression, IPropertyBase propertyBase)
+        private Expression CreateSnapshotValueExpression(Expression expression, IPropertyBase propertyBase)
         {
             if (propertyBase is IProperty property)
             {
-                var comparer = property.GetValueComparer() ?? property.FindMapping()?.Comparer;
+                var comparer = GetValueComparer(property);
 
                 if (comparer != null)
                 {
@@ -176,6 +176,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             return expression;
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected abstract ValueComparer GetValueComparer([NotNull] IProperty property);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/ChangeTracking/Internal/StoreGeneratedValues.cs
+++ b/src/EFCore/ChangeTracking/Internal/StoreGeneratedValues.cs
@@ -87,7 +87,22 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         CoreStrings.DatabaseGeneratedNull(propertyBase.Name, propertyBase.DeclaringType.DisplayName()));
                 }
 
-                _values[index] = value ?? _nullSentinel;
+                _values[index] = SnapshotValue(propertyBase, value) ?? _nullSentinel;
+            }
+
+            private static object SnapshotValue(IPropertyBase propertyBase, object value)
+            {
+                if (propertyBase is IProperty property)
+                {
+                    var comparer = property.GetValueComparer() ?? property.FindMapping()?.Comparer;
+
+                    if (comparer != null)
+                    {
+                        return comparer.Snapshot(value);
+                    }
+                }
+
+                return value;
             }
         }
     }


### PR DESCRIPTION
Fixes #12790

We were using it when creating the original snapshot, but not on later updates, such as in AcceptChanges.
