### PR TITLE
Allow specifying online option on MSSQL indexes

### DIFF
--- a/src/EFCore.SqlServer/Extensions/SqlServerIndexBuilderExtensions.cs
+++ b/src/EFCore.SqlServer/Extensions/SqlServerIndexBuilderExtensions.cs
@@ -83,6 +83,30 @@ namespace Microsoft.EntityFrameworkCore
             return indexBuilder;
         }
 
+        /// <summary>
+        ///     Configures index include properties when targeting SQL Server.
+        /// </summary>
+        /// <param name="indexBuilder"> The builder for the index being configured. </param>
+        /// <param name="online"> A value indicating whether the index is created with online option. </param>
+        /// <returns> A builder to further configure the index. </returns>
+        public static IndexBuilder ForSqlServerIsOnline([NotNull] this IndexBuilder indexBuilder, bool online = true)
+        {
+            Check.NotNull(indexBuilder, nameof(indexBuilder));
+
+            indexBuilder.Metadata.SqlServer().IsOnline = online;
+
+            return indexBuilder;
+        }
+
+        /// <summary>
+        ///     Configures whether the index is created with online option when targeting SQL Server.
+        /// </summary>
+        /// <param name="indexBuilder"> The builder for the index being configured. </param>
+        /// <param name="online"> A value indicating whether the index is created with online option. </param>
+        /// <returns> A builder to further configure the index. </returns>
+        public static IndexBuilder<TEntity> ForSqlServerIsOnline<TEntity>([NotNull] this IndexBuilder<TEntity> indexBuilder, bool online = true)
+            => (IndexBuilder<TEntity>)ForSqlServerIsOnline((IndexBuilder)indexBuilder, online);
+
         private static string GetSimpleMemberName(MemberInfo member)
         {
             var name = member.Name;

--- a/src/EFCore.SqlServer/Metadata/ISqlServerIndexAnnotations.cs
+++ b/src/EFCore.SqlServer/Metadata/ISqlServerIndexAnnotations.cs
@@ -21,5 +21,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     Returns included property names, or <c>null</c> if they have not been specified.
         /// </summary>
         IReadOnlyList<string> IncludeProperties { get; }
+
+        /// <summary>
+        ///     Indicates whether or not the index is created with online option, or <c>null</c> if
+        ///     online option has not been specified.
+        /// </summary>
+        bool? IsOnline { get; }
     }
 }

--- a/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationNames.cs
+++ b/src/EFCore.SqlServer/Metadata/Internal/SqlServerAnnotationNames.cs
@@ -31,6 +31,12 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public const string Online = Prefix + "Online";
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public const string ValueGenerationStrategy = Prefix + "ValueGenerationStrategy";
 
         /// <summary>

--- a/src/EFCore.SqlServer/Metadata/SqlServerIndexAnnotations.cs
+++ b/src/EFCore.SqlServer/Metadata/SqlServerIndexAnnotations.cs
@@ -71,5 +71,24 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             => Annotations.SetAnnotation(
                 SqlServerAnnotationNames.Include,
                 properties);
+
+        /// <summary>
+        ///     Indicates whether or not the index is online, or <c>null</c> if online option has not
+        ///     been specified.
+        /// </summary>
+        public virtual bool? IsOnline
+        {
+            get => (bool?)Annotations.Metadata[SqlServerAnnotationNames.Online];
+            set => SetIsOnline(value);
+        }
+
+        /// <summary>
+        ///     Attempts to set online option using the semantics of the <see cref="RelationalAnnotations" /> in use.
+        /// </summary>
+        /// <param name="value"> The value to set. </param>
+        /// <returns> <c>True</c> if the annotation was set; <c>false</c> otherwise. </returns>
+        protected virtual bool SetIsOnline(bool? value) => Annotations.SetAnnotation(
+            SqlServerAnnotationNames.Online,
+            value);
     }
 }

--- a/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationsAnnotationProvider.cs
+++ b/src/EFCore.SqlServer/Migrations/Internal/SqlServerMigrationsAnnotationProvider.cs
@@ -75,6 +75,14 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Migrations.Internal
                     SqlServerAnnotationNames.Include,
                     includeProperties);
             }
+
+            var isOnline = index.SqlServer().IsOnline;
+            if (isOnline.HasValue)
+            {
+                yield return new Annotation(
+                    SqlServerAnnotationNames.Online,
+                    isOnline.Value);
+            }
         }
 
         /// <summary>

--- a/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
+++ b/src/EFCore.SqlServer/Migrations/SqlServerMigrationsSqlGenerator.cs
@@ -1587,6 +1587,11 @@ namespace Microsoft.EntityFrameworkCore.Migrations
             }
 
             base.IndexOptions(operation, model, builder);
+
+            if (operation[SqlServerAnnotationNames.Online] is bool isOnline && isOnline)
+            {
+                builder.Append(" WITH (ONLINE = ON)");
+            }
         }
 
         /// <summary>

--- a/src/EFCore.SqlServer/breakingchanges.netcore.json
+++ b/src/EFCore.SqlServer/breakingchanges.netcore.json
@@ -1,0 +1,7 @@
+  [
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.ISqlServerIndexAnnotations : Microsoft.EntityFrameworkCore.Metadata.IRelationalIndexAnnotations",
+      "MemberId": "System.Nullable<System.Boolean> get_IsOnline()",
+      "Kind": "Addition"
+    }
+  ]

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerMigrationSqlGeneratorTest.cs
@@ -640,6 +640,53 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [Fact]
+        public virtual void AlterColumnOperation_with_added_online_index()
+        {
+            Generate(
+                modelBuilder => modelBuilder
+                    .HasAnnotation(CoreAnnotationNames.ProductVersionAnnotation, "1.1.0")
+                    .Entity(
+                        "Person", x =>
+                        {
+                            x.Property<string>("Name").HasMaxLength(30);
+                            x.HasIndex("Name").ForSqlServerIsOnline();
+                        }),
+                new AlterColumnOperation
+                {
+                    Table = "Person",
+                    Name = "Name",
+                    ClrType = typeof(string),
+                    MaxLength = 30,
+                    IsNullable = true,
+                    OldColumn = new ColumnOperation
+                    {
+                        ClrType = typeof(string),
+                        IsNullable = true
+                    }
+                },
+                new CreateIndexOperation
+                {
+                    Name = "IX_Person_Name",
+                    Table = "Person",
+                    Columns = new[] { "Name" },
+                    [SqlServerAnnotationNames.Online] = true
+                });
+
+            Assert.Equal(
+                "DECLARE @var0 sysname;" + EOL +
+                "SELECT @var0 = [d].[name]" + EOL +
+                "FROM [sys].[default_constraints] [d]" + EOL +
+                "INNER JOIN [sys].[columns] [c] ON [d].[parent_column_id] = [c].[column_id] AND [d].[parent_object_id] = [c].[object_id]" + EOL +
+                "WHERE ([d].[parent_object_id] = OBJECT_ID(N'[Person]') AND [c].[name] = N'Name');" + EOL +
+                "IF @var0 IS NOT NULL EXEC(N'ALTER TABLE [Person] DROP CONSTRAINT [' + @var0 + '];');" + EOL +
+                "ALTER TABLE [Person] ALTER COLUMN [Name] nvarchar(30) NULL;" + EOL +
+                "GO" + EOL +
+                EOL +
+                "CREATE INDEX [IX_Person_Name] ON [Person] ([Name]) WITH (ONLINE = ON);" + EOL,
+                Sql);
+        }
+
+        [Fact]
         public virtual void AlterColumnOperation_identity()
         {
             Generate(
@@ -972,6 +1019,26 @@ namespace Microsoft.EntityFrameworkCore
 
             Assert.Equal(
                 "CREATE UNIQUE INDEX [IX_People_Name] ON [People] ([Name]) INCLUDE ([FirstName], [LastName]) WHERE [Name] IS NOT NULL AND <> '';" + EOL,
+                Sql);
+        }
+
+        [Fact]
+        public virtual void CreateIndexOperation_unique_with_include_and_filter_online()
+        {
+            Generate(
+                new CreateIndexOperation
+                {
+                    Name = "IX_People_Name",
+                    Table = "People",
+                    Columns = new[] { "Name" },
+                    IsUnique = true,
+                    Filter = "[Name] IS NOT NULL AND <> ''",
+                    [SqlServerAnnotationNames.Include] = new[] { "FirstName", "LastName" },
+                    [SqlServerAnnotationNames.Online] = true
+                });
+
+            Assert.Equal(
+                "CREATE UNIQUE INDEX [IX_People_Name] ON [People] ([Name]) INCLUDE ([FirstName], [LastName]) WHERE [Name] IS NOT NULL AND <> '' WITH (ONLINE = ON);" + EOL,
                 Sql);
         }
 

--- a/test/EFCore.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
+++ b/test/EFCore.SqlServer.Tests/Metadata/SqlServerBuilderExtensionsTest.cs
@@ -830,6 +830,36 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         }
 
         [Fact]
+        public void Can_set_index_online()
+        {
+            var modelBuilder = CreateConventionModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .ForSqlServerHasIndex(e => e.Name)
+                .ForSqlServerIsOnline();
+
+            var index = modelBuilder.Model.FindEntityType(typeof(Customer)).GetIndexes().Single();
+
+            Assert.True(index.SqlServer().IsOnline);
+        }
+
+        [Fact]
+        public void Can_set_index_online_non_generic()
+        {
+            var modelBuilder = CreateConventionModelBuilder();
+
+            modelBuilder
+                .Entity<Customer>()
+                .HasIndex(e => e.Name)
+                .ForSqlServerIsOnline();
+
+            var index = modelBuilder.Model.FindEntityType(typeof(Customer)).GetIndexes().Single();
+
+            Assert.True(index.SqlServer().IsOnline);
+        }
+
+        [Fact]
         public void Can_set_sequences_for_model()
         {
             var modelBuilder = CreateConventionModelBuilder();

--- a/test/EFCore.SqlServer.Tests/SqlServerModelValidatorTest.cs
+++ b/test/EFCore.SqlServer.Tests/SqlServerModelValidatorTest.cs
@@ -288,6 +288,16 @@ namespace Microsoft.EntityFrameworkCore
             VerifyError(SqlServerStrings.IncludePropertyInIndex(nameof(Dog), nameof(Dog.Name)), modelBuilder.Model);
         }
 
+        [Fact]
+        public void Passes_for_online_index()
+        {
+            var modelBuilder = CreateConventionalModelBuilder();
+            modelBuilder.Entity<Dog>().Property(c => c.Type);
+            modelBuilder.Entity<Dog>().HasIndex(nameof(Dog.Name)).ForSqlServerIsOnline();
+
+            Validate(modelBuilder.Model);
+        }
+
         private static void GenerateMapping(IMutableProperty property)
             => property[CoreAnnotationNames.TypeMapping] =
                 new SqlServerTypeMappingSource(


### PR DESCRIPTION
Introduces new `ForSqlServerIsOnline` extension to index builder.

There is a breaking change in `EFCore.SqlServer` in form of new property 
`ISqlServerIndexAnnotations.IsOnline`.

Note that enabling/disabling online index creation does trigger a migration even though I believe it has no effect on the resulting index so it's essentially rebuilt for no reason. If this should be avoided I'd like to request a hint on how to achieve that.

Fixes #11499 