### PR TITLE
Fix the file path to signed package items and remove obsolete signing properties

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,13 +11,10 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)build\Key.snk</AssemblyOriginatorKeyFile>
     <PackageTags>Entity Framework Core;entity-framework-core;EF;Data;O/RM;EntityFramework;EntityFrameworkCore;EFCore</PackageTags>
     <Product>Microsoft Entity Framework Core</Product>
-    <PublicSign Condition="'$(OS)' != 'Windows_NT'">True</PublicSign>
     <RepositoryType>git</RepositoryType>
     <RepositoryRoot>$(MSBuildThisFileDirectory)</RepositoryRoot>
-    <RepositoryUrl>https://github.com/aspnet/EntityFramework.git</RepositoryUrl>
+    <RepositoryUrl>https://github.com/aspnet/EntityFramework</RepositoryUrl>
     <SignAssembly>True</SignAssembly>
-    <AssemblySigningCertName>Microsoft</AssemblySigningCertName>
-    <PackageSigningCertName>MicrosoftNuGet</PackageSigningCertName>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>7.2</LangVersion>
     <NoWarn>$(NoWarn);CA1032;CA1034;CA1052;CA1063;CA1815;CA1819;CA1822;CA2231</NoWarn>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <Product>Microsoft Entity Framework Core</Product>
     <RepositoryType>git</RepositoryType>
     <RepositoryRoot>$(MSBuildThisFileDirectory)</RepositoryRoot>
-    <RepositoryUrl>https://github.com/aspnet/EntityFramework</RepositoryUrl>
+    <RepositoryUrl>https://github.com/aspnet/EntityFrameworkCore</RepositoryUrl>
     <SignAssembly>True</SignAssembly>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>7.2</LangVersion>

--- a/src/EFCore.Analyzers/EFCore.Analyzers.csproj
+++ b/src/EFCore.Analyzers/EFCore.Analyzers.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <!-- Code sign the analyzer assembly -->
-    <SignedPackageFile Include="analyzers/dotnet/cs/$(TargetFileName)" Certificate="$(AssemblySigningCertName)" />
+    <SignedPackageFile Include="$(TargetPath)" PackagePath="analyzers/dotnet/cs/$(TargetFileName)" Certificate="$(AssemblySigningCertName)" />
   </ItemGroup>
 
   <Target Name="PopulateNuspec" BeforeTargets="GenerateNuspec" DependsOnTargets="Build">

--- a/src/EFCore.Tools/EFCore.Tools.csproj
+++ b/src/EFCore.Tools/EFCore.Tools.csproj
@@ -30,17 +30,17 @@ Update-Database
 
   <ItemGroup>
     <!-- PowerShell files should be code signed -->
-    <SignedPackageFile Include="tools/EntityFrameworkCore.PowerShell2.psd1" Certificate="$(AssemblySigningCertName)" />
-    <SignedPackageFile Include="tools/EntityFrameworkCore.PowerShell2.psm1" Certificate="$(AssemblySigningCertName)" />
-    <SignedPackageFile Include="tools/EntityFrameworkCore.psd1" Certificate="$(AssemblySigningCertName)" />
-    <SignedPackageFile Include="tools/EntityFrameworkCore.psm1" Certificate="$(AssemblySigningCertName)" />
-    <SignedPackageFile Include="tools/init.ps1" Certificate="$(AssemblySigningCertName)" />
-    <SignedPackageFile Include="tools/install.ps1" Certificate="$(AssemblySigningCertName)" />
+    <SignedPackageFile Include="$(TargetDir)EntityFrameworkCore.PowerShell2.psd1" PackagePath="tools/EntityFrameworkCore.PowerShell2.psd1" Certificate="$(PowerShellSigningCertName)" />
+    <SignedPackageFile Include="$(TargetDir)EntityFrameworkCore.psd1" PackagePath="tools/EntityFrameworkCore.psd1" Certificate="$(PowerShellSigningCertName)" />
+    <SignedPackageFile Include="tools/EntityFrameworkCore.PowerShell2.psm1" PackagePath="tools/EntityFrameworkCore.PowerShell2.psm1" Certificate="$(PowerShellSigningCertName)" />
+    <SignedPackageFile Include="tools/EntityFrameworkCore.psm1" PackagePath="tools/EntityFrameworkCore.psm1" Certificate="$(PowerShellSigningCertName)" />
+    <SignedPackageFile Include="tools/init.ps1" PackagePath="tools/init.ps1" Certificate="$(PowerShellSigningCertName)" />
+    <SignedPackageFile Include="tools/install.ps1" PackagePath="tools/install.ps1" Certificate="$(PowerShellSigningCertName)" />
 
     <!-- Additional assemblies to be code signed -->
-    <SignedPackageFile Include="tools/net461/any/ef.exe" Certificate="$(AssemblySigningCertName)" />
-    <SignedPackageFile Include="tools/net461/win-x86/ef.exe" Certificate="$(AssemblySigningCertName)" />
-    <SignedPackageFile Include="tools/netcoreapp2.0/any/ef.dll" Certificate="$(AssemblySigningCertName)" />
+    <SignedPackageFile Include="../ef/bin/$(Configuration)/net461/ef.exe" PackagePath="tools/net461/any/ef.exe" Certificate="$(AssemblySigningCertName)" />
+    <SignedPackageFile Include="../ef/bin/x86/$(Configuration)/net461/ef.exe" PackagePath="tools/net461/win-x86/ef.exe" Certificate="$(AssemblySigningCertName)" />
+    <SignedPackageFile Include="../ef/bin/$(Configuration)/netcoreapp2.0/ef.dll" PackagePath="tools/netcoreapp2.0/any/ef.dll" Certificate="$(AssemblySigningCertName)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet-ef/dotnet-ef.csproj
+++ b/src/dotnet-ef/dotnet-ef.csproj
@@ -76,12 +76,12 @@ dotnet ef database update
 
   <ItemGroup>
     <!-- Additional files to be code signed -->
-    <SignedPackageFile Include="tools/netcoreapp2.2/any/tools/netcoreapp2.0/any/ef.dll" Certificate="$(AssemblySigningCertName)" />
-    <SignedPackageFile Include="tools/netcoreapp2.2/any/tools/net461/any/ef.exe" Certificate="$(AssemblySigningCertName)" />
-    <SignedPackageFile Include="tools/netcoreapp2.2/any/tools/net461/win-x86/ef.exe" Certificate="$(AssemblySigningCertName)" />
+    <SignedPackageFile Include="$(TargetPath)" PackagePath="tools/$(TargetFramework)/any/tools/netcoreapp2.0/any/ef.dll" Certificate="$(AssemblySigningCertName)" />
+    <SignedPackageFile Include="..\ef\bin\$(Configuration)\net461\ef.exe" PackagePath="tools/$(TargetFramework)/any/tools/net461/any/ef.exe" Certificate="$(AssemblySigningCertName)" />
+    <SignedPackageFile Include="..\ef\bin\x86\$(Configuration)\net461\ef.exe" PackagePath="tools/$(TargetFramework)/any/tools/net461/win-x86/ef.exe" Certificate="$(AssemblySigningCertName)" />
 
-    <!-- Third-party assemblies should be signed with the 3PartyDual certificate -->
-    <SignedPackageFile Include="tools/netcoreapp2.2/any/Newtonsoft.Json.dll" Certificate="3PartyDual" />
+    <!-- Third-party assemblies should be signed with the 3rd party certificate -->
+    <SignedPackageFile Include="$(PublishDir)\Newtonsoft.Json.dll" PackagePath="tools/$(TargetFramework)/any/Newtonsoft.Json.dll" Certificate="$(AssemblySigning3rdPartyCertName)" />
   </ItemGroup>
 
   <Target Name="PopulateNuspec" BeforeTargets="GenerateNuspec" DependsOnTargets="Build">


### PR DESCRIPTION
React to https://github.com/aspnet/BuildTools/pull/766 which will enable code signing to run as a part of build.ps1, including a dry-run for local developer builds.