### PR TITLE
Adding regression test for re-parenting bug

### DIFF
--- a/src/EFCore.Specification.Tests/GraphUpdatesFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/GraphUpdatesFixtureBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
@@ -405,6 +406,8 @@ namespace Microsoft.EntityFrameworkCore
                     .HasForeignKey(tc => tc.QuestTaskId);
 
                 modelBuilder.Entity<TaskChoice>();
+                modelBuilder.Entity<ParentAsAChild>();
+                modelBuilder.Entity<ChildAsAParent>();
             }
 
             protected virtual object CreateFullGraph()
@@ -674,6 +677,12 @@ namespace Microsoft.EntityFrameworkCore
                     new BadOrder
                     {
                         BadCustomer = new BadCustomer()
+                    });
+
+                context.Add(
+                    new ParentAsAChild
+                    {
+                        ChildAsAParent = new ChildAsAParent()
                     });
 
                 context.SaveChanges();
@@ -2740,6 +2749,50 @@ namespace Microsoft.EntityFrameworkCore
             {
                 get => _questTaskId;
                 set => SetWithNotify(value, ref _questTaskId);
+            }
+        }
+
+        protected class ParentAsAChild : NotifyingEntity
+        {
+            private int _id;
+            private int? _childAsAParentId;
+            private ChildAsAParent _childAsAParent;
+
+            [DatabaseGenerated(DatabaseGeneratedOption.None)]
+            public int Id
+            {
+                get => _id;
+                set => SetWithNotify(value, ref _id);
+            }
+
+            public int? ChildAsAParentId
+            {
+                get => _childAsAParentId;
+                set => SetWithNotify(value, ref _childAsAParentId);
+            }
+
+            public ChildAsAParent ChildAsAParent
+            {
+                get => _childAsAParent;
+                set => SetWithNotify(value, ref _childAsAParent);
+            }
+        }
+
+        protected class ChildAsAParent : NotifyingEntity
+        {
+            private int _id;
+            private ParentAsAChild _parentAsAChild;
+
+            public int Id
+            {
+                get => _id;
+                set => SetWithNotify(value, ref _id);
+            }
+
+            public ParentAsAChild ParentAsAChild
+            {
+                get => _parentAsAChild;
+                set => SetWithNotify(value, ref _parentAsAChild);
             }
         }
 

--- a/src/EFCore.Specification.Tests/GraphUpdatesTestBase.cs
+++ b/src/EFCore.Specification.Tests/GraphUpdatesTestBase.cs
@@ -6189,6 +6189,46 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
+        public virtual void Re_childing_parent_to_new_child_with_delete()
+        {
+            var oldId = 0;
+            var newId = 0;
+
+            ExecuteWithStrategyInTransaction(
+                context =>
+                {
+                    var parent = context.Set<ParentAsAChild>().Include(p => p.ChildAsAParent).Single();
+
+                    var oldChild = parent.ChildAsAParent;
+                    oldId = oldChild.Id;
+
+                    context.Remove(oldChild);
+
+                    var newChild = new ChildAsAParent();
+                    parent.ChildAsAParent = newChild;
+
+                    context.SaveChanges();
+
+                    newId = newChild.Id;
+                    Assert.NotEqual(newId, oldId);
+
+                    Assert.Equal(newId, parent.ChildAsAParentId);
+                    Assert.Same(newChild, parent.ChildAsAParent);
+
+                    Assert.Equal(EntityState.Detached, context.Entry(oldChild).State);
+                    Assert.Equal(EntityState.Unchanged, context.Entry(newChild).State);
+                    Assert.Equal(EntityState.Unchanged, context.Entry(parent).State);
+                },
+                context =>
+                {
+                    var parent = context.Set<ParentAsAChild>().Include(p => p.ChildAsAParent).Single();
+                    Assert.Equal(newId, parent.ChildAsAParentId);
+                    Assert.Equal(newId, parent.ChildAsAParent.Id);
+                    Assert.Null(context.Set<ChildAsAParent>().Find(oldId));
+                });
+        }
+
+        [ConditionalFact]
         public virtual void Sometimes_not_calling_DetectChanges_when_required_does_not_throw_for_null_ref()
         {
             ExecuteWithStrategyInTransaction(
@@ -6224,7 +6264,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        public virtual void Can_add_valid_first_depedent_when_multiple_possible_principal_sides()
+        public virtual void Can_add_valid_first_dependent_when_multiple_possible_principal_sides()
         {
             ExecuteWithStrategyInTransaction(
                 context =>
@@ -6249,7 +6289,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        public virtual void Can_add_valid_second_depedent_when_multiple_possible_principal_sides()
+        public virtual void Can_add_valid_second_dependent_when_multiple_possible_principal_sides()
         {
             ExecuteWithStrategyInTransaction(
                 context =>
@@ -6274,7 +6314,7 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [ConditionalFact]
-        public virtual void Can_add_multiple_depedents_when_multiple_possible_principal_sides()
+        public virtual void Can_add_multiple_dependents_when_multiple_possible_principal_sides()
         {
             ExecuteWithStrategyInTransaction(
                 context =>


### PR DESCRIPTION
The issue is already fixed in 2.2, so just adding a test.

Fixes #13219
