### PR TITLE
Specify OrderBy for several tests that expect clustered index to be sorted by default

### DIFF
--- a/src/EFCore.Specification.Tests/Query/QueryNavigationsTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/QueryNavigationsTestBase.cs
@@ -922,7 +922,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                       orderby c.CustomerID
                       select new
                       {
-                          First = c.Orders.FirstOrDefault()
+                          First = c.Orders.OrderBy(o => o.OrderID).FirstOrDefault()
                       },
                 cs => from c in cs
                       orderby c.CustomerID

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.JoinGroupJoin.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.JoinGroupJoin.cs
@@ -75,9 +75,9 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery<Employee>(
                 isAsync,
                 es =>
-                    from e1 in es.Take(2)
-                    join e2 in es.Take(2) on e1.EmployeeID equals GetEmployeeID(e2)
-                    from e3 in es.Skip(6).Take(2)
+                    from e1 in es.OrderBy(e => e.EmployeeID).Take(2)
+                    join e2 in es.OrderBy(e => e.EmployeeID).Take(2) on e1.EmployeeID equals GetEmployeeID(e2)
+                    from e3 in es.OrderBy(e => e.EmployeeID).Skip(6).Take(2)
                     select new
                     {
                         e1,

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -1642,7 +1642,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                 isAsync,
                 (cs, os) =>
                     from c in cs.OrderBy(c => c.CustomerID).Take(3)
-                    select os.OrderBy(o => c.CustomerID).Skip(100).Take(2),
+                    select os.OrderBy(o => o.OrderID).ThenBy(o => c.CustomerID).Skip(100).Take(2),
                 elementSorter: CollectionSorter<Order>(),
                 elementAsserter: CollectionAsserter<Order>());
         }

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -1641,7 +1641,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             return AssertQuery<Customer, Order>(
                 isAsync,
                 (cs, os) =>
-                    from c in cs.Take(3)
+                    from c in cs.OrderBy(c => c.CustomerID).Take(3)
                     select os.OrderBy(o => c.CustomerID).Skip(100).Take(2),
                 elementSorter: CollectionSorter<Order>(),
                 elementAsserter: CollectionAsserter<Order>());
@@ -3447,7 +3447,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             using (var context = CreateContext())
             {
                 var orders
-                    = (from o in context.Orders.Take(1)
+                    = (from o in context.Orders.OrderBy(o => o.OrderID).Take(1)
                            // ReSharper disable once UseMethodAny.0
                        where (from od in context.OrderDetails.OrderBy(od => od.OrderID).Take(2)
                               where (from c in context.Set<Customer>()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/QueryNavigationsSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/QueryNavigationsSqlServerTest.cs
@@ -851,13 +851,15 @@ ORDER BY [c].[CustomerID]",
 
 SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]",
+WHERE @_outer_CustomerID = [o].[CustomerID]
+ORDER BY [o].[OrderID]",
                 //
                 @"@_outer_CustomerID='ANATR' (Size = 5)
 
 SELECT TOP(1) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]
-WHERE @_outer_CustomerID = [o].[CustomerID]");
+WHERE @_outer_CustomerID = [o].[CustomerID]
+ORDER BY [o].[OrderID]");
         }
 
         public override async Task Collection_select_nav_prop_first_or_default_then_nav_prop(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.JoinGroupJoin.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.JoinGroupJoin.cs
@@ -49,6 +49,7 @@ SELECT [t0].[EmployeeID], [t0].[City], [t0].[Country], [t0].[FirstName], [t0].[R
 FROM (
     SELECT TOP(@__p_0) [e0].[EmployeeID], [e0].[City], [e0].[Country], [e0].[FirstName], [e0].[ReportsTo], [e0].[Title]
     FROM [Employees] AS [e0]
+    ORDER BY [e0].[EmployeeID]
 ) AS [t0]",
                 //
                 @"@__p_0='2'
@@ -57,13 +58,14 @@ SELECT [t].[EmployeeID], [t].[City], [t].[Country], [t].[FirstName], [t].[Report
 FROM (
     SELECT TOP(@__p_0) [e].[EmployeeID], [e].[City], [e].[Country], [e].[FirstName], [e].[ReportsTo], [e].[Title]
     FROM [Employees] AS [e]
+    ORDER BY [e].[EmployeeID]
 ) AS [t]",
                 //
                 @"SELECT [t1].[EmployeeID], [t1].[City], [t1].[Country], [t1].[FirstName], [t1].[ReportsTo], [t1].[Title]
 FROM (
     SELECT [e1].[EmployeeID], [e1].[City], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
     FROM [Employees] AS [e1]
-    ORDER BY (SELECT 1)
+    ORDER BY [e1].[EmployeeID]
     OFFSET 6 ROWS FETCH NEXT 2 ROWS ONLY
 ) AS [t1]",
                 //
@@ -71,7 +73,7 @@ FROM (
 FROM (
     SELECT [e1].[EmployeeID], [e1].[City], [e1].[Country], [e1].[FirstName], [e1].[ReportsTo], [e1].[Title]
     FROM [Employees] AS [e1]
-    ORDER BY (SELECT 1)
+    ORDER BY [e1].[EmployeeID]
     OFFSET 6 ROWS FETCH NEXT 2 ROWS ONLY
 ) AS [t1]");
         }

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -646,6 +646,7 @@ SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
 FROM (
     SELECT TOP(@__p_0) [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
     FROM [Orders] AS [o]
+    ORDER BY [o].[OrderID]
 ) AS [t]
 ORDER BY [t].[OrderID]",
                 //
@@ -2450,7 +2451,8 @@ WHERE [o].[CustomerID] = @_outer_CustomerID");
                 @"@__p_0='3'
 
 SELECT TOP(@__p_0) [c].[CustomerID]
-FROM [Customers] AS [c]",
+FROM [Customers] AS [c]
+ORDER BY [c].[CustomerID]",
                 //
                 @"SELECT [o].[OrderID], [o].[CustomerID], [o].[EmployeeID], [o].[OrderDate]
 FROM [Orders] AS [o]",


### PR DESCRIPTION
There are 3 tests in SimpleQueryTestBase (and still finding more tests along the way) which relies on the assumption that clustered index will be sorted by default e.g in SQL Server.

Those tests fail for database engine which does not sort by default e.g DB2.

This commit modifies the affected tests to include explicit OrderBy for those query that have Skip / Take statement.