### PR TITLE
Modelbuilding: Set TypeConfigurationSource for property when we confi…

### DIFF
--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -1648,6 +1648,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 }
 
                 propertyType = memberInfo.GetMemberType();
+                typeConfigurationSource = ConfigurationSource.Convention.Max(typeConfigurationSource);
             }
             else
             {

--- a/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
+++ b/test/EFCore.Tests/ModelBuilding/NonRelationshipTestBase.cs
@@ -1287,6 +1287,19 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
                 Assert.Equal(-1, data.First().Values.Single());
                 Assert.Equal(-2, data.Last().Values.Single());
             }
+
+            [Fact]
+            public virtual void Private_property_is_not_discovered_by_convention()
+            {
+                var modelBuilder = CreateModelBuilder();
+
+                modelBuilder.Ignore<Alpha>();
+                modelBuilder.Entity<Gamma>();
+
+                modelBuilder.Validate();
+
+                Assert.Single(modelBuilder.Model.FindEntityType(typeof(Gamma)).GetProperties());
+            }
         }
     }
 }

--- a/test/EFCore.Tests/ModelBuilding/TestModel.cs
+++ b/test/EFCore.Tests/ModelBuilding/TestModel.cs
@@ -377,6 +377,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         protected class Gamma
         {
             public int Id { get; set; }
+            private int PrivateProperty { get; set; }
 
             public List<Alpha> Alphas { get; set; }
         }


### PR DESCRIPTION
…gure type using memberInfo

Issue: When `Property(string)` method is used without specifying the type, we try to look for memberInfo using reflection and use type from that. But we did not set the _typeConfigurationSource to Convention which later caused issue when recreating FK with mismatched PK.

Resolves #13108
