### PR TITLE
Changing metadata to allow setting properties based on an indexer

### DIFF
--- a/src/EFCore/Metadata/Internal/IndexedPropertyGetterFactory.cs
+++ b/src/EFCore/Metadata/Internal/IndexedPropertyGetterFactory.cs
@@ -29,7 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             // find indexer with single argument of type string which returns an object
             var indexerPropertyInfo =
-                (from p in propertyBase.DeclaringType.ClrType.GetDefaultMembers().OfType<PropertyInfo>()
+                (from p in propertyBase.DeclaringType.ClrType.GetRuntimeProperties()
                  where p.PropertyType == typeof(object)
                  let q = p.GetIndexParameters()
                  where q.Length == 1 && q[0].ParameterType == typeof(string)
@@ -37,9 +37,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             if (indexerPropertyInfo == null)
             {
-                throw new InvalidOperationException(CoreStrings.NoIndexer(propertyBase.Name,
-                        propertyBase.DeclaringType.DisplayName(), typeof(string).ShortDisplayName(),
-                        typeof(object).ShortDisplayName()));
+                throw new InvalidOperationException(
+                    CoreStrings.NoIndexer(propertyBase.Name, propertyBase.DeclaringType.DisplayName()));
             }
 
             var entityParameter = Expression.Parameter(typeof(TEntity), "entity");

--- a/src/EFCore/Metadata/Internal/IndexedPropertySetterFactory.cs
+++ b/src/EFCore/Metadata/Internal/IndexedPropertySetterFactory.cs
@@ -7,7 +7,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Internal;
 
 namespace Microsoft.EntityFrameworkCore.Metadata.Internal
@@ -16,13 +15,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public class IndexedPropertyGetterFactory : ClrAccessorFactory<IClrPropertyGetter>
+    public class IndexedPropertySetterFactory : ClrAccessorFactory<IClrPropertySetter>
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        protected override IClrPropertyGetter CreateGeneric<TEntity, TValue, TNonNullableEnumValue>(
+        protected override IClrPropertySetter CreateGeneric<TEntity, TValue, TNonNullableEnumValue>(
             PropertyInfo propertyInfo, IPropertyBase propertyBase)
         {
             Debug.Assert(propertyBase != null);
@@ -43,31 +42,28 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             }
 
             var entityParameter = Expression.Parameter(typeof(TEntity), "entity");
+            var valueParameter = Expression.Parameter(typeof(TValue), "value");
             var indexerParameterList = new List<Expression>() { Expression.Constant(propertyBase.Name) };
-            Expression readExpression = Expression.MakeIndex(
-                entityParameter, indexerPropertyInfo, indexerParameterList);
 
-            if (readExpression.Type != typeof(TValue))
-            {
-                readExpression = Expression.Convert(readExpression, typeof(TValue));
-            }
+            // the indexer expects the value to be an object, so cast it to that if necessary
+            var propertyType = propertyBase.ClrType;
+            var convertedParameter = propertyType == typeof(object)
+                ? (Expression)valueParameter
+                : Expression.TypeAs(valueParameter, typeof(object));
 
-            var property = propertyBase as IProperty;
-            var comparer = typeof(TValue).IsNullableType()
-                ? null
-                : property?.GetValueComparer()
-                  ?? property?.FindMapping()?.Comparer
-                  ?? (ValueComparer)Activator.CreateInstance(
-                      typeof(ValueComparer<>).MakeGenericType(typeof(TValue)),
-                      new object[] { false });
+            Expression writeExpression = Expression.Assign(
+                Expression.MakeIndex(entityParameter, indexerPropertyInfo, indexerParameterList),
+                convertedParameter);
 
-            var hasDefaultValueExpression = comparer == null
-                ? Expression.Equal(readExpression, Expression.Default(typeof(TValue)))
-                : comparer.ExtractEqualsBody(readExpression, Expression.Default(typeof(TValue)));
+            var setter = Expression.Lambda<Action<TEntity, TValue>>(
+                writeExpression,
+                entityParameter,
+                valueParameter).Compile();
 
-            return new ClrPropertyGetter<TEntity, TValue>(
-                Expression.Lambda<Func<TEntity, TValue>>(readExpression, entityParameter).Compile(),
-                Expression.Lambda<Func<TEntity, bool>>(hasDefaultValueExpression, entityParameter).Compile());
+            return propertyType.IsNullableType()
+                   && propertyType.UnwrapNullableType().GetTypeInfo().IsEnum
+                ? new NullableEnumClrPropertySetter<TEntity, TValue, TNonNullableEnumValue>(setter)
+                : (IClrPropertySetter)new ClrPropertySetter<TEntity, TValue>(setter);
         }
     }
 }

--- a/src/EFCore/Metadata/Internal/IndexedPropertySetterFactory.cs
+++ b/src/EFCore/Metadata/Internal/IndexedPropertySetterFactory.cs
@@ -28,7 +28,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             // find indexer with single argument of type string which returns an object
             var indexerPropertyInfo =
-                (from p in propertyBase.DeclaringType.ClrType.GetDefaultMembers().OfType<PropertyInfo>()
+                (from p in propertyBase.DeclaringType.ClrType.GetRuntimeProperties()
                  where p.PropertyType == typeof(object)
                  let q = p.GetIndexParameters()
                  where q.Length == 1 && q[0].ParameterType == typeof(string)
@@ -36,9 +36,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             if (indexerPropertyInfo == null)
             {
-                throw new InvalidOperationException(CoreStrings.NoIndexer(propertyBase.Name,
-                        propertyBase.DeclaringType.DisplayName(), typeof(string).ShortDisplayName(),
-                        typeof(object).ShortDisplayName()));
+                throw new InvalidOperationException(
+                    CoreStrings.NoIndexer(propertyBase.Name, propertyBase.DeclaringType.DisplayName()));
             }
 
             var entityParameter = Expression.Parameter(typeof(TEntity), "entity");

--- a/src/EFCore/Metadata/Internal/PropertyBase.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBase.cs
@@ -24,7 +24,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         private IClrPropertySetter _setter;
         private PropertyAccessors _accessors;
         private PropertyIndexes _indexes;
-        private bool _isIndexProperty;
+        private bool _isIndexedProperty;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -41,7 +41,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Name = name;
             PropertyInfo = propertyInfo;
             _fieldInfo = fieldInfo;
-            _isIndexProperty = isIndexProperty;
+            _isIndexedProperty = isIndexProperty;
         }
 
         /// <summary>
@@ -261,7 +261,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual IClrPropertyGetter Getter => _isIndexProperty
+        public virtual IClrPropertyGetter Getter => _isIndexedProperty
             ? NonCapturingLazyInitializer.EnsureInitialized(ref _getter, this, p => new IndexedPropertyGetterFactory().Create(p))
             : NonCapturingLazyInitializer.EnsureInitialized(ref _getter, this, p => new ClrPropertyGetterFactory().Create(p));
 
@@ -269,8 +269,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual IClrPropertySetter Setter
-            => NonCapturingLazyInitializer.EnsureInitialized(ref _setter, this, p => new ClrPropertySetterFactory().Create(p));
+        public virtual IClrPropertySetter Setter => _isIndexedProperty
+            ? NonCapturingLazyInitializer.EnsureInitialized(ref _setter, this, p => new IndexedPropertySetterFactory().Create(p))
+            : NonCapturingLazyInitializer.EnsureInitialized(ref _setter, this, p => new ClrPropertySetterFactory().Create(p));
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2784,12 +2784,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 navigation, principalType, dependentType);
 
         /// <summary>
-        ///     Property '{property}' on entity type '{entity}' was created as an indexed property. But there is no indexer on '{entity}' taking a single argument of type '{stringType}' and returning type '{objectType}'.
+        ///     Property '{property}' on entity type '{entity}' was created as an indexed property. But there is no public indexer on '{entity}' taking a single argument of type 'string' and returning type 'object'.
         /// </summary>
-        public static string NoIndexer([CanBeNull] object property, [CanBeNull] object entity, [CanBeNull] object stringType, [CanBeNull] object objectType)
+        public static string NoIndexer([CanBeNull] object property, [CanBeNull] object entity)
             => string.Format(
-                GetString("NoIndexer", nameof(property), nameof(entity), nameof(stringType), nameof(objectType)),
-                property, entity, stringType, objectType);
+                GetString("NoIndexer", nameof(property), nameof(entity)),
+                property, entity);
 
         private static string GetString(string name, params string[] formatterNames)
         {

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2784,12 +2784,12 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 navigation, principalType, dependentType);
 
         /// <summary>
-        ///     Property '{property}' on entity type '{entity}' was created as an indexed property. But there is no indexer on '{entity}' taking a single argument of type '{type}'.
+        ///     Property '{property}' on entity type '{entity}' was created as an indexed property. But there is no indexer on '{entity}' taking a single argument of type '{stringType}' and returning type '{objectType}'.
         /// </summary>
-        public static string NoIndexer([CanBeNull] object property, [CanBeNull] object entity, [CanBeNull] object type)
+        public static string NoIndexer([CanBeNull] object property, [CanBeNull] object entity, [CanBeNull] object stringType, [CanBeNull] object objectType)
             => string.Format(
-                GetString("NoIndexer", nameof(property), nameof(entity), nameof(type)),
-                property, entity, type);
+                GetString("NoIndexer", nameof(property), nameof(entity), nameof(stringType), nameof(objectType)),
+                property, entity, stringType, objectType);
 
         private static string GetString(string name, params string[] formatterNames)
         {

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1123,6 +1123,6 @@
     <value>The ForeignKeyAttribute for the navigation '{navigation}' cannot be specified on the entity type '{principalType}' since it represents a one-to-many relationship. Move the ForeignKeyAttribute to a property on '{dependentType}'.</value>
   </data>
   <data name="NoIndexer" xml:space="preserve">
-    <value>Property '{property}' on entity type '{entity}' was created as an indexed property. But there is no indexer on '{entity}' taking a single argument of type '{stringType}' and returning type '{objectType}'.</value>
+    <value>Property '{property}' on entity type '{entity}' was created as an indexed property. But there is no public indexer on '{entity}' taking a single argument of type 'string' and returning type 'object'.</value>
   </data>
 </root>

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1123,6 +1123,6 @@
     <value>The ForeignKeyAttribute for the navigation '{navigation}' cannot be specified on the entity type '{principalType}' since it represents a one-to-many relationship. Move the ForeignKeyAttribute to a property on '{dependentType}'.</value>
   </data>
   <data name="NoIndexer" xml:space="preserve">
-    <value>Property '{property}' on entity type '{entity}' was created as an indexed property. But there is no indexer on '{entity}' taking a single argument of type '{type}'.</value>
+    <value>Property '{property}' on entity type '{entity}' was created as an indexed property. But there is no indexer on '{entity}' taking a single argument of type '{stringType}' and returning type '{objectType}'.</value>
   </data>
 </root>

--- a/test/EFCore.Tests/Metadata/Internal/IndexedPropertySetterFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/IndexedPropertySetterFactoryTest.cs
@@ -1,0 +1,77 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    public class IndexedPropertySetterFactoryTest
+    {
+        [Fact]
+        public void Delegate_setter_is_returned_for_indexed_property()
+        {
+            var entityType = new Model().AddEntityType(typeof(IndexedClass));
+            var idProperty = entityType.AddProperty("Id", typeof(int));
+            var propertyA = entityType.AddIndexedProperty("PropertyA", typeof(string));
+            var propertyB = entityType.AddIndexedProperty("PropertyB", typeof(int));
+
+            var indexedClass = new IndexedClass
+            {
+                Id = 1
+            };
+
+            new IndexedPropertySetterFactory().Create(propertyA).SetClrValue(indexedClass, "UpdatedValueA");
+            new IndexedPropertySetterFactory().Create(propertyB).SetClrValue(indexedClass, 456);
+
+            Assert.Equal("UpdatedValueA", indexedClass["PropertyA"]);
+            Assert.Equal(456, indexedClass["PropertyB"]);
+        }
+
+        [Fact]
+        public void Exception_is_returned_when_setting_indexed_property_without_indexer()
+        {
+            var entityType = new Model().AddEntityType(typeof(NonIndexedClass));
+            var idProperty = entityType.AddProperty("Id", typeof(int));
+            var propertyA = entityType.AddIndexedProperty("PropertyA", typeof(string));
+            var propertyB = entityType.AddIndexedProperty("PropertyB", typeof(int));
+
+            var indexedClass = new NonIndexedClass
+            {
+                Id = 1,
+                PropA = "PropAValue",
+                PropB = 123
+            };
+
+            Assert.Throws<InvalidOperationException>(
+                () => new IndexedPropertySetterFactory().Create(propertyA).SetClrValue(indexedClass, "UpdatedValueA"));
+            Assert.Throws<InvalidOperationException>(
+                () => new IndexedPropertySetterFactory().Create(propertyB).SetClrValue(indexedClass, 456));
+        }
+
+        private class IndexedClass
+        {
+            private Dictionary<string, object> _internalValues = new Dictionary<string, object>()
+                {
+                    { "PropertyA", "ValueA" },
+                    { "PropertyB", 123 }
+                };
+
+            internal int Id { get; set; }
+
+            public object this[string name]
+            {
+                get => _internalValues[name];
+                set => _internalValues[name] = value;
+            }
+        }
+
+        private class NonIndexedClass
+        {
+            internal int Id { get; set; }
+            public string PropA { get; set; }
+            public int PropB { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Update EF metadata to allow properties to use a setter based on an indexer on the surrounding entity class rather than a member. This addresses part of issue #13610.

(Also found a small update to the way the getter for indexers should work - this is a follow-on to PR #13656).