### PR TITLE
SqlServer Spatial: Use Parse for more SQL constants

### DIFF
--- a/src/EFCore.Specification.Tests/Query/SpatialQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/SpatialQueryTestBase.cs
@@ -318,6 +318,78 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task Distance_constant(bool isAsync)
+        {
+            return AssertQuery<PointEntity>(
+                isAsync,
+                es => es.Select(
+                    e => new
+                    {
+                        e.Id,
+                        Distance = e.Point == null ? -1 : e.Point.Distance(new Point(0, 1))
+                    }),
+                elementSorter: e => e.Id,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.Id, a.Id);
+
+                    if (AssertDistances)
+                    {
+                        Assert.Equal(e.Distance, a.Distance);
+                    }
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Distance_constant_srid_4326(bool isAsync)
+        {
+            return AssertQuery<PointEntity>(
+                isAsync,
+                es => es.Select(
+                    e => new
+                    {
+                        e.Id,
+                        Distance = e.Point == null ? -1 : e.Point.Distance(new Point(0, 1) { SRID = 4326 })
+                    }),
+                elementSorter: e => e.Id,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.Id, a.Id);
+
+                    if (AssertDistances)
+                    {
+                        Assert.Equal(e.Distance, a.Distance);
+                    }
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Distance_constant_lhs(bool isAsync)
+        {
+            return AssertQuery<PointEntity>(
+                isAsync,
+                es => es.Select(
+                    e => new
+                    {
+                        e.Id,
+                        Distance = e.Point == null ? -1 : new Point(0, 1).Distance(e.Point)
+                    }),
+                elementSorter: e => e.Id,
+                elementAsserter: (e, a) =>
+                {
+                    Assert.Equal(e.Id, a.Id);
+
+                    if (AssertDistances)
+                    {
+                        Assert.Equal(e.Distance, a.Distance);
+                    }
+                });
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task EndPoint(bool isAsync)
         {
             return AssertQuery<LineStringEntity>(isAsync, es => es.Select(e => new { e.Id, e.LineString.EndPoint }));

--- a/src/EFCore.Sqlite.NTS/Storage/Internal/SqliteGeometryTypeMapping.cs
+++ b/src/EFCore.Sqlite.NTS/Storage/Internal/SqliteGeometryTypeMapping.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Data.Common;
 using System.Reflection;
+using System.Text;
 using GeoAPI;
 using GeoAPI.Geometries;
 using JetBrains.Annotations;
@@ -57,14 +58,24 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal
         /// </summary>
         protected override string GenerateNonNullSqlLiteral(object value)
         {
+            var builder = new StringBuilder();
             var geometry = (IGeometry)value;
-            var srid = geometry.SRID;
 
-            var text = "'" + geometry.AsText() + "'";
+            builder
+                .Append("GeomFromText('")
+                .Append(geometry.AsText())
+                .Append("'");
 
-            return srid != 0
-                ? $"GeomFromText({text}, {srid})"
-                : $"GeomFromText({text})";
+            if (geometry.SRID != 0)
+            {
+                builder
+                    .Append(", ")
+                    .Append(geometry.SRID);
+            }
+
+            builder.Append(")");
+
+            return builder.ToString();
         }
 
         /// <summary>

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeographyTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeographyTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -139,6 +140,30 @@ SELECT [e].[Id], CASE
     THEN -1.0E0 ELSE [e].[Point].STDistance(@__point_0)
 END AS [Distance]
 FROM [PointEntity] AS [e]");
+        }
+
+        [ConditionalTheory(Skip = "Mixing SRIDs not supported")]
+        public override Task Distance_constant(bool isAsync)
+        {
+            return base.Distance_constant(isAsync);
+        }
+
+        public override async Task Distance_constant_srid_4326(bool isAsync)
+        {
+            await base.Distance_constant_srid_4326(isAsync);
+
+            AssertSql(
+                @"SELECT [e].[Id], CASE
+    WHEN [e].[Point] IS NULL
+    THEN -1.0E0 ELSE [e].[Point].STDistance('POINT (0 1)')
+END AS [Distance]
+FROM [PointEntity] AS [e]");
+        }
+
+        [ConditionalTheory(Skip = "Mixing SRIDs not supported")]
+        public override Task Distance_constant_lhs(bool isAsync)
+        {
+            return base.Distance_constant_lhs(isAsync);
         }
 
         public override async Task EndPoint(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeometryTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SpatialQuerySqlServerGeometryTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Xunit.Abstractions;
 
 namespace Microsoft.EntityFrameworkCore.Query
@@ -130,6 +131,36 @@ FROM [LineStringEntity] AS [e]");
 
 SELECT [e].[Id], [e].[Polygon].STDifference(@__polygon_0) AS [Difference]
 FROM [PolygonEntity] AS [e]");
+        }
+
+        public override async Task Distance_constant(bool isAsync)
+        {
+            await base.Distance_constant(isAsync);
+
+            AssertSql(
+                @"SELECT [e].[Id], CASE
+    WHEN [e].[Point] IS NULL
+    THEN -1.0E0 ELSE [e].[Point].STDistance('POINT (0 1)')
+END AS [Distance]
+FROM [PointEntity] AS [e]");
+        }
+
+        [ConditionalTheory(Skip = "Mixing SRIDs not supported")]
+        public override Task Distance_constant_srid_4326(bool isAsync)
+        {
+            return base.Distance_constant_srid_4326(isAsync);
+        }
+
+        public override async Task Distance_constant_lhs(bool isAsync)
+        {
+            await base.Distance_constant_lhs(isAsync);
+
+            AssertSql(
+                @"SELECT [e].[Id], CASE
+    WHEN [e].[Point] IS NULL
+    THEN -1.0E0 ELSE geometry::Parse('POINT (0 1)').STDistance([e].[Point])
+END AS [Distance]
+FROM [PointEntity] AS [e]");
         }
 
         public override async Task Dimension(bool isAsync)

--- a/test/EFCore.Sqlite.FunctionalTests/Query/SpatialQuerySqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/SpatialQuerySqliteTest.cs
@@ -201,6 +201,42 @@ END AS ""Distance""
 FROM ""PointEntity"" AS ""e""");
         }
 
+        public override async Task Distance_constant(bool isAsync)
+        {
+            await base.Distance_constant(isAsync);
+
+            AssertSql(
+                @"SELECT ""e"".""Id"", CASE
+    WHEN ""e"".""Point"" IS NULL
+    THEN -1.0 ELSE Distance(""e"".""Point"", GeomFromText('POINT (0 1)'))
+END AS ""Distance""
+FROM ""PointEntity"" AS ""e""");
+        }
+
+        public override async Task Distance_constant_srid_4326(bool isAsync)
+        {
+            await base.Distance_constant_srid_4326(isAsync);
+
+            AssertSql(
+                @"SELECT ""e"".""Id"", CASE
+    WHEN ""e"".""Point"" IS NULL
+    THEN -1.0 ELSE Distance(""e"".""Point"", GeomFromText('POINT (0 1)', 4326))
+END AS ""Distance""
+FROM ""PointEntity"" AS ""e""");
+        }
+
+        public override async Task Distance_constant_lhs(bool isAsync)
+        {
+            await base.Distance_constant_lhs(isAsync);
+
+            AssertSql(
+                @"SELECT ""e"".""Id"", CASE
+    WHEN ""e"".""Point"" IS NULL
+    THEN -1.0 ELSE Distance(GeomFromText('POINT (0 1)'), ""e"".""Point"")
+END AS ""Distance""
+FROM ""PointEntity"" AS ""e""");
+        }
+
         public override async Task EndPoint(bool isAsync)
         {
             await base.EndPoint(isAsync);


### PR DESCRIPTION
Fixes #13181