### PR TITLE
ModelBuilding: Don't match FK properties which are part of Key for non-unique FK

### DIFF
--- a/src/EFCore/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/ForeignKeyPropertyDiscoveryConvention.cs
@@ -409,21 +409,29 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             foreach (var key in dependentEntityType.GetKeys())
             {
-                var isContainedInForeignKey = true;
+                var isKeyContainedInForeignKey = true;
                 // ReSharper disable once LoopCanBeConvertedToQuery
                 // ReSharper disable once ForCanBeConvertedToForeach
                 for (var i = 0; i < key.Properties.Count; i++)
                 {
                     if (!foreignKeyProperties.Contains(key.Properties[i]))
                     {
-                        isContainedInForeignKey = false;
+                        isKeyContainedInForeignKey = false;
                         break;
+                    }
+                    else
+                    {
+                        if (!foreignKey.IsUnique)
+                        {
+                            // Stop searching if match found, but is incompatible
+                            return true;
+                        }
                     }
                 }
 
-                if (isContainedInForeignKey
-                    && (!foreignKey.IsUnique
-                        || (key.IsPrimaryKey() && !matchPK)))
+                if (isKeyContainedInForeignKey
+                    && key.IsPrimaryKey()
+                    && !matchPK)
                 {
                     // Stop searching if match found, but is incompatible
                     return true;

--- a/test/EFCore.Tests/ModelBuilding/OneToManyTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OneToManyTestBase.cs
@@ -2592,6 +2592,17 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 }
             }
 
+            [Fact]
+            public virtual void Do_not_match_non_unique_FK_when_overlap_with_PK()
+            {
+                var modelBuilder = CreateModelBuilder();
+
+                modelBuilder.Entity<CompositeChild>().HasKey(e => new { e.Id, e.Value });
+
+                var fk = modelBuilder.Model.FindEntityType(typeof(CompositeChild)).GetForeignKeys().Single();
+                Assert.Equal("ParentId", fk.Properties[0].Name);
+            }
+
             private static void AssertGraph(
                 ModifierGroupHeader parent,
                 ModifierGroupHeader child1,

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -634,5 +634,18 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public int CustomerId { get; set; }
             public Customer Customer { get; set; }
         }
+
+        protected class Parent
+        {
+            public int Id { get; set; }
+            public List<CompositeChild> Children { get; set; }
+        }
+
+        protected class CompositeChild
+        {
+            public int Id { get; set; }
+            public int Value { get; set; }
+            public Parent Parent { get; set; }
+        }
     }
 }


### PR DESCRIPTION
Resolves #12508

Issue: While discovering FK, we try to find if a key is fully contained inside proposed FK and make decision based on that if we can use it.
But if the Key has overlap rather than containment, then our logic was still identifying it as no overlap making us to use a property with key for non-unique FK
Fix: If FK is non-unique and proposed match has any property with key defined on it then we don't match it
