### PR TITLE
Updating query to allow group-by and joins on indexed properties.

### DIFF
--- a/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
+++ b/src/EFCore.Relational/Query/ExpressionVisitors/SqlTranslatingExpressionVisitor.cs
@@ -610,9 +610,15 @@ namespace Microsoft.EntityFrameworkCore.Query.ExpressionVisitors
         {
             Check.NotNull(methodCallExpression, nameof(methodCallExpression));
 
-            var operand = _queryModelVisitor.QueryCompilationContext.Model.Relational().FindDbFunction(methodCallExpression.Method) != null
-                ? methodCallExpression.Object
-                : Visit(methodCallExpression.Object);
+            // if method is EFIndexer then we need to skip attempting to translate
+            // the method call and fall through to binding the expression below
+            // (this supports joining on an indexed property)
+            var operand =
+                methodCallExpression.Method.IsEFIndexer()
+                ? null
+                :  _queryModelVisitor.QueryCompilationContext.Model.Relational().FindDbFunction(methodCallExpression.Method) != null
+                    ? methodCallExpression.Object
+                    : Visit(methodCallExpression.Object);
 
             if (operand != null
                 || methodCallExpression.Object == null)

--- a/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
+++ b/src/EFCore.Relational/Query/Internal/RelationalResultOperatorHandler.cs
@@ -492,7 +492,16 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
                         break;
 
                     case MethodCallExpression methodCallExpression
-                    when methodCallExpression.IsEFProperty():
+                    when methodCallExpression.IsEFProperty()
+                        || methodCallExpression.Method.IsEFIndexer():
+                        sql = sqlTranslatingExpressionVisitor.Visit(methodCallExpression);
+                        memberInfoMappings[groupByKeyMemberInfo] = sql;
+                        key = new[] { sql };
+                        break;
+
+                    case UnaryExpression unaryExpression
+                    when unaryExpression.RemoveConvert() is MethodCallExpression methodCallExpression
+                        && methodCallExpression.Method.IsEFIndexer():
                         sql = sqlTranslatingExpressionVisitor.Visit(methodCallExpression);
                         memberInfoMappings[groupByKeyMemberInfo] = sql;
                         key = new[] { sql };

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -3609,6 +3609,37 @@ namespace Microsoft.EntityFrameworkCore.Query
                       select c);
         }
 
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Can_group_by_indexed_property_on_query(bool isAsync)
+        {
+            return AssertQueryScalar<City>(
+                isAsync,
+                cs => cs.GroupBy(c => c[City.NationPropertyName]).Select(g => g.Count()));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Can_group_by_converted_indexed_property_on_query(bool isAsync)
+        {
+            return AssertQueryScalar<City>(
+                isAsync,
+                cs => cs.GroupBy(c => (string)c[City.NationPropertyName]).Select(g => g.Count()));
+        }
+
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Can_join_on_indexed_property_on_query(bool isAsync)
+        {
+            return AssertQuery<City>(
+                isAsync,
+                cs =>
+                    (from c1 in cs
+                     join c2 in cs
+                         on c1[City.NationPropertyName] equals c2[City.NationPropertyName]
+                     select new { c1.Name, c2.Location }));
+        }
+
         [ConditionalFact]
         public virtual void Navigation_access_on_derived_entity_using_cast()
         {

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -3834,6 +3834,36 @@ FROM [Cities] AS [c]
 ORDER BY [c].[Nation]");
         }
 
+        public override async Task Can_group_by_indexed_property_on_query(bool isAsync)
+        {
+            await base.Can_group_by_indexed_property_on_query(isAsync);
+
+            AssertSql(
+                @"SELECT COUNT(*)
+FROM [Cities] AS [c]
+GROUP BY [c].[Nation]");
+        }
+
+        public override async Task Can_group_by_converted_indexed_property_on_query(bool isAsync)
+        {
+            await base.Can_group_by_converted_indexed_property_on_query(isAsync);
+
+            AssertSql(
+                @"SELECT COUNT(*)
+FROM [Cities] AS [c]
+GROUP BY [c].[Nation]");
+        }
+
+        public override async Task Can_join_on_indexed_property_on_query(bool isAsync)
+        {
+            await base.Can_join_on_indexed_property_on_query(isAsync);
+
+            AssertSql(
+                @"SELECT [c1].[Name], [c2].[Location]
+FROM [Cities] AS [c1]
+INNER JOIN [Cities] AS [c2] ON [c1].[Nation] = [c2].[Nation]");
+        }
+
         public override void Navigation_access_on_derived_entity_using_cast()
         {
             base.Navigation_access_on_derived_entity_using_cast();


### PR DESCRIPTION
Updating query to allow group-by and joins on indexed properties. This addresses part of issue #13610.