### PR TITLE
Query: Remove VisitSqlFunctionName redudant method

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/UdfDbFunctionTestBase.cs
@@ -246,6 +246,9 @@ namespace Microsoft.EntityFrameworkCore.Query
                 return builder.ConfigureWarnings(w => w.Ignore(RelationalEventId.QueryClientEvaluationWarning));
             }
 
+            protected override bool ShouldLogCategory(string logCategory)
+                => logCategory == DbLoggerCategory.Query.Name;
+
             protected override void Seed(DbContext context)
             {
                 context.Database.EnsureCreatedResiliently();

--- a/test/EFCore.SqlServer.FunctionalTests/Query/UdfDbFunctionSqlServerTests.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/UdfDbFunctionSqlServerTests.cs
@@ -19,8 +19,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         public UdfDbFunctionSqlServerTests(SqlServer fixture, ITestOutputHelper testOutputHelper)
             : base(fixture)
         {
-            fixture.TestSqlLoggerFactory.Clear();
-            //fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
+            Fixture.TestSqlLoggerFactory.Clear();
+            //Fixture.TestSqlLoggerFactory.SetTestOutputHelper(testOutputHelper);
         }
 
         #region Scalar Tests


### PR DESCRIPTION
Resolves #13537

