### PR TITLE
Append pseudo from clause to DefaultQuerySqlGenerator.GenerateOrdering

### DIFF
--- a/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
+++ b/src/EFCore.Relational/Query/Sql/DefaultQuerySqlGenerator.cs
@@ -644,7 +644,9 @@ namespace Microsoft.EntityFrameworkCore.Query.Sql
                 if (processedExperssion.RemoveConvert() is ConstantExpression
                     || processedExperssion.RemoveConvert() is ParameterExpression)
                 {
-                    _relationalCommandBuilder.Append("(SELECT 1)");
+                    _relationalCommandBuilder.Append("(SELECT 1");
+                    GeneratePseudoFromClause();
+                    _relationalCommandBuilder.Append(")");
                 }
                 else
                 {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] The code builds and tests pass (verified by our automated build checks)
- [ ] Commit messages follow this format
```
    Summary of the changes
    - DefaultQuerySqlGenerator.GenerateOrdering() should be calling GeneratePseudoFromClause() when generating "SELECT 1"
```
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Code meets the expectations our engineering guidelines. https://github.com/aspnet/Home/wiki/Engineering-guidelines.

Please review the guidelines for CONTRIBUTING.md for more details.