### PR TITLE
Microsoft.Data.Sqlite: Add incremental blob I/O

### DIFF
--- a/Microsoft.Data.Sqlite.sln
+++ b/Microsoft.Data.Sqlite.sln
@@ -60,6 +60,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ResultMetadataSample", "sam
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ScalarFunctionSample", "samples\ScalarFunctionSample\ScalarFunctionSample.csproj", "{4A78B130-96DB-408F-A601-AFDA94347F06}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StreamingSample", "samples\StreamingSample\StreamingSample.csproj", "{62DE9566-0419-4E60-9254-2F455ECEB7E4}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -130,6 +132,10 @@ Global
 		{4A78B130-96DB-408F-A601-AFDA94347F06}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4A78B130-96DB-408F-A601-AFDA94347F06}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4A78B130-96DB-408F-A601-AFDA94347F06}.Release|Any CPU.Build.0 = Release|Any CPU
+		{62DE9566-0419-4E60-9254-2F455ECEB7E4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{62DE9566-0419-4E60-9254-2F455ECEB7E4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{62DE9566-0419-4E60-9254-2F455ECEB7E4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{62DE9566-0419-4E60-9254-2F455ECEB7E4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -151,6 +157,7 @@ Global
 		{C228450F-7EE3-463D-AA64-8AA3CAEDE4CA} = {D30CC1C7-D46C-4640-8CE6-EC9ED34DEDA5}
 		{6A153ED3-5C47-4CFF-8ED5-1B73E8E9667E} = {D30CC1C7-D46C-4640-8CE6-EC9ED34DEDA5}
 		{4A78B130-96DB-408F-A601-AFDA94347F06} = {D30CC1C7-D46C-4640-8CE6-EC9ED34DEDA5}
+		{62DE9566-0419-4E60-9254-2F455ECEB7E4} = {D30CC1C7-D46C-4640-8CE6-EC9ED34DEDA5}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DF78D8CC-5604-4059-9EFB-291E2629523E}

--- a/samples/StreamingSample/Program.cs
+++ b/samples/StreamingSample/Program.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+
+namespace StreamingSample
+{
+    class Program
+    {
+        static async Task Main()
+        {
+            var connection = new SqliteConnection("Data Source=StreamingSample.db");
+            connection.Open();
+
+            var createCommand = connection.CreateCommand();
+            createCommand.CommandText =
+            @"
+                CREATE TABLE data (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    value BLOB
+                )
+            ";
+            createCommand.ExecuteNonQuery();
+
+            // You can reduce memory usage while reading and writing large objects by streaming
+            // the data into and out of the database. This can be especially useful when
+            // parsing or transforming the data
+
+            using (var inputStream = File.OpenRead("input.txt"))
+            {
+                // Start by inserting a row as normal. Use the zeroblob() function to allocate
+                // space in the database for the large object. The last_insert_rowid() function
+                // provides a convenient way to get its rowid
+                var insertCommand = connection.CreateCommand();
+                insertCommand.CommandText =
+                @"
+                    INSERT INTO data(value)
+                    VALUES (zeroblob($length));
+
+                    SELECT last_insert_rowid();
+                ";
+                insertCommand.Parameters.AddWithValue("$length", inputStream.Length);
+                var rowid = (long)insertCommand.ExecuteScalar();
+
+                // After inserting the row, open a stream to write the large object
+                using (var writeStream = new SqliteBlob(connection, "data", "value", rowid, writable: true))
+                {
+                    Console.WriteLine("Writing the large object...");
+
+                    // NB: Although SQLite doesn't support async, other types of streams do
+                    await inputStream.CopyToAsync(writeStream);
+                }
+            }
+
+            using (var outputStream = Console.OpenStandardOutput())
+            {
+                // To stream the large object, you must select the rowid or one of its aliases as
+                // show here in addition to the large object's column. If you don't, the entire
+                // object will be loaded into memory
+                var selectCommand = connection.CreateCommand();
+                selectCommand.CommandText =
+                @"
+                    SELECT id, value
+                    FROM data
+                    LIMIT 1
+                ";
+                using (var reader = selectCommand.ExecuteReader())
+                {
+                    while (reader.Read())
+                    {
+                        using (var readStream = reader.GetStream(1))
+                        {
+                            Console.WriteLine("Reading the large object...");
+                            await readStream.CopyToAsync(outputStream);
+                        }
+                    }
+                }
+            }
+
+            // Clean up
+            connection.Close();
+            File.Delete("StreamingSample.db");
+        }
+    }
+}

--- a/samples/StreamingSample/StreamingSample.csproj
+++ b/samples/StreamingSample/StreamingSample.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Data.Sqlite.Core\Microsoft.Data.Sqlite.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SQLitePCLRaw.bundle_green" Version="$(SQLitePCLRawBundleGreenPackageVersion)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="input.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/samples/StreamingSample/input.txt
+++ b/samples/StreamingSample/input.txt
@@ -1,0 +1,1 @@
+This isn't really a large object, but you get the idea.

--- a/src/Microsoft.Data.Sqlite.Core/Properties/Resources.Designer.cs
+++ b/src/Microsoft.Data.Sqlite.Core/Properties/Resources.Designer.cs
@@ -236,6 +236,12 @@ namespace Microsoft.Data.Sqlite.Properties
                 GetString("UDFCalledWithNull", nameof(function), nameof(ordinal)),
                 function, ordinal);
 
+        /// <summary>
+        /// SqliteBlob can only be used when the connection is open.
+        /// </summary>
+        public static string SqlBlobRequiresOpenConnection
+            => GetString("SqlBlobRequiresOpenConnection");
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/Microsoft.Data.Sqlite.Core/Properties/Resources.resx
+++ b/src/Microsoft.Data.Sqlite.Core/Properties/Resources.resx
@@ -210,4 +210,7 @@
   <data name="UDFCalledWithNull" xml:space="preserve">
     <value>The SQL function '{function}' was called with a NULL argument at ordinal {ordinal}. Create the function using a Nullable parameter or rewrite your query to avoid passing NULL.</value>
   </data>
+  <data name="SqlBlobRequiresOpenConnection" xml:space="preserve">
+    <value>SqliteBlob can only be used when the connection is open.</value>
+  </data>
 </root>

--- a/src/Microsoft.Data.Sqlite.Core/SqliteBlob.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteBlob.cs
@@ -1,0 +1,233 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using SQLitePCL;
+
+namespace Microsoft.Data.Sqlite
+{
+    /// <summary>
+    /// Provides methods to access the contents of a BLOB.
+    /// </summary>
+    public class SqliteBlob : Stream
+    {
+        private const string MainDatabaseName = "main";
+
+        private readonly sqlite3_blob _blob;
+        private readonly sqlite3 _db;
+        private readonly bool _writable;
+        private readonly long _length;
+        private bool _disposed = false;
+        private int _position = 0;
+
+        /// <summary>
+        /// Gets the length of the BLOB in bytes.
+        /// </summary>
+        /// <value>Length of the BLOB in bytes.</value>
+        public override long Length => _length;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqliteBlob"/> class.
+        /// </summary>
+        /// <param name="connection">Sqlite connection to be used.</param>
+        /// <param name="tableName">The table name.</param>
+        /// <param name="columnName">The column name.</param>
+        /// <param name="rowid">The row index.</param>
+        /// <param name="writable">Flag indicating whether the blob can be written to.</param>
+        /// <returns>Object to access the BLOB.</returns>
+        public SqliteBlob(SqliteConnection connection, string tableName, string columnName, long rowid, bool writable) :
+            this(connection, MainDatabaseName, tableName, columnName, rowid, writable)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SqliteBlob"/> class.
+        /// </summary>
+        /// <param name="connection">Sqlite connection to be used.</param>
+        /// <param name="databaseName">The name of the database ('main' is default table).</param>
+        /// <param name="tableName">The table name.</param>
+        /// <param name="columnName">The column name.</param>
+        /// <param name="rowid">The row index.</param>
+        /// <param name="writable">Flag indicating whether the blob can be written to.</param>
+        /// <returns>Object to access the BLOB.</returns>
+        public SqliteBlob(SqliteConnection connection, string databaseName, string tableName, string columnName, long rowid, bool writable)
+        {
+            _db = connection.Handle;
+            _writable = writable;
+            var rc = raw.sqlite3_blob_open(_db, databaseName, tableName, columnName, rowid, writable ? 1 : 0, out _blob);
+            SqliteException.ThrowExceptionForRC(rc, _db);
+            _length = raw.sqlite3_blob_bytes(_blob);
+        }
+
+        private SqliteBlob() => throw new NotSupportedException();
+
+        /// <summary>
+        /// Gets a value indicating whether the current stream supports reading.
+        /// </summary>
+        /// <value>true if the stream supports reading; otherwise, false.</value>
+        public override bool CanRead => true;
+
+        /// <summary>
+        /// Gets a value indicating whether the current stream supports writing.
+        /// </summary>
+        /// <value>true if the stream supports writing; otherwise, false.</value>
+        public override bool CanWrite => _writable;
+
+        /// <summary>
+        /// Gets a value indicating whether the current stream supports seeking.
+        /// </summary>
+        /// <value>true if the stream supports seeking; otherwise, false.</value>
+        public override bool CanSeek { get; }
+
+        /// <summary>
+        /// Gets or sets the position within the current stream.
+        /// </summary>
+        /// <value>The current position within the stream.</value>
+        public override long Position
+        {
+            get => _position;
+            set => _position = (int)value;
+        }
+
+        /// <summary>
+        /// Reads a sequence of bytes from the current stream and advances the position
+        /// within the stream by the number of bytes read.
+        /// </summary>
+        /// <param name="buffer">An array of bytes. When this method returns, the buffer contains the specified byte array
+        /// with the values between offset and (offset + count - 1) replaced by the bytes read from the current source.</param>
+        /// <param name="offset">The zero-based byte offset in buffer at which to begin storing the data read from the current stream.</param>
+        /// <param name="count">The maximum number of bytes to be read from the current stream.</param>
+        /// <returns>The total number of bytes read into the buffer.</returns>
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+            if (offset < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(offset));
+            }
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+            if (offset + count > buffer.Length)
+            {
+                throw new ArgumentException("The sum of offset and count is larger than the buffer length.");
+            }
+
+            if (_position + count > Length)
+            {
+                count = (int)(Length - _position);
+                if (count == 0)
+                {
+                    return 0;
+                }
+            }
+
+            var rc = raw.sqlite3_blob_read(_blob, buffer, offset, count, _position);
+            SqliteException.ThrowExceptionForRC(rc, _db);
+            _position += count;
+            return count;
+        }
+
+        /// <summary>
+        /// Writes a sequence of bytes to the current stream and advances the current position
+        /// within this stream by the number of bytes written.
+        /// </summary>
+        /// <param name="buffer">An array of bytes. This method copies count bytes from buffer to the current stream.</param>
+        /// <param name="offset">The zero-based byte offset in buffer at which to begin copying bytes to the current stream.</param>
+        /// <param name="count">The number of bytes to be written to the current stream.</param>
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            if (!_writable)
+            {
+                throw new InvalidOperationException("Blob is not openned as writable!");
+            }
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+            if (offset < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(offset));
+            }
+            if (count < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(count));
+            }
+            if (offset + count > buffer.Length)
+            {
+                throw new ArgumentException("The sum of offset and count is larger than the buffer length.");
+            }
+
+            var rc = raw.sqlite3_blob_write(_blob, buffer, count, _position);
+            SqliteException.ThrowExceptionForRC(rc, _db);
+            _position += count;
+        }
+
+        /// <summary>
+        ///  Sets the position within the current stream.
+        /// </summary>
+        /// <param name="offset">A byte offset relative to the origin parameter.</param>
+        /// <param name="origin">A value indicating the reference point used to obtain the new position.</param>
+        /// <returns>The new position within the current stream.</returns>
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            switch (origin)
+            {
+                case SeekOrigin.Begin:
+                    _position = (int)offset;
+                    break;
+                case SeekOrigin.Current:
+                    _position += (int)offset;
+                    break;
+                case SeekOrigin.End:
+                    _position = (int)(Length - offset);
+                    break;
+                default:
+                    throw new ArgumentException("Invalid value: " + origin, nameof(origin));
+            }
+
+            return _position;
+        }
+
+        /// <summary>
+        ///     Releases any resources used by the BLOB and closes it.
+        /// </summary>
+        /// <param name="disposing">
+        ///     true to release managed and unmanaged resources; false to release only unmanaged resources.
+        /// </param>
+        protected override void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                raw.sqlite3_blob_close(_blob);
+                _disposed = true;
+                base.Dispose(disposing);
+            }
+        }
+
+        /// <summary>
+        /// Finalizes an instance of the <see cref="SqliteBlob"/> class.
+        /// </summary>
+        ~SqliteBlob()
+        {
+            Dispose(false);
+        }
+
+        /// <summary>
+        /// Clears all buffers for this stream and causes any buffered data to be written to the underlying device.
+        /// Is a noop in this case.
+        /// </summary>
+        public override void Flush() { }
+
+        /// <summary>
+        /// Sets the length of the current stream. This is not supported by sqlite blobs.
+        /// </summary>
+        /// <param name="value">The desired length of the current stream in bytes.</param>
+        public override void SetLength(long value) => throw new NotSupportedException("Blob cannot be resized.");
+    }
+}

--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Data.Sqlite
             if (stmtQueue.Count != 0)
             {
                 (_stmt, _hasRows) = stmtQueue.Dequeue();
-                _record = new SqliteDataRecord(_stmt);
+                _record = new SqliteDataRecord(_stmt, command.Connection);
             }
 
             _command = command;
@@ -154,7 +154,7 @@ namespace Microsoft.Data.Sqlite
             raw.sqlite3_reset(_stmt);
 
             (_stmt, _hasRows) = _stmtQueue.Dequeue();
-            _record = new SqliteDataRecord(_stmt);
+            _record = new SqliteDataRecord(_stmt, _command.Connection);
             _stepped = false;
             _done = false;
 
@@ -412,7 +412,16 @@ namespace Microsoft.Data.Sqlite
         /// <param name="ordinal">The zero-based column ordinal.</param>
         /// <returns>The returned object.</returns>
         public override Stream GetStream(int ordinal)
-            => _record.GetStream(ordinal);
+            => GetStream(ordinal, false);
+
+        /// <summary>
+        ///     Retrieves data as a Stream.
+        /// </summary>
+        /// <param name="ordinal">The zero-based column ordinal.</param>
+        /// <param name="writable">Flag indicating, whether the stream can be written to.</param>
+        /// <returns>The returned object.</returns>
+        public virtual Stream GetStream(int ordinal, bool writable)
+            => _record.GetStream(ordinal, writable);
 
         /// <summary>
         ///     Gets the value of the specified column.

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteBlobTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteBlobTest.cs
@@ -1,0 +1,428 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.IO;
+using Microsoft.Data.Sqlite.Properties;
+using SQLitePCL;
+using Xunit;
+
+namespace Microsoft.Data.Sqlite
+{
+    public class SqliteBlobTest : IDisposable
+    {
+        private const string Table = "data";
+        private const string Column = "value";
+        private const long Rowid = 1;
+
+        private readonly SqliteConnection _connection = new SqliteConnection("Data Source=:memory:");
+
+        public SqliteBlobTest()
+        {
+            _connection.Open();
+            _connection.ExecuteNonQuery(
+                "CREATE TABLE " + Table + " (" + Column + " BLOB);" +
+                "INSERT INTO " + Table + " (rowid, " + Column + ") VALUES (" + Rowid + ", X'0102');");
+        }
+
+        [Fact]
+        public void Ctor_throws_when_connection_closed()
+        {
+            var connection = new SqliteConnection();
+
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => new SqliteBlob(connection, Table, Column, Rowid, writable: false));
+            Assert.Equal(Resources.SqlBlobRequiresOpenConnection, ex.Message);
+        }
+
+        [Fact]
+        public void Ctor_throws_when_error()
+        {
+            var ex = Assert.Throws<SqliteException>(
+                () => new SqliteBlob(_connection, "UnknownTable", Column, Rowid, writable: false));
+            Assert.Equal(raw.SQLITE_ERROR, ex.SqliteErrorCode);
+        }
+
+        [Fact]
+        public void Ctor_throws_when_table_null()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(
+                () => new SqliteBlob(_connection, null, Column, Rowid, writable: false));
+            Assert.Equal("tableName", ex.ParamName);
+        }
+
+        [Fact]
+        public void Ctor_throws_when_column_null()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(
+                () => new SqliteBlob(_connection, Table, null, Rowid, writable: false));
+            Assert.Equal("columnName", ex.ParamName);
+        }
+
+        [Fact]
+        public void CanRead_works()
+        {
+            using (var stream = CreateStream())
+            {
+                Assert.True(stream.CanRead);
+            }
+        }
+
+        [Fact]
+        public void CanSeek_works()
+        {
+            using (var stream = CreateStream())
+            {
+                Assert.True(stream.CanSeek);
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void CanWrite_works(bool writable)
+        {
+            using (var stream = CreateStream(writable))
+            {
+                Assert.Equal(writable, stream.CanWrite);
+            }
+        }
+
+        [Fact]
+        public void Length_works()
+        {
+            using (var stream = CreateStream())
+            {
+                Assert.Equal(2, stream.Length);
+            }
+        }
+
+        [Fact]
+        public void Position_throws_when_negative()
+        {
+            using (var stream = CreateStream())
+            {
+                var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                    () => stream.Position = -1);
+                Assert.Equal("value", ex.ParamName);
+            }
+        }
+
+        [Fact]
+        public void Flush_works()
+        {
+            using (var stream = CreateStream())
+            {
+                stream.Flush();
+            }
+        }
+
+        [Theory]
+        [InlineData(0, new byte[] { }, 0, 0, 0)]
+        [InlineData(0, new byte[] { 0 }, 0, 0, 0)]
+        [InlineData(0, new byte[] { 0 }, 2, 0, 1)]
+        [InlineData(0, new byte[] { 0 }, 3, 0, 1)]
+        [InlineData(1, new byte[] { 1 }, 0, 0, 1)]
+        [InlineData(1, new byte[] { 1, 0 }, 0, 0, 1)]
+        [InlineData(1, new byte[] { 2 }, 1, 0, 1)]
+        [InlineData(1, new byte[] { 2, 0 }, 1, 0, 2)]
+        [InlineData(1, new byte[] { 0, 1 }, 0, 1, 1)]
+        public void Read_works(
+            int expectedBytesRead,
+            byte[] expectedBuffer,
+            long initialPosition,
+            int offset,
+            int count)
+        {
+            using (var stream = CreateStream())
+            {
+                stream.Position = initialPosition;
+                var buffer = new byte[expectedBuffer.Length];
+
+                var bytesRead = stream.Read(buffer, offset, count);
+
+                Assert.Equal(expectedBytesRead, bytesRead);
+                Assert.Equal(expectedBuffer, buffer);
+                Assert.Equal(initialPosition + bytesRead, stream.Position);
+            }
+        }
+
+        [Fact]
+        public void Read_throws_when_buffer_null()
+        {
+            using (var stream = CreateStream())
+            {
+                var ex = Assert.Throws<ArgumentNullException>(
+                    () => stream.Read(null, 0, 1));
+
+                Assert.Equal(ex.ParamName, "buffer");
+            }
+        }
+
+        [Fact]
+        public void Read_throws_when_offset_negative()
+        {
+            using (var stream = CreateStream())
+            {
+                var buffer = new byte[1];
+
+                var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                    () => stream.Read(buffer, -1, 1));
+                Assert.Equal(ex.ParamName, "offset");
+            }
+        }
+
+        [Fact]
+        public void Read_throws_when_offset_out_of_range()
+        {
+            using (var stream = CreateStream())
+            {
+                var buffer = new byte[1];
+
+                var ex = Assert.Throws<ArgumentException>(
+                    () => stream.Read(buffer, 1, 1));
+                Assert.Null(ex.ParamName);
+                Assert.Equal("The sum of offset and count is larger than the buffer length.", ex.Message);
+            }
+        }
+
+        [Fact]
+        public void Read_throws_when_count_negative()
+        {
+            using (var stream = CreateStream())
+            {
+                var buffer = new byte[1];
+
+                var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                    () => stream.Read(buffer, 0, -1));
+                Assert.Equal(ex.ParamName, "count");
+            }
+        }
+
+        [Fact]
+        public void Read_throws_when_count_out_of_range()
+        {
+            using (var stream = CreateStream())
+            {
+                var buffer = new byte[1];
+
+                var ex = Assert.Throws<ArgumentException>(
+                    () => stream.Read(buffer, 0, 2));
+
+                Assert.Null(ex.ParamName);
+                Assert.Equal("The sum of offset and count is larger than the buffer length.", ex.Message);
+            }
+        }
+
+        [Fact]
+        public void Read_throws_when_disposed()
+        {
+            var buffer = new byte[1];
+
+            var stream = CreateStream();
+            stream.Dispose();
+
+            var ex = Assert.Throws<ObjectDisposedException>(
+                () => stream.Read(buffer, 0, 1));
+        }
+
+        [Theory]
+        [InlineData(0, 1, 0, SeekOrigin.Begin)]
+        [InlineData(1, 1, 1, SeekOrigin.Begin)]
+        [InlineData(3, 1, 3, SeekOrigin.Begin)]
+        [InlineData(0, 1, -1, SeekOrigin.Current)]
+        [InlineData(1, 1, 0, SeekOrigin.Current)]
+        [InlineData(2, 1, 1, SeekOrigin.Current)]
+        [InlineData(3, 1, 2, SeekOrigin.Current)]
+        [InlineData(1, 1, -1, SeekOrigin.End)]
+        [InlineData(2, 1, 0, SeekOrigin.End)]
+        [InlineData(3, 1, 1, SeekOrigin.End)]
+        public void Seek_works(
+            long expected,
+            long initialPosition,
+            long offset,
+            SeekOrigin origin)
+        {
+
+            using (var stream = CreateStream())
+            {
+                stream.Position = initialPosition;
+
+                var position = stream.Seek(offset, origin);
+
+                Assert.Equal(expected, stream.Position);
+                Assert.Equal(stream.Position, position);
+            }
+        }
+
+        [Theory]
+        [InlineData(0, 1, -1, SeekOrigin.Begin)]
+        [InlineData(0, 1, -2, SeekOrigin.Current)]
+        [InlineData(0, 1, -3, SeekOrigin.End)]
+        public void Seek_throws_when_negative(
+            long expected,
+            long initialPosition,
+            long offset,
+            SeekOrigin origin)
+        {
+            using (var stream = CreateStream())
+            {
+                stream.Position = initialPosition;
+
+                var ex = Assert.Throws<IOException>(
+                    () => stream.Seek(offset, origin));
+                Assert.Equal("An attempt was made to move the position before the beginning of the stream.", ex.Message);
+            }
+        }
+
+        [Fact]
+        public void Seek_validates_origin()
+        {
+            using (var stream = CreateStream())
+            {
+                var ex = Assert.Throws<ArgumentException>(
+                    () => stream.Seek(0, (SeekOrigin)(-1)));
+                Assert.Equal("origin", ex.ParamName);
+                Assert.Contains("Invalid value: -1", ex.Message);
+            }
+        }
+
+        [Fact]
+        public void SetLength_throws()
+        {
+            using (var stream = CreateStream(writable: true))
+            {
+                var ex = Assert.Throws<NotSupportedException>(
+                    () => stream.SetLength(1));
+                Assert.Equal("Blob cannot be resized.", ex.Message);
+            }
+        }
+
+        [Theory]
+        [InlineData(new byte[] { 3, 4 }, 0, new byte[] { 3, 4 }, 0, 2)]
+        [InlineData(new byte[] { 3, 2 }, 0, new byte[] { 3, 4 }, 0, 1)]
+        [InlineData(new byte[] { 4, 2 }, 0, new byte[] { 3, 4 }, 1, 1)]
+        [InlineData(new byte[] { 1, 3 }, 1, new byte[] { 3 }, 0, 1)]
+        [InlineData(new byte[] { 1, 2 }, 0, new byte[] { }, 0, 0)]
+        [InlineData(new byte[] { 1, 2 }, 2, new byte[] { }, 0, 0)]
+        [InlineData(new byte[] { 1, 2 }, 3, new byte[] { }, 0, 0)]
+        [InlineData(new byte[] { 1, 2 }, 0, new byte[] { 3 }, 1, 0)]
+        public void Write_works(
+            byte[] expected,
+            long initialPosition,
+            byte[] buffer,
+            int offset,
+            int count)
+        {
+            using (var stream = CreateStream(writable: true))
+            {
+                stream.Position = initialPosition;
+                stream.Write(buffer, offset, count);
+
+                Assert.Equal(initialPosition + count, stream.Position);
+            }
+
+            Assert.Equal(
+                expected,
+                _connection.ExecuteScalar<byte[]>(
+                    $"SELECT {Column} FROM {Table} WHERE rowid = {Rowid}"));
+        }
+
+        [Fact]
+        public void Write_throws_when_buffer_null()
+        {
+            using (var stream = CreateStream(writable: true))
+            {
+                var ex = Assert.Throws<ArgumentNullException>(
+                    () => stream.Write(null, 0, 0));
+                Assert.Equal("buffer", ex.ParamName);
+            }
+        }
+
+        [Fact]
+        public void Write_throws_when_count_out_of_range()
+        {
+            using (var stream = CreateStream(writable: true))
+            {
+                var ex = Assert.Throws<ArgumentException>(
+                    () => stream.Write(new byte[] { 3 }, 0, 2));
+                Assert.Null(ex.ParamName);
+                Assert.Equal("The sum of offset and count is larger than the buffer length.", ex.Message);
+            }
+        }
+
+        [Fact]
+        public void Write_throws_when_count_negative()
+        {
+            using (var stream = CreateStream(writable: true))
+            {
+                var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                    () => stream.Write(Array.Empty<byte>(), 0, -1));
+                Assert.Equal("count", ex.ParamName);
+            }
+        }
+
+        [Fact]
+        public void Write_throws_when_offset_out_of_range()
+        {
+            using (var stream = CreateStream(writable: true))
+            {
+                var ex = Assert.Throws<ArgumentException>(
+                    () => stream.Write(new byte[] { 3 }, 1, 1));
+                Assert.Null(ex.ParamName);
+                Assert.Equal("The sum of offset and count is larger than the buffer length.", ex.Message);
+            }
+        }
+
+        [Fact]
+        public void Write_throws_when_offset_negative()
+        {
+            using (var stream = CreateStream(writable: true))
+            {
+                var ex = Assert.Throws<ArgumentOutOfRangeException>(
+                    () => stream.Write(new byte[] { 3, 4 }, -1, 2));
+                Assert.Equal("offset", ex.ParamName);
+            }
+        }
+
+        [Fact]
+        public void Write_throws_when_position_at_end_of_stream()
+        {
+            using (var stream = CreateStream(writable: true))
+            {
+                stream.Position = 2;
+                var ex = Assert.Throws<NotSupportedException>(
+                    () => stream.Write(new byte[] { 3 }, 0, 1));
+                Assert.Equal("Blob cannot be resized.", ex.Message);
+            }
+        }
+
+        [Fact]
+        public void Write_throws_when_not_writable()
+        {
+            using (var stream = CreateStream(writable: false))
+            {
+                var ex = Assert.Throws<NotSupportedException>(
+                    () => stream.Write(new byte[] { 1 }, 0, 1));
+
+                Assert.Equal("Blob is not openned as writable!", ex.Message);
+            }
+        }
+
+        [Fact]
+        public void Write_throws_when_disposed()
+        {
+            var stream = CreateStream(writable: true);
+            stream.Dispose();
+
+            var ex = Assert.Throws<ObjectDisposedException>(
+                () => stream.Write(new byte[] { 3 }, 0, 1));
+        }
+
+        protected Stream CreateStream(bool writable = false)
+            => new SqliteBlob(_connection, Table, Column, Rowid, writable);
+
+        public void Dispose()
+            => _connection.Dispose();
+    }
+}

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionTest.cs
@@ -235,57 +235,6 @@ namespace Microsoft.Data.Sqlite
         }
 
         [Fact]
-        public void OpenBlob_works()
-        {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-
-                connection.ExecuteNonQuery(
-                    "CREATE TABLE DataTable (Id INTEGER PRIMARY KEY, Data BLOB);" +
-                    "INSERT INTO DataTable VALUES (5, X'01020304');");
-
-                var command = connection.CreateCommand();
-                command.CommandText = "INSERT INTO DataTable VALUES (@Id, zeroblob(@BlobSize));";
-                command.Parameters.AddWithValue("@Id", 7);
-                command.Parameters.AddWithValue("@BlobSize", 5);
-                command.ExecuteNonQuery();
-
-                using (var blob = new SqliteBlob(connection, "main", "DataTable", "Data", 5, writable: true))
-                {
-                    Assert.Equal(4, blob.Length);
-                    var buffer = new byte[2];
-                    blob.Position = 1;
-                    blob.Read(buffer, 0, 2);
-                    Assert.Equal(new byte[2] { 0x02, 0x03 }, buffer);
-                    buffer = new byte[2] { 0x42, 0x43 };
-                    blob.Seek(1, SeekOrigin.Begin);
-                    blob.Write(buffer, 0, 2);
-                    buffer = new byte[4];
-                    blob.Seek(-3, SeekOrigin.Current);
-                    blob.Read(buffer, 0, 4);
-                    Assert.Equal(new byte[4] { 0x01, 0x42, 0x43, 0x04 }, buffer);
-                }
-
-                // TODO: when sqlite3_blob_reopen is added to SQLitePCL.raw add possibility to change the rowid
-                using (var blob = new SqliteBlob(connection, "main", "DataTable", "Data", 7, writable: true))
-                {
-                    Assert.Equal(5, blob.Length);
-                    var buffer = new byte[5];
-                    blob.Read(buffer, 0, 5);
-                    Assert.Equal(new byte[5] { 0, 0, 0, 0, 0 }, buffer);
-                    blob.Seek(0, SeekOrigin.Begin);
-                    var writeBuffer = new byte[5] { 0x10, 0x20, 0x30, 0x40, 0x50 };
-                    blob.Write(writeBuffer, 0, 5);
-                    buffer = new byte[5];
-                    blob.Seek(0, SeekOrigin.Begin);
-                    blob.Read(buffer, 0, 5);
-                    Assert.Equal(writeBuffer, buffer);
-                }
-            }
-        }
-
-        [Fact]
         public void BackupDatabase_works()
         {
             using (var connection1 = new SqliteConnection("Data Source=:memory:"))

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteDataReaderTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.IO;
 using Microsoft.Data.Sqlite.Properties;
 using Xunit;
 
@@ -213,6 +214,134 @@ namespace Microsoft.Data.Sqlite
                     var stream2 = reader.GetStream(0);
                     Assert.Equal(0x42, stream2.ReadByte());
                     Assert.Equal(0x7E, stream.ReadByte());
+                }
+            }
+        }
+
+        [Fact]
+        public void GetStream_throws_blob_cannot_be_opened_as_writeable()
+        {
+            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            {
+                connection.Open();
+
+                using (var reader = connection.ExecuteReader("SELECT x'427E5743';"))
+                {
+                    var hasData = reader.Read();
+                    Assert.True(hasData);
+
+                    Assert.Throws<InvalidOperationException>(() => reader.GetStream(0, true));
+                }
+            }
+        }
+
+        [Fact]
+        public void GetStream_works_with_text()
+        {
+            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            {
+                connection.Open();
+                
+                using (var reader = connection.ExecuteReader("SELECT 'abcdefghi';"))
+                {
+                    var hasData = reader.Read();
+                    Assert.True(hasData);
+
+                    var stream = reader.GetStream(0);
+                    Assert.Equal((byte)'a', stream.ReadByte());
+                    var stream2 = reader.GetStream(0);
+                    Assert.Equal((byte)'a', stream2.ReadByte());
+                    Assert.Equal((byte)'b', stream.ReadByte());
+                }
+            }
+        }
+
+        [Fact]
+        public void GetStream_works_with_int()
+        {
+            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            {
+                connection.Open();
+                
+                using (var reader = connection.ExecuteReader("SELECT 12;"))
+                {
+                    var hasData = reader.Read();
+                    Assert.True(hasData);
+
+                    var stream = reader.GetStream(0);
+                    Assert.Equal((byte)'1', stream.ReadByte());
+                    var stream2 = reader.GetStream(0);
+                    Assert.Equal((byte)'1', stream2.ReadByte());
+                    Assert.Equal((byte)'2', stream.ReadByte());
+                }
+            }
+        }
+
+
+        [Fact]
+        public void GetStream_works_with_float()
+        {
+            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            {
+                connection.Open();
+
+                using (var reader = connection.ExecuteReader("SELECT 1.2;"))
+                {
+                    var hasData = reader.Read();
+                    Assert.True(hasData);
+
+                    var stream = reader.GetStream(0);
+                    Assert.Equal((byte)'1', stream.ReadByte());
+                    var stream2 = reader.GetStream(0);
+                    Assert.Equal((byte)'1', stream2.ReadByte());
+                    Assert.Equal((byte)'.', stream.ReadByte());
+                    Assert.Equal((byte)'2', stream.ReadByte());
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("CREATE TABLE DataTable (Id INTEGER, Data BLOB);", "SELECT rowid, Data FROM DataTable WHERE Id = 7")]
+        [InlineData("CREATE TABLE DataTable (Id INTEGER PRIMARY KEY, Data BLOB);", "SELECT rowid, Data FROM DataTable WHERE Id = 7")]
+        [InlineData("CREATE TABLE DataTable (Id INTEGER PRIMARY KEY, Data BLOB);", "SELECT Id, Data FROM DataTable WHERE Id = 7")]
+        public void GetStream_Blob_works(string createTableCmd, string selectCmd)
+        {
+            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            {
+                connection.Open();
+
+                connection.ExecuteNonQuery(
+                    createTableCmd + "INSERT INTO DataTable VALUES (5, X'01020304');");
+
+                var command = connection.CreateCommand();
+                command.CommandText = "INSERT INTO DataTable VALUES (@Id, zeroblob(@BlobSize));";
+                command.Parameters.AddWithValue("@Id", 7);
+                command.Parameters.AddWithValue("@BlobSize", 5);
+                command.ExecuteNonQuery();
+
+                var writeBuffer = new byte[5] { 0x10, 0x20, 0x30, 0x40, 0x50 };
+                var testBuffer = new byte[6] { writeBuffer[0], writeBuffer[1], writeBuffer[2], writeBuffer[3], writeBuffer[4], 0x00 };
+
+                var selectCommand = connection.CreateCommand();
+                selectCommand.CommandText = selectCmd;
+                using (var reader = selectCommand.ExecuteReader())
+                {
+                    Assert.True(reader.Read());
+                    using (var destinationStream = reader.GetStream(1, writable: true))
+                    {
+                        Assert.True(destinationStream is SqliteBlob);
+                        var sourceStream = new MemoryStream(writeBuffer);
+                        sourceStream.CopyTo(destinationStream);
+                    }
+                }
+
+                using (var reader = selectCommand.ExecuteReader())
+                {
+                    Assert.True(reader.Read());
+                    var buffer = new byte[6];
+                    var bytesRead = reader.GetBytes(1, 0, buffer, 0, buffer.Length);
+                    Assert.Equal(5, bytesRead);
+                    Assert.Equal(testBuffer, buffer);
                 }
             }
         }


### PR DESCRIPTION
Adds incremental blob I/O to Microsoft.Data.Sqlite. 
Already presented as PR https://github.com/aspnet/Microsoft.Data.Sqlite/pull/501.
Fixes #13824 
