### PR TITLE
Fix to #12984 - Collection navigations should use reference equality by default

### DIFF
--- a/src/EFCore/Metadata/Internal/ClrCollectionAccessorFactory.cs
+++ b/src/EFCore/Metadata/Internal/ClrCollectionAccessorFactory.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
@@ -24,6 +25,18 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         private static readonly MethodInfo _create
             = typeof(ClrCollectionAccessorFactory).GetTypeInfo().GetDeclaredMethod(nameof(CreateCollection));
+
+        private static readonly MethodInfo _createAndSetHashSet
+            = typeof(ClrCollectionAccessorFactory).GetTypeInfo().GetDeclaredMethod(nameof(CreateAndSetHashSet));
+
+        private static readonly MethodInfo _createHashSet
+            = typeof(ClrCollectionAccessorFactory).GetTypeInfo().GetDeclaredMethod(nameof(CreateHashSet));
+
+        private static readonly MethodInfo _createAndSetObservableHashSet
+            = typeof(ClrCollectionAccessorFactory).GetTypeInfo().GetDeclaredMethod(nameof(CreateAndSetObservableHashSet));
+
+        private static readonly MethodInfo _createObservableHashSet
+            = typeof(ClrCollectionAccessorFactory).GetTypeInfo().GetDeclaredMethod(nameof(CreateObservableHashSet));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -108,21 +121,55 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var concreteType = new CollectionTypeFactory().TryFindTypeToInstantiate(typeof(TEntity), typeof(TCollection));
             if (concreteType != null)
             {
+                var isHashSet = concreteType.IsGenericType && concreteType.GetGenericTypeDefinition() == typeof(HashSet<>);
                 if (setterDelegate != null)
                 {
-                    createAndSetDelegate = (Func<TEntity, Action<TEntity, TCollection>, TCollection>)_createAndSet
-                        .MakeGenericMethod(typeof(TEntity), typeof(TCollection), concreteType)
-                        .CreateDelegate(typeof(Func<TEntity, Action<TEntity, TCollection>, TCollection>));
+                    if (isHashSet)
+                    {
+                        createAndSetDelegate = (Func<TEntity, Action<TEntity, TCollection>, TCollection>)_createAndSetHashSet
+                            .MakeGenericMethod(typeof(TEntity), typeof(TCollection), typeof(TElement))
+                            .CreateDelegate(typeof(Func<TEntity, Action<TEntity, TCollection>, TCollection>));
+                    }
+                    else if (IsObservableHashSet(concreteType))
+                    {
+                        createAndSetDelegate = (Func<TEntity, Action<TEntity, TCollection>, TCollection>)_createAndSetObservableHashSet
+                            .MakeGenericMethod(typeof(TEntity), typeof(TCollection), typeof(TElement))
+                            .CreateDelegate(typeof(Func<TEntity, Action<TEntity, TCollection>, TCollection>));
+                    }
+                    else
+                    {
+                        createAndSetDelegate = (Func<TEntity, Action<TEntity, TCollection>, TCollection>)_createAndSet
+                            .MakeGenericMethod(typeof(TEntity), typeof(TCollection), concreteType)
+                            .CreateDelegate(typeof(Func<TEntity, Action<TEntity, TCollection>, TCollection>));
+                    }
                 }
 
-                createDelegate = (Func<TCollection>)_create
-                    .MakeGenericMethod(typeof(TCollection), concreteType)
-                    .CreateDelegate(typeof(Func<TCollection>));
+                if (isHashSet)
+                {
+                    createDelegate = (Func<TCollection>)_createHashSet
+                        .MakeGenericMethod(typeof(TCollection), typeof(TElement))
+                        .CreateDelegate(typeof(Func<TCollection>));
+                }
+                else if (IsObservableHashSet(concreteType))
+                {
+                    createDelegate = (Func<TCollection>)_createObservableHashSet
+                        .MakeGenericMethod(typeof(TCollection), typeof(TElement))
+                        .CreateDelegate(typeof(Func<TCollection>));
+                }
+                else
+                {
+                    createDelegate = (Func<TCollection>)_create
+                        .MakeGenericMethod(typeof(TCollection), concreteType)
+                        .CreateDelegate(typeof(Func<TCollection>));
+                }
             }
 
             return new ClrICollectionAccessor<TEntity, TCollection, TElement>(
                 navigation.Name, getterDelegate, setterDelegate, createAndSetDelegate, createDelegate);
         }
+
+        private static bool IsObservableHashSet(Type type)
+            => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ObservableHashSet<>);
 
         [UsedImplicitly]
         private static TCollection CreateAndSet<TEntity, TCollection, TConcreteCollection>(
@@ -142,5 +189,43 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             where TCollection : class
             where TConcreteCollection : TCollection, new()
             => new TConcreteCollection();
+
+        [UsedImplicitly]
+        private static TCollection CreateAndSetHashSet<TEntity, TCollection, TElement>(
+            TEntity entity,
+            Action<TEntity, TCollection> setterDelegate)
+            where TEntity : class
+            where TCollection : class
+            where TElement : class
+        {
+            var collection = (TCollection)(ICollection<TElement>)new HashSet<TElement>(ReferenceEqualityComparer.Instance);
+            setterDelegate(entity, collection);
+            return collection;
+        }
+
+        [UsedImplicitly]
+        private static TCollection CreateHashSet<TCollection, TElement>()
+            where TCollection : class
+            where TElement : class
+            => (TCollection)(ICollection<TElement>)new HashSet<TElement>(ReferenceEqualityComparer.Instance);
+
+        [UsedImplicitly]
+        private static TCollection CreateAndSetObservableHashSet<TEntity, TCollection, TElement>(
+            TEntity entity,
+            Action<TEntity, TCollection> setterDelegate)
+            where TEntity : class
+            where TCollection : class
+            where TElement : class
+        {
+            var collection = (TCollection)(ICollection<TElement>)new ObservableHashSet<TElement>(ReferenceEqualityComparer.Instance);
+            setterDelegate(entity, collection);
+            return collection;
+        }
+
+        [UsedImplicitly]
+        private static TCollection CreateObservableHashSet<TCollection, TElement>()
+            where TCollection : class
+            where TElement : class
+            => (TCollection)(ICollection<TElement>)new ObservableHashSet<TElement>(ReferenceEqualityComparer.Instance);
     }
 }

--- a/src/EFCore/Metadata/Internal/CollectionTypeFactory.cs
+++ b/src/EFCore/Metadata/Internal/CollectionTypeFactory.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             // Code taken from EF6. The rules are:
             // If the collection is defined as a concrete type with a public parameterless constructor, then create an instance of that type
-            // Else, if entity type is notifying and ObservableCollection{T} can be assigned to the type, then use ObservableCollection{T}
+            // Else, if entity type is notifying and ObservableHashSet{T} can be assigned to the type, then use ObservableHashSet{T}
             // Else, if HashSet{T} can be assigned to the type, then use HashSet{T}
             // Else, if List{T} can be assigned to the type, then use List{T}
             // Else, return null.


### PR DESCRIPTION
Problem was that when we were creating collection navigations we were using default ctors. This would cause (observable) HashSets to use element's Equals method when determining if the given entity is already part of the collection. This could lead to the same collection being added multiple times etc.

Fix is to special-case create collection delegates for well known concrete types like HashSet<T> and ObservableHashSet<T> and instantiate them using constructor that takes equality comparer argument. This way we can always ensure reference equality being perform on its elements.

For List<T> there is no such overload and for custom collection types we can't know which ctor to use so the behavior there stays the same.