### PR TITLE
fixed precompiled query not returning a result for a different inmemo…

### DIFF
--- a/src/EFCore.InMemory/Storage/Internal/InMemoryStoreCache.cs
+++ b/src/EFCore.InMemory/Storage/Internal/InMemoryStoreCache.cs
@@ -16,7 +16,6 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
     public class InMemoryStoreCache : IInMemoryStoreCache
     {
         private readonly IInMemoryTableFactory _tableFactory;
-        private readonly bool _useNameMatching;
         private readonly ConcurrentDictionary<string, IInMemoryStore> _namedStores;
 
         /// <summary>
@@ -41,8 +40,6 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
 
             if (options?.DatabaseRoot != null)
             {
-                _useNameMatching = true;
-
                 LazyInitializer.EnsureInitialized(
                     ref options.DatabaseRoot.Instance,
                     () => new ConcurrentDictionary<string, IInMemoryStore>());
@@ -60,6 +57,6 @@ namespace Microsoft.EntityFrameworkCore.InMemory.Storage.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual IInMemoryStore GetStore(string name)
-            => _namedStores.GetOrAdd(name, _ => new InMemoryStore(_tableFactory, _useNameMatching));
+            => _namedStores.GetOrAdd(name, _ => new InMemoryStore(_tableFactory));
     }
 }

--- a/test/EFCore.InMemory.FunctionalTests/Query/CompiledQueryInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/CompiledQueryInMemoryTest.cs
@@ -1,8 +1,12 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.TestModels.Northwind;
 using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -12,6 +16,70 @@ namespace Microsoft.EntityFrameworkCore.Query
         public CompiledQueryInMemoryTest(NorthwindQueryInMemoryFixture<NoopModelCustomizer> fixture)
             : base(fixture)
         {
+        }
+        
+        public class MyServiceCollection : ServiceCollection
+        {
+            public MyServiceCollection(string dbName)
+            {
+                this.AddDbContext<NorthwindContext>(
+                    o => o.UseInMemoryDatabase(dbName));
+            }
+        }
+
+        [Fact]
+        public void Query_Different_InMemoryDatabases()
+        {
+            var preCompiled = EF.CompileQuery<NorthwindContext, Customer>(ctx => ctx.Customers.SingleOrDefault());
+
+            using (var services = new MyServiceCollection("FOO").BuildServiceProvider())
+            {
+                using (var scope = services.GetRequiredService<IServiceScopeFactory>().CreateScope())
+                {
+                    var ctx = scope.ServiceProvider.GetRequiredService<NorthwindContext>();
+
+                    ctx.Database.EnsureDeleted();
+                    ctx.Database.EnsureCreated();
+
+                    ctx.Add(new Customer { ContactName = "One" });
+
+                    ctx.SaveChanges();
+
+                    var item = preCompiled(ctx);
+                    Assert.Equal("One", item?.ContactName);
+                }
+
+                using (var scope = services.GetRequiredService<IServiceScopeFactory>().CreateScope())
+                {
+                    var ctx = scope.ServiceProvider.GetRequiredService<NorthwindContext>();
+                    var item = preCompiled(ctx);
+                    Assert.Equal("One", item?.ContactName);
+                }
+            }
+
+            using (var services = new MyServiceCollection("BAR").BuildServiceProvider())
+            {
+                using (var scope = services.GetRequiredService<IServiceScopeFactory>().CreateScope())
+                {
+                    var ctx = scope.ServiceProvider.GetRequiredService<NorthwindContext>();
+                    ctx.Database.EnsureDeleted();
+                    ctx.Database.EnsureCreated();
+
+                    ctx.Add(new Customer { ContactName = "Two" });
+
+                    ctx.SaveChanges();
+
+                    var item = preCompiled(ctx);
+                    Assert.Equal("Two", item?.ContactName);
+                }
+
+                using (var scope = services.GetRequiredService<IServiceScopeFactory>().CreateScope())
+                {
+                    var ctx = scope.ServiceProvider.GetRequiredService<NorthwindContext>();
+                    var item = preCompiled(ctx);
+                    Assert.Equal("Two", item?.ContactName);
+                }
+            }
         }
 
         [Fact(Skip = "See issue#13857")]

--- a/test/EFCore.Tests/ModelBuilding/OneToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToManyTestBase.cs
@@ -2562,7 +2562,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 var contextOptions = new DbContextOptionsBuilder()
                     .UseModel(modelBuilder.Model)
-                    .UseInMemoryDatabase("Can_use_self_referencing_overlapping_FK_PK")
+                    .UseInMemoryDatabase(GetType().FullName + "Can_use_self_referencing_overlapping_FK_PK")
                     .Options;
 
                 using (var context = new DbContext(contextOptions))

--- a/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToOneTestBase.cs
@@ -4200,7 +4200,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 var contextOptions = new DbContextOptionsBuilder()
                     .UseModel(modelBuilder.Model)
-                    .UseInMemoryDatabase("Can_use_self_referencing_overlapping_FK_PK_one_to_one")
+                    .UseInMemoryDatabase(GetType().FullName + "Can_use_self_referencing_overlapping_FK_PK")
                     .Options;
 
                 using (var context = new DbContext(contextOptions))


### PR DESCRIPTION
…ry database

fixed compiled queries not returning a result when applied to different in memory database

- locate inmemory tables by entitytype.toString() (using entitytype.Name is not sufficient because it is ambigus)
- removed option useNameMatching as the new method works for all scenarios

fixes #13483
