### PR TITLE
Fixes #12771 - Support lowering user constructed expression with default

### DIFF
--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -297,6 +297,29 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
         }
 
+        [ConditionalFact] // See issue #12771
+        public virtual void Can_convert_manually_build_expression_with_default()
+        {
+            using (var context = CreateContext())
+            {
+                var parameter = Expression.Parameter(typeof(Customer));
+                var defaultExpression =
+                    Expression.Lambda<Func<Customer, bool>>(
+                        Expression.NotEqual(
+                            Expression.Property(
+                                parameter,
+                                "CustomerID"),
+                            Expression.Default(typeof(string))),
+                        parameter);
+
+                // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
+                context.Set<Customer>().Where(defaultExpression).Count();
+
+                // ReSharper disable once ReturnValueOfPureMethodIsNotUsed
+                context.Set<Customer>().Count(defaultExpression);
+            }
+        }
+
         // ReSharper disable once ClassNeverInstantiated.Local
         private static class InMemoryCheck
         {

--- a/src/EFCore/Query/Internal/ExpressionEqualityComparer.cs
+++ b/src/EFCore/Query/Internal/ExpressionEqualityComparer.cs
@@ -423,10 +423,15 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         return CompareListInit((ListInitExpression)a, (ListInitExpression)b);
                     case ExpressionType.Extension:
                         return CompareExtension(a, b);
+                    case ExpressionType.Default:
+                        return CompareDefault((DefaultExpression)a, (DefaultExpression)b);    
                     default:
                         throw new NotImplementedException();
                 }
             }
+
+            private bool CompareDefault(DefaultExpression a, DefaultExpression b)
+                => a.Type == b.Type;
 
             private bool CompareUnary(UnaryExpression a, UnaryExpression b)
                 => Equals(a.Method, b.Method)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -36,6 +36,20 @@ FROM [Customers] AS [e]
 WHERE [e].[CustomerID] = N'ALFKI'");
         }
 
+        public override void Can_convert_manually_build_expression_with_default()
+        {
+            base.Can_convert_manually_build_expression_with_default();
+
+            AssertSql(
+                @"SELECT COUNT(*)
+FROM [Customers] AS [e]
+WHERE [e].[CustomerID] IS NOT NULL",
+                //
+                @"SELECT COUNT(*)
+FROM [Customers] AS [e]
+WHERE [e].[CustomerID] IS NOT NULL");
+        }
+
         public override void Lifting_when_subquery_nested_order_by_anonymous()
         {
             base.Lifting_when_subquery_nested_order_by_anonymous();

--- a/test/EFCore.Tests/Query/ExpressionEqualityComparerTest.cs
+++ b/test/EFCore.Tests/Query/ExpressionEqualityComparerTest.cs
@@ -54,6 +54,23 @@ namespace Microsoft.EntityFrameworkCore.Query
             Assert.True(expressionComparer.Equals(e1, e1));
         }
 
+        [Fact]
+        public void Default_expressions_are_compared_correctly()
+        {
+            var expressionComparer = ExpressionEqualityComparer.Instance;
+            
+            Expression e1 = Expression.Default(typeof(int));
+            Expression e2 = Expression.Default(typeof(int));
+            Expression e3 = Expression.Default(typeof(string));            
+
+            Assert.Equal(expressionComparer.GetHashCode(e1), expressionComparer.GetHashCode(e2));
+            Assert.NotEqual(expressionComparer.GetHashCode(e1), expressionComparer.GetHashCode(e3));
+            Assert.True(expressionComparer.Equals(e1, e2));
+            Assert.False(expressionComparer.Equals(e1, e3));
+            Assert.Equal(expressionComparer.GetHashCode(e1), expressionComparer.GetHashCode(e1));
+            Assert.True(expressionComparer.Equals(e1, e1));
+        }
+
         private class Node
         {
             [UsedImplicitly]


### PR DESCRIPTION
Add missing case to take into account ExpressionType.Default
- Implement DefaultExpression equality by comparing the type
- Add test to ensure ExpressionEqualityComparer works as expected with the new expression type
- Add test to cover the expression example from the linked issue
Fixes #12771


