### PR TITLE
Scaffold NTS literals for in model snapshot

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -1135,10 +1135,16 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                                     firstProperty = false;
                                 }
 
+                                var mapping = property.FindRelationalMapping()
+                                              ?? Dependencies.TypeMappingSource.FindMapping(property);
+
+                                var literal = mapping?.FindCodeLiteral(value, ".cs")
+                                              ?? Code.UnknownLiteral(value);
+
                                 stringBuilder
                                     .Append(Code.Identifier(property.Name))
                                     .Append(" = ")
-                                    .Append(Code.UnknownLiteral(value));
+                                    .Append(literal);
                             }
                         }
 

--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGeneratorDependencies.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGeneratorDependencies.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Migrations.Design
@@ -44,11 +45,16 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         ///     </para>
         /// </summary>
         /// <param name="csharpHelper"> The C# helper. </param>
-        public CSharpSnapshotGeneratorDependencies([NotNull] ICSharpHelper csharpHelper)
+        /// <param name="typeMappingSource"> The type mapper. </param>
+        public CSharpSnapshotGeneratorDependencies(
+            [NotNull] ICSharpHelper csharpHelper,
+            [NotNull] IRelationalTypeMappingSource typeMappingSource)
         {
             Check.NotNull(csharpHelper, nameof(csharpHelper));
+            Check.NotNull(typeMappingSource, nameof(typeMappingSource));
 
             CSharpHelper = csharpHelper;
+            TypeMappingSource = typeMappingSource;
         }
 
         /// <summary>
@@ -57,11 +63,26 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         public ICSharpHelper CSharpHelper { get; }
 
         /// <summary>
+        ///     The type mapper.
+        /// </summary>
+        public IRelationalTypeMappingSource TypeMappingSource { get; }
+
+        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="csharpHelper"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
-        public CSharpSnapshotGeneratorDependencies With([NotNull] ICSharpHelper csharpHelper)
-            => new CSharpSnapshotGeneratorDependencies(csharpHelper);
+        public CSharpSnapshotGeneratorDependencies With(
+            [NotNull] ICSharpHelper csharpHelper)
+            => new CSharpSnapshotGeneratorDependencies(csharpHelper, TypeMappingSource);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="typeMappingSource"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public CSharpSnapshotGeneratorDependencies With(
+            [NotNull] IRelationalTypeMappingSource typeMappingSource)
+            => new CSharpSnapshotGeneratorDependencies(CSharpHelper, typeMappingSource);
     }
 }

--- a/src/EFCore.Design/Migrations/Design/MigrationsCodeGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/MigrationsCodeGenerator.cs
@@ -243,12 +243,24 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                 RelationalAnnotationNames.SequencePrefix
             };
 
-            return items.SelectMany(i => i.GetAnnotations())
-                .Where(
-                    a => a.Value != null
-                         && !ignoredAnnotations.Contains(a.Name)
-                         && !ignoredAnnotationTypes.Any(p => a.Name.StartsWith(p, StringComparison.Ordinal)))
-                .SelectMany(a => a.Value.GetType().GetNamespaces());
+            return items.SelectMany(
+                i => i.GetAnnotations().Select(
+                        a => new
+                        {
+                            Annotatable = i,
+                            Annotation = a
+                        })
+                    .Where(
+                        a => a.Annotation.Value != null
+                             && !ignoredAnnotations.Contains(a.Annotation.Name)
+                             && !ignoredAnnotationTypes.Any(p => a.Annotation.Name.StartsWith(p, StringComparison.Ordinal)))
+                    .SelectMany(a => GetProviderType(a.Annotatable, a.Annotation.Value.GetType()).GetNamespaces()));
         }
+
+        private static Type GetProviderType(IAnnotatable annotatable, Type valueType)
+            => annotatable is IProperty property
+               && valueType.UnwrapNullableType() == property.ClrType.UnwrapNullableType()
+                ? property.FindMapping()?.Converter?.ProviderClrType ?? valueType
+                : valueType;
     }
 }

--- a/src/EFCore.Design/breakingchanges.netcore.json
+++ b/src/EFCore.Design/breakingchanges.netcore.json
@@ -17,5 +17,10 @@
     "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.Design.MigrationsScaffolder",
     "MemberId": "public virtual Microsoft.EntityFrameworkCore.Migrations.Design.ScaffoldedMigration ScaffoldMigration(System.String migrationName, System.String rootNamespace, System.String subNamespace = null)",
     "Kind": "Removal"
+  },
+  {
+    "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Migrations.Design.CSharpSnapshotGeneratorDependencies",
+    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Design.ICSharpHelper csharpHelper)",
+    "Kind": "Removal"
   }
 ]

--- a/src/EFCore.Design/breakingchanges.netframework.json
+++ b/src/EFCore.Design/breakingchanges.netframework.json
@@ -17,5 +17,10 @@
     "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.Design.MigrationsScaffolder",
     "MemberId": "public virtual Microsoft.EntityFrameworkCore.Migrations.Design.ScaffoldedMigration ScaffoldMigration(System.String migrationName, System.String rootNamespace, System.String subNamespace = null)",
     "Kind": "Removal"
+  },
+  {
+    "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Migrations.Design.CSharpSnapshotGeneratorDependencies",
+    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Design.ICSharpHelper csharpHelper)",
+    "Kind": "Removal"
   }
 ]

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryTypeMapping.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryTypeMapping.cs
@@ -22,12 +22,13 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
         public InMemoryTypeMapping(
             [NotNull] Type clrType,
             [CanBeNull] ValueComparer comparer = null,
+            [CanBeNull] ValueComparer keyComparer = null,
             [CanBeNull] ValueComparer deepComparer = null)
             : base(new CoreTypeMappingParameters(
                 clrType,
                 converter: null,
                 comparer,
-                keyComparer: null,
+                keyComparer,
                 deepComparer,
                 valueGeneratorFactory: null))
         {

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryTypeMappingSource.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryTypeMappingSource.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
@@ -43,10 +44,16 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
                 return new InMemoryTypeMapping(clrType, deepComparer: new ArrayDeepComparer<byte>());
             }
 
-            if (clrType.Name == "GeoAPI.Geometries.IGeometry"
+            if (clrType.FullName == "GeoAPI.Geometries.IGeometry"
                 || clrType.GetInterface("GeoAPI.Geometries.IGeometry") != null)
             {
-                return new InMemoryTypeMapping(clrType, new GeometryValueComparer(clrType));
+                var comparer = (ValueComparer)Activator.CreateInstance(typeof(GeometryValueComparer<>).MakeGenericType(clrType));
+
+                return new InMemoryTypeMapping(
+                    clrType,
+                    comparer,
+                    comparer,
+                    comparer);
             }
 
             return base.FindMapping(mappingInfo);

--- a/src/EFCore.Relational/Storage/RelationalGeometryTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/RelationalGeometryTypeMapping.cs
@@ -1,0 +1,135 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Remotion.Linq.Parsing.ExpressionVisitors;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    /// <summary>
+    ///     Base class for relation type mappings to NTS IGeometry and implementing types.
+    /// </summary>
+    /// <typeparam name="TGeometry"> The geometry type. </typeparam>
+    /// <typeparam name="TProvider"> The native type of the database provider. </typeparam>
+    public abstract class RelationalGeometryTypeMapping<TGeometry, TProvider> : RelationalTypeMapping
+    {
+        private readonly ValueConverter<TGeometry, TProvider> _converter;
+
+        /// <summary>
+        ///     Creates a new instance of the <see cref="RelationalGeometryTypeMapping{TGeometry,TProvider}" /> class.
+        /// </summary>
+        /// <param name="converter"> The converter to use when converting to and from database types. </param>
+        /// <param name="storeType"> The store type name. </param>
+        protected RelationalGeometryTypeMapping(
+            [NotNull] ValueConverter<TGeometry, TProvider> converter,
+            [NotNull] string storeType)
+            : base(CreateRelationalTypeMappingParameters(storeType))
+        {
+            _converter = converter;
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="RelationalTypeMapping" /> class.
+        /// </summary>
+        /// <param name="parameters"> The parameters for this mapping. </param>
+        protected RelationalGeometryTypeMapping(RelationalTypeMappingParameters parameters)
+            : base(parameters)
+        {
+        }
+
+        private static RelationalTypeMappingParameters CreateRelationalTypeMappingParameters(string storeType)
+        {
+            var comparer = new GeometryValueComparer<TGeometry>();
+
+            return new RelationalTypeMappingParameters(
+                new CoreTypeMappingParameters(
+                    typeof(TGeometry),
+                    null,
+                    comparer,
+                    comparer),
+                storeType);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="DbParameter" /> with the appropriate type information configured.
+        /// </summary>
+        /// <param name="command"> The command the parameter should be created on. </param>
+        /// <param name="name"> The name of the parameter. </param>
+        /// <param name="value"> The value to be assigned to the parameter. </param>
+        /// <param name="nullable"> A value indicating whether the parameter should be a nullable type. </param>
+        /// <returns> The newly created parameter. </returns>
+        public override DbParameter CreateParameter(DbCommand command, string name, object value, bool? nullable = null)
+        {
+            var parameter = command.CreateParameter();
+            parameter.Direction = ParameterDirection.Input;
+            parameter.ParameterName = name;
+
+            parameter.Value = value == null
+                ? DBNull.Value
+                : _converter.ConvertToProvider(value);
+
+            if (nullable.HasValue)
+            {
+                parameter.IsNullable = nullable.Value;
+            }
+
+            ConfigureParameter(parameter);
+
+            return parameter;
+        }
+
+        /// <summary>
+        ///     Gets a custom expression tree for the code to convert from the database value
+        ///     to the model value.
+        /// </summary>
+        /// <param name="expression"> The input expression, containing the database value. </param>
+        /// <returns> The expression with conversion added. </returns>
+        public override Expression AddCustomConversion(Expression expression)
+        {
+            if (expression.Type != _converter.ProviderClrType)
+            {
+                expression = Expression.Convert(expression, _converter.ProviderClrType);
+            }
+
+            return ReplacingExpressionVisitor.Replace(
+                _converter.ConvertFromProviderExpression.Parameters.Single(),
+                expression,
+                _converter.ConvertFromProviderExpression.Body);
+        }
+
+        /// <summary>
+        ///     Attempts generation of a code (e.g. C#) literal for the given value.
+        /// </summary>
+        /// <param name="value"> The value for which a literal is needed. </param>
+        /// <param name="languageCode"> The language code, which is typically the common file extension (e.g. ".cs") for the language. </param>
+        /// <returns> The generated literal, or <c>null</c> if a literal could not be generated. </returns>
+        public override string FindCodeLiteral(object value, string languageCode)
+        {
+            var geometryText = AsText(value);
+
+            // TODO: Handle SRID
+            // TODO: Consider constructing C# objects directly
+            // TODO: Allow additional namespaces needed to be put in using directives
+            return geometryText != null
+                   && languageCode.Equals(".cs", StringComparison.OrdinalIgnoreCase)
+                ? $"({value.GetType().ShortDisplayName()})new NetTopologySuite.IO.WKTReader().Read(\"{geometryText}\")"
+                : null;
+        }
+
+        /// <summary>
+        ///     Returns the Well-Known-Text (WKT) representation of the given object, or <c>null</c>
+        ///     if the object is not an 'IGeometry'.
+        /// </summary>
+        /// <param name="value"> The value. </param>
+        /// <returns> The WKT. </returns>
+        protected abstract string AsText(object value);
+    }
+}

--- a/src/EFCore.Specification.Tests/TestModels/UpdatesModel/AFewBytes.cs
+++ b/src/EFCore.Specification.Tests/TestModels/UpdatesModel/AFewBytes.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using GeoAPI.Geometries;
+using NetTopologySuite.Geometries;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.UpdatesModel
 {
@@ -9,5 +11,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.UpdatesModel
     {
         public Guid Id { get; set; }
         public byte[] Bytes { get; set; }
+        public Point Point { get; set; }
+        public IGeometry PolygonAsGeometry { get; set; }
     }
 }

--- a/src/EFCore.SqlServer.NTS/Storage/Internal/SqlServerGeometryTypeMapping.cs
+++ b/src/EFCore.SqlServer.NTS/Storage/Internal/SqlServerGeometryTypeMapping.cs
@@ -1,20 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Data;
-using System.Data.Common;
 using System.Data.SqlClient;
-using System.Linq;
-using System.Linq.Expressions;
+using System.Data.SqlTypes;
 using System.Reflection;
 using GeoAPI.Geometries;
-using Microsoft.EntityFrameworkCore.ChangeTracking;
-using Microsoft.EntityFrameworkCore.Internal;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.ValueConversion.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using NetTopologySuite.IO;
-using Remotion.Linq.Parsing.ExpressionVisitors;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
 {
@@ -22,28 +16,20 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class SqlServerGeometryTypeMapping<TGeometry> : RelationalTypeMapping
+    public class SqlServerGeometryTypeMapping<TGeometry> : RelationalGeometryTypeMapping<TGeometry, SqlBytes>
         where TGeometry : IGeometry
     {
         private static readonly MethodInfo _getSqlBytes
             = typeof(SqlDataReader).GetTypeInfo().GetDeclaredMethod(nameof(SqlDataReader.GetSqlBytes));
 
-        private readonly GeometryValueConverter<TGeometry> _converter;
-
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public SqlServerGeometryTypeMapping(Type clrType, SqlServerSpatialReader reader, string storeType)
-            : base(
-                new RelationalTypeMappingParameters(
-                    new CoreTypeMappingParameters(
-                        clrType,
-                        null,
-                        new GeometryValueComparer(clrType)),
-                    storeType))
+        [UsedImplicitly]
+        public SqlServerGeometryTypeMapping(SqlServerSpatialReader reader, string storeType)
+            : base(new GeometryValueConverter<TGeometry>(reader), storeType)
         {
-            _converter = new GeometryValueConverter<TGeometry>(reader);
         }
 
         /// <summary>
@@ -83,30 +69,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override DbParameter CreateParameter(DbCommand command, string name, object value, bool? nullable = null)
-        {
-            var parameter = command.CreateParameter();
-            parameter.Direction = ParameterDirection.Input;
-            parameter.ParameterName = name;
-
-            parameter.Value = value == null
-                ? DBNull.Value
-                : _converter.ConvertToProvider(value);
-
-            if (nullable.HasValue)
-            {
-                parameter.IsNullable = nullable.Value;
-            }
-
-            ConfigureParameter(parameter);
-
-            return parameter;
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
         public override MethodInfo GetDataReaderMethod()
             => _getSqlBytes;
 
@@ -114,30 +76,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override Expression AddCustomConversion(Expression expression)
-        {
-            if (expression.Type != _converter.ProviderClrType)
-            {
-                expression = Expression.Convert(expression, _converter.ProviderClrType);
-            }
-
-            return ReplacingExpressionVisitor.Replace(
-                _converter.ConvertFromProviderExpression.Parameters.Single(),
-                expression,
-                _converter.ConvertFromProviderExpression.Body);
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override string FindCodeLiteral(object value, string languageCode)
-            // TODO: Handle SRID
-            // TODO: Consider constructing C# objects directly
-            // TODO: Allow additional namespaces needed to be put in using directives
-            => languageCode.Equals(".cs", StringComparison.OrdinalIgnoreCase)
-               && value is IGeometry geometry
-                ? $"({value.GetType().ShortDisplayName()})new NetTopologySuite.IO.WKTReader().Read(\"{geometry.AsText()}\")"
-                : null;
+        protected override string AsText(object value)
+            => (value is IGeometry geometry) ? geometry.AsText() : null;
     }
 }

--- a/src/EFCore.SqlServer.NTS/Storage/Internal/SqlServerNTSTypeMappingSourcePlugin.cs
+++ b/src/EFCore.SqlServer.NTS/Storage/Internal/SqlServerNTSTypeMappingSourcePlugin.cs
@@ -51,7 +51,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
                        && _spatialStoreTypes.Contains(storeTypeName))
                 ? (RelationalTypeMapping)Activator.CreateInstance(
                     typeof(SqlServerGeometryTypeMapping<>).MakeGenericType(clrType),
-                    clrType,
                     _reader,
                     storeTypeName ?? "geometry")
                 : null;

--- a/src/EFCore.SqlServer.NTS/Storage/ValueConversion/Internal/GeometryValueConverter.cs
+++ b/src/EFCore.SqlServer.NTS/Storage/ValueConversion/Internal/GeometryValueConverter.cs
@@ -1,12 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Data.SqlTypes;
-using System.Linq.Expressions;
-using System.Reflection;
 using GeoAPI.Geometries;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.IO;
 
@@ -16,85 +12,21 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.ValueConversion.Intern
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class GeometryValueConverter : ValueConverter
+    public class GeometryValueConverter<TGeometry> : ValueConverter<TGeometry, SqlBytes>
+    where TGeometry : IGeometry
     {
         private static readonly SqlServerSpatialWriter _writer
             = new SqlServerSpatialWriter { HandleOrdinates = Ordinates.XYZM };
 
-        private Func<object, object> _convertToProvider;
-        private Func<object, object> _convertFromProvider;
-
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public GeometryValueConverter(Type type, SqlServerSpatialReader reader)
+        public GeometryValueConverter(SqlServerSpatialReader reader)
             : base(
-                  (Expression<Func<IGeometry, SqlBytes>>)(g => new SqlBytes(_writer.Write(g))),
-                  GetConvertFromProviderExpression(type, reader))
+                g => new SqlBytes(_writer.Write(g)),
+                b => (TGeometry)reader.Read(b.Value))
         {
-            ModelClrType = type;
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override Func<object, object> ConvertToProvider
-            => NonCapturingLazyInitializer.EnsureInitialized(
-                ref _convertToProvider,
-                this,
-                x => Compile(x.ConvertToProviderExpression));
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override Func<object, object> ConvertFromProvider
-            => NonCapturingLazyInitializer.EnsureInitialized(
-                ref _convertFromProvider,
-                this,
-                x => Compile(x.ConvertFromProviderExpression));
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override Type ModelClrType { get; }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override Type ProviderClrType
-            => typeof(SqlBytes);
-
-        private static LambdaExpression GetConvertFromProviderExpression(Type type, SqlServerSpatialReader reader)
-        {
-            var bytes = Expression.Parameter(typeof(SqlBytes), "bytes");
-
-            Expression body = Expression.Call(
-                Expression.Constant(reader),
-                typeof(SqlServerSpatialReader).GetRuntimeMethod(nameof(SqlServerSpatialReader.Read), new[] { typeof(byte[]) }),
-                new[]
-                {
-                    Expression.Property(bytes, nameof(SqlBytes.Value))
-                });
-            if (!type.IsAssignableFrom(typeof(IGeometry)))
-            {
-                body = Expression.Convert(body, type);
-            }
-
-            return Expression.Lambda(body, bytes);
-        }
-
-        private static Func<object, object> Compile(LambdaExpression convertExpression)
-        {
-            var compiled = convertExpression.Compile();
-
-            return x => x != null
-                ? compiled.DynamicInvoke(x)
-                : null;
         }
     }
 }

--- a/src/EFCore.Sqlite.NTS/Storage/Internal/SqliteNTSTypeMappingSourcePlugin.cs
+++ b/src/EFCore.Sqlite.NTS/Storage/Internal/SqliteNTSTypeMappingSourcePlugin.cs
@@ -57,10 +57,12 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
             string defaultStoreType = null;
             Type defaultClrType = null;
 
-            return (clrType != null && TryGetDefaultStoreType(clrType, out defaultStoreType)
-                    || storeTypeName != null && _storeTypeMappings.TryGetValue(storeTypeName, out defaultClrType))
-                ? new SqliteGeometryTypeMapping(
-                    clrType ?? defaultClrType ?? typeof(IGeometry),
+            return (clrType != null
+                    && TryGetDefaultStoreType(clrType, out defaultStoreType))
+                   || (storeTypeName != null
+                       && _storeTypeMappings.TryGetValue(storeTypeName, out defaultClrType))
+                ? (RelationalTypeMapping)Activator.CreateInstance(
+                    typeof(SqliteGeometryTypeMapping<>).MakeGenericType(clrType ?? defaultClrType ?? typeof(IGeometry)),
                     _reader,
                     storeTypeName ?? defaultStoreType ?? "GEOMETRY")
                 : null;

--- a/src/EFCore.Sqlite.NTS/Storage/ValueConversion/Internal/GeometryValueConverter.cs
+++ b/src/EFCore.Sqlite.NTS/Storage/ValueConversion/Internal/GeometryValueConverter.cs
@@ -2,10 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq.Expressions;
-using System.Reflection;
 using GeoAPI.Geometries;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.IO;
 
@@ -15,81 +12,20 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.ValueConversion.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class GeometryValueConverter : ValueConverter
+    public class GeometryValueConverter<TGeometry> : ValueConverter<TGeometry, byte[]>
+        where TGeometry : IGeometry
     {
         private static readonly GaiaGeoWriter _writer = new GaiaGeoWriter();
 
-        private Func<object, object> _convertToProvider;
-        private Func<object, object> _convertFromProvider;
-
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public GeometryValueConverter(Type type, GaiaGeoReader reader)
+        public GeometryValueConverter(GaiaGeoReader reader)
             : base(
-                  (Expression<Func<IGeometry, byte[]>>)(g => _writer.Write(g)),
-                  GetConvertFromProviderExpression(type, reader))
+                g => _writer.Write(g),
+                b => (TGeometry)reader.Read(b))
         {
-            ModelClrType = type;
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override Func<object, object> ConvertToProvider
-            => NonCapturingLazyInitializer.EnsureInitialized(
-                ref _convertToProvider,
-                this,
-                x => Compile(x.ConvertToProviderExpression));
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override Func<object, object> ConvertFromProvider
-            => NonCapturingLazyInitializer.EnsureInitialized(
-                ref _convertFromProvider,
-                this,
-                x => Compile(x.ConvertFromProviderExpression));
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override Type ModelClrType { get; }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override Type ProviderClrType
-            => typeof(byte[]);
-
-        private static LambdaExpression GetConvertFromProviderExpression(Type type, GaiaGeoReader reader)
-        {
-            var bytes = Expression.Parameter(typeof(byte[]), "blob");
-
-            Expression body = Expression.Call(
-                Expression.Constant(reader),
-                typeof(GaiaGeoReader).GetRuntimeMethod(nameof(GaiaGeoReader.Read), new[] { typeof(byte[]) }),
-                bytes);
-            if (!type.IsAssignableFrom(typeof(IGeometry)))
-            {
-                body = Expression.Convert(body, type);
-            }
-
-            return Expression.Lambda(body, bytes);
-        }
-
-        private static Func<object, object> Compile(LambdaExpression convertExpression)
-        {
-            var compiled = convertExpression.Compile();
-
-            return x => x != null
-                ? compiled.DynamicInvoke(x)
-                : null;
         }
     }
 }

--- a/src/EFCore/Storage/CoreTypeMapping.cs
+++ b/src/EFCore/Storage/CoreTypeMapping.cs
@@ -218,5 +218,14 @@ namespace Microsoft.EntityFrameworkCore.Storage
         /// <param name="converter"> The converter to use. </param>
         /// <returns> A new type mapping </returns>
         public abstract CoreTypeMapping Clone([CanBeNull] ValueConverter converter);
+
+        /// <summary>
+        ///     Attempts generation of a code (e.g. C#) literal for the given value.
+        /// </summary>
+        /// <param name="value"> The value for which a literal is needed. </param>
+        /// <param name="languageCode"> The language code, which is typically the common file extension (e.g. ".cs") for the language. </param>
+        /// <returns> The generated literal, or <c>null</c> if a literal could not be generated. </returns>
+        public virtual string FindCodeLiteral([CanBeNull] object value, [NotNull] string languageCode)
+            => null;
     }
 }

--- a/test/EFCore.Design.Tests/EFCore.Design.Tests.csproj
+++ b/test/EFCore.Design.Tests/EFCore.Design.Tests.csproj
@@ -21,6 +21,10 @@
     <ProjectReference Include="..\EFCore.Relational.Tests\EFCore.Relational.Tests.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(FunctionalTests_PackageVersion)' != '2.1.0'">
+    <ProjectReference Include="..\..\src\EFCore.SqlServer.NTS\EFCore.SqlServer.NTS.csproj" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(MicrosoftCodeAnalysisCSharpPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="$(MicrosoftExtensionsDependencyModelPackageVersion)" />

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -17,6 +17,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Operations;
+using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -188,7 +189,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             Action<TestCSharpSnapshotGenerator, IMutableAnnotatable, IndentedStringBuilder> test)
         {
             var codeHelper = new CSharpHelper();
-            var generator = new TestCSharpSnapshotGenerator(new CSharpSnapshotGeneratorDependencies(codeHelper));
+            var generator = new TestCSharpSnapshotGenerator(
+                new CSharpSnapshotGeneratorDependencies(
+                    codeHelper,
+                    new SqlServerTypeMappingSource(
+                        TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
+                        TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())));
 
             foreach (var field in typeof(CoreAnnotationNames).GetFields().Concat(
                 typeof(RelationalAnnotationNames).GetFields().Where(f => f.Name != "Prefix")))
@@ -259,7 +265,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     codeHelper,
                     new CSharpMigrationOperationGenerator(
                         new CSharpMigrationOperationGeneratorDependencies(codeHelper)),
-                    new CSharpSnapshotGenerator(new CSharpSnapshotGeneratorDependencies(codeHelper))));
+                    new CSharpSnapshotGenerator(
+                        new CSharpSnapshotGeneratorDependencies(
+                            codeHelper,
+                            new SqlServerTypeMappingSource(
+                                TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
+                                TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())))));
 
             var modelBuilder = RelationalTestHelpers.Instance.CreateConventionBuilder();
             modelBuilder.Entity<WithAnnotations>(
@@ -328,7 +339,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             modelBuilder.GetInfrastructure().Metadata.Validate();
 
             var codeHelper = new CSharpHelper();
-            var generator = new TestCSharpSnapshotGenerator(new CSharpSnapshotGeneratorDependencies(codeHelper));
+            var generator = new TestCSharpSnapshotGenerator(
+                new CSharpSnapshotGeneratorDependencies(
+                    codeHelper,
+                    new SqlServerTypeMappingSource(
+                        TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
+                        TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())));
 
             property.SetValueConverter(valueConverter);
 
@@ -834,6 +850,7 @@ namespace MyNamespace
 
         private static IMigrationsCodeGenerator CreateMigrationsCodeGenerator()
             => new ServiceCollection()
+                .AddEntityFrameworkSqlServer()
                 .AddEntityFrameworkDesignTimeServices()
                 .BuildServiceProvider()
                 .GetRequiredService<IMigrationsCodeGenerator>();

--- a/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
@@ -11,6 +11,7 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Migrations.Internal;
+using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider;
@@ -84,7 +85,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                                     code,
                                     new CSharpMigrationOperationGenerator(
                                         new CSharpMigrationOperationGeneratorDependencies(code)),
-                                    new CSharpSnapshotGenerator(new CSharpSnapshotGeneratorDependencies(code))))
+                                    new CSharpSnapshotGenerator(
+                                        new CSharpSnapshotGeneratorDependencies(
+                                            code,
+                                            new SqlServerTypeMappingSource(
+                                                TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
+                                                TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())))))
                         }),
                     historyRepository,
                     reporter,

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -7,6 +7,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using GeoAPI.Geometries;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Design.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -21,6 +22,8 @@ using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Storage.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
+using Microsoft.Extensions.DependencyInjection;
+using NetTopologySuite.Geometries;
 using Xunit;
 
 // ReSharper disable InconsistentNaming
@@ -32,6 +35,98 @@ namespace Microsoft.EntityFrameworkCore.Migrations
 {
     public class ModelSnapshotSqlServerTest
     {
+        private class EntityWithManyProperties
+        {
+            public int Id { get; set; }
+            public string String { get; set; }
+            public byte[] Bytes { get; set; }
+            public short Int16 { get; set; }
+            public int Int32 { get; set; }
+            public long Int64 { get; set; }
+            public double Double { get; set; }
+            public decimal Decimal { get; set; }
+            public DateTime DateTime { get; set; }
+            public DateTimeOffset DateTimeOffset { get; set; }
+            public TimeSpan TimeSpan { get; set; }
+            public float Single { get; set; }
+            public bool Boolean { get; set; }
+            public byte Byte { get; set; }
+            public ushort UnsignedInt16 { get; set; }
+            public uint UnsignedInt32 { get; set; }
+            public ulong UnsignedInt64 { get; set; }
+            public char Character { get; set; }
+            public sbyte SignedByte { get; set; }
+            public Enum64 Enum64 { get; set; }
+            public Enum32 Enum32 { get; set; }
+            public Enum16 Enum16 { get; set; }
+            public Enum8 Enum8 { get; set; }
+            public EnumU64 EnumU64 { get; set; }
+            public EnumU32 EnumU32 { get; set; }
+            public EnumU16 EnumU16 { get; set; }
+            public EnumS8 EnumS8 { get; set; }
+            public IGeometry SpatialBGeometryCollection { get; set; }
+            public IGeometry SpatialBLineString { get; set; }
+            public IGeometry SpatialBMultiLineString { get; set; }
+            public IGeometry SpatialBMultiPoint{ get; set; }
+            public IGeometry SpatialBMultiPolygon{ get; set; }
+            public IGeometry SpatialBPoint{ get; set; }
+            public IGeometry SpatialBPolygon{ get; set; }
+            public GeometryCollection SpatialCGeometryCollection { get; set; }
+            public LineString SpatialCLineString { get; set; }
+            public MultiLineString SpatialCMultiLineString { get; set; }
+            public MultiPoint SpatialCMultiPoint { get; set; }
+            public MultiPolygon SpatialCMultiPolygon { get; set; }
+            public Point SpatialCPoint { get; set; }
+            public Polygon SpatialCPolygon { get; set; }
+            public IGeometryCollection SpatialIGeometryCollection { get; set; }
+            public ILineString SpatialILineString { get; set; }
+            public IMultiLineString SpatialIMultiLineString { get; set; }
+            public IMultiPoint SpatialIMultiPoint { get; set; }
+            public IMultiPolygon SpatialIMultiPolygon { get; set; }
+            public IPoint SpatialIPoint { get; set; }
+            public IPolygon SpatialIPolygon { get; set; }
+        }
+
+        private enum Enum64 : long
+        {
+            SomeValue = 1
+        }
+
+        private enum Enum32
+        {
+            SomeValue = 1
+        }
+
+        private enum Enum16 : short
+        {
+            SomeValue = 1
+        }
+
+        private enum Enum8 : byte
+        {
+            SomeValue = 1
+        }
+
+        private enum EnumU64 : ulong
+        {
+            SomeValue = 1234567890123456789UL
+        }
+
+        private enum EnumU32 : uint
+        {
+            SomeValue = uint.MaxValue
+        }
+
+        private enum EnumU16 : ushort
+        {
+            SomeValue = ushort.MaxValue
+        }
+
+        private enum EnumS8 : sbyte
+        {
+            SomeValue = sbyte.MinValue
+        }
+
         private class EntityWithOneProperty
         {
             public int Id { get; set; }
@@ -139,12 +234,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations
         {
             Test(
                 builder => { builder.HasAnnotation("AnnotationName", "AnnotationValue"); },
-                @"builder
-    .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
-    .HasAnnotation(""ChangeDetector.SkipDetectChanges"", ""true"")
-    .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
-    .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
-",
+                AddBoilerPlate(@"
+            modelBuilder
+                .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
+                .HasAnnotation(""ChangeDetector.SkipDetectChanges"", ""true"")
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
+                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);"),
                 o =>
                 {
                     Assert.Equal(4, o.GetAnnotations().Count());
@@ -161,13 +256,13 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     builder.HasDefaultSchema("DefaultSchema");
                     builder.HasAnnotation("AnnotationName", "AnnotationValue");
                 },
-                @"builder
-    .HasDefaultSchema(""DefaultSchema"")
-    .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
-    .HasAnnotation(""ChangeDetector.SkipDetectChanges"", ""true"")
-    .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
-    .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
-",
+                AddBoilerPlate(@"
+            modelBuilder
+                .HasDefaultSchema(""DefaultSchema"")
+                .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
+                .HasAnnotation(""ChangeDetector.SkipDetectChanges"", ""true"")
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
+                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);"),
                 o =>
                 {
                     Assert.Equal(5, o.GetAnnotations().Count());
@@ -185,31 +280,30 @@ namespace Microsoft.EntityFrameworkCore.Migrations
                     builder.Entity<EntityWithOneProperty>().Ignore(e => e.EntityWithTwoProperties);
                     builder.Entity<EntityWithTwoProperties>().Ignore(e => e.EntityWithOneProperty);
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithOneProperty"");
-    });
+                    b.ToTable(""EntityWithOneProperty"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"");
+                    b.Property<int>(""AlternateId"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
-",
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
                 o =>
                 {
                     Assert.Equal(2, o.GetEntityTypes().Count());
@@ -233,20 +327,19 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     builder.Entity<EntityWithOneProperty>().HasAnnotation("AnnotationName", "AnnotationValue");
                     builder.Ignore<EntityWithTwoProperties>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithOneProperty"");
+                    b.ToTable(""EntityWithOneProperty"");
 
-        b.HasAnnotation(""AnnotationName"", ""AnnotationValue"");
-    });
-",
+                    b.HasAnnotation(""AnnotationName"", ""AnnotationValue"");
+                });"),
                 o =>
                 {
                     Assert.Equal(2, o.GetEntityTypes().First().GetAnnotations().Count());
@@ -263,41 +356,40 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     builder.Entity<DerivedEntity>().HasBaseType<BaseEntity>();
                     builder.Entity<AnotherDerivedEntity>().HasBaseType<BaseEntity>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+BaseEntity"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+BaseEntity"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<string>(""Discriminator"")
-            .IsRequired();
+                    b.Property<string>(""Discriminator"")
+                        .IsRequired();
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""BaseEntity"");
+                    b.ToTable(""BaseEntity"");
 
-        b.HasDiscriminator<string>(""Discriminator"").HasValue(""BaseEntity"");
-    });
+                    b.HasDiscriminator<string>(""Discriminator"").HasValue(""BaseEntity"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+AnotherDerivedEntity"", b =>
-    {
-        b.HasBaseType(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+BaseEntity"");
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+AnotherDerivedEntity"", b =>
+                {
+                    b.HasBaseType(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+BaseEntity"");
 
-        b.Property<string>(""Title"");
+                    b.Property<string>(""Title"");
 
-        b.HasDiscriminator().HasValue(""AnotherDerivedEntity"");
-    });
+                    b.HasDiscriminator().HasValue(""AnotherDerivedEntity"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+DerivedEntity"", b =>
-    {
-        b.HasBaseType(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+BaseEntity"");
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+DerivedEntity"", b =>
+                {
+                    b.HasBaseType(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+BaseEntity"");
 
-        b.Property<string>(""Name"");
+                    b.Property<string>(""Name"");
 
-        b.HasDiscriminator().HasValue(""DerivedEntity"");
-    });
-",
+                    b.HasDiscriminator().HasValue(""DerivedEntity"");
+                });"),
                 o =>
                 {
                     Assert.Equal(3, o.GetEntityTypes().Count());
@@ -324,41 +416,40 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                         .HasValue(typeof(DerivedEntity), typeof(DerivedEntity).Name)
                         .HasValue(typeof(AnotherDerivedEntity), typeof(AnotherDerivedEntity).Name);
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+BaseEntity"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+BaseEntity"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<string>(""Discriminator"")
-            .IsRequired();
+                    b.Property<string>(""Discriminator"")
+                        .IsRequired();
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""BaseEntity"");
+                    b.ToTable(""BaseEntity"");
 
-        b.HasDiscriminator<string>(""Discriminator"").HasValue(""BaseEntity"");
-    });
+                    b.HasDiscriminator<string>(""Discriminator"").HasValue(""BaseEntity"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+AnotherDerivedEntity"", b =>
-    {
-        b.HasBaseType(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+BaseEntity"");
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+AnotherDerivedEntity"", b =>
+                {
+                    b.HasBaseType(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+BaseEntity"");
 
-        b.Property<string>(""Title"");
+                    b.Property<string>(""Title"");
 
-        b.HasDiscriminator().HasValue(""AnotherDerivedEntity"");
-    });
+                    b.HasDiscriminator().HasValue(""AnotherDerivedEntity"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+DerivedEntity"", b =>
-    {
-        b.HasBaseType(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+BaseEntity"");
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+DerivedEntity"", b =>
+                {
+                    b.HasBaseType(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+BaseEntity"");
 
-        b.Property<string>(""Name"");
+                    b.Property<string>(""Name"");
 
-        b.HasDiscriminator().HasValue(""DerivedEntity"");
-    });
-",
+                    b.HasDiscriminator().HasValue(""DerivedEntity"");
+                });"),
                 o =>
                 {
                     Assert.Equal("Discriminator", o.FindEntityType(typeof(BaseEntity))[RelationalAnnotationNames.DiscriminatorProperty]);
@@ -377,20 +468,19 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     builder.Entity<EntityWithTwoProperties>();
                     builder.Ignore<EntityWithOneProperty>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"");
+                    b.Property<int>(""AlternateId"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
-",
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
                 o =>
                 {
                     Assert.Equal(2, o.GetEntityTypes().First().GetProperties().Count());
@@ -416,18 +506,17 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                         });
                     builder.Ignore<EntityWithOneProperty>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"");
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"");
 
-        b.Property<int>(""AlternateId"");
+                    b.Property<int>(""AlternateId"");
 
-        b.HasKey(""Id"", ""AlternateId"");
+                    b.HasKey(""Id"", ""AlternateId"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
-",
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
                 o =>
                 {
                     Assert.Equal(2, o.GetEntityTypes().First().FindPrimaryKey().Properties.Count);
@@ -453,22 +542,21 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                         });
                     builder.Ignore<EntityWithOneProperty>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"");
+                    b.Property<int>(""AlternateId"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.HasAlternateKey(""Id"", ""AlternateId"");
+                    b.HasAlternateKey(""Id"", ""AlternateId"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
-",
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
                 o =>
                 {
                     Assert.Collection(
@@ -488,22 +576,21 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     builder.Entity<EntityWithTwoProperties>().HasIndex(t => t.AlternateId);
                     builder.Ignore<EntityWithOneProperty>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"");
+                    b.Property<int>(""AlternateId"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.HasIndex(""AlternateId"");
+                    b.HasIndex(""AlternateId"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
-",
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
                 o =>
                 {
                     Assert.Equal(1, o.GetEntityTypes().First().GetIndexes().Count());
@@ -525,22 +612,21 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                         });
                     builder.Ignore<EntityWithOneProperty>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"");
+                    b.Property<int>(""AlternateId"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.HasIndex(""Id"", ""AlternateId"");
+                    b.HasIndex(""Id"", ""AlternateId"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
-",
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
                 o =>
                 {
                     Assert.Equal(1, o.GetEntityTypes().First().GetIndexes().Count());
@@ -563,42 +649,41 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                         .WithOne(e => e.EntityWithTwoProperties)
                         .HasForeignKey<EntityWithTwoProperties>(e => e.AlternateId);
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithOneProperty"");
-    });
+                    b.ToTable(""EntityWithOneProperty"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"");
+                    b.Property<int>(""AlternateId"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.HasIndex(""AlternateId"")
-            .IsUnique();
+                    b.HasIndex(""AlternateId"")
+                        .IsUnique();
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
+                    b.ToTable(""EntityWithTwoProperties"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""EntityWithOneProperty"")
-            .WithOne(""EntityWithTwoProperties"")
-            .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
-            .OnDelete(DeleteBehavior.Cascade);
-    });
-",
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""EntityWithOneProperty"")
+                        .WithOne(""EntityWithTwoProperties"")
+                        .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });"),
                 o =>
                 {
                     var foreignKey = o.FindEntityType(typeof(EntityWithTwoProperties)).GetForeignKeys().Single();
@@ -620,17 +705,16 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
 
                     originalModel = builder.Model;
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithGenericKey<System.Guid>"", b =>
-    {
-        b.Property<Guid>(""Id"")
-            .ValueGeneratedOnAdd();
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithGenericKey<System.Guid>"", b =>
+                {
+                    b.Property<Guid>(""Id"")
+                        .ValueGeneratedOnAdd();
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithGenericKey<Guid>"");
-    });
-",
+                    b.ToTable(""EntityWithGenericKey<Guid>"");
+                });", usingSystem: true),
                 model =>
                 {
                     var originalEntity = originalModel.FindEntityType(typeof(EntityWithGenericKey<Guid>));
@@ -653,17 +737,16 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
 
                     originalModel = builder.Model;
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithGenericKey<System.Guid>"", b =>
-    {
-        b.Property<Guid>(""Id"")
-            .ValueGeneratedOnAdd();
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithGenericKey<System.Guid>"", b =>
+                {
+                    b.Property<Guid>(""Id"")
+                        .ValueGeneratedOnAdd();
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithGenericKey<Guid>"");
-    });
-",
+                    b.ToTable(""EntityWithGenericKey<Guid>"");
+                });", usingSystem: true),
                 model =>
                 {
                     var originalEntity = originalModel.FindEntityType(typeof(EntityWithGenericKey<Guid>));
@@ -689,22 +772,21 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
 
                     originalModel = builder.Model;
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithGenericProperty<System.Guid>"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithGenericProperty<System.Guid>"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<Guid>(""Property"");
+                    b.Property<Guid>(""Property"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.HasAlternateKey(""Property"");
+                    b.HasAlternateKey(""Property"");
 
-        b.ToTable(""EntityWithGenericProperty<Guid>"");
-    });
-",
+                    b.ToTable(""EntityWithGenericProperty<Guid>"");
+                });", usingSystem: true),
                 model =>
                 {
                     var originalEntity = originalModel.FindEntityType(typeof(EntityWithGenericProperty<Guid>));
@@ -723,22 +805,21 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
         {
             Test(
                 builder => builder.Entity<EntityWithEnumType>().HasDiscriminator(e => e.Day),
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithEnumType"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithEnumType"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<long>(""Day"");
+                    b.Property<long>(""Day"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithEnumType"");
+                    b.ToTable(""EntityWithEnumType"");
 
-        b.HasDiscriminator<long>(""Day"");
-    });
-",
+                    b.HasDiscriminator<long>(""Day"");
+                });"),
                 model => Assert.Equal(typeof(long), model.GetEntityTypes().First().Relational().DiscriminatorProperty.ClrType));
         }
 
@@ -752,23 +833,22 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                         x.Property(e => e.Day).HasConversion<string>();
                         x.HasDiscriminator(e => e.Day);
                     }),
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithEnumType"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithEnumType"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<string>(""Day"")
-            .IsRequired();
+                    b.Property<string>(""Day"")
+                        .IsRequired();
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithEnumType"");
+                    b.ToTable(""EntityWithEnumType"");
 
-        b.HasDiscriminator<string>(""Day"");
-    });
-",
+                    b.HasDiscriminator<string>(""Day"");
+                });"),
                 model =>
                 {
                     var discriminatorProperty = model.GetEntityTypes().First().Relational().DiscriminatorProperty;
@@ -822,113 +902,112 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                         });
                     });
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.HasKey(""Id"")
-            .HasName(""PK_Custom"");
+                    b.HasKey(""Id"")
+                        .HasName(""PK_Custom"");
 
-        b.ToTable(""EntityWithOneProperty"");
+                    b.ToTable(""EntityWithOneProperty"");
 
-        b.HasData(
-            new
-            {
-                Id = 1
-            });
-    });
+                    b.HasData(
+                        new
+                        {
+                            Id = 1
+                        });
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"", b =>
-    {
-        b.Property<string>(""Id"")
-            .ValueGeneratedOnAdd();
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"", b =>
+                {
+                    b.Property<string>(""Id"")
+                        .ValueGeneratedOnAdd();
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithStringKey"");
-    });
+                    b.ToTable(""EntityWithStringKey"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
-    {
-        b.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""EntityWithTwoProperties"", b1 =>
-            {
-                b1.Property<int>(""AlternateId"")
-                    .ValueGeneratedOnAdd()
-                    .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+                {
+                    b.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""EntityWithTwoProperties"", b1 =>
+                        {
+                            b1.Property<int>(""AlternateId"")
+                                .ValueGeneratedOnAdd()
+                                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-                b1.Property<string>(""EntityWithStringKeyId"");
+                            b1.Property<string>(""EntityWithStringKeyId"");
 
-                b1.Property<int>(""Id"");
+                            b1.Property<int>(""Id"");
 
-                b1.HasKey(""AlternateId"")
-                    .HasName(""PK_Custom"");
+                            b1.HasKey(""AlternateId"")
+                                .HasName(""PK_Custom"");
 
-                b1.HasIndex(""EntityWithStringKeyId"")
-                    .IsUnique()
-                    .HasFilter(""[EntityWithTwoProperties_EntityWithStringKeyId] IS NOT NULL"");
+                            b1.HasIndex(""EntityWithStringKeyId"")
+                                .IsUnique()
+                                .HasFilter(""[EntityWithTwoProperties_EntityWithStringKeyId] IS NOT NULL"");
 
-                b1.HasIndex(""Id"");
+                            b1.HasIndex(""Id"");
 
-                b1.ToTable(""EntityWithOneProperty"");
+                            b1.ToTable(""EntityWithOneProperty"");
 
-                b1.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""EntityWithOneProperty"")
-                    .WithOne(""EntityWithTwoProperties"")
-                    .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
-                    .HasConstraintName(""FK_Custom"")
-                    .OnDelete(DeleteBehavior.Cascade);
+                            b1.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""EntityWithOneProperty"")
+                                .WithOne(""EntityWithTwoProperties"")
+                                .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
+                                .HasConstraintName(""FK_Custom"")
+                                .OnDelete(DeleteBehavior.Cascade);
 
-                b1.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"", ""EntityWithStringKey"")
-                    .WithOne()
-                    .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""EntityWithStringKeyId"");
+                            b1.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"", ""EntityWithStringKey"")
+                                .WithOne()
+                                .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""EntityWithStringKeyId"");
 
-                b1.HasData(
-                    new
-                    {
-                        AlternateId = 1,
-                        Id = -1
-                    });
-            });
-    });
+                            b1.HasData(
+                                new
+                                {
+                                    AlternateId = 1,
+                                    Id = -1
+                                });
+                        });
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"", b =>
-    {
-        b.OwnsMany(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", ""Properties"", b1 =>
-            {
-                b1.Property<int>(""Id"")
-                    .ValueGeneratedOnAdd()
-                    .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"", b =>
+                {
+                    b.OwnsMany(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", ""Properties"", b1 =>
+                        {
+                            b1.Property<int>(""Id"")
+                                .ValueGeneratedOnAdd()
+                                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-                b1.Property<int?>(""EntityWithOnePropertyId"");
+                            b1.Property<int?>(""EntityWithOnePropertyId"");
 
-                b1.Property<string>(""EntityWithStringKeyId"")
-                    .IsRequired();
+                            b1.Property<string>(""EntityWithStringKeyId"")
+                                .IsRequired();
 
-                b1.Property<string>(""Name"");
+                            b1.Property<string>(""Name"");
 
-                b1.HasKey(""Id"");
+                            b1.HasKey(""Id"");
 
-                b1.HasIndex(""EntityWithOnePropertyId"")
-                    .IsUnique()
-                    .HasFilter(""[EntityWithOnePropertyId] IS NOT NULL"");
+                            b1.HasIndex(""EntityWithOnePropertyId"")
+                                .IsUnique()
+                                .HasFilter(""[EntityWithOnePropertyId] IS NOT NULL"");
 
-                b1.HasIndex(""EntityWithStringKeyId"");
+                            b1.HasIndex(""EntityWithStringKeyId"");
 
-                b1.ToTable(""EntityWithStringProperty"");
+                            b1.ToTable(""EntityWithStringProperty"");
 
-                b1.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""EntityWithOneProperty"")
-                    .WithOne()
-                    .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", ""EntityWithOnePropertyId"");
+                            b1.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""EntityWithOneProperty"")
+                                .WithOne()
+                                .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", ""EntityWithOnePropertyId"");
 
-                b1.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"")
-                    .WithMany(""Properties"")
-                    .HasForeignKey(""EntityWithStringKeyId"")
-                    .OnDelete(DeleteBehavior.Cascade);
-            });
-    });
-",
+                            b1.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"")
+                                .WithMany(""Properties"")
+                                .HasForeignKey(""EntityWithStringKeyId"")
+                                .OnDelete(DeleteBehavior.Cascade);
+                        });
+                });", usingSystem: true),
                 o =>
                 {
                     var entityWithOneProperty = o.FindEntityType(typeof(EntityWithOneProperty));
@@ -1003,123 +1082,122 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                         od.OwnsOne(c => c.StreetAddress);
                     });
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Order"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Order"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""Order"");
-    });
+                    b.ToTable(""Order"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Order"", b =>
-    {
-        b.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderInfo"", ""OrderInfo"", b1 =>
-            {
-                b1.Property<int>(""OrderId"")
-                    .ValueGeneratedOnAdd()
-                    .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Order"", b =>
+                {
+                    b.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderInfo"", ""OrderInfo"", b1 =>
+                        {
+                            b1.Property<int>(""OrderId"")
+                                .ValueGeneratedOnAdd()
+                                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-                b1.HasKey(""OrderId"");
+                            b1.HasKey(""OrderId"");
 
-                b1.ToTable(""Order"");
+                            b1.ToTable(""Order"");
 
-                b1.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Order"")
-                    .WithOne(""OrderInfo"")
-                    .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderInfo"", ""OrderId"")
-                    .OnDelete(DeleteBehavior.Cascade);
+                            b1.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Order"")
+                                .WithOne(""OrderInfo"")
+                                .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderInfo"", ""OrderId"")
+                                .OnDelete(DeleteBehavior.Cascade);
 
-                b1.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+StreetAddress"", ""StreetAddress"", b2 =>
-                    {
-                        b2.Property<int>(""OrderInfoOrderId"")
-                            .ValueGeneratedOnAdd()
-                            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                            b1.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+StreetAddress"", ""StreetAddress"", b2 =>
+                                {
+                                    b2.Property<int>(""OrderInfoOrderId"")
+                                        .ValueGeneratedOnAdd()
+                                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-                        b2.Property<string>(""City"");
+                                    b2.Property<string>(""City"");
 
-                        b2.HasKey(""OrderInfoOrderId"");
+                                    b2.HasKey(""OrderInfoOrderId"");
 
-                        b2.ToTable(""Order"");
+                                    b2.ToTable(""Order"");
 
-                        b2.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderInfo"")
-                            .WithOne(""StreetAddress"")
-                            .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+StreetAddress"", ""OrderInfoOrderId"")
-                            .OnDelete(DeleteBehavior.Cascade);
-                    });
-            });
+                                    b2.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderInfo"")
+                                        .WithOne(""StreetAddress"")
+                                        .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+StreetAddress"", ""OrderInfoOrderId"")
+                                        .OnDelete(DeleteBehavior.Cascade);
+                                });
+                        });
 
-        b.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderDetails"", ""OrderBillingDetails"", b1 =>
-            {
-                b1.Property<int>(""OrderId"")
-                    .ValueGeneratedOnAdd()
-                    .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                    b.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderDetails"", ""OrderBillingDetails"", b1 =>
+                        {
+                            b1.Property<int>(""OrderId"")
+                                .ValueGeneratedOnAdd()
+                                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-                b1.HasKey(""OrderId"");
+                            b1.HasKey(""OrderId"");
 
-                b1.ToTable(""Order"");
+                            b1.ToTable(""Order"");
 
-                b1.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Order"")
-                    .WithOne(""OrderBillingDetails"")
-                    .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderDetails"", ""OrderId"")
-                    .OnDelete(DeleteBehavior.Cascade);
+                            b1.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Order"")
+                                .WithOne(""OrderBillingDetails"")
+                                .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderDetails"", ""OrderId"")
+                                .OnDelete(DeleteBehavior.Cascade);
 
-                b1.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+StreetAddress"", ""StreetAddress"", b2 =>
-                    {
-                        b2.Property<int>(""OrderDetailsOrderId"")
-                            .ValueGeneratedOnAdd()
-                            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                            b1.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+StreetAddress"", ""StreetAddress"", b2 =>
+                                {
+                                    b2.Property<int>(""OrderDetailsOrderId"")
+                                        .ValueGeneratedOnAdd()
+                                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-                        b2.Property<string>(""City"");
+                                    b2.Property<string>(""City"");
 
-                        b2.HasKey(""OrderDetailsOrderId"");
+                                    b2.HasKey(""OrderDetailsOrderId"");
 
-                        b2.ToTable(""Order"");
+                                    b2.ToTable(""Order"");
 
-                        b2.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderDetails"")
-                            .WithOne(""StreetAddress"")
-                            .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+StreetAddress"", ""OrderDetailsOrderId"")
-                            .OnDelete(DeleteBehavior.Cascade);
-                    });
-            });
+                                    b2.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderDetails"")
+                                        .WithOne(""StreetAddress"")
+                                        .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+StreetAddress"", ""OrderDetailsOrderId"")
+                                        .OnDelete(DeleteBehavior.Cascade);
+                                });
+                        });
 
-        b.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderDetails"", ""OrderShippingDetails"", b1 =>
-            {
-                b1.Property<int>(""OrderId"")
-                    .ValueGeneratedOnAdd()
-                    .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                    b.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderDetails"", ""OrderShippingDetails"", b1 =>
+                        {
+                            b1.Property<int>(""OrderId"")
+                                .ValueGeneratedOnAdd()
+                                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-                b1.HasKey(""OrderId"");
+                            b1.HasKey(""OrderId"");
 
-                b1.ToTable(""Order"");
+                            b1.ToTable(""Order"");
 
-                b1.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Order"")
-                    .WithOne(""OrderShippingDetails"")
-                    .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderDetails"", ""OrderId"")
-                    .OnDelete(DeleteBehavior.Cascade);
+                            b1.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+Order"")
+                                .WithOne(""OrderShippingDetails"")
+                                .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderDetails"", ""OrderId"")
+                                .OnDelete(DeleteBehavior.Cascade);
 
-                b1.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+StreetAddress"", ""StreetAddress"", b2 =>
-                    {
-                        b2.Property<int>(""OrderDetailsOrderId"")
-                            .ValueGeneratedOnAdd()
-                            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                            b1.OwnsOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+StreetAddress"", ""StreetAddress"", b2 =>
+                                {
+                                    b2.Property<int>(""OrderDetailsOrderId"")
+                                        .ValueGeneratedOnAdd()
+                                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-                        b2.Property<string>(""City"");
+                                    b2.Property<string>(""City"");
 
-                        b2.HasKey(""OrderDetailsOrderId"");
+                                    b2.HasKey(""OrderDetailsOrderId"");
 
-                        b2.ToTable(""Order"");
+                                    b2.ToTable(""Order"");
 
-                        b2.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderDetails"")
-                            .WithOne(""StreetAddress"")
-                            .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+StreetAddress"", ""OrderDetailsOrderId"")
-                            .OnDelete(DeleteBehavior.Cascade);
-                    });
-            });
-    });
-",
+                                    b2.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+OrderDetails"")
+                                        .WithOne(""StreetAddress"")
+                                        .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+StreetAddress"", ""OrderDetailsOrderId"")
+                                        .OnDelete(DeleteBehavior.Cascade);
+                                });
+                        });
+                });"),
                 o =>
                 {
                     Assert.Equal(7, o.GetEntityTypes().Count());
@@ -1187,19 +1265,18 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
 
                     builder.Ignore<EntityWithTwoProperties>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithOneProperty"");
-    });
-",
+                    b.ToTable(""EntityWithOneProperty"");
+                });"),
                 o => { Assert.Equal("AnnotationValue", o.GetEntityTypes().First().FindProperty("Id")["AnnotationName"]); }
             );
         }
@@ -1213,18 +1290,17 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     builder.Entity<EntityWithOneProperty>().Property<int>("Id").HasValueGenerator<CustomValueGenerator>();
                     builder.Ignore<EntityWithTwoProperties>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithOneProperty"");
-    });
-",
+                    b.ToTable(""EntityWithOneProperty"");
+                });"),
                 o => { Assert.Null(o.GetEntityTypes().First().FindProperty("Id")[CoreAnnotationNames.ValueGeneratorFactoryAnnotation]); }
             );
         }
@@ -1234,21 +1310,20 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
         {
             Test(
                 builder => { builder.Entity<EntityWithStringProperty>().Property<string>("Name").IsRequired(); },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<string>(""Name"")
-            .IsRequired();
+                    b.Property<string>(""Name"")
+                        .IsRequired();
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithStringProperty"");
-    });
-",
+                    b.ToTable(""EntityWithStringProperty"");
+                });"),
                 o => { Assert.False(o.GetEntityTypes().First().FindProperty("Name").IsNullable); });
         }
 
@@ -1261,22 +1336,21 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     builder.Entity<EntityWithTwoProperties>().Property<int>("AlternateId").HasDefaultValue();
                     builder.Ignore<EntityWithOneProperty>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"")
-            .ValueGeneratedOnAdd()
-            .HasDefaultValue(null);
+                    b.Property<int>(""AlternateId"")
+                        .ValueGeneratedOnAdd()
+                        .HasDefaultValue(null);
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
-",
+                    b.ToTable(""EntityWithTwoProperties"");
+                });", usingSystem: true),
                 o => { Assert.Equal(ValueGenerated.OnAdd, o.GetEntityTypes().First().FindProperty("AlternateId").ValueGenerated); });
         }
 
@@ -1285,21 +1359,20 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
         {
             Test(
                 builder => { builder.Entity<EntityWithStringProperty>().Property<string>("Name").HasMaxLength(100); },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<string>(""Name"")
-            .HasMaxLength(100);
+                    b.Property<string>(""Name"")
+                        .HasMaxLength(100);
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithStringProperty"");
-    });
-",
+                    b.ToTable(""EntityWithStringProperty"");
+                });"),
                 o => { Assert.Equal(100, o.GetEntityTypes().First().FindProperty("Name").GetMaxLength()); });
         }
 
@@ -1308,21 +1381,20 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
         {
             Test(
                 builder => { builder.Entity<EntityWithStringProperty>().Property<string>("Name").IsUnicode(false); },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<string>(""Name"")
-            .IsUnicode(false);
+                    b.Property<string>(""Name"")
+                        .IsUnicode(false);
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithStringProperty"");
-    });
-",
+                    b.ToTable(""EntityWithStringProperty"");
+                });"),
                 o => { Assert.False(o.GetEntityTypes().First().FindProperty("Name").IsUnicode()); });
         }
 
@@ -1331,21 +1403,20 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
         {
             Test(
                 builder => { builder.Entity<EntityWithStringProperty>().Property<string>("Name").IsFixedLength(true); },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<string>(""Name"")
-            .IsFixedLength(true);
+                    b.Property<string>(""Name"")
+                        .IsFixedLength(true);
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithStringProperty"");
-    });
-",
+                    b.ToTable(""EntityWithStringProperty"");
+                });"),
                 o => { Assert.True(o.GetEntityTypes().First().FindProperty("Name").Relational().IsFixedLength); });
         }
 
@@ -1361,23 +1432,22 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                         .IsUnicode(false)
                         .HasAnnotation("AnnotationName", "AnnotationValue");
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<string>(""Name"")
-            .HasMaxLength(100)
-            .IsUnicode(false)
-            .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
+                    b.Property<string>(""Name"")
+                        .HasMaxLength(100)
+                        .IsUnicode(false)
+                        .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithStringProperty"");
-    });
-",
+                    b.ToTable(""EntityWithStringProperty"");
+                });"),
                 o =>
                 {
                     var property = o.GetEntityTypes().First().FindProperty("Name");
@@ -1396,21 +1466,20 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     builder.Entity<EntityWithTwoProperties>().Property<int>("AlternateId").IsConcurrencyToken();
                     builder.Ignore<EntityWithOneProperty>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"")
-            .IsConcurrencyToken();
+                    b.Property<int>(""AlternateId"")
+                        .IsConcurrencyToken();
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
-",
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
                 o => { Assert.True(o.GetEntityTypes().First().FindProperty("AlternateId").IsConcurrencyToken); });
         }
 
@@ -1423,21 +1492,20 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     builder.Entity<EntityWithTwoProperties>().Property<int>("AlternateId").HasColumnName("CName");
                     builder.Ignore<EntityWithOneProperty>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"")
-            .HasColumnName(""CName"");
+                    b.Property<int>(""AlternateId"")
+                        .HasColumnName(""CName"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
-",
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
                 o => { Assert.Equal("CName", o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:ColumnName"]); });
         }
 
@@ -1450,21 +1518,20 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     builder.Entity<EntityWithTwoProperties>().Property<int>("AlternateId").HasColumnType("CType");
                     builder.Ignore<EntityWithOneProperty>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"")
-            .HasColumnType(""CType"");
+                    b.Property<int>(""AlternateId"")
+                        .HasColumnType(""CType"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
-",
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
                 o => { Assert.Equal("CType", o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:ColumnType"]); });
         }
 
@@ -1477,22 +1544,21 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     builder.Entity<EntityWithTwoProperties>().Property<int>("AlternateId").HasDefaultValue(1);
                     builder.Ignore<EntityWithOneProperty>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"")
-            .ValueGeneratedOnAdd()
-            .HasDefaultValue(1);
+                    b.Property<int>(""AlternateId"")
+                        .ValueGeneratedOnAdd()
+                        .HasDefaultValue(1);
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
-",
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
                 o => { Assert.Equal(1, o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:DefaultValue"]); });
         }
 
@@ -1505,22 +1571,21 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     builder.Entity<EntityWithTwoProperties>().Property<int>("AlternateId").HasDefaultValueSql("SQL");
                     builder.Ignore<EntityWithOneProperty>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"")
-            .ValueGeneratedOnAdd()
-            .HasDefaultValueSql(""SQL"");
+                    b.Property<int>(""AlternateId"")
+                        .ValueGeneratedOnAdd()
+                        .HasDefaultValueSql(""SQL"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
-",
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
                 o => { Assert.Equal("SQL", o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:DefaultValueSql"]); });
         }
 
@@ -1533,22 +1598,21 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     builder.Entity<EntityWithTwoProperties>().Property<int>("AlternateId").HasComputedColumnSql("SQL");
                     builder.Ignore<EntityWithOneProperty>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"")
-            .ValueGeneratedOnAddOrUpdate()
-            .HasComputedColumnSql(""SQL"");
+                    b.Property<int>(""AlternateId"")
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasComputedColumnSql(""SQL"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
-",
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
                 o => { Assert.Equal("SQL", o.GetEntityTypes().First().FindProperty("AlternateId")["Relational:ComputedColumnSql"]); });
         }
 
@@ -1557,22 +1621,21 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
         {
             Test(
                 builder => { builder.Entity<EntityWithEnumType>().Property(e => e.Day).HasDefaultValue(Days.Wed); },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithEnumType"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithEnumType"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<long>(""Day"")
-            .ValueGeneratedOnAdd()
-            .HasDefaultValue(3L);
+                    b.Property<long>(""Day"")
+                        .ValueGeneratedOnAdd()
+                        .HasDefaultValue(3L);
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithEnumType"");
-    });
-",
+                    b.ToTable(""EntityWithEnumType"");
+                });"),
                 o => { Assert.Equal(3L, o.GetEntityTypes().First().FindProperty("Day")["Relational:DefaultValue"]); });
         }
 
@@ -1592,30 +1655,29 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                                 Day = Days.Fri
                             });
                     }),
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithEnumType"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithEnumType"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<string>(""Day"")
-            .IsRequired()
-            .ValueGeneratedOnAdd()
-            .HasDefaultValue(""Wed"");
+                    b.Property<string>(""Day"")
+                        .IsRequired()
+                        .ValueGeneratedOnAdd()
+                        .HasDefaultValue(""Wed"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithEnumType"");
+                    b.ToTable(""EntityWithEnumType"");
 
-        b.HasData(
-            new
-            {
-                Id = 1,
-                Day = ""Fri""
-            });
-    });
-",
+                    b.HasData(
+                        new
+                        {
+                            Id = 1,
+                            Day = ""Fri""
+                        });
+                });"),
                 o =>
                 {
                     var property = o.GetEntityTypes().First().FindProperty("Day");
@@ -1630,20 +1692,19 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
         {
             Test(
                 builder => builder.Entity<EntityWithNullableEnumType>().Property(e => e.Day),
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithNullableEnumType"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithNullableEnumType"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<long?>(""Day"");
+                    b.Property<long?>(""Day"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithNullableEnumType"");
-    });
-",
+                    b.ToTable(""EntityWithNullableEnumType"");
+                });"),
                 o => Assert.True(o.GetEntityTypes().First().FindProperty("Day").IsNullable));
         }
 
@@ -1653,20 +1714,19 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
             Test(
                 builder => builder.Entity<EntityWithEnumType>().Property(e => e.Day)
                     .HasConversion(m => (long?)m, p => p.HasValue ? (Days)p.Value : default),
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithEnumType"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithEnumType"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<long>(""Day"");
+                    b.Property<long>(""Day"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithEnumType"");
-    });
-",
+                    b.ToTable(""EntityWithEnumType"");
+                });", usingSystem: true),
                 o => Assert.False(o.GetEntityTypes().First().FindProperty("Day").IsNullable));
         }
 
@@ -1675,20 +1735,19 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
         {
             Test(
                 builder => builder.Entity<EntityWithNullableEnumType>().Property(e => e.Day).HasConversion<string>(),
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithNullableEnumType"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithNullableEnumType"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<string>(""Day"");
+                    b.Property<string>(""Day"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithNullableEnumType"");
-    });
-",
+                    b.ToTable(""EntityWithNullableEnumType"");
+                });"),
                 o => Assert.True(o.GetEntityTypes().First().FindProperty("Day").IsNullable));
         }
 
@@ -1701,22 +1760,21 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     builder.Entity<EntityWithTwoProperties>().Property<int>("AlternateId").HasColumnName("CName").HasAnnotation("AnnotationName", "AnnotationValue");
                     builder.Ignore<EntityWithOneProperty>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"")
-            .HasColumnName(""CName"")
-            .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
+                    b.Property<int>(""AlternateId"")
+                        .HasColumnName(""CName"")
+                        .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
-",
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
                 o =>
                 {
                     var property = o.GetEntityTypes().First().FindProperty("AlternateId");
@@ -1740,23 +1798,22 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                         .HasAnnotation("AnnotationName", "AnnotationValue");
                     builder.Ignore<EntityWithOneProperty>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"");
+                    b.Property<int>(""AlternateId"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.HasAlternateKey(""AlternateId"")
-            .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
+                    b.HasAlternateKey(""AlternateId"")
+                        .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
-",
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
                 o => { Assert.Equal("AnnotationValue", o.GetEntityTypes().First().GetKeys().Where(k => !k.IsPrimaryKey()).First()["AnnotationName"]); });
         }
 
@@ -1769,23 +1826,22 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     builder.Entity<EntityWithTwoProperties>().HasAlternateKey(t => t.AlternateId).HasName("KeyName");
                     builder.Ignore<EntityWithOneProperty>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"");
+                    b.Property<int>(""AlternateId"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.HasAlternateKey(""AlternateId"")
-            .HasName(""KeyName"");
+                    b.HasAlternateKey(""AlternateId"")
+                        .HasName(""KeyName"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
-",
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
                 o => { Assert.Equal("KeyName", o.GetEntityTypes().First().GetKeys().Where(k => !k.IsPrimaryKey()).First()["Relational:Name"]); });
         }
 
@@ -1798,24 +1854,23 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     builder.Entity<EntityWithTwoProperties>().HasAlternateKey(t => t.AlternateId).HasName("IndexName").HasAnnotation("AnnotationName", "AnnotationValue");
                     builder.Ignore<EntityWithOneProperty>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"");
+                    b.Property<int>(""AlternateId"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.HasAlternateKey(""AlternateId"")
-            .HasName(""IndexName"")
-            .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
+                    b.HasAlternateKey(""AlternateId"")
+                        .HasName(""IndexName"")
+                        .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
-",
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
                 o =>
                 {
                     var key = o.GetEntityTypes().First().GetKeys().Where(k => !k.IsPrimaryKey()).First();
@@ -1839,23 +1894,22 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                         .HasAnnotation("AnnotationName", "AnnotationValue");
                     builder.Ignore<EntityWithOneProperty>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"");
+                    b.Property<int>(""AlternateId"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.HasIndex(""AlternateId"")
-            .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
+                    b.HasIndex(""AlternateId"")
+                        .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
-",
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
                 o => { Assert.Equal("AnnotationValue", o.GetEntityTypes().First().GetIndexes().First()["AnnotationName"]); });
         }
 
@@ -1868,23 +1922,22 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     builder.Entity<EntityWithTwoProperties>().HasIndex(t => t.AlternateId).IsUnique();
                     builder.Ignore<EntityWithOneProperty>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"");
+                    b.Property<int>(""AlternateId"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.HasIndex(""AlternateId"")
-            .IsUnique();
+                    b.HasIndex(""AlternateId"")
+                        .IsUnique();
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
-",
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
                 o => { Assert.True(o.GetEntityTypes().First().GetIndexes().First().IsUnique); });
         }
 
@@ -1897,23 +1950,22 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     builder.Entity<EntityWithTwoProperties>().HasIndex(t => t.AlternateId).HasName("IndexName");
                     builder.Ignore<EntityWithOneProperty>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"");
+                    b.Property<int>(""AlternateId"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.HasIndex(""AlternateId"")
-            .HasName(""IndexName"");
+                    b.HasIndex(""AlternateId"")
+                        .HasName(""IndexName"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
-",
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
                 o => { Assert.Equal("IndexName", o.GetEntityTypes().First().GetIndexes().First()["Relational:Name"]); });
         }
 
@@ -1927,23 +1979,22 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                         .HasFilter("AlternateId <> 0");
                     builder.Ignore<EntityWithOneProperty>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"");
+                    b.Property<int>(""AlternateId"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.HasIndex(""AlternateId"")
-            .HasFilter(""AlternateId <> 0"");
+                    b.HasIndex(""AlternateId"")
+                        .HasFilter(""AlternateId <> 0"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
-",
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
                 o => Assert.Equal(
                     "AlternateId <> 0",
                     o.GetEntityTypes().First().GetIndexes().First().Relational().Filter));
@@ -1958,24 +2009,23 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     builder.Entity<EntityWithTwoProperties>().HasIndex(t => t.AlternateId).HasName("IndexName").HasAnnotation("AnnotationName", "AnnotationValue");
                     builder.Ignore<EntityWithOneProperty>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"");
+                    b.Property<int>(""AlternateId"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.HasIndex(""AlternateId"")
-            .HasName(""IndexName"")
-            .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
+                    b.HasIndex(""AlternateId"")
+                        .HasName(""IndexName"")
+                        .HasAnnotation(""AnnotationName"", ""AnnotationValue"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
-",
+                    b.ToTable(""EntityWithTwoProperties"");
+                });"),
                 o =>
                 {
                     var index = o.GetEntityTypes().First().GetIndexes().First();
@@ -1996,24 +2046,23 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                         x.Property<string>(propertyName);
                         x.HasIndex(propertyName);
                     }),
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<string>(""Name"");
+                    b.Property<string>(""Name"");
 
-        b.Property<string>(""SomePropertyWithAnExceedinglyLongIdentifierThatCausesTheDefaultIndexNameToExceedTheMaximumIdentifierLimit"");
+                    b.Property<string>(""SomePropertyWithAnExceedinglyLongIdentifierThatCausesTheDefaultIndexNameToExceedTheMaximumIdentifierLimit"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.HasIndex(""SomePropertyWithAnExceedinglyLongIdentifierThatCausesTheDefaultIndexNameToExceedTheMaximumIdentifierLimit"");
+                    b.HasIndex(""SomePropertyWithAnExceedinglyLongIdentifierThatCausesTheDefaultIndexNameToExceedTheMaximumIdentifierLimit"");
 
-        b.ToTable(""EntityWithStringProperty"");
-    });
-",
+                    b.ToTable(""EntityWithStringProperty"");
+                });"),
                 model => Assert.Equal(128, model.GetEntityTypes().First().GetIndexes().First().Relational().Name.Length));
         }
 
@@ -2033,43 +2082,42 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                         .HasForeignKey<EntityWithTwoProperties>(e => e.AlternateId)
                         .HasAnnotation("AnnotationName", "AnnotationValue");
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithOneProperty"");
-    });
+                    b.ToTable(""EntityWithOneProperty"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"");
+                    b.Property<int>(""AlternateId"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.HasIndex(""AlternateId"")
-            .IsUnique();
+                    b.HasIndex(""AlternateId"")
+                        .IsUnique();
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
+                    b.ToTable(""EntityWithTwoProperties"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""EntityWithOneProperty"")
-            .WithOne(""EntityWithTwoProperties"")
-            .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
-            .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
-            .OnDelete(DeleteBehavior.Cascade);
-    });
-",
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""EntityWithOneProperty"")
+                        .WithOne(""EntityWithTwoProperties"")
+                        .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
+                        .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });"),
                 o => { Assert.Equal("AnnotationValue", o.FindEntityType(typeof(EntityWithTwoProperties)).GetForeignKeys().First()["AnnotationName"]); });
         }
 
@@ -2086,42 +2134,41 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                         .HasForeignKey<EntityWithStringProperty>(e => e.Name)
                         .IsRequired();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"", b =>
-    {
-        b.Property<string>(""Id"")
-            .ValueGeneratedOnAdd();
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"", b =>
+                {
+                    b.Property<string>(""Id"")
+                        .ValueGeneratedOnAdd();
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithStringKey"");
-    });
+                    b.ToTable(""EntityWithStringKey"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<string>(""Name"")
-            .IsRequired();
+                    b.Property<string>(""Name"")
+                        .IsRequired();
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.HasIndex(""Name"")
-            .IsUnique();
+                    b.HasIndex(""Name"")
+                        .IsUnique();
 
-        b.ToTable(""EntityWithStringProperty"");
-    });
+                    b.ToTable(""EntityWithStringProperty"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
-    {
-        b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"")
-            .WithOne()
-            .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", ""Name"")
-            .OnDelete(DeleteBehavior.Cascade);
-    });
-",
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
+                {
+                    b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"")
+                        .WithOne()
+                        .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", ""Name"")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });"),
                 o => { Assert.False(o.FindEntityType(typeof(EntityWithStringProperty)).FindProperty("Name").IsNullable); });
         }
 
@@ -2136,39 +2183,38 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                         .WithMany(e => e.Properties)
                         .HasForeignKey(e => e.Name);
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"", b =>
-    {
-        b.Property<string>(""Id"")
-            .ValueGeneratedOnAdd();
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"", b =>
+                {
+                    b.Property<string>(""Id"")
+                        .ValueGeneratedOnAdd();
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithStringKey"");
-    });
+                    b.ToTable(""EntityWithStringKey"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<string>(""Name"");
+                    b.Property<string>(""Name"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.HasIndex(""Name"");
+                    b.HasIndex(""Name"");
 
-        b.ToTable(""EntityWithStringProperty"");
-    });
+                    b.ToTable(""EntityWithStringProperty"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
-    {
-        b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"")
-            .WithMany(""Properties"")
-            .HasForeignKey(""Name"");
-    });
-",
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringProperty"", b =>
+                {
+                    b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithStringKey"")
+                        .WithMany(""Properties"")
+                        .HasForeignKey(""Name"");
+                });"),
                 o => { Assert.False(o.FindEntityType(typeof(EntityWithStringProperty)).GetForeignKeys().First().IsUnique); });
         }
 
@@ -2184,37 +2230,36 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                         .HasForeignKey(e => e.Id);
                     builder.Entity<EntityWithTwoProperties>().Ignore(e => e.EntityWithOneProperty);
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
-    {
-        b.Property<int>(""Id"");
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+                {
+                    b.Property<int>(""Id"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithOneProperty"");
-    });
+                    b.ToTable(""EntityWithOneProperty"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"");
+                    b.Property<int>(""AlternateId"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
+                    b.ToTable(""EntityWithTwoProperties"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
-    {
-        b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""EntityWithTwoProperties"")
-            .WithMany()
-            .HasForeignKey(""Id"")
-            .OnDelete(DeleteBehavior.Cascade);
-    });
-",
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+                {
+                    b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""EntityWithTwoProperties"")
+                        .WithMany()
+                        .HasForeignKey(""Id"")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });"),
                 o => { Assert.Equal(DeleteBehavior.Cascade, o.FindEntityType(typeof(EntityWithOneProperty)).GetForeignKeys().First().DeleteBehavior); });
         }
 
@@ -2229,37 +2274,36 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                         .WithOne(e => e.EntityWithOneProperty)
                         .HasForeignKey<EntityWithOneProperty>(e => e.Id);
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
-    {
-        b.Property<int>(""Id"");
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+                {
+                    b.Property<int>(""Id"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithOneProperty"");
-    });
+                    b.ToTable(""EntityWithOneProperty"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"");
+                    b.Property<int>(""AlternateId"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
+                    b.ToTable(""EntityWithTwoProperties"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
-    {
-        b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""EntityWithTwoProperties"")
-            .WithOne(""EntityWithOneProperty"")
-            .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""Id"")
-            .OnDelete(DeleteBehavior.Cascade);
-    });
-",
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+                {
+                    b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""EntityWithTwoProperties"")
+                        .WithOne(""EntityWithOneProperty"")
+                        .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""Id"")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });"),
                 o => { Assert.Equal(DeleteBehavior.Cascade, o.FindEntityType(typeof(EntityWithOneProperty)).GetForeignKeys().First().DeleteBehavior); });
         }
 
@@ -2276,40 +2320,39 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
 
                     originalModel = builder.Model;
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithGenericKey<System.Guid>"", b =>
-    {
-        b.Property<Guid>(""Id"")
-            .ValueGeneratedOnAdd();
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithGenericKey<System.Guid>"", b =>
+                {
+                    b.Property<Guid>(""Id"")
+                        .ValueGeneratedOnAdd();
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithGenericKey<Guid>"");
-    });
+                    b.ToTable(""EntityWithGenericKey<Guid>"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithGenericProperty<System.Guid>"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithGenericProperty<System.Guid>"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<Guid>(""Property"");
+                    b.Property<Guid>(""Property"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.HasIndex(""Property"");
+                    b.HasIndex(""Property"");
 
-        b.ToTable(""EntityWithGenericProperty<Guid>"");
-    });
+                    b.ToTable(""EntityWithGenericProperty<Guid>"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithGenericProperty<System.Guid>"", b =>
-    {
-        b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithGenericKey<System.Guid>"")
-            .WithMany()
-            .HasForeignKey(""Property"")
-            .OnDelete(DeleteBehavior.Cascade);
-    });
-",
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithGenericProperty<System.Guid>"", b =>
+                {
+                    b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithGenericKey<System.Guid>"")
+                        .WithMany()
+                        .HasForeignKey(""Property"")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });", usingSystem: true),
                 model =>
                 {
                     var originalParent = originalModel.FindEntityType(typeof(EntityWithGenericKey<Guid>));
@@ -2350,43 +2393,42 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                         .HasForeignKey<EntityWithTwoProperties>(e => e.AlternateId)
                         .HasConstraintName("Constraint");
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithOneProperty"");
-    });
+                    b.ToTable(""EntityWithOneProperty"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"");
+                    b.Property<int>(""AlternateId"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.HasIndex(""AlternateId"")
-            .IsUnique();
+                    b.HasIndex(""AlternateId"")
+                        .IsUnique();
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
+                    b.ToTable(""EntityWithTwoProperties"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""EntityWithOneProperty"")
-            .WithOne(""EntityWithTwoProperties"")
-            .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
-            .HasConstraintName(""Constraint"")
-            .OnDelete(DeleteBehavior.Cascade);
-    });
-",
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""EntityWithOneProperty"")
+                        .WithOne(""EntityWithTwoProperties"")
+                        .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
+                        .HasConstraintName(""Constraint"")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });"),
                 o => { Assert.Equal("Constraint", o.FindEntityType(typeof(EntityWithTwoProperties)).GetForeignKeys().First()["Relational:Name"]); });
         }
 
@@ -2403,44 +2445,43 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                         .HasAnnotation("AnnotationName", "AnnotationValue")
                         .HasConstraintName("Constraint");
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithOneProperty"");
-    });
+                    b.ToTable(""EntityWithOneProperty"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"");
+                    b.Property<int>(""AlternateId"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.HasIndex(""AlternateId"")
-            .IsUnique();
+                    b.HasIndex(""AlternateId"")
+                        .IsUnique();
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
+                    b.ToTable(""EntityWithTwoProperties"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""EntityWithOneProperty"")
-            .WithOne(""EntityWithTwoProperties"")
-            .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
-            .HasConstraintName(""Constraint"")
-            .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
-            .OnDelete(DeleteBehavior.Cascade);
-    });
-",
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""EntityWithOneProperty"")
+                        .WithOne(""EntityWithTwoProperties"")
+                        .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
+                        .HasConstraintName(""Constraint"")
+                        .HasAnnotation(""AnnotationName"", ""AnnotationValue"")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });"),
                 o =>
                 {
                     var fk = o.FindEntityType(typeof(EntityWithTwoProperties)).GetForeignKeys().First();
@@ -2460,52 +2501,51 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                     builder.Ignore<EntityWithTwoProperties>();
                     builder.Entity<DerivedType>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+BaseType"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+BaseType"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<string>(""Discriminator"")
-            .IsRequired();
+                    b.Property<string>(""Discriminator"")
+                        .IsRequired();
 
-        b.Property<int?>(""NavigationId"");
+                    b.Property<int?>(""NavigationId"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.HasIndex(""NavigationId"");
+                    b.HasIndex(""NavigationId"");
 
-        b.ToTable(""BaseType"");
+                    b.ToTable(""BaseType"");
 
-        b.HasDiscriminator<string>(""Discriminator"").HasValue(""BaseType"");
-    });
+                    b.HasDiscriminator<string>(""Discriminator"").HasValue(""BaseType"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithOneProperty"");
-    });
+                    b.ToTable(""EntityWithOneProperty"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+DerivedType"", b =>
-    {
-        b.HasBaseType(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+BaseType"");
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+DerivedType"", b =>
+                {
+                    b.HasBaseType(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+BaseType"");
 
-        b.HasDiscriminator().HasValue(""DerivedType"");
-    });
+                    b.HasDiscriminator().HasValue(""DerivedType"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+BaseType"", b =>
-    {
-        b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""Navigation"")
-            .WithMany()
-            .HasForeignKey(""NavigationId"");
-    });
-",
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+BaseType"", b =>
+                {
+                    b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""Navigation"")
+                        .WithMany()
+                        .HasForeignKey(""NavigationId"");
+                });", usingSystem: true),
                 o => { });
         }
 
@@ -2521,38 +2561,37 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
                         .HasForeignKey<EntityWithOneProperty>(e => e.Id)
                         .HasPrincipalKey<EntityWithTwoProperties>(e => e.AlternateId);
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
-    {
-        b.Property<int>(""Id"");
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+                {
+                    b.Property<int>(""Id"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithOneProperty"");
-    });
+                    b.ToTable(""EntityWithOneProperty"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"");
+                    b.Property<int>(""AlternateId"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
+                    b.ToTable(""EntityWithTwoProperties"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
-    {
-        b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""EntityWithTwoProperties"")
-            .WithOne(""EntityWithOneProperty"")
-            .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""Id"")
-            .HasPrincipalKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
-            .OnDelete(DeleteBehavior.Cascade);
-    });
-",
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+                {
+                    b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""EntityWithTwoProperties"")
+                        .WithOne(""EntityWithOneProperty"")
+                        .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""Id"")
+                        .HasPrincipalKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });"),
                 o =>
                 {
                     Assert.Equal(2, o.FindEntityType(typeof(EntityWithTwoProperties)).GetKeys().Count());
@@ -2574,41 +2613,40 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
 
                     builder.Entity<EntityWithTwoProperties>().HasAlternateKey(e => e.AlternateId).HasAnnotation("Name", "Value");
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
-    {
-        b.Property<int>(""Id"");
+                AddBoilerPlate(GetHeading() + @"
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+                {
+                    b.Property<int>(""Id"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.ToTable(""EntityWithOneProperty"");
-    });
+                    b.ToTable(""EntityWithOneProperty"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<int>(""AlternateId"");
+                    b.Property<int>(""AlternateId"");
 
-        b.HasKey(""Id"");
+                    b.HasKey(""Id"");
 
-        b.HasAlternateKey(""AlternateId"")
-            .HasAnnotation(""Name"", ""Value"");
+                    b.HasAlternateKey(""AlternateId"")
+                        .HasAnnotation(""Name"", ""Value"");
 
-        b.ToTable(""EntityWithTwoProperties"");
-    });
+                    b.ToTable(""EntityWithTwoProperties"");
+                });
 
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
-    {
-        b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""EntityWithTwoProperties"")
-            .WithOne(""EntityWithOneProperty"")
-            .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""Id"")
-            .HasPrincipalKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
-            .OnDelete(DeleteBehavior.Cascade);
-    });
-",
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+                {
+                    b.HasOne(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""EntityWithTwoProperties"")
+                        .WithOne(""EntityWithOneProperty"")
+                        .HasForeignKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", ""Id"")
+                        .HasPrincipalKey(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", ""AlternateId"")
+                        .OnDelete(DeleteBehavior.Cascade);
+                });"),
                 o =>
                 {
                     var entityType = o.FindEntityType(typeof(EntityWithTwoProperties));
@@ -2621,149 +2659,478 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
         #endregion
 
         #region SeedData
-
+#if !Test21
         [Fact]
         public virtual void SeedData_annotations_are_stored_in_snapshot()
         {
+            var lineString1 = new LineString(
+                new[] { new Coordinate(1.1, 2.2), new Coordinate(2.2, 2.2), new Coordinate(2.2, 1.1), new Coordinate(7.1, 7.2) });
+
+            var lineString2 = new LineString(
+                new[] { new Coordinate(7.1, 7.2), new Coordinate(20.2, 20.2), new Coordinate(20.20, 1.1), new Coordinate(70.1, 70.2) });
+
+            var multiPoint = new MultiPoint(
+                new IPoint[] { new Point(1.1, 2.2), new Point(2.2, 2.2), new Point(2.2, 1.1) });
+
+            var polygon1 = new Polygon(
+                new LinearRing(
+                    new[] { new Coordinate(1.1, 2.2), new Coordinate(2.2, 2.2), new Coordinate(2.2, 1.1), new Coordinate(1.1, 2.2) }));
+
+            var polygon2 = new Polygon(
+                new LinearRing(
+                    new[] { new Coordinate(10.1, 20.2), new Coordinate(20.2, 20.2), new Coordinate(20.2, 10.1), new Coordinate(10.1, 20.2) }));
+
+            var point1 = new Point(1.1, 2.2, 3.3);
+
+            var multiLineString = new MultiLineString(
+                new ILineString[] { lineString1, lineString2, });
+
+            var multiPolygon = new MultiPolygon(
+                new IPolygon[] { polygon2, polygon1, });
+
+            var geometryCollection = new GeometryCollection(
+                new IGeometry[] { lineString1, lineString2, multiPoint, polygon1, polygon2, point1, multiLineString, multiPolygon });
+
             Test(
                 builder =>
                 {
-                    builder.Entity<EntityWithOneProperty>(
+                    builder.Entity<EntityWithManyProperties>(
                         eb =>
                         {
-                            eb.Ignore(e => e.EntityWithTwoProperties);
                             eb.Property<decimal?>("OptionalProperty");
+
                             eb.HasData(
-                                new EntityWithOneProperty
+                                new EntityWithManyProperties
                                 {
-                                    Id = 42
+                                    Id = 42,
+                                    String = "FortyThree",
+                                    Bytes = new byte[] { 44, 45 },
+                                    Int16 = 46,
+                                    Int32 = 47,
+                                    Int64 = 48,
+                                    Double = 49.0,
+                                    Decimal = 50.0m,
+                                    DateTime = new DateTime(1973, 9, 3, 12, 10, 42, 344, DateTimeKind.Utc),
+                                    DateTimeOffset = new DateTimeOffset(new DateTime(1973, 9, 3, 12, 10, 42, 344), new TimeSpan(1, 0, 0)),
+                                    TimeSpan = new TimeSpan(51, 52, 53),
+                                    Single = 54.0f,
+                                    Boolean = true,
+                                    Byte = 55,
+                                    UnsignedInt16 = 56,
+                                    UnsignedInt32 = 57,
+                                    UnsignedInt64 = 58,
+                                    Character = '9',
+                                    SignedByte = 60,
+                                    Enum64 = Enum64.SomeValue,
+                                    Enum32 = Enum32.SomeValue,
+                                    Enum16 = Enum16.SomeValue,
+                                    Enum8 = Enum8.SomeValue,
+                                    EnumU64 = EnumU64.SomeValue,
+                                    EnumU32 = EnumU32.SomeValue,
+                                    EnumU16 = EnumU16.SomeValue,
+                                    EnumS8 = EnumS8.SomeValue,
+                                    SpatialBGeometryCollection = geometryCollection,
+                                    SpatialBLineString = lineString1,
+                                    SpatialBMultiLineString = multiLineString,
+                                    SpatialBMultiPoint = multiPoint,
+                                    SpatialBMultiPolygon = multiPolygon,
+                                    SpatialBPoint = point1,
+                                    SpatialBPolygon = polygon1,
+                                    SpatialCGeometryCollection = geometryCollection,
+                                    SpatialCLineString = lineString1,
+                                    SpatialCMultiLineString = multiLineString,
+                                    SpatialCMultiPoint = multiPoint,
+                                    SpatialCMultiPolygon = multiPolygon,
+                                    SpatialCPoint = point1,
+                                    SpatialCPolygon = polygon1,
+                                    SpatialIGeometryCollection = geometryCollection,
+                                    SpatialILineString = lineString1,
+                                    SpatialIMultiLineString = multiLineString,
+                                    SpatialIMultiPoint = multiPoint,
+                                    SpatialIMultiPolygon = multiPolygon,
+                                    SpatialIPoint = point1,
+                                    SpatialIPolygon = polygon1
                                 },
                                 new
                                 {
                                     Id = 43,
-                                    OptionalProperty = 4.3M
+                                    String = "FortyThree",
+                                    Bytes = new byte[] { 44, 45 },
+                                    Int16 = (short)-46,
+                                    Int32 = -47,
+                                    Int64 = (long)-48,
+                                    Double = -49.0,
+                                    Decimal = -50.0m,
+                                    DateTime = new DateTime(1973, 9, 3, 12, 10, 42, 344, DateTimeKind.Utc),
+                                    DateTimeOffset = new DateTimeOffset(new DateTime(1973, 9, 3, 12, 10, 42, 344), new TimeSpan(-1, 0, 0)),
+                                    TimeSpan = new TimeSpan(-51, 52, 53),
+                                    Single = -54.0f,
+                                    Boolean = true,
+                                    Byte = (byte)55,
+                                    UnsignedInt16 = (ushort)56,
+                                    UnsignedInt32 = (uint)57,
+                                    UnsignedInt64 = (ulong)58,
+                                    Character = '9',
+                                    SignedByte = (sbyte)-60,
+                                    Enum64 = Enum64.SomeValue,
+                                    Enum32 = Enum32.SomeValue,
+                                    Enum16 = Enum16.SomeValue,
+                                    Enum8 = Enum8.SomeValue,
+                                    EnumU64 = EnumU64.SomeValue,
+                                    EnumU32 = EnumU32.SomeValue,
+                                    EnumU16 = EnumU16.SomeValue,
+                                    EnumS8 = EnumS8.SomeValue
                                 });
                         });
                     builder.Ignore<EntityWithTwoProperties>();
                 },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
+                @"// <auto-generated />
+using System;
+using GeoAPI.Geometries;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using NetTopologySuite.Geometries;
+
+namespace RootNamespace
+{
+    [DbContext(typeof(DbContext))]
+    partial class Snapshot : ModelSnapshot
     {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+#pragma warning disable 612, 618
+            modelBuilder
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
+                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.Property<decimal?>(""OptionalProperty"");
+            modelBuilder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithManyProperties"", b =>
+                {
+                    b.Property<int>(""Id"")
+                        .ValueGeneratedOnAdd()
+                        .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 
-        b.HasKey(""Id"");
+                    b.Property<bool>(""Boolean"");
 
-        b.ToTable(""EntityWithOneProperty"");
+                    b.Property<byte>(""Byte"");
 
-        b.HasData(
-            new
-            {
-                Id = 42
-            },
-            new
-            {
-                Id = 43,
-                OptionalProperty = 4.3m
-            });
-    });
+                    b.Property<byte[]>(""Bytes"");
+
+                    b.Property<string>(""Character"")
+                        .IsRequired()
+                        .HasConversion(new ValueConverter<string, string>(v => default(string), v => default(string), new ConverterMappingHints(size: 1)));
+
+                    b.Property<DateTime>(""DateTime"");
+
+                    b.Property<DateTimeOffset>(""DateTimeOffset"");
+
+                    b.Property<decimal>(""Decimal"");
+
+                    b.Property<double>(""Double"");
+
+                    b.Property<short>(""Enum16"");
+
+                    b.Property<int>(""Enum32"");
+
+                    b.Property<long>(""Enum64"");
+
+                    b.Property<byte>(""Enum8"");
+
+                    b.Property<short>(""EnumS8"");
+
+                    b.Property<int>(""EnumU16"");
+
+                    b.Property<long>(""EnumU32"");
+
+                    b.Property<decimal>(""EnumU64"")
+                        .HasConversion(new ValueConverter<decimal, decimal>(v => default(decimal), v => default(decimal), new ConverterMappingHints(precision: 20, scale: 0)));
+
+                    b.Property<short>(""Int16"");
+
+                    b.Property<int>(""Int32"");
+
+                    b.Property<long>(""Int64"");
+
+                    b.Property<decimal?>(""OptionalProperty"");
+
+                    b.Property<short>(""SignedByte"");
+
+                    b.Property<float>(""Single"");
+
+                    b.Property<IGeometry>(""SpatialBGeometryCollection"");
+
+                    b.Property<IGeometry>(""SpatialBLineString"");
+
+                    b.Property<IGeometry>(""SpatialBMultiLineString"");
+
+                    b.Property<IGeometry>(""SpatialBMultiPoint"");
+
+                    b.Property<IGeometry>(""SpatialBMultiPolygon"");
+
+                    b.Property<IGeometry>(""SpatialBPoint"");
+
+                    b.Property<IGeometry>(""SpatialBPolygon"");
+
+                    b.Property<GeometryCollection>(""SpatialCGeometryCollection"");
+
+                    b.Property<LineString>(""SpatialCLineString"");
+
+                    b.Property<MultiLineString>(""SpatialCMultiLineString"");
+
+                    b.Property<MultiPoint>(""SpatialCMultiPoint"");
+
+                    b.Property<MultiPolygon>(""SpatialCMultiPolygon"");
+
+                    b.Property<Point>(""SpatialCPoint"");
+
+                    b.Property<Polygon>(""SpatialCPolygon"");
+
+                    b.Property<IGeometryCollection>(""SpatialIGeometryCollection"");
+
+                    b.Property<ILineString>(""SpatialILineString"");
+
+                    b.Property<IMultiLineString>(""SpatialIMultiLineString"");
+
+                    b.Property<IMultiPoint>(""SpatialIMultiPoint"");
+
+                    b.Property<IMultiPolygon>(""SpatialIMultiPolygon"");
+
+                    b.Property<IPoint>(""SpatialIPoint"");
+
+                    b.Property<IPolygon>(""SpatialIPolygon"");
+
+                    b.Property<string>(""String"");
+
+                    b.Property<TimeSpan>(""TimeSpan"");
+
+                    b.Property<int>(""UnsignedInt16"");
+
+                    b.Property<long>(""UnsignedInt32"");
+
+                    b.Property<decimal>(""UnsignedInt64"")
+                        .HasConversion(new ValueConverter<decimal, decimal>(v => default(decimal), v => default(decimal), new ConverterMappingHints(precision: 20, scale: 0)));
+
+                    b.HasKey(""Id"");
+
+                    b.ToTable(""EntityWithManyProperties"");
+
+                    b.HasData(
+                        new
+                        {
+                            Id = 42,
+                            Boolean = true,
+                            Byte = (byte)55,
+                            Bytes = new byte[] { 44, 45 },
+                            Character = ""9"",
+                            DateTime = new DateTime(1973, 9, 3, 12, 10, 42, 344, DateTimeKind.Utc),
+                            DateTimeOffset = new DateTimeOffset(new DateTime(1973, 9, 3, 12, 10, 42, 344, DateTimeKind.Unspecified), new TimeSpan(0, 1, 0, 0, 0)),
+                            Decimal = 50.0m,
+                            Double = 49.0,
+                            Enum16 = (short)1,
+                            Enum32 = 1,
+                            Enum64 = 1L,
+                            Enum8 = (byte)1,
+                            EnumS8 = (short)-128,
+                            EnumU16 = 65535,
+                            EnumU32 = 4294967295L,
+                            EnumU64 = 1234567890123456789m,
+                            Int16 = (short)46,
+                            Int32 = 47,
+                            Int64 = 48L,
+                            SignedByte = (short)60,
+                            Single = 54f,
+                            SpatialBGeometryCollection = (GeometryCollection)new NetTopologySuite.IO.WKTReader().Read(""GEOMETRYCOLLECTION (LINESTRING (1.1 2.2, 2.2 2.2, 2.2 1.1, 7.1 7.2), LINESTRING (7.1 7.2, 20.2 20.2, 20.2 1.1, 70.1 70.2), MULTIPOINT ((1.1 2.2), (2.2 2.2), (2.2 1.1)), POLYGON ((1.1 2.2, 2.2 2.2, 2.2 1.1, 1.1 2.2)), POLYGON ((10.1 20.2, 20.2 20.2, 20.2 10.1, 10.1 20.2)), POINT (1.1 2.2 3.3), MULTILINESTRING ((1.1 2.2, 2.2 2.2, 2.2 1.1, 7.1 7.2), (7.1 7.2, 20.2 20.2, 20.2 1.1, 70.1 70.2)), MULTIPOLYGON (((10.1 20.2, 20.2 20.2, 20.2 10.1, 10.1 20.2)), ((1.1 2.2, 2.2 2.2, 2.2 1.1, 1.1 2.2))))""),
+                            SpatialBLineString = (LineString)new NetTopologySuite.IO.WKTReader().Read(""LINESTRING (1.1 2.2, 2.2 2.2, 2.2 1.1, 7.1 7.2)""),
+                            SpatialBMultiLineString = (MultiLineString)new NetTopologySuite.IO.WKTReader().Read(""MULTILINESTRING ((1.1 2.2, 2.2 2.2, 2.2 1.1, 7.1 7.2), (7.1 7.2, 20.2 20.2, 20.2 1.1, 70.1 70.2))""),
+                            SpatialBMultiPoint = (MultiPoint)new NetTopologySuite.IO.WKTReader().Read(""MULTIPOINT ((1.1 2.2), (2.2 2.2), (2.2 1.1))""),
+                            SpatialBMultiPolygon = (MultiPolygon)new NetTopologySuite.IO.WKTReader().Read(""MULTIPOLYGON (((10.1 20.2, 20.2 20.2, 20.2 10.1, 10.1 20.2)), ((1.1 2.2, 2.2 2.2, 2.2 1.1, 1.1 2.2)))""),
+                            SpatialBPoint = (Point)new NetTopologySuite.IO.WKTReader().Read(""POINT (1.1 2.2 3.3)""),
+                            SpatialBPolygon = (Polygon)new NetTopologySuite.IO.WKTReader().Read(""POLYGON ((1.1 2.2, 2.2 2.2, 2.2 1.1, 1.1 2.2))""),
+                            SpatialCGeometryCollection = (GeometryCollection)new NetTopologySuite.IO.WKTReader().Read(""GEOMETRYCOLLECTION (LINESTRING (1.1 2.2, 2.2 2.2, 2.2 1.1, 7.1 7.2), LINESTRING (7.1 7.2, 20.2 20.2, 20.2 1.1, 70.1 70.2), MULTIPOINT ((1.1 2.2), (2.2 2.2), (2.2 1.1)), POLYGON ((1.1 2.2, 2.2 2.2, 2.2 1.1, 1.1 2.2)), POLYGON ((10.1 20.2, 20.2 20.2, 20.2 10.1, 10.1 20.2)), POINT (1.1 2.2 3.3), MULTILINESTRING ((1.1 2.2, 2.2 2.2, 2.2 1.1, 7.1 7.2), (7.1 7.2, 20.2 20.2, 20.2 1.1, 70.1 70.2)), MULTIPOLYGON (((10.1 20.2, 20.2 20.2, 20.2 10.1, 10.1 20.2)), ((1.1 2.2, 2.2 2.2, 2.2 1.1, 1.1 2.2))))""),
+                            SpatialCLineString = (LineString)new NetTopologySuite.IO.WKTReader().Read(""LINESTRING (1.1 2.2, 2.2 2.2, 2.2 1.1, 7.1 7.2)""),
+                            SpatialCMultiLineString = (MultiLineString)new NetTopologySuite.IO.WKTReader().Read(""MULTILINESTRING ((1.1 2.2, 2.2 2.2, 2.2 1.1, 7.1 7.2), (7.1 7.2, 20.2 20.2, 20.2 1.1, 70.1 70.2))""),
+                            SpatialCMultiPoint = (MultiPoint)new NetTopologySuite.IO.WKTReader().Read(""MULTIPOINT ((1.1 2.2), (2.2 2.2), (2.2 1.1))""),
+                            SpatialCMultiPolygon = (MultiPolygon)new NetTopologySuite.IO.WKTReader().Read(""MULTIPOLYGON (((10.1 20.2, 20.2 20.2, 20.2 10.1, 10.1 20.2)), ((1.1 2.2, 2.2 2.2, 2.2 1.1, 1.1 2.2)))""),
+                            SpatialCPoint = (Point)new NetTopologySuite.IO.WKTReader().Read(""POINT (1.1 2.2 3.3)""),
+                            SpatialCPolygon = (Polygon)new NetTopologySuite.IO.WKTReader().Read(""POLYGON ((1.1 2.2, 2.2 2.2, 2.2 1.1, 1.1 2.2))""),
+                            SpatialIGeometryCollection = (GeometryCollection)new NetTopologySuite.IO.WKTReader().Read(""GEOMETRYCOLLECTION (LINESTRING (1.1 2.2, 2.2 2.2, 2.2 1.1, 7.1 7.2), LINESTRING (7.1 7.2, 20.2 20.2, 20.2 1.1, 70.1 70.2), MULTIPOINT ((1.1 2.2), (2.2 2.2), (2.2 1.1)), POLYGON ((1.1 2.2, 2.2 2.2, 2.2 1.1, 1.1 2.2)), POLYGON ((10.1 20.2, 20.2 20.2, 20.2 10.1, 10.1 20.2)), POINT (1.1 2.2 3.3), MULTILINESTRING ((1.1 2.2, 2.2 2.2, 2.2 1.1, 7.1 7.2), (7.1 7.2, 20.2 20.2, 20.2 1.1, 70.1 70.2)), MULTIPOLYGON (((10.1 20.2, 20.2 20.2, 20.2 10.1, 10.1 20.2)), ((1.1 2.2, 2.2 2.2, 2.2 1.1, 1.1 2.2))))""),
+                            SpatialILineString = (LineString)new NetTopologySuite.IO.WKTReader().Read(""LINESTRING (1.1 2.2, 2.2 2.2, 2.2 1.1, 7.1 7.2)""),
+                            SpatialIMultiLineString = (MultiLineString)new NetTopologySuite.IO.WKTReader().Read(""MULTILINESTRING ((1.1 2.2, 2.2 2.2, 2.2 1.1, 7.1 7.2), (7.1 7.2, 20.2 20.2, 20.2 1.1, 70.1 70.2))""),
+                            SpatialIMultiPoint = (MultiPoint)new NetTopologySuite.IO.WKTReader().Read(""MULTIPOINT ((1.1 2.2), (2.2 2.2), (2.2 1.1))""),
+                            SpatialIMultiPolygon = (MultiPolygon)new NetTopologySuite.IO.WKTReader().Read(""MULTIPOLYGON (((10.1 20.2, 20.2 20.2, 20.2 10.1, 10.1 20.2)), ((1.1 2.2, 2.2 2.2, 2.2 1.1, 1.1 2.2)))""),
+                            SpatialIPoint = (Point)new NetTopologySuite.IO.WKTReader().Read(""POINT (1.1 2.2 3.3)""),
+                            SpatialIPolygon = (Polygon)new NetTopologySuite.IO.WKTReader().Read(""POLYGON ((1.1 2.2, 2.2 2.2, 2.2 1.1, 1.1 2.2))""),
+                            String = ""FortyThree"",
+                            TimeSpan = new TimeSpan(2, 3, 52, 53, 0),
+                            UnsignedInt16 = 56,
+                            UnsignedInt32 = 57L,
+                            UnsignedInt64 = 58m
+                        },
+                        new
+                        {
+                            Id = 43,
+                            Boolean = true,
+                            Byte = (byte)55,
+                            Bytes = new byte[] { 44, 45 },
+                            Character = ""9"",
+                            DateTime = new DateTime(1973, 9, 3, 12, 10, 42, 344, DateTimeKind.Utc),
+                            DateTimeOffset = new DateTimeOffset(new DateTime(1973, 9, 3, 12, 10, 42, 344, DateTimeKind.Unspecified), new TimeSpan(0, -1, 0, 0, 0)),
+                            Decimal = -50.0m,
+                            Double = -49.0,
+                            Enum16 = (short)1,
+                            Enum32 = 1,
+                            Enum64 = 1L,
+                            Enum8 = (byte)1,
+                            EnumS8 = (short)-128,
+                            EnumU16 = 65535,
+                            EnumU32 = 4294967295L,
+                            EnumU64 = 1234567890123456789m,
+                            Int16 = (short)-46,
+                            Int32 = -47,
+                            Int64 = -48L,
+                            SignedByte = (short)-60,
+                            Single = -54f,
+                            String = ""FortyThree"",
+                            TimeSpan = new TimeSpan(-2, -2, -7, -7, 0),
+                            UnsignedInt16 = 56,
+                            UnsignedInt32 = 57L,
+                            UnsignedInt64 = 58m
+                        });
+                });
+#pragma warning restore 612, 618
+        }
+    }
+}
 ",
                 o => Assert.Collection(
                     o.GetEntityTypes().SelectMany(e => e.GetData()),
-                    seed => Assert.Equal(42, seed["Id"]),
-                    seed =>
-                    {
-                        Assert.Equal(43, seed["Id"]);
-                        Assert.Equal(4.3m, seed["OptionalProperty"]);
-                    }));
-        }
-
-        [Fact]
-        public virtual void SeedData_for_multiple_entities_are_stored_in_model_snapshot()
-        {
-            Test(
-                builder =>
-                {
-                    builder.Entity<EntityWithOneProperty>()
-                        .Ignore(e => e.EntityWithTwoProperties)
-                        .HasData(
-                            new EntityWithOneProperty
-                            {
-                                Id = 27
-                            });
-                    builder.Entity<EntityWithTwoProperties>()
-                        .Ignore(e => e.EntityWithOneProperty)
-                        .HasData(
-                            new EntityWithTwoProperties
-                            {
-                                Id = 42,
-                                AlternateId = 43
-                            });
-                },
-                GetHeading() + @"
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithOneProperty"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
-
-        b.HasKey(""Id"");
-
-        b.ToTable(""EntityWithOneProperty"");
-
-        b.HasData(
-            new
-            {
-                Id = 27
-            });
-    });
-
-builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServerTest+EntityWithTwoProperties"", b =>
-    {
-        b.Property<int>(""Id"")
-            .ValueGeneratedOnAdd()
-            .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
-
-        b.Property<int>(""AlternateId"");
-
-        b.HasKey(""Id"");
-
-        b.ToTable(""EntityWithTwoProperties"");
-
-        b.HasData(
-            new
-            {
-                Id = 42,
-                AlternateId = 43
-            });
-    });
-",
-                o => Assert.Collection(
-                    o.GetEntityTypes().Select(e => e.GetData().Single()),
-                    seed => Assert.Equal(27, seed["Id"]),
                     seed =>
                     {
                         Assert.Equal(42, seed["Id"]);
-                        Assert.Equal(43, seed["AlternateId"]);
+                        Assert.Equal("FortyThree", seed["String"]);
+                        Assert.Equal(new byte[] { 44, 45 }, seed["Bytes"]);
+                        Assert.Equal((short)46, seed["Int16"]);
+                        Assert.Equal((int)47, seed["Int32"]);
+                        Assert.Equal((long)48, seed["Int64"]);
+                        Assert.Equal(49.0, seed["Double"]);
+                        Assert.Equal(50.0m, seed["Decimal"]);
+                        Assert.Equal(new DateTime(1973, 9, 3, 12, 10, 42, 344, DateTimeKind.Utc), seed["DateTime"]);
+                        Assert.Equal(new DateTimeOffset(new DateTime(1973, 9, 3, 12, 10, 42, 344), new TimeSpan(1, 0, 0)), seed["DateTimeOffset"]);
+                        Assert.Equal(new TimeSpan(51, 52, 53), seed["TimeSpan"]);
+                        Assert.Equal(54.0f, seed["Single"]);
+                        Assert.Equal(true, seed["Boolean"]);
+                        Assert.Equal((byte)55, seed["Byte"]);
+                        Assert.Equal(56, seed["UnsignedInt16"]);
+                        Assert.Equal((long)57, seed["UnsignedInt32"]);
+                        Assert.Equal((decimal)58, seed["UnsignedInt64"]);
+                        Assert.Equal("9", seed["Character"]);
+                        Assert.Equal((short)60, seed["SignedByte"]);
+                        Assert.Equal(1L, seed["Enum64"]);
+                        Assert.Equal(1, seed["Enum32"]);
+                        Assert.Equal((short)1, seed["Enum16"]);
+                        Assert.Equal((byte)1, seed["Enum8"]);
+                        Assert.Equal(1234567890123456789m, seed["EnumU64"]);
+                        Assert.Equal(4294967295L, seed["EnumU32"]);
+                        Assert.Equal(65535, seed["EnumU16"]);
+                        Assert.Equal((short)-128, seed["EnumS8"]);
+                        Assert.Equal(geometryCollection, seed["SpatialBGeometryCollection"]);
+                        Assert.Equal(lineString1, seed["SpatialBLineString"]);
+                        Assert.Equal(multiLineString, seed["SpatialBMultiLineString"]);
+                        Assert.Equal(multiPoint, seed["SpatialBMultiPoint"]);
+                        Assert.Equal(multiPolygon, seed["SpatialBMultiPolygon"]);
+                        Assert.Equal(point1, seed["SpatialBPoint"]);
+                        Assert.Equal(polygon1, seed["SpatialBPolygon"]);
+                        Assert.Equal(geometryCollection, seed["SpatialCGeometryCollection"]);
+                        Assert.Equal(lineString1, seed["SpatialCLineString"]);
+                        Assert.Equal(multiLineString, seed["SpatialCMultiLineString"]);
+                        Assert.Equal(multiPoint, seed["SpatialCMultiPoint"]);
+                        Assert.Equal(multiPolygon, seed["SpatialCMultiPolygon"]);
+                        Assert.Equal(point1, seed["SpatialCPoint"]);
+                        Assert.Equal(polygon1, seed["SpatialCPolygon"]);
+                        Assert.Equal(geometryCollection, seed["SpatialIGeometryCollection"]);
+                        Assert.Equal(lineString1, seed["SpatialILineString"]);
+                        Assert.Equal(multiLineString, seed["SpatialIMultiLineString"]);
+                        Assert.Equal(multiPoint, seed["SpatialIMultiPoint"]);
+                        Assert.Equal(multiPolygon, seed["SpatialIMultiPolygon"]);
+                        Assert.Equal(point1, seed["SpatialIPoint"]);
+                        Assert.Equal(polygon1, seed["SpatialIPolygon"]);
+                    },
+                    seed =>
+                    {
+                        Assert.Equal(43, seed["Id"]);
+                        Assert.Equal("FortyThree", seed["String"]);
+                        Assert.Equal(new byte[] { 44, 45 }, seed["Bytes"]);
+                        Assert.Equal((short)-46, seed["Int16"]);
+                        Assert.Equal((int)-47, seed["Int32"]);
+                        Assert.Equal((long)-48, seed["Int64"]);
+                        Assert.Equal(-49.0, seed["Double"]);
+                        Assert.Equal(-50.0m, seed["Decimal"]);
+                        Assert.Equal(new DateTime(1973, 9, 3, 12, 10, 42, 344, DateTimeKind.Utc), seed["DateTime"]);
+                        Assert.Equal(new DateTimeOffset(new DateTime(1973, 9, 3, 12, 10, 42, 344), new TimeSpan(-1, 0, 0)), seed["DateTimeOffset"]);
+                        Assert.Equal(new TimeSpan(-51, 52, 53), seed["TimeSpan"]);
+                        Assert.Equal(-54.0f, seed["Single"]);
+                        Assert.Equal(true, seed["Boolean"]);
+                        Assert.Equal((byte)55, seed["Byte"]);
+                        Assert.Equal(56, seed["UnsignedInt16"]);
+                        Assert.Equal((long)57, seed["UnsignedInt32"]);
+                        Assert.Equal((decimal)58, seed["UnsignedInt64"]);
+                        Assert.Equal("9", seed["Character"]);
+                        Assert.Equal((short)-60, seed["SignedByte"]);
+                        Assert.Equal(1L, seed["Enum64"]);
+                        Assert.Equal(1, seed["Enum32"]);
+                        Assert.Equal((short)1, seed["Enum16"]);
+                        Assert.Equal((byte)1, seed["Enum8"]);
+                        Assert.Equal(1234567890123456789m, seed["EnumU64"]);
+                        Assert.Equal(4294967295L, seed["EnumU32"]);
+                        Assert.Equal(65535, seed["EnumU16"]);
+                        Assert.Equal((short)-128, seed["EnumS8"]);
                     }));
         }
+#endif
 
         #endregion
 
-        protected virtual string GetHeading() => @"builder
-    .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
-    .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
+        protected virtual string GetHeading() => @"
+            modelBuilder
+                .HasAnnotation(""Relational:MaxIdentifierLength"", 128)
+                .HasAnnotation(""SqlServer:ValueGenerationStrategy"", SqlServerValueGenerationStrategy.IdentityColumn);
 ";
-
         protected virtual ICollection<BuildReference> GetReferences() => new List<BuildReference>
         {
+            BuildReference.ByName("System.Runtime.Extensions"),
             BuildReference.ByName("Microsoft.EntityFrameworkCore"),
             BuildReference.ByName("Microsoft.EntityFrameworkCore.Relational"),
-            BuildReference.ByName("Microsoft.EntityFrameworkCore.SqlServer")
+            BuildReference.ByName("Microsoft.EntityFrameworkCore.SqlServer"),
+#if !Test21
+            BuildReference.ByName("GeoAPI"),
+            BuildReference.ByName("NetTopologySuite"),
+#endif
         };
+
+        protected virtual string AddBoilerPlate(string code, bool usingSystem = false)
+            => $@"// <auto-generated />
+{(usingSystem
+                ? @"using System;
+"
+                : "")}using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+namespace RootNamespace
+{{
+    [DbContext(typeof(DbContext))]
+    partial class Snapshot : ModelSnapshot
+    {{
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {{
+#pragma warning disable 612, 618{code}
+#pragma warning restore 612, 618
+        }}
+    }}
+}}
+";
 
         protected void Test(Action<ModelBuilder> buildModel, string expectedCode, Action<IModel> assert)
         {
@@ -2775,11 +3142,21 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
             CreateModelValidator().Validate(modelBuilder.Model);
             var model = modelBuilder.Model;
 
-            var generator = new CSharpSnapshotGenerator(new CSharpSnapshotGeneratorDependencies(new CSharpHelper()));
+            var codeHelper = new CSharpHelper();
+            var generator = new CSharpMigrationsGenerator(
+                new MigrationsCodeGeneratorDependencies(),
+                new CSharpMigrationsGeneratorDependencies(
+                    codeHelper,
+                    new CSharpMigrationOperationGenerator(
+                        new CSharpMigrationOperationGeneratorDependencies(codeHelper)),
+                    new CSharpSnapshotGenerator(
+                        new CSharpSnapshotGeneratorDependencies(
+                            codeHelper,
+                            new SqlServerTypeMappingSource(
+                                TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
+                                TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())))));
 
-            var builder = new IndentedStringBuilder();
-            generator.Generate("builder", model, builder);
-            var code = builder.ToString();
+            var code = generator.GenerateSnapshot("RootNamespace", typeof(DbContext), "Snapshot", model);
 
             Assert.Equal(expectedCode, code, ignoreLineEndingDifferences: true);
 
@@ -2787,27 +3164,7 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
             {
                 Sources =
                 {
-                    @"
-                    using System;
-                    using Microsoft.EntityFrameworkCore;
-                    using Microsoft.EntityFrameworkCore.Metadata;
-                    using Microsoft.EntityFrameworkCore.Metadata.Conventions;
-                    using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-
-                    public static class ModelSnapshot
-                    {
-                        public static IModel Model
-                        {
-                            get
-                            {
-                                var builder = new ModelBuilder(new ConventionSet());
-                                " + code + @"
-
-                                return builder.Model;
-                            }
-                        }
-                   }
-                "
+                    code
                 }
             };
 
@@ -2817,18 +3174,44 @@ builder.Entity(""Microsoft.EntityFrameworkCore.Migrations.ModelSnapshotSqlServer
             }
 
             var assembly = build.BuildInMemory();
-            var factoryType = assembly.GetType("ModelSnapshot");
-            var property = factoryType.GetTypeInfo().GetDeclaredProperty("Model");
-            var value = (IModel)property.GetValue(null);
+            var factoryType = assembly.GetType("RootNamespace.Snapshot");
+
+            var buildModelMethod = factoryType.GetTypeInfo().GetMethod(
+                "BuildModel",
+                BindingFlags.Instance | BindingFlags.NonPublic,
+                null,
+                new[] { typeof(ModelBuilder)},
+                null);
+
+            var builder = new ModelBuilder(new ConventionSet());
+
+            buildModelMethod.Invoke(
+                Activator.CreateInstance(factoryType),
+                new object[] { builder });
+
+            var value = builder.Model;
             Assert.NotNull(value);
 
             var reporter = new TestOperationReporter();
-            value = new SnapshotModelProcessor(reporter).Process(value);
-
-            assert(value);
+            assert(new SnapshotModelProcessor(reporter).Process(value));
         }
 
-        protected ModelBuilder CreateConventionalModelBuilder() => new ModelBuilder(SqlServerConventionSetBuilder.Build());
+        protected ModelBuilder CreateConventionalModelBuilder()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFrameworkSqlServer()
+                .AddEntityFrameworkSqlServerNetTopologySuite()
+                .AddDbContext<DbContext>(o => o.UseSqlServer("Server=.", b => b.UseNetTopologySuite()))
+                .BuildServiceProvider();
+
+            using (var serviceScope = serviceProvider.GetRequiredService<IServiceScopeFactory>().CreateScope())
+            {
+                using (var context = serviceScope.ServiceProvider.GetService<DbContext>())
+                {
+                    return new ModelBuilder(ConventionSet.CreateConventionSet(context));
+                }
+            }
+        }
 
         protected ModelValidator CreateModelValidator()
             => new SqlServerModelValidator(

--- a/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerFixture.cs
@@ -1,8 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.TestModels.UpdatesModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -10,6 +12,17 @@ namespace Microsoft.EntityFrameworkCore
     {
         protected override ITestStoreFactory TestStoreFactory => SqlServerTestStoreFactory.Instance;
 
+        protected override IServiceCollection AddServices(IServiceCollection serviceCollection)
+            => base.AddServices(serviceCollection)
+                .AddEntityFrameworkSqlServerNetTopologySuite();
+
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+        {
+            var optionsBuilder = base.AddOptions(builder);
+            new SqlServerDbContextOptionsBuilder(optionsBuilder).UseNetTopologySuite();
+
+            return optionsBuilder;
+        }
         protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
         {
             base.OnModelCreating(modelBuilder, context);

--- a/test/EFCore.Sqlite.FunctionalTests/UpdatesSqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/UpdatesSqliteFixture.cs
@@ -1,12 +1,26 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore
 {
     public class UpdatesSqliteFixture : UpdatesRelationalFixture
     {
         protected override ITestStoreFactory TestStoreFactory => SqliteTestStoreFactory.Instance;
+
+        protected override IServiceCollection AddServices(IServiceCollection serviceCollection)
+            => base.AddServices(serviceCollection)
+                .AddEntityFrameworkSqliteNetTopologySuite();
+
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+        {
+            var optionsBuilder = base.AddOptions(builder);
+            new SqliteDbContextOptionsBuilder(optionsBuilder).UseNetTopologySuite();
+
+            return optionsBuilder;
+        }
     }
 }


### PR DESCRIPTION
Part of #8741

Currently, as a first step, the scaffolding using WKT as a serialization format. This could be replaced with "pure" C# code calling nested constructors, etc. Also, SRID is not yet round-tripped.

Also, changed to a generic ValueConverter to take advantage of infrastructure and reduce custom overrides in the converter.

Still to do for #8741 - literals in other places
