### PR TITLE
SqlServer Spatial: Improve type inference

### DIFF
--- a/src/EFCore.Relational/Extensions/RelationalExpressionExtensions.cs
+++ b/src/EFCore.Relational/Extensions/RelationalExpressionExtensions.cs
@@ -98,9 +98,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
                     IEnumerable<Expression> arguments = functionExpression.Arguments;
                     if (functionExpression.Instance != null)
                     {
-                        arguments = Enumerable.Concat(
-                            new[] { functionExpression.Instance },
-                            arguments);
+                        arguments = arguments.Concat(
+                            new[] { functionExpression.Instance });
                     }
 
                     var properties = arguments
@@ -151,5 +150,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
 
             return null;
         }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static Expression UnwrapAliasExpression(this Expression expression)
+            => (expression as AliasExpression)?.Expression ?? expression;
     }
 }

--- a/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
+++ b/src/EFCore.Relational/Query/Expressions/SelectExpression.cs
@@ -750,6 +750,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
                             ? ((UnaryExpression)e).Operand.Type
                             : e.Type;
 
+                        var mapping = (e.UnwrapAliasExpression() as SqlFunctionExpression)?.ResultTypeMapping;
+
                         bool? fromLeftOuterJoin = null;
 
                         var originatingColumnExpression = e.FindOriginatingColumnExpression();
@@ -767,7 +769,8 @@ namespace Microsoft.EntityFrameworkCore.Query.Expressions
                             queryType,
                             e.FindProperty(queryType),
                             Dependencies.TypeMappingSource,
-                            fromLeftOuterJoin);
+                            fromLeftOuterJoin,
+                            mapping: mapping);
                     }))
                 {
                     yield return typeMaterializationInfo;

--- a/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -226,7 +226,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                 if (!ContainsSelect(expression))
                 {
-                    expression = UnwrapAliasExpression(expression);
+                    expression = expression.UnwrapAliasExpression();
 
                     var inputType = handlerContext.QueryModel.SelectClause.Selector.Type;
                     var outputType = inputType;
@@ -855,7 +855,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     var minExpression = new SqlFunctionExpression(
                         "MIN",
                         handlerContext.QueryModel.SelectClause.Selector.Type,
-                        new[] { UnwrapAliasExpression(expression) });
+                        new[] { expression.UnwrapAliasExpression() });
 
                     handlerContext.SelectExpression.SetProjectionExpression(minExpression);
 
@@ -884,7 +884,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     var maxExpression = new SqlFunctionExpression(
                         "MAX",
                         handlerContext.QueryModel.SelectClause.Selector.Type,
-                        new[] { UnwrapAliasExpression(expression) });
+                        new[] { expression.UnwrapAliasExpression() });
 
                     handlerContext.SelectExpression.SetProjectionExpression(maxExpression);
 
@@ -973,7 +973,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                     var inputType = handlerContext.QueryModel.SelectClause.Selector.Type;
 
                     Expression sumExpression = new SqlFunctionExpression(
-                        "SUM", inputType, new[] { UnwrapAliasExpression(expression) });
+                        "SUM", inputType, new[] { expression.UnwrapAliasExpression() });
                     if (inputType.UnwrapNullableType() == typeof(float))
                     {
                         sumExpression = new ExplicitCastExpression(sumExpression, inputType);
@@ -1058,9 +1058,6 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
         private static bool IsGroupByAggregate(QueryModel queryModel)
             => queryModel.MainFromClause.FromExpression is QuerySourceReferenceExpression mainFromClauseQsre
                 && mainFromClauseQsre.ReferencedQuerySource.ItemType.IsGrouping();
-
-        private static Expression UnwrapAliasExpression(Expression expression)
-            => (expression as AliasExpression)?.Expression ?? expression;
 
         private static readonly MethodInfo _transformClientExpressionMethodInfo
             = typeof(RelationalResultOperatorHandler).GetTypeInfo()

--- a/src/EFCore.Relational/Storage/TypeMaterializationInfo.cs
+++ b/src/EFCore.Relational/Storage/TypeMaterializationInfo.cs
@@ -50,12 +50,38 @@ namespace Microsoft.EntityFrameworkCore.Storage
             [CanBeNull] IProperty property,
             [CanBeNull] IRelationalTypeMappingSource typeMappingSource,
             bool? fromLeftOuterJoin,
-            int index = -1)
+            int index)
+            : this(modelClrType, property, typeMappingSource, fromLeftOuterJoin, index, mapping: null)
+        {
+        }
+
+        /// <summary>
+        ///     Creates a new <see cref="TypeMaterializationInfo" /> instance.
+        /// </summary>
+        /// <param name="modelClrType"> The type that is needed in the model after conversion. </param>
+        /// <param name="property"> The property associated with the type, or <c>null</c> if none. </param>
+        /// <param name="typeMappingSource"> The type mapping source to use to find a mapping if the property does not have one already bound. </param>
+        /// <param name="fromLeftOuterJoin"> Whether or not the value is coming from a LEFT OUTER JOIN operation. </param>
+        /// <param name="index">
+        ///     The index of the underlying result set that should be used for this type,
+        ///     or -1 if no index mapping is needed.
+        /// </param>
+        /// <param name="mapping"> The type mapping to use or <c>null</c> to infer one. </param>
+        public TypeMaterializationInfo(
+            [NotNull] Type modelClrType,
+            [CanBeNull] IProperty property,
+            [CanBeNull] IRelationalTypeMappingSource typeMappingSource,
+            bool? fromLeftOuterJoin,
+            int index = -1,
+            [CanBeNull] RelationalTypeMapping mapping = null)
         {
             Check.NotNull(modelClrType, nameof(modelClrType));
 
-            var mapping = property?.FindRelationalMapping()
+            if (mapping == null)
+            {
+                mapping = property?.FindRelationalMapping()
                           ?? typeMappingSource?.GetMapping(modelClrType);
+            }
 
             ProviderClrType = mapping?.Converter?.ProviderClrType
                               ?? modelClrType;

--- a/src/EFCore.SqlServer.NTS/Internal/SqlServerNetTopologySuiteExpressionExtensions.cs
+++ b/src/EFCore.SqlServer.NTS/Internal/SqlServerNetTopologySuiteExpressionExtensions.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using GeoAPI.Geometries;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public static class SqlServerNetTopologySuiteExpressionExtensions
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static string FindSpatialStoreType([NotNull] this Expression expression)
+            => expression.FindProperties()
+                .FirstOrDefault(p => typeof(IGeometry).IsAssignableFrom(p.ClrType))
+                ?.FindRelationalMapping()
+                ?.StoreType;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        private static IEnumerable<IProperty> FindProperties([NotNull] this Expression expression)
+        {
+            switch (expression)
+            {
+                case ColumnExpression columnExpression:
+                    yield return columnExpression.Property;
+                    break;
+
+                case UnaryExpression unaryExpression:
+                    foreach (var property in unaryExpression.Operand.FindProperties())
+                    {
+                        yield return property;
+                    }
+                    break;
+
+                case SqlFunctionExpression functionExpression:
+                    {
+                        IEnumerable<Expression> arguments = functionExpression.Arguments;
+                        if (functionExpression.Instance != null)
+                        {
+                            arguments = arguments.Concat(new[] { functionExpression.Instance });
+                        }
+                        foreach (var property in arguments.SelectMany(FindProperties))
+                        {
+                            yield return property;
+                        }
+                    }
+                    break;
+
+                case MethodCallExpression methodCallExpression:
+                    {
+                        IEnumerable<Expression> arguments = methodCallExpression.Arguments;
+                        if (methodCallExpression.Object != null)
+                        {
+                            arguments = arguments.Concat(new[] { methodCallExpression.Object });
+                        }
+                        foreach (var property in arguments.SelectMany(FindProperties))
+                        {
+                            yield return property;
+                        }
+                    }
+                    break;
+
+                case MemberExpression memberExpression:
+                    foreach (var property in memberExpression.Expression.FindProperties())
+                    {
+                        yield return property;
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/src/EFCore.SqlServer.NTS/Query/ExpressionTranslators/Internal/SqlServerGeometryCollectionMethodTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/ExpressionTranslators/Internal/SqlServerGeometryCollectionMethodTranslator.cs
@@ -4,8 +4,10 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using GeoAPI.Geometries;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.Internal
 {
@@ -17,12 +19,28 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
     {
         private static readonly MethodInfo _item = typeof(IGeometryCollection).GetRuntimeProperty("Item").GetMethod;
 
+        private readonly IRelationalTypeMappingSource _typeMappingSource;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public SqlServerGeometryCollectionMethodTranslator(IRelationalTypeMappingSource typeMappingSource)
+            => _typeMappingSource = typeMappingSource;
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
+            if (!typeof(IGeometryCollection).IsAssignableFrom(methodCallExpression.Method.DeclaringType))
+            {
+                return null;
+            }
+
+            var storeType = methodCallExpression.FindSpatialStoreType();
+
             var method = methodCallExpression.Method.OnInterface(typeof(IGeometryCollection));
             if (Equals(method, _item))
             {
@@ -30,7 +48,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
                     methodCallExpression.Object,
                     "STGeometryN",
                     methodCallExpression.Type,
-                    new[] { Expression.Add(methodCallExpression.Arguments[0], Expression.Constant(1)) });
+                    new[] { Expression.Add(methodCallExpression.Arguments[0], Expression.Constant(1)) },
+                    _typeMappingSource.FindMapping(typeof(IGeometry), storeType));
             }
 
             return null;

--- a/src/EFCore.SqlServer.NTS/Query/ExpressionTranslators/Internal/SqlServerGeometryMemberTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/ExpressionTranslators/Internal/SqlServerGeometryMemberTranslator.cs
@@ -10,6 +10,7 @@ using GeoAPI.Geometries;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.Internal
 {
@@ -44,27 +45,45 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         private static readonly MemberInfo _ogcGeometryType = typeof(IGeometry).GetRuntimeProperty(nameof(IGeometry.OgcGeometryType));
         private static readonly MemberInfo _srid = typeof(IGeometry).GetRuntimeProperty(nameof(IGeometry.SRID));
 
+        private readonly IRelationalTypeMappingSource _typeMappingSource;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public SqlServerGeometryMemberTranslator(IRelationalTypeMappingSource typeMappingSource)
+            => _typeMappingSource = typeMappingSource;
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual Expression Translate(MemberExpression memberExpression)
         {
-            var instance = memberExpression.Expression;
-            var isGeography = string.Equals(
-                instance.FindProperty(instance.Type)?.Relational().ColumnType,
-                "geography",
-                StringComparison.OrdinalIgnoreCase);
+            if (!typeof(IGeometry).IsAssignableFrom(memberExpression.Member.DeclaringType))
+            {
+                return null;
+            }
+
+            var storeType = memberExpression.FindSpatialStoreType();
+            var isGeography = string.Equals(storeType, "geography", StringComparison.OrdinalIgnoreCase);
 
             var member = memberExpression.Member.OnInterface(typeof(IGeometry));
             if (_memberToFunctionName.TryGetValue(member, out var functionName)
                 || (!isGeography && _geometryMemberToFunctionName.TryGetValue(member, out functionName)))
             {
+                RelationalTypeMapping resultTypeMapping = null;
+                if (typeof(IGeometry).IsAssignableFrom(memberExpression.Type))
+                {
+                    resultTypeMapping = _typeMappingSource.FindMapping(memberExpression.Type, storeType);
+                }
+
                 return new SqlFunctionExpression(
-                    instance,
+                    memberExpression.Expression,
                     functionName,
                     memberExpression.Type,
-                    Enumerable.Empty<Expression>());
+                    Enumerable.Empty<Expression>(),
+                    resultTypeMapping);
             }
             if (Equals(member, _ogcGeometryType))
             {
@@ -88,7 +107,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
 
                 return new CaseExpression(
                     new SqlFunctionExpression(
-                        instance,
+                        memberExpression.Expression,
                         "STGeometryType",
                         typeof(string),
                         Enumerable.Empty<Expression>()),
@@ -97,7 +116,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
             if (Equals(member, _srid))
             {
                 return new SqlFunctionExpression(
-                    instance,
+                    memberExpression.Expression,
                     "STSrid",
                     memberExpression.Type,
                     niladic: true);

--- a/src/EFCore.SqlServer.NTS/Query/ExpressionTranslators/Internal/SqlServerGeometryMethodTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/ExpressionTranslators/Internal/SqlServerGeometryMethodTranslator.cs
@@ -9,6 +9,7 @@ using GeoAPI.Geometries;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
+using Microsoft.EntityFrameworkCore.Storage;
 using NetTopologySuite.Geometries;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.Internal
@@ -50,44 +51,78 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         private static readonly MethodInfo _getGeometryN = typeof(IGeometry).GetRuntimeMethod(nameof(IGeometry.GetGeometryN), new[] { typeof(int) });
         private static readonly MethodInfo _isWithinDistance = typeof(IGeometry).GetRuntimeMethod(nameof(IGeometry.IsWithinDistance), new[] { typeof(IGeometry), typeof(double) });
 
+        private readonly IRelationalTypeMappingSource _typeMappingSource;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public SqlServerGeometryMethodTranslator(IRelationalTypeMappingSource typeMappingSource)
+            => _typeMappingSource = typeMappingSource;
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            var instance = methodCallExpression.Object;
-            var isGeography = string.Equals(
-                instance.FindProperty(instance.Type)?.Relational().ColumnType,
-                "geography",
-                StringComparison.OrdinalIgnoreCase);
+            if (!typeof(IGeometry).IsAssignableFrom(methodCallExpression.Method.DeclaringType))
+            {
+                return null;
+            }
+
+            var storeType = methodCallExpression.FindSpatialStoreType();
+            var isGeography = string.Equals(storeType, "geography", StringComparison.OrdinalIgnoreCase);
 
             var method = methodCallExpression.Method.OnInterface(typeof(IGeometry));
             if (_methodToFunctionName.TryGetValue(method, out var functionName)
                 || (!isGeography && _geometryMethodToFunctionName.TryGetValue(method, out functionName)))
             {
+                var argumentTypeMappings = new RelationalTypeMapping[methodCallExpression.Arguments.Count];
+                for (var i = 0; i < methodCallExpression.Arguments.Count; i++)
+                {
+                    var type = methodCallExpression.Arguments[i].Type;
+                    if (typeof(IGeometry).IsAssignableFrom(type))
+                    {
+                        argumentTypeMappings[i] = _typeMappingSource.FindMapping(type, storeType);
+                    }
+                }
+
+                RelationalTypeMapping resultTypeMapping = null;
+                if (typeof(IGeometry).IsAssignableFrom(methodCallExpression.Type))
+                {
+                    resultTypeMapping = _typeMappingSource.FindMapping(methodCallExpression.Type, storeType);
+                }
+
                 return new SqlFunctionExpression(
-                    instance,
+                    methodCallExpression.Object,
                     functionName,
                     methodCallExpression.Type,
-                    methodCallExpression.Arguments);
+                    methodCallExpression.Arguments,
+                    resultTypeMapping,
+                    _typeMappingSource.FindMapping(methodCallExpression.Object.Type, storeType),
+                    argumentTypeMappings);
             }
             if (Equals(method, _getGeometryN))
             {
                 return new SqlFunctionExpression(
-                    instance,
+                    methodCallExpression.Object,
                     "STGeometryN",
                     methodCallExpression.Type,
-                    new[] { Expression.Add(methodCallExpression.Arguments[0], Expression.Constant(1)) });
+                    new[] { Expression.Add(methodCallExpression.Arguments[0], Expression.Constant(1)) },
+                    _typeMappingSource.FindMapping(typeof(IGeometry), storeType));
             }
             if (Equals(method, _isWithinDistance))
             {
                 return Expression.LessThanOrEqual(
                     new SqlFunctionExpression(
-                        instance,
+                        methodCallExpression.Object,
                         "STDistance",
                         typeof(double),
-                        new[] { methodCallExpression.Arguments[0] }),
+                        new[] { methodCallExpression.Arguments[0] },
+                        resultTypeMapping: null,
+                        _typeMappingSource.FindMapping(methodCallExpression.Object.Type, storeType),
+                        new[] { _typeMappingSource.FindMapping(typeof(IGeometry), storeType) }),
                     methodCallExpression.Arguments[1]);
             }
 

--- a/src/EFCore.SqlServer.NTS/Query/ExpressionTranslators/Internal/SqlServerLineStringMethodTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/ExpressionTranslators/Internal/SqlServerLineStringMethodTranslator.cs
@@ -4,8 +4,10 @@
 using System.Linq.Expressions;
 using System.Reflection;
 using GeoAPI.Geometries;
+using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.Internal
 {
@@ -17,12 +19,28 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
     {
         private static readonly MethodInfo _getPointN = typeof(ILineString).GetRuntimeMethod(nameof(ILineString.GetPointN), new[] { typeof(int) });
 
+        private readonly IRelationalTypeMappingSource _typeMappingSource;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public SqlServerLineStringMethodTranslator(IRelationalTypeMappingSource typeMappingSource)
+            => _typeMappingSource = typeMappingSource;
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
+            if (!typeof(ILineString).IsAssignableFrom(methodCallExpression.Method.DeclaringType))
+            {
+                return null;
+            }
+
+            var storeType = methodCallExpression.FindSpatialStoreType();
+
             var method = methodCallExpression.Method.OnInterface(typeof(ILineString));
             if (Equals(method, _getPointN))
             {
@@ -30,7 +48,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
                     methodCallExpression.Object,
                     "STPointN",
                     methodCallExpression.Type,
-                    new[] { Expression.Add(methodCallExpression.Arguments[0], Expression.Constant(1)) });
+                    new[] { Expression.Add(methodCallExpression.Arguments[0], Expression.Constant(1)) },
+                    _typeMappingSource.FindMapping(typeof(IPoint), storeType));
             }
 
             return null;

--- a/src/EFCore.SqlServer.NTS/Query/ExpressionTranslators/Internal/SqlServerNetTopologySuiteMemberTranslatorPlugin.cs
+++ b/src/EFCore.SqlServer.NTS/Query/ExpressionTranslators/Internal/SqlServerNetTopologySuiteMemberTranslatorPlugin.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.Internal
 {
@@ -16,16 +17,24 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual IEnumerable<IMemberTranslator> Translators { get; }
-            = new IMemberTranslator[]
+        public SqlServerNetTopologySuiteMemberTranslatorPlugin(IRelationalTypeMappingSource typeMappingSource)
+        {
+            Translators = new IMemberTranslator[]
             {
-                new SqlServerCurveMemberTranslator(),
-                new SqlServerGeometryMemberTranslator(),
+                new SqlServerCurveMemberTranslator(typeMappingSource),
+                new SqlServerGeometryMemberTranslator(typeMappingSource),
                 new SqlServerGeometryCollectionMemberTranslator(),
                 new SqlServerLineStringMemberTranslator(),
                 new SqlServerMultiCurveMemberTranslator(),
                 new SqlServerPointMemberTranslator(),
-                new SqlServerPolygonMemberTranslator()
+                new SqlServerPolygonMemberTranslator(typeMappingSource)
             };
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual IEnumerable<IMemberTranslator> Translators { get; }
     }
 }

--- a/src/EFCore.SqlServer.NTS/Query/ExpressionTranslators/Internal/SqlServerNetTopologySuiteMethodCallTranslatorPlugin.cs
+++ b/src/EFCore.SqlServer.NTS/Query/ExpressionTranslators/Internal/SqlServerNetTopologySuiteMethodCallTranslatorPlugin.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.Internal
 {
@@ -16,12 +17,21 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual IEnumerable<IMethodCallTranslator> Translators { get; } = new IMethodCallTranslator[]
+        public SqlServerNetTopologySuiteMethodCallTranslatorPlugin(IRelationalTypeMappingSource typeMappingSource)
         {
-            new SqlServerGeometryMethodTranslator(),
-            new SqlServerGeometryCollectionMethodTranslator(),
-            new SqlServerLineStringMethodTranslator(),
-            new SqlServerPolygonMethodTranslator()
-        };
+            Translators = new IMethodCallTranslator[]
+            {
+                new SqlServerGeometryMethodTranslator(typeMappingSource),
+                new SqlServerGeometryCollectionMethodTranslator(typeMappingSource),
+                new SqlServerLineStringMethodTranslator(typeMappingSource),
+                new SqlServerPolygonMethodTranslator(typeMappingSource)
+            };
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual IEnumerable<IMethodCallTranslator> Translators { get; }
     }
 }

--- a/src/EFCore.SqlServer.NTS/Query/ExpressionTranslators/Internal/SqlServerPolygonMethodTranslator.cs
+++ b/src/EFCore.SqlServer.NTS/Query/ExpressionTranslators/Internal/SqlServerPolygonMethodTranslator.cs
@@ -8,6 +8,7 @@ using GeoAPI.Geometries;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query.Expressions;
 using Microsoft.EntityFrameworkCore.Query.ExpressionTranslators;
+using Microsoft.EntityFrameworkCore.Storage;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.Internal
 {
@@ -19,17 +20,28 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
     {
         private static readonly MethodInfo _getInteriorRingN = typeof(IPolygon).GetRuntimeMethod(nameof(IPolygon.GetInteriorRingN), new[] { typeof(int) });
 
+        private readonly IRelationalTypeMappingSource _typeMappingSource;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public SqlServerPolygonMethodTranslator(IRelationalTypeMappingSource typeMappingSource)
+            => _typeMappingSource = typeMappingSource;
+
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual Expression Translate(MethodCallExpression methodCallExpression)
         {
-            var instance = methodCallExpression.Object;
-            var isGeography = string.Equals(
-                instance.FindProperty(instance.Type)?.Relational().ColumnType,
-                "geography",
-                StringComparison.OrdinalIgnoreCase);
+            if (!typeof(IPolygon).IsAssignableFrom(methodCallExpression.Method.DeclaringType))
+            {
+                return null;
+            }
+
+            var storeType = methodCallExpression.FindSpatialStoreType();
+            var isGeography = string.Equals(storeType, "geography", StringComparison.OrdinalIgnoreCase);
 
             var method = methodCallExpression.Method.OnInterface(typeof(IPolygon));
             if (isGeography)
@@ -37,19 +49,21 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Query.ExpressionTranslators.In
                 if (Equals(method, _getInteriorRingN))
                 {
                     return new SqlFunctionExpression(
-                        instance,
+                        methodCallExpression.Object,
                         "RingN",
                         methodCallExpression.Type,
-                        new[] { Expression.Add(methodCallExpression.Arguments[0], Expression.Constant(2)) });
+                        new[] { Expression.Add(methodCallExpression.Arguments[0], Expression.Constant(2)) },
+                        _typeMappingSource.FindMapping(typeof(ILineString), storeType));
                 }
             }
             else if (Equals(method, _getInteriorRingN))
             {
                 return new SqlFunctionExpression(
-                    instance,
+                    methodCallExpression.Object,
                     "STInteriorRingN",
                     methodCallExpression.Type,
-                    new[] { Expression.Add(methodCallExpression.Arguments[0], Expression.Constant(1)) });
+                    new[] { Expression.Add(methodCallExpression.Arguments[0], Expression.Constant(1)) },
+                    _typeMappingSource.FindMapping(typeof(ILineString), storeType));
             }
 
             return null;

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeometryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeometryTest.cs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -55,7 +54,6 @@ WHERE [e].[Id] = '2f39aade-4d8d-42d2-88ce-775c84ab83b1'");
 FROM [PolygonEntity] AS [e]");
         }
 
-        [ConditionalTheory(Skip = "Needs better result type inference")]
         public override async Task Buffer(bool isAsync)
         {
             await base.Buffer(isAsync);
@@ -85,7 +83,6 @@ SELECT [e].[Id], [e].[Polygon].STContains(@__point_0) AS [Contains]
 FROM [PolygonEntity] AS [e]");
         }
 
-        [ConditionalTheory(Skip = "Needs better result type inference")]
         public override async Task ConvexHull(bool isAsync)
         {
             await base.ConvexHull(isAsync);
@@ -113,7 +110,6 @@ FROM [MultiLineStringEntity] AS [e]");
 FROM [LineStringEntity] AS [e]");
         }
 
-        [ConditionalTheory(Skip = "Needs better argument type inference")]
         public override async Task Crosses(bool isAsync)
         {
             await base.Crosses(isAsync);
@@ -125,7 +121,6 @@ SELECT [e].[Id], [e].[LineString].STCrosses(@__lineString_0) AS [Crosses]
 FROM [LineStringEntity] AS [e]");
         }
 
-        [ConditionalTheory(Skip = "Needs better result type inference")]
         public override async Task Difference(bool isAsync)
         {
             await base.Difference(isAsync);
@@ -158,7 +153,6 @@ SELECT [e].[Id], [e].[Polygon].STDisjoint(@__point_0) AS [Disjoint]
 FROM [PolygonEntity] AS [e]");
         }
 
-        [ConditionalTheory(Skip = "Needs better argument type inference")]
         public override async Task Distance(bool isAsync)
         {
             await base.Distance(isAsync);
@@ -166,11 +160,13 @@ FROM [PolygonEntity] AS [e]");
             AssertSql(
                 @"@__point_0='0x00000000010C0000000000000000000000000000F03F' (Size = 22) (DbType = Binary)
 
-SELECT [e].[Id], [e].[Point].STDistance(@__point_0) AS [Distance]
+SELECT [e].[Id], CASE
+    WHEN [e].[Point] IS NULL
+    THEN -1.0E0 ELSE [e].[Point].STDistance(@__point_0)
+END AS [Distance]
 FROM [PointEntity] AS [e]");
         }
 
-        [ConditionalTheory(Skip = "Needs better result type inference")]
         public override async Task EndPoint(bool isAsync)
         {
             await base.EndPoint(isAsync);
@@ -180,7 +176,6 @@ FROM [PointEntity] AS [e]");
 FROM [LineStringEntity] AS [e]");
         }
 
-        [ConditionalTheory(Skip = "Needs better result type inference")]
         public override async Task Envelope(bool isAsync)
         {
             await base.Envelope(isAsync);
@@ -202,7 +197,6 @@ FROM [PointEntity] AS [e]
 WHERE [e].[Id] = '2f39aade-4d8d-42d2-88ce-775c84ab83b1'");
         }
 
-        [ConditionalTheory(Skip = "Needs better result type inference")]
         public override async Task ExteriorRing(bool isAsync)
         {
             await base.ExteriorRing(isAsync);
@@ -221,7 +215,6 @@ FROM [PolygonEntity] AS [e]");
 FROM [PointEntity] AS [e]");
         }
 
-        [ConditionalTheory(Skip = "Needs better result type inference")]
         public override async Task GetGeometryN(bool isAsync)
         {
             await base.GetGeometryN(isAsync);
@@ -259,7 +252,6 @@ FROM [LineStringEntity] AS [e]");
 FROM [PolygonEntity] AS [e]");
         }
 
-        [ConditionalTheory(Skip = "Needs better result type inference")]
         public override async Task Intersection(bool isAsync)
         {
             await base.Intersection(isAsync);
@@ -271,7 +263,6 @@ SELECT [e].[Id], [e].[Polygon].STIntersection(@__polygon_0) AS [Intersection]
 FROM [PolygonEntity] AS [e]");
         }
 
-        [ConditionalTheory(Skip = "Needs better argument type inference")]
         public override async Task Intersects(bool isAsync)
         {
             await base.Intersects(isAsync);
@@ -338,7 +329,6 @@ FROM [PointEntity] AS [e]
 WHERE [e].[Id] = '2f39aade-4d8d-42d2-88ce-775c84ab83b1'");
         }
 
-        [ConditionalTheory(Skip = "Needs better argument type inference")]
         public override async Task IsWithinDistance(bool isAsync)
         {
             await base.IsWithinDistance(isAsync);
@@ -347,13 +337,12 @@ WHERE [e].[Id] = '2f39aade-4d8d-42d2-88ce-775c84ab83b1'");
                 @"@__point_0='0x00000000010C0000000000000000000000000000F03F' (Size = 22) (DbType = Binary)
 
 SELECT [e].[Id], CASE
-    WHEN [e].[Point].STDistance(@__point_0) <= 1.0E0
+    WHEN [e].[Point] IS NOT NULL AND ([e].[Point].STDistance(@__point_0) <= 1.0E0)
     THEN CAST(1 AS BIT) ELSE CAST(0 AS BIT)
 END AS [IsWithinDistance]
 FROM [PointEntity] AS [e]");
         }
 
-        [ConditionalTheory(Skip = "Needs better result type inference")]
         public override async Task Item(bool isAsync)
         {
             await base.Item(isAsync);
@@ -483,7 +472,6 @@ FROM [PointEntity] AS [e]");
 FROM [LineStringEntity] AS [e]");
         }
 
-        [ConditionalTheory(Skip = "Needs better result type inference")]
         public override async Task SymmetricDifference(bool isAsync)
         {
             await base.SymmetricDifference(isAsync);
@@ -513,7 +501,6 @@ FROM [PointEntity] AS [e]");
 FROM [PointEntity] AS [e]");
         }
 
-        [ConditionalTheory(Skip = "Needs better argument type inference")]
         public override async Task Touches(bool isAsync)
         {
             await base.Touches(isAsync);
@@ -525,7 +512,6 @@ SELECT [e].[Id], [e].[Polygon].STTouches(@__polygon_0) AS [Touches]
 FROM [PolygonEntity] AS [e]");
         }
 
-        [ConditionalTheory(Skip = "Needs better result type inference")]
         public override async Task Union(bool isAsync)
         {
             await base.Union(isAsync);


### PR DESCRIPTION
Fixes #13580 

**Providers**, type mappings can now be specified on SqlFunctionExpression to improve the handling of arguments and results.