### PR TITLE
Allow null geometry values

### DIFF
--- a/src/EFCore.Relational/Storage/Internal/DbParameterCollectionExtensions.cs
+++ b/src/EFCore.Relational/Storage/Internal/DbParameterCollectionExtensions.cs
@@ -170,7 +170,16 @@ namespace Microsoft.EntityFrameworkCore.Storage.Internal
                 if (valueProperty != null
                     && valueProperty.PropertyType != parameterValue.GetType())
                 {
-                    FormatParameterValue(builder, valueProperty.GetValue(parameterValue));
+                    var isNullProperty = parameterValue.GetType().GetRuntimeProperty("IsNull");
+                    if (isNullProperty != null
+                        && (bool)isNullProperty.GetValue(parameterValue))
+                    {
+                        builder.Append("''");
+                    }
+                    else
+                    {
+                        FormatParameterValue(builder, valueProperty.GetValue(parameterValue));
+                    }
                 }
                 else
                 {

--- a/src/EFCore.Specification.Tests/Query/SpatialQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/SpatialQueryTestBase.cs
@@ -48,7 +48,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery<PointEntity>(
                 isAsync,
-                es => es.Select(e => new { e.Id, Binary = e.Point.AsBinary() }),
+                es => es.Where(e => e.Id == PointEntity.WellKnownId).Select(e => new { e.Id, Binary = e.Point.AsBinary() }),
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.Id, a.Id);
@@ -62,7 +62,7 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery<PointEntity>(
                 isAsync,
-                es => es.Select(e => new { e.Id, Text = e.Point.AsText() }),
+                es => es.Where(e => e.Id == PointEntity.WellKnownId).Select(e => new { e.Id, Text = e.Point.AsText() }),
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.Id, a.Id);
@@ -200,12 +200,14 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             return AssertQuery<PointEntity>(
                 isAsync,
-                es => es.Select(
-                    e => new
-                    {
-                        e.Id,
-                        CoveredBy = e.Point.CoveredBy(polygon)
-                    }));
+                es => es
+                    .Where(e => e.Id == PointEntity.WellKnownId)
+                    .Select(
+                        e => new
+                        {
+                            e.Id,
+                            CoveredBy = e.Point.CoveredBy(polygon)
+                        }));
         }
 
         [ConditionalTheory]
@@ -272,7 +274,9 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Dimension(bool isAsync)
         {
-            return AssertQuery<PointEntity>(isAsync, es => es.Select(e => new { e.Id, e.Point.Dimension }));
+            return AssertQuery<PointEntity>(
+                isAsync,
+                es => es.Where(e => e.Id == PointEntity.WellKnownId).Select(e => new { e.Id, e.Point.Dimension }));
         }
 
         [ConditionalTheory]
@@ -294,7 +298,13 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             return AssertQuery<PointEntity>(
                 isAsync,
-                es => es.Select(e => new { e.Id, Distance = e.Point.Distance(point) }),
+                es => es.Select(
+                    e => new
+                    {
+                        e.Id,
+                        Distance = e.Point == null ? -1 : e.Point.Distance(point)
+                    }),
+                elementSorter: e => e.Id,
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.Id, a.Id);
@@ -335,7 +345,9 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             return AssertQuery<PointEntity>(
                 isAsync,
-                es => es.Select(e => new { e.Id, EqualsTopologically = e.Point.EqualsTopologically(point) }));
+                es => es
+                    .Where(e => e.Id == PointEntity.WellKnownId)
+                    .Select(e => new { e.Id, EqualsTopologically = e.Point.EqualsTopologically(point) }));
         }
 
         [ConditionalTheory]
@@ -349,7 +361,10 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task GeometryType(bool isAsync)
         {
-            return AssertQuery<PointEntity>(isAsync, es => es.Select(e => new { e.Id, e.Point.GeometryType }));
+            return AssertQuery<PointEntity>(
+                isAsync,
+                es => es.Select(
+                    e => new { e.Id, GeometryType = e.Point == null ? null : e.Point.GeometryType }));
         }
 
         [ConditionalTheory]
@@ -488,7 +503,11 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task IsValid(bool isAsync)
         {
-            return AssertQuery<PointEntity>(isAsync, es => es.Select(e => new { e.Id, e.Point.IsValid }));
+            return AssertQuery<PointEntity>(
+                isAsync,
+                es => es
+                    .Where(e => e.Id == PointEntity.WellKnownId)
+                    .Select(e => new { e.Id, e.Point.IsValid }));
         }
 
         [ConditionalTheory]
@@ -499,7 +518,8 @@ namespace Microsoft.EntityFrameworkCore.Query
 
             return AssertQuery<PointEntity>(
                 isAsync,
-                es => es.Select(e => new { e.Id, IsWithinDistance = e.Point.IsWithinDistance(point, 1) }),
+                es => es.Select(e => new { e.Id, IsWithinDistance = e.Point != null && e.Point.IsWithinDistance(point, 1) }),
+                elementSorter: e => e.Id,
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.Id, a.Id);
@@ -544,11 +564,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery<PointEntity>(
                 isAsync,
-                es => es.Select(e => new { e.Id, M = (double?)e.Point.M }),
+                es => es.Select(e => new { e.Id, M = e.Point == null ? null : (double?)e.Point.M }),
+                elementSorter: e => e.Id,
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.Id, a.Id);
-                    Assert.Equal(e.M, a.M ?? double.NaN);
+                    Assert.Equal(a.M ?? double.NaN, a.M ?? double.NaN);
                 });
         }
 
@@ -581,7 +602,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task OgcGeometryType(bool isAsync)
         {
-            return AssertQuery<PointEntity>(isAsync, es => es.Select(e => new { e.Id, e.Point.OgcGeometryType }));
+            return AssertQuery<PointEntity>(
+                isAsync,
+                es => es.Select(
+                    e => new
+                    {
+                        e.Id,
+                        OgcGeometryType = e.Point == null ? (OgcGeometryType)0 : e.Point.OgcGeometryType
+                    }));
         }
 
         [ConditionalTheory]
@@ -657,7 +685,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task SRID(bool isAsync)
         {
-            return AssertQuery<PointEntity>(isAsync, es => es.Select(e => new { e.Id, e.Point.SRID }));
+            return AssertQuery<PointEntity>(
+                isAsync,
+                es => es.Select(
+                    e => new
+                    {
+                        e.Id,
+                        SRID = e.Point == null ? -1 : e.Point.SRID
+                    }));
         }
 
         [ConditionalTheory]
@@ -704,7 +739,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery<PointEntity>(
                 isAsync,
-                es => es.Select(e => new { e.Id, Binary = ((Geometry)e.Point).ToBinary() }),
+                es => es.Select(e => new { e.Id, Binary = e.Point == null ? null : ((Geometry)e.Point).ToBinary() }),
+                elementSorter: e => e.Id,
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.Id, a.Id);
@@ -718,11 +754,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery<PointEntity>(
                 isAsync,
-                es => es.Select(e => new { e.Id, Text = ((Geometry)e.Point).ToText() }),
+                es => es.Select(e => new { e.Id, Text = e.Point == null ? null : ((Geometry)e.Point).ToText() }),
+                elementSorter: e => e.Id,
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.Id, a.Id);
-                    Assert.Equal(e.Text, a.Text, WKTComparer.Instance);
+                    Assert.Equal((string)e.Text, (string)a.Text, WKTComparer.Instance);
                 });
         }
 
@@ -806,7 +843,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     e => new
                     {
                         e.Id,
-                        Within = e.Point.Within(polygon)
+                        Within = e.Point != null && e.Point.Within(polygon)
                     }));
         }
 
@@ -814,14 +851,14 @@ namespace Microsoft.EntityFrameworkCore.Query
         [MemberData(nameof(IsAsyncData))]
         public virtual Task X(bool isAsync)
         {
-            return AssertQuery<PointEntity>(isAsync, es => es.Select(e => new { e.Id, e.Point.X }));
+            return AssertQuery<PointEntity>(isAsync, es => es.Select(e => new { e.Id, X = e.Point == null ? -1.0 : e.Point.X }));
         }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Y(bool isAsync)
         {
-            return AssertQuery<PointEntity>(isAsync, es => es.Select(e => new { e.Id, e.Point.Y }));
+            return AssertQuery<PointEntity>(isAsync, es => es.Select(e => new { e.Id, Y = e.Point == null ? -1.0 : e.Point.Y }));
         }
 
         [ConditionalTheory]
@@ -830,11 +867,12 @@ namespace Microsoft.EntityFrameworkCore.Query
         {
             return AssertQuery<PointEntity>(
                 isAsync,
-                es => es.Select(e => new { e.Id, Z = (double?)e.Point.Z }),
+                es => es.Select(e => new { e.Id, Z = e.Point == null ? -1.0 : (double?)e.Point.Z }),
+                elementSorter: e => e.Id,
                 elementAsserter: (e, a) =>
                 {
                     Assert.Equal(e.Id, a.Id);
-                    Assert.Equal(e.Z, a.Z ?? double.NaN);
+                    Assert.Equal((double?)e.Z, (double?)(a.Z ?? double.NaN));
                 });
         }
     }

--- a/src/EFCore.Specification.Tests/TestModels/SpatialModel/PointEntity.cs
+++ b/src/EFCore.Specification.Tests/TestModels/SpatialModel/PointEntity.cs
@@ -8,6 +8,8 @@ namespace Microsoft.EntityFrameworkCore.TestModels.SpatialModel
 {
     public class PointEntity
     {
+        public static readonly Guid WellKnownId = Guid.Parse("2F39AADE-4D8D-42D2-88CE-775C84AB83B1");
+
         public Guid Id { get; set; }
         public IPoint Point { get; set; }
     }

--- a/src/EFCore.Specification.Tests/TestModels/SpatialModel/SpatialData.cs
+++ b/src/EFCore.Specification.Tests/TestModels/SpatialModel/SpatialData.cs
@@ -52,9 +52,14 @@ namespace Microsoft.EntityFrameworkCore.TestModels.SpatialModel
             {
                 new PointEntity
                 {
-                    Id = Guid.Parse("2F39AADE-4D8D-42D2-88CE-775C84AB83B1"),
+                    Id = PointEntity.WellKnownId,
                     Point = factory.CreatePoint(
                         new Coordinate(0, 0))
+                },
+                new PointEntity
+                {
+                    Id = Guid.Parse("67A54C9B-4C3B-4B27-8B4E-C0335E50E551"),
+                    Point = null
                 }
             };
 

--- a/src/EFCore.SqlServer.NTS/Storage/Internal/SqlServerGeometryTypeMapping.cs
+++ b/src/EFCore.SqlServer.NTS/Storage/Internal/SqlServerGeometryTypeMapping.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Data.Common;
 using System.Data.SqlClient;
 using System.Data.SqlTypes;
 using System.Globalization;
@@ -103,6 +104,18 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal
         /// </summary>
         protected override Type WKTReaderType
             => typeof(WKTReader);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override void ConfigureParameter(DbParameter parameter)
+        {
+            if (parameter.Value == DBNull.Value)
+            {
+                parameter.Value = SqlBytes.Null;
+            }
+        }
 
         private static SqlServerBytesReader CreateReader(IGeometryServices services, bool isGeography)
             => new SqlServerBytesReader(services) { IsGeography = isGeography };

--- a/src/EFCore/ChangeTracking/Internal/SnapshotFactoryFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/SnapshotFactoryFactory.cs
@@ -167,10 +167,17 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
                 if (comparer != null)
                 {
-                    expression = ReplacingExpressionVisitor.Replace(
+                    var snapshotExpression = ReplacingExpressionVisitor.Replace(
                         comparer.SnapshotExpression.Parameters.Single(),
                         expression,
                         comparer.SnapshotExpression.Body);
+
+                    expression = propertyBase.ClrType.IsNullableType()
+                        ? Expression.Condition(
+                            Expression.Equal(expression, Expression.Constant(null, propertyBase.ClrType)),
+                            Expression.Constant(null, propertyBase.ClrType),
+                            snapshotExpression)
+                        : snapshotExpression;
                 }
             }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeographyTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeographyTest.cs
@@ -34,7 +34,8 @@ FROM [PolygonEntity] AS [e]");
 
             AssertSql(
                 @"SELECT [e].[Id], [e].[Point].STAsBinary() AS [Binary]
-FROM [PointEntity] AS [e]");
+FROM [PointEntity] AS [e]
+WHERE [e].[Id] = '2f39aade-4d8d-42d2-88ce-775c84ab83b1'");
         }
 
         public override async Task AsText(bool isAsync)
@@ -43,7 +44,8 @@ FROM [PointEntity] AS [e]");
 
             AssertSql(
                 @"SELECT [e].[Id], [e].[Point].AsTextZM() AS [Text]
-FROM [PointEntity] AS [e]");
+FROM [PointEntity] AS [e]
+WHERE [e].[Id] = '2f39aade-4d8d-42d2-88ce-775c84ab83b1'");
         }
 
         public override async Task Buffer(bool isAsync)
@@ -110,7 +112,8 @@ FROM [PolygonEntity] AS [e]");
 
             AssertSql(
                 @"SELECT [e].[Id], [e].[Point].STDimension() AS [Dimension]
-FROM [PointEntity] AS [e]");
+FROM [PointEntity] AS [e]
+WHERE [e].[Id] = '2f39aade-4d8d-42d2-88ce-775c84ab83b1'");
         }
 
         public override async Task Disjoint(bool isAsync)
@@ -131,7 +134,10 @@ FROM [PolygonEntity] AS [e]");
             AssertSql(
                 @"@__point_0='0xE6100000010C000000000000F03F0000000000000000' (Size = 22) (DbType = Binary)
 
-SELECT [e].[Id], [e].[Point].STDistance(@__point_0) AS [Distance]
+SELECT [e].[Id], CASE
+    WHEN [e].[Point] IS NULL
+    THEN -1.0E0 ELSE [e].[Point].STDistance(@__point_0)
+END AS [Distance]
 FROM [PointEntity] AS [e]");
         }
 
@@ -152,7 +158,8 @@ FROM [LineStringEntity] AS [e]");
                 @"@__point_0='0xE6100000010C00000000000000000000000000000000' (Size = 22) (DbType = Binary)
 
 SELECT [e].[Id], [e].[Point].STEquals(@__point_0) AS [EqualsTopologically]
-FROM [PointEntity] AS [e]");
+FROM [PointEntity] AS [e]
+WHERE [e].[Id] = '2f39aade-4d8d-42d2-88ce-775c84ab83b1'");
         }
 
         public override async Task ExteriorRing(bool isAsync)
@@ -256,7 +263,8 @@ FROM [MultiLineStringEntity] AS [e]");
 
             AssertSql(
                 @"SELECT [e].[Id], [e].[Point].STIsValid() AS [IsValid]
-FROM [PointEntity] AS [e]");
+FROM [PointEntity] AS [e]
+WHERE [e].[Id] = '2f39aade-4d8d-42d2-88ce-775c84ab83b1'");
         }
 
         public override async Task IsWithinDistance(bool isAsync)
@@ -267,7 +275,7 @@ FROM [PointEntity] AS [e]");
                 @"@__point_0='0xE6100000010C000000000000F03F0000000000000000' (Size = 22) (DbType = Binary)
 
 SELECT [e].[Id], CASE
-    WHEN [e].[Point].STDistance(@__point_0) <= 1.0E0
+    WHEN [e].[Point] IS NOT NULL AND ([e].[Point].STDistance(@__point_0) <= 1.0E0)
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END AS [IsWithinDistance]
 FROM [PointEntity] AS [e]");
@@ -332,18 +340,21 @@ FROM [LineStringEntity] AS [e]");
             await base.OgcGeometryType(isAsync);
 
             AssertSql(
-                @"SELECT [e].[Id], CASE [e].[Point].STGeometryType()
-    WHEN N'Point' THEN 1
-    WHEN N'LineString' THEN 2
-    WHEN N'Polygon' THEN 3
-    WHEN N'MultiPoint' THEN 4
-    WHEN N'MultiLineString' THEN 5
-    WHEN N'MultiPolygon' THEN 6
-    WHEN N'GeometryCollection' THEN 7
-    WHEN N'CircularString' THEN 8
-    WHEN N'CompoundCurve' THEN 9
-    WHEN N'CurvePolygon' THEN 10
-    WHEN N'FullGlobe' THEN 126
+                @"SELECT [e].[Id], CASE
+    WHEN [e].[Point] IS NULL
+    THEN 0 ELSE CASE [e].[Point].STGeometryType()
+        WHEN N'Point' THEN 1
+        WHEN N'LineString' THEN 2
+        WHEN N'Polygon' THEN 3
+        WHEN N'MultiPoint' THEN 4
+        WHEN N'MultiLineString' THEN 5
+        WHEN N'MultiPolygon' THEN 6
+        WHEN N'GeometryCollection' THEN 7
+        WHEN N'CircularString' THEN 8
+        WHEN N'CompoundCurve' THEN 9
+        WHEN N'CurvePolygon' THEN 10
+        WHEN N'FullGlobe' THEN 126
+    END
 END AS [OgcGeometryType]
 FROM [PointEntity] AS [e]");
         }
@@ -364,7 +375,10 @@ FROM [PolygonEntity] AS [e]");
             await base.SRID(isAsync);
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Point].STSrid AS [SRID]
+                @"SELECT [e].[Id], CASE
+    WHEN [e].[Point] IS NULL
+    THEN -1 ELSE [e].[Point].STSrid
+END AS [SRID]
 FROM [PointEntity] AS [e]");
         }
 
@@ -424,7 +438,10 @@ FROM [PolygonEntity] AS [e]");
             AssertSql(
                 @"@__polygon_0='0xE6100000010405000000000000000000F0BF000000000000F0BF000000000000...' (Size = 112) (DbType = Binary)
 
-SELECT [e].[Id], [e].[Point].STWithin(@__polygon_0) AS [Within]
+SELECT [e].[Id], CASE
+    WHEN [e].[Point] IS NOT NULL AND ([e].[Point].STWithin(@__polygon_0) = 1)
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END AS [Within]
 FROM [PointEntity] AS [e]");
         }
 
@@ -433,7 +450,10 @@ FROM [PointEntity] AS [e]");
             await base.X(isAsync);
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Point].Long AS [X]
+                @"SELECT [e].[Id], CASE
+    WHEN [e].[Point] IS NULL
+    THEN -1.0E0 ELSE [e].[Point].Long
+END AS [X]
 FROM [PointEntity] AS [e]");
         }
 
@@ -442,7 +462,10 @@ FROM [PointEntity] AS [e]");
             await base.Y(isAsync);
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Point].Lat AS [Y]
+                @"SELECT [e].[Id], CASE
+    WHEN [e].[Point] IS NULL
+    THEN -1.0E0 ELSE [e].[Point].Lat
+END AS [Y]
 FROM [PointEntity] AS [e]");
         }
 
@@ -451,7 +474,10 @@ FROM [PointEntity] AS [e]");
             await base.Z(isAsync);
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Point].Z AS [Z]
+                @"SELECT [e].[Id], CASE
+    WHEN [e].[Point] IS NULL
+    THEN -1.0E0 ELSE [e].[Point].Z
+END AS [Z]
 FROM [PointEntity] AS [e]");
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeometryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeometryTest.cs
@@ -32,7 +32,8 @@ FROM [PolygonEntity] AS [e]");
 
             AssertSql(
                 @"SELECT [e].[Id], [e].[Point].STAsBinary() AS [Binary]
-FROM [PointEntity] AS [e]");
+FROM [PointEntity] AS [e]
+WHERE [e].[Id] = '2f39aade-4d8d-42d2-88ce-775c84ab83b1'");
         }
 
         public override async Task AsText(bool isAsync)
@@ -41,7 +42,8 @@ FROM [PointEntity] AS [e]");
 
             AssertSql(
                 @"SELECT [e].[Id], [e].[Point].AsTextZM() AS [Text]
-FROM [PointEntity] AS [e]");
+FROM [PointEntity] AS [e]
+WHERE [e].[Id] = '2f39aade-4d8d-42d2-88ce-775c84ab83b1'");
         }
 
         public override async Task Boundary(bool isAsync)
@@ -141,7 +143,8 @@ FROM [PolygonEntity] AS [e]");
 
             AssertSql(
                 @"SELECT [e].[Id], [e].[Point].STDimension() AS [Dimension]
-FROM [PointEntity] AS [e]");
+FROM [PointEntity] AS [e]
+WHERE [e].[Id] = '2f39aade-4d8d-42d2-88ce-775c84ab83b1'");
         }
 
         public override async Task Disjoint(bool isAsync)
@@ -195,7 +198,8 @@ FROM [PolygonEntity] AS [e]");
                 @"@__point_0='0x00000000010C00000000000000000000000000000000' (Size = 22) (DbType = Binary)
 
 SELECT [e].[Id], [e].[Point].STEquals(@__point_0) AS [EqualsTopologically]
-FROM [PointEntity] AS [e]");
+FROM [PointEntity] AS [e]
+WHERE [e].[Id] = '2f39aade-4d8d-42d2-88ce-775c84ab83b1'");
         }
 
         [ConditionalTheory(Skip = "Needs better result type inference")]
@@ -330,7 +334,8 @@ FROM [LineStringEntity] AS [e]");
 
             AssertSql(
                 @"SELECT [e].[Id], [e].[Point].STIsValid() AS [IsValid]
-FROM [PointEntity] AS [e]");
+FROM [PointEntity] AS [e]
+WHERE [e].[Id] = '2f39aade-4d8d-42d2-88ce-775c84ab83b1'");
         }
 
         [ConditionalTheory(Skip = "Needs better argument type inference")]
@@ -408,17 +413,20 @@ FROM [LineStringEntity] AS [e]");
             await base.OgcGeometryType(isAsync);
 
             AssertSql(
-                @"SELECT [e].[Id], CASE [e].[Point].STGeometryType()
-    WHEN N'Point' THEN 1
-    WHEN N'LineString' THEN 2
-    WHEN N'Polygon' THEN 3
-    WHEN N'MultiPoint' THEN 4
-    WHEN N'MultiLineString' THEN 5
-    WHEN N'MultiPolygon' THEN 6
-    WHEN N'GeometryCollection' THEN 7
-    WHEN N'CircularString' THEN 8
-    WHEN N'CompoundCurve' THEN 9
-    WHEN N'CurvePolygon' THEN 10
+                @"SELECT [e].[Id], CASE
+    WHEN [e].[Point] IS NULL
+    THEN 0 ELSE CASE [e].[Point].STGeometryType()
+        WHEN N'Point' THEN 1
+        WHEN N'LineString' THEN 2
+        WHEN N'Polygon' THEN 3
+        WHEN N'MultiPoint' THEN 4
+        WHEN N'MultiLineString' THEN 5
+        WHEN N'MultiPolygon' THEN 6
+        WHEN N'GeometryCollection' THEN 7
+        WHEN N'CircularString' THEN 8
+        WHEN N'CompoundCurve' THEN 9
+        WHEN N'CurvePolygon' THEN 10
+    END
 END AS [OgcGeometryType]
 FROM [PointEntity] AS [e]");
         }
@@ -459,7 +467,10 @@ FROM [PolygonEntity] AS [e]");
             await base.SRID(isAsync);
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Point].STSrid AS [SRID]
+                @"SELECT [e].[Id], CASE
+    WHEN [e].[Point] IS NULL
+    THEN -1 ELSE [e].[Point].STSrid
+END AS [SRID]
 FROM [PointEntity] AS [e]");
         }
 
@@ -533,7 +544,10 @@ FROM [PolygonEntity] AS [e]");
             AssertSql(
                 @"@__polygon_0='0x00000000010405000000000000000000F0BF000000000000F0BF000000000000...' (Size = 112) (DbType = Binary)
 
-SELECT [e].[Id], [e].[Point].STWithin(@__polygon_0) AS [Within]
+SELECT [e].[Id], CASE
+    WHEN [e].[Point] IS NOT NULL AND ([e].[Point].STWithin(@__polygon_0) = 1)
+    THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
+END AS [Within]
 FROM [PointEntity] AS [e]");
         }
 
@@ -542,7 +556,10 @@ FROM [PointEntity] AS [e]");
             await base.X(isAsync);
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Point].STX AS [X]
+                @"SELECT [e].[Id], CASE
+    WHEN [e].[Point] IS NULL
+    THEN -1.0E0 ELSE [e].[Point].STX
+END AS [X]
 FROM [PointEntity] AS [e]");
         }
 
@@ -551,7 +568,10 @@ FROM [PointEntity] AS [e]");
             await base.Y(isAsync);
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Point].STY AS [Y]
+                @"SELECT [e].[Id], CASE
+    WHEN [e].[Point] IS NULL
+    THEN -1.0E0 ELSE [e].[Point].STY
+END AS [Y]
 FROM [PointEntity] AS [e]");
         }
 
@@ -560,7 +580,10 @@ FROM [PointEntity] AS [e]");
             await base.Z(isAsync);
 
             AssertSql(
-                @"SELECT [e].[Id], [e].[Point].Z AS [Z]
+                @"SELECT [e].[Id], CASE
+    WHEN [e].[Point] IS NULL
+    THEN -1.0E0 ELSE [e].[Point].Z
+END AS [Z]
 FROM [PointEntity] AS [e]");
         }
 


### PR DESCRIPTION
Make sure that snapshotting null always returns null. Also, required a change to send a SqlBytes null sentinel, instead of DBNull, but this could potentially be fixed in NTS instead.

Fixes #13457 