### PR TITLE
Fix erroneous diff in data seeding with binary values

### DIFF
--- a/src/EFCore/ChangeTracking/ArrayStructuralComparer.cs
+++ b/src/EFCore/ChangeTracking/ArrayStructuralComparer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// </summary>
         public ArrayStructuralComparer()
             : base(
-                CreateDefaultEqualsExpression(favorStructuralComparisons: true),
+                CreateDefaultEqualsExpression(),
                 CreateDefaultHashCodeExpression(favorStructuralComparisons: true),
                 v => v == null ? null : v.ToArray())
         {

--- a/src/EFCore/ChangeTracking/ValueComparer`.cs
+++ b/src/EFCore/ChangeTracking/ValueComparer`.cs
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// </param>
         public ValueComparer(bool favorStructuralComparisons)
             : this(
-                CreateDefaultEqualsExpression(favorStructuralComparisons),
+                CreateDefaultEqualsExpression(),
                 CreateDefaultHashCodeExpression(favorStructuralComparisons))
         {
         }
@@ -87,18 +87,14 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// <summary>
         ///     Creates an expression for equality.
         /// </summary>
-        /// <param name="favorStructuralComparisons">
-        ///     If <c>true</c>, then <see cref="IStructuralEquatable" /> is used if the type implements it.
-        /// </param>
         /// <returns> The equality expression. </returns>
-        protected static Expression<Func<T, T, bool>> CreateDefaultEqualsExpression(bool favorStructuralComparisons)
+        protected static Expression<Func<T, T, bool>> CreateDefaultEqualsExpression()
         {
             var type = typeof(T);
             var param1 = Expression.Parameter(type, "v1");
             var param2 = Expression.Parameter(type, "v2");
 
-            if (favorStructuralComparisons
-                && typeof(IStructuralEquatable).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()))
+            if (typeof(IStructuralEquatable).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()))
             {
                 return Expression.Lambda<Func<T, T, bool>>(
                     Expression.Call(

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -6187,6 +6187,98 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
         }
 
         [Fact]
+        public void SeedData_binary_change()
+        {
+            Execute(
+                _ => { },
+                source => source.Entity(
+                    "EntityWithTwoProperties",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.Property<byte[]>("Value1");
+                        x.HasData(
+                            new
+                            {
+                                Id = 42,
+                                Value1 = new byte[] { 2, 1 }
+                            });
+                    }),
+                target => target.Entity(
+                    "EntityWithTwoProperties",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.Property<byte[]>("Value1");
+                        x.HasData(
+                            new
+                            {
+                                Id = 42,
+                                Value1 = new byte[] { 1, 2 }
+                            });
+                    }),
+                upOps => Assert.Collection(
+                    upOps,
+                    o =>
+                    {
+                        var m = Assert.IsType<UpdateDataOperation>(o);
+                        AssertMultidimensionalArray(
+                            m.KeyValues,
+                            v => Assert.Equal(42, v));
+                        AssertMultidimensionalArray(
+                            m.Values,
+                            v => Assert.Equal(new byte[] { 1, 2 }, v));
+                    }),
+                downOps => Assert.Collection(
+                    downOps,
+                    o =>
+                    {
+                        var m = Assert.IsType<UpdateDataOperation>(o);
+                        AssertMultidimensionalArray(
+                            m.KeyValues,
+                            v => Assert.Equal(42, v));
+                        AssertMultidimensionalArray(
+                            m.Values,
+                            v => Assert.Equal(new byte[] { 2, 1 }, v));
+                    }));
+        }
+
+        [Fact]
+        public void SeedData_binary_no_change()
+        {
+            Execute(
+                _ => { },
+                source => source.Entity(
+                    "EntityWithTwoProperties",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.Property<byte[]>("Value1");
+                        x.HasData(
+                            new
+                            {
+                                Id = 42,
+                                Value1 = new byte[] { 1, 2 }
+                            });
+                    }),
+                target => target.Entity(
+                    "EntityWithTwoProperties",
+                    x =>
+                    {
+                        x.Property<int>("Id");
+                        x.Property<byte[]>("Value1");
+                        x.HasData(
+                            new
+                            {
+                                Id = 42,
+                                Value1 = new byte[] { 1, 2 }
+                            });
+                    }),
+                upOps => Assert.Empty(upOps),
+                downOps => Assert.Empty(downOps));
+        }
+
+        [Fact]
         public void SeedData_update_with_table_rename()
         {
             Execute(

--- a/test/EFCore.Tests/Storage/ValueComparerTest.cs
+++ b/test/EFCore.Tests/Storage/ValueComparerTest.cs
@@ -559,7 +559,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
             var value2 = new byte[] { 2, 1 };
 
             Assert.True(equals(value1a, value1a));
-            Assert.False(equals(value1a, value1b));
+            Assert.True(equals(value1a, value1b));
             Assert.False(equals(value1a, value2));
 
             Assert.True(keyEquals(value1a, value1a));
@@ -662,7 +662,7 @@ namespace Microsoft.EntityFrameworkCore.Storage
 
             Assert.True(equals(value1a, value1a));
             Assert.True(equals(value1a, value1b)); // Underlying array instances the same
-            Assert.False(equals(value1a, value1c)); // Underlying array instances different
+            Assert.True(equals(value1a, value1c)); // Underlying array instances different
             Assert.False(keyEquals(value1a, value2)); // Underlying array instances different values
 
             Assert.True(keyEquals(value1a, value1a));


### PR DESCRIPTION
Fixes #13172

This change means we use structural comparisons for Equals now in regular DetectChanges. In the common case of DetectChanges, this short-circuits to quick same reference check, since the bytes are still not snapshotted. However, in case where the reference has changed, but the bytes are the same, we no longer get an erroneous Modified state, which as well as fixing this issue also means that we can avoid sending an update for data that hasn't changed.
