### PR TITLE
ModelBuilding: Preserve Principal key configuration for FK on weak types

### DIFF
--- a/src/EFCore/Metadata/Internal/InternalRelationshipBuilder.cs
+++ b/src/EFCore/Metadata/Internal/InternalRelationshipBuilder.cs
@@ -1526,7 +1526,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 resetIsRequired = true;
             }
 
-            if (dependentEntityType != Metadata.DeclaringEntityType
+            if ((dependentEntityType != Metadata.DeclaringEntityType
+                 && dependentEntityType == Metadata.PrincipalEntityType) // Check if inverted
                 || (properties.Count != 0
                     && !ForeignKey.AreCompatible(
                         principalKeyProperties,

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericStringTest.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilderNonGenericStringTest.cs
@@ -33,6 +33,18 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 Can_configure_one_to_one_relationship_from_an_owned_type(modelBuilder);
             }
+
+            public override void Weak_types_with_FK_to_another_entity_works()
+            {
+                var modelBuilder = CreateModelBuilder();
+
+                // Test issue: HasOne<Country> in the base test is adding a shadow entity type when strings are
+                // used. This would not normally happen, but it happens here because no navigation property
+                // or type to do otherwise.
+                modelBuilder.Entity<Country>();
+
+                Weak_types_with_FK_to_another_entity_works(modelBuilder);
+            }
         }
 
         public class NonGenericStringOneToManyType : OneToManyTestBase

--- a/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
@@ -178,7 +178,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Can_configure_one_to_one_relationship_from_an_owned_type(CreateModelBuilder());
             }
 
-            public virtual void Can_configure_one_to_one_relationship_from_an_owned_type(TestModelBuilder modelBuilder)
+            protected virtual void Can_configure_one_to_one_relationship_from_an_owned_type(TestModelBuilder modelBuilder)
             {
                 var model = modelBuilder.Model;
 
@@ -498,7 +498,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 modelBuilder.Owned<SpecialOrder>();
 
-                 modelBuilder.Entity<SpecialCustomer>();
+                modelBuilder.Entity<SpecialCustomer>();
                 var specialCustomer = modelBuilder.Entity<SpecialCustomer>().OwnsMany(c => c.SpecialOrders, so =>
                     {
                         so.Ignore(o => o.Customer);
@@ -957,6 +957,24 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 modelBuilder.Entity<PrincipalEntity>().OwnsOne(o => o.InverseNav);
 
                 Assert.Single(modelBuilder.Model.GetEntityTypes(typeof(List<DependentEntity>)));
+            }
+
+            [Fact]
+            public virtual void Weak_types_with_FK_to_another_entity_works()
+            {
+                Weak_types_with_FK_to_another_entity_works(CreateModelBuilder());
+            }
+
+            public virtual void Weak_types_with_FK_to_another_entity_works(TestModelBuilder modelBuilder)
+            {
+                var ownerEntityTypeBuilder = modelBuilder.Entity<BillingOwner>();
+                ownerEntityTypeBuilder.OwnsOne(e => e.Bill1,
+                    o => o.HasOne<Country>().WithMany().HasPrincipalKey(c => c.Name).HasForeignKey(d => d.Country));
+
+                ownerEntityTypeBuilder.OwnsOne(e => e.Bill2,
+                    o => o.HasOne<Country>().WithMany().HasPrincipalKey(c => c.Name).HasForeignKey(d => d.Country));
+
+                modelBuilder.Validate();
             }
         }
     }

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -647,5 +647,24 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public int Value { get; set; }
             public Parent Parent { get; set; }
         }
+
+        protected class BillingOwner
+        {
+            public int Id { get; set; }
+            public BillingDetail Bill1 { get; set; }
+            public BillingDetail Bill2 { get; set; }
+        }
+
+        protected class BillingDetail
+        {
+            public string Country { get; set; }
+        }
+
+        protected class Country
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+
+        }
     }
 }


### PR DESCRIPTION
Issue: When an owned type is converted to weak type, we detach/attach relationships. In the process we are losing the principal key configuration for non-ownership Fks
This caused explicitly configured relationship to use shadow AK when PK type was different than FK.
Fix: We were resetting PrincipalKey when dependentType is not same as FK.DependentType. Though for owned to weak conversion it is never same but the condition is only supposed to capture inversion. Hence expanded the check to match if dependentType is same as PrincipalEntityType
Resolves #12423

