### PR TITLE
Replaced top SelectExpression with Visitor for nested aggregate queries

### DIFF
--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.ResultOperators.cs
@@ -212,6 +212,27 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task Sum_over_nested_subquery_is_client_eval(bool isAsync)
+        {
+            return AssertSum<Customer, Customer>(
+                isAsync,
+                cs => cs,
+                selector: c => c.Orders.Sum(o => 5 + o.OrderDetails.Sum(od => od.ProductID)));
+        }
+
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Sum_over_min_subquery_is_client_eval(bool isAsync)
+        {
+            return AssertSum<Customer, Customer>(
+                isAsync,
+                cs => cs,
+                selector: c => c.Orders.Sum(o => 5 + o.OrderDetails.Min(od => od.ProductID)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task Sum_on_float_column(bool isAsync)
         {
             return AssertSum<OrderDetail, OrderDetail>(
@@ -314,6 +335,26 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 cs => cs,
                 selector: c => c.Orders.Sum(o => o.OrderID));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Average_over_nested_subquery_is_client_eval(bool isAsync)
+        {
+            return AssertAverage<Customer, Customer>(
+                isAsync,
+                cs => cs.Take(3),
+                selector: c => (decimal)c.Orders.Average(o => 5 + o.OrderDetails.Average(od => od.ProductID)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Average_over_max_subquery_is_client_eval(bool isAsync)
+        {
+            return AssertAverage<Customer, Customer>(
+                isAsync,
+                cs => cs.Take(3),
+                selector: c => (decimal)c.Orders.Average(o => 5 + o.OrderDetails.Max(od => od.ProductID)));
         }
 
         [ConditionalTheory]
@@ -458,6 +499,25 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task Min_over_nested_subquery_is_client_eval(bool isAsync)
+        {
+            return AssertMin<Customer, Customer>(
+                isAsync,
+                cs => cs.Take(3),
+                selector: c => c.Orders.Min(o => 5 + o.OrderDetails.Min(od => od.ProductID)));
+        }
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Min_over_max_subquery_is_client_eval(bool isAsync)
+        {
+            return AssertMin<Customer, Customer>(
+                isAsync,
+                cs => cs.Take(3),
+                selector: c => c.Orders.Min(o => 5 + o.OrderDetails.Max(od => od.ProductID)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task Max_with_no_arg(bool isAsync)
         {
             return AssertMax<Order>(
@@ -493,6 +553,26 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 cs => cs,
                 selector: c => c.Orders.Sum(o => o.OrderID));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Max_over_nested_subquery_is_client_eval(bool isAsync)
+        {
+            return AssertMax<Customer, Customer>(
+               isAsync,
+               cs => cs.Take(3),
+               selector: c => c.Orders.Max(o => 5 + o.OrderDetails.Max(od => od.ProductID)));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Max_over_sum_subquery_is_client_eval(bool isAsync)
+        {
+            return AssertMax<Customer, Customer>(
+               isAsync,
+               cs => cs.Take(3),
+               selector: c => c.Orders.Max(o => 5 + o.OrderDetails.Sum(od => od.ProductID)));
         }
 
         [ConditionalTheory]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
@@ -115,6 +115,22 @@ WHERE [p].[ProductID] < 40");
 FROM [Customers] AS [c]");
         }
 
+        public override async Task Sum_over_nested_subquery_is_client_eval(bool isAsync)
+        {
+            await base.Sum_over_nested_subquery_is_client_eval(isAsync);
+            AssertSql(
+               @"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]");
+        }
+
+        public override async Task Sum_over_min_subquery_is_client_eval(bool isAsync)
+        {
+            await base.Sum_over_min_subquery_is_client_eval(isAsync);
+            AssertSql(
+               @"SELECT [c].[CustomerID]
+FROM [Customers] AS [c]");
+        }
+
         public override async Task Sum_on_float_column(bool isAsync)
         {
             await base.Sum_on_float_column(isAsync);
@@ -216,6 +232,26 @@ WHERE [p].[ProductID] < 40");
 FROM [Customers] AS [c]");
         }
 
+        public override async Task Average_over_nested_subquery_is_client_eval(bool isAsync)
+        {
+            await base.Average_over_nested_subquery_is_client_eval(isAsync);
+            AssertSql(
+               @"@__p_0='3'
+
+SELECT TOP(@__p_0) [c].[CustomerID]
+FROM [Customers] AS [c]");
+        }
+
+        public override async Task Average_over_max_subquery_is_client_eval(bool isAsync)
+        {
+            await base.Average_over_max_subquery_is_client_eval(isAsync);
+            AssertSql(
+               @"@__p_0='3'
+
+SELECT TOP(@__p_0) [c].[CustomerID]
+FROM [Customers] AS [c]");
+        }
+
         public override async Task Average_on_float_column(bool isAsync)
         {
             await base.Average_on_float_column(isAsync);
@@ -301,6 +337,28 @@ WHERE [p].[ProductID] < 40");
 FROM [Customers] AS [c]");
         }
 
+        public override async Task Min_over_nested_subquery_is_client_eval(bool isAsync)
+        {
+            await base.Min_over_nested_subquery_is_client_eval(isAsync);
+
+            AssertSql(
+               @"@__p_0='3'
+
+SELECT TOP(@__p_0) [c].[CustomerID]
+FROM [Customers] AS [c]");
+        }
+
+        public override async Task Min_over_max_subquery_is_client_eval(bool isAsync)
+        {
+            await base.Min_over_max_subquery_is_client_eval(isAsync);
+
+            AssertSql(
+               @"@__p_0='3'
+
+SELECT TOP(@__p_0) [c].[CustomerID]
+FROM [Customers] AS [c]");
+        }
+
         public override async Task Max_with_no_arg(bool isAsync)
         {
             await base.Max_with_no_arg(isAsync);
@@ -339,6 +397,28 @@ WHERE [p].[ProductID] < 40");
     FROM [Orders] AS [o]
     WHERE [c].[CustomerID] = [o].[CustomerID]
 )
+FROM [Customers] AS [c]");
+        }
+
+        public override async Task Max_over_nested_subquery_is_client_eval(bool isAsync)
+        {
+            await base.Max_over_nested_subquery_is_client_eval(isAsync);
+
+            AssertSql(
+               @"@__p_0='3'
+
+SELECT TOP(@__p_0) [c].[CustomerID]
+FROM [Customers] AS [c]");
+        }
+
+        public override async Task Max_over_sum_subquery_is_client_eval(bool isAsync)
+        {
+            await base.Max_over_sum_subquery_is_client_eval(isAsync);
+
+            AssertSql(
+               @"@__p_0='3'
+
+SELECT TOP(@__p_0) [c].[CustomerID]
 FROM [Customers] AS [c]");
         }
 


### PR DESCRIPTION
Complex aggregate queries now evaluate outer aggregates on client.

Replaced check for SelectExpression from top projection in RelationalResultOperatorHandler with a check that visits entire expression tree.
-Affects Average, Min, Max and Sum
-Added tests for all 4 aggregates
-Added 4 additional tests that combine aggregates: Sum/Min, Average/Max, Min/Max, and Max/Sum

Fixes #11922