### PR TITLE
Use expressions to represent type mapping code literals

### DIFF
--- a/src/EFCore.Design/Properties/DesignStrings.Designer.cs
+++ b/src/EFCore.Design/Properties/DesignStrings.Designer.cs
@@ -169,6 +169,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 literalType);
 
         /// <summary>
+        ///     The literal expression '{expression}' for '{type}' cannot be parsed. Only simple constructor calls and factory methods are supported.
+        /// </summary>
+        public static string LiteralExpressionNotSupported([CanBeNull] object expression, [CanBeNull] object type)
+            => string.Format(
+                GetString("LiteralExpressionNotSupported", nameof(expression), nameof(type)),
+                expression, type);
+
+        /// <summary>
         ///     Unable to find provider assembly with name {assemblyName}. Ensure the specified name is correct and is referenced by the project.
         /// </summary>
         public static string CannotFindRuntimeProviderAssembly([CanBeNull] object assemblyName)

--- a/src/EFCore.Design/Properties/DesignStrings.resx
+++ b/src/EFCore.Design/Properties/DesignStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -176,6 +176,9 @@
   </data>
   <data name="UnknownLiteral" xml:space="preserve">
     <value>The current CSharpHelper cannot scaffold literals of type '{literalType}'. Configure your services to use one that can.</value>
+  </data>
+  <data name="LiteralExpressionNotSupported" xml:space="preserve">
+    <value>The literal expression '{expression}' for '{type}' cannot be parsed. Only simple constructor calls and factory methods are supported.</value>
   </data>
   <data name="CannotFindRuntimeProviderAssembly" xml:space="preserve">
     <value>Unable to find provider assembly with name {assemblyName}. Ensure the specified name is correct and is referenced by the project.</value>

--- a/src/EFCore.SqlServer.NTS/Storage/Internal/SqlServerGeometryTypeMapping.cs
+++ b/src/EFCore.SqlServer.NTS/Storage/Internal/SqlServerGeometryTypeMapping.cs
@@ -90,10 +90,6 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         protected override string AsText(object value)
         {
             var geometry = (IGeometry)value;
-            if (geometry == null)
-            {
-                return null;
-            }
 
             var srid = geometry.SRID;
 
@@ -105,6 +101,13 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
 
             return text;
         }
+
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override Type WKTReaderType => typeof(WKTReader);
 
         private static SqlServerSpatialReader CreateReader(IGeometryServices services, bool isGeography)
             => new SqlServerSpatialReader(services) { IsGeography = isGeography };

--- a/src/EFCore.Sqlite.NTS/Storage/Internal/SqliteGeometryTypeMapping.cs
+++ b/src/EFCore.Sqlite.NTS/Storage/Internal/SqliteGeometryTypeMapping.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Data.Common;
-using System.Globalization;
 using System.Reflection;
 using GeoAPI;
 using GeoAPI.Geometries;
@@ -81,10 +81,6 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
         protected override string AsText(object value)
         {
             var geometry = (IGeometry)value;
-            if (geometry == null)
-            {
-                return null;
-            }
 
             var srid = geometry.SRID;
 
@@ -96,6 +92,12 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
 
             return text;
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override Type WKTReaderType => typeof(WKTReader);
 
         private static GaiaGeoReader CreateReader(IGeometryServices geometryServices)
             => new GaiaGeoReader(

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -49,6 +49,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
             => GetString("StillUsingTypeMapper");
 
         /// <summary>
+        ///     The type mapping for '{type}' has not implemented code literal generation.
+        /// </summary>
+        public static string LiteralGenerationNotSupported([CanBeNull] object type)
+            => string.Format(
+                GetString("LiteralGenerationNotSupported", nameof(type)),
+                type);
+
+        /// <summary>
         ///     The properties expression '{expression}' is not valid. The expression should represent a simple property access: 't =&gt; t.MyProperty'. When specifying multiple properties use an anonymous type: 't =&gt; new {{ t.MyProperty1, t.MyProperty2 }}'.
         /// </summary>
         public static string InvalidPropertiesExpression([CanBeNull] object expression)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -130,6 +130,9 @@
   <data name="StillUsingTypeMapper" xml:space="preserve">
     <value>The application or database provider is using an Obsolete TypeMapper API even after the provider has implemented a TypeMappingSource. The code must be updated to use the non-obsolete replacement APIs, as indicated by the Obsolete compiler warnings.</value>
   </data>
+  <data name="LiteralGenerationNotSupported" xml:space="preserve">
+    <value>The type mapping for '{type}' has not implemented code literal generation.</value>
+  </data>
   <data name="InvalidPropertiesExpression" xml:space="preserve">
     <value>The properties expression '{expression}' is not valid. The expression should represent a simple property access: 't =&gt; t.MyProperty'. When specifying multiple properties use an anonymous type: 't =&gt; new {{ t.MyProperty1, t.MyProperty2 }}'.</value>
   </data>

--- a/src/EFCore/Storage/CoreTypeMapping.cs
+++ b/src/EFCore/Storage/CoreTypeMapping.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Linq.Expressions;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -220,12 +221,13 @@ namespace Microsoft.EntityFrameworkCore.Storage
         public abstract CoreTypeMapping Clone([CanBeNull] ValueConverter converter);
 
         /// <summary>
-        ///     Attempts generation of a code (e.g. C#) literal for the given value.
+        ///     Creates a an expression tree that can be used to generate code for the literal value.
+        ///     Currently, only very basic expressions such as constructor calls and factory methods taking
+        ///     simple constants are supported.
         /// </summary>
         /// <param name="value"> The value for which a literal is needed. </param>
-        /// <param name="language"> The language, for example "C#". </param>
-        /// <returns> The generated literal, or <c>null</c> if a literal could not be generated. </returns>
-        public virtual string FindCodeLiteral([CanBeNull] object value, [NotNull] string language)
-            => null;
+        /// <returns> An expression tree that can be used to generate code for the literal value. </returns>
+        public virtual Expression GenerateLiteralExpression([NotNull] object value)
+            => throw new NotSupportedException(CoreStrings.LiteralGenerationNotSupported(ClrType.ShortDisplayName()));
     }
 }


### PR DESCRIPTION
Mean that type mappings can support language independent code literals. Only the C#/VB/F# helper needs to be language specific, even for unknown types.

Fixes #13414
