### PR TITLE
Metadata: Keep track of referencing FKs defined on QueryTypes

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
+++ b/src/EFCore/ChangeTracking/Internal/NavigationFixer.cs
@@ -582,8 +582,9 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             foreach (var foreignKey in entityType.GetReferencingForeignKeys())
             {
-                if (handledForeignKeys == null
-                    || !handledForeignKeys.Contains(foreignKey))
+                if (!foreignKey.DeclaringEntityType.IsQueryType
+                    && (handledForeignKeys == null
+                        || !handledForeignKeys.Contains(foreignKey)))
                 {
                     var dependents = stateManager.GetDependents(entry, foreignKey);
                     if (foreignKey.IsUnique)
@@ -618,45 +619,48 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
                 foreach (var foreignKey in entityType.GetReferencingForeignKeys())
                 {
-                    var principalToDependent = foreignKey.PrincipalToDependent;
-                    if (principalToDependent != null)
+                    if (!foreignKey.DeclaringEntityType.IsQueryType)
                     {
-                        var navigationValue = entry[principalToDependent];
-                        if (navigationValue != null)
+                        var principalToDependent = foreignKey.PrincipalToDependent;
+                        if (principalToDependent != null)
                         {
-                            if (principalToDependent.IsCollection())
+                            var navigationValue = entry[principalToDependent];
+                            if (navigationValue != null)
                             {
-                                var dependents = ((IEnumerable)navigationValue).Cast<object>().ToList();
-                                foreach (var dependentEntity in dependents)
+                                if (principalToDependent.IsCollection())
                                 {
-                                    var dependentEntry = stateManager.TryGetEntry(dependentEntity, foreignKey.DeclaringEntityType);
+                                    var dependents = ((IEnumerable)navigationValue).Cast<object>().ToList();
+                                    foreach (var dependentEntity in dependents)
+                                    {
+                                        var dependentEntry = stateManager.TryGetEntry(dependentEntity, foreignKey.DeclaringEntityType);
+                                        if (dependentEntry == null
+                                            || dependentEntry.EntityState == EntityState.Detached)
+                                        {
+                                            // If dependents in collection are not yet tracked, then save them away so that
+                                            // when we start tracking them we can come back and fixup this principal to them
+                                            stateManager.RecordReferencedUntrackedEntity(dependentEntity, principalToDependent, entry);
+                                        }
+                                        else
+                                        {
+                                            FixupToDependent(entry, dependentEntry, foreignKey, setModified);
+                                        }
+                                    }
+                                }
+                                else
+                                {
+                                    var targetEntityType = principalToDependent.GetTargetType();
+                                    var dependentEntry = stateManager.TryGetEntry(navigationValue, targetEntityType);
                                     if (dependentEntry == null
                                         || dependentEntry.EntityState == EntityState.Detached)
                                     {
-                                        // If dependents in collection are not yet tracked, then save them away so that
-                                        // when we start tracking them we can come back and fixup this principal to them
-                                        stateManager.RecordReferencedUntrackedEntity(dependentEntity, principalToDependent, entry);
+                                        // If dependent is not yet tracked, then save it away so that
+                                        // when we start tracking it we can come back and fixup this principal to it
+                                        stateManager.RecordReferencedUntrackedEntity(navigationValue, principalToDependent, entry);
                                     }
                                     else
                                     {
                                         FixupToDependent(entry, dependentEntry, foreignKey, setModified);
                                     }
-                                }
-                            }
-                            else
-                            {
-                                var targetEntityType = principalToDependent.GetTargetType();
-                                var dependentEntry = stateManager.TryGetEntry(navigationValue, targetEntityType);
-                                if (dependentEntry == null
-                                    || dependentEntry.EntityState == EntityState.Detached)
-                                {
-                                    // If dependent is not yet tracked, then save it away so that
-                                    // when we start tracking it we can come back and fixup this principal to it
-                                    stateManager.RecordReferencedUntrackedEntity(navigationValue, principalToDependent, entry);
-                                }
-                                else
-                                {
-                                    FixupToDependent(entry, dependentEntry, foreignKey, setModified);
                                 }
                             }
                         }

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -126,7 +126,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         /// </summary>
         public virtual InternalEntityTypeBuilder Builder
         {
-            [DebuggerStepThrough] get;
+            [DebuggerStepThrough]
+            get;
             [DebuggerStepThrough]
             [param: CanBeNull]
             set;
@@ -897,33 +898,30 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
 
-            if (!IsQueryType)
+            if (principalKey.ReferencingForeignKeys == null)
             {
-                if (principalKey.ReferencingForeignKeys == null)
-                {
-                    principalKey.ReferencingForeignKeys = new SortedSet<ForeignKey>(ForeignKeyComparer.Instance)
+                principalKey.ReferencingForeignKeys = new SortedSet<ForeignKey>(ForeignKeyComparer.Instance)
                     {
                         foreignKey
                     };
-                }
-                else
-                {
-                    var added = principalKey.ReferencingForeignKeys.Add(foreignKey);
-                    Debug.Assert(added);
-                }
+            }
+            else
+            {
+                var added = principalKey.ReferencingForeignKeys.Add(foreignKey);
+                Debug.Assert(added);
+            }
 
-                if (principalEntityType.DeclaredReferencingForeignKeys == null)
-                {
-                    principalEntityType.DeclaredReferencingForeignKeys = new SortedSet<ForeignKey>(ForeignKeyComparer.Instance)
+            if (principalEntityType.DeclaredReferencingForeignKeys == null)
+            {
+                principalEntityType.DeclaredReferencingForeignKeys = new SortedSet<ForeignKey>(ForeignKeyComparer.Instance)
                     {
                         foreignKey
                     };
-                }
-                else
-                {
-                    var added = principalEntityType.DeclaredReferencingForeignKeys.Add(foreignKey);
-                    Debug.Assert(added);
-                }
+            }
+            else
+            {
+                var added = principalEntityType.DeclaredReferencingForeignKeys.Add(foreignKey);
+                Debug.Assert(added);
             }
 
             PropertyMetadataChanged();
@@ -1140,11 +1138,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
             }
 
-            if (!IsQueryType)
-            {
-                foreignKey.PrincipalKey.ReferencingForeignKeys.Remove(foreignKey);
-                foreignKey.PrincipalEntityType.DeclaredReferencingForeignKeys.Remove(foreignKey);
-            }
+            foreignKey.PrincipalKey.ReferencingForeignKeys.Remove(foreignKey);
+            foreignKey.PrincipalEntityType.DeclaredReferencingForeignKeys.Remove(foreignKey);
 
             PropertyMetadataChanged();
 

--- a/test/EFCore.Tests/ModelBuilding/QueryTypesTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/QueryTypesTestBase.cs
@@ -1,4 +1,5 @@
-﻿// Copyright (c) .NET Foundation. All rights reserved.
+﻿
+// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
@@ -13,7 +14,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         public abstract class QueryTypesTestBase : ModelBuilderTestBase
         {
             [Fact]
-            public void Entity_throws_when_called_for_query()
+            public virtual void Entity_throws_when_called_for_query()
             {
                 var modelBuilder = CreateModelBuilder();
 
@@ -23,6 +24,22 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                     CoreStrings.CannotAccessQueryAsEntity(nameof(Customer)),
                     Assert.Throws<InvalidOperationException>(
                         () => modelBuilder.Entity<Customer>()).Message);
+            }
+
+            [Fact]
+            public virtual void Query_type_discovered_before_entity_type_does_not_leave_temp_id()
+            {
+                var modelBuilder = CreateModelBuilder();
+
+                modelBuilder.Ignore<Order>();
+                modelBuilder.Ignore<CustomerDetails>();
+
+                modelBuilder.Query<QueryType>();
+                modelBuilder.Entity<Customer>();
+
+                modelBuilder.Validate();
+
+                Assert.Null(modelBuilder.Model.FindEntityType(typeof(Customer))?.FindProperty("TempId"));
             }
         }
     }

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -628,5 +628,11 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public int ValueId { get; set; }
             public Value Value { get; set; }
         }
+
+        protected class QueryType
+        {
+            public int CustomerId { get; set; }
+            public Customer Customer { get; set; }
+        }
     }
 }


### PR DESCRIPTION
Issue: We did not keep track of referencing FKs on QueryTypes. This causes issue when query type is discovered first making FK to TempId.
Since when PK is discovered on EntityType, we cannot find referencing FK to replace on QueryType.

Resolves #13382
