### PR TITLE
Add short circuit for null coalesce expression

### DIFF
--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -704,6 +704,19 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
+        public virtual Task Null_Coalesce_Short_Circuit(bool isAsync)
+        {
+            List<int> values = null;
+            bool? test = false;
+
+            return AssertQuery<Customer>(
+                isAsync,
+                cs => cs.Distinct().Select(c => new { Customer = c, Test = (test ?? values.Contains(1)) }),
+                entryCount: 91);
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
         public virtual Task Distinct_Skip_Take(bool isAsync)
         {
             return AssertQuery<Customer>(

--- a/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
+++ b/src/EFCore/Query/ExpressionVisitors/Internal/ParameterExtractingExpressionVisitor.cs
@@ -380,7 +380,7 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors.Internal
         /// </summary>
         protected override Expression VisitBinary(BinaryExpression binaryExpression)
         {
-            if (binaryExpression.NodeType == ExpressionType.ArrayIndex
+            if ((binaryExpression.NodeType == ExpressionType.ArrayIndex || binaryExpression.NodeType == ExpressionType.Coalesce)
                 && _partialEvaluationInfo.IsEvaluatableExpression(binaryExpression))
             {
                 return TryExtractParameter(binaryExpression);

--- a/test/EFCore.InMemory.FunctionalTests/Query/QueryBugsInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/QueryBugsInMemoryTest.cs
@@ -20,41 +20,6 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     {
-        #region Bug13068
-
-        [Fact]
-        public void Null_coalesce_does_not_short_circuit_well_13068()
-        {
-            List<int> values = null;
-            bool? test = false;
-
-            using (CreateScratch<DatabaseContext_13068>(_ => { }, "13068"))
-            {
-                using (var db = new DatabaseContext_13068())
-                {
-                    var result = db.Foos.Select(b => new { Test = (test ?? values.Contains(1)) }).ToList();
-                    Assert.All(result, x => Assert.False(x.Test));
-                }
-            }
-        }
-
-        public class DatabaseContext_13068 : DbContext
-        {
-            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-            {
-                optionsBuilder.UseInMemoryDatabase("13068").EnableDetailedErrors().EnableSensitiveDataLogging();
-            }
-
-            public DbSet<Foo_13068> Foos { get; set; }
-        }
-
-        public class Foo_13068
-        {
-            public long Id { get; set; }
-            public ICollection<Motor> Motors { get; set; } = new HashSet<Motor>();
-        }
-
-        #endregion
 
         #region Bug9849
 

--- a/test/EFCore.InMemory.FunctionalTests/Query/QueryBugsInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/Query/QueryBugsInMemoryTest.cs
@@ -20,6 +20,42 @@ namespace Microsoft.EntityFrameworkCore.Query
 {
     public class QueryBugsInMemoryTest : IClassFixture<InMemoryFixture>
     {
+        #region Bug13068
+
+        [Fact]
+        public void Null_coalesce_does_not_short_circuit_well_13068()
+        {
+            List<int> values = null;
+            bool? test = false;
+
+            using (CreateScratch<DatabaseContext_13068>(_ => { }, "13068"))
+            {
+                using (var db = new DatabaseContext_13068())
+                {
+                    var result = db.Foos.Select(b => new { Test = (test ?? values.Contains(1)) }).ToList();
+                    Assert.All(result, x => Assert.False(x.Test));
+                }
+            }
+        }
+
+        public class DatabaseContext_13068 : DbContext
+        {
+            protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+            {
+                optionsBuilder.UseInMemoryDatabase("13068").EnableDetailedErrors().EnableSensitiveDataLogging();
+            }
+
+            public DbSet<Foo_13068> Foos { get; set; }
+        }
+
+        public class Foo_13068
+        {
+            public long Id { get; set; }
+            public ICollection<Motor> Motors { get; set; } = new HashSet<Motor>();
+        }
+
+        #endregion
+
         #region Bug9849
 
         [Fact]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -2518,6 +2518,18 @@ ORDER BY CASE
 END");
         }
 
+        public override async Task Null_Coalesce_Short_Circuit(bool isAsync)
+        {
+            await base.Null_Coalesce_Short_Circuit(isAsync);
+
+            AssertSql(
+                @"SELECT [t].[CustomerID], [t].[Address], [t].[City], [t].[CompanyName], [t].[ContactName], [t].[ContactTitle], [t].[Country], [t].[Fax], [t].[Phone], [t].[PostalCode], [t].[Region]
+FROM (
+    SELECT DISTINCT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+    FROM [Customers] AS [c]
+) AS [t]");
+        }
+
         public override async Task OrderBy_conditional_operator_where_condition_null(bool isAsync)
         {
             await base.OrderBy_conditional_operator_where_condition_null(isAsync);


### PR DESCRIPTION
Added a short circuit so the whole expression did not get evaluated. 

Fixes #13068
