### PR TITLE
Disable net461 build on non-Windows platforms

### DIFF
--- a/src/EFCore.Design/EFCore.Design.csproj
+++ b/src/EFCore.Design/EFCore.Design.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <Description>Shared design-time components for Entity Framework Core tools.</Description>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(DeveloperBuild)' != 'True' AND '$(CoreOnly)' != 'True' AND '$(OS)' == 'Windows_NT' ">net461;$(TargetFrameworks)</TargetFrameworks>
     <AssemblyName>Microsoft.EntityFrameworkCore.Design</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/EFCore.Relational.Specification.Tests/EFCore.Relational.Specification.Tests.csproj
+++ b/src/EFCore.Relational.Specification.Tests/EFCore.Relational.Specification.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <Description>Shared test suite for Entity Framework Core relational database providers.</Description>
-    <TargetFrameworks>netcoreapp2.2;net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(DeveloperBuild)' != 'True' AND '$(CoreOnly)' != 'True' AND '$(OS)' == 'Windows_NT' ">net461;$(TargetFrameworks)</TargetFrameworks>
     <AssemblyName>Microsoft.EntityFrameworkCore.Relational.Specification.Tests</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/src/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
+++ b/src/EFCore.Specification.Tests/EFCore.Specification.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <Description>Shared test suite for Entity Framework Core database providers.</Description>
-    <TargetFrameworks>netcoreapp2.2;net461;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.2;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(DeveloperBuild)' != 'True' AND '$(CoreOnly)' != 'True' AND '$(OS)' == 'Windows_NT' ">net461;$(TargetFrameworks)</TargetFrameworks>
     <AssemblyName>Microsoft.EntityFrameworkCore.Specification.Tests</AssemblyName>
     <RootNamespace>Microsoft.EntityFrameworkCore</RootNamespace>
     <NoWarn>$(NoWarn);CS1591</NoWarn>


### PR DESCRIPTION
When trying to work on EF Core on Linux, the build is complicated by the fact that some projects target net461. While [various workarounds exist](https://github.com/dotnet/sdk/issues/335) for targeting .NET Framework on non-Windows platforms with mono, this is complicated. In addition, while the test infrastructure does contain logic to skip .NET Framework on non-Windows platforms (see `test/Directory.Build.props`), 3 projects under src do not.

This PR conditionally adds net461 in these 3 projects, only when on Windows. I'm not sure what effects this could have (I don't know the EF Core build system well yet), but it does help me build the project. If this needs to be done in some other way (or is not possible for some reason), please let me know. This is not urgent.