### PR TITLE
Update BuildTools and add an Azure Pipelines ci definition

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,10 +11,9 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)build\Key.snk</AssemblyOriginatorKeyFile>
     <PackageTags>Entity Framework Core;entity-framework-core;EF;Data;O/RM;EntityFramework;EntityFrameworkCore;EFCore</PackageTags>
     <Product>Microsoft Entity Framework Core</Product>
-    <PublicSign Condition="'$(OS)' != 'Windows_NT'">True</PublicSign>
     <RepositoryType>git</RepositoryType>
     <RepositoryRoot>$(MSBuildThisFileDirectory)</RepositoryRoot>
-    <RepositoryUrl>https://github.com/aspnet/EntityFramework.git</RepositoryUrl>
+    <RepositoryUrl>https://github.com/aspnet/EntityFrameworkCore</RepositoryUrl>
     <SignAssembly>True</SignAssembly>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>7.2</LangVersion>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,37 @@
+#
+# See https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema for details
+#
+
+# Only run CI builds for these branches
+trigger:
+  branches:
+    include:
+    - 'master'
+    - 'release/*'
+# Run PR validation on all branches
+pr:
+  branches:
+    include:
+    - '*'
+
+name: $(Date:yyMMdd)-$(Rev:rr)
+
+jobs:
+- template: build/templates/default-build.yml
+  parameters:
+    agentOs: Windows
+    codeSign: true
+    configuration: Release
+    artifacts:
+      publish: true
+      path: 'artifacts/build/'
+
+- template: build/templates/default-build.yml
+  parameters:
+    agentOs: macOS
+    configuration: Release
+
+- template: build/templates/default-build.yml
+  parameters:
+    agentOs: Linux
+    configuration: Release

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -7,15 +7,15 @@
   <PropertyGroup Label="Package Versions: Auto">
     <CastleCorePackageVersion>4.2.1</CastleCorePackageVersion>
     <FunctionalTests_PackageVersion>0.0.0</FunctionalTests_PackageVersion>
-    <InternalAspNetCoreSdkPackageVersion>2.1.3-rtm-15802</InternalAspNetCoreSdkPackageVersion>
+    <InternalAspNetCoreSdkPackageVersion>2.1.3-rtm-15839</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftAzureDocumentDBCorePackageVersion>1.7.1</MicrosoftAzureDocumentDBCorePackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>2.8.0</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>2.8.0</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
     <MicrosoftCSharpPackageVersion>4.5.0</MicrosoftCSharpPackageVersion>
     <MicrosoftExtensionsDependencyModelPackageVersion>2.1.0</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftNETCoreApp11PackageVersion>1.1.2</MicrosoftNETCoreApp11PackageVersion>
-    <MicrosoftNETCoreApp20PackageVersion>2.0.0</MicrosoftNETCoreApp20PackageVersion>
-    <MicrosoftNETCoreApp21PackageVersion>2.1.2</MicrosoftNETCoreApp21PackageVersion>
+    <MicrosoftNETCoreApp11PackageVersion>1.1.8</MicrosoftNETCoreApp11PackageVersion>
+    <MicrosoftNETCoreApp20PackageVersion>2.0.9</MicrosoftNETCoreApp20PackageVersion>
+    <MicrosoftNETCoreApp21PackageVersion>2.1.5</MicrosoftNETCoreApp21PackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.6.1</MicrosoftNETTestSdkPackageVersion>
     <NETStandardLibrary20PackageVersion>2.0.3</NETStandardLibrary20PackageVersion>
     <NewtonsoftJsonPackageVersion>11.0.2</NewtonsoftJsonPackageVersion>
@@ -28,13 +28,13 @@
     <SystemCollectionsImmutablePackageVersion>1.5.0</SystemCollectionsImmutablePackageVersion>
     <SystemComponentModelAnnotationsPackageVersion>4.5.0</SystemComponentModelAnnotationsPackageVersion>
     <SystemDataSqlClientPackageVersion>4.5.1</SystemDataSqlClientPackageVersion>
-    <SystemDiagnosticsDiagnosticSourcePackageVersion>4.5.0</SystemDiagnosticsDiagnosticSourcePackageVersion>
+    <SystemDiagnosticsDiagnosticSourcePackageVersion>4.5.1</SystemDiagnosticsDiagnosticSourcePackageVersion>
     <SystemInteractiveAsyncPackageVersion>3.1.1</SystemInteractiveAsyncPackageVersion>
-    <XunitAnalyzersPackageVersion>0.8.0</XunitAnalyzersPackageVersion>
+    <XunitAnalyzersPackageVersion>0.10.0</XunitAnalyzersPackageVersion>
     <XunitAssertPackageVersion>2.3.1</XunitAssertPackageVersion>
     <XunitCorePackageVersion>2.3.1</XunitCorePackageVersion>
     <XunitPackageVersion>2.3.1</XunitPackageVersion>
-    <XunitRunnerVisualStudioPackageVersion>2.4.0-beta.1.build3945</XunitRunnerVisualStudioPackageVersion>
+    <XunitRunnerVisualStudioPackageVersion>2.4.0</XunitRunnerVisualStudioPackageVersion>
   </PropertyGroup>
 
   <!-- This may import a generated file which may override the variables above. -->

--- a/build/repo.props
+++ b/build/repo.props
@@ -18,7 +18,7 @@
   <PropertyGroup>
     <!-- These properties are use by the automation that updates dependencies.props -->
     <LineupPackageId>Internal.AspNetCore.Universe.Lineup</LineupPackageId>
-    <LineupPackageVersion>2.1.0-rc1-*</LineupPackageVersion>
+    <LineupPackageVersion>2.1.6-*</LineupPackageVersion>
     <LineupPackageRestoreSource>https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json</LineupPackageRestoreSource>
   </PropertyGroup>
 

--- a/build/templates/default-build.yml
+++ b/build/templates/default-build.yml
@@ -90,8 +90,7 @@ jobs:
       _SignType:
     ${{ if and(eq(parameters.codeSign, 'true'), eq(variables['System.TeamProject'], 'internal')) }}:
       TeamName: AspNetCore
-      # TODO: once real-signing is approved, change this to 'real'
-      _SignType: test
+      _SignType: real
     ${{ insert }}: ${{ parameters.variables }}
   steps:
   - checkout: self

--- a/build/templates/default-build.yml
+++ b/build/templates/default-build.yml
@@ -1,0 +1,140 @@
+# default-build.yml
+#
+# Description: Defines a build phase for invoking build.sh/cmd
+# Parameters:
+#   jobName: string
+#       The name of the job. Defaults to the name of the OS. No spaces allowed
+#   jobDisplayName: string
+#       The friendly job name to display in the UI. Defaults to the name of the OS.
+#   poolName: string
+#       The name of the VSTS agent queue to use.
+#   agentOs: string
+#       Used in templates to define variables which are OS specific. Typically from the set { Windows, Linux, macOS }
+#   buildArgs: string
+#       Additional arguments to pass to the build.sh/cmd script.
+#       Note: -ci is always passed
+#   beforeBuild: [steps]
+#       Additional steps to run before build.sh/cmd
+#   afterBuild: [steps]
+#       Additional steps to run after build.sh/cmd
+#   artifacts:
+#      publish: boolean
+#           Should artifacts be published
+#      path: string
+#           The file path to artifacts output
+#      name: string
+#           The name of the artifact container
+#   variables: { string: string }
+#     A map of custom variables
+#   matrix: { string: { string: string } }
+#     A map of matrix configurations and variables. https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema?view=vsts#matrix
+#   demands: string | [ string ]
+#     A list of agent demands. https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema?view=vsts#demands
+#   dependsOn: string | [ string ]
+#     For fan-out/fan-in. https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema?view=vsts#phase
+#   codeSign: boolean
+#       This build definition is enabled for code signing. (Only applies to Windows)
+
+parameters:
+  agentOs: 'Windows'
+  poolName: ''
+  buildArgs: ''
+  configuration: 'Release'
+  demands: []
+  beforeBuild: []
+  afterBuild: []
+  codeSign: false
+  variables: {}
+  dependsOn: ''
+  artifacts:
+    publish: false
+    path: 'artifacts/'
+  # buildSteps: [] - don't define an empty object default because there is no way in template expression yet to check "if isEmpty(parameters.buildSteps)"
+  # jobName: '' - use agentOs by default.
+  # jobDisplayName: '' - use agentOs by default.
+  # matrix: {} - don't define an empty object default because there is no way in template expression yet to check "if isEmpty(parameters.matrix)"
+
+jobs:
+- job: ${{ coalesce(parameters.jobName, parameters.agentOs) }}
+  displayName: ${{ coalesce(parameters.jobDisplayName, parameters.agentOs) }}
+  dependsOn: ${{ parameters.dependsOn }}
+  workspace:
+    clean: all
+  strategy:
+    ${{ if ne(parameters.matrix, '') }}:
+      maxParallel: 8
+      matrix: ${{ parameters.matrix }}
+  # Map friendly OS names to the right queue
+  pool:
+    ${{ if ne(parameters.poolName, '') }}:
+      name: ${{ parameters.poolName }}
+    ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'macOS')) }}:
+      name: Hosted macOS
+      vmImage: macOS-10.13
+    ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'Linux')) }}:
+      name: Hosted Ubuntu 1604
+      vmImage: ubuntu-16.04
+    ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'Windows')) }}:
+      # These Windows pools are temporary while the .NET Core engineering team does more infrastructure work
+      ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+        name: DotNetCore-Windows
+      ${{ if ne(variables['System.TeamProject'], 'internal') }}:
+        name: dotnet-external-temp
+  variables:
+    AgentOsName: ${{ parameters.agentOs }}
+    DOTNET_HOME: $(Agent.WorkFolder)/.dotnet
+    BuildScriptArgs: ${{ parameters.buildArgs }}
+    BuildConfiguration: ${{ parameters.configuration }}
+    VSTS_OVERWRITE_TEMP: false # Workaround for https://github.com/dotnet/core-eng/issues/2812
+    ${{ if or(ne(parameters.codeSign, 'true'), ne(variables['System.TeamProject'], 'internal')) }}:
+      _SignType:
+    ${{ if and(eq(parameters.codeSign, 'true'), eq(variables['System.TeamProject'], 'internal')) }}:
+      TeamName: AspNetCore
+      # TODO: once real-signing is approved, change this to 'real'
+      _SignType: test
+    ${{ insert }}: ${{ parameters.variables }}
+  steps:
+  - checkout: self
+    clean: true
+  - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.agentOs, 'Windows'), eq(parameters.codeSign, 'true')) }}:
+    - task: MicroBuildSigningPlugin@1
+      displayName: Install MicroBuild Signing plugin
+      condition: and(succeeded(), in(variables['_SignType'], 'test', 'real'))
+      inputs:
+        signType: $(_SignType)
+        zipSources: false
+  - ${{ parameters.beforeBuild }}
+  - ${{ if eq(parameters.buildSteps, '') }}:
+    - ${{ if eq(parameters.agentOs, 'Windows') }}:
+      - script: .\build.cmd -ci /p:SignType=$(_SignType) /p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
+        displayName: Run build.cmd
+    - ${{ if ne(parameters.agentOs, 'Windows') }}:
+      - script: ./build.sh -ci -p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
+        displayName: Run build.sh
+  - ${{ if ne(parameters.buildSteps, '') }}:
+    - ${{ parameters.buildSteps }}
+  - task: PublishTestResults@2
+    displayName: Publish test results
+    condition: always()
+    inputs:
+      testRunTitle: $(AgentOsName)-$(BuildConfiguration)
+      testRunner: vstest
+      testResultsFiles: 'artifacts/logs/**/*.trx'
+      mergeTestResults: true
+  - ${{ if eq(parameters.artifacts.publish, 'true') }}:
+    - task: PublishBuildArtifacts@1
+      displayName: Upload artifacts
+      condition: eq(variables['system.pullrequest.isfork'], false)
+      inputs:
+        pathtoPublish: ${{ parameters.artifacts.path }}
+        ${{ if eq(parameters.artifacts.name, '') }}:
+          artifactName: artifacts-$(AgentOsName)-$(BuildConfiguration)
+        ${{ if ne(parameters.artifacts.name, '') }}:
+          artifactName: ${{ parameters.artifacts.name }}
+        artifactType: Container
+        parallel: true
+  - ${{ parameters.afterBuild }}
+  - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.agentOs, 'Windows')) }}:
+    - task: MicroBuildCleanup@1
+      displayName: Cleanup MicroBuild tasks
+      condition: always()

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.3-rtm-15802
-commithash:a7c08b45b440a7d2058a0aa1eaa3eb6ba811976a
+version:2.1.3-rtm-15839
+commithash:ee0ad5bd4ede948c6954704b621acc0c83445e5d

--- a/src/EFCore.Analyzers/EFCore.Analyzers.csproj
+++ b/src/EFCore.Analyzers/EFCore.Analyzers.csproj
@@ -23,6 +23,11 @@
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Code sign the analyzer assembly -->
+    <SignedPackageFile Include="$(TargetPath)" PackagePath="analyzers/dotnet/cs/$(TargetFileName)" Certificate="$(AssemblySigningCertName)" />
+  </ItemGroup>
+
   <Target Name="PopulateNuspec" BeforeTargets="GenerateNuspec" DependsOnTargets="Build">
 
     <PropertyGroup>

--- a/src/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
+++ b/src/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
@@ -9,12 +9,14 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EnableApiCheck>false</EnableApiCheck>
     <IsPackable>true</IsPackable>
+    <!-- xunit.core sets this to true even though this project isn't supposed to be a runnable test project. -->
+    <IsTestProject>false</IsTestProject>
   </PropertyGroup>
-  
+
   <PropertyGroup Condition="'$(FunctionalTests_PackageVersion)' == '2.0.0'">
    <DefineConstants>$(DefineConstants);Test20</DefineConstants>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\EFCore\EFCore.csproj" />
     <ProjectReference Include="..\EFCore.Proxies\EFCore.Proxies.csproj" />

--- a/src/EFCore.Sqlite/EFCore.Sqlite.csproj
+++ b/src/EFCore.Sqlite/EFCore.Sqlite.csproj
@@ -9,7 +9,6 @@
     <PackageId>Microsoft.EntityFrameworkCore.Sqlite</PackageId>
     <PackageTags>$(PackageTags);SQLite</PackageTags>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <IncludeSource>false</IncludeSource>
     <IncludeSymbols>false</IncludeSymbols>
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <EnableApiCheck>false</EnableApiCheck>
@@ -24,7 +23,7 @@
       <PrivateAssets>None</PrivateAssets>
     </PackageReference>
   </ItemGroup>
-  
+
   <ItemGroup>
     <None Include="lib\**\*">
       <Pack>True</Pack>

--- a/src/EFCore.Tools/EFCore.Tools.csproj
+++ b/src/EFCore.Tools/EFCore.Tools.csproj
@@ -28,6 +28,20 @@ Update-Database
   </ItemGroup>
 
   <ItemGroup>
+    <!-- PowerShell files should be code signed -->
+    <SignedPackageFile Include="EntityFrameworkCore.PowerShell2.psd1" Certificate="$(PowerShellSigningCertName)" />
+    <SignedPackageFile Include="EntityFrameworkCore.PowerShell2.psm1" Certificate="$(PowerShellSigningCertName)" />
+    <SignedPackageFile Include="EntityFrameworkCore.psd1" Certificate="$(PowerShellSigningCertName)" />
+    <SignedPackageFile Include="EntityFrameworkCore.psm1" Certificate="$(PowerShellSigningCertName)" />
+    <SignedPackageFile Include="init.ps1" Certificate="$(PowerShellSigningCertName)" />
+    <SignedPackageFile Include="install.ps1" Certificate="$(PowerShellSigningCertName)" />
+
+    <!-- Additional assemblies to be code signed -->
+    <SignedPackageFile Include="ef.exe" Certificate="$(AssemblySigningCertName)" />
+    <SignedPackageFile Include="ef.dll" Certificate="$(AssemblySigningCertName)" />
+  </ItemGroup>
+
+  <ItemGroup>
     <GeneratedContent Include="*.psd1.in">
       <Properties>VersionPrefix=$(VersionPrefix)</Properties>
     </GeneratedContent>

--- a/src/dotnet-ef/dotnet-ef.csproj
+++ b/src/dotnet-ef/dotnet-ef.csproj
@@ -1,7 +1,4 @@
-﻿<Project>
-
-  <Sdk Name="Microsoft.NET.Sdk" />
-  <Sdk Name="Microsoft.DotNet.GlobalTools.Sdk" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Entity Framework Core Tools for the .NET Command-Line Interface.
@@ -18,7 +15,9 @@ dotnet ef database update
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
-    <GenerateToolShims>true</GenerateToolShims>
+    <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86</PackAsToolShimRuntimeIdentifiers>
+    <!-- Because this project uses a custom nuspec, this is necessary to ensure the generated shims are a consistent directory. -->
+    <PackagedShimOutputRootDirectory>$(IntermediateOutputPath)</PackagedShimOutputRootDirectory>
     <RootNamespace>Microsoft.EntityFrameworkCore.Tools</RootNamespace>
     <IncludeSource>false</IncludeSource>
     <EnableApiCheck>false</EnableApiCheck>
@@ -76,6 +75,15 @@ dotnet ef database update
     </Compile>
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Additional files to be code signed -->
+    <SignedPackageFile Include="$(TargetFileName)" Certificate="$(AssemblySigningCertName)" />
+    <SignedPackageFile Include="ef.exe" Certificate="$(AssemblySigningCertName)" />
+
+    <!-- Third-party assemblies should be signed with the 3rd party certificate -->
+    <SignedPackageFile Include="Newtonsoft.Json.dll" Certificate="$(AssemblySigning3rdPartyCertName)" />
+  </ItemGroup>
+
   <Target Name="PopulateNuspec" BeforeTargets="GenerateNuspec" DependsOnTargets="Build">
 
     <PropertyGroup>
@@ -100,7 +108,7 @@ dotnet ef database update
 
         SettingsFile=$(_ToolsSettingsFilePath);
         Output=$(PublishDir)**\*;
-        OutputShims=$(IntermediateOutputPath)shims\**\*;
+        OutputShims=$(PackagedShimOutputRootDirectory)shims\$(TargetFramework)\**\*;
         OutputBinary=..\ef\bin\$(Configuration)\netcoreapp2.0\ef.dll;
         OutputRuntimeConfig=..\ef\bin\$(Configuration)\netcoreapp2.0\ef.runtimeconfig.json;
         OutputSymbol=..\ef\bin\$(Configuration)\netcoreapp2.0\ef.pdb;

--- a/tools/CleanMSSQLLocalDB.cmd
+++ b/tools/CleanMSSQLLocalDB.cmd
@@ -5,4 +5,4 @@ del "DropAll.sql"
 sqllocaldb stop mssqllocaldb
 sqllocaldb delete mssqllocaldb
 
-ShrinkLocalDBModel.cmd
+%~dp0ShrinkLocalDBModel.cmd


### PR DESCRIPTION
Changes:

* Update BuildTools and react to changes in code signing configuration and shim generation
* Update dependencies
* Add an Azure Pipelines build definition
* Update bootstrappers to support the --ci switch

This works around #12842 by using a different agent pool which has more CPU resources.

NB: this targets the release/2.1 branch, and will be merged forward into release/2.2 This will replace the files in https://github.com/aspnet/EntityFrameworkCore/tree/master/.vsts-pipelines/builds