### PR TITLE
DateTime mapping in CosmosDb query

### DIFF
--- a/src/EFCore.Cosmos.Sql/Query/ExpressionVisitors/Internal/CosmosSqlGenerator.cs
+++ b/src/EFCore.Cosmos.Sql/Query/ExpressionVisitors/Internal/CosmosSqlGenerator.cs
@@ -8,6 +8,8 @@ using System.Linq.Expressions;
 using System.Text;
 using Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.Expressions.Internal;
 using Microsoft.EntityFrameworkCore.Cosmos.Sql.Storage.Internal;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.ExpressionVisitors.Internal
 {
@@ -113,9 +115,10 @@ namespace Microsoft.EntityFrameworkCore.Cosmos.Sql.Query.ExpressionVisitors.Inte
             {
                 _sqlBuilder.Append("null");
             }
-            else if (value.GetType().IsNumeric())
+            else if (value.GetType().IsNumeric() || value is DateTime || value is DateTimeOffset)
             {
-                _sqlBuilder.Append(value);
+                var jsonValue = JToken.FromObject(value);
+                _sqlBuilder.Append(jsonValue.ToString(Formatting.None));
             }
             else if (value is bool boolValue)
             {

--- a/test/EFCore.Cosmos.Sql.FunctionalTests/Query/SimpleQueryCosmosSqlTest.Where.cs
+++ b/test/EFCore.Cosmos.Sql.FunctionalTests/Query/SimpleQueryCosmosSqlTest.Where.cs
@@ -1631,16 +1631,14 @@ FROM root c
 WHERE ((c[""Discriminator""] = ""Customer"") AND (c[""Discriminator""] = ""Customer""))");
         }
 
-        public override Task Where_chain(bool isAsync)
+        public override async Task Where_chain(bool isAsync)
         {
-            // #13190
-            //await base.Where_chain(isAsync);
+            await base.Where_chain(isAsync);
 
-            //            AssertSql(
-            //                @"SELECT c
-            //FROM root c
-            //WHERE (c[""Discriminator""] = ""Customer""))");
-            return Task.CompletedTask;
+            AssertSql(
+                @"SELECT c
+FROM root c
+WHERE (((c[""Discriminator""] = ""Order"") AND (c[""CustomerID""] = ""QUICK"")) AND (c[""OrderDate""] > ""1998-01-01T00:00:00""))");
         }
 
         public override void Where_navigation_contains()


### PR DESCRIPTION
Fixes: #13190 Cosmos.SQL: Incorrect datetime mapping

Cosmos DB SQL generator generates string value for DateTime and DateTimeOffset constants. Additionally it uses JSON serializer to generate numeric constants, so that it is culture independent.

**Please check if the PR fulfills these requirements**

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
```
    Summary of the changes
    - Detail 1
    - Detail 2

    Fixes #bugnumber
```
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines. https://github.com/aspnet/Home/wiki/Engineering-guidelines.

Please review the guidelines for CONTRIBUTING.md for more details.