### PR TITLE
[WIP] Adding test infra for procedural test generation

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/TestUtilities/TestSqlLoggerFactory.cs
+++ b/src/EFCore.Relational.Specification.Tests/TestUtilities/TestSqlLoggerFactory.cs
@@ -13,6 +13,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
 {
     public class TestSqlLoggerFactory : ListLoggerFactory
     {
+        private bool _proceduralQueryGeneration = false;
+
         private const string FileNewLine = @"
 ";
 
@@ -41,6 +43,12 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                 return;
             }
 #endif
+
+            if (_proceduralQueryGeneration)
+            {
+                return;
+            }
+
             try
             {
                 if (assertOrder)

--- a/src/EFCore.Specification.Tests/Query/QueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/QueryTestBase.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -990,9 +991,10 @@ namespace Microsoft.EntityFrameworkCore.Query
             Func<dynamic, object> elementSorter = null,
             Action<dynamic, dynamic> elementAsserter = null,
             bool assertOrder = false,
-            int entryCount = 0)
+            int entryCount = 0,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => Fixture.QueryAsserter.AssertQuery(query, query, elementSorter, elementAsserter, assertOrder, entryCount, isAsync);
+            => Fixture.QueryAsserter.AssertQuery(query, query, elementSorter, elementAsserter, assertOrder, entryCount, isAsync, testMethodName);
 
         public Task AssertQuery<TItem1>(
             bool isAsync,
@@ -1001,9 +1003,10 @@ namespace Microsoft.EntityFrameworkCore.Query
             Func<dynamic, object> elementSorter = null,
             Action<dynamic, dynamic> elementAsserter = null,
             bool assertOrder = false,
-            int entryCount = 0)
+            int entryCount = 0,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => Fixture.QueryAsserter.AssertQuery(actualQuery, expectedQuery, elementSorter, elementAsserter, assertOrder, entryCount, isAsync);
+            => Fixture.QueryAsserter.AssertQuery(actualQuery, expectedQuery, elementSorter, elementAsserter, assertOrder, entryCount, isAsync, testMethodName);
 
         public Task AssertQuery<TItem1, TItem2>(
             bool isAsync,
@@ -1011,10 +1014,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             Func<dynamic, object> elementSorter = null,
             Action<dynamic, dynamic> elementAsserter = null,
             bool assertOrder = false,
-            int entryCount = 0)
+            int entryCount = 0,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
             where TItem2 : class
-            => Fixture.QueryAsserter.AssertQuery(query, query, elementSorter, elementAsserter, assertOrder, entryCount, isAsync);
+            => Fixture.QueryAsserter.AssertQuery(query, query, elementSorter, elementAsserter, assertOrder, entryCount, isAsync, testMethodName);
 
         public Task AssertQuery<TItem1, TItem2>(
             bool isAsync,
@@ -1023,10 +1027,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             Func<dynamic, object> elementSorter = null,
             Action<dynamic, dynamic> elementAsserter = null,
             bool assertOrder = false,
-            int entryCount = 0)
+            int entryCount = 0,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
             where TItem2 : class
-            => Fixture.QueryAsserter.AssertQuery(actualQuery, expectedQuery, elementSorter, elementAsserter, assertOrder, entryCount, isAsync);
+            => Fixture.QueryAsserter.AssertQuery(actualQuery, expectedQuery, elementSorter, elementAsserter, assertOrder, entryCount, isAsync, testMethodName);
 
         public Task AssertQuery<TItem1, TItem2, TItem3>(
             bool isAsync,
@@ -1034,11 +1039,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             Func<dynamic, object> elementSorter = null,
             Action<dynamic, dynamic> elementAsserter = null,
             bool assertOrder = false,
-            int entryCount = 0)
+            int entryCount = 0,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
             where TItem2 : class
             where TItem3 : class
-            => AssertQuery(isAsync, query, query, elementSorter, elementAsserter, assertOrder, entryCount);
+            => AssertQuery(isAsync, query, query, elementSorter, elementAsserter, assertOrder, entryCount, testMethodName);
 
         public Task AssertQuery<TItem1, TItem2, TItem3>(
             bool isAsync,
@@ -1047,11 +1053,12 @@ namespace Microsoft.EntityFrameworkCore.Query
             Func<dynamic, object> elementSorter = null,
             Action<dynamic, dynamic> elementAsserter = null,
             bool assertOrder = false,
-            int entryCount = 0)
+            int entryCount = 0,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
             where TItem2 : class
             where TItem3 : class
-            => Fixture.QueryAsserter.AssertQuery(actualQuery, expectedQuery, elementSorter, elementAsserter, assertOrder, entryCount, isAsync);
+            => Fixture.QueryAsserter.AssertQuery(actualQuery, expectedQuery, elementSorter, elementAsserter, assertOrder, entryCount, isAsync, testMethodName);
 
         #endregion
 
@@ -1060,187 +1067,210 @@ namespace Microsoft.EntityFrameworkCore.Query
         public Task AssertQueryScalar<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<int>> query,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder);
+            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<double>> query,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder);
+            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<int>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<int>> expectedQuery,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => AssertQueryScalar<TItem1, int>(isAsync, actualQuery, expectedQuery, assertOrder);
+            => AssertQueryScalar<TItem1, int>(isAsync, actualQuery, expectedQuery, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<uint>> query,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder);
+            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<uint>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<uint>> expectedQuery,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => AssertQueryScalar<TItem1, uint>(isAsync, actualQuery, expectedQuery, assertOrder);
+            => AssertQueryScalar<TItem1, uint>(isAsync, actualQuery, expectedQuery, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<long>> query,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder);
+            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<short>> query,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder);
+            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<bool>> query,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder);
+            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<bool>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<bool>> expectedQuery,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => AssertQueryScalar<TItem1, bool>(isAsync, actualQuery, expectedQuery, assertOrder);
+            => AssertQueryScalar<TItem1, bool>(isAsync, actualQuery, expectedQuery, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<DateTime>> query,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder);
+            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<DateTimeOffset>> query,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder);
+            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TimeSpan>> query,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder);
+            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1, TResult>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TResult>> query,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
             where TResult : struct
-            => AssertQueryScalar(isAsync, query, query, assertOrder);
+            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1, TResult>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TResult>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TResult>> expectedQuery,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
             where TResult : struct
-            => Fixture.QueryAsserter.AssertQueryScalar(actualQuery, expectedQuery, assertOrder, isAsync);
+            => Fixture.QueryAsserter.AssertQueryScalar(actualQuery, expectedQuery, assertOrder, isAsync, testMethodName);
 
         public Task AssertQueryScalar<TItem1, TItem2>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<int>> query,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
             where TItem2 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder);
+            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1, TItem2>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<int>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<int>> expectedQuery,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
             where TItem2 : class
-            => AssertQueryScalar<TItem1, TItem2, int>(isAsync, actualQuery, expectedQuery, assertOrder);
+            => AssertQueryScalar<TItem1, TItem2, int>(isAsync, actualQuery, expectedQuery, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1, TItem2>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<bool>> query,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
             where TItem2 : class
-            => AssertQueryScalar<TItem1, TItem2, bool>(isAsync, query, query, assertOrder);
+            => AssertQueryScalar<TItem1, TItem2, bool>(isAsync, query, query, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1, TItem2>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<bool>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<bool>> expectedQuery,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
             where TItem2 : class
-            => AssertQueryScalar<TItem1, TItem2, bool>(isAsync, actualQuery, expectedQuery, assertOrder);
+            => AssertQueryScalar<TItem1, TItem2, bool>(isAsync, actualQuery, expectedQuery, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1, TItem2>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<DateTime>> query,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
             where TItem2 : class
-            => AssertQueryScalar<TItem1, TItem2, DateTime>(isAsync, query, query, assertOrder);
+            => AssertQueryScalar<TItem1, TItem2, DateTime>(isAsync, query, query, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1, TItem2>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<DateTime>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<DateTime>> expectedQuery,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
             where TItem2 : class
-            => AssertQueryScalar<TItem1, TItem2, DateTime>(isAsync, actualQuery, expectedQuery, assertOrder);
+            => AssertQueryScalar<TItem1, TItem2, DateTime>(isAsync, actualQuery, expectedQuery, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1, TItem2, TResult>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TResult>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TResult>> expectedQuery,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
             where TItem2 : class
             where TResult : struct
-            => Fixture.QueryAsserter.AssertQueryScalar(actualQuery, expectedQuery, assertOrder, isAsync);
+            => Fixture.QueryAsserter.AssertQueryScalar(actualQuery, expectedQuery, assertOrder, isAsync, testMethodName);
 
         public Task AssertQueryScalar<TItem1, TItem2, TItem3>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<int>> query,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
             where TItem2 : class
             where TItem3 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder);
+            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1, TItem2, TItem3, TResult>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<TResult>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<TResult>> expectedQuery,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
             where TItem2 : class
             where TItem3 : class
             where TResult : struct
-            => Fixture.QueryAsserter.AssertQueryScalar(actualQuery, expectedQuery, assertOrder, isAsync);
+            => Fixture.QueryAsserter.AssertQueryScalar(actualQuery, expectedQuery, assertOrder, isAsync, testMethodName);
 
         #endregion
 
@@ -1249,82 +1279,92 @@ namespace Microsoft.EntityFrameworkCore.Query
         public Task AssertQueryScalar<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<int?>> query,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder);
+            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<int?>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<int?>> expectedQuery,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => AssertQueryScalar<TItem1, int>(isAsync, actualQuery, expectedQuery, assertOrder);
+            => AssertQueryScalar<TItem1, int>(isAsync, actualQuery, expectedQuery, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<bool?>> query,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder);
+            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TimeSpan?>> query,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder);
+            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<DateTime?>> query,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder);
+            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<bool?>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<bool?>> expectedQuery,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => AssertQueryScalar<TItem1, bool>(isAsync, actualQuery, expectedQuery, assertOrder);
+            => AssertQueryScalar<TItem1, bool>(isAsync, actualQuery, expectedQuery, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1, TResult>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TResult?>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TResult?>> expectedQuery,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
             where TResult : struct
-            => Fixture.QueryAsserter.AssertQueryScalar(actualQuery, expectedQuery, assertOrder, isAsync);
+            => Fixture.QueryAsserter.AssertQueryScalar(actualQuery, expectedQuery, assertOrder, isAsync, testMethodName);
 
         public Task AssertQueryScalar<TItem1, TItem2>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<int?>> query,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
             where TItem2 : class
-            => AssertQueryScalar(isAsync, query, query, assertOrder);
+            => AssertQueryScalar(isAsync, query, query, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1, TItem2>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<int?>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<int?>> expectedQuery,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
             where TItem2 : class
-            => AssertQueryScalar<TItem1, TItem2, int>(isAsync, actualQuery, expectedQuery, assertOrder);
+            => AssertQueryScalar<TItem1, TItem2, int>(isAsync, actualQuery, expectedQuery, assertOrder, testMethodName);
 
         public Task AssertQueryScalar<TItem1, TItem2, TResult>(
             bool isAsync,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TResult?>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TResult?>> expectedQuery,
-            bool assertOrder = false)
+            bool assertOrder = false,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
             where TItem2 : class
             where TResult : struct
-            => Fixture.QueryAsserter.AssertQueryScalar(actualQuery, expectedQuery, assertOrder, isAsync);
+            => Fixture.QueryAsserter.AssertQueryScalar(actualQuery, expectedQuery, assertOrder, isAsync, testMethodName);
 
         #endregion
 
@@ -1337,9 +1377,10 @@ namespace Microsoft.EntityFrameworkCore.Query
             Func<dynamic, object> elementSorter = null,
             List<Func<dynamic, object>> clientProjections = null,
             bool assertOrder = false,
-            int entryCount = 0)
+            int entryCount = 0,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => AssertIncludeQuery(isAsync, query, query, expectedIncludes, elementSorter, clientProjections, assertOrder, entryCount);
+            => AssertIncludeQuery(isAsync, query, query, expectedIncludes, elementSorter, clientProjections, assertOrder, entryCount, testMethodName);
 
         public Task<List<object>> AssertIncludeQuery<TItem1>(
             bool isAsync,
@@ -1349,9 +1390,10 @@ namespace Microsoft.EntityFrameworkCore.Query
             Func<dynamic, object> elementSorter = null,
             List<Func<dynamic, object>> clientProjections = null,
             bool assertOrder = false,
-            int entryCount = 0)
+            int entryCount = 0,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => Fixture.QueryAsserter.AssertIncludeQuery(actualQuery, expectedQuery, expectedIncludes, elementSorter, clientProjections, assertOrder, entryCount, isAsync);
+            => Fixture.QueryAsserter.AssertIncludeQuery(actualQuery, expectedQuery, expectedIncludes, elementSorter, clientProjections, assertOrder, entryCount, isAsync, testMethodName);
 
         public Task<List<object>> AssertIncludeQuery<TItem1, TItem2>(
             bool isAsync,
@@ -1360,10 +1402,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             Func<dynamic, object> elementSorter = null,
             List<Func<dynamic, object>> clientProjections = null,
             bool assertOrder = false,
-            int entryCount = 0)
+            int entryCount = 0,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
             where TItem2 : class
-            => AssertIncludeQuery(isAsync, query, query, expectedIncludes, elementSorter, clientProjections, assertOrder, entryCount);
+            => AssertIncludeQuery(isAsync, query, query, expectedIncludes, elementSorter, clientProjections, assertOrder, entryCount, testMethodName);
 
         public Task<List<object>> AssertIncludeQuery<TItem1, TItem2>(
             bool isAsync,
@@ -1373,10 +1416,11 @@ namespace Microsoft.EntityFrameworkCore.Query
             Func<dynamic, object> elementSorter = null,
             List<Func<dynamic, object>> clientProjections = null,
             bool assertOrder = false,
-            int entryCount = 0)
+            int entryCount = 0,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
             where TItem2 : class
-            => Fixture.QueryAsserter.AssertIncludeQuery(actualQuery, expectedQuery, expectedIncludes, elementSorter, clientProjections, assertOrder, entryCount, isAsync);
+            => Fixture.QueryAsserter.AssertIncludeQuery(actualQuery, expectedQuery, expectedIncludes, elementSorter, clientProjections, assertOrder, entryCount, isAsync, testMethodName);
 
         #endregion
 
@@ -1387,9 +1431,10 @@ namespace Microsoft.EntityFrameworkCore.Query
             Func<IQueryable<TItem1>, object> syncQuery,
             Func<IQueryable<TItem1>, Task<object>> asyncQuery,
             Action<object, object> asserter = null,
-            int entryCount = 0)
+            int entryCount = 0,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => AssertSingleResult(isAsync, syncQuery, asyncQuery, syncQuery, asserter, entryCount);
+            => AssertSingleResult(isAsync, syncQuery, asyncQuery, syncQuery, asserter, entryCount, testMethodName);
 
         protected Task AssertSingleResult<TItem1>(
             bool isAsync,
@@ -1397,18 +1442,20 @@ namespace Microsoft.EntityFrameworkCore.Query
             Func<IQueryable<TItem1>, Task<object>> actualAsyncQuery,
             Func<IQueryable<TItem1>, object> expectedQuery,
             Action<object, object> asserter = null,
-            int entryCount = 0)
+            int entryCount = 0,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => Fixture.QueryAsserter.AssertSingleResult(actualSyncQuery, actualAsyncQuery, expectedQuery, asserter, entryCount, isAsync);
+            => Fixture.QueryAsserter.AssertSingleResult(actualSyncQuery, actualAsyncQuery, expectedQuery, asserter, entryCount, isAsync, testMethodName);
 
         protected Task AssertSingleResult<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, int> syncQuery,
             Func<IQueryable<TItem1>, Task<int>> asyncQuery,
             Action<object, object> asserter = null,
-            int entryCount = 0)
+            int entryCount = 0,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => AssertSingleResult(isAsync, syncQuery, asyncQuery, syncQuery, asserter, entryCount);
+            => AssertSingleResult(isAsync, syncQuery, asyncQuery, syncQuery, asserter, entryCount, testMethodName);
 
         protected Task AssertSingleResult<TItem1>(
             bool isAsync,
@@ -1416,18 +1463,20 @@ namespace Microsoft.EntityFrameworkCore.Query
             Func<IQueryable<TItem1>, Task<int>> actualAsyncQuery,
             Func<IQueryable<TItem1>, int> expectedQuery,
             Action<object, object> asserter = null,
-            int entryCount = 0)
+            int entryCount = 0,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => Fixture.QueryAsserter.AssertSingleResult(actualSyncQuery, actualAsyncQuery, expectedQuery, asserter, entryCount, isAsync);
+            => Fixture.QueryAsserter.AssertSingleResult(actualSyncQuery, actualAsyncQuery, expectedQuery, asserter, entryCount, isAsync, testMethodName);
 
         protected Task AssertSingleResult<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, long> syncQuery,
             Func<IQueryable<TItem1>, Task<long>> asyncQuery,
             Action<object, object> asserter = null,
-            int entryCount = 0)
+            int entryCount = 0,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => AssertSingleResult(isAsync, syncQuery, asyncQuery, syncQuery, asserter, entryCount);
+            => AssertSingleResult(isAsync, syncQuery, asyncQuery, syncQuery, asserter, entryCount, testMethodName);
 
         protected Task AssertSingleResult<TItem1>(
             bool isAsync,
@@ -1435,18 +1484,20 @@ namespace Microsoft.EntityFrameworkCore.Query
             Func<IQueryable<TItem1>, Task<long>> actualAsyncQuery,
             Func<IQueryable<TItem1>, long> expectedQuery,
             Action<object, object> asserter = null,
-            int entryCount = 0)
+            int entryCount = 0,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => Fixture.QueryAsserter.AssertSingleResult(actualSyncQuery, actualAsyncQuery, expectedQuery, asserter, entryCount, isAsync);
+            => Fixture.QueryAsserter.AssertSingleResult(actualSyncQuery, actualAsyncQuery, expectedQuery, asserter, entryCount, isAsync, testMethodName);
 
         protected Task AssertSingleResult<TItem1>(
             bool isAsync,
             Func<IQueryable<TItem1>, bool> syncQuery,
             Func<IQueryable<TItem1>, Task<bool>> asyncQuery,
             Action<object, object> asserter = null,
-            int entryCount = 0)
+            int entryCount = 0,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => AssertSingleResult(isAsync, syncQuery, asyncQuery, syncQuery, asserter, entryCount);
+            => AssertSingleResult(isAsync, syncQuery, asyncQuery, syncQuery, asserter, entryCount, testMethodName);
 
         protected Task AssertSingleResult<TItem1>(
             bool isAsync,
@@ -1454,9 +1505,10 @@ namespace Microsoft.EntityFrameworkCore.Query
             Func<IQueryable<TItem1>, Task<bool>> actualAsyncQuery,
             Func<IQueryable<TItem1>, bool> expectedQuery,
             Action<object, object> asserter = null,
-            int entryCount = 0)
+            int entryCount = 0,
+            [CallerMemberName] string testMethodName = null)
             where TItem1 : class
-            => Fixture.QueryAsserter.AssertSingleResult(actualSyncQuery, actualAsyncQuery, expectedQuery, asserter, entryCount, isAsync);
+            => Fixture.QueryAsserter.AssertSingleResult(actualSyncQuery, actualAsyncQuery, expectedQuery, asserter, entryCount, isAsync, testMethodName);
 
         #endregion
 

--- a/src/EFCore.Specification.Tests/TestUtilities/QueryAsserterBase.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/QueryAsserterBase.cs
@@ -20,27 +20,30 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<IQueryable<TItem1>, object> actualSyncQuery,
             Func<IQueryable<TItem1>, Task<object>> actualAsyncQuery,
             Func<IQueryable<TItem1>, object> expectedQuery,
-            Action<object, object> asserter = null,
-            int entryCount = 0,
-            bool isAsync = false)
+            Action<object, object> asserter,
+            int entryCount,
+            bool isAsync,
+            string testMethodName)
             where TItem1 : class;
 
         public abstract Task AssertSingleResult<TItem1, TResult>(
             Func<IQueryable<TItem1>, TResult> actualSyncQuery,
             Func<IQueryable<TItem1>, Task<TResult>> actualAsyncQuery,
             Func<IQueryable<TItem1>, TResult> expectedQuery,
-            Action<object, object> asserter = null,
-            int entryCount = 0,
-            bool isAsync = false)
+            Action<object, object> asserter,
+            int entryCount,
+            bool isAsync,
+            string testMethodName)
             where TItem1 : class;
 
         public abstract Task AssertSingleResult<TItem1, TItem2>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, object> actualSyncQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, Task<object>> actualAsyncQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, object> expectedQuery,
-            Action<object, object> asserter = null,
-            int entryCount = 0,
-            bool isAsync = false)
+            Action<object, object> asserter,
+            int entryCount,
+            bool isAsync,
+            string testMethodName)
             where TItem1 : class
             where TItem2 : class;
 
@@ -48,9 +51,10 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<IQueryable<TItem1>, IQueryable<TItem2>, TResult> actualSyncQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, Task<TResult>> actualAsyncQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, TResult> expectedQuery,
-            Action<object, object> asserter = null,
-            int entryCount = 0,
-            bool isAsync = false)
+            Action<object, object> asserter,
+            int entryCount,
+            bool isAsync,
+            string testMethodName)
             where TItem1 : class
             where TItem2 : class;
 
@@ -58,9 +62,10 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, object> actualSyncQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, Task<object>> actualAsyncQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, object> expectedQuery,
-            Action<object, object> asserter = null,
-            int entryCount = 0,
-            bool isAsync = false)
+            Action<object, object> asserter,
+            int entryCount,
+            bool isAsync,
+            string testMethodName)
             where TItem1 : class
             where TItem2 : class
             where TItem3 : class;
@@ -69,9 +74,10 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, TResult> actualSyncQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, Task<TResult>> actualAsyncQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, TResult> expectedQuery,
-            Action<object, object> asserter = null,
-            int entryCount = 0,
-            bool isAsync = false)
+            Action<object, object> asserter,
+            int entryCount,
+            bool isAsync,
+            string testMethodName)
             where TItem1 : class
             where TItem2 : class
             where TItem3 : class;
@@ -83,32 +89,35 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public abstract Task AssertQuery<TItem1>(
             Func<IQueryable<TItem1>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<object>> expectedQuery,
-            Func<dynamic, object> elementSorter = null,
-            Action<dynamic, dynamic> elementAsserter = null,
-            bool assertOrder = false,
-            int entryCount = 0,
-            bool isAsync = false)
+            Func<dynamic, object> elementSorter,
+            Action<dynamic, dynamic> elementAsserter,
+            bool assertOrder,
+            int entryCount,
+            bool isAsync,
+            string testMethodName)
             where TItem1 : class;
 
         public abstract Task AssertQuery<TItem1, TItem2>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> expectedQuery,
-            Func<dynamic, object> elementSorter = null,
-            Action<dynamic, dynamic> elementAsserter = null,
-            bool assertOrder = false,
-            int entryCount = 0,
-            bool isAsync = false)
+            Func<dynamic, object> elementSorter,
+            Action<dynamic, dynamic> elementAsserter,
+            bool assertOrder,
+            int entryCount,
+            bool isAsync,
+            string testMethodName)
             where TItem1 : class
             where TItem2 : class;
 
         public abstract Task AssertQuery<TItem1, TItem2, TItem3>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<object>> expectedQuery,
-            Func<dynamic, object> elementSorter = null,
-            Action<dynamic, dynamic> elementAsserter = null,
-            bool assertOrder = false,
-            int entryCount = 0,
-            bool isAsync = false)
+            Func<dynamic, object> elementSorter,
+            Action<dynamic, dynamic> elementAsserter,
+            bool assertOrder,
+            int entryCount,
+            bool isAsync,
+            string testMethodName)
             where TItem1 : class
             where TItem2 : class
             where TItem3 : class;
@@ -120,23 +129,26 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public abstract Task AssertQueryScalar<TItem1, TResult>(
             Func<IQueryable<TItem1>, IQueryable<TResult>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TResult>> expectedQuery,
-            bool assertOrder = false,
-            bool isAsync = false)
+            bool assertOrder,
+            bool isAsync,
+            string testMethodName)
             where TItem1 : class;
 
         public abstract Task AssertQueryScalar<TItem1, TItem2, TResult>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TResult>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TResult>> expectedQuery,
-            bool assertOrder = false,
-            bool isAsync = false)
+            bool assertOrder,
+            bool isAsync,
+            string testMethodName)
             where TItem1 : class
             where TItem2 : class;
 
         public abstract Task AssertQueryScalar<TItem1, TItem2, TItem3, TResult>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<TResult>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TItem3>, IQueryable<TResult>> expectedQuery,
-            bool assertOrder = false,
-            bool isAsync = false)
+            bool assertOrder,
+            bool isAsync,
+            string testMethodName)
             where TItem1 : class
             where TItem2 : class
             where TItem3 : class;
@@ -148,16 +160,18 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public abstract Task AssertQueryScalar<TItem1, TResult>(
             Func<IQueryable<TItem1>, IQueryable<TResult?>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TResult?>> expectedQuery,
-            bool assertOrder = false,
-            bool isAsync = false)
+            bool assertOrder,
+            bool isAsync,
+            string testMethodName)
             where TItem1 : class
             where TResult : struct;
 
         public abstract Task AssertQueryScalar<TItem1, TItem2, TResult>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TResult?>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<TResult?>> expectedQuery,
-            bool assertOrder = false,
-            bool isAsync = false)
+            bool assertOrder,
+            bool isAsync,
+            string testMethodName)
             where TItem1 : class
             where TItem2 : class
             where TResult : struct;
@@ -170,22 +184,24 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
             Func<IQueryable<TItem1>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<object>> expectedQuery,
             List<IExpectedInclude> expectedIncludes,
-            Func<dynamic, object> elementSorter = null,
-            List<Func<dynamic, object>> clientProjections = null,
-            bool assertOrder = false,
-            int entryCount = 0,
-            bool isAsync = false)
+            Func<dynamic, object> elementSorter,
+            List<Func<dynamic, object>> clientProjections,
+            bool assertOrder,
+            int entryCount,
+            bool isAsync,
+            string testMethodName)
             where TItem1 : class;
 
         public abstract Task<List<object>> AssertIncludeQuery<TItem1, TItem2>(
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> actualQuery,
             Func<IQueryable<TItem1>, IQueryable<TItem2>, IQueryable<object>> expectedQuery,
             List<IExpectedInclude> expectedIncludes,
-            Func<dynamic, object> elementSorter = null,
-            List<Func<dynamic, object>> clientProjections = null,
-            bool assertOrder = false,
-            int entryCount = 0,
-            bool isAsync = false)
+            Func<dynamic, object> elementSorter,
+            List<Func<dynamic, object>> clientProjections,
+            bool assertOrder,
+            int entryCount,
+            bool isAsync,
+            string testMethodName)
             where TItem1 : class
             where TItem2 : class;
 

--- a/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/AppendCorrelatedCollectionExpressionMutator.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/AppendCorrelatedCollectionExpressionMutator.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration
+{
+    public class AppendCorrelatedCollectionExpressionMutator : ExpressionMutator
+    {
+        public AppendCorrelatedCollectionExpressionMutator(DbContext context)
+            : base(context)
+        {
+        }
+
+        private bool ContainsCollectionNavigation(Type type)
+            => Context.Model.FindEntityType(type)?.GetNavigations().Any(n => n.IsCollection()) ?? false;
+
+        public override bool IsValid(Expression expression)
+            => IsQueryableResult(expression)
+            && IsEntityType(expression.Type.GetGenericArguments()[0])
+            && ContainsCollectionNavigation(expression.Type.GetGenericArguments()[0]);
+
+        public override Expression Apply(Expression expression, Random random)
+        {
+            var typeArgument = expression.Type.GetGenericArguments()[0];
+            var navigations = Context.Model.FindEntityType(typeArgument).GetNavigations().Where(n => n.IsCollection()).ToList();
+
+            var i = random.Next(navigations.Count);
+            var navigation = navigations[i];
+
+            var collectionElementType = navigation.ForeignKey.DeclaringEntityType.ClrType;
+            var listType = typeof(List<>).MakeGenericType(collectionElementType);
+
+            var select = SelectMethodInfo.MakeGenericMethod(typeArgument, listType);
+            var where = EnumerableWhereMethodInfo.MakeGenericMethod(collectionElementType);
+            var toList = ToListMethodInfo.MakeGenericMethod(collectionElementType);
+
+            var outerPrm = Expression.Parameter(typeArgument, "outerPrm");
+            var innerPrm = Expression.Parameter(collectionElementType, "innerPrm");
+
+            var outerLambdaBody = Expression.Call(
+                toList,
+                    Expression.Call(
+                    where,
+                    Expression.Property(outerPrm, navigation.PropertyInfo),
+                    Expression.Lambda(Expression.Constant(true), innerPrm)));
+
+            var resultExpression = Expression.Call(
+                select,
+                expression,
+                Expression.Lambda(outerLambdaBody, outerPrm));
+
+            return resultExpression;
+        }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/AppendIncludeToExistingExpressionMutator.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/AppendIncludeToExistingExpressionMutator.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Extensions.Internal;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration
+{
+    public class AppendIncludeToExistingExpressionMutator : ExpressionMutator
+    {
+        public AppendIncludeToExistingExpressionMutator(DbContext context)
+            : base(context)
+        {
+        }
+
+        private ExpressionFinder _expressionFinder;
+
+        public override bool IsValid(Expression expression)
+        {
+            _expressionFinder = new ExpressionFinder(this);
+            _expressionFinder.Visit(expression);
+
+            return _expressionFinder.FoundExpressions.Any();
+        }
+
+        public override Expression Apply(Expression expression, Random random)
+        {
+            var i = random.Next(_expressionFinder.FoundExpressions.Count);
+            var expr = _expressionFinder.FoundExpressions[i];
+            var thenInclude = random.Next(3) > 0;
+
+            var entityType = expr.Type.GetGenericArguments()[0];
+            var propertyType = expr.Type.GetGenericArguments()[1];
+            var propertyElementType = IsEnumerableType(propertyType) || propertyType.GetInterfaces().Any(ii => IsEnumerableType(ii))
+                ? propertyType.GetGenericArguments()[0]
+                : propertyType;
+
+            var navigations = thenInclude
+                ? Context.Model.FindEntityType(propertyElementType)?.GetNavigations().ToList()
+                : Context.Model.FindEntityType(entityType)?.GetNavigations().ToList();
+
+            var prm = thenInclude
+                ? Expression.Parameter(propertyElementType, "prm")
+                : Expression.Parameter(entityType, "prm");
+
+            if (navigations != null && navigations.Any())
+            {
+                var j = random.Next(navigations.Count);
+                var navigation = navigations[j];
+
+                if (thenInclude)
+                {
+                    var thenIncludeMethod = IsEnumerableType(propertyType) || propertyType.GetInterfaces().Any(ii => IsEnumerableType(ii))
+                        ? ThenIncludeCollectionMethodInfo.MakeGenericMethod(entityType, propertyElementType, navigation.ClrType)
+                        : ThenIncludeReferenceMethodInfo.MakeGenericMethod(entityType, propertyElementType, navigation.ClrType);
+
+                    var injector = new ExpressionInjector(
+                        _expressionFinder.FoundExpressions[i],
+                        e => Expression.Call(
+                            thenIncludeMethod,
+                            e,
+                            Expression.Lambda(Expression.Property(prm, navigation.Name), prm)));
+
+                    return injector.Visit(expression);
+                }
+                else
+                {
+                    var includeMethod = IncludeMethodInfo.MakeGenericMethod(entityType, navigation.ClrType);
+
+                    var injector = new ExpressionInjector(
+                        _expressionFinder.FoundExpressions[i],
+                        e => Expression.Call(
+                            includeMethod,
+                            e,
+                            Expression.Lambda(Expression.Property(prm, navigation.Name), prm)));
+
+                    return injector.Visit(expression);
+                }
+            }
+
+            return expression;
+        }
+
+        private class ExpressionFinder : ExpressionVisitor
+        {
+            private AppendIncludeToExistingExpressionMutator _mutator;
+
+            public ExpressionFinder(AppendIncludeToExistingExpressionMutator mutator)
+            {
+                _mutator = mutator;
+            }
+
+            public List<Expression> FoundExpressions = new List<Expression>();
+
+            protected override Expression VisitMethodCall(MethodCallExpression node)
+            {
+                // can't handle string overloads = need type information to construct Expression calls.
+                if (node != null
+                    && (node.Method.MethodIsClosedFormOf(IncludeMethodInfo)
+                    || node.Method.MethodIsClosedFormOf(ThenIncludeReferenceMethodInfo)
+                    || node.Method.MethodIsClosedFormOf(ThenIncludeCollectionMethodInfo)))
+                {
+                    FoundExpressions.Add(node);
+
+                    // need to short-circuit on ThenInclude, if we inject include before, it could change the IIncludeQueryable type that this ThenInclude is expecting
+                    if (node.Method.Name == nameof(EntityFrameworkQueryableExtensions.ThenInclude))
+                    {
+                        return node;
+                    }
+                }
+
+                return base.VisitMethodCall(node);
+            }
+        }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/AppendOrderByIdentityExpressionMutator.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/AppendOrderByIdentityExpressionMutator.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration
+{
+    public class AppendOrderByIdentityExpressionMutator : ExpressionMutator
+    {
+        public AppendOrderByIdentityExpressionMutator(DbContext context)
+            : base(context)
+        {
+        }
+
+        public override bool IsValid(Expression expression)
+            => IsQueryableResult(expression)
+            && IsOrderedableType(expression.Type.GetGenericArguments()[0]);
+
+        public override Expression Apply(Expression expression, Random random)
+        {
+            var typeArgument = expression.Type.GetGenericArguments()[0];
+
+            var isDescending = random.Next(3) == 0;
+            var orderBy = isDescending
+                ? OrderByDescendingMethodInfo.MakeGenericMethod(typeArgument, typeArgument)
+                : OrderByMethodInfo.MakeGenericMethod(typeArgument, typeArgument);
+
+            var prm = Expression.Parameter(typeArgument, "prm");
+            var lambda = Expression.Lambda(prm, prm);
+            var resultExpression = Expression.Call(orderBy, expression, lambda);
+
+            return resultExpression;
+        }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/AppendOrderByPropertyExpressionMutator.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/AppendOrderByPropertyExpressionMutator.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration
+{
+    public class AppendOrderByPropertyExpressionMutator : ExpressionMutator
+    {
+        public AppendOrderByPropertyExpressionMutator(DbContext context)
+            : base(context)
+        {
+        }
+
+        private bool HasValidPropertyToOrderBy(Expression expression)
+            => expression.Type.GetGenericArguments()[0].GetProperties().Where(p => !p.GetMethod.IsStatic)
+                .Any(p => IsOrderedableType(p.PropertyType));
+
+        public override bool IsValid(Expression expression)
+            => IsQueryableResult(expression)
+                && HasValidPropertyToOrderBy(expression);
+
+        public override Expression Apply(Expression expression, Random random)
+        {
+            var typeArgument = expression.Type.GetGenericArguments()[0];
+            var properties = typeArgument.GetProperties().Where(p => !p.GetMethod.IsStatic && IsOrderedableType(p.PropertyType)).ToList();
+            properties = FilterPropertyInfos(typeArgument, properties);
+
+            var i = random.Next(properties.Count);
+
+            var isDescending = random.Next(3) == 0;
+            var orderBy = isDescending
+                ? OrderByDescendingMethodInfo.MakeGenericMethod(typeArgument, properties[i].PropertyType)
+                : OrderByMethodInfo.MakeGenericMethod(typeArgument, properties[i].PropertyType);
+
+            var prm = Expression.Parameter(typeArgument, "prm");
+
+            var lambdaBody = (Expression)Expression.Property(prm, properties[i]);
+
+            if (properties[i].PropertyType.IsValueType
+                && !(properties[i].PropertyType.IsGenericType && properties[i].PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>)))
+            {
+                var nullablePropertyType = typeof(Nullable<>).MakeGenericType(properties[i].PropertyType);
+
+                orderBy = isDescending
+                    ? OrderByDescendingMethodInfo.MakeGenericMethod(typeArgument, nullablePropertyType)
+                    : OrderByMethodInfo.MakeGenericMethod(typeArgument, nullablePropertyType);
+
+                lambdaBody = Expression.Convert(lambdaBody, nullablePropertyType);
+            }
+
+            if (typeArgument == typeof(string))
+            {
+                // string.Length - make it nullable in case we access optional argument
+                orderBy = OrderByMethodInfo.MakeGenericMethod(typeArgument, typeof(int?));
+                lambdaBody = Expression.Convert(lambdaBody, typeof(int?));
+            }
+
+            var lambda = Expression.Lambda(lambdaBody, prm);
+            var resultExpression = Expression.Call(orderBy, expression, lambda);
+
+            return resultExpression;
+        }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/AppendSelectConstantExpressionMutator.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/AppendSelectConstantExpressionMutator.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration
+{
+    public class AppendSelectConstantExpressionMutator : ExpressionMutator
+    {
+        public AppendSelectConstantExpressionMutator(DbContext context)
+            : base(context)
+        {
+        }
+
+        private List<(Type type, Expression expression)> _expressions = new List<(Type type, Expression expression)>
+        {
+            (type: typeof(int), expression: Expression.Constant(42, typeof(int))),
+            (type: typeof(int?), expression: Expression.Constant(7, typeof(int?))),
+            (type: typeof(int?), expression: Expression.Constant(null, typeof(int?))),
+            (type: typeof(string), expression: Expression.Constant("Foo", typeof(string))),
+            (type: typeof(string), expression: Expression.Constant(null, typeof(string))),
+        };
+
+        public override bool IsValid(Expression expression) => IsQueryableResult(expression);
+
+        public override Expression Apply(Expression expression, Random random)
+        {
+            var i = random.Next(_expressions.Count);
+
+            var typeArgument = expression.Type.GetGenericArguments()[0];
+            var select = SelectMethodInfo.MakeGenericMethod(typeArgument, _expressions[i].type);
+            var lambda = Expression.Lambda(_expressions[i].expression, Expression.Parameter(typeArgument, "prm"));
+            var resultExpression = Expression.Call(select, expression, lambda);
+
+            return resultExpression;
+        }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/AppendSelectIdentityExpressionMutator.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/AppendSelectIdentityExpressionMutator.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration
+{
+    public class AppendSelectIdentityExpressionMutator : ExpressionMutator
+    {
+        public AppendSelectIdentityExpressionMutator(DbContext context)
+            : base(context)
+        {
+        }
+
+        public override bool IsValid(Expression expression) => IsQueryableResult(expression);
+
+        public override Expression Apply(Expression expression, Random random)
+        {
+            var typeArgument = expression.Type.GetGenericArguments()[0];
+            var select = SelectMethodInfo.MakeGenericMethod(typeArgument, typeArgument);
+            var prm = Expression.Parameter(typeArgument, "prm");
+            var lambda = Expression.Lambda(prm, prm);
+            var resultExpression = Expression.Call(select, expression, lambda);
+
+            return resultExpression;
+        }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/AppendSelectPropertyExpressionMutator.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/AppendSelectPropertyExpressionMutator.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration
+{
+    public class AppendSelectPropertyExpressionMutator : ExpressionMutator
+    {
+        private bool HasValidPropertyToSelect(Expression expression)
+            => expression.Type.GetGenericArguments()[0].GetProperties().Any(p => !p.GetMethod.IsStatic);
+
+        public AppendSelectPropertyExpressionMutator(DbContext context)
+            : base(context)
+        {
+        }
+
+        public override bool IsValid(Expression expression)
+            => IsQueryableResult(expression)
+                && HasValidPropertyToSelect(expression);
+
+        public override Expression Apply(Expression expression, Random random)
+        {
+            var typeArgument = expression.Type.GetGenericArguments()[0];
+            var properties = typeArgument.GetProperties().Where(p => !p.GetMethod.IsStatic).ToList();
+            properties = FilterPropertyInfos(typeArgument, properties);
+
+            var i = random.Next(properties.Count);
+
+            var select = SelectMethodInfo.MakeGenericMethod(typeArgument, properties[i].PropertyType);
+            var prm = Expression.Parameter(typeArgument, "prm");
+
+            var lambdaBody = (Expression)Expression.Property(prm, properties[i]);
+
+            if (properties[i].PropertyType.IsValueType
+                && !(properties[i].PropertyType.IsGenericType && properties[i].PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>)))
+            {
+                var nullablePropertyType = typeof(Nullable<>).MakeGenericType(properties[i].PropertyType);
+                select = SelectMethodInfo.MakeGenericMethod(typeArgument, nullablePropertyType);
+                lambdaBody = Expression.Convert(lambdaBody, nullablePropertyType);
+            }
+
+            if (typeArgument == typeof(string))
+            {
+                // string.Length - make it nullable in case we access optional argument
+                select = SelectMethodInfo.MakeGenericMethod(typeArgument, typeof(int?));
+                lambdaBody = Expression.Convert(lambdaBody, typeof(int?));
+            }
+
+            var lambda = Expression.Lambda(lambdaBody, prm);
+            var resultExpression = Expression.Call(select, expression, lambda);
+
+            return resultExpression;
+        }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/AppendTakeExpressionMutator.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/AppendTakeExpressionMutator.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration
+{
+    public class AppendTakeExpressionMutator : ExpressionMutator
+    {
+        public AppendTakeExpressionMutator(DbContext context)
+            : base(context)
+        {
+        }
+
+        public override bool IsValid(Expression expression)
+            => IsOrderedQueryableResult(expression);
+
+        public override Expression Apply(Expression expression, Random random)
+        {
+            var typeArgument = expression.Type.GetGenericArguments()[0];
+            var take = TakeMethodInfo.MakeGenericMethod(typeArgument);
+            var count = random.Next(20);
+            var resultExpression = Expression.Call(take, expression, Expression.Constant(count));
+
+            return resultExpression;
+        }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/AppendThenByIdentityExpressionMutator.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/AppendThenByIdentityExpressionMutator.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration
+{
+    public class AppendThenByIdentityExpressionMutator : ExpressionMutator
+    {
+        public AppendThenByIdentityExpressionMutator(DbContext context)
+            : base(context)
+        {
+        }
+
+        public override bool IsValid(Expression expression)
+            => IsOrderedQueryableResult(expression)
+            && IsOrderedableType(expression.Type.GetGenericArguments()[0]);
+
+        public override Expression Apply(Expression expression, Random random)
+        {
+            var typeArgument = expression.Type.GetGenericArguments()[0];
+
+            var isDescending = random.Next(3) == 0;
+            var thenBy = isDescending
+                ? ThenByDescendingMethodInfo.MakeGenericMethod(typeArgument, typeArgument)
+                : ThenByMethodInfo.MakeGenericMethod(typeArgument, typeArgument);
+
+            var prm = Expression.Parameter(typeArgument, "prm");
+            var lambda = Expression.Lambda(prm, prm);
+            var resultExpression = Expression.Call(thenBy, expression, lambda);
+
+            return resultExpression;
+        }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/ExpressionMutator.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/ExpressionMutator.cs
@@ -1,0 +1,151 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using GeoAPI.Geometries;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration
+{
+    public abstract class ExpressionMutator
+    {
+        protected static MethodInfo WhereMethodInfo;
+        protected static MethodInfo SelectMethodInfo;
+        protected static MethodInfo OrderByMethodInfo;
+        protected static MethodInfo OrderByDescendingMethodInfo;
+        protected static MethodInfo ThenByMethodInfo;
+        protected static MethodInfo ThenByDescendingMethodInfo;
+        protected static MethodInfo TakeMethodInfo;
+        protected static MethodInfo JoinMethodInfo;
+        protected static MethodInfo IncludeMethodInfo;
+        protected static MethodInfo ThenIncludeReferenceMethodInfo;
+        protected static MethodInfo ThenIncludeCollectionMethodInfo;
+        protected static MethodInfo ToListMethodInfo;
+
+        protected static MethodInfo EnumerableWhereMethodInfo;
+        protected static MethodInfo EnumerableAnyMethodInfo;
+
+        protected DbContext Context { get; }
+
+        static ExpressionMutator()
+        {
+            WhereMethodInfo = typeof(Queryable).GetMethods().Where(m => m.Name == nameof(Queryable.Where) && m.GetParameters()[1].ParameterType.GetGenericArguments()[0].GetGenericArguments().Count() == 2).Single();
+            SelectMethodInfo = typeof(Queryable).GetMethods().Where(m => m.Name == nameof(Queryable.Select) && m.GetParameters()[1].ParameterType.GetGenericArguments()[0].GetGenericArguments().Count() == 2).Single();
+            OrderByMethodInfo = typeof(Queryable).GetMethods().Where(m => m.Name == nameof(Queryable.OrderBy) && m.GetParameters().Count() == 2).Single();
+            OrderByDescendingMethodInfo = typeof(Queryable).GetMethods().Where(m => m.Name == nameof(Queryable.OrderByDescending) && m.GetParameters().Count() == 2).Single();
+            ThenByMethodInfo = typeof(Queryable).GetMethods().Where(m => m.Name == nameof(Queryable.ThenBy) && m.GetParameters().Count() == 2).Single();
+            ThenByDescendingMethodInfo = typeof(Queryable).GetMethods().Where(m => m.Name == nameof(Queryable.ThenByDescending) && m.GetParameters().Count() == 2).Single();
+            TakeMethodInfo = typeof(Queryable).GetMethods().Where(m => m.Name == nameof(Queryable.Take)).Single();
+            JoinMethodInfo = typeof(Queryable).GetMethods().Where(m => m.Name == nameof(Queryable.Join) && m.GetParameters().Count() == 5).Single();
+            IncludeMethodInfo = typeof(EntityFrameworkQueryableExtensions).GetMethods().Where(m => m.Name == nameof(EntityFrameworkQueryableExtensions.Include) && m.GetParameters()[1].ParameterType != typeof(string)).Single();
+            ThenIncludeCollectionMethodInfo = typeof(EntityFrameworkQueryableExtensions).GetMethods().Where(m => m.Name == nameof(EntityFrameworkQueryableExtensions.ThenInclude)
+                && m.GetParameters()[0].ParameterType.GetGenericArguments()[1].IsGenericType
+                && m.GetParameters()[0].ParameterType.GetGenericArguments()[1].GetGenericTypeDefinition() == typeof(IEnumerable<>)).Single();
+
+            ThenIncludeReferenceMethodInfo = typeof(EntityFrameworkQueryableExtensions).GetMethods().Where(m => m.Name == nameof(EntityFrameworkQueryableExtensions.ThenInclude)
+                && m != ThenIncludeCollectionMethodInfo).Single();
+
+            ToListMethodInfo = typeof(Enumerable).GetMethods().Where(m => m.Name == nameof(Enumerable.ToList)).Single();
+
+            EnumerableWhereMethodInfo = typeof(Enumerable).GetMethods().Where(m => m.Name == nameof(Enumerable.Where) && m.GetParameters()[1].ParameterType.GetGenericArguments().Count() == 2).Single();
+            EnumerableAnyMethodInfo = typeof(Enumerable).GetMethods().Where(m => m.Name == nameof(Enumerable.Any) && m.GetParameters().Count() == 1).Single();
+        }
+
+        public ExpressionMutator(DbContext context)
+        {
+            Context = context;
+        }
+
+        protected static bool IsQueryableType(Type type)
+            => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IQueryable<>);
+
+        protected static bool IsEnumerableType(Type type)
+            => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IEnumerable<>);
+
+        protected static bool IsQueryableResult(Expression expression)
+            => IsQueryableType(expression.Type)
+                || expression.Type.GetInterfaces().Any(i => IsQueryableType(i));
+
+        private static bool IsOrderedQueryableType(Type type)
+            => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(IOrderedQueryable<>);
+
+        protected static bool IsOrderedQueryableResult(Expression expression)
+            => IsOrderedQueryableType(expression.Type)
+                || expression.Type.GetInterfaces().Any(i => IsOrderedQueryableType(i));
+
+        protected static bool IsOrderedableType(Type type)
+            => type != typeof(IGeometry)
+            && !type.GetInterfaces().Any(i => i == typeof(IGeometry))
+            && type.GetInterfaces().Any(i => i == typeof(IComparable));
+
+        protected List<PropertyInfo> FilterPropertyInfos(Type type, List<PropertyInfo> properties)
+        {
+            if (type == typeof(string))
+            {
+                properties = properties.Where(p => p.Name != "Chars").ToList();
+            }
+
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(List<>))
+            {
+                properties = properties.Where(p => p.Name != "Item" && p.Name != "Capacity").ToList();
+            }
+
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ICollection<>)
+                || type.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(ICollection<>)))
+            {
+                properties = properties.Where(p => p.Name != "IsReadOnly").ToList();
+            }
+
+            if (type.IsArray)
+            {
+                properties = properties.Where(p => p.Name != "Rank" && p.Name != "IsFixedSize" && p.Name != "IsSynchronized").ToList();
+            }
+
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                properties = properties.Where(p => p.Name != "Value").ToList();
+            }
+
+            var entityType = Context.Model.FindEntityType(type);
+            if (entityType != null)
+            {
+                properties = properties.Where(p => entityType.GetProperties().Where(pp => pp.PropertyInfo != null).Select(pp => pp.Name).Contains(p.Name)).ToList();
+            }
+
+            return properties;
+        }
+
+        protected bool IsEntityType(Type type)
+            => Context.Model.FindEntityType(type) != null;
+
+        public abstract bool IsValid(Expression expression);
+        public abstract Expression Apply(Expression expression, Random random);
+
+        protected class ExpressionInjector : ExpressionVisitor
+        {
+            private Expression _expressionToInject;
+            private Func<Expression, Expression> _injectionPattern;
+
+            public ExpressionInjector(Expression expressionToInject, Func<Expression, Expression> injectionPattern)
+            {
+                _expressionToInject = expressionToInject;
+                _injectionPattern = injectionPattern;
+            }
+
+            public override Expression Visit(Expression node)
+            {
+                if (node == _expressionToInject)
+                {
+                    return _injectionPattern(node);
+                }
+                else
+                {
+                    return base.Visit(node);
+                }
+            }
+        }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectCoalesceExpressionMutator.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectCoalesceExpressionMutator.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration
+{
+    public class InjectCoalesceExpressionMutator : ExpressionMutator
+    {
+        private ExpressionFinder _expressionFinder = new ExpressionFinder();
+
+        public InjectCoalesceExpressionMutator(DbContext context)
+            : base(context)
+        {
+        }
+
+        public override bool IsValid(Expression expression)
+        {
+            _expressionFinder.Visit(expression);
+
+            return _expressionFinder.FoundExpressions.Any();
+        }
+
+        public override Expression Apply(Expression expression, Random random)
+        {
+            var i = random.Next(_expressionFinder.FoundExpressions.Count);
+
+            var injector = new ExpressionInjector(
+                _expressionFinder.FoundExpressions[i],
+                e => Expression.Convert(
+                    Expression.Coalesce(
+                        e,
+                        Expression.Default(e.Type.GetGenericArguments()[0])),
+                    e.Type));
+
+            return injector.Visit(expression);
+        }
+
+        private class ExpressionFinder : ExpressionVisitor
+        {
+            private bool _insideLambda = false;
+
+            public List<Expression> FoundExpressions { get; } = new List<Expression>();
+
+            public override Expression Visit(Expression node)
+            {
+                if (_insideLambda
+                    && node != null
+                    && node.NodeType != ExpressionType.Parameter
+                    && node.Type.IsGenericType
+                    && node.Type.GetGenericTypeDefinition() == typeof(Nullable<>))
+                {
+                    FoundExpressions.Add(node);
+                }
+
+                return base.Visit(node);
+            }
+
+            protected override Expression VisitLambda<T>(Expression<T> node)
+            {
+                var oldInsideLambda = _insideLambda;
+                _insideLambda = true;
+
+                var result = base.VisitLambda(node);
+
+                _insideLambda = oldInsideLambda;
+
+                return result;
+            }
+        }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectIncludeExpressionMutator.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectIncludeExpressionMutator.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration
+{
+    public class InjectIncludeExpressionMutator : ExpressionMutator
+    {
+        public InjectIncludeExpressionMutator(DbContext context)
+            : base(context)
+        {
+        }
+
+        private ExpressionFinder _expressionFinder;
+
+        public override bool IsValid(Expression expression)
+        {
+            _expressionFinder = new ExpressionFinder(this);
+            if (IsQueryableResult(expression))
+            {
+                _expressionFinder.TryAddType(expression.Type.GetGenericArguments()[0]);
+                _expressionFinder.Visit(expression);
+            }
+
+            return _expressionFinder.FoundExpressions.Any();
+        }
+
+        public override Expression Apply(Expression expression, Random random)
+        {
+            var i = random.Next(_expressionFinder.FoundExpressions.Count);
+            var expr = _expressionFinder.FoundExpressions[i];
+
+            var entityType = expr.Type.GetGenericArguments()[0];
+            var navigations = Context.Model.FindEntityType(entityType)?.GetNavigations().ToList();
+
+            var prm = Expression.Parameter(entityType, "prm");
+
+            if (navigations != null && navigations.Any())
+            {
+                var j = random.Next(navigations.Count);
+                var navigation = navigations[j];
+
+                var includeMethod = IncludeMethodInfo.MakeGenericMethod(entityType, navigation.ClrType);
+
+                var injector = new ExpressionInjector(
+                    _expressionFinder.FoundExpressions[i],
+                    e => Expression.Call(
+                        includeMethod,
+                        e,
+                        Expression.Lambda(Expression.Property(prm, navigation.Name), prm)));
+
+                return injector.Visit(expression);
+            }
+
+            return expression;
+        }
+
+        private class ExpressionFinder : ExpressionVisitor
+        {
+            private InjectIncludeExpressionMutator _mutator;
+
+            private List<IEntityType> _topLevelEntityTypes = new List<IEntityType>();
+
+            public ExpressionFinder(InjectIncludeExpressionMutator mutator)
+            {
+                _mutator = mutator;
+            }
+
+            public List<Expression> FoundExpressions = new List<Expression>();
+
+            private int _depth = 0;
+
+            private const int MaxDepth = 5;
+
+            public void TryAddType(Type type)
+            {
+                if (!type.IsValueType && _depth < MaxDepth)
+                {
+                    var entityType = _mutator.Context.Model.FindEntityType(type);
+                    if (entityType != null)
+                    {
+                        _topLevelEntityTypes.Add(entityType);
+                    }
+                    else
+                    {
+                        var properties = type.GetProperties().ToList();
+                        foreach (var property in properties)
+                        {
+                            _depth++;
+                            TryAddType(property.PropertyType);
+                            _depth--;
+                        }
+                    }
+                }
+            }
+
+            protected override Expression VisitConstant(ConstantExpression node)
+            {
+                if (node.Type.IsGenericType && node.Type.GetGenericTypeDefinition() == typeof(EntityQueryable<>))
+                {
+                    FoundExpressions.Add(node);
+                }
+
+                return base.VisitConstant(node);
+            }
+        }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectJoinWithSelfExpressionMutator.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectJoinWithSelfExpressionMutator.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration
+{
+    public class InjectJoinWithSelfExpressionMutator : ExpressionMutator
+    {
+        public InjectJoinWithSelfExpressionMutator(DbContext context)
+            : base(context)
+        {
+        }
+
+        private ExpressionFinder _expressionFinder;
+
+        public override bool IsValid(Expression expression)
+        {
+            _expressionFinder = new ExpressionFinder(this);
+            _expressionFinder.Visit(expression);
+
+            return _expressionFinder.FoundExpressions.Any();
+        }
+
+        public override Expression Apply(Expression expression, Random random)
+        {
+            var i = random.Next(_expressionFinder.FoundExpressions.Count);
+
+            var expr = _expressionFinder.FoundExpressions[i];
+            var elementType = expr.Type.GetGenericArguments()[0];
+
+            var join = JoinMethodInfo.MakeGenericMethod(elementType, elementType, elementType, elementType);
+
+            var outerKeySelectorPrm = Expression.Parameter(elementType, "oks");
+            var innerKeySelectorPrm = Expression.Parameter(elementType, "iks");
+
+            var injector = new ExpressionInjector(
+                _expressionFinder.FoundExpressions[i],
+                e => Expression.Call(
+                    join,
+                    e,
+                    e,
+                    Expression.Lambda(outerKeySelectorPrm, outerKeySelectorPrm),
+                    Expression.Lambda(innerKeySelectorPrm, innerKeySelectorPrm),
+                    Expression.Lambda(outerKeySelectorPrm, outerKeySelectorPrm, innerKeySelectorPrm)));
+
+            return injector.Visit(expression);
+        }
+
+        private class ExpressionFinder : ExpressionVisitor
+        {
+            private bool _insideThenBy = false;
+
+            private InjectJoinWithSelfExpressionMutator _mutator;
+
+            public ExpressionFinder(InjectJoinWithSelfExpressionMutator mutator)
+            {
+                _mutator = mutator;
+            }
+
+            public List<Expression> FoundExpressions { get; set; } = new List<Expression>();
+
+            protected override Expression VisitMethodCall(MethodCallExpression node)
+            {
+                if (node?.Method.Name == nameof(Queryable.ThenBy)
+                    || node?.Method.Name == nameof(Queryable.ThenByDescending)
+                    || node?.Method.Name == nameof(EntityFrameworkQueryableExtensions.ThenInclude))
+                {
+                    return node;
+                }
+
+                return base.VisitMethodCall(node);
+            }
+
+            public override Expression Visit(Expression node)
+            {
+                if (node != null
+                    && !_insideThenBy
+                    && IsQueryableResult(node)
+                    && _mutator.IsEntityType(node.Type.GetGenericArguments()[0]))
+                {
+                    FoundExpressions.Add(node);
+                }
+
+                return base.Visit(node);
+            }
+        }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectOrderByPropertyExpressionMutator.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectOrderByPropertyExpressionMutator.cs
@@ -1,0 +1,125 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration
+{
+    public class InjectOrderByPropertyExpressionMutator : ExpressionMutator
+    {
+        private ExpressionFinder _expressionFinder;
+
+        public InjectOrderByPropertyExpressionMutator(DbContext context)
+            : base(context)
+        {
+        }
+
+        public override bool IsValid(Expression expression)
+        {
+            _expressionFinder = new ExpressionFinder(this);
+            _expressionFinder.Visit(expression);
+
+            return _expressionFinder.FoundExpressions.Any();
+        }
+
+        public override Expression Apply(Expression expression, Random random)
+        {
+            var i = random.Next(_expressionFinder.FoundExpressions.Count);
+            var expressionToInject = _expressionFinder.FoundExpressions.ToList()[i].Key;
+            var j = random.Next(_expressionFinder.FoundExpressions[expressionToInject].Count);
+            var property = _expressionFinder.FoundExpressions[expressionToInject][j];
+
+            var typeArgument = expressionToInject.Type.GetGenericArguments()[0];
+
+            var isDescending = random.Next(3) == 0;
+            var orderBy = isDescending
+                ? OrderByDescendingMethodInfo.MakeGenericMethod(typeArgument, property.PropertyType)
+                : OrderByMethodInfo.MakeGenericMethod(typeArgument, property.PropertyType);
+
+            var prm = Expression.Parameter(typeArgument, "prm");
+            var lambdaBody = (Expression)Expression.Property(prm, property);
+
+            if (property.PropertyType.IsValueType
+                && !(property.PropertyType.IsGenericType && property.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>)))
+            {
+                var nullablePropertyType = typeof(Nullable<>).MakeGenericType(property.PropertyType);
+
+                orderBy = isDescending
+                    ? OrderByDescendingMethodInfo.MakeGenericMethod(typeArgument, nullablePropertyType)
+                    : OrderByMethodInfo.MakeGenericMethod(typeArgument, nullablePropertyType);
+
+                lambdaBody = Expression.Convert(lambdaBody, nullablePropertyType);
+            }
+
+            if (typeArgument == typeof(string))
+            {
+                // string.Length - make it nullable in case we access optional argument
+                orderBy = OrderByMethodInfo.MakeGenericMethod(typeArgument, typeof(int?));
+                lambdaBody = Expression.Convert(lambdaBody, typeof(int?));
+            }
+
+            var lambda = Expression.Lambda(lambdaBody, prm);
+            var injector = new ExpressionInjector(expressionToInject, e => Expression.Call(orderBy, e, lambda));
+
+            return injector.Visit(expression);
+        }
+
+        private class ExpressionFinder : ExpressionVisitor
+        {
+            private List<PropertyInfo> GetValidPropertiesForOrderBy(Expression expression)
+                => expression.Type.GetGenericArguments()[0].GetProperties().Where(p => !p.GetMethod.IsStatic)
+                    .Where(p => IsOrderedableType(p.PropertyType)).ToList();
+
+            private bool _insideThenInclude = false;
+            private InjectOrderByPropertyExpressionMutator _mutator;
+
+            public ExpressionFinder(InjectOrderByPropertyExpressionMutator mutator)
+            {
+                _mutator = mutator;
+            }
+
+            public Dictionary<Expression, List<PropertyInfo>> FoundExpressions { get; set; } = new Dictionary<Expression, List<PropertyInfo>>();
+
+            public override Expression Visit(Expression expression)
+            {
+                // can't inject OrderBy inside of include - would have to rewrite the ThenInclude method to one that accepts ordered input
+                var insideThenInclude = default(bool?);
+                if (expression is MethodCallExpression methodCallExpression
+                    && (methodCallExpression.Method.Name == "ThenInclude"
+                    || methodCallExpression.Method.Name == "ThenBy"
+                    || methodCallExpression.Method.Name == "ThenByDescending"))
+                {
+                    insideThenInclude = _insideThenInclude;
+                    _insideThenInclude = true;
+                }
+
+                if (!_insideThenInclude
+                    && expression != null
+                    && IsQueryableResult(expression)
+                    && !FoundExpressions.ContainsKey(expression))
+                {
+                    var validProperties = GetValidPropertiesForOrderBy(expression);
+                    validProperties = _mutator.FilterPropertyInfos(expression.Type.GetGenericArguments()[0], validProperties);
+
+                    if (validProperties.Any())
+                    {
+                        FoundExpressions.Add(expression, validProperties);
+                    }
+                }
+
+                try
+                {
+                    return base.Visit(expression);
+                }
+                finally
+                {
+                    _insideThenInclude = insideThenInclude ?? _insideThenInclude;
+                }
+            }
+        }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectStringFunctionExpressionMutator.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectStringFunctionExpressionMutator.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Extensions.Internal;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration
+{
+    public class InjectStringFunctionExpressionMutator : ExpressionMutator
+    {
+        private ExpressionFinder _expressionFinder = new ExpressionFinder();
+
+        public InjectStringFunctionExpressionMutator(DbContext context)
+            : base(context)
+        {
+        }
+
+        public override bool IsValid(Expression expression)
+        {
+            _expressionFinder.Visit(expression);
+
+            return _expressionFinder.FoundExpressions.Any();
+        }
+
+        public override Expression Apply(Expression expression, Random random)
+        {
+            var i = random.Next(_expressionFinder.FoundExpressions.Count);
+            var methodNames = new[] { nameof(string.ToLower), nameof(string.ToUpper), nameof(string.Trim) };
+
+            var methodInfos = methodNames.Select(n => typeof(string).GetRuntimeMethod(n, new Type[] { })).ToList();
+            var methodInfo = methodInfos[random.Next(methodInfos.Count)];
+
+            var injector = new ExpressionInjector(_expressionFinder.FoundExpressions[i], e => Expression.Call(e, methodInfo));
+
+            return injector.Visit(expression);
+        }
+
+        private class ExpressionFinder : ExpressionVisitor
+        {
+            private bool _insideLambda = false;
+            private bool _insideEFProperty = false;
+
+            public List<Expression> FoundExpressions { get; } = new List<Expression>();
+
+            public override Expression Visit(Expression node)
+            {
+                if (_insideLambda
+                    && !_insideEFProperty
+                    && node?.Type == typeof(string)
+                    && node?.NodeType != ExpressionType.Parameter
+                    && (node?.NodeType != ExpressionType.Constant || ((ConstantExpression)node)?.Value != null))
+                {
+                    FoundExpressions.Add(node);
+                }
+
+                return base.Visit(node);
+            }
+
+            protected override Expression VisitMethodCall(MethodCallExpression node)
+            {
+                if (node != null && node.IsEFProperty())
+                {
+                    var oldInsideEFProperty = _insideEFProperty;
+                    _insideEFProperty = true;
+
+                    var result = base.VisitMethodCall(node);
+
+                    _insideEFProperty = oldInsideEFProperty;
+
+                    return result;
+                }
+
+                return base.VisitMethodCall(node);
+            }
+
+            protected override Expression VisitLambda<T>(Expression<T> node)
+            {
+                var oldInsideLambda = _insideLambda;
+                _insideLambda = true;
+
+                var result = base.VisitLambda(node);
+
+                _insideLambda = oldInsideLambda;
+
+                return result;
+            }
+        }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectThenByPropertyExpressionMutator.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectThenByPropertyExpressionMutator.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration
+{
+    public class InjectThenByPropertyExpressionMutator : ExpressionMutator
+    {
+        private ExpressionFinder _expressionFinder;
+
+        public InjectThenByPropertyExpressionMutator(DbContext context)
+            : base(context)
+        {
+        }
+
+        public override bool IsValid(Expression expression)
+        {
+            _expressionFinder = new ExpressionFinder(this);
+            _expressionFinder.Visit(expression);
+
+            return _expressionFinder.FoundExpressions.Any();
+        }
+
+        public override Expression Apply(Expression expression, Random random)
+        {
+            var i = random.Next(_expressionFinder.FoundExpressions.Count);
+            var expressionToInject = _expressionFinder.FoundExpressions.ToList()[i].Key;
+            var j = random.Next(_expressionFinder.FoundExpressions[expressionToInject].Count);
+            var property = _expressionFinder.FoundExpressions[expressionToInject][j];
+
+            var typeArgument = expressionToInject.Type.GetGenericArguments()[0];
+
+            var isDescending = random.Next(3) == 0;
+            var thenBy = isDescending
+                ? ThenByDescendingMethodInfo.MakeGenericMethod(typeArgument, property.PropertyType)
+                : ThenByMethodInfo.MakeGenericMethod(typeArgument, property.PropertyType);
+
+            var prm = Expression.Parameter(typeArgument, "prm");
+            var lambdaBody = (Expression)Expression.Property(prm, property);
+
+            if (property.PropertyType.IsValueType
+                && !(property.PropertyType.IsGenericType && property.PropertyType.GetGenericTypeDefinition() == typeof(Nullable<>)))
+            {
+                var nullablePropertyType = typeof(Nullable<>).MakeGenericType(property.PropertyType);
+
+                thenBy = isDescending
+                    ? ThenByDescendingMethodInfo.MakeGenericMethod(typeArgument, nullablePropertyType)
+                    : ThenByMethodInfo.MakeGenericMethod(typeArgument, nullablePropertyType);
+
+                lambdaBody = Expression.Convert(lambdaBody, nullablePropertyType);
+            }
+
+            if (typeArgument == typeof(string))
+            {
+                // string.Length - make it nullable in case we access optional argument
+                thenBy = OrderByMethodInfo.MakeGenericMethod(typeArgument, typeof(int?));
+                lambdaBody = Expression.Convert(lambdaBody, typeof(int?));
+            }
+
+            var lambda = Expression.Lambda(lambdaBody, prm);
+            var injector = new ExpressionInjector(expressionToInject, e => Expression.Call(thenBy, e, lambda));
+
+            return injector.Visit(expression);
+        }
+
+        private class ExpressionFinder : ExpressionVisitor
+        {
+            private List<PropertyInfo> GetValidPropertiesForOrderBy(Expression expression)
+                => expression.Type.GetGenericArguments()[0].GetProperties().Where(p => !p.GetMethod.IsStatic)
+                    .Where(p => IsOrderedableType(p.PropertyType)).ToList();
+
+            private bool _insideThenInclude = false;
+            private InjectThenByPropertyExpressionMutator _mutator;
+
+            public ExpressionFinder(InjectThenByPropertyExpressionMutator mutator)
+            {
+                _mutator = mutator;
+            }
+
+            public Dictionary<Expression, List<PropertyInfo>> FoundExpressions { get; set; } = new Dictionary<Expression, List<PropertyInfo>>();
+
+            public override Expression Visit(Expression expression)
+            {
+                // can't inject OrderBy inside of include - would have to rewrite the ThenInclude method to one that accepts ordered input
+                var insideThenInclude = default(bool?);
+                if (expression is MethodCallExpression methodCallExpression
+                    && (methodCallExpression.Method.Name == "ThenInclude" || methodCallExpression.Method.Name == "ThenIncludeDescending"))
+                {
+                    insideThenInclude = _insideThenInclude;
+                    _insideThenInclude = true;
+                }
+
+                if (!_insideThenInclude
+                    && expression != null
+                    && !(expression is ConstantExpression)
+                    && IsOrderedQueryableResult(expression)
+                    && !FoundExpressions.ContainsKey(expression))
+                {
+                    var validProperties = GetValidPropertiesForOrderBy(expression);
+                    validProperties = _mutator.FilterPropertyInfos(expression.Type.GetGenericArguments()[0], validProperties);
+
+                    if (validProperties.Any())
+                    {
+                        FoundExpressions.Add(expression, validProperties);
+                    }
+                }
+
+                try
+                {
+                    return base.Visit(expression);
+                }
+                finally
+                {
+                    _insideThenInclude = insideThenInclude ?? _insideThenInclude;
+                }
+            }
+        }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectWhereExpressionMutator.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/InjectWhereExpressionMutator.cs
@@ -1,0 +1,146 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration
+{
+    public class InjectWhereExpressionMutator : ExpressionMutator
+    {
+        private ExpressionFinder _expressionFinder;
+
+        public InjectWhereExpressionMutator(DbContext context)
+            : base(context)
+        {
+        }
+
+        public override bool IsValid(Expression expression)
+        {
+            _expressionFinder = new ExpressionFinder(this);
+            _expressionFinder.Visit(expression);
+
+            return _expressionFinder.FoundExpressions.Any();
+        }
+
+        public override Expression Apply(Expression expression, Random random)
+        {
+            var i = random.Next(_expressionFinder.FoundExpressions.Count);
+            var expressionToInject = _expressionFinder.FoundExpressions[i];
+
+            var typeArgument = expressionToInject.Type.GetGenericArguments()[0];
+            var prm = Expression.Parameter(typeArgument, "prm");
+
+            var candidateExpressions = new List<Expression>
+            {
+                Expression.Constant(random.Choose(new List<bool>{ true, false })),
+            };
+
+            if (typeArgument == typeof(bool))
+            {
+                candidateExpressions.Add(prm);
+            }
+
+            var properties = typeArgument.GetProperties().Where(p => !p.GetMethod.IsStatic).ToList();
+            properties = FilterPropertyInfos(typeArgument, properties);
+
+            var boolProperties = properties.Where(p => p.PropertyType == typeof(bool)).ToList();
+            if (boolProperties.Any())
+            {
+                candidateExpressions.Add(Expression.Property(prm, random.Choose(boolProperties)));
+            }
+
+            // compare two properties
+            var propertiesOfTheSameType = properties.GroupBy(p => p.PropertyType).Where(g => g.Count() > 1).ToList();
+            if (propertiesOfTheSameType.Any())
+            {
+                var propertyGroup = random.Choose(propertiesOfTheSameType).ToList();
+
+                var firstProperty = random.Choose(propertyGroup);
+                var secondProperty = random.Choose(propertyGroup.Where(p => p != firstProperty).ToList());
+
+                candidateExpressions.Add(Expression.NotEqual(Expression.Property(prm, firstProperty), Expression.Property(prm, secondProperty)));
+            }
+
+            // compare property to constant
+            if (properties.Any())
+            {
+                var property = random.Choose(properties);
+                candidateExpressions.Add(
+                    Expression.NotEqual(
+                        Expression.Property(prm, property),
+                        Expression.Default(property.PropertyType)));
+            }
+
+            if (IsEntityType(typeArgument))
+            {
+                var entityType = Context.Model.FindEntityType(typeArgument);
+                var navigations = entityType.GetNavigations().ToList();
+                var collectionNavigations = navigations.Where(n => n.IsCollection()).ToList();
+
+                var collectionNavigation = random.Choose(collectionNavigations);
+                if (collectionNavigation != null)
+                {
+                    var any = EnumerableAnyMethodInfo.MakeGenericMethod(collectionNavigation.ForeignKey.DeclaringEntityType.ClrType);
+
+                    // collection.Any()
+                    candidateExpressions.Add(
+                        Expression.Call(
+                            any,
+                            Expression.Property(prm, collectionNavigation.PropertyInfo)));
+                }
+
+                var navigation = random.Choose(navigations);
+            }
+
+            var lambdaBody = random.Choose(candidateExpressions);
+
+            var negated = random.Next(6) > 3;
+            if (negated)
+            {
+                lambdaBody = Expression.Not(lambdaBody);
+            }
+
+            var where = WhereMethodInfo.MakeGenericMethod(typeArgument);
+            var lambda = Expression.Lambda(lambdaBody, prm);
+            var injector = new ExpressionInjector(expressionToInject, e => Expression.Call(where, e, lambda));
+
+            return injector.Visit(expression);
+        }
+
+        private class ExpressionFinder : ExpressionVisitor
+        {
+            private InjectWhereExpressionMutator _mutator;
+
+            public ExpressionFinder(InjectWhereExpressionMutator mutator)
+            {
+                _mutator = mutator;
+            }
+
+            public List<Expression> FoundExpressions { get; set; } = new List<Expression>();
+
+            public override Expression Visit(Expression expression)
+            {
+                if (expression is MethodCallExpression methodCallExpression
+                    && (methodCallExpression.Method.Name == "ThenInclude"
+                    || methodCallExpression.Method.Name == "ThenBy"
+                    || methodCallExpression.Method.Name == "ThenByDescending"
+                    || methodCallExpression.Method.Name == "Skip"
+                    || methodCallExpression.Method.Name == "Take"))
+                {
+                    return expression;
+                }
+
+                if (expression != null
+                    && IsQueryableResult(expression))
+                {
+                    FoundExpressions.Add(expression);
+                }
+
+                return base.Visit(expression);
+            }
+        }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/ProceduralQueryExpressionGenerator.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/ProceduralQueryExpressionGenerator.cs
@@ -1,0 +1,393 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore.Query.Internal;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration
+{
+    public class ProceduralQueryExpressionGenerator
+    {
+        private List<ExpressionMutator> _mutators;
+
+        // used to hard code the seed used for test generation
+        public static readonly int? Seed = null;
+
+        public ProceduralQueryExpressionGenerator(DbContext context)
+        {
+            _mutators = new List<ExpressionMutator>
+            {
+                new AppendSelectConstantExpressionMutator(context),
+                new AppendSelectIdentityExpressionMutator(context),
+                new AppendSelectPropertyExpressionMutator(context),
+                new AppendOrderByIdentityExpressionMutator(context),
+                new AppendOrderByPropertyExpressionMutator(context),
+                new AppendThenByIdentityExpressionMutator(context),
+                new AppendTakeExpressionMutator(context),
+                new StringConcatWithSelfExpressionMutator(context),
+                new InjectCoalesceExpressionMutator(context),
+                new InjectStringFunctionExpressionMutator(context),
+                new InjectJoinWithSelfExpressionMutator(context),
+                new InjectOrderByPropertyExpressionMutator(context),
+                new InjectThenByPropertyExpressionMutator(context),
+                new AppendCorrelatedCollectionExpressionMutator(context),
+                new AppendIncludeToExistingExpressionMutator(context),
+                new InjectIncludeExpressionMutator(context),
+                new InjectWhereExpressionMutator(context),
+            };
+        }
+
+        public Expression Generate(Expression expression, Random random)
+        {
+            var validMutators = _mutators.Where(m => m.IsValid(expression)).ToList();
+            if (validMutators.Any())
+            {
+                var i = random.Next(validMutators.Count);
+                var result = validMutators[i].Apply(expression, random);
+
+                return result;
+            }
+
+            return expression;
+        }
+    }
+
+    public class ProcedurallyGeneratedQueryExecutor
+    {
+        private static Dictionary<string, List<string>> _knownFailingTests = new Dictionary<string, List<string>>();
+
+        static ProcedurallyGeneratedQueryExecutor()
+        {
+            // various failures due to random expressions being generated
+            AddExpectedFailure("Where_Join_Exists", "Year, Month, and Day parameters describe an un-representable DateTime.");
+            AddExpectedFailure("Where_Join_Exists_Inequality", "Year, Month, and Day parameters describe an un-representable DateTime.");
+            AddExpectedFailure("Where_Join_Any", "Year, Month, and Day parameters describe an un-representable DateTime.");
+
+            AddExpectedFailure("Select_non_matching_value_types_from_binary_expression_nested_introduces_top_level_explicit_cast", "Arithmetic overflow error");
+            AddExpectedFailure("Project_single_element_from_collection_with_OrderBy_Take_and_SingleOrDefault", "Sequence contains more than one element");
+
+            // NRE due to client eval
+            AddExpectedFailure("GroupJoin_on_a_subquery_containing_another_GroupJoin_projecting_outer_with_client_method", "Object reference not set to an instance of an object.");
+            AddExpectedFailure("Null_reference_protection_complex_client_eval", "Object reference not set to an instance of an object.");
+            AddExpectedFailure("Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault_with_parameter", "Object reference not set to an instance of an object.");
+            AddExpectedFailure("Project_single_element_from_collection_with_OrderBy_Skip_and_FirstOrDefault", "Object reference not set to an instance of an object.");
+            AddExpectedFailure("Select_null_propagation_negative4", "Object reference not set to an instance of an object.");
+            AddExpectedFailure("Select_null_propagation_negative5", "Object reference not set to an instance of an object.");
+            AddExpectedFailure("Select_conditional_with_anonymous_type_and_null_constant", "Object reference not set to an instance of an object.");
+            AddExpectedFailure("SelectMany_with_order_by_and_Include", "Object reference not set to an instance of an object.");
+            AddExpectedFailure("Include_with_orderby_skip_preserves_ordering", "Object reference not set to an instance of an object.");
+            AddExpectedFailure("SelectMany_with_Include_and_order_by", "Object reference not set to an instance of an object.");
+            AddExpectedFailure("Where_complex_predicate_with_with_nav_prop_and_OrElse1", "Object reference not set to an instance of an object.");
+            AddExpectedFailure("SelectMany_with_Include1", "Object reference not set to an instance of an object.");
+            AddExpectedFailure("Include_collection_with_Cast_to_base", "Object reference not set to an instance of an object.");
+
+            AddExpectedFailure("Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_conditional_result", "Value cannot be null.");
+            AddExpectedFailure("Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_inheritance_and_coalesce_result", "Value cannot be null.");
+            AddExpectedFailure("Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result3", "Value cannot be null.");
+            AddExpectedFailure("SelectMany_with_Include_and_order_by", "Value cannot be null.");
+
+            // using EF.Property on client due to client eval
+            AddExpectedFailure("SelectMany_navigation_comparison3", "The EF.Property<T> method may only be used within LINQ queries.");
+            AddExpectedFailure("Manually_created_left_join_propagates_nullability_to_navigations", "The EF.Property<T> method may only be used within LINQ queries.");
+            AddExpectedFailure("Correlated_collections_left_join_with_self_reference", "The EF.Property<T> method may only be used within LINQ queries.");
+            AddExpectedFailure("Correlated_collections_on_left_join_with_null_value", "The EF.Property<T> method may only be used within LINQ queries.");
+            AddExpectedFailure("GroupBy_Shadow", "The EF.Property<T> method may only be used within LINQ queries.");
+            AddExpectedFailure("GroupBy_Shadow3", "The EF.Property<T> method may only be used within LINQ queries.");
+            AddExpectedFailure("Collection_select_nav_prop_first_or_default_then_nav_prop_nested_using_property_method", "The EF.Property<T> method may only be used within LINQ queries.");
+
+            // ---------------------------------------------------------------- won't fix bugs -----------------------------------------------------------------
+
+            AddExpectedFailure("Select_constant_null_string", "A constant expression was encountered in the ORDER BY list, position 1."); // 12638
+
+            // -------------------------------------------------------------- actual product bugs --------------------------------------------------------------
+
+            AddExpectedFailure("Default_if_empty_top_level", "Object reference not set to an instance of an object."); // 12567
+            AddExpectedFailure("Default_if_empty_top_level_positive", "Object reference not set to an instance of an object."); // 12567
+            AddExpectedFailure("Default_if_empty_top_level_projection", "Object reference not set to an instance of an object."); // 12567
+
+            AddExpectedFailure("Except_simple", "cannot be used for"); // 12568
+            AddExpectedFailure("Except_dbset", "cannot be used for"); // 12568
+            AddExpectedFailure("Except_nested", "cannot be used for"); // 12568
+
+            AddExpectedFailure("GroupBy_aggregate_Pushdown", "Invalid column name 'c'."); // 12569
+            AddExpectedFailure("GroupBy_with_orderby_take_skip_distinct", "Invalid column name 'c'."); // 12569
+
+            AddExpectedFailure("Default_if_empty_top_level_arg", "Expression of type 'Microsoft.EntityFrameworkCore.TestModels.Northwind.Employee' cannot be used for parameter of type"); // 12572
+
+            AddExpectedFailure("GroupBy_Select_First_GroupBy", "Query source (from Customer c in [g]) has already been associated with an expression."); // 12573
+
+            AddExpectedFailure("Join_Customers_Orders_Skip_Take", "Object reference not set to an instance of an object."); // 12574
+            AddExpectedFailure("Join_Customers_Orders_Projection_With_String_Concat_Skip_Take", "Object reference not set to an instance of an object."); // 12574
+            AddExpectedFailure("Join_Customers_Orders_Orders_Skip_Take_Same_Properties", "Object reference not set to an instance of an object."); // 12574
+
+            AddExpectedFailure("SelectMany_navigation_property", "The property '' on entity type 'Level2' could not be found. Ensure that the property exists and has been included in the model."); // 12575
+            AddExpectedFailure("SelectMany_navigation_property_and_filter_before", "The property '' on entity type 'Level2' could not be found. Ensure that the property exists and has been included in the model."); // 12575
+            AddExpectedFailure("SelectMany_navigation_property_and_filter_after", "The property '' on entity type 'Level2' could not be found. Ensure that the property exists and has been included in the model."); // 12575
+            AddExpectedFailure("SelectMany_where_with_subquery", "The property '' on entity type 'Level2' could not be found. Ensure that the property exists and has been included in the model."); // 12575
+            AddExpectedFailure("SelectMany_nested_navigation_property_required", "The property '' on entity type 'Level3' could not be found. Ensure that the property exists and has been included in the model."); // 12575
+            AddExpectedFailure("SelectMany_navigation_property_with_another_navigation_in_subquery", "The property '' on entity type 'Level2' could not be found. Ensure that the property exists and has been included in the model."); // 12575
+            AddExpectedFailure("SelectMany_navigation_property_with_another_navigation_in_subquery", "The property '' on entity type 'Level3' could not be found. Ensure that the property exists and has been included in the model."); // 12575
+            AddExpectedFailure("Multiple_SelectMany_calls", "The property '' on entity type 'Level3' could not be found. Ensure that the property exists and has been included in the model."); // 12575
+
+            AddExpectedFailure("GroupBy_with_orderby_take_skip_distinct", "Unable to cast object of type 'Remotion.Linq.Clauses.ResultOperators.DistinctResultOperator' to type 'Remotion.Linq.Clauses.ResultOperators.GroupResultOperator'."); // 12576
+            AddExpectedFailure("GroupBy_Distinct", "Unable to cast object of type 'Remotion.Linq.Clauses.ResultOperators.DistinctResultOperator' to type 'Remotion.Linq.Clauses.ResultOperators.GroupResultOperator'."); // 12576
+
+            AddExpectedFailure("Correlated_collections_naked_navigation_with_ToList", "Rewriting child expression from type"); // 12579
+
+            AddExpectedFailure("Project_single_element_from_collection_with_OrderBy_Distinct_and_FirstOrDefault", "Only one expression can be specified in the select list when the subquery is not introduced with EXISTS."); // 12580
+
+            AddExpectedFailure("Optional_navigation_type_compensation_works_with_DTOs", "Value cannot be null."); // 12591
+            AddExpectedFailure("ToString_with_formatter_is_evaluated_on_the_client", "Value cannot be null."); // 12591
+            AddExpectedFailure("Select_expression_datetime_add_hour", "Value cannot be null."); // 12591
+            AddExpectedFailure("Select_expression_long_to_string", "Value cannot be null."); // 12591
+            AddExpectedFailure("Query_expression_with_to_string_and_contains", "Value cannot be null."); // 12591
+            AddExpectedFailure("Queryable_reprojection", "Value cannot be null."); // 12591
+            AddExpectedFailure("Queryable_simple_anonymous_subquery", "Value cannot be null."); // 12591
+
+            AddExpectedFailure("Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault", "Object reference not set to an instance of an object."); // 12597
+            AddExpectedFailure("Project_single_element_from_collection_with_multiple_OrderBys_Take_and_FirstOrDefault_2", "Object reference not set to an instance of an object."); // 12597
+            AddExpectedFailure("Project_single_element_from_collection_with_OrderBy_Take_and_FirstOrDefault", "Object reference not set to an instance of an object."); // 12597
+
+            AddExpectedFailure("Order_by_length_twice", "Unable to cast object of type 'System.Linq.Expressions.PropertyExpression' to type 'Remotion.Linq.Clauses.Expressions.QuerySourceReferenceExpression'."); // 12598
+
+            AddExpectedFailure("GroupBy_Shadow3", "Column 'Employees.Title' is invalid in the select list because it is not contained in either an aggregate function or the GROUP BY clause."); // 12598
+
+            AddExpectedFailure("GroupBy_Shadow", "Unable to cast object of type 'System.String' to type"); // 12601
+            AddExpectedFailure("Collection_select_nav_prop_first_or_default_then_nav_prop_nested_using_property_method", "Unable to cast object of type 'System.String' to type"); // 12601
+
+            AddExpectedFailure("GroupBy_Shadow", "Value does not fall within the expected range."); // 12640
+            AddExpectedFailure("GroupBy_Shadow3", "Value does not fall within the expected range."); // 12640
+            AddExpectedFailure("GroupBy_SelectMany", "Value does not fall within the expected range."); // 12640
+
+            AddExpectedFailure("GroupBy_with_orderby_take_skip_distinct", "_TrackGroupedEntities"); // 12641
+
+            AddExpectedFailure("Select_collection_navigation_simple", "Index was out of range. Must be non-negative and less than the size of the collection."); // 12643
+            AddExpectedFailure("Correlated_collections_nested_with_custom_ordering", "Index was out of range. Must be non-negative and less than the size of the collection."); // 12643
+            AddExpectedFailure("Correlated_collections_multiple_nested_complex_collections", "Index was out of range. Must be non-negative and less than the size of the collection."); // 12643
+
+            AddExpectedFailure("GroupJoin_GroupBy_Aggregate_5", "Incorrect syntax near '+'."); // 12656
+            AddExpectedFailure("GroupBy_Key_as_part_of_element_selector", "Incorrect syntax near '+'."); // 12656
+            AddExpectedFailure("GroupBy_Property_Select_Key_Min", "Incorrect syntax near '+'."); // 12656
+            AddExpectedFailure("GroupBy_Property_Include_Aggregate_with_anonymous_selector", "Incorrect syntax near '+'."); // 12656
+            AddExpectedFailure("GroupBy_aggregate_Pushdown", "Incorrect syntax near '+'."); // 12656
+            AddExpectedFailure("GroupBy_anonymous_with_alias_Select_Key_Sum", "Incorrect syntax near '+'."); // 12656
+            AddExpectedFailure("GroupBy_Property_Select_Key_LongCount", "Incorrect syntax near '+'."); // 12656
+            AddExpectedFailure("GroupBy_filter_count_OrderBy_count_Select_sum", "Incorrect syntax near '+'."); // 12656
+            AddExpectedFailure("GroupBy_filter_key", "Incorrect syntax near '+'."); // 12656
+            AddExpectedFailure("Join_GroupBy_Aggregate_multijoins", "Incorrect syntax near '+'."); // 12656
+            AddExpectedFailure("GroupBy_Property_Select_Key_Sum_Min_Max_Avg", "Incorrect syntax near '+'."); // 12656
+            AddExpectedFailure("GroupBy_optional_navigation_member_Aggregate", "Incorrect syntax near '+'."); // 12656
+            AddExpectedFailure("GroupBy_Property_Select_Key_Max", "Incorrect syntax near '+'."); // 12656
+
+            AddExpectedFailure("Collection_select_nav_prop_sum", "Nullable object must have a value."); // 12657
+
+            AddExpectedFailure("Simple_owned_level1_level2_GroupBy_Having_Count", "Incorrect syntax near '+'."); // 12658
+
+            AddExpectedFailure("Join_navigation_translated_to_subquery_composite_key", "Invalid column name 'Note'."); // 12786
+            AddExpectedFailure("Join_on_entity_qsre_keys_inner_key_is_navigation_composite_key", "Invalid column name 'Note'."); // 12786
+            AddExpectedFailure("Join_on_entity_qsre_keys_inner_key_is_navigation", "Invalid column name 'Nickname'."); // 12786
+            AddExpectedFailure("Client_method_on_collection_navigation_in_outer_join_key", "Invalid column name 'Nickname'."); // 12786
+
+            AddExpectedFailure("Join_navigation_translated_to_subquery_deeply_nested_non_key_join", "Parameter name: tableExpression"); // 12787
+            AddExpectedFailure("Join_on_entity_qsre_keys_inner_key_is_nested_navigation", "Parameter name: tableExpression"); // 12787
+            AddExpectedFailure("Join_navigation_translated_to_subquery_deeply_nested_required", "Parameter name: tableExpression"); // 12787
+            AddExpectedFailure("Join_navigation_translated_to_subquery_nested", "Parameter name: tableExpression"); // 12787
+            AddExpectedFailure("Query_source_materialization_bug_4547", "Parameter name: tableExpression"); // 12787
+            AddExpectedFailure("GroupJoin_with_complex_subquery_and_LOJ_gets_flattened", "Parameter name: tableExpression"); // 12787
+            AddExpectedFailure("GroupJoin_with_complex_subquery_and_LOJ_gets_flattened2", "Parameter name: tableExpression"); // 12787
+
+            AddExpectedFailure("SelectMany_with_Include1", "must be reducible node"); // 12794
+            AddExpectedFailure("Multiple_SelectMany_with_Include", "must be reducible node"); // 12794
+            AddExpectedFailure("SelectMany_with_Include_ThenInclude", "must be reducible node"); // 12794
+            AddExpectedFailure("Include_after_SelectMany_and_reference_navigation", "must be reducible node"); // 12794
+            AddExpectedFailure("Include_after_multiple_SelectMany_and_reference_navigation", "must be reducible node"); // 12794
+            AddExpectedFailure("Include_after_SelectMany_and_multiple_reference_navigations", "must be reducible node"); // 12794
+            AddExpectedFailure("Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result4", "must be reducible node"); // 12794
+            AddExpectedFailure("Include_with_join_collection2", "must be reducible node"); // 12794
+            AddExpectedFailure("Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_conditional_result", "must be reducible node"); // 12794
+            AddExpectedFailure("Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result3", "must be reducible node"); // 12794
+            AddExpectedFailure("Include_with_join_and_inheritance3", "must be reducible node"); // 12794
+
+            AddExpectedFailure("Join_GroupBy_Aggregate", "must be reducible node"); // 12799
+            AddExpectedFailure("GroupJoin_GroupBy_Aggregate_2", "must be reducible node"); // 12799
+            AddExpectedFailure("GroupJoin_GroupBy_Aggregate_3", "must be reducible node"); // 12799
+            AddExpectedFailure("GroupJoin_GroupBy_Aggregate_4", "must be reducible node"); // 12799
+            AddExpectedFailure("GroupJoin_GroupBy_Aggregate_5", "must be reducible node"); // 12799
+            AddExpectedFailure("Self_join_GroupBy_Aggregate", "must be reducible node"); // 12799
+            AddExpectedFailure("Join_complex_GroupBy_Aggregate", "must be reducible node"); // 12799
+            AddExpectedFailure("OrderBy_Take_GroupBy_Aggregate", "must be reducible node"); // 12799
+
+            AddExpectedFailure("Include_with_join_collection2", "could not be found. Ensure that the property exists and has been included in the model."); // 12802
+            AddExpectedFailure("Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result3", "could not be found. Ensure that the property exists and has been included in the model."); // 12802
+            AddExpectedFailure("Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_coalesce_result4", "could not be found. Ensure that the property exists and has been included in the model."); // 12802
+            AddExpectedFailure("Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_conditional_result", "could not be found. Ensure that the property exists and has been included in the model."); // 12802
+            AddExpectedFailure("Include_on_GroupJoin_SelectMany_DefaultIfEmpty_with_inheritance_and_coalesce_result", "could not be found. Ensure that the property exists and has been included in the model."); // 12802
+            AddExpectedFailure("Include_with_join_and_inheritance3", "could not be found. Ensure that the property exists and has been included in the model."); // 12802
+
+            AddExpectedFailure("Join_navigation_translated_to_subquery_non_key_join", "Index was outside the bounds of the array."); // 12804
+
+            AddExpectedFailure("OrderBy_Skip_GroupBy_Aggregate", "Value does not fall within the expected range."); // 12805
+            AddExpectedFailure("OrderBy_Skip_Take_GroupBy_Aggregate", "Value does not fall within the expected range."); // 12805
+            AddExpectedFailure("GroupJoin_complex_GroupBy_Aggregate", "Value does not fall within the expected range."); // 12805
+            AddExpectedFailure("OrderBy_GroupBy_SelectMany", "Value does not fall within the expected range."); // 12805
+
+            AddExpectedFailure("GroupJoin_on_a_subquery_containing_another_GroupJoin_projecting_inner", "Invalid column name 'Level1_Optional_Id'."); // 12806
+
+            AddExpectedFailure("Let_group_by_nav_prop", "A column has been specified more than once in the order by list. Columns in the order by list must be unique."); // 12816
+
+            AddExpectedFailure("Select_expression_references_are_updated_correctly_with_subquery", "The conversion of a varchar data type to a datetime data type resulted in an out-of-range value."); // 12819
+            AddExpectedFailure("Select_expression_int_to_string", "The conversion of a varchar data type to a datetime data type resulted in an out-of-range value."); // 12819
+            AddExpectedFailure("ToString_with_formatter_is_evaluated_on_the_client", "The conversion of a varchar data type to a datetime data type resulted in an out-of-range value."); // 12819
+            AddExpectedFailure("Query_expression_with_to_string_and_contains", "The conversion of a varchar data type to a datetime data type resulted in an out-of-range value."); // 12819
+            AddExpectedFailure("Projection_containing_DateTime_subtraction", "The conversion of a varchar data type to a datetime data type resulted in an out-of-range value."); // 12819
+            AddExpectedFailure("Select_expression_other_to_string", "The conversion of a varchar data type to a datetime data type resulted in an out-of-range value."); // 12819
+            AddExpectedFailure("Select_expression_long_to_string", "The conversion of a varchar data type to a datetime data type resulted in an out-of-range value."); // 12819
+            AddExpectedFailure("Select_expression_date_add_year", "The conversion of a varchar data type to a datetime data type resulted in an out-of-range value."); // 12819
+            AddExpectedFailure("Select_expression_datetime_add_month", "The conversion of a varchar data type to a datetime data type resulted in an out-of-range value."); // 12819
+            AddExpectedFailure("Select_expression_datetime_add_hour", "The conversion of a varchar data type to a datetime data type resulted in an out-of-range value."); // 12819
+            AddExpectedFailure("Select_expression_datetime_add_minute", "The conversion of a varchar data type to a datetime data type resulted in an out-of-range value."); // 12819
+            AddExpectedFailure("Select_expression_datetime_add_second", "The conversion of a varchar data type to a datetime data type resulted in an out-of-range value."); // 12819
+            AddExpectedFailure("Select_expression_date_add_milliseconds_below_the_range", "The conversion of a varchar data type to a datetime data type resulted in an out-of-range value."); // 12819
+            AddExpectedFailure("Select_expression_date_add_milliseconds_above_the_range", "The conversion of a varchar data type to a datetime data type resulted in an out-of-range value."); // 12819
+            AddExpectedFailure("Select_expression_date_add_milliseconds_large_number_divided", "The conversion of a varchar data type to a datetime data type resulted in an out-of-range value."); // 12819
+            AddExpectedFailure("Select_expression_datetime_add_ticks", "The conversion of a varchar data type to a datetime data type resulted in an out-of-range value."); // 12819
+
+            AddExpectedFailure("Projection_containing_DateTime_subtraction", "Conversion failed when converting date and/or time from character string."); // 12797
+            AddExpectedFailure("Where_chain", "Conversion failed when converting date and/or time from character string."); // 12797
+            AddExpectedFailure("Projection_containing_DateTime_subtraction", "Conversion failed when converting date and/or time from character string."); // 12797
+            AddExpectedFailure("Where_Join_Exists_Inequality", "Conversion failed when converting date and/or time from character string."); // 12797
+            AddExpectedFailure("Where_Join_Any", "Conversion failed when converting date and/or time from character string."); // 12797
+            AddExpectedFailure("Where_Join_Exists", "Conversion failed when converting date and/or time from character string."); // 12797
+
+            AddExpectedFailure("Parameter_extraction_short_circuits_1", "An exception was thrown while attempting to evaluate the LINQ query parameter expression"); // 12820
+            AddExpectedFailure("Parameter_extraction_short_circuits_3", "An exception was thrown while attempting to evaluate the LINQ query parameter expression"); // 12820
+
+            AddExpectedFailure("Include_with_join_reference2", "Invalid column name '"); // 12827
+            AddExpectedFailure("Include_with_join_and_inheritance1", "Invalid column name '"); // 12827
+            AddExpectedFailure("Include_with_join_and_inheritance3", "Invalid column name '"); // 12827
+
+            AddExpectedFailure("Entity_equality_local", "has already been declared. Variable names must be unique within a query batch or stored procedure."); // 12871
+            AddExpectedFailure("Where_poco_closure", "has already been declared. Variable names must be unique within a query batch or stored procedure."); // 12871
+
+            AddExpectedFailure("Default_if_empty_top_level_positive", "Operation is not valid due to the current state of the object."); // 12872
+            AddExpectedFailure("Default_if_empty_top_level", "Operation is not valid due to the current state of the object."); // 12872
+
+            AddExpectedFailure("QueryType_with_defining_query", "Object reference not set to an instance of an object."); // 12873
+
+            AddExpectedFailure("QueryType_with_included_navs_multi_level", "Object reference not set to an instance of an object."); // 12874
+
+            AddExpectedFailure("Include_with_concat", ", but it has items of type 'Microsoft.EntityFrameworkCore.Query.Internal.AnonymousObject'."); // 12889
+            AddExpectedFailure("Concat_with_groupings", ", but it has items of type 'Microsoft.EntityFrameworkCore.Query.Internal.AnonymousObject'."); // 12889
+            AddExpectedFailure("Union_dbset", ", but it has items of type 'Microsoft.EntityFrameworkCore.Query.Internal.AnonymousObject'."); // 12889
+            AddExpectedFailure("Concat_nested", ", but it has items of type 'Microsoft.EntityFrameworkCore.Query.Internal.AnonymousObject'."); // 12889
+            AddExpectedFailure("Union_simple", ", but it has items of type 'Microsoft.EntityFrameworkCore.Query.Internal.AnonymousObject'."); // 12889
+            AddExpectedFailure("Union_nested", ", but it has items of type 'Microsoft.EntityFrameworkCore.Query.Internal.AnonymousObject'."); // 12889
+            AddExpectedFailure("Where_subquery_concat_order_by_firstordefault_boolean", ", but it has items of type 'Microsoft.EntityFrameworkCore.Query.Internal.AnonymousObject'."); // 12889
+
+            AddExpectedFailure("Select_null_propagation_negative1", "Specified cast is not valid."); // 12958
+            AddExpectedFailure("Select_null_propagation_negative2", "Specified cast is not valid."); // 12958
+            AddExpectedFailure("Select_null_propagation_negative3", "Specified cast is not valid."); // 12958
+            AddExpectedFailure("Select_null_propagation_negative4", "Specified cast is not valid."); // 12958
+            AddExpectedFailure("Select_null_propagation_negative5", "Specified cast is not valid."); // 12958
+            AddExpectedFailure("Select_null_propagation_negative6", "Specified cast is not valid."); // 12958
+            AddExpectedFailure("Select_null_propagation_negative7", "Specified cast is not valid."); // 12958
+
+            AddExpectedFailure("DefaultIfEmpty_in_subquery", "' is not defined for type '"); // 12960
+            AddExpectedFailure("SelectMany_Joined_DefaultIfEmpty2", "' is not defined for type '"); // 12960
+        }
+
+        private static void AddExpectedFailure(string testName, string expectedException)
+        {
+            if (_knownFailingTests.ContainsKey(testName))
+            {
+                _knownFailingTests[testName].Add(expectedException);
+            }
+            else
+            {
+                _knownFailingTests[testName] = new List<string> { expectedException };
+            }
+        }
+
+        public void Execute<TElement>(IQueryable<TElement> query, DbContext context, string testMethodName)
+        {
+            var seed = ProceduralQueryExpressionGenerator.Seed ?? new Random().Next();
+            var random = new Random(seed);
+            var depth = 2;
+
+            IQueryable newQuery = query;
+            Expression newExpression = null;
+            for (var i = 0; i < depth; i++)
+            {
+                var expression = newQuery.Expression;
+
+                try
+                {
+                    var queryGenerator = new ProceduralQueryExpressionGenerator(context);
+                    newExpression = queryGenerator.Generate(expression, random);
+                }
+                catch
+                {
+                    Console.WriteLine("SEED:" + seed);
+
+                    throw;
+                }
+
+                newQuery = query.Provider.CreateQuery(newExpression);
+            }
+
+            // printed just for debugging purposes
+            var queryString = new ExpressionPrinter().PrintDebug(newExpression, printConnections: false);
+
+            try
+            {
+                foreach (var r in newQuery)
+                {
+                }
+            }
+            catch (Exception exception)
+            {
+                if (exception.Message.Contains("A constant expression was encountered in the ORDER BY list")
+                    || exception.Message.Contains("has already been associated with an expression.")
+                    || exception.Message.Contains("Object reference not set to an instance of an object."))
+                {
+                }
+                else if (exception.Message == @"Invalid column name 'Key'.") // 12564
+                {
+                }
+                else if (exception.Message.StartsWith(@"Error generated for warning 'Microsoft.EntityFrameworkCore.Query.IncludeIgnoredWarning"))
+                {
+                }
+                else if (exception.Message.Contains(@"The expected type was 'System.Int64' but the actual value was of type")) // 12570
+                {
+                }
+                else if (exception.Message.Contains(@"The expected type was 'System.UInt32' but the actual value was of type 'System.Int32'")
+                    || exception.Message.Contains(@"The expected type was 'System.Nullable`1[System.UInt32]' but the actual value was of type 'System.Int32'.")) // 13753
+                {
+                }
+                else if (exception.Message == @"The binary operator NotEqual is not defined for the types 'Microsoft.EntityFrameworkCore.Storage.ValueBuffer' and 'Microsoft.EntityFrameworkCore.Storage.ValueBuffer'.") // 12788
+                {
+                }
+                else if (exception.Message.Contains(@"Incorrect syntax near the keyword 'AS'.")) // 12826
+                {
+                }
+                else
+                {
+                    if (_knownFailingTests.ContainsKey(testMethodName)
+                        && _knownFailingTests[testMethodName].Any(e => exception.Message.Contains(e)))
+                    {
+                    }
+                    else
+                    {
+                        Console.WriteLine("SEED: " + seed + " TEST: " + testMethodName);
+
+                        throw;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/QueryTestGenerationExtensions.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/QueryTestGenerationExtensions.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration
+{
+    public static class QueryTestGenerationExtensions
+    {
+        public static TResult Choose<TResult>(this Random random, List<TResult> list)
+        {
+            if (list.Count == 0)
+            {
+                return default;
+            }
+
+            return list[random.Next(list.Count)];
+        }
+    }
+}

--- a/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/StringConcatWithSelfExpressionMutator.cs
+++ b/src/EFCore.Specification.Tests/TestUtilities/QueryTestGeneration/StringConcatWithSelfExpressionMutator.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore.Extensions.Internal;
+
+namespace Microsoft.EntityFrameworkCore.TestUtilities.QueryTestGeneration
+{
+    public class StringConcatWithSelfExpressionMutator : ExpressionMutator
+    {
+        private ExpressionFinder _expressionFinder = new ExpressionFinder();
+
+        public StringConcatWithSelfExpressionMutator(DbContext context)
+            : base(context)
+        {
+        }
+
+        public override bool IsValid(Expression expression)
+        {
+            _expressionFinder.Visit(expression);
+
+            return _expressionFinder.FoundExpressions.Any();
+        }
+
+        public override Expression Apply(Expression expression, Random random)
+        {
+            var i = random.Next(_expressionFinder.FoundExpressions.Count);
+
+            var stringConcatMethodInfo
+                = typeof(string).GetRuntimeMethod(
+                    nameof(string.Concat),
+                    new[] { typeof(string), typeof(string) });
+
+            var injector = new ExpressionInjector(_expressionFinder.FoundExpressions[i], e => Expression.Add(e, e, stringConcatMethodInfo));
+
+            return injector.Visit(expression);
+        }
+
+        private class ExpressionFinder : ExpressionVisitor
+        {
+            private bool _insideLambda = false;
+
+            public List<Expression> FoundExpressions { get; } = new List<Expression>();
+
+            public override Expression Visit(Expression node)
+            {
+                if (_insideLambda && node?.Type == typeof(string) && node.NodeType != ExpressionType.Parameter)
+                {
+                    FoundExpressions.Add(node);
+                }
+
+                return base.Visit(node);
+            }
+
+            protected override Expression VisitLambda<T>(Expression<T> node)
+            {
+                var oldInsideLambda = _insideLambda;
+                _insideLambda = true;
+
+                var result = base.VisitLambda(node);
+
+                _insideLambda = oldInsideLambda;
+
+                return result;
+            }
+
+            protected override Expression VisitMethodCall(MethodCallExpression node)
+            {
+                if (node != null && node.IsEFProperty())
+                {
+                    return node;
+                }
+
+                return base.VisitMethodCall(node);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This aims to increase our query test coverage - new component hooks into AssertQuery and alters existing tests before executing them.
We do it using Mutators - classes that modify the expression, if the expression meets given mutator's requirement.
Currently they are very simple (select property, order by, inject include, inject correlated collection, basic arithmetic operations) and will be extended in the future.

Due to non-deterministic nature of generated queries we are unable to verify SQL as well as reliably verify results - only catching compilation and runtime exceptions.