### PR TITLE
Cosmos SQL: Preserve unmapped properties.

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -7,7 +7,6 @@
     <FunctionalTests_PackageVersion>0.0.0</FunctionalTests_PackageVersion>
     <InternalAspNetCoreSdkPackageVersion>2.2.0-preview1-20180918.1</InternalAspNetCoreSdkPackageVersion>
     <InternalWebHostBuilderFactorySourcesPackageVersion>2.2.0-preview3-35301</InternalWebHostBuilderFactorySourcesPackageVersion>
-    <MicrosoftAzureDocumentDBCorePackageVersion>1.7.1</MicrosoftAzureDocumentDBCorePackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>2.8.0</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>2.8.0</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
     <MicrosoftCSharpPackageVersion>4.5.0</MicrosoftCSharpPackageVersion>

--- a/src/EFCore.Cosmos.Sql/Metadata/Conventions/Internal/StoreKeyConvention.cs
+++ b/src/EFCore.Cosmos.Sql/Metadata/Conventions/Internal/StoreKeyConvention.cs
@@ -4,18 +4,24 @@
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.ValueGeneration.Internal;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Metadata.Conventions.Internal
 {
     public class StoreKeyConvention : IEntityTypeAddedConvention
     {
+        public static readonly string IdPropertyName = "id";
+        public static readonly string JObjectPropertyName = "__jObject";
+
         public InternalEntityTypeBuilder Apply(InternalEntityTypeBuilder entityTypeBuilder)
         {
             if (entityTypeBuilder.Metadata.BaseType == null)
             {
-                var idProperty = entityTypeBuilder.Property("id", typeof(string), ConfigurationSource.Convention);
+                var idProperty = entityTypeBuilder.Property(IdPropertyName, typeof(string), ConfigurationSource.Convention);
                 idProperty.HasValueGenerator((_, __) => new StringValueGenerator(generateTemporaryValues: false), ConfigurationSource.Convention);
                 entityTypeBuilder.HasKey(new[] { idProperty.Metadata }, ConfigurationSource.Convention);
+
+                var jObjectProperty = entityTypeBuilder.Property(JObjectPropertyName, typeof(JObject), ConfigurationSource.Convention);
             }
 
             return entityTypeBuilder;

--- a/src/EFCore.Cosmos.Sql/Query/Internal/ValueBufferFactoryFactory.cs
+++ b/src/EFCore.Cosmos.Sql/Query/Internal/ValueBufferFactoryFactory.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using Microsoft.EntityFrameworkCore.Cosmos.Sql.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Newtonsoft.Json.Linq;
 
@@ -34,6 +35,11 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.Internal
             Expression jObjectExpression,
             IPropertyBase property)
         {
+            if (property.Name == StoreKeyConvention.JObjectPropertyName)
+            {
+                return jObjectExpression;
+            }
+
             var expression = Expression.Convert(
                 Expression.Call(
                     jObjectExpression,

--- a/src/EFCore.Cosmos.Sql/Storage/Internal/CosmosClient.cs
+++ b/src/EFCore.Cosmos.Sql/Storage/Internal/CosmosClient.cs
@@ -648,7 +648,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Storage.Internal
                     var hasNext = _underlyingEnumerator.MoveNext();
                     if (hasNext)
                     {
-                        Current = _underlyingEnumerator.Current.First.First.ToObject<JObject>();
+                        Current = (JObject)_underlyingEnumerator.Current.First.First;
                         return true;
                     }
 
@@ -737,7 +737,7 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Storage.Internal
                     var hasNext = _underlyingEnumerator.MoveNext();
                     if (hasNext)
                     {
-                        Current = _underlyingEnumerator.Current.First.First.ToObject<JObject>();
+                        Current = (JObject)_underlyingEnumerator.Current.First.First;
                         return true;
                     }
 


### PR DESCRIPTION
This is accomplished by storing the JObject returned from the store in a shadow property.
