### PR TITLE
Remove language info in EfCore documentation url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Entity Framework Core
 
-Documentation on using EF Core is available at <https://docs.microsoft.com/en-us/ef/core/>.
+Documentation on using EF Core is available at <https://docs.microsoft.com/ef/core/>.
 
 ## EF Core here, EF6 elsewhere
 
@@ -25,7 +25,7 @@ InMemory (for testing) | `Microsoft.EntityFrameworkCore.InMemory`  | [![NuGet](h
 
 ## Project Wiki
 
-More details about our project, like our release [roadmap](https://docs.microsoft.com/en-us/ef/core/what-is-new/roadmap), or [how to get and build our code](https://github.com/aspnet/EntityFrameworkCore/wiki/getting-and-building-the-code), are located in our our [project wiki](https://github.com/aspnet/EntityFrameworkCore/wiki/).
+More details about our project, like our release [roadmap](https://docs.microsoft.com/ef/core/what-is-new/roadmap), or [how to get and build our code](https://github.com/aspnet/EntityFrameworkCore/wiki/getting-and-building-the-code), are located in our our [project wiki](https://github.com/aspnet/EntityFrameworkCore/wiki/).
 
 ## Building from source
 


### PR DESCRIPTION
Remove language info in EfCore documentation URL.

So that it is consistent with other URLs such as
- https://docs.microsoft.com/ef/core/providers/