### PR TITLE
RevEng: Enable plugins to generate provider and DbContext options

### DIFF
--- a/samples/OracleProvider/src/OracleProvider/Scaffolding/Internal/OracleCodeGenerator.cs
+++ b/samples/OracleProvider/src/OracleProvider/Scaffolding/Internal/OracleCodeGenerator.cs
@@ -17,7 +17,13 @@ namespace Microsoft.EntityFrameworkCore.Oracle.Scaffolding.Internal
         {
         }
 
-        public override MethodCallCodeFragment GenerateUseProvider(string connectionString)
-            => new MethodCallCodeFragment(nameof(OracleDbContextOptionsExtensions.UseOracle), connectionString);
+        public override MethodCallCodeFragment GenerateUseProvider(
+            string connectionString,
+            MethodCallCodeFragment providerOptions)
+            => new MethodCallCodeFragment(
+                nameof(OracleDbContextOptionsExtensions.UseOracle),
+                providerOptions == null
+                ? new object[] { connectionString }
+                : new object[] { connectionString, new NestedClosureCodeFragment("x", providerOptions) });
     }
 }

--- a/samples/OracleProvider/test/OracleProvider.FunctionalTests/Scaffolding/OracleCodeGeneratorTest.cs
+++ b/samples/OracleProvider/test/OracleProvider.FunctionalTests/Scaffolding/OracleCodeGeneratorTest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Oracle.Scaffolding.Internal;
 using Xunit;
 
@@ -11,14 +13,41 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
         [Fact]
         public virtual void Use_provider_method_is_generated_correctly()
         {
-            var codeGenerator = new OracleCodeGenerator(new ProviderCodeGeneratorDependencies());
+            var codeGenerator = new OracleCodeGenerator(
+                new ProviderCodeGeneratorDependencies(
+                    Enumerable.Empty<IProviderCodeGeneratorPlugin>()));
 
-            var result = codeGenerator.GenerateUseProvider("Data Source=Test");
+            var result = codeGenerator.GenerateUseProvider("Data Source=Test", providerOptions: null);
 
             Assert.Equal("UseOracle", result.Method);
             Assert.Collection(
                 result.Arguments,
                 a => Assert.Equal("Data Source=Test", a));
+        }
+
+        [Fact]
+        public virtual void Use_provider_method_is_generated_correctly_with_options()
+        {
+            var codeGenerator = new OracleCodeGenerator(
+                new ProviderCodeGeneratorDependencies(
+                    Enumerable.Empty<IProviderCodeGeneratorPlugin>()));
+
+            var providerOptions = new MethodCallCodeFragment("SetProviderOption");
+
+            var result = codeGenerator.GenerateUseProvider("Data Source=Test", providerOptions);
+
+            Assert.Equal("UseOracle", result.Method);
+            Assert.Collection(
+                result.Arguments,
+                a => Assert.Equal("Data Source=Test", a),
+                a =>
+                {
+                    var nestedClosure = Assert.IsType<NestedClosureCodeFragment>(a);
+
+                    Assert.Equal("x", nestedClosure.Parameter);
+                    Assert.Same(providerOptions, nestedClosure.MethodCall);
+                });
+            Assert.Null(result.ChainedCall);
         }
     }
 }

--- a/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
+++ b/src/EFCore.Design/Scaffolding/Internal/CSharpDbContextGenerator.cs
@@ -203,15 +203,29 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding.Internal
                             .IncrementIndent();
                     }
 
-                    _sb.Append("optionsBuilder")
-                        .Append(
-                            _providerConfigurationCodeGenerator != null
-                                ? _code.Fragment(
-                                    _providerConfigurationCodeGenerator.GenerateUseProvider(connectionString))
+                    _sb.Append("optionsBuilder");
+
+                    if (_providerConfigurationCodeGenerator != null)
+                    {
+                        var useProviderCall = _providerConfigurationCodeGenerator.GenerateUseProvider(
+                            connectionString,
+                            _providerConfigurationCodeGenerator.GenerateProviderOptions());
+                        var contextOptions = _providerConfigurationCodeGenerator.GenerateContextOptions();
+                        if (contextOptions != null)
+                        {
+                            useProviderCall = useProviderCall.Chain(contextOptions);
+                        }
+
+                        _sb.Append(_code.Fragment(useProviderCall));
+                    }
+                    else
+                    {
 #pragma warning disable CS0618 // Type or member is obsolete
-                                : _legacyProviderCodeGenerator.GenerateUseProvider(connectionString, Language))
+                        _sb.Append(_legacyProviderCodeGenerator.GenerateUseProvider(connectionString, Language));
 #pragma warning restore CS0618 // Type or member is obsolete
-                        .AppendLine(";");
+                    }
+
+                    _sb.AppendLine(";");
                 }
 
                 _sb.AppendLine("}");

--- a/src/EFCore.Relational/Design/MethodCallCodeFragment.cs
+++ b/src/EFCore.Relational/Design/MethodCallCodeFragment.cs
@@ -70,6 +70,17 @@ namespace Microsoft.EntityFrameworkCore.Design
         /// <param name="arguments"> The next method call's arguments. </param>
         /// <returns> A new fragment representing the method chain. </returns>
         public virtual MethodCallCodeFragment Chain([NotNull] string method, [NotNull] params object[] arguments)
-            => new MethodCallCodeFragment(Method, _arguments.ToArray(), new MethodCallCodeFragment(method, arguments));
+            => Chain(new MethodCallCodeFragment(method, arguments));
+
+        /// <summary>
+        ///     Creates a method chain from this method to another.
+        /// </summary>
+        /// <param name="call"> The next method. </param>
+        /// <returns> A new fragment representing the method chain. </returns>
+        public virtual MethodCallCodeFragment Chain([NotNull] MethodCallCodeFragment call)
+            => new MethodCallCodeFragment(
+                Method,
+                _arguments.ToArray(),
+                ChainedCall?.Chain(call) ?? call);
     }
 }

--- a/src/EFCore.Relational/Scaffolding/IProviderCodeGeneratorPlugin.cs
+++ b/src/EFCore.Relational/Scaffolding/IProviderCodeGeneratorPlugin.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace Microsoft.EntityFrameworkCore.Scaffolding
+{
+    /// <summary>
+    ///     Implemented by plugins to generate code fragments for reverse engineering.
+    /// </summary>
+    public interface IProviderCodeGeneratorPlugin
+    {
+        /// <summary>
+        ///     Generates a method chain used to configure provider-specific options.
+        /// </summary>
+        /// <returns> The method chain. May be null. </returns>
+        MethodCallCodeFragment GenerateProviderOptions();
+
+        /// <summary>
+        ///     Generates a method chain to configure additional context options.
+        /// </summary>
+        /// <returns> The method chain. May be null. </returns>
+        MethodCallCodeFragment GenerateContextOptions();
+    }
+}

--- a/src/EFCore.Relational/Scaffolding/IProviderConfigurationCodeGenerator.cs
+++ b/src/EFCore.Relational/Scaffolding/IProviderConfigurationCodeGenerator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Design;
 
@@ -13,11 +14,35 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
     public interface IProviderConfigurationCodeGenerator
     {
         /// <summary>
+        ///     Generates a method chain used to configure provider-specific options.
+        /// </summary>
+        /// <returns> The method chain. May be null. </returns>
+        MethodCallCodeFragment GenerateProviderOptions();
+
+        /// <summary>
         ///     Generates a code fragment like <c>.UseSqlServer("Database=Foo")</c> which can be used in
         ///     the <see cref="DbContext.OnConfiguring" /> method of the generated DbContext.
         /// </summary>
         /// <param name="connectionString"> The connection string to include in the code fragment. </param>
         /// <returns> The code fragment. </returns>
+        [Obsolete("Use the overload that takes provider options instead.")]
         MethodCallCodeFragment GenerateUseProvider([NotNull] string connectionString);
+
+        /// <summary>
+        ///     Generates a code fragment like <c>.UseSqlServer("Database=Foo")</c> which can be used in
+        ///     the <see cref="DbContext.OnConfiguring" /> method of the generated DbContext.
+        /// </summary>
+        /// <param name="connectionString"> The connection string to include in the code fragment. </param>
+        /// <param name="providerOptions"> The method chain used to configure provider options. </param>
+        /// <returns> The code fragment. </returns>
+        MethodCallCodeFragment GenerateUseProvider(
+            [NotNull] string connectionString,
+            [CanBeNull] MethodCallCodeFragment providerOptions);
+
+        /// <summary>
+        ///     Generates a method chain to configure additional context options.
+        /// </summary>
+        /// <returns> The method chain. May be null. </returns>
+        MethodCallCodeFragment GenerateContextOptions();
     }
 }

--- a/src/EFCore.Relational/Scaffolding/ProviderCodeGenerator.cs
+++ b/src/EFCore.Relational/Scaffolding/ProviderCodeGenerator.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Utilities;
@@ -25,11 +26,71 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
         protected virtual ProviderCodeGeneratorDependencies Dependencies { get; }
 
         /// <summary>
+        ///     Generates a method chain used to configure provider-specific options.
+        /// </summary>
+        /// <returns> The method chain. May be null. </returns>
+        public virtual MethodCallCodeFragment GenerateProviderOptions()
+        {
+            MethodCallCodeFragment providerOptions = null;
+
+            foreach (var plugin in Dependencies.Plugins)
+            {
+                var chainedCall = plugin.GenerateProviderOptions();
+                if (chainedCall == null)
+                {
+                    continue;
+                }
+
+                providerOptions = providerOptions?.Chain(chainedCall) ?? chainedCall;
+            }
+
+            return providerOptions;
+        }
+
+        /// <summary>
         ///     Generates a code fragment like <c>.UseSqlServer("Database=Foo")</c> which can be used in
         ///     the <see cref="DbContext.OnConfiguring" /> method of the generated DbContext.
         /// </summary>
         /// <param name="connectionString"> The connection string to include in the code fragment. </param>
         /// <returns> The code fragment. </returns>
-        public abstract MethodCallCodeFragment GenerateUseProvider(string connectionString);
+        [Obsolete("Use the overload that takes provider options instead.")]
+        public virtual MethodCallCodeFragment GenerateUseProvider(string connectionString)
+            => throw new NotImplementedException();
+
+        /// <summary>
+        ///     Generates a code fragment like <c>.UseSqlServer("Database=Foo")</c> which can be used in
+        ///     the <see cref="DbContext.OnConfiguring" /> method of the generated DbContext.
+        /// </summary>
+        /// <param name="connectionString"> The connection string to include in the code fragment. </param>
+        /// <param name="providerOptions"> The method chain used to configure provider options. </param>
+        /// <returns> The code fragment. </returns>
+        public virtual MethodCallCodeFragment GenerateUseProvider(
+            string connectionString,
+            MethodCallCodeFragment providerOptions)
+#pragma warning disable CS0618 // Type or member is obsolete
+            => GenerateUseProvider(connectionString);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        /// <summary>
+        ///     Generates a method chain to configure additional context options.
+        /// </summary>
+        /// <returns> The method chain. May be null. </returns>
+        public virtual MethodCallCodeFragment GenerateContextOptions()
+        {
+            MethodCallCodeFragment contextOptions = null;
+
+            foreach (var plugin in Dependencies.Plugins)
+            {
+                var chainedCall = plugin.GenerateContextOptions();
+                if (chainedCall == null)
+                {
+                    continue;
+                }
+
+                contextOptions = contextOptions?.Chain(chainedCall) ?? chainedCall;
+            }
+
+            return contextOptions;
+        }
     }
 }

--- a/src/EFCore.Relational/Scaffolding/ProviderCodeGeneratorDependencies.cs
+++ b/src/EFCore.Relational/Scaffolding/ProviderCodeGeneratorDependencies.cs
@@ -1,6 +1,10 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Utilities;
+
 namespace Microsoft.EntityFrameworkCore.Scaffolding
 {
     /// <summary>
@@ -35,9 +39,25 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
         ///         the constructor at any point in this process.
         ///     </para>
         /// </summary>
-        // ReSharper disable once EmptyConstructor
-        public ProviderCodeGeneratorDependencies()
+        /// <param name="plugins"> The plugins. </param>
+        public ProviderCodeGeneratorDependencies([NotNull] IEnumerable<IProviderCodeGeneratorPlugin> plugins)
         {
+            Check.NotNull(plugins, nameof(plugins));
+
+            Plugins = plugins;
         }
+
+        /// <summary>
+        ///     Gets the plugins.
+        /// </summary>
+        public IEnumerable<IProviderCodeGeneratorPlugin> Plugins { get; }
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="plugins"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public ProviderCodeGeneratorDependencies With([NotNull] IEnumerable<IProviderCodeGeneratorPlugin> plugins)
+            => new ProviderCodeGeneratorDependencies(plugins);
     }
 }

--- a/src/EFCore.Relational/Scaffolding/ProviderCodeGeneratorPlugin.cs
+++ b/src/EFCore.Relational/Scaffolding/ProviderCodeGeneratorPlugin.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace Microsoft.EntityFrameworkCore.Scaffolding
+{
+    /// <summary>
+    ///     Base class used by plugins to generate code fragments for reverse engineering.
+    /// </summary>
+    public class ProviderCodeGeneratorPlugin : IProviderCodeGeneratorPlugin
+    {
+        /// <summary>
+        ///     Generates a method chain used to configure provider-specific options.
+        /// </summary>
+        /// <returns> The method chain. May be null. </returns>
+        public virtual MethodCallCodeFragment GenerateContextOptions()
+            => null;
+
+        /// <summary>
+        ///     Generates a method chain to configure additional context options.
+        /// </summary>
+        /// <returns> The method chain. May be null. </returns>
+        public virtual MethodCallCodeFragment GenerateProviderOptions()
+            => null;
+    }
+}

--- a/src/EFCore.Relational/breakingchanges.netcore.json
+++ b/src/EFCore.Relational/breakingchanges.netcore.json
@@ -10,6 +10,11 @@
       "Kind": "Removal"
     },
     {
+      "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Scaffolding.ProviderCodeGeneratorDependencies",
+      "MemberId": "public .ctor()",
+      "Kind": "Removal"
+    },
+    {
       "TypeId": "public sealed class Microsoft.EntityFrameworkCore.Query.ExpressionTranslators.RelationalCompositeMemberTranslatorDependencies",
       "MemberId": "public .ctor()",
       "Kind": "Removal"
@@ -123,6 +128,21 @@
       "TypeId": "public class Microsoft.EntityFrameworkCore.Storage.UShortTypeMapping : Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping",
       "MemberId": "public override Microsoft.EntityFrameworkCore.Storage.RelationalTypeMapping Clone(System.String storeType, System.Nullable<System.Int32> size)",
       "Kind": "Removal"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Scaffolding.IProviderConfigurationCodeGenerator",
+      "MemberId": "Microsoft.EntityFrameworkCore.Design.MethodCallCodeFragment GenerateContextOptions()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Scaffolding.IProviderConfigurationCodeGenerator",
+      "MemberId": "Microsoft.EntityFrameworkCore.Design.MethodCallCodeFragment GenerateProviderOptions()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Scaffolding.IProviderConfigurationCodeGenerator",
+      "MemberId": "Microsoft.EntityFrameworkCore.Design.MethodCallCodeFragment GenerateUseProvider(System.String connectionString, Microsoft.EntityFrameworkCore.Design.MethodCallCodeFragment providerOptions)",
+      "Kind": "Addition"
     },
     {
       "TypeId": "public interface Microsoft.EntityFrameworkCore.Query.Sql.ISqlExpressionVisitor",

--- a/src/EFCore.SqlServer.NTS/Design/Internal/SqlServerNetTopologySuiteDesignTimeServices.cs
+++ b/src/EFCore.SqlServer.NTS/Design/Internal/SqlServerNetTopologySuiteDesignTimeServices.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Scaffolding;
+using Microsoft.EntityFrameworkCore.SqlServer.Scaffolding.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,6 +25,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Design.Internal
         public virtual void ConfigureDesignTimeServices(IServiceCollection serviceCollection)
             => serviceCollection
                 .AddSingleton<IRelationalTypeMappingSourcePlugin, SqlServerNetTopologySuiteTypeMappingSourcePlugin>()
+                .AddSingleton<IProviderCodeGeneratorPlugin, SqlServerNetTopologySuiteCodeGeneratorPlugin>()
                 .TryAddSingleton(NtsGeometryServices.Instance);
     }
 }

--- a/src/EFCore.SqlServer.NTS/Scaffolding/Internal/SqlServerNetTopologySuiteCodeGeneratorPlugin.cs
+++ b/src/EFCore.SqlServer.NTS/Scaffolding/Internal/SqlServerNetTopologySuiteCodeGeneratorPlugin.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Scaffolding;
+
+namespace Microsoft.EntityFrameworkCore.SqlServer.Scaffolding.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class SqlServerNetTopologySuiteCodeGeneratorPlugin : ProviderCodeGeneratorPlugin
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override MethodCallCodeFragment GenerateProviderOptions()
+            => new MethodCallCodeFragment(
+                nameof(SqlServerNetTopologySuiteDbContextOptionsBuilderExtensions.UseNetTopologySuite));
+    }
+}

--- a/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerCodeGenerator.cs
+++ b/src/EFCore.SqlServer/Scaffolding/Internal/SqlServerCodeGenerator.cs
@@ -26,7 +26,13 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.Scaffolding.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override MethodCallCodeFragment GenerateUseProvider(string connectionString)
-            => new MethodCallCodeFragment(nameof(SqlServerDbContextOptionsExtensions.UseSqlServer), connectionString);
+        public override MethodCallCodeFragment GenerateUseProvider(
+            string connectionString,
+            MethodCallCodeFragment providerOptions)
+            => new MethodCallCodeFragment(
+                nameof(SqlServerDbContextOptionsExtensions.UseSqlServer),
+                providerOptions == null
+                ? new object[] { connectionString }
+                : new object[] { connectionString, new NestedClosureCodeFragment("x", providerOptions) });
     }
 }

--- a/src/EFCore.Sqlite.Core/Scaffolding/Internal/SqliteCodeGenerator.cs
+++ b/src/EFCore.Sqlite.Core/Scaffolding/Internal/SqliteCodeGenerator.cs
@@ -26,7 +26,13 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public override MethodCallCodeFragment GenerateUseProvider(string connectionString)
-            => new MethodCallCodeFragment(nameof(SqliteDbContextOptionsBuilderExtensions.UseSqlite), connectionString);
+        public override MethodCallCodeFragment GenerateUseProvider(
+            string connectionString,
+            MethodCallCodeFragment providerOptions)
+            => new MethodCallCodeFragment(
+                nameof(SqliteDbContextOptionsBuilderExtensions.UseSqlite),
+                providerOptions == null
+                ? new object[] { connectionString }
+                : new object[] { connectionString, new NestedClosureCodeFragment("x", providerOptions) });
     }
 }

--- a/src/EFCore.Sqlite.NTS/Design/Internal/SqliteNetTopologySuiteDesignTimeServices.cs
+++ b/src/EFCore.Sqlite.NTS/Design/Internal/SqliteNetTopologySuiteDesignTimeServices.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Scaffolding;
+using Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal;
 using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,6 +25,7 @@ namespace Microsoft.EntityFrameworkCore.Sqlite.Design.Internal
         public virtual void ConfigureDesignTimeServices(IServiceCollection serviceCollection)
             => serviceCollection
                 .AddSingleton<IRelationalTypeMappingSourcePlugin, SqliteNetTopologySuiteTypeMappingSourcePlugin>()
+                .AddSingleton<IProviderCodeGeneratorPlugin, SqliteNetTopologySuiteCodeGeneratorPlugin>()
                 .TryAddSingleton(NtsGeometryServices.Instance);
     }
 }

--- a/src/EFCore.Sqlite.NTS/Scaffolding/Internal/SqliteNetTopologySuiteCodeGeneratorPlugin.cs
+++ b/src/EFCore.Sqlite.NTS/Scaffolding/Internal/SqliteNetTopologySuiteCodeGeneratorPlugin.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Scaffolding;
+
+namespace Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class SqliteNetTopologySuiteCodeGeneratorPlugin : ProviderCodeGeneratorPlugin
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public override MethodCallCodeFragment GenerateProviderOptions()
+            => new MethodCallCodeFragment(
+                nameof(SqliteNetTopologySuiteDbContextOptionsBuilderExtensions.UseNetTopologySuite));
+    }
+}

--- a/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
+++ b/test/EFCore.Design.Tests/Design/Internal/CSharpHelperTest.cs
@@ -4,8 +4,6 @@
 using System;
 using System.Data.SqlTypes;
 using System.Linq.Expressions;
-using System.Reflection;
-using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.SqlServer.Storage.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -320,6 +318,28 @@ namespace Microsoft.EntityFrameworkCore.Design.Internal
             var result = new CSharpHelper(TypeMappingSource).Fragment(method);
 
             Assert.Equal(".Test().Test()", result);
+        }
+
+        [Fact]
+        public void Fragment_MethodCallCodeFragment_works_when_chaining_on_chain()
+        {
+            var method = new MethodCallCodeFragment("One", Array.Empty<object>(), new MethodCallCodeFragment("Two"))
+                .Chain("Three");
+
+            var result = new CSharpHelper(TypeMappingSource).Fragment(method);
+
+            Assert.Equal(".One().Two().Three()", result);
+        }
+
+        [Fact]
+        public void Fragment_MethodCallCodeFragment_works_when_chaining_on_chain_with_call()
+        {
+            var method = new MethodCallCodeFragment("One", Array.Empty<object>(), new MethodCallCodeFragment("Two"))
+                .Chain(new MethodCallCodeFragment("Three", Array.Empty<object>(), new MethodCallCodeFragment("Four")));
+
+            var result = new CSharpHelper(TypeMappingSource).Fragment(method);
+
+            Assert.Equal(".One().Two().Three().Four()", result);
         }
 
         [Fact]

--- a/test/EFCore.Relational.Tests/TestUtilities/TestProviderCodeGenerator.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/TestProviderCodeGenerator.cs
@@ -13,7 +13,13 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         {
         }
 
-        public override MethodCallCodeFragment GenerateUseProvider(string connectionString)
-            => new MethodCallCodeFragment("UseTestProvider", connectionString);
+        public override MethodCallCodeFragment GenerateUseProvider(
+            string connectionString,
+            MethodCallCodeFragment providerOptions)
+            => new MethodCallCodeFragment(
+                "UseTestProvider",
+                providerOptions == null
+                ? new object[] { connectionString }
+                : new object[] { connectionString, new NestedClosureCodeFragment("x", providerOptions) });
     }
 }

--- a/test/EFCore.SqlServer.Tests/Scaffolding/SqlServerCodeGeneratorTest.cs
+++ b/test/EFCore.SqlServer.Tests/Scaffolding/SqlServerCodeGeneratorTest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.SqlServer.Scaffolding.Internal;
 using Xunit;
 
@@ -12,14 +14,42 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
         [Fact]
         public virtual void Use_provider_method_is_generated_correctly()
         {
-            var codeGenerator = new SqlServerCodeGenerator(new ProviderCodeGeneratorDependencies());
+            var codeGenerator = new SqlServerCodeGenerator(
+                new ProviderCodeGeneratorDependencies(
+                    Enumerable.Empty<IProviderCodeGeneratorPlugin>()));
 
-            var result = codeGenerator.GenerateUseProvider("Data Source=Test");
+            var result = codeGenerator.GenerateUseProvider("Data Source=Test", providerOptions: null);
 
             Assert.Equal("UseSqlServer", result.Method);
             Assert.Collection(
                 result.Arguments,
                 a => Assert.Equal("Data Source=Test", a));
+            Assert.Null(result.ChainedCall);
+        }
+
+        [Fact]
+        public virtual void Use_provider_method_is_generated_correctly_with_options()
+        {
+            var codeGenerator = new SqlServerCodeGenerator(
+                new ProviderCodeGeneratorDependencies(
+                    Enumerable.Empty<IProviderCodeGeneratorPlugin>()));
+
+            var providerOptions = new MethodCallCodeFragment("SetProviderOption");
+
+            var result = codeGenerator.GenerateUseProvider("Data Source=Test", providerOptions);
+
+            Assert.Equal("UseSqlServer", result.Method);
+            Assert.Collection(
+                result.Arguments,
+                a => Assert.Equal("Data Source=Test", a),
+                a =>
+                {
+                    var nestedClosure = Assert.IsType<NestedClosureCodeFragment>(a);
+
+                    Assert.Equal("x", nestedClosure.Parameter);
+                    Assert.Same(providerOptions, nestedClosure.MethodCall);
+                });
+            Assert.Null(result.ChainedCall);
         }
     }
 }

--- a/test/EFCore.Sqlite.Tests/Scaffolding/SqliteCodeGeneratorTest.cs
+++ b/test/EFCore.Sqlite.Tests/Scaffolding/SqliteCodeGeneratorTest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Linq;
+using Microsoft.EntityFrameworkCore.Design;
 using Microsoft.EntityFrameworkCore.Sqlite.Scaffolding.Internal;
 using Xunit;
 
@@ -11,14 +13,42 @@ namespace Microsoft.EntityFrameworkCore.Scaffolding
         [Fact]
         public virtual void Use_provider_method_is_generated_correctly()
         {
-            var codeGenerator = new SqliteCodeGenerator(new ProviderCodeGeneratorDependencies());
+            var codeGenerator = new SqliteCodeGenerator(
+                new ProviderCodeGeneratorDependencies(
+                    Enumerable.Empty<IProviderCodeGeneratorPlugin>()));
 
-            var result = codeGenerator.GenerateUseProvider("Data Source=Test");
+            var result = codeGenerator.GenerateUseProvider("Data Source=Test", providerOptions: null);
 
             Assert.Equal("UseSqlite", result.Method);
             Assert.Collection(
                 result.Arguments,
                 a => Assert.Equal("Data Source=Test", a));
+            Assert.Null(result.ChainedCall);
+        }
+
+        [Fact]
+        public virtual void Use_provider_method_is_generated_correctly_with_options()
+        {
+            var codeGenerator = new SqliteCodeGenerator(
+                new ProviderCodeGeneratorDependencies(
+                    Enumerable.Empty<IProviderCodeGeneratorPlugin>()));
+
+            var providerOptions = new MethodCallCodeFragment("SetProviderOption");
+
+            var result = codeGenerator.GenerateUseProvider("Data Source=Test", providerOptions);
+
+            Assert.Equal("UseSqlite", result.Method);
+            Assert.Collection(
+                result.Arguments,
+                a => Assert.Equal("Data Source=Test", a),
+                a =>
+                {
+                    var nestedClosure = Assert.IsType<NestedClosureCodeFragment>(a);
+
+                    Assert.Equal("x", nestedClosure.Parameter);
+                    Assert.Same(providerOptions, nestedClosure.MethodCall);
+                });
+            Assert.Null(result.ChainedCall);
         }
     }
 }


### PR DESCRIPTION
Manually verified that `UseNetTopologySuite()` is generated correctly.

Fixes #13764

cc @roji 