### PR TITLE
Allow indexers to work in query

### DIFF
--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryFixtureBase.cs
@@ -230,6 +230,8 @@ namespace Microsoft.EntityFrameworkCore.Query
         protected override void OnModelCreating(ModelBuilder modelBuilder, DbContext context)
         {
             modelBuilder.Entity<City>().HasKey(c => c.Name);
+            modelBuilder.Entity<City>(
+                    city => city.Metadata.AddIndexedProperty(City.NationPropertyName, typeof(string)));
 
             modelBuilder.Entity<Gear>(
                 b =>

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -3564,6 +3564,27 @@ namespace Microsoft.EntityFrameworkCore.Query
         }
 
         [ConditionalFact]
+        public virtual void Can_query_on_indexed_properties()
+        {
+            using (var context = CreateContext())
+            {
+                // using variables for the property names (rather than constants) tests that
+                // query can replace the value of that variable correctly in the expression tree
+                var nationPropertyName = City.NationPropertyName;
+
+                var tyrusCities = context.Cities
+                    .Where(city => (string)city[nationPropertyName] == "Tyrus").ToArray();
+                Assert.Equal(2, tyrusCities.Length);
+
+                // check that materialization has populated the Nation indexed property
+                foreach(var tyrusCity in tyrusCities)
+                {
+                    Assert.Equal("Tyrus", tyrusCity[nationPropertyName]);
+                }
+            }
+        }
+
+        [ConditionalFact]
         public virtual void Navigation_access_on_derived_entity_using_cast()
         {
             using (var ctx = CreateContext())

--- a/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/City.cs
+++ b/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/City.cs
@@ -1,16 +1,43 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
 {
     public class City
     {
+        public const string NationPropertyName = "Nation";
+        private string _nationProperty = "Undefined";
+
         // non-integer key with not conventional name
         public string Name { get; set; }
 
         public string Location { get; set; }
+
+        public object this[string indexedPropertyName]
+        {
+            get
+            {
+                if (!NationPropertyName.Equals(indexedPropertyName, StringComparison.Ordinal))
+                {
+                    throw new Exception("Invalid attempt to get indexed property " + nameof(City) + "." + indexedPropertyName);
+                }
+
+                return _nationProperty;
+            }
+
+            set
+            {
+                if (!NationPropertyName.Equals(indexedPropertyName, StringComparison.Ordinal))
+                {
+                    throw new Exception("Invalid attempt to set indexed property " + nameof(City) + "." + indexedPropertyName);
+                }
+
+                _nationProperty = (string)value;
+            }
+        }
 
         public List<Gear> BornGears { get; set; }
         public List<Gear> StationedGears { get; set; }

--- a/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarData.cs
+++ b/src/EFCore.Specification.Tests/TestModels/GearsOfWarModel/GearsOfWarData.cs
@@ -144,29 +144,36 @@ namespace Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel
             };
 
         public static IReadOnlyList<City> CreateCities()
-            => new List<City>
+        {
+            var jacinto = new City
             {
-                new City
-                {
-                    Location = "Jacinto's location",
-                    Name = "Jacinto"
-                },
-                new City
-                {
-                    Location = "Ephyra's location",
-                    Name = "Ephyra"
-                },
-                new City
-                {
-                    Location = "Hanover's location",
-                    Name = "Hanover"
-                },
-                new City
-                {
-                    Location = "Unknown",
-                    Name = "Unknown"
-                }
+                Location = "Jacinto's location",
+                Name = "Jacinto"
             };
+            jacinto[City.NationPropertyName] = "Tyrus";
+
+            var ephyra = new City
+            {
+                Location = "Ephyra's location",
+                Name = "Ephyra"
+            };
+            ephyra[City.NationPropertyName] = "Tyrus";
+
+            var hanover = new City
+            {
+                Location = "Hanover's location",
+                Name = "Hanover"
+            };
+
+            var unknown = new City
+            {
+                Location = "Unknown",
+                Name = "Unknown"
+            };
+
+            var cities = new List<City>() { jacinto, ephyra, hanover, unknown };
+            return cities;
+        }
 
         public static IReadOnlyList<Weapon> CreateWeapons()
             => new List<Weapon>

--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -589,7 +589,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         /// </summary>
         protected virtual object ReadPropertyValue([NotNull] IPropertyBase propertyBase)
         {
-            Debug.Assert(!propertyBase.IsShadowProperty);
+            Debug.Assert(propertyBase.IsIndexedProperty || !propertyBase.IsShadowProperty);
 
             return ((PropertyBase)propertyBase).Getter.GetClrValue(Entity);
         }

--- a/src/EFCore/ChangeTracking/Internal/InternalMixedEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalMixedEntityEntry.cs
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected override object ReadPropertyValue(IPropertyBase propertyBase)
-            => !propertyBase.IsShadowProperty
+            => propertyBase.IsIndexedProperty || !propertyBase.IsShadowProperty
                 ? base.ReadPropertyValue(propertyBase)
                 : _shadowValues[propertyBase.GetShadowIndex()];
 

--- a/src/EFCore/Extensions/Internal/EFPropertyExtensions.cs
+++ b/src/EFCore/Extensions/Internal/EFPropertyExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using JetBrains.Annotations;
@@ -38,6 +39,17 @@ namespace Microsoft.EntityFrameworkCore.Extensions.Internal
                || methodInfo?.IsGenericMethod == true
                && methodInfo.Name == nameof(EF.Property)
                && methodInfo.DeclaringType?.FullName == _efTypeName;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static bool IsEFIndexer(this MethodInfo methodInfo)
+            => !methodInfo.IsStatic
+               && "get_Item".Equals(methodInfo.Name, StringComparison.Ordinal)
+               && typeof(object) == methodInfo.ReturnType
+               && methodInfo.GetParameters()?.Count() == 1
+               && typeof(string) == methodInfo.GetParameters().First().ParameterType;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/IPropertyBase.cs
+++ b/src/EFCore/Metadata/IPropertyBase.cs
@@ -47,5 +47,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         ///     the <see cref="ChangeTracker" /> rather than being stored in instances of the entity class.
         /// </summary>
         bool IsShadowProperty { get; }
+
+        /// <summary>
+        ///     Gets a value indicating whether this is an indexed property. An indexed property is one that does not have a
+        ///     corresponding property in the entity class, rather the entity class has an indexer which takes the name
+        ///     of the property as argument and returns an object.
+        /// </summary>
+        bool IsIndexedProperty { get; }
     }
 }

--- a/src/EFCore/Metadata/Internal/EntityMaterializerSource.cs
+++ b/src/EFCore/Metadata/Internal/EntityMaterializerSource.cs
@@ -138,12 +138,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         constructorExpression)
                 };
 
-            var indexerPropertyInfo =
-                (from p in entityType.ClrType.GetRuntimeProperties()
-                 where p.PropertyType == typeof(object)
-                 let q = p.GetIndexParameters()
-                 where q.Length == 1 && q[0].ParameterType == typeof(string)
-                 select p).FirstOrDefault();
+            var indexerPropertyInfo = entityType.EFIndexerProperty();
 
             blockExpressions.AddRange(
                 from property in properties

--- a/src/EFCore/Metadata/Internal/IndexedPropertyGetterFactory.cs
+++ b/src/EFCore/Metadata/Internal/IndexedPropertyGetterFactory.cs
@@ -27,14 +27,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             Debug.Assert(propertyBase != null);
 
-            // find indexer with single argument of type string which returns an object
-            var indexerPropertyInfo =
-                (from p in propertyBase.DeclaringType.ClrType.GetRuntimeProperties()
-                 where p.PropertyType == typeof(object)
-                 let q = p.GetIndexParameters()
-                 where q.Length == 1 && q[0].ParameterType == typeof(string)
-                 select p).FirstOrDefault();
-
+            var indexerPropertyInfo = propertyBase.DeclaringType.EFIndexerProperty();
             if (indexerPropertyInfo == null)
             {
                 throw new InvalidOperationException(

--- a/src/EFCore/Metadata/Internal/IndexedPropertySetterFactory.cs
+++ b/src/EFCore/Metadata/Internal/IndexedPropertySetterFactory.cs
@@ -26,14 +26,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             Debug.Assert(propertyBase != null);
 
-            // find indexer with single argument of type string which returns an object
-            var indexerPropertyInfo =
-                (from p in propertyBase.DeclaringType.ClrType.GetRuntimeProperties()
-                 where p.PropertyType == typeof(object)
-                 let q = p.GetIndexParameters()
-                 where q.Length == 1 && q[0].ParameterType == typeof(string)
-                 select p).FirstOrDefault();
-
+            var indexerPropertyInfo = propertyBase.DeclaringType.EFIndexerProperty();
             if (indexerPropertyInfo == null)
             {
                 throw new InvalidOperationException(

--- a/src/EFCore/Metadata/Internal/PropertyBase.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBase.cs
@@ -69,6 +69,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public virtual bool IsIndexedProperty => _isIndexedProperty;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual PropertyInfo PropertyInfo { [DebuggerStepThrough] get; }
 
         /// <summary>

--- a/src/EFCore/Metadata/Internal/TypeBaseExtensions.cs
+++ b/src/EFCore/Metadata/Internal/TypeBaseExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Internal;
@@ -39,5 +40,23 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         [DebuggerStepThrough]
         public static bool IsAbstract([NotNull] this ITypeBase type)
             => type.ClrType?.GetTypeInfo().IsAbstract ?? false;
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public static PropertyInfo EFIndexerProperty([NotNull] this ITypeBase type)
+        {
+            var runtimeProperties = type is TypeBase typeBase
+                ? typeBase.GetRuntimeProperties().Values // better perf if we've already computed them once
+                : type.ClrType.GetRuntimeProperties();
+
+            // find the indexer with single argument of type string which returns an object
+            return (from p in runtimeProperties
+                    where p.PropertyType == typeof(object)
+                    let q = p.GetIndexParameters()
+                    where q.Length == 1 && q[0].ParameterType == typeof(string)
+                    select p).FirstOrDefault();
+        }
     }
 }

--- a/src/EFCore/breakingchanges.netcore.json
+++ b/src/EFCore/breakingchanges.netcore.json
@@ -1,4 +1,4 @@
-﻿﻿  [
+﻿  [
     {
       "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.ValueConversion.CharToStringConverter : Microsoft.EntityFrameworkCore.Storage.ValueConversion.ValueConverter<System.Char, System.String>",
       "Kind": "Removal"
@@ -46,6 +46,10 @@
       "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType : Microsoft.EntityFrameworkCore.Metadata.IEntityType, Microsoft.EntityFrameworkCore.Metadata.IMutableTypeBase",
       "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IMutableProperty AddIndexedProperty(System.String name, System.Type propertyType)",
       "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IPropertyBase : Microsoft.EntityFrameworkCore.Infrastructure.IAnnotatable",
+      "MemberId": "System.Boolean get_IsIndexedProperty()",
+      "Kind": "Addition"
     }
   ]
-

--- a/src/EFCore/breakingchanges.netcore.json
+++ b/src/EFCore/breakingchanges.netcore.json
@@ -1,4 +1,4 @@
-﻿  [
+﻿﻿  [
     {
       "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.ValueConversion.CharToStringConverter : Microsoft.EntityFrameworkCore.Storage.ValueConversion.ValueConverter<System.Char, System.String>",
       "Kind": "Removal"
@@ -48,3 +48,4 @@
       "Kind": "Addition"
     }
   ]
+

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -141,7 +141,7 @@ LEFT JOIN [Squads] AS [t.Gear.Squad] ON [t0].[SquadId] = [t.Gear.Squad].[Id]");
             await base.Include_multiple_circular(isAsync);
 
             AssertSql(
-                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.CityOfBirth].[Name], [g.CityOfBirth].[Location]
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.CityOfBirth].[Name], [g.CityOfBirth].[Location], [g.CityOfBirth].[Nation]
 FROM [Gears] AS [g]
 INNER JOIN [Cities] AS [g.CityOfBirth] ON [g].[CityOrBirthName] = [g.CityOfBirth].[Name]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
@@ -164,7 +164,7 @@ ORDER BY [t].[Name]");
             await base.Include_multiple_circular_with_filter(isAsync);
 
             AssertSql(
-                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.CityOfBirth].[Name], [g.CityOfBirth].[Location]
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.CityOfBirth].[Name], [g.CityOfBirth].[Location], [g.CityOfBirth].[Nation]
 FROM [Gears] AS [g]
 INNER JOIN [Cities] AS [g.CityOfBirth] ON [g].[CityOrBirthName] = [g.CityOfBirth].[Name]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[Nickname] = N'Marcus')
@@ -207,7 +207,7 @@ ORDER BY [t].[FullName]");
             await base.Include_multiple_include_then_include(isAsync);
 
             AssertSql(
-                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.CityOfBirth].[Name], [g.CityOfBirth].[Location], [g.AssignedCity].[Name], [g.AssignedCity].[Location]
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.CityOfBirth].[Name], [g.CityOfBirth].[Location], [g.CityOfBirth].[Nation], [g.AssignedCity].[Name], [g.AssignedCity].[Location], [g.AssignedCity].[Nation]
 FROM [Gears] AS [g]
 INNER JOIN [Cities] AS [g.CityOfBirth] ON [g].[CityOrBirthName] = [g.CityOfBirth].[Name]
 LEFT JOIN [Cities] AS [g.AssignedCity] ON [g].[AssignedCityName] = [g.AssignedCity].[Name]
@@ -329,7 +329,7 @@ WHERE [t].[Nickname] = N'Marcus'");
             await base.Include_with_join_reference1(isAsync);
 
             AssertSql(
-                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.CityOfBirth].[Name], [g.CityOfBirth].[Location]
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.CityOfBirth].[Name], [g.CityOfBirth].[Location], [g.CityOfBirth].[Nation]
 FROM [Gears] AS [g]
 INNER JOIN [Cities] AS [g.CityOfBirth] ON [g].[CityOrBirthName] = [g.CityOfBirth].[Name]
 INNER JOIN [Tags] AS [t] ON ([g].[SquadId] = [t].[GearSquadId]) AND ([g].[Nickname] = [t].[GearNickName])
@@ -341,7 +341,7 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear')");
             await base.Include_with_join_reference2(isAsync);
 
             AssertSql(
-                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.CityOfBirth].[Name], [g.CityOfBirth].[Location]
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.CityOfBirth].[Name], [g.CityOfBirth].[Location], [g.CityOfBirth].[Nation]
 FROM [Tags] AS [t]
 INNER JOIN [Gears] AS [g] ON ([t].[GearSquadId] = [g].[SquadId]) AND ([t].[GearNickName] = [g].[Nickname])
 INNER JOIN [Cities] AS [g.CityOfBirth] ON [g].[CityOrBirthName] = [g.CityOfBirth].[Name]
@@ -446,7 +446,7 @@ FROM [Tags] AS [t]");
             await base.Include_with_join_multi_level(isAsync);
 
             AssertSql(
-                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.CityOfBirth].[Name], [g.CityOfBirth].[Location]
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.CityOfBirth].[Name], [g.CityOfBirth].[Location], [g.CityOfBirth].[Nation]
 FROM [Gears] AS [g]
 INNER JOIN [Cities] AS [g.CityOfBirth] ON [g].[CityOrBirthName] = [g.CityOfBirth].[Name]
 INNER JOIN [Tags] AS [t] ON ([g].[SquadId] = [t].[GearSquadId]) AND ([g].[Nickname] = [t].[GearNickName])
@@ -471,7 +471,7 @@ ORDER BY [t1].[Name]");
             await base.Include_with_join_and_inheritance1(isAsync);
 
             AssertSql(
-                @"SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOrBirthName], [o].[Discriminator], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], [o.CityOfBirth].[Name], [o.CityOfBirth].[Location]
+                @"SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOrBirthName], [o].[Discriminator], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank], [o.CityOfBirth].[Name], [o.CityOfBirth].[Location], [o.CityOfBirth].[Nation]
 FROM [Tags] AS [t]
 INNER JOIN [Gears] AS [o] ON ([t].[GearSquadId] = [o].[SquadId]) AND ([t].[GearNickName] = [o].[Nickname])
 INNER JOIN [Cities] AS [o.CityOfBirth] ON [o].[CityOrBirthName] = [o.CityOfBirth].[Name]
@@ -2121,7 +2121,7 @@ WHERE [g].[Discriminator] = N'Officer'");
             await base.Non_unicode_string_literal_is_used_for_non_unicode_column(isAsync);
 
             AssertSql(
-                @"SELECT [c].[Name], [c].[Location]
+                @"SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
 WHERE [c].[Location] = 'Unknown'");
         }
@@ -2131,7 +2131,7 @@ WHERE [c].[Location] = 'Unknown'");
             await base.Non_unicode_string_literal_is_used_for_non_unicode_column_right(isAsync);
 
             AssertSql(
-                @"SELECT [c].[Name], [c].[Location]
+                @"SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
 WHERE 'Unknown' = [c].[Location]");
         }
@@ -2143,7 +2143,7 @@ WHERE 'Unknown' = [c].[Location]");
             AssertSql(
                 @"@__value_0='Unknown' (Size = 100) (DbType = AnsiString)
 
-SELECT [c].[Name], [c].[Location]
+SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
 WHERE [c].[Location] = @__value_0");
         }
@@ -2153,7 +2153,7 @@ WHERE [c].[Location] = @__value_0");
             await base.Non_unicode_string_literals_in_contains_is_used_for_non_unicode_column(isAsync);
 
             AssertSql(
-                @"SELECT [c].[Name], [c].[Location]
+                @"SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
 WHERE [c].[Location] IN ('Unknown', 'Jacinto''s location', 'Ephyra''s location')");
         }
@@ -2163,7 +2163,7 @@ WHERE [c].[Location] IN ('Unknown', 'Jacinto''s location', 'Ephyra''s location')
             await base.Non_unicode_string_literals_is_used_for_non_unicode_column_with_subquery(isAsync);
 
             AssertSql(
-                @"SELECT [c].[Name], [c].[Location]
+                @"SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
 WHERE ([c].[Location] = 'Unknown') AND ((
     SELECT COUNT(*)
@@ -2188,7 +2188,7 @@ WHERE [g].[Discriminator] IN (N'Officer', N'Gear') AND (([g].[Nickname] = N'Marc
             await base.Non_unicode_string_literals_is_used_for_non_unicode_column_with_contains(isAsync);
 
             AssertSql(
-                @"SELECT [c].[Name], [c].[Location]
+                @"SELECT [c].[Name], [c].[Location], [c].[Nation]
 FROM [Cities] AS [c]
 WHERE CHARINDEX(N'Jacinto', [c].[Location]) > 0");
         }
@@ -3535,7 +3535,7 @@ ORDER BY [gear].[Nickname], [tag0].[Id], [tag].[Note]");
             base.Subquery_created_by_include_gets_lifted_nested();
 
             AssertSql(
-                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.CityOfBirth].[Name], [g.CityOfBirth].[Location]
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.CityOfBirth].[Name], [g.CityOfBirth].[Location], [g.CityOfBirth].[Nation]
 FROM [Gears] AS [g]
 INNER JOIN [Cities] AS [g.CityOfBirth] ON [g].[CityOrBirthName] = [g.CityOfBirth].[Name]
 WHERE ([g].[Discriminator] IN (N'Officer', N'Gear') AND EXISTS (
@@ -3794,6 +3794,16 @@ WHERE ([f].[Discriminator] = N'LocustHorde') AND ([f].[Discriminator] = N'Locust
 ORDER BY [f].[Name]");
         }
 
+        public override void Can_query_on_indexed_properties()
+        {
+            base.Can_query_on_indexed_properties();
+
+            AssertSql(
+                @"SELECT [city].[Name], [city].[Location], [city].[Nation]
+FROM [Cities] AS [city]
+WHERE [city].[Nation] = N'Tyrus'");
+        }
+
         public override void Navigation_access_on_derived_entity_using_cast()
         {
             base.Navigation_access_on_derived_entity_using_cast();
@@ -3978,7 +3988,7 @@ ORDER BY [t1].[Name], [t1].[Id]");
             base.Include_on_derived_entity_using_subquery_with_cast_cross_product_base_entity();
 
             AssertSql(
-                @"SELECT [f2].[Id], [f2].[CapitalName], [f2].[Discriminator], [f2].[Name], [f2].[CommanderName], [f2].[Eradicated], [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [ff].[Id], [ff].[CapitalName], [ff].[Discriminator], [ff].[Name], [ff].[CommanderName], [ff].[Eradicated], [ff.Capital].[Name], [ff.Capital].[Location]
+                @"SELECT [f2].[Id], [f2].[CapitalName], [f2].[Discriminator], [f2].[Name], [f2].[CommanderName], [f2].[Eradicated], [t].[Name], [t].[Discriminator], [t].[LocustHordeId], [t].[ThreatLevel], [t].[DefeatedByNickname], [t].[DefeatedBySquadId], [t].[HighCommandId], [ff].[Id], [ff].[CapitalName], [ff].[Discriminator], [ff].[Name], [ff].[CommanderName], [ff].[Eradicated], [ff.Capital].[Name], [ff.Capital].[Location], [ff.Capital].[Nation]
 FROM [Factions] AS [f2]
 LEFT JOIN (
     SELECT [f2.Commander].*
@@ -4293,7 +4303,7 @@ LEFT JOIN (
 WHERE [l].[Discriminator] IN (N'LocustCommander', N'LocustLeader')
 ORDER BY [t].[Nickname], [t].[SquadId]",
                 //
-                @"SELECT [l.DefeatedBy.Reports].[Nickname], [l.DefeatedBy.Reports].[SquadId], [l.DefeatedBy.Reports].[AssignedCityName], [l.DefeatedBy.Reports].[CityOrBirthName], [l.DefeatedBy.Reports].[Discriminator], [l.DefeatedBy.Reports].[FullName], [l.DefeatedBy.Reports].[HasSoulPatch], [l.DefeatedBy.Reports].[LeaderNickname], [l.DefeatedBy.Reports].[LeaderSquadId], [l.DefeatedBy.Reports].[Rank], [g.CityOfBirth].[Name], [g.CityOfBirth].[Location]
+                @"SELECT [l.DefeatedBy.Reports].[Nickname], [l.DefeatedBy.Reports].[SquadId], [l.DefeatedBy.Reports].[AssignedCityName], [l.DefeatedBy.Reports].[CityOrBirthName], [l.DefeatedBy.Reports].[Discriminator], [l.DefeatedBy.Reports].[FullName], [l.DefeatedBy.Reports].[HasSoulPatch], [l.DefeatedBy.Reports].[LeaderNickname], [l.DefeatedBy.Reports].[LeaderSquadId], [l.DefeatedBy.Reports].[Rank], [g.CityOfBirth].[Name], [g.CityOfBirth].[Location], [g.CityOfBirth].[Nation]
 FROM [Gears] AS [l.DefeatedBy.Reports]
 INNER JOIN [Cities] AS [g.CityOfBirth] ON [l.DefeatedBy.Reports].[CityOrBirthName] = [g.CityOfBirth].[Name]
 INNER JOIN (
@@ -7861,7 +7871,7 @@ ORDER BY [Key]");
             await base.Group_by_with_include_with_entity_in_result_selector(isAsync);
 
             AssertSql(
-                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.CityOfBirth].[Name], [g.CityOfBirth].[Location]
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.CityOfBirth].[Name], [g.CityOfBirth].[Location], [g.CityOfBirth].[Nation]
 FROM [Gears] AS [g]
 INNER JOIN [Cities] AS [g.CityOfBirth] ON [g].[CityOrBirthName] = [g.CityOfBirth].[Name]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
@@ -7884,7 +7894,7 @@ GROUP BY [g].[Rank]");
             await base.Include_with_group_by_and_FirstOrDefault_gets_properly_applied(isAsync);
 
             AssertSql(
-                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.CityOfBirth].[Name], [g.CityOfBirth].[Location]
+                @"SELECT [g].[Nickname], [g].[SquadId], [g].[AssignedCityName], [g].[CityOrBirthName], [g].[Discriminator], [g].[FullName], [g].[HasSoulPatch], [g].[LeaderNickname], [g].[LeaderSquadId], [g].[Rank], [g.CityOfBirth].[Name], [g.CityOfBirth].[Location], [g.CityOfBirth].[Nation]
 FROM [Gears] AS [g]
 INNER JOIN [Cities] AS [g.CityOfBirth] ON [g].[CityOrBirthName] = [g.CityOfBirth].[Name]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear')

--- a/test/EFCore.Tests/Metadata/Internal/ClrCollectionAccessorFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ClrCollectionAccessorFactoryTest.cs
@@ -44,6 +44,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             public PropertyInfo PropertyInfo { get; }
             public FieldInfo FieldInfo { get; }
             public bool IsShadowProperty { get; }
+            public bool IsIndexedProperty { get; }
             public IEntityType DeclaringEntityType { get; }
             public IForeignKey ForeignKey { get; }
             public bool IsEagerLoaded { get; }

--- a/test/EFCore.Tests/Metadata/Internal/ClrPropertyGetterFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ClrPropertyGetterFactoryTest.cs
@@ -31,6 +31,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             public ITypeBase DeclaringType { get; }
             public Type ClrType { get; }
             public bool IsShadowProperty { get; }
+            public bool IsIndexedProperty { get; }
             public IEntityType DeclaringEntityType { get; }
             public bool IsNullable { get; }
             public PropertySaveBehavior BeforeSaveBehavior { get; }

--- a/test/EFCore.Tests/Metadata/Internal/ClrPropertySetterFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ClrPropertySetterFactoryTest.cs
@@ -29,6 +29,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             public ITypeBase DeclaringType { get; }
             public Type ClrType { get; }
             public bool IsShadowProperty { get; }
+            public bool IsIndexedProperty { get; }
             public IEntityType DeclaringEntityType { get; }
             public bool IsNullable { get; }
             public PropertySaveBehavior BeforeSaveBehavior { get; }

--- a/test/EFCore.Tests/Metadata/Internal/NavigationTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/NavigationTest.cs
@@ -33,6 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             public PropertyInfo PropertyInfo { get; }
             public FieldInfo FieldInfo { get; }
             public bool IsShadowProperty { get; }
+            public bool IsIndexedProperty { get; }
             public IEntityType DeclaringEntityType { get; }
             public IForeignKey ForeignKey { get; }
             public bool IsEagerLoaded { get; }

--- a/test/EFCore.Tests/Metadata/Internal/PropertyTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/PropertyTest.cs
@@ -46,6 +46,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             public ITypeBase DeclaringType { get; }
             public Type ClrType { get; }
             public bool IsShadowProperty { get; }
+            public bool IsIndexedProperty { get; }
             public IEntityType DeclaringEntityType { get; }
             public bool IsNullable { get; }
             public PropertySaveBehavior BeforeSaveBehavior { get; }


### PR DESCRIPTION
Update query to allow references to indexed properties. This addresses part of issue #13610.

Note: at the moment this only addresses entity queries. I'm still working on `ValueBuffer` queries.