### PR TITLE
Build fix: Avoid cache miss

### DIFF
--- a/src/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
+++ b/src/EFCore.Relational.Specification.Tests/Query/FromSqlQueryTestBase.cs
@@ -897,7 +897,7 @@ AND ((]UnitsInStock] + [UnitsOnOrder]) < [ReorderLevel])"))
 
                 var query1 = context.Orders
                     .FromSql(NormalizeDelimeters($"SELECT * FROM [Orders] WHERE [OrderID] >= {min}"))
-                    .Select(o => o.OrderID);
+                    .Select(i => i.OrderID);
                 query1.ToList();
 
                 var query2 = context.Orders

--- a/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/FromSqlQuerySqlServerTest.cs
@@ -694,10 +694,10 @@ WHERE [o].[CustomerID] IN (
             AssertSql(
                 @"@p0='10300'
 
-SELECT [o].[OrderID]
+SELECT [i].[OrderID]
 FROM (
     SELECT * FROM ""Orders"" WHERE ""OrderID"" >= @p0
-) AS [o]",
+) AS [i]",
                 //
                 @"@__max_0='10400'
 @p0='10300'
@@ -705,10 +705,10 @@ FROM (
 SELECT [o].[OrderID]
 FROM [Orders] AS [o]
 WHERE ([o].[OrderID] <= @__max_0) AND [o].[OrderID] IN (
-    SELECT [o0].[OrderID]
+    SELECT [i].[OrderID]
     FROM (
         SELECT * FROM ""Orders"" WHERE ""OrderID"" >= @p0
-    ) AS [o0]
+    ) AS [i]
 )",
                 //
                 @"@__max_0='10400'


### PR DESCRIPTION
Making sure to use same query from cache

Resolves #13902

