### PR TITLE
Metadata: Discover nullability of owned columns properly in nested ow…

### DIFF
--- a/src/EFCore.Relational/Metadata/RelationalPropertyExtensions.cs
+++ b/src/EFCore.Relational/Metadata/RelationalPropertyExtensions.cs
@@ -34,8 +34,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata
 
             return property.IsPrimaryKey()
                 ? false
-                : property.DeclaringEntityType.FindPrimaryKey()?.Properties.First()
-                       ?.FindSharedTableLink()?.PrincipalEntityType.BaseType != null;
+                : IsOwnedByDerivedType(property.DeclaringEntityType);
+        }
+
+        private static bool IsOwnedByDerivedType(IEntityType entityType)
+        {
+            var ownerEntityType = entityType.FindPrimaryKey()?.Properties.First()
+                ?.FindSharedTableLink()?.PrincipalEntityType;
+
+            if (ownerEntityType?.BaseType != null)
+            {
+                return true;
+            }
+
+            return ownerEntityType != null && IsOwnedByDerivedType(ownerEntityType);
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryBugsTest.cs
@@ -5140,6 +5140,79 @@ ORDER BY [t].[Id]");
 
         #endregion
 
+        #region Bug13079
+
+        [Fact]
+        public virtual void Test()
+        {
+            using (CreateDatabase13079())
+            {
+                using (var context = new MyContext13079(_options))
+                {
+                    context.Add(new BaseEntity13079());
+                    context.SaveChanges();
+
+                    AssertSql(
+                        @"@p0='BaseEntity13079' (Nullable = false) (Size = 4000)
+
+SET NOCOUNT ON;
+INSERT INTO [BaseEntities] ([Discriminator])
+VALUES (@p0);
+SELECT [Id]
+FROM [BaseEntities]
+WHERE @@ROWCOUNT = 1 AND [Id] = scope_identity();");
+                }
+            }
+        }
+
+        private SqlServerTestStore CreateDatabase13079()
+        {
+            return CreateTestStore(
+                () => new MyContext13079(_options),
+                context =>
+                {
+                    ClearLog();
+                });
+        }
+
+        public class MyContext13079 : DbContext
+        {
+            public virtual DbSet<BaseEntity13079> BaseEntities { get; set; }
+
+            public MyContext13079(DbContextOptions options)
+               : base(options)
+            {
+            }
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
+                modelBuilder.Entity<DerivedEntity13079>().OwnsOne(e => e.Data, b => b.OwnsOne(e => e.SubData));
+            }
+        }
+
+        public class BaseEntity13079
+        {
+            public int Id { get; set; }
+        }
+
+        public class DerivedEntity13079 : BaseEntity13079
+        {
+            public int Property { get; set; }
+            public OwnedData13079 Data { get; set; }
+        }
+
+        public class OwnedData13079
+        {
+            public int Property { get; set; }
+            public OwnedSubData13079 SubData { get; set; }
+        }
+        public class OwnedSubData13079
+        {
+            public int Property { get; set; }
+        }
+
+        #endregion
+
         private DbContextOptions _options;
 
         private SqlServerTestStore CreateTestStore<TContext>(


### PR DESCRIPTION
…ned types

Issue: While discovering nullability of owned column, we checked if the owned is derived type or not. But for nested owned type, we need to go multiple level to find the owner which is not owned to accurately make the decision.

Resolves #13079

