### PR TITLE
Ensure QueryTrackingBehavior is reset when pooling

### DIFF
--- a/src/EFCore/ChangeTracking/ChangeTracker.cs
+++ b/src/EFCore/ChangeTracking/ChangeTracker.cs
@@ -18,10 +18,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
     ///     Instances of this class are typically obtained from <see cref="DbContext.ChangeTracker" /> and it is not designed
     ///     to be directly constructed in your application code.
     /// </summary>
-    public class ChangeTracker : IInfrastructure<IStateManager>
+    public class ChangeTracker : IInfrastructure<IStateManager>, IResettableService
     {
         private readonly IModel _model;
         private QueryTrackingBehavior _queryTrackingBehavior;
+        private QueryTrackingBehavior _defaultQueryTrackingBehavior;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -40,13 +41,16 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
 
             Context = context;
 
-            _queryTrackingBehavior = context
-                                         .GetService<IDbContextOptions>()
-                                         .Extensions
-                                         .OfType<CoreOptionsExtension>()
-                                         .FirstOrDefault()
-                                         ?.QueryTrackingBehavior
-                                     ?? QueryTrackingBehavior.TrackAll;
+            _defaultQueryTrackingBehavior
+                = context
+                      .GetService<IDbContextOptions>()
+                      .Extensions
+                      .OfType<CoreOptionsExtension>()
+                      .FirstOrDefault()
+                      ?.QueryTrackingBehavior
+                  ?? QueryTrackingBehavior.TrackAll;
+
+            _queryTrackingBehavior = _defaultQueryTrackingBehavior;
 
             StateManager = stateManager;
             ChangeDetector = changeDetector;
@@ -329,6 +333,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking
         /// <returns> A string that represents the current object. </returns>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override string ToString() => base.ToString();
+
+        void IResettableService.ResetState()
+        {
+            _queryTrackingBehavior = _defaultQueryTrackingBehavior;
+            AutoDetectChangesEnabled = true;
+        }
 
         /// <summary>
         ///     Determines whether the specified object is equal to the current object.

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -571,17 +571,21 @@ namespace Microsoft.EntityFrameworkCore
 
             if (configurationSnapshot.AutoDetectChangesEnabled != null)
             {
-                ChangeTracker.AutoDetectChangesEnabled = configurationSnapshot.AutoDetectChangesEnabled.Value;
-            }
+                Debug.Assert(configurationSnapshot.QueryTrackingBehavior.HasValue);
 
-            if (configurationSnapshot.QueryTrackingBehavior != null)
-            {
+                ChangeTracker.AutoDetectChangesEnabled = configurationSnapshot.AutoDetectChangesEnabled.Value;
                 ChangeTracker.QueryTrackingBehavior = configurationSnapshot.QueryTrackingBehavior.Value;
             }
-
-            if (configurationSnapshot.AutoTransactionsEnabled != null)
+            else
             {
-                Database.AutoTransactionsEnabled = configurationSnapshot.AutoTransactionsEnabled.Value;
+                ((IResettableService)_changeTracker)?.ResetState();
+            }
+
+            if (_database != null)
+            {
+                _database.AutoTransactionsEnabled
+                    = configurationSnapshot.AutoTransactionsEnabled == null
+                      || configurationSnapshot.AutoTransactionsEnabled.Value;
             }
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
@@ -26,7 +26,6 @@ namespace Microsoft.EntityFrameworkCore
             where TContextService : class
             where TContext : DbContext, TContextService
             => new ServiceCollection()
-                .AddEntityFrameworkSqlServer()
                 .AddDbContextPool<TContextService, TContext>(
                     ob => ob.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString),
                     poolSize)
@@ -38,7 +37,6 @@ namespace Microsoft.EntityFrameworkCore
         private static IServiceProvider BuildServiceProvider<TContext>(int poolSize = 32)
             where TContext : DbContext
             => new ServiceCollection()
-                .AddEntityFrameworkSqlServer()
                 .AddDbContextPool<TContext>(
                     ob => ob.UseSqlServer(SqlServerNorthwindTestStoreFactory.NorthwindConnectionString),
                     poolSize)
@@ -49,6 +47,15 @@ namespace Microsoft.EntityFrameworkCore
 
         private interface IPooledContext
         {
+        }
+
+        private class DefaultOptionsPooledContext : DbContext
+        {
+            public DefaultOptionsPooledContext(DbContextOptions options)
+                : base(options)
+            {
+                //ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+            }
         }
 
         private class PooledContext : DbContext, IPooledContext
@@ -295,6 +302,34 @@ namespace Microsoft.EntityFrameworkCore
             Assert.False(context2.ChangeTracker.AutoDetectChangesEnabled);
             Assert.Equal(QueryTrackingBehavior.TrackAll, context2.ChangeTracker.QueryTrackingBehavior);
             Assert.False(context2.Database.AutoTransactionsEnabled);
+        }
+
+        [Fact]
+        public void Default_Context_configuration__is_reset()
+        {
+            var serviceProvider = BuildServiceProvider<DefaultOptionsPooledContext>();
+
+            var serviceScope = serviceProvider.CreateScope();
+            var scopedProvider = serviceScope.ServiceProvider;
+
+            var context1 = scopedProvider.GetService<DefaultOptionsPooledContext>();
+
+            context1.ChangeTracker.AutoDetectChangesEnabled = false;
+            context1.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+            context1.Database.AutoTransactionsEnabled = false;
+
+            serviceScope.Dispose();
+
+            serviceScope = serviceProvider.CreateScope();
+            scopedProvider = serviceScope.ServiceProvider;
+
+            var context2 = scopedProvider.GetService<DefaultOptionsPooledContext>();
+
+            Assert.Same(context1, context2);
+
+            Assert.True(context2.ChangeTracker.AutoDetectChangesEnabled);
+            Assert.Equal(QueryTrackingBehavior.TrackAll, context2.ChangeTracker.QueryTrackingBehavior);
+            Assert.True(context2.Database.AutoTransactionsEnabled);
         }
 
         [Theory]


### PR DESCRIPTION
Fixes #13491

The issue was that if an option was not been changed from the default when the context instance was created, then it isn't saved away for resetting, which means that even if changed later it would not then be reset. The fix is to make sure these things are reset even if they were not changed when the instance was created.
