### PR TITLE
Query: Don't remove ExplicitCast for aggregate operators

### DIFF
--- a/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -222,12 +222,10 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 && handlerContext.SelectExpression.Projection.Count == 1)
             {
                 PrepareSelectExpressionForAggregate(handlerContext.SelectExpression, handlerContext.QueryModel);
-
-                var expression = handlerContext.SelectExpression.Projection.First();
+                var expression = handlerContext.SelectExpression.Projection[0];
 
                 if (!ContainsSelect(expression))
                 {
-                    expression = (expression as ExplicitCastExpression)?.Operand ?? expression;
                     expression = UnwrapAliasExpression(expression);
 
                     var inputType = handlerContext.QueryModel.SelectClause.Selector.Type;
@@ -850,7 +848,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 && handlerContext.SelectExpression.Projection.Count == 1)
             {
                 PrepareSelectExpressionForAggregate(handlerContext.SelectExpression, handlerContext.QueryModel);
-                var expression = handlerContext.SelectExpression.Projection.First();
+                var expression = handlerContext.SelectExpression.Projection[0];
 
                 if (!ContainsSelect(expression))
                 {
@@ -879,7 +877,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 && handlerContext.SelectExpression.Projection.Count == 1)
             {
                 PrepareSelectExpressionForAggregate(handlerContext.SelectExpression, handlerContext.QueryModel);
-                var expression = handlerContext.SelectExpression.Projection.First();
+                var expression = handlerContext.SelectExpression.Projection[0];
 
                 if (!ContainsSelect(expression))
                 {
@@ -968,13 +966,12 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                 && handlerContext.SelectExpression.Projection.Count == 1)
             {
                 PrepareSelectExpressionForAggregate(handlerContext.SelectExpression, handlerContext.QueryModel);
-                var expression = handlerContext.SelectExpression.Projection.First();
+                var expression = handlerContext.SelectExpression.Projection[0];
 
                 if (!ContainsSelect(expression))
                 {
                     var inputType = handlerContext.QueryModel.SelectClause.Selector.Type;
 
-                    expression = (expression as ExplicitCastExpression)?.Operand ?? expression;
                     Expression sumExpression = new SqlFunctionExpression(
                         "SUM", inputType, new[] { UnwrapAliasExpression(expression) });
                     if (inputType.UnwrapNullableType() == typeof(float))

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryNavigationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryNavigationsSqlServerTest.cs
@@ -389,7 +389,7 @@ WHERE ([o.Customer].[City] = N'Seattle') AND (([o.Customer].[Phone] <> N'555 555
 
             AssertSql(
                 @"SELECT (
-    SELECT SUM([od].[Quantity])
+    SELECT SUM(CAST([od].[Quantity] AS int))
     FROM [Order Details] AS [od]
     WHERE [o].[OrderID] = [od].[OrderID]
 ) + (

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.ResultOperators.cs
@@ -1048,7 +1048,7 @@ ORDER BY [o].[OrderID]");
             await base.Average_with_non_matching_types_in_projection_doesnt_produce_second_explicit_cast(isAsync);
 
             AssertSql(
-                @"SELECT AVG(CAST([o].[OrderID] AS float))
+                @"SELECT AVG(CAST(CAST([o].[OrderID] AS bigint) AS float))
 FROM [Orders] AS [o]
 WHERE [o].[CustomerID] LIKE N'A' + N'%' AND (LEFT([o].[CustomerID], LEN(N'A')) = N'A')");
         }


### PR DESCRIPTION
We were losing convert nodes added by users and ended up getting results in wrong type

Resolves #13587
