### PR TITLE
RelationalConnection._activeQueries MemoryLeak Fix

### DIFF
--- a/src/EFCore.Relational/Query/Internal/AsyncQueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/AsyncQueryingEnumerable.cs
@@ -222,6 +222,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                             _relationalQueryContext.Connection?.Close();
                         }
+                        _relationalQueryContext.Connection?.UnregisterBufferable(this);
 
                         _disposed = true;
                     }

--- a/src/EFCore.Relational/Query/Internal/QueryingEnumerable.cs
+++ b/src/EFCore.Relational/Query/Internal/QueryingEnumerable.cs
@@ -209,6 +209,7 @@ namespace Microsoft.EntityFrameworkCore.Query.Internal
 
                         _relationalQueryContext.Connection?.Close();
                     }
+                    _relationalQueryContext.Connection?.UnregisterBufferable(this);
 
                     _disposed = true;
                 }

--- a/src/EFCore.Relational/Storage/IRelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/IRelationalConnection.cs
@@ -92,6 +92,12 @@ namespace Microsoft.EntityFrameworkCore.Storage
         void RegisterBufferable([NotNull] IBufferable bufferable);
 
         /// <summary>
+        ///     Unregisters a potentially bufferable active query.
+        /// </summary>
+        /// <param name="bufferable"> The bufferable query. </param>
+        void UnregisterBufferable([NotNull] IBufferable bufferable);
+
+        /// <summary>
         ///     Asynchronously registers a potentially bufferable active query.
         /// </summary>
         /// <param name="bufferable"> The bufferable query. </param>

--- a/src/EFCore.Relational/Storage/RelationalConnection.cs
+++ b/src/EFCore.Relational/Storage/RelationalConnection.cs
@@ -638,6 +638,21 @@ namespace Microsoft.EntityFrameworkCore.Storage
         }
 
         /// <summary>
+        ///     Unregisters a potentially bufferable active query.
+        /// </summary>
+        /// <param name="bufferable"> The bufferable query. </param>
+        void IRelationalConnection.UnregisterBufferable(IBufferable bufferable)
+        {
+            // hot path
+            Debug.Assert(bufferable != null);
+
+            if (!IsMultipleActiveResultSetsEnabled)
+            {
+                _activeQueries.Remove(bufferable);
+            }
+        }
+
+        /// <summary>
         ///     Asynchronously registers a potentially bufferable active query.
         /// </summary>
         /// <param name="bufferable"> The bufferable query. </param>

--- a/src/EFCore.Relational/breakingchanges.netcore
+++ b/src/EFCore.Relational/breakingchanges.netcore
@@ -1,0 +1,7 @@
+[
+     {
+       "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
+       "MemberId": "System.Void UnregisterBufferable(Microsoft.EntityFrameworkCore.Query.Internal.IBufferable bufferable)",
+       "Kind": "Addition"
+     }
+]

--- a/src/EFCore.Relational/breakingchanges.netcore
+++ b/src/EFCore.Relational/breakingchanges.netcore
@@ -1,7 +1,0 @@
-[
-     {
-       "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
-       "MemberId": "System.Void UnregisterBufferable(Microsoft.EntityFrameworkCore.Query.Internal.IBufferable bufferable)",
-       "Kind": "Addition"
-     }
-]

--- a/src/EFCore.Relational/breakingchanges.netcore.json
+++ b/src/EFCore.Relational/breakingchanges.netcore.json
@@ -1,0 +1,7 @@
+[
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
+    "MemberId": "System.Void UnregisterBufferable(Microsoft.EntityFrameworkCore.Query.Internal.IBufferable bufferable)",
+    "Kind": "Addition"
+  }
+]

--- a/src/EFCore.Relational/breakingchanges.netcore.json
+++ b/src/EFCore.Relational/breakingchanges.netcore.json
@@ -1,7 +1,7 @@
 [
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
-    "MemberId": "System.Void UnregisterBufferable(Microsoft.EntityFrameworkCore.Query.Internal.IBufferable bufferable)",
-    "Kind": "Addition"
-  }
+     {
+       "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
+       "MemberId": "System.Void UnregisterBufferable(Microsoft.EntityFrameworkCore.Query.Internal.IBufferable bufferable)",
+       "Kind": "Addition"
+     }
 ]

--- a/src/EFCore.Relational/breakingchanges.netcore.json~HEAD
+++ b/src/EFCore.Relational/breakingchanges.netcore.json~HEAD
@@ -1,7 +1,0 @@
-[
-  {
-    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
-    "MemberId": "System.Void UnregisterBufferable(Microsoft.EntityFrameworkCore.Query.Internal.IBufferable bufferable)",
-    "Kind": "Addition"
-  }
-]

--- a/src/EFCore.Relational/breakingchanges.netcore.json~HEAD
+++ b/src/EFCore.Relational/breakingchanges.netcore.json~HEAD
@@ -1,0 +1,7 @@
+[
+  {
+    "TypeId": "public interface Microsoft.EntityFrameworkCore.Storage.IRelationalConnection : Microsoft.EntityFrameworkCore.Storage.IRelationalTransactionManager, System.IDisposable",
+    "MemberId": "System.Void UnregisterBufferable(Microsoft.EntityFrameworkCore.Query.Internal.IBufferable bufferable)",
+    "Kind": "Addition"
+  }
+]

--- a/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
+++ b/test/EFCore.Relational.Tests/RelationalEventIdTest.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Transactions;
+using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.Infrastructure;
@@ -123,6 +124,7 @@ namespace Microsoft.EntityFrameworkCore
             public SemaphoreSlim Semaphore => throw new NotImplementedException();
             public void RegisterBufferable(IBufferable bufferable) => throw new NotImplementedException();
             public Task RegisterBufferableAsync(IBufferable bufferable, CancellationToken cancellationToken) => throw new NotImplementedException();
+            public void UnregisterBufferable([NotNull] IBufferable bufferable) => throw new NotImplementedException();
             public IDbContextTransaction BeginTransaction(IsolationLevel isolationLevel) => throw new NotImplementedException();
             public IDbContextTransaction BeginTransaction() => throw new NotImplementedException();
             public Task<IDbContextTransaction> BeginTransactionAsync(IsolationLevel isolationLevel, CancellationToken cancellationToken = default) => throw new NotImplementedException();

--- a/test/EFCore.Sqlite.FunctionalTests/Query/BadDataSqliteTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/Query/BadDataSqliteTest.cs
@@ -385,6 +385,7 @@ namespace Microsoft.EntityFrameworkCore.Query
             }
 
             public Task RegisterBufferableAsync(IBufferable bufferable, CancellationToken cancellationToken) => throw new NotImplementedException();
+            public void UnregisterBufferable(IBufferable bufferable) => throw new NotImplementedException();
             public string ConnectionString { get; }
             public DbConnection DbConnection { get; }
             public Guid ConnectionId { get; }


### PR DESCRIPTION
Summary of the changes
- Unregister Query in RelationalConnection

Fixes #13888 