### PR TITLE
Changing metadata to allow getting properties based on an indexer

### DIFF
--- a/src/EFCore/Metadata/IMutableEntityType.cs
+++ b/src/EFCore/Metadata/IMutableEntityType.cs
@@ -184,6 +184,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         IMutableProperty AddProperty([NotNull] string name, [CanBeNull] Type propertyType);
 
         /// <summary>
+        ///     Adds a property based on an indexer to this entity.
+        /// </summary>
+        /// <param name="name"> The name of the property to add. </param>
+        /// <param name="propertyType"> The type of value the property will hold. </param>
+        /// <returns> The newly created property. </returns>
+        IMutableProperty AddIndexedProperty([NotNull] string name, [NotNull] Type propertyType);
+
+        /// <summary>
         ///     <para>
         ///         Gets the property with a given name. Returns null if no property with the given name is defined.
         ///     </para>

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -1597,7 +1597,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 ClrType?.GetMembersInHierarchy(name).FirstOrDefault(),
                 configurationSource,
                 typeConfigurationSource,
-                false);
+                isIndexProperty: false);
         }
 
         /// <summary>
@@ -1628,7 +1628,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 memberInfo,
                 configurationSource,
                 configurationSource,
-                false);
+                isIndexProperty: false);
         }
 
 
@@ -1652,7 +1652,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 null,
                 configurationSource,
                 typeConfigurationSource,
-                true);
+                isIndexProperty: true);
         }
 
         private Property AddProperty(

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -1596,7 +1596,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 propertyType,
                 ClrType?.GetMembersInHierarchy(name).FirstOrDefault(),
                 configurationSource,
-                typeConfigurationSource);
+                typeConfigurationSource,
+                false);
         }
 
         /// <summary>
@@ -1621,7 +1622,37 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         memberInfo.Name, this.DisplayName(), memberInfo.DeclaringType?.ShortDisplayName()));
             }
 
-            return AddProperty(memberInfo.GetSimpleMemberName(), memberInfo.GetMemberType(), memberInfo, configurationSource, configurationSource);
+            return AddProperty(
+                memberInfo.GetSimpleMemberName(),
+                memberInfo.GetMemberType(),
+                memberInfo,
+                configurationSource,
+                configurationSource,
+                false);
+        }
+
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual Property AddIndexedProperty(
+            [NotNull] string name,
+            [NotNull] Type propertyType,
+            // ReSharper disable once MethodOverloadWithOptionalParameter
+            ConfigurationSource configurationSource = ConfigurationSource.Explicit,
+            ConfigurationSource? typeConfigurationSource = ConfigurationSource.Explicit)
+        {
+            Check.NotNull(name, nameof(name));
+            Check.NotNull(propertyType, nameof(propertyType));
+
+            return AddProperty(
+                name,
+                propertyType,
+                null,
+                configurationSource,
+                typeConfigurationSource,
+                true);
         }
 
         private Property AddProperty(
@@ -1629,7 +1660,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Type propertyType,
             MemberInfo memberInfo,
             ConfigurationSource configurationSource,
-            ConfigurationSource? typeConfigurationSource)
+            ConfigurationSource? typeConfigurationSource,
+            bool isIndexProperty)
         {
             var conflictingMember = FindMembersInHierarchy(name).FirstOrDefault();
             if (conflictingMember != null)
@@ -1666,7 +1698,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             var property = new Property(
                 name, propertyType, memberInfo as PropertyInfo, memberInfo as FieldInfo, this,
-                configurationSource, typeConfigurationSource);
+                configurationSource, typeConfigurationSource, isIndexProperty);
 
             _properties.Add(property.Name, property);
             PropertyMetadataChanged();
@@ -2224,6 +2256,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             => RemoveIndex(properties);
 
         IMutableProperty IMutableEntityType.AddProperty(string name, Type propertyType) => AddProperty(name, propertyType);
+
+        IMutableProperty IMutableEntityType.AddIndexedProperty(string name, Type propertyType) => AddIndexedProperty(name, propertyType);
 
         [DebuggerStepThrough]
         IProperty IEntityType.FindProperty(string name) => FindProperty(name);

--- a/src/EFCore/Metadata/Internal/IndexedPropertyGetterFactory.cs
+++ b/src/EFCore/Metadata/Internal/IndexedPropertyGetterFactory.cs
@@ -1,0 +1,71 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Internal;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class IndexedPropertyGetterFactory : ClrAccessorFactory<IClrPropertyGetter>
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected override IClrPropertyGetter CreateGeneric<TEntity, TValue, TNonNullableEnumValue>(
+            PropertyInfo propertyInfo, IPropertyBase propertyBase)
+        {
+            Debug.Assert(propertyBase != null);
+
+            // find indexer with single argument of type string
+            var indexerPropertyInfo =
+                (from p in propertyBase.DeclaringType.ClrType.GetDefaultMembers().OfType<PropertyInfo>()
+                 let q = p.GetIndexParameters()
+                 where q.Length == 1 && q[0].ParameterType == typeof(string)
+                 select p).FirstOrDefault();
+
+            if (indexerPropertyInfo == null)
+            {
+                throw new InvalidOperationException(CoreStrings.NoIndexer(propertyBase.Name,
+                        propertyBase.DeclaringType.DisplayName(), typeof(string).ShortDisplayName()));
+            }
+
+            var entityParameter = Expression.Parameter(typeof(TEntity), "entity");
+            var indexerParameterList = new List<Expression>() { Expression.Constant(propertyBase.Name) };
+            Expression readExpression = Expression.MakeIndex(
+                entityParameter, indexerPropertyInfo, indexerParameterList);
+
+            if (readExpression.Type != typeof(TValue))
+            {
+                readExpression = Expression.Convert(readExpression, typeof(TValue));
+            }
+
+            var property = propertyBase as IProperty;
+            var comparer = typeof(TValue).IsNullableType()
+                ? null
+                : property?.GetValueComparer()
+                  ?? property?.FindMapping()?.Comparer
+                  ?? (ValueComparer)Activator.CreateInstance(
+                      typeof(ValueComparer<>).MakeGenericType(typeof(TValue)),
+                      new object[] { false });
+
+            var hasDefaultValueExpression = comparer == null
+                ? Expression.Equal(readExpression, Expression.Default(typeof(TValue)))
+                : comparer.ExtractEqualsBody(readExpression, Expression.Default(typeof(TValue)));
+
+            return new ClrPropertyGetter<TEntity, TValue>(
+                Expression.Lambda<Func<TEntity, TValue>>(readExpression, entityParameter).Compile(),
+                Expression.Lambda<Func<TEntity, bool>>(hasDefaultValueExpression, entityParameter).Compile());
+        }
+    }
+}

--- a/src/EFCore/Metadata/Internal/Property.cs
+++ b/src/EFCore/Metadata/Internal/Property.cs
@@ -45,8 +45,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [CanBeNull] FieldInfo fieldInfo,
             [NotNull] EntityType declaringEntityType,
             ConfigurationSource configurationSource,
-            ConfigurationSource? typeConfigurationSource)
-            : base(name, propertyInfo, fieldInfo)
+            ConfigurationSource? typeConfigurationSource,
+            bool isIndexProperty = false)
+            : base(name, propertyInfo, fieldInfo, isIndexProperty)
         {
             Check.NotNull(clrType, nameof(clrType));
             Check.NotNull(declaringEntityType, nameof(declaringEntityType));

--- a/src/EFCore/Metadata/Internal/PropertyBase.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBase.cs
@@ -24,6 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private IClrPropertySetter _setter;
         private PropertyAccessors _accessors;
         private PropertyIndexes _indexes;
+        private bool _isIndexProperty;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -32,13 +33,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         protected PropertyBase(
             [NotNull] string name,
             [CanBeNull] PropertyInfo propertyInfo,
-            [CanBeNull] FieldInfo fieldInfo)
+            [CanBeNull] FieldInfo fieldInfo,
+            bool isIndexProperty = false)
         {
             Check.NotEmpty(name, nameof(name));
 
             Name = name;
             PropertyInfo = propertyInfo;
             _fieldInfo = fieldInfo;
+            _isIndexProperty = isIndexProperty;
         }
 
         /// <summary>
@@ -258,8 +261,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual IClrPropertyGetter Getter
-            => NonCapturingLazyInitializer.EnsureInitialized(ref _getter, this, p => new ClrPropertyGetterFactory().Create(p));
+        public virtual IClrPropertyGetter Getter => _isIndexProperty
+            ? NonCapturingLazyInitializer.EnsureInitialized(ref _getter, this, p => new IndexedPropertyGetterFactory().Create(p))
+            : NonCapturingLazyInitializer.EnsureInitialized(ref _getter, this, p => new ClrPropertyGetterFactory().Create(p));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2783,6 +2783,14 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 GetString("FkAttributeOnNonUniquePrincipal", nameof(navigation), nameof(principalType), nameof(dependentType)),
                 navigation, principalType, dependentType);
 
+        /// <summary>
+        ///     Property '{property}' on entity type '{entity}' was created as an indexed property. But there is no indexer on '{entity}' taking a single argument of type '{type}'.
+        /// </summary>
+        public static string NoIndexer([CanBeNull] object property, [CanBeNull] object entity, [CanBeNull] object type)
+            => string.Format(
+                GetString("NoIndexer", nameof(property), nameof(entity), nameof(type)),
+                property, entity, type);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-    Microsoft ResX Schema
-
+  <!-- 
+    Microsoft ResX Schema 
+    
     Version 2.0
-
-    The primary goals of this format is to allow a simple XML format
-    that is mostly human readable. The generation and parsing of the
-    various data types are done through the TypeConverter classes
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
     associated with the data types.
-
+    
     Example:
-
+    
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-
-    There are any number of "resheader" rows that contain simple
+                
+    There are any number of "resheader" rows that contain simple 
     name/value pairs.
-
-    Each data row contains a name, and value. The row also contains a
-    type or mimetype. Type corresponds to a .NET class that support
-    text/value conversion through the TypeConverter architecture.
-    Classes that don't support this are serialized and stored with the
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
     mimetype set.
-
-    The mimetype is used for serialized objects, and tells the
-    ResXResourceReader how to depersist the object. This is currently not
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
     extensible. For a given mimetype the value must be set accordingly:
-
-    Note - application/x-microsoft.net.object.binary.base64 is the format
-    that the ResXResourceWriter will generate, however the reader can
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
     read any of the formats listed below.
-
+    
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-
+    
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with
+    value   : The object must be serialized with 
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array
+    value   : The object must be serialized into a byte array 
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -1121,5 +1121,8 @@
   </data>
   <data name="FkAttributeOnNonUniquePrincipal" xml:space="preserve">
     <value>The ForeignKeyAttribute for the navigation '{navigation}' cannot be specified on the entity type '{principalType}' since it represents a one-to-many relationship. Move the ForeignKeyAttribute to a property on '{dependentType}'.</value>
+  </data>
+  <data name="NoIndexer" xml:space="preserve">
+    <value>Property '{property}' on entity type '{entity}' was created as an indexed property. But there is no indexer on '{entity}' taking a single argument of type '{type}'.</value>
   </data>
 </root>

--- a/src/EFCore/breakingchanges.netcore.json
+++ b/src/EFCore/breakingchanges.netcore.json
@@ -113,5 +113,10 @@
     "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IEntityType : Microsoft.EntityFrameworkCore.Metadata.ITypeBase",
     "MemberId": "System.Collections.Generic.IEnumerable<Microsoft.EntityFrameworkCore.Metadata.IServiceProperty> GetServiceProperties()",
     "Kind": "Addition"
+  },
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType : Microsoft.EntityFrameworkCore.Metadata.IEntityType, Microsoft.EntityFrameworkCore.Metadata.IMutableTypeBase",
+    "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IMutableProperty AddIndexedProperty(System.String name, System.Type propertyType)",
+    "Kind": "Addition"
   }
 ]

--- a/test/EFCore.Tests/Metadata/Internal/IndexedPropertyGetterFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/IndexedPropertyGetterFactoryTest.cs
@@ -1,0 +1,43 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Xunit;
+
+// ReSharper disable InconsistentNaming
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    public class IndexedPropertyGetterFactoryTest
+    {
+        [Fact]
+        public void Delegate_getter_is_returned_for_indexed_property()
+        {
+            var entityType = new Model().AddEntityType(typeof(IndexedClass));
+            var idProperty = entityType.AddProperty("Id", typeof(int));
+            var propertyA = entityType.AddIndexedProperty("PropertyA", typeof(string));
+            var propertyB = entityType.AddIndexedProperty("PropertyB", typeof(int));
+
+            var indexedClass = new IndexedClass();
+            Assert.Equal(
+                "ValueA", new IndexedPropertyGetterFactory().Create(propertyA).GetClrValue(indexedClass));
+            Assert.Equal(
+                123, new IndexedPropertyGetterFactory().Create(propertyB).GetClrValue(indexedClass));
+        }
+
+        private class IndexedClass
+        {
+            private Dictionary<string, object> _internalValues = new Dictionary<string, object>()
+                {
+                    { "PropertyA", "ValueA" },
+                    { "PropertyB", 123 }
+                };
+
+            internal int Id { get; set; }
+
+            public object this[string name]
+            {
+                get => _internalValues[name];
+            }
+        }
+    }
+}

--- a/test/EFCore.Tests/Metadata/Internal/IndexedPropertyGetterFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/IndexedPropertyGetterFactoryTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 using Xunit;
 
@@ -24,6 +25,21 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 123, new IndexedPropertyGetterFactory().Create(propertyB).GetClrValue(indexedClass));
         }
 
+        [Fact]
+        public void Exception_is_returned_for_indexed_property_without_indexer()
+        {
+            var entityType = new Model().AddEntityType(typeof(NonIndexedClass));
+            var idProperty = entityType.AddProperty("Id", typeof(int));
+            var propertyA = entityType.AddIndexedProperty("PropertyA", typeof(string));
+            var propertyB = entityType.AddIndexedProperty("PropertyB", typeof(int));
+
+            var nonIndexedClass = new NonIndexedClass();
+            Assert.Throws<InvalidOperationException>(
+                () => new IndexedPropertyGetterFactory().Create(propertyA).GetClrValue(nonIndexedClass));
+            Assert.Throws<InvalidOperationException>(
+                () => new IndexedPropertyGetterFactory().Create(propertyB).GetClrValue(nonIndexedClass));
+        }
+
         private class IndexedClass
         {
             private Dictionary<string, object> _internalValues = new Dictionary<string, object>()
@@ -38,6 +54,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             {
                 get => _internalValues[name];
             }
+        }
+
+        private class NonIndexedClass
+        {
+            internal int Id { get; set; }
+            public string PropA { get; set; }
+            public int PropB { get; set; }
         }
     }
 }


### PR DESCRIPTION
Update EF metadata to allow properties to use a getter based on an indexer on the surrounding entity class rather than a member. (Note: setting is not in this PR - that will come later). This addresses part of issue #13610.