### PR TITLE
Tools: Don't warn for mismatched patch version

### DIFF
--- a/src/EFCore.Design/Design/OperationExecutor.cs
+++ b/src/EFCore.Design/Design/OperationExecutor.cs
@@ -60,7 +60,7 @@ namespace Microsoft.EntityFrameworkCore.Design
 
             var runtimeVersion = ProductInfo.GetVersion();
             if (toolsVersion != null
-                && new SemanticVersionComparer().Compare(toolsVersion, runtimeVersion) < 0)
+                && new SemanticVersionComparer().Compare(RemovePatch(toolsVersion), RemovePatch(runtimeVersion)) < 0)
             {
                 reporter.WriteWarning(DesignStrings.VersionMismatch(toolsVersion, runtimeVersion));
             }
@@ -105,6 +105,19 @@ namespace Microsoft.EntityFrameworkCore.Design
                     rootNamespace,
                     language,
                     designArgs));
+
+            string RemovePatch(string versionString)
+            {
+                var prereleaseIndex = versionString.IndexOf("-", StringComparison.Ordinal);
+                if (prereleaseIndex != -1)
+                {
+                    versionString = versionString.Substring(0, prereleaseIndex);
+                }
+
+                var version = new Version(versionString);
+
+                return new Version(version.Major, version.Minor).ToString();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Manually verified the following scenarios:

Tool | Runtime | Result
--- | --- | ---
2.1.4 | 2.2.0 | Warning
2.2.0 | 2.2.0 | OK
2.2.0 | 2.2.1 | OK

Fixes #12869 