### PR TITLE
Spatial types literal generation for SQLite snapshots

### DIFF
--- a/src/EFCore.InMemory/Storage/Internal/InMemoryTypeMapping.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryTypeMapping.cs
@@ -22,12 +22,13 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
         public InMemoryTypeMapping(
             [NotNull] Type clrType,
             [CanBeNull] ValueComparer comparer = null,
+            [CanBeNull] ValueComparer keyComparer = null,
             [CanBeNull] ValueComparer deepComparer = null)
             : base(new CoreTypeMappingParameters(
                 clrType,
                 converter: null,
                 comparer,
-                keyComparer: null,
+                keyComparer,
                 deepComparer,
                 valueGeneratorFactory: null))
         {

--- a/src/EFCore.InMemory/Storage/Internal/InMemoryTypeMappingSource.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryTypeMappingSource.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
@@ -43,10 +44,16 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
                 return new InMemoryTypeMapping(clrType, deepComparer: new ArrayDeepComparer<byte>());
             }
 
-            if (clrType.Name == "GeoAPI.Geometries.IGeometry"
+            if (clrType.FullName == "GeoAPI.Geometries.IGeometry"
                 || clrType.GetInterface("GeoAPI.Geometries.IGeometry") != null)
             {
-                return new InMemoryTypeMapping(clrType, new GeometryValueComparer(clrType));
+                var comparer = (ValueComparer)Activator.CreateInstance(typeof(GeometryValueComparer<>).MakeGenericType(clrType));
+
+                return new InMemoryTypeMapping(
+                    clrType,
+                    comparer,
+                    comparer,
+                    comparer);
             }
 
             return base.FindMapping(mappingInfo);

--- a/src/EFCore.Relational/Storage/RelationalGeometryTypeMapping.cs
+++ b/src/EFCore.Relational/Storage/RelationalGeometryTypeMapping.cs
@@ -1,0 +1,135 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Data;
+using System.Data.Common;
+using System.Linq;
+using System.Linq.Expressions;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Remotion.Linq.Parsing.ExpressionVisitors;
+
+namespace Microsoft.EntityFrameworkCore.Storage
+{
+    /// <summary>
+    ///     Base class for relation type mappings to NTS IGeometry and implementing types.
+    /// </summary>
+    /// <typeparam name="TGeometry"> The geometry type. </typeparam>
+    /// <typeparam name="TProvider"> The native type of the database provider. </typeparam>
+    public abstract class RelationalGeometryTypeMapping<TGeometry, TProvider> : RelationalTypeMapping
+    {
+        private readonly ValueConverter<TGeometry, TProvider> _converter;
+
+        /// <summary>
+        ///     Creates a new instance of the <see cref="RelationalGeometryTypeMapping{TGeometry,TProvider}" /> class.
+        /// </summary>
+        /// <param name="converter"> The converter to use when converting to and from database types. </param>
+        /// <param name="storeType"> The store type name. </param>
+        protected RelationalGeometryTypeMapping(
+            [NotNull] ValueConverter<TGeometry, TProvider> converter,
+            [NotNull] string storeType)
+            : base(CreateRelationalTypeMappingParameters(storeType))
+        {
+            _converter = converter;
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="RelationalTypeMapping" /> class.
+        /// </summary>
+        /// <param name="parameters"> The parameters for this mapping. </param>
+        protected RelationalGeometryTypeMapping(RelationalTypeMappingParameters parameters)
+            : base(parameters)
+        {
+        }
+
+        private static RelationalTypeMappingParameters CreateRelationalTypeMappingParameters(string storeType)
+        {
+            var comparer = new GeometryValueComparer<TGeometry>();
+
+            return new RelationalTypeMappingParameters(
+                new CoreTypeMappingParameters(
+                    typeof(TGeometry),
+                    null,
+                    comparer,
+                    comparer),
+                storeType);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="DbParameter" /> with the appropriate type information configured.
+        /// </summary>
+        /// <param name="command"> The command the parameter should be created on. </param>
+        /// <param name="name"> The name of the parameter. </param>
+        /// <param name="value"> The value to be assigned to the parameter. </param>
+        /// <param name="nullable"> A value indicating whether the parameter should be a nullable type. </param>
+        /// <returns> The newly created parameter. </returns>
+        public override DbParameter CreateParameter(DbCommand command, string name, object value, bool? nullable = null)
+        {
+            var parameter = command.CreateParameter();
+            parameter.Direction = ParameterDirection.Input;
+            parameter.ParameterName = name;
+
+            parameter.Value = value == null
+                ? DBNull.Value
+                : _converter.ConvertToProvider(value);
+
+            if (nullable.HasValue)
+            {
+                parameter.IsNullable = nullable.Value;
+            }
+
+            ConfigureParameter(parameter);
+
+            return parameter;
+        }
+
+        /// <summary>
+        ///     Gets a custom expression tree for the code to convert from the database value
+        ///     to the model value.
+        /// </summary>
+        /// <param name="expression"> The input expression, containing the database value. </param>
+        /// <returns> The expression with conversion added. </returns>
+        public override Expression AddCustomConversion(Expression expression)
+        {
+            if (expression.Type != _converter.ProviderClrType)
+            {
+                expression = Expression.Convert(expression, _converter.ProviderClrType);
+            }
+
+            return ReplacingExpressionVisitor.Replace(
+                _converter.ConvertFromProviderExpression.Parameters.Single(),
+                expression,
+                _converter.ConvertFromProviderExpression.Body);
+        }
+
+        /// <summary>
+        ///     Attempts generation of a code (e.g. C#) literal for the given value.
+        /// </summary>
+        /// <param name="value"> The value for which a literal is needed. </param>
+        /// <param name="languageCode"> The language code, which is typically the common file extension (e.g. ".cs") for the language. </param>
+        /// <returns> The generated literal, or <c>null</c> if a literal could not be generated. </returns>
+        public override string FindCodeLiteral(object value, string languageCode)
+        {
+            var geometryText = AsText(value);
+
+            // TODO: Handle SRID
+            // TODO: Consider constructing C# objects directly
+            // TODO: Allow additional namespaces needed to be put in using directives
+            return geometryText != null
+                   && languageCode.Equals(".cs", StringComparison.OrdinalIgnoreCase)
+                ? $"({value.GetType().ShortDisplayName()})new NetTopologySuite.IO.WKTReader().Read(\"{geometryText}\")"
+                : null;
+        }
+
+        /// <summary>
+        ///     Returns the Well-Known-Text (WKT) representation of the given object, or <c>null</c>
+        ///     if the object is not an 'IGeometry'.
+        /// </summary>
+        /// <param name="value"> The value. </param>
+        /// <returns> The WKT. </returns>
+        protected abstract string AsText(object value);
+    }
+}

--- a/src/EFCore.Specification.Tests/TestModels/UpdatesModel/AFewBytes.cs
+++ b/src/EFCore.Specification.Tests/TestModels/UpdatesModel/AFewBytes.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using GeoAPI.Geometries;
+using NetTopologySuite.Geometries;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.UpdatesModel
 {
@@ -9,5 +11,7 @@ namespace Microsoft.EntityFrameworkCore.TestModels.UpdatesModel
     {
         public Guid Id { get; set; }
         public byte[] Bytes { get; set; }
+        public Point Point { get; set; }
+        public IGeometry PolygonAsGeometry { get; set; }
     }
 }

--- a/src/EFCore.SqlServer.NTS/Storage/Internal/SqlServerGeometryTypeMapping.cs
+++ b/src/EFCore.SqlServer.NTS/Storage/Internal/SqlServerGeometryTypeMapping.cs
@@ -1,20 +1,14 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Data;
-using System.Data.Common;
 using System.Data.SqlClient;
-using System.Linq;
-using System.Linq.Expressions;
+using System.Data.SqlTypes;
 using System.Reflection;
 using GeoAPI.Geometries;
-using Microsoft.EntityFrameworkCore.ChangeTracking;
-using Microsoft.EntityFrameworkCore.Internal;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.ValueConversion.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using NetTopologySuite.IO;
-using Remotion.Linq.Parsing.ExpressionVisitors;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
 {
@@ -22,28 +16,20 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class SqlServerGeometryTypeMapping<TGeometry> : RelationalTypeMapping
+    public class SqlServerGeometryTypeMapping<TGeometry> : RelationalGeometryTypeMapping<TGeometry, SqlBytes>
         where TGeometry : IGeometry
     {
         private static readonly MethodInfo _getSqlBytes
             = typeof(SqlDataReader).GetTypeInfo().GetDeclaredMethod(nameof(SqlDataReader.GetSqlBytes));
 
-        private readonly GeometryValueConverter<TGeometry> _converter;
-
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public SqlServerGeometryTypeMapping(Type clrType, SqlServerSpatialReader reader, string storeType)
-            : base(
-                new RelationalTypeMappingParameters(
-                    new CoreTypeMappingParameters(
-                        clrType,
-                        null,
-                        new GeometryValueComparer(clrType)),
-                    storeType))
+        [UsedImplicitly]
+        public SqlServerGeometryTypeMapping(SqlServerSpatialReader reader, string storeType)
+            : base(new GeometryValueConverter<TGeometry>(reader), storeType)
         {
-            _converter = new GeometryValueConverter<TGeometry>(reader);
         }
 
         /// <summary>
@@ -83,30 +69,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override DbParameter CreateParameter(DbCommand command, string name, object value, bool? nullable = null)
-        {
-            var parameter = command.CreateParameter();
-            parameter.Direction = ParameterDirection.Input;
-            parameter.ParameterName = name;
-
-            parameter.Value = value == null
-                ? DBNull.Value
-                : _converter.ConvertToProvider(value);
-
-            if (nullable.HasValue)
-            {
-                parameter.IsNullable = nullable.Value;
-            }
-
-            ConfigureParameter(parameter);
-
-            return parameter;
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
         public override MethodInfo GetDataReaderMethod()
             => _getSqlBytes;
 
@@ -114,30 +76,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override Expression AddCustomConversion(Expression expression)
-        {
-            if (expression.Type != _converter.ProviderClrType)
-            {
-                expression = Expression.Convert(expression, _converter.ProviderClrType);
-            }
-
-            return ReplacingExpressionVisitor.Replace(
-                _converter.ConvertFromProviderExpression.Parameters.Single(),
-                expression,
-                _converter.ConvertFromProviderExpression.Body);
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override string FindCodeLiteral(object value, string languageCode)
-            // TODO: Handle SRID
-            // TODO: Consider constructing C# objects directly
-            // TODO: Allow additional namespaces needed to be put in using directives
-            => languageCode.Equals(".cs", StringComparison.OrdinalIgnoreCase)
-               && value is IGeometry geometry
-                ? $"({value.GetType().ShortDisplayName()})new NetTopologySuite.IO.WKTReader().Read(\"{geometry.AsText()}\")"
-                : null;
+        protected override string AsText(object value)
+            => (value is IGeometry geometry) ? geometry.AsText() : null;
     }
 }

--- a/src/EFCore.SqlServer.NTS/Storage/Internal/SqlServerNTSTypeMappingSourcePlugin.cs
+++ b/src/EFCore.SqlServer.NTS/Storage/Internal/SqlServerNTSTypeMappingSourcePlugin.cs
@@ -51,7 +51,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
                        && _spatialStoreTypes.Contains(storeTypeName))
                 ? (RelationalTypeMapping)Activator.CreateInstance(
                     typeof(SqlServerGeometryTypeMapping<>).MakeGenericType(clrType),
-                    clrType,
                     _reader,
                     storeTypeName ?? "geometry")
                 : null;

--- a/src/EFCore.Sqlite.NTS/Storage/Internal/SqliteNTSTypeMappingSourcePlugin.cs
+++ b/src/EFCore.Sqlite.NTS/Storage/Internal/SqliteNTSTypeMappingSourcePlugin.cs
@@ -57,10 +57,12 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
             string defaultStoreType = null;
             Type defaultClrType = null;
 
-            return (clrType != null && TryGetDefaultStoreType(clrType, out defaultStoreType)
-                    || storeTypeName != null && _storeTypeMappings.TryGetValue(storeTypeName, out defaultClrType))
-                ? new SqliteGeometryTypeMapping(
-                    clrType ?? defaultClrType ?? typeof(IGeometry),
+            return (clrType != null
+                    && TryGetDefaultStoreType(clrType, out defaultStoreType))
+                   || (storeTypeName != null
+                       && _storeTypeMappings.TryGetValue(storeTypeName, out defaultClrType))
+                ? (RelationalTypeMapping)Activator.CreateInstance(
+                    typeof(SqliteGeometryTypeMapping<>).MakeGenericType(clrType ?? defaultClrType ?? typeof(IGeometry)),
                     _reader,
                     storeTypeName ?? defaultStoreType ?? "GEOMETRY")
                 : null;

--- a/src/EFCore.Sqlite.NTS/Storage/ValueConversion/Internal/GeometryValueConverter.cs
+++ b/src/EFCore.Sqlite.NTS/Storage/ValueConversion/Internal/GeometryValueConverter.cs
@@ -2,10 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Linq.Expressions;
-using System.Reflection;
 using GeoAPI.Geometries;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.IO;
 
@@ -15,81 +12,20 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.ValueConversion.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class GeometryValueConverter : ValueConverter
+    public class GeometryValueConverter<TGeometry> : ValueConverter<TGeometry, byte[]>
+        where TGeometry : IGeometry
     {
         private static readonly GaiaGeoWriter _writer = new GaiaGeoWriter();
 
-        private Func<object, object> _convertToProvider;
-        private Func<object, object> _convertFromProvider;
-
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public GeometryValueConverter(Type type, GaiaGeoReader reader)
+        public GeometryValueConverter(GaiaGeoReader reader)
             : base(
-                  (Expression<Func<IGeometry, byte[]>>)(g => _writer.Write(g)),
-                  GetConvertFromProviderExpression(type, reader))
+                g => _writer.Write(g),
+                b => (TGeometry)reader.Read(b))
         {
-            ModelClrType = type;
-        }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override Func<object, object> ConvertToProvider
-            => NonCapturingLazyInitializer.EnsureInitialized(
-                ref _convertToProvider,
-                this,
-                x => Compile(x.ConvertToProviderExpression));
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override Func<object, object> ConvertFromProvider
-            => NonCapturingLazyInitializer.EnsureInitialized(
-                ref _convertFromProvider,
-                this,
-                x => Compile(x.ConvertFromProviderExpression));
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override Type ModelClrType { get; }
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        public override Type ProviderClrType
-            => typeof(byte[]);
-
-        private static LambdaExpression GetConvertFromProviderExpression(Type type, GaiaGeoReader reader)
-        {
-            var bytes = Expression.Parameter(typeof(byte[]), "blob");
-
-            Expression body = Expression.Call(
-                Expression.Constant(reader),
-                typeof(GaiaGeoReader).GetRuntimeMethod(nameof(GaiaGeoReader.Read), new[] { typeof(byte[]) }),
-                bytes);
-            if (!type.IsAssignableFrom(typeof(IGeometry)))
-            {
-                body = Expression.Convert(body, type);
-            }
-
-            return Expression.Lambda(body, bytes);
-        }
-
-        private static Func<object, object> Compile(LambdaExpression convertExpression)
-        {
-            var compiled = convertExpression.Compile();
-
-            return x => x != null
-                ? compiled.DynamicInvoke(x)
-                : null;
         }
     }
 }

--- a/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/UpdatesSqlServerFixture.cs
@@ -1,8 +1,10 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.TestModels.UpdatesModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore
 {
@@ -10,6 +12,17 @@ namespace Microsoft.EntityFrameworkCore
     {
         protected override ITestStoreFactory TestStoreFactory => SqlServerTestStoreFactory.Instance;
 
+        protected override IServiceCollection AddServices(IServiceCollection serviceCollection)
+            => base.AddServices(serviceCollection)
+                .AddEntityFrameworkSqlServerNetTopologySuite();
+
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+        {
+            var optionsBuilder = base.AddOptions(builder);
+            new SqlServerDbContextOptionsBuilder(optionsBuilder).UseNetTopologySuite();
+
+            return optionsBuilder;
+        }
         protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
         {
             base.OnModelCreating(modelBuilder, context);

--- a/test/EFCore.Sqlite.FunctionalTests/UpdatesSqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/UpdatesSqliteFixture.cs
@@ -1,12 +1,26 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore
 {
     public class UpdatesSqliteFixture : UpdatesRelationalFixture
     {
         protected override ITestStoreFactory TestStoreFactory => SqliteTestStoreFactory.Instance;
+
+        protected override IServiceCollection AddServices(IServiceCollection serviceCollection)
+            => base.AddServices(serviceCollection)
+                .AddEntityFrameworkSqliteNetTopologySuite();
+
+        public override DbContextOptionsBuilder AddOptions(DbContextOptionsBuilder builder)
+        {
+            var optionsBuilder = base.AddOptions(builder);
+            new SqliteDbContextOptionsBuilder(optionsBuilder).UseNetTopologySuite();
+
+            return optionsBuilder;
+        }
     }
 }


### PR DESCRIPTION
Also making SQLite mapping consistent with recent SQL Server changes and add deep copying for in-memory spatial values.

Fixes #13098
Fixes #13072
Part of #8741
