### PR TITLE
Added a ModelBuilder.FinalizeModel method to support building outside the context

### DIFF
--- a/samples/OracleProvider/test/OracleProvider.FunctionalTests/F1OracleFixture.cs
+++ b/samples/OracleProvider/test/OracleProvider.FunctionalTests/F1OracleFixture.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
@@ -10,9 +11,12 @@ namespace Microsoft.EntityFrameworkCore
     {
         protected override ITestStoreFactory TestStoreFactory => OracleTestStoreFactory.Instance;
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+        public override ModelBuilder CreateModelBuilder()
+            => new ModelBuilder(OracleConventionSetBuilder.Build());
+
+        protected override void BuildModelExternal(ModelBuilder modelBuilder)
         {
-            base.OnModelCreating(modelBuilder, context);
+            base.BuildModelExternal(modelBuilder);
 
             modelBuilder.Entity<Chassis>().Property<byte[]>("Version").IsRowVersion();
             modelBuilder.Entity<Driver>().Property<byte[]>("Version").IsRowVersion();

--- a/src/EFCore.InMemory/Metadata/Conventions/Internal/InMemoryConventionSetBuilder.cs
+++ b/src/EFCore.InMemory/Metadata/Conventions/Internal/InMemoryConventionSetBuilder.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.InMemory.Metadata.Conventions.Internal
 {
@@ -17,5 +19,25 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Metadata.Conventions.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual ConventionSet AddConventions(ConventionSet conventionSet) => conventionSet;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static ConventionSet Build()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFrameworkInMemoryDatabase()
+                .AddDbContext<DbContext>(o => o.UseInMemoryDatabase(Guid.NewGuid().ToString()))
+                .BuildServiceProvider();
+
+            using (var serviceScope = serviceProvider.GetRequiredService<IServiceScopeFactory>().CreateScope())
+            {
+                using (var context = serviceScope.ServiceProvider.GetService<DbContext>())
+                {
+                    return ConventionSet.CreateConventionSet(context);
+                }
+            }
+        }
     }
 }

--- a/src/EFCore.Relational.Specification.Tests/F1RelationalFixture.cs
+++ b/src/EFCore.Relational.Specification.Tests/F1RelationalFixture.cs
@@ -15,9 +15,9 @@ namespace Microsoft.EntityFrameworkCore
             => base.AddOptions(builder).ConfigureWarnings(w =>
                 w.Ignore(RelationalEventId.BatchSmallerThanMinBatchSize));
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+        protected override void BuildModelExternal(ModelBuilder modelBuilder)
         {
-            base.OnModelCreating(modelBuilder, context);
+            base.BuildModelExternal(modelBuilder);
 
             modelBuilder.Entity<Chassis>().ToTable("Chassis");
             modelBuilder.Entity<Team>().ToTable("Teams").Property(e => e.Id).ValueGeneratedNever();

--- a/src/EFCore.Relational.Specification.Tests/MigrationSqlGeneratorTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/MigrationSqlGeneratorTestBase.cs
@@ -725,6 +725,7 @@ namespace Microsoft.EntityFrameworkCore
         protected virtual void Generate(Action<ModelBuilder> buildAction, params MigrationOperation[] operation)
         {
             var modelBuilder = TestHelpers.CreateConventionBuilder();
+            modelBuilder.Model.RemoveAnnotation(CoreAnnotationNames.ProductVersionAnnotation);
             buildAction(modelBuilder);
 
             var batch = TestHelpers.CreateContextServices().GetRequiredService<IMigrationsSqlGenerator>()

--- a/src/EFCore.Specification.Tests/DataAnnotationTestBase.cs
+++ b/src/EFCore.Specification.Tests/DataAnnotationTestBase.cs
@@ -48,9 +48,14 @@ namespace Microsoft.EntityFrameworkCore
             var conventionSetBuilder = CreateConventionSetBuilder(context);
             var conventionSet = new CoreConventionSetBuilder(context.GetService<CoreConventionSetBuilderDependencies>())
                 .CreateConventionSet();
+
             conventionSet = conventionSetBuilder == null
                 ? conventionSet
                 : conventionSetBuilder.AddConventions(conventionSet);
+
+            conventionSet.ModelBuiltConventions.Add(
+                new ValidatingConvention(context.GetService<IModelValidator>()));
+
             return new ModelBuilder(conventionSet);
         }
 
@@ -58,11 +63,7 @@ namespace Microsoft.EntityFrameworkCore
             => new CompositeConventionSetBuilder(context.GetService<IEnumerable<IConventionSetBuilder>>().ToList());
 
         protected virtual void Validate(ModelBuilder modelBuilder)
-        {
-            modelBuilder.GetInfrastructure().Metadata.Validate();
-            var context = CreateContext();
-            context.GetService<IModelValidator>().Validate(modelBuilder.Model);
-        }
+            => modelBuilder.FinalizeModel();
 
         protected class Person
         {

--- a/src/EFCore.Specification.Tests/OptimisticConcurrencyTestBase.cs
+++ b/src/EFCore.Specification.Tests/OptimisticConcurrencyTestBase.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
@@ -27,6 +28,18 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         protected TFixture Fixture { get; }
+
+        [Fact]
+        public virtual void External_model_builder_uses_validation()
+        {
+            var modelBuilder = Fixture.CreateModelBuilder();
+            modelBuilder.Entity("Dummy");
+
+            Assert.Equal(
+                CoreStrings.ShadowEntity("Dummy"),
+                Assert.Throws<InvalidOperationException>
+                    (() => modelBuilder.FinalizeModel()).Message);
+        }
 
         [Fact]
         public virtual void Nullable_client_side_concurrency_token_can_be_used()

--- a/src/EFCore.Specification.Tests/TestUtilities/TestModelSource.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/TestModelSource.cs
@@ -3,7 +3,6 @@
 
 using System;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -24,20 +23,17 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         protected override IModel CreateModel(DbContext context, IConventionSetBuilder conventionSetBuilder, IModelValidator validator)
         {
             var conventionSet = CreateConventionSet(conventionSetBuilder);
+            conventionSet.ModelBuiltConventions.Add(new ValidatingConvention(validator));
 
             var modelBuilder = new ModelBuilder(conventionSet);
-            var model = modelBuilder.GetInfrastructure().Metadata;
-            model.SetProductVersion(ProductInfo.GetVersion());
 
             Dependencies.ModelCustomizer.Customize(modelBuilder, context);
 
             _onModelCreating(modelBuilder, context);
 
-            model.Validate();
+            modelBuilder.FinalizeModel();
 
-            validator.Validate(model);
-
-            return model;
+            return modelBuilder.GetInfrastructure().Metadata;
         }
 
         public static Func<IServiceProvider, IModelSource> GetFactory(Action<ModelBuilder> onModelCreating)

--- a/src/EFCore/Infrastructure/ModelSource.cs
+++ b/src/EFCore/Infrastructure/ModelSource.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Threading;
 using JetBrains.Annotations;
-using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
@@ -76,18 +75,15 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             Check.NotNull(validator, nameof(validator));
 
             var conventionSet = CreateConventionSet(conventionSetBuilder);
+            conventionSet.ModelBuiltConventions.Add(new ValidatingConvention(validator));
 
             var modelBuilder = new ModelBuilder(conventionSet);
-            var model = modelBuilder.GetInfrastructure().Metadata;
-            model.SetProductVersion(ProductInfo.GetVersion());
 
             Dependencies.ModelCustomizer.Customize(modelBuilder, context);
 
-            model.Validate();
+            modelBuilder.FinalizeModel();
 
-            validator.Validate(model);
-
-            return model;
+            return modelBuilder.GetInfrastructure().Metadata;
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Conventions/ConventionSet.cs
+++ b/src/EFCore/Metadata/Conventions/ConventionSet.cs
@@ -162,7 +162,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public static ConventionSet CreateConventionSet([NotNull] DbContext context)
-            => new CompositeConventionSetBuilder(context.GetService<IEnumerable<IConventionSetBuilder>>().ToList())
-                .AddConventions(context.GetService<ICoreConventionSetBuilder>().CreateConventionSet());
+        {
+            var conventionSet = new CompositeConventionSetBuilder(
+                    context.GetService<IEnumerable<IConventionSetBuilder>>().ToList())
+                .AddConventions(
+                    context.GetService<ICoreConventionSetBuilder>().CreateConventionSet());
+
+            conventionSet.ModelBuiltConventions.Add(new ValidatingConvention(context.GetService<IModelValidator>()));
+
+            return conventionSet;
+        }
     }
 }

--- a/src/EFCore/Metadata/Conventions/Internal/ValidatingConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ValidatingConvention.cs
@@ -1,0 +1,38 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class ValidatingConvention : IModelBuiltConvention
+    {
+        private readonly IModelValidator _validator;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public ValidatingConvention([NotNull] IModelValidator validator)
+        {
+            _validator = validator;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual InternalModelBuilder Apply(InternalModelBuilder modelBuilder)
+        {
+            _validator.Validate(modelBuilder.Metadata);
+
+            return modelBuilder;
+        }
+    }
+}

--- a/src/EFCore/ModelBuilder.cs
+++ b/src/EFCore/ModelBuilder.cs
@@ -5,6 +5,7 @@ using System;
 using System.ComponentModel;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
@@ -38,6 +39,8 @@ namespace Microsoft.EntityFrameworkCore
             Check.NotNull(conventions, nameof(conventions));
 
             _builder = new InternalModelBuilder(new Model(conventions));
+
+            _builder.Metadata.SetProductVersion(ProductInfo.GetVersion());
         }
 
         /// <summary>
@@ -389,6 +392,21 @@ namespace Microsoft.EntityFrameworkCore
         public virtual ModelBuilder UsePropertyAccessMode(PropertyAccessMode propertyAccessMode)
         {
             Builder.UsePropertyAccessMode(propertyAccessMode, ConfigurationSource.Explicit);
+
+            return this;
+        }
+
+        /// <summary>
+        ///     Forces post-processing on the model such that it is ready for use by the runtime. This post
+        ///     processing happens automatically when using OnModelCreating; this method allows it to be run
+        ///     explicitly in cases where the automatic execution is not possible.
+        /// </summary>
+        /// <returns>
+        ///     The same <see cref="ModelBuilder" /> instance so that additional configuration calls can be chained.
+        /// </returns>
+        public virtual ModelBuilder FinalizeModel()
+        {
+            Builder.Metadata.Validate();
 
             return this;
         }

--- a/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/Design/CSharpMigrationsGeneratorTest.cs
@@ -273,6 +273,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                             codeHelper))));
 
             var modelBuilder = RelationalTestHelpers.Instance.CreateConventionBuilder();
+            modelBuilder.Model.RemoveAnnotation(CoreAnnotationNames.ProductVersionAnnotation);
             modelBuilder.Entity<WithAnnotations>(
                 eb =>
                 {
@@ -282,7 +283,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
                     eb.Property<RawEnum>("EnumDiscriminator").HasConversion<int>();
                 });
 
-            modelBuilder.GetInfrastructure().Metadata.Validate();
+            modelBuilder.FinalizeModel();
 
             var modelSnapshotCode = generator.GenerateSnapshot(
                 "MyNamespace",
@@ -336,7 +337,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Design
             var property = modelBuilder.Entity<WithAnnotations>().Property(e => e.Id).Metadata;
             property.SetMaxLength(1000);
 
-            modelBuilder.GetInfrastructure().Metadata.Validate();
+            modelBuilder.FinalizeModel();
 
             var codeHelper = new CSharpHelper(new SqlServerTypeMappingSource(
                 TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
@@ -520,6 +521,7 @@ namespace MyNamespace
             var generator = CreateMigrationsCodeGenerator();
 
             var modelBuilder = RelationalTestHelpers.Instance.CreateConventionBuilder();
+            modelBuilder.Model.RemoveAnnotation(CoreAnnotationNames.ProductVersionAnnotation);
             modelBuilder.Entity<EntityWithConstructorBinding>(
                 x =>
                 {
@@ -539,7 +541,7 @@ namespace MyNamespace
             var property2 = entityType.AddProperty("Ham", typeof(RawEnum));
             property2.SetValueConverter(new ValueConverter<RawEnum, string>(v => v.ToString(), v => (RawEnum)Enum.Parse(typeof(RawEnum), v), new ConverterMappingHints(size: 10)));
 
-            modelBuilder.GetInfrastructure().Metadata.Validate();
+            modelBuilder.FinalizeModel();
 
             var modelSnapshotCode = generator.GenerateSnapshot(
                 "MyNamespace",

--- a/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
+++ b/test/EFCore.Design.Tests/Migrations/ModelSnapshotSqlServerTest.cs
@@ -3186,10 +3186,10 @@ namespace RootNamespace
         {
             var modelBuilder = CreateConventionalModelBuilder();
             modelBuilder.HasChangeTrackingStrategy(ChangeTrackingStrategy.Snapshot);
+            modelBuilder.Model.RemoveAnnotation(CoreAnnotationNames.ProductVersionAnnotation);
             buildModel(modelBuilder);
 
-            modelBuilder.GetInfrastructure().Metadata.Validate();
-            CreateModelValidator().Validate(modelBuilder.Model);
+            modelBuilder.FinalizeModel();
             var model = modelBuilder.Model;
 
             var codeHelper = new CSharpHelper(
@@ -3238,6 +3238,7 @@ namespace RootNamespace
                 null);
 
             var builder = new ModelBuilder(new ConventionSet());
+            builder.Model.RemoveAnnotation(CoreAnnotationNames.ProductVersionAnnotation);
 
             buildModelMethod.Invoke(
                 Activator.CreateInstance(factoryType),
@@ -3266,24 +3267,5 @@ namespace RootNamespace
                 }
             }
         }
-
-        protected ModelValidator CreateModelValidator()
-            => new SqlServerModelValidator(
-                new ModelValidatorDependencies(
-                    new DiagnosticsLogger<DbLoggerCategory.Model.Validation>(
-                        new ListLoggerFactory(l => false),
-                        new LoggingOptions(),
-                        new DiagnosticListener("Fake")),
-                    new DiagnosticsLogger<DbLoggerCategory.Model>(
-                        new ListLoggerFactory(l => false),
-                        new LoggingOptions(),
-                        new DiagnosticListener("Fake"))),
-                new RelationalModelValidatorDependencies(
-#pragma warning disable 618
-                    TestServiceFactory.Instance.Create<ObsoleteRelationalTypeMapper>(),
-#pragma warning restore 618
-                    new SqlServerTypeMappingSource(
-                        TestServiceFactory.Instance.Create<TypeMappingSourceDependencies>(),
-                        TestServiceFactory.Instance.Create<RelationalTypeMappingSourceDependencies>())));
     }
 }

--- a/test/EFCore.Design.Tests/Scaffolding/Internal/ModelCodeGeneratorTestBase.cs
+++ b/test/EFCore.Design.Tests/Scaffolding/Internal/ModelCodeGeneratorTestBase.cs
@@ -8,23 +8,46 @@ using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Design.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
 {
+
     public abstract class ModelCodeGeneratorTestBase
     {
+        public static ConventionSet BuildNonValidatingConventionSet()
+        {
+            var serviceProvider = new ServiceCollection()
+                .AddEntityFrameworkSqlServer()
+                .AddDbContext<DbContext>(o => o.UseSqlServer("Server=."))
+                .BuildServiceProvider();
+
+            using (var serviceScope = serviceProvider.GetRequiredService<IServiceScopeFactory>().CreateScope())
+            {
+                using (var context = serviceScope.ServiceProvider.GetService<DbContext>())
+                {
+                    return new CompositeConventionSetBuilder(
+                            context.GetService<IEnumerable<IConventionSetBuilder>>().ToList())
+                        .AddConventions(
+                            context.GetService<ICoreConventionSetBuilder>().CreateConventionSet());
+                }
+            }
+        }
+
         protected void Test(
             Action<ModelBuilder> buildModel,
             ModelCodeGenerationOptions options,
             Action<ScaffoldedModel> assertScaffold,
             Action<IModel> assertModel)
         {
-            var modelBuilder = new ModelBuilder(SqlServerConventionSetBuilder.Build());
+            var modelBuilder = new ModelBuilder(BuildNonValidatingConventionSet());
+            modelBuilder.Model.RemoveAnnotation(CoreAnnotationNames.ProductVersionAnnotation);
             buildModel(modelBuilder);
-            modelBuilder.GetInfrastructure().Metadata.Validate();
+            modelBuilder.FinalizeModel();
 
             var model = modelBuilder.Model;
 

--- a/test/EFCore.InMemory.FunctionalTests/F1InMemoryFixture.cs
+++ b/test/EFCore.InMemory.FunctionalTests/F1InMemoryFixture.cs
@@ -1,12 +1,16 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.InMemory.Metadata.Conventions.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore
 {
     public class F1InMemoryFixture : F1FixtureBase
     {
+        public override ModelBuilder CreateModelBuilder()
+            => new ModelBuilder(InMemoryConventionSetBuilder.Build());
+
         protected override ITestStoreFactory TestStoreFactory => InMemoryTestStoreFactory.Instance;
     }
 }

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -1595,8 +1595,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             var targetModelBuilder = CreateModelBuilder();
             targetModelBuilder.Entity<Crab>();
 
-            // NB: Call Validate() so ModelBuilt conventions are applied.
-            targetModelBuilder.GetInfrastructure().Metadata.Validate();
+            targetModelBuilder.FinalizeModel();
 
             var modelDiffer = RelationalTestHelpers.Instance.CreateContextServices()
                 .GetRequiredService<IMigrationsModelDiffer>();

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTestBase.cs
@@ -41,12 +41,12 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
             var sourceModelBuilder = CreateModelBuilder();
             buildCommonAction(sourceModelBuilder);
             buildSourceAction(sourceModelBuilder);
-            sourceModelBuilder.GetInfrastructure().Metadata.Validate();
+            sourceModelBuilder.FinalizeModel();
 
             var targetModelBuilder = CreateModelBuilder();
             buildCommonAction(targetModelBuilder);
             buildTargetAction(targetModelBuilder);
-            targetModelBuilder.GetInfrastructure().Metadata.Validate();
+            targetModelBuilder.FinalizeModel();
 
             var modelDiffer = CreateModelDiffer(targetModelBuilder.Model);
 

--- a/test/EFCore.SqlServer.FunctionalTests/F1SqlServerFixture.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/F1SqlServerFixture.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.TestModels.ConcurrencyModel;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
@@ -11,9 +11,12 @@ namespace Microsoft.EntityFrameworkCore
     {
         protected override ITestStoreFactory TestStoreFactory => SqlServerTestStoreFactory.Instance;
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
+        public override ModelBuilder CreateModelBuilder()
+            => new ModelBuilder(SqlServerConventionSetBuilder.Build());
+
+        protected override void BuildModelExternal(ModelBuilder modelBuilder)
         {
-            base.OnModelCreating(modelBuilder, context);
+            base.BuildModelExternal(modelBuilder);
 
             modelBuilder.Entity<Chassis>().Property<byte[]>("Version").IsRowVersion();
             modelBuilder.Entity<Driver>().Property<byte[]>("Version").IsRowVersion();

--- a/test/EFCore.SqlServer.Tests/Metadata/Conventions/SqlServerValueGenerationStrategyConventionTest.cs
+++ b/test/EFCore.SqlServer.Tests/Metadata/Conventions/SqlServerValueGenerationStrategyConventionTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -15,6 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
         public void Annotations_are_added_when_conventional_model_builder_is_used()
         {
             var model = SqlServerTestHelpers.Instance.CreateConventionBuilder().Model;
+            model.RemoveAnnotation(CoreAnnotationNames.ProductVersionAnnotation);
 
             var annotations = model.GetAnnotations().OrderBy(a => a.Name).ToList();
             Assert.Equal(2, annotations.Count);
@@ -29,6 +31,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions
             var model = SqlServerTestHelpers.Instance.CreateConventionBuilder()
                 .ForSqlServerUseSequenceHiLo()
                 .Model;
+
+            model.RemoveAnnotation(CoreAnnotationNames.ProductVersionAnnotation);
 
             var annotations = model.GetAnnotations().OrderBy(a => a.Name).ToList();
             Assert.Equal(4, annotations.Count);

--- a/test/EFCore.Sqlite.FunctionalTests/F1SqliteFixture.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/F1SqliteFixture.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
 namespace Microsoft.EntityFrameworkCore
@@ -8,5 +9,8 @@ namespace Microsoft.EntityFrameworkCore
     public class F1SqliteFixture : F1RelationalFixture
     {
         protected override ITestStoreFactory TestStoreFactory => PrivateCacheSqliteTestStoreFactory.Instance;
+
+        public override ModelBuilder CreateModelBuilder()
+            => new ModelBuilder(SqliteConventionSetBuilder.Build());
     }
 }


### PR DESCRIPTION
Fixes #11738

Naming to be discussed.

This runs the model-based conventions, and model validation. Also moved setting or product version annotation to any use of the ModelBuilder and then removed from places in the tests that this would cause problems when the version changes.
