### PR TITLE
Change Spec.Tests dependency on xunit.core to xunit.extensibility.execution

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,7 +5,7 @@
   <PropertyGroup Label="Package Versions">
     <CastleCorePackageVersion>4.2.1</CastleCorePackageVersion>
     <FunctionalTests_PackageVersion>0.0.0</FunctionalTests_PackageVersion>
-    <InternalAspNetCoreSdkPackageVersion>2.2.0-preview1-20180918.1</InternalAspNetCoreSdkPackageVersion>
+    <InternalAspNetCoreSdkPackageVersion>2.2.0-preview1-20180928.3</InternalAspNetCoreSdkPackageVersion>
     <InternalWebHostBuilderFactorySourcesPackageVersion>2.2.0-preview3-35301</InternalWebHostBuilderFactorySourcesPackageVersion>
     <MicrosoftAzureDocumentDBCorePackageVersion>1.7.1</MicrosoftAzureDocumentDBCorePackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>2.8.0</MicrosoftCodeAnalysisCSharpPackageVersion>
@@ -40,6 +40,7 @@
     <SystemInteractiveAsyncPackageVersion>3.2.0</SystemInteractiveAsyncPackageVersion>
     <XunitAssertPackageVersion>2.3.1</XunitAssertPackageVersion>
     <XunitCorePackageVersion>2.3.1</XunitCorePackageVersion>
+    <XunitExtensibilityExecutionPackageVersion>2.3.1</XunitExtensibilityExecutionPackageVersion>
     <XunitRunnerVisualStudioPackageVersion>2.4.0</XunitRunnerVisualStudioPackageVersion>
   </PropertyGroup>
   <Import Project="$(DotNetPackageVersionPropsPath)" Condition=" '$(DotNetPackageVersionPropsPath)' != '' " />

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.2.0-preview1-20180918.1
-commithash:ad5e3fc53442741a0dd49bce437d2ac72f4b5800
+version:2.2.0-preview1-20180928.3
+commithash:51fa917a4f9840f6de5ad384a2a3c80abb0fe2d5

--- a/src/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
+++ b/src/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
@@ -28,8 +28,8 @@
 
   <ItemGroup>
     <PackageReference Include="NetTopologySuite.Core" Version="$(NetTopologySuiteCorePackageVersion)" />
-    <!-- Using xunit.core and xunit.assert instead of 'xunit', which would force consumers to use xunit.analyzers. -->
-    <PackageReference Include="xunit.core" Version="$(XunitCorePackageVersion)" />
+    <!-- Using xunit.extensibility.execution and xunit.assert instead of 'xunit', which would force consumers to use xunit.analyzers. -->
+    <PackageReference Include="xunit.extensibility.execution" Version="$(XunitExtensibilityExecutionPackageVersion)" />
     <PackageReference Include="xunit.assert" Version="$(XunitAssertPackageVersion)" />
   </ItemGroup>
 

--- a/src/dotnet-ef/dotnet-ef.csproj
+++ b/src/dotnet-ef/dotnet-ef.csproj
@@ -76,7 +76,7 @@ dotnet ef database update
 
   <ItemGroup>
     <!-- Additional files to be code signed -->
-    <SignedPackageFile Include="$(TargetPath)" PackagePath="tools/$(TargetFramework)/any/tools/netcoreapp2.0/any/ef.dll" Certificate="$(AssemblySigningCertName)" />
+    <SignedPackageFile Include="$(TargetPath)" PackagePath="tools/$(TargetFramework)/any/dotnet-ef.dll" Certificate="$(AssemblySigningCertName)" />
     <SignedPackageFile Include="..\ef\bin\$(Configuration)\net461\ef.exe" PackagePath="tools/$(TargetFramework)/any/tools/net461/any/ef.exe" Certificate="$(AssemblySigningCertName)" />
     <SignedPackageFile Include="..\ef\bin\x86\$(Configuration)\net461\ef.exe" PackagePath="tools/$(TargetFramework)/any/tools/net461/win-x86/ef.exe" Certificate="$(AssemblySigningCertName)" />
 


### PR DESCRIPTION
Per xunit guidance, class libraries which deliver xunit bits shouldn't also depend on the xunit or xunit.core metapackage. These packages contain project settings to make a test project runnable, but are not needed for class libraries which need to compile for xunit API's.

> https://xunit.github.io/releases/2.3:
> As a reminder: If you're extending xUnit.net and want to publish your extension as a NuGet package, you should import xunit.extensibility.core and/or xunit.extensibility.execution, not xunit or xunit.core. If you do this wrong, you might have problems generating your NuGet package via dotnet pack.

Incidentally, this resolves an issue with upcoming changes to KoreBuild which uses the `IsTestProject` property to skip code signing for test projects.