### PR TITLE
Spatial RevEng: Automatically load NetTopologySuite services at design-time

### DIFF
--- a/src/EFCore.SqlServer.NTS/Design/Internal/SqlServerNetTopologySuiteDesignTimeServices.cs
+++ b/src/EFCore.SqlServer.NTS/Design/Internal/SqlServerNetTopologySuiteDesignTimeServices.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NetTopologySuite;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.Design.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class SqlServerNetTopologySuiteDesignTimeServices : IDesignTimeServices
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void ConfigureDesignTimeServices(IServiceCollection serviceCollection)
+            => serviceCollection
+                .AddSingleton<IRelationalTypeMappingSourcePlugin, SqlServerNetTopologySuiteTypeMappingSourcePlugin>()
+                .TryAddSingleton(NtsGeometryServices.Instance);
+    }
+}

--- a/src/EFCore.SqlServer.NTS/EFCore.SqlServer.NTS.csproj
+++ b/src/EFCore.SqlServer.NTS/EFCore.SqlServer.NTS.csproj
@@ -17,6 +17,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="build\**\*">
+      <Pack>True</Pack>
+      <PackagePath>build</PackagePath>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\EFCore.SqlServer\EFCore.SqlServer.csproj" PrivateAssets="contentfiles;build" />
   </ItemGroup>
 

--- a/src/EFCore.SqlServer.NTS/Extensions/SqlServerNetTopologySuiteServiceCollectionExtensions.cs
+++ b/src/EFCore.SqlServer.NTS/Extensions/SqlServerNetTopologySuiteServiceCollectionExtensions.cs
@@ -28,7 +28,6 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             Check.NotNull(serviceCollection, nameof(serviceCollection));
 
-            // TODO: Use EF infrastructure?
             serviceCollection.TryAddSingleton(NtsGeometryServices.Instance);
 
             new EntityFrameworkRelationalServicesBuilder(serviceCollection)

--- a/src/EFCore.SqlServer.NTS/build/netstandard2.0/Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite.targets
+++ b/src/EFCore.SqlServer.NTS/build/netstandard2.0/Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite.targets
@@ -1,0 +1,46 @@
+<Project>
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <EFCoreSqlServerNetTopologySuiteFile>$(IntermediateOutputPath)EFCoreSqlServerNetTopologySuite$(DefaultLanguageSourceExtension)</EFCoreSqlServerNetTopologySuiteFile>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(Language)' == 'F#'">
+      <Choose>
+        <When Condition="'$(OutputType)' == 'Exe' OR '$(OutputType)' == 'WinExe'">
+          <PropertyGroup>
+            <CodeFragmentItemGroup>CompileBefore</CodeFragmentItemGroup>
+          </PropertyGroup>
+        </When>
+        <Otherwise>
+          <PropertyGroup>
+            <CodeFragmentItemGroup>CompileAfter</CodeFragmentItemGroup>
+          </PropertyGroup>
+        </Otherwise>
+      </Choose>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <CodeFragmentItemGroup>Compile</CodeFragmentItemGroup>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Target Name="AddEFCoreSqlServerNetTopologySuite"
+          BeforeTargets="CoreCompile"
+          DependsOnTargets="PrepareForBuild"
+          Condition="'$(DesignTimeBuild)' != 'True'"
+          Inputs="$(MSBuildAllProjects)"
+          Outputs="$(EFCoreSqlServerNetTopologySuiteFile)">
+    <ItemGroup>
+      <EFCoreSqlServerNetTopologySuiteServices Include="Microsoft.EntityFrameworkCore.Design.DesignTimeServicesReferenceAttribute">
+        <_Parameter1>Microsoft.EntityFrameworkCore.SqlServer.Design.Internal.SqlServerNetTopologySuiteDesignTimeServices, Microsoft.EntityFrameworkCore.SqlServer.NetTopologySuite</_Parameter1>
+        <_Parameter2>Microsoft.EntityFrameworkCore.SqlServer</_Parameter2>
+      </EFCoreSqlServerNetTopologySuiteServices>
+    </ItemGroup>
+    <WriteCodeFragment AssemblyAttributes="@(EFCoreSqlServerNetTopologySuiteServices)"
+                       Language="$(Language)"
+                       OutputFile="$(EFCoreSqlServerNetTopologySuiteFile)">
+      <Output TaskParameter="OutputFile" ItemName="$(CodeFragmentItemGroup)" />
+      <Output TaskParameter="OutputFile" ItemName="FileWrites" />
+    </WriteCodeFragment>
+  </Target>
+</Project>

--- a/src/EFCore.Sqlite.Core/Scaffolding/Internal/SqliteDatabaseModelFactory.cs
+++ b/src/EFCore.Sqlite.Core/Scaffolding/Internal/SqliteDatabaseModelFactory.cs
@@ -152,7 +152,13 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal
                     .AppendLine("FROM \"sqlite_master\"")
                     .Append("WHERE \"type\" = 'table' AND instr(\"name\", 'sqlite_') <> 1 AND \"name\" NOT IN ('")
                     .Append(HistoryRepository.DefaultTableName)
-                    .AppendLine("', 'geometry_columns', 'spatial_ref_sys', 'spatialite_history');")
+                    .Append("', 'ElementaryGeometries', 'geometry_columns', 'geometry_columns_auth', ")
+                    .Append("'geometry_columns_field_infos', 'geometry_columns_statistics', 'geometry_columns_time', ")
+                    .Append("'spatial_ref_sys', 'spatial_ref_sys_aux', 'SpatialIndex', 'spatialite_history', ")
+                    .Append("'sql_statements_log', 'views_geometry_columns', 'views_geometry_columns_auth', ")
+                    .Append("'views_geometry_columns_field_infos', 'views_geometry_columns_statistics', ")
+                    .Append("'virts_geometry_columns', 'virts_geometry_columns_auth', ")
+                    .AppendLine("'virts_geometry_columns_field_infos', 'virts_geometry_columns_statistics');")
                     .ToString();
 
                 using (var reader = command.ExecuteReader())

--- a/src/EFCore.Sqlite.NTS/Design/Internal/SqliteNetTopologySuiteDesignTimeServices.cs
+++ b/src/EFCore.Sqlite.NTS/Design/Internal/SqliteNetTopologySuiteDesignTimeServices.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using NetTopologySuite;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Design.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class SqliteNetTopologySuiteDesignTimeServices : IDesignTimeServices
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual void ConfigureDesignTimeServices(IServiceCollection serviceCollection)
+            => serviceCollection
+                .AddSingleton<IRelationalTypeMappingSourcePlugin, SqliteNetTopologySuiteTypeMappingSourcePlugin>()
+                .TryAddSingleton(NtsGeometryServices.Instance);
+    }
+}

--- a/src/EFCore.Sqlite.NTS/EFCore.Sqlite.NTS.csproj
+++ b/src/EFCore.Sqlite.NTS/EFCore.Sqlite.NTS.csproj
@@ -18,6 +18,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="build\**\*">
+      <Pack>True</Pack>
+      <PackagePath>build</PackagePath>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\EFCore.Sqlite.Core\EFCore.Sqlite.Core.csproj" PrivateAssets="contentfiles;build" />
   </ItemGroup>
 

--- a/src/EFCore.Sqlite.NTS/build/netstandard2.0/Microsoft.EntityFrameworkCore.Sqlite.NetTopologySuite.targets
+++ b/src/EFCore.Sqlite.NTS/build/netstandard2.0/Microsoft.EntityFrameworkCore.Sqlite.NetTopologySuite.targets
@@ -1,0 +1,46 @@
+<Project>
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <EFCoreSqliteNetTopologySuiteFile>$(IntermediateOutputPath)EFCoreSqliteNetTopologySuite$(DefaultLanguageSourceExtension)</EFCoreSqliteNetTopologySuiteFile>
+  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(Language)' == 'F#'">
+      <Choose>
+        <When Condition="'$(OutputType)' == 'Exe' OR '$(OutputType)' == 'WinExe'">
+          <PropertyGroup>
+            <CodeFragmentItemGroup>CompileBefore</CodeFragmentItemGroup>
+          </PropertyGroup>
+        </When>
+        <Otherwise>
+          <PropertyGroup>
+            <CodeFragmentItemGroup>CompileAfter</CodeFragmentItemGroup>
+          </PropertyGroup>
+        </Otherwise>
+      </Choose>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <CodeFragmentItemGroup>Compile</CodeFragmentItemGroup>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
+  <Target Name="AddEFCoreSqliteNetTopologySuite"
+          BeforeTargets="CoreCompile"
+          DependsOnTargets="PrepareForBuild"
+          Condition="'$(DesignTimeBuild)' != 'True'"
+          Inputs="$(MSBuildAllProjects)"
+          Outputs="$(EFCoreSqliteNetTopologySuiteFile)">
+    <ItemGroup>
+      <EFCoreSqliteNetTopologySuiteServices Include="Microsoft.EntityFrameworkCore.Design.DesignTimeServicesReferenceAttribute">
+        <_Parameter1>Microsoft.EntityFrameworkCore.Sqlite.Design.Internal.SqliteNetTopologySuiteDesignTimeServices, Microsoft.EntityFrameworkCore.Sqlite.NetTopologySuite</_Parameter1>
+        <_Parameter2>Microsoft.EntityFrameworkCore.Sqlite</_Parameter2>
+      </EFCoreSqliteNetTopologySuiteServices>
+    </ItemGroup>
+    <WriteCodeFragment AssemblyAttributes="@(EFCoreSqliteNetTopologySuiteServices)"
+                       Language="$(Language)"
+                       OutputFile="$(EFCoreSqliteNetTopologySuiteFile)">
+      <Output TaskParameter="OutputFile" ItemName="$(CodeFragmentItemGroup)" />
+      <Output TaskParameter="OutputFile" ItemName="FileWrites" />
+    </WriteCodeFragment>
+  </Target>
+</Project>

--- a/src/EFCore/Design/DesignTimeServicesReferenceAttribute.cs
+++ b/src/EFCore/Design/DesignTimeServicesReferenceAttribute.cs
@@ -16,7 +16,7 @@ namespace Microsoft.EntityFrameworkCore.Design
     ///         This attribute is typically used by design-time extensions. It is generally not used in application code.
     ///     </para>
     /// </summary>
-    [AttributeUsage(AttributeTargets.Assembly)]
+    [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
     public sealed class DesignTimeServicesReferenceAttribute : Attribute
     {
         /// <summary>
@@ -27,10 +27,27 @@ namespace Microsoft.EntityFrameworkCore.Design
         ///     This type should implement <see cref="IDesignTimeServices" />.
         /// </param>
         public DesignTimeServicesReferenceAttribute([NotNull] string typeName)
+            : this(typeName, forProvider: null)
+        {
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="DesignTimeServicesReferenceAttribute" /> class.
+        /// </summary>
+        /// <param name="typeName">
+        ///     The assembly-qualified name of the type that can be used to add additional design time services to a <see cref="ServiceCollection" />.
+        ///     This type should implement <see cref="IDesignTimeServices" />.
+        /// </param>
+        /// <param name="forProvider">
+        ///     The name of the provider for which these services should be added. If null, the services will be added
+        ///     for all providers.
+        /// </param>
+        public DesignTimeServicesReferenceAttribute([NotNull] string typeName, [CanBeNull] string forProvider)
         {
             Check.NotEmpty(typeName, nameof(typeName));
 
             TypeName = typeName;
+            ForProvider = forProvider;
         }
 
         /// <summary>
@@ -39,5 +56,11 @@ namespace Microsoft.EntityFrameworkCore.Design
         ///     This type should implement <see cref="IDesignTimeServices" />.
         /// </summary>
         public string TypeName { get; }
+
+        /// <summary>
+        ///     Gets the name of the provider for which these services should be added. If null, the services will be
+        ///     added for all providers.
+        /// </summary>
+        public string ForProvider { get; }
     }
 }


### PR DESCRIPTION
Verification: I manually bashed on this. I verified it works with multiple provider-specific services and non-provider-specific services.

Resolves #12083, resolves #13283