### PR TITLE
Use full provider type mapping for NTS types

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGenerator.cs
@@ -172,7 +172,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     builder
                         .AppendLine(",")
                         .Append("computedColumnSql: ")
-                        .Append(Code.UnknownLiteral(operation.ComputedColumnSql));
+                        .Append(Code.Literal(operation.ComputedColumnSql));
                 }
                 else if (operation.DefaultValue != null)
                 {
@@ -469,7 +469,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     builder
                         .AppendLine(",")
                         .Append("computedColumnSql: ")
-                        .Append(Code.UnknownLiteral(operation.ComputedColumnSql));
+                        .Append(Code.Literal(operation.ComputedColumnSql));
                 }
                 else if (operation.DefaultValue != null)
                 {
@@ -540,7 +540,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     builder
                         .AppendLine(",")
                         .Append("oldComputedColumnSql: ")
-                        .Append(Code.UnknownLiteral(operation.OldColumn.ComputedColumnSql));
+                        .Append(Code.Literal(operation.OldColumn.ComputedColumnSql));
                 }
                 else if (operation.OldColumn.DefaultValue != null)
                 {

--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -717,7 +717,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                         .Append("<")
                         .Append(Code.Reference(propertyClrType))
                         .Append(">(")
-                        .Append(Code.UnknownLiteral(discriminatorPropertyAnnotation.Value))
+                        .Append(Code.Literal((string)discriminatorPropertyAnnotation.Value))
                         .Append(")");
                 }
                 else

--- a/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/RelationalTypeMapping.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
 using System.Globalization;
+using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -598,5 +599,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
                 ? method
                 : _getFieldValueMethod.MakeGenericMethod(type);
         }
+
+        /// <summary>
+        ///     Gets a custom expression tree for the code to convert from the database value
+        ///     to the model value.
+        /// </summary>
+        /// <param name="expression"> The input expression, containing the database value. </param>
+        /// <returns> The expression with conversion added. </returns>
+        public virtual Expression AddCustomConversion([NotNull] Expression expression)
+            => expression;
     }
 }

--- a/src/EFCore.SqlServer.NTS/Storage/Internal/SqlServerGeometryTypeMapping.cs
+++ b/src/EFCore.SqlServer.NTS/Storage/Internal/SqlServerGeometryTypeMapping.cs
@@ -2,13 +2,18 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Data;
+using System.Data.Common;
 using System.Data.SqlClient;
-using System.Data.SqlTypes;
+using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
+using GeoAPI.Geometries;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.ValueConversion.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using NetTopologySuite.IO;
+using Remotion.Linq.Parsing.ExpressionVisitors;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
 {
@@ -22,6 +27,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
             = typeof(SqlDataReader).GetTypeInfo().GetDeclaredMethod(nameof(SqlDataReader.GetSqlBytes));
 
         private readonly SqlServerSpatialReader _reader;
+        private readonly GeometryValueConverter _converter;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -29,14 +35,15 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         /// </summary>
         public SqlServerGeometryTypeMapping(Type clrType, SqlServerSpatialReader reader, string storeType)
             : base(
-                 new RelationalTypeMappingParameters(
-                     new CoreTypeMappingParameters(
-                         clrType,
-                         new GeometryValueConverter(clrType, reader),
-                         new GeometryValueComparer(clrType)),
-                     storeType))
+                new RelationalTypeMappingParameters(
+                    new CoreTypeMappingParameters(
+                        clrType,
+                        null,
+                        new GeometryValueComparer(clrType)),
+                    storeType))
         {
             _reader = reader;
+            _converter = new GeometryValueConverter(clrType, reader);
         }
 
         /// <summary>
@@ -61,8 +68,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         /// </summary>
         protected override string GenerateNonNullSqlLiteral(object value)
         {
-            // TODO: Avoid converting in the first place
-            var geometry = _reader.Read(((SqlBytes)value).Value);
+            var geometry = (IGeometry)value;
             var srid = geometry.SRID;
 
             // TODO: This won't emit M (see NetTopologySuite/NetTopologySuite#156)
@@ -77,7 +83,48 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public override DbParameter CreateParameter(DbCommand command, string name, object value, bool? nullable = null)
+        {
+            var parameter = command.CreateParameter();
+            parameter.Direction = ParameterDirection.Input;
+            parameter.ParameterName = name;
+
+            parameter.Value = value == null
+                ? DBNull.Value
+                : _converter.ConvertToProvider(value);
+
+            if (nullable.HasValue)
+            {
+                parameter.IsNullable = nullable.Value;
+            }
+
+            ConfigureParameter(parameter);
+
+            return parameter;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public override MethodInfo GetDataReaderMethod()
             => _getSqlBytes;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override Expression AddCustomConversion(Expression expression)
+        {
+            if (expression.Type != _converter.ProviderClrType)
+            {
+                expression = Expression.Convert(expression, _converter.ProviderClrType);
+            }
+
+            return ReplacingExpressionVisitor.Replace(
+                _converter.ConvertFromProviderExpression.Parameters.Single(),
+                expression,
+                _converter.ConvertFromProviderExpression.Body);
+        }
     }
 }


### PR DESCRIPTION
Avoids having to deal with SqlBytes outside of the data reader and parameters