### PR TITLE
Avoid double writes of dotnet-ef.dll during build

### DIFF
--- a/src/dotnet-ef/dotnet-ef.csproj
+++ b/src/dotnet-ef/dotnet-ef.csproj
@@ -86,7 +86,7 @@ dotnet ef database update
     <SignedPackageFile Include="$(PublishDir)\Newtonsoft.Json.dll" PackagePath="tools/$(TargetFramework)/any/Newtonsoft.Json.dll" Certificate="$(AssemblySigning3rdPartyCertName)" />
   </ItemGroup>
 
-  <Target Name="PopulateNuspec" BeforeTargets="GenerateNuspec" DependsOnTargets="Build">
+  <Target Name="PopulateNuspec" BeforeTargets="GenerateNuspec">
 
     <PropertyGroup>
       <!-- Make sure we create a symbols.nupkg. -->


### PR DESCRIPTION
This target dependency causes /t:Pack to re-build dotnet-ef.dll, even when `NoBuild=true` is specified. Removing this because the target dependency should be unnecessary.