### PR TITLE
ModelBuilder: Only remove owned entity if it is not in use

### DIFF
--- a/src/EFCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/RelationshipDiscoveryConvention.cs
@@ -469,7 +469,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 {
                     filteredRelationshipCandidates.Add(relationshipCandidate);
                 }
-                else if (relationshipCandidate.TargetTypeBuilder.Metadata.HasDefiningNavigation()
+                else if (IsCandidateUnusedOwnedType(relationshipCandidate.TargetTypeBuilder.Metadata)
                          && filteredRelationshipCandidates.All(
                              c => c.TargetTypeBuilder.Metadata != relationshipCandidate.TargetTypeBuilder.Metadata))
                 {
@@ -610,7 +610,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 {
                     filteredRelationshipCandidates.Add(relationshipCandidate);
                 }
-                else if (relationshipCandidate.TargetTypeBuilder.Metadata.HasDefiningNavigation()
+                else if (IsCandidateUnusedOwnedType(relationshipCandidate.TargetTypeBuilder.Metadata)
                          && filteredRelationshipCandidates.All(
                              c => c.TargetTypeBuilder.Metadata != relationshipCandidate.TargetTypeBuilder.Metadata))
                 {
@@ -840,7 +840,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
 
             foreach (var unusedEntityType in unusedEntityTypes)
             {
-                if (unusedEntityType.HasDefiningNavigation()
+                if (IsCandidateUnusedOwnedType(unusedEntityType)
                     && unusedEntityType.DefiningEntityType.FindNavigation(unusedEntityType.DefiningNavigationName) == null)
                 {
                     entityTypeBuilder.ModelBuilder.RemoveEntityType(unusedEntityType, ConfigurationSource.Convention);
@@ -1064,6 +1064,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
             InternalEntityTypeBuilder entityTypeBuilder,
             ImmutableSortedDictionary<PropertyInfo, Type> navigationCandidates)
             => entityTypeBuilder.HasAnnotation(NavigationCandidatesAnnotationName, navigationCandidates, ConfigurationSource.Convention);
+
+        private static bool IsCandidateUnusedOwnedType(EntityType entityType)
+            => entityType.HasDefiningNavigation() && !entityType.GetForeignKeys().Any();
 
         private static bool IsAmbiguous(EntityType entityType, MemberInfo navigationProperty)
         {

--- a/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/OwnedTypesTestBase.cs
@@ -976,6 +976,18 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
 
                 modelBuilder.Validate();
             }
+
+            [Fact]
+            public virtual void Inheritance_where_base_has_multiple_owned_types_works()
+            {
+                var modelBuilder = CreateModelBuilder();
+                modelBuilder.Entity<BaseOwner>();
+                modelBuilder.Entity<DerivedOwner>();
+
+                modelBuilder.Validate();
+
+                Assert.Equal(4, modelBuilder.Model.GetEntityTypes().Count());
+            }
         }
     }
 }

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -678,5 +678,26 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
             public Guid PrincipalShadowFkId { get; set; }
             public List<DependentShadowFk> Dependends { get; set; }
         }
+
+        protected class BaseOwner
+        {
+            public int Id { get; set; }
+            public OwnedTypeInheritance1 Owned1 { get; set; }
+            public OwnedTypeInheritance2 Owned2 { get; set; }
+        }
+
+        protected class DerivedOwner : BaseOwner { }
+
+        [Owned]
+        protected class OwnedTypeInheritance1
+        {
+            public string Value { get; set; }
+        }
+
+        [Owned]
+        protected class OwnedTypeInheritance2
+        {
+            public string Value { get; set; }
+        }
     }
 }


### PR DESCRIPTION
Issue: When adding derived entity's relationship, we saw that owned navigations are not compatible and we removed them. The conditions incorrectly converted it to owned type not being in use. Hence owned types were removed (Since they were discovered using convention). Which in turn triggers relationship discovery and adds them again in derived type and goes into recursion.

Resolves #12628
