### PR TITLE
Regression Test for joining DbSet from different contexts

### DIFF
--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -67,6 +67,24 @@ namespace Microsoft.EntityFrameworkCore.Query
                         Assert.Throws<InvalidOperationException>(
                             () =>
                                 (from c in context1.Customers
+                                 from o in context2.Orders
+                                 select c).First()).Message);
+                }
+            }
+        }
+
+        [ConditionalFact]
+        public virtual void Multiple_context_instances_2()
+        {
+            using (var context1 = CreateContext())
+            {
+                using (var context2 = CreateContext())
+                {
+                    Assert.Equal(
+                        CoreStrings.ErrorInvalidQueryable,
+                        Assert.Throws<InvalidOperationException>(
+                            () =>
+                                (from c in context1.Customers
                                  from o in context2.Set<Order>()
                                  select c).First()).Message);
                 }


### PR DESCRIPTION
Issue: We were checking for QueryProvider being the same except for the path when we accessing DbSet property on DbContext which is converted to ConstantExpression of EntityQueryable

Fixed by #13862

Resolves #13775

