### PR TITLE
Fix to #12738 - FirstOrDefault within Automapper causing Error

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -370,12 +370,15 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
                             _querySource = qs;
                             _propertyName = p.Name;
 
-                            if ((_queryModelVisitor.QueryCompilationContext.FindEntityType(_querySource)
-                                 ?? _queryModelVisitor.QueryCompilationContext.Model.FindEntityType(_querySource.ItemType))
-                                ?.FindProperty(_propertyName)?.IsPrimaryKey()
-                                ?? false)
+                            if (_querySource != null)
                             {
-                                _propertyName = null;
+                                if ((_queryModelVisitor.QueryCompilationContext.FindEntityType(_querySource)
+                                     ?? _queryModelVisitor.QueryCompilationContext.Model.FindEntityType(_querySource.ItemType))
+                                    ?.FindProperty(_propertyName)?.IsPrimaryKey()
+                                    ?? false)
+                                {
+                                    _propertyName = null;
+                                }
                             }
                         });
                 }

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -3931,6 +3931,25 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task Subquery_member_pushdown_does_not_change_original_subquery_model2(bool isAsync)
+        {
+            return AssertQuery<Order, Customer>(
+                isAsync,
+                (os, cs) =>
+                    os.OrderBy(o => o.OrderID)
+                        .Take(3)
+                        .Select(
+                            o => new
+                            {
+                                OrderId = o.OrderID,
+                                City = EF.Property<string>(cs.SingleOrDefault(c => c.CustomerID == o.CustomerID), "City")
+                            })
+                        .OrderBy(o => o.City),
+                assertOrder: true);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task Query_expression_with_to_string_and_contains(bool isAsync)
         {
             return AssertQuery<Order>(

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -3048,6 +3048,57 @@ FROM [Customers] AS [c2]
 WHERE [c2].[CustomerID] = @_outer_CustomerID1");
         }
 
+        public override async Task Subquery_member_pushdown_does_not_change_original_subquery_model2(bool isAsync)
+        {
+            await base.Subquery_member_pushdown_does_not_change_original_subquery_model2(isAsync);
+
+            AssertSql(
+                @"@__p_0='3'
+
+SELECT [t].[CustomerID], [t].[OrderID]
+FROM (
+    SELECT TOP(@__p_0) [o].*
+    FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
+) AS [t]",
+                //
+                @"@_outer_CustomerID='VINET' (Size = 5)
+
+SELECT TOP(2) [c0].[City]
+FROM [Customers] AS [c0]
+WHERE [c0].[CustomerID] = @_outer_CustomerID",
+                //
+                @"@_outer_CustomerID='TOMSP' (Size = 5)
+
+SELECT TOP(2) [c0].[City]
+FROM [Customers] AS [c0]
+WHERE [c0].[CustomerID] = @_outer_CustomerID",
+                //
+                @"@_outer_CustomerID='HANAR' (Size = 5)
+
+SELECT TOP(2) [c0].[City]
+FROM [Customers] AS [c0]
+WHERE [c0].[CustomerID] = @_outer_CustomerID",
+                //
+                @"@_outer_CustomerID1='TOMSP' (Size = 5)
+
+SELECT TOP(2) [c2].[City]
+FROM [Customers] AS [c2]
+WHERE [c2].[CustomerID] = @_outer_CustomerID1",
+                //
+                @"@_outer_CustomerID1='VINET' (Size = 5)
+
+SELECT TOP(2) [c2].[City]
+FROM [Customers] AS [c2]
+WHERE [c2].[CustomerID] = @_outer_CustomerID1",
+                //
+                @"@_outer_CustomerID1='HANAR' (Size = 5)
+
+SELECT TOP(2) [c2].[City]
+FROM [Customers] AS [c2]
+WHERE [c2].[CustomerID] = @_outer_CustomerID1");
+        }
+
         public override async Task Query_expression_with_to_string_and_contains(bool isAsync)
         {
             await base.Query_expression_with_to_string_and_contains(isAsync);


### PR DESCRIPTION
Problem was that the query had the same subquery present multiple times in the actual model and when we applied SubqueryMemberPushDownExpressionVisitor on one of those we would consequently mutate it in other place also, leading to invalid QM.
Previously we encountered this issue but only fixed it for pushdown via MemberExpression, missing cases that use EF.Property.

Fix is to clone the subquery before mutating it in the subquery member pushdown for EF.Property cases.