### PR TITLE
Finishing up spatial literal generation for 2.2

### DIFF
--- a/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGeneratorDependencies.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpMigrationOperationGeneratorDependencies.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Migrations.Design
 {
@@ -45,6 +46,8 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         /// <param name="csharpHelper"> The C# helper. </param>
         public CSharpMigrationOperationGeneratorDependencies([NotNull] ICSharpHelper csharpHelper)
         {
+            Check.NotNull(csharpHelper, nameof(csharpHelper));
+
             CSharpHelper = csharpHelper;
         }
 

--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGenerator.cs
@@ -1135,16 +1135,10 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                                     firstProperty = false;
                                 }
 
-                                var mapping = property.FindRelationalMapping()
-                                              ?? Dependencies.TypeMappingSource.FindMapping(property);
-
-                                var literal = mapping?.FindCodeLiteral(value, "C#")
-                                              ?? Code.UnknownLiteral(value);
-
                                 stringBuilder
                                     .Append(Code.Identifier(property.Name))
                                     .Append(" = ")
-                                    .Append(literal);
+                                    .Append(Code.UnknownLiteral(value));
                             }
                         }
 

--- a/src/EFCore.Design/Migrations/Design/CSharpSnapshotGeneratorDependencies.cs
+++ b/src/EFCore.Design/Migrations/Design/CSharpSnapshotGeneratorDependencies.cs
@@ -3,7 +3,6 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Design;
-using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 
 namespace Microsoft.EntityFrameworkCore.Migrations.Design
@@ -45,16 +44,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         ///     </para>
         /// </summary>
         /// <param name="csharpHelper"> The C# helper. </param>
-        /// <param name="typeMappingSource"> The type mapper. </param>
         public CSharpSnapshotGeneratorDependencies(
-            [NotNull] ICSharpHelper csharpHelper,
-            [NotNull] IRelationalTypeMappingSource typeMappingSource)
+            [NotNull] ICSharpHelper csharpHelper)
         {
             Check.NotNull(csharpHelper, nameof(csharpHelper));
-            Check.NotNull(typeMappingSource, nameof(typeMappingSource));
 
             CSharpHelper = csharpHelper;
-            TypeMappingSource = typeMappingSource;
         }
 
         /// <summary>
@@ -63,26 +58,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         public ICSharpHelper CSharpHelper { get; }
 
         /// <summary>
-        ///     The type mapper.
-        /// </summary>
-        public IRelationalTypeMappingSource TypeMappingSource { get; }
-
-        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="csharpHelper"> A replacement for the current dependency of this type. </param>
         /// <returns> A new parameter object with the given service replaced. </returns>
         public CSharpSnapshotGeneratorDependencies With(
             [NotNull] ICSharpHelper csharpHelper)
-            => new CSharpSnapshotGeneratorDependencies(csharpHelper, TypeMappingSource);
-
-        /// <summary>
-        ///     Clones this dependency parameter object with one service replaced.
-        /// </summary>
-        /// <param name="typeMappingSource"> A replacement for the current dependency of this type. </param>
-        /// <returns> A new parameter object with the given service replaced. </returns>
-        public CSharpSnapshotGeneratorDependencies With(
-            [NotNull] IRelationalTypeMappingSource typeMappingSource)
-            => new CSharpSnapshotGeneratorDependencies(CSharpHelper, typeMappingSource);
+            => new CSharpSnapshotGeneratorDependencies(csharpHelper);
     }
 }

--- a/src/EFCore.Design/breakingchanges.netcore.json
+++ b/src/EFCore.Design/breakingchanges.netcore.json
@@ -17,10 +17,5 @@
     "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.Design.MigrationsScaffolder",
     "MemberId": "public virtual Microsoft.EntityFrameworkCore.Migrations.Design.ScaffoldedMigration ScaffoldMigration(System.String migrationName, System.String rootNamespace, System.String subNamespace = null)",
     "Kind": "Removal"
-  },
-  {
-    "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Migrations.Design.CSharpSnapshotGeneratorDependencies",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Design.ICSharpHelper csharpHelper)",
-    "Kind": "Removal"
   }
 ]

--- a/src/EFCore.Design/breakingchanges.netframework.json
+++ b/src/EFCore.Design/breakingchanges.netframework.json
@@ -17,10 +17,5 @@
     "TypeId": "public class Microsoft.EntityFrameworkCore.Migrations.Design.MigrationsScaffolder",
     "MemberId": "public virtual Microsoft.EntityFrameworkCore.Migrations.Design.ScaffoldedMigration ScaffoldMigration(System.String migrationName, System.String rootNamespace, System.String subNamespace = null)",
     "Kind": "Removal"
-  },
-  {
-    "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Migrations.Design.CSharpSnapshotGeneratorDependencies",
-    "MemberId": "public .ctor(Microsoft.EntityFrameworkCore.Design.ICSharpHelper csharpHelper)",
-    "Kind": "Removal"
   }
 ]

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -188,13 +188,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             string generationDefault,
             Action<TestCSharpSnapshotGenerator, IMutableAnnotatable, IndentedStringBuilder> test)
         {
-            var codeHelper = new CSharpHelper();
+            var codeHelper = new CSharpHelper(new SqlServerTypeMappingSource(
+                TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
+                TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()));
+
             var generator = new TestCSharpSnapshotGenerator(
-                new CSharpSnapshotGeneratorDependencies(
-                    codeHelper,
-                    new SqlServerTypeMappingSource(
-                        TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
-                        TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())));
+                new CSharpSnapshotGeneratorDependencies(codeHelper));
 
             foreach (var field in typeof(CoreAnnotationNames).GetFields().Concat(
                 typeof(RelationalAnnotationNames).GetFields().Where(f => f.Name != "Prefix")))
@@ -258,19 +257,20 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         [Fact]
         public void Snapshot_with_enum_discriminator_uses_converted_values()
         {
-            var codeHelper = new CSharpHelper();
+            var codeHelper = new CSharpHelper(new SqlServerTypeMappingSource(
+                TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
+                TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()));
+
             var generator = new CSharpMigrationsGenerator(
                 new MigrationsCodeGeneratorDependencies(),
                 new CSharpMigrationsGeneratorDependencies(
                     codeHelper,
                     new CSharpMigrationOperationGenerator(
-                        new CSharpMigrationOperationGeneratorDependencies(codeHelper)),
+                        new CSharpMigrationOperationGeneratorDependencies(
+                            codeHelper)),
                     new CSharpSnapshotGenerator(
                         new CSharpSnapshotGeneratorDependencies(
-                            codeHelper,
-                            new SqlServerTypeMappingSource(
-                                TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
-                                TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())))));
+                            codeHelper))));
 
             var modelBuilder = RelationalTestHelpers.Instance.CreateConventionBuilder();
             modelBuilder.Entity<WithAnnotations>(
@@ -338,13 +338,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
 
             modelBuilder.GetInfrastructure().Metadata.Validate();
 
-            var codeHelper = new CSharpHelper();
+            var codeHelper = new CSharpHelper(new SqlServerTypeMappingSource(
+                TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
+                TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()));
+
             var generator = new TestCSharpSnapshotGenerator(
-                new CSharpSnapshotGeneratorDependencies(
-                    codeHelper,
-                    new SqlServerTypeMappingSource(
-                        TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
-                        TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())));
+                new CSharpSnapshotGeneratorDependencies(codeHelper));
 
             property.SetValueConverter(valueConverter);
 

--- a/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/MigrationScaffolderTest.cs
@@ -50,7 +50,9 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
         {
             var currentContext = new CurrentDbContext(new TContext());
             var idGenerator = new MigrationsIdGenerator();
-            var code = new CSharpHelper();
+            var code = new CSharpHelper(new SqlServerTypeMappingSource(
+                TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
+                TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>()));
             var reporter = new TestOperationReporter();
             var migrationAssembly
                 = new MigrationsAssembly(
@@ -84,13 +86,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                                 new CSharpMigrationsGeneratorDependencies(
                                     code,
                                     new CSharpMigrationOperationGenerator(
-                                        new CSharpMigrationOperationGeneratorDependencies(code)),
+                                        new CSharpMigrationOperationGeneratorDependencies(
+                                            code)),
                                     new CSharpSnapshotGenerator(
                                         new CSharpSnapshotGeneratorDependencies(
-                                            code,
-                                            new SqlServerTypeMappingSource(
-                                                TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
-                                                TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())))))
+                                            code))))
                         }),
                     historyRepository,
                     reporter,

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpModelGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/CSharpModelGeneratorTest.cs
@@ -48,6 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 
         private static IModelCodeGenerator CreateGenerator()
             => new ServiceCollection()
+                .AddEntityFrameworkSqlServer()
                 .AddEntityFrameworkDesignTimeServices()
                 .AddSingleton<IAnnotationCodeGenerator, AnnotationCodeGenerator>()
                 .AddSingleton<IProviderConfigurationCodeGenerator, TestProviderCodeGenerator>()


### PR DESCRIPTION
Fixes #8741
Fixes #13297

Moves the dependency on the type mapper onto the CSharpHelper.