### PR TITLE
[WIP] - VerificationException when creating OriginalValues for indexed property test

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -589,7 +589,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         /// </summary>
         protected virtual object ReadPropertyValue([NotNull] IPropertyBase propertyBase)
         {
-            Debug.Assert(propertyBase.IsIndexedProperty || !propertyBase.IsShadowProperty);
+            Debug.Assert(!propertyBase.IsShadowProperty);
 
             return ((PropertyBase)propertyBase).Getter.GetClrValue(Entity);
         }

--- a/src/EFCore/ChangeTracking/Internal/InternalMixedEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalMixedEntityEntry.cs
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected override object ReadPropertyValue(IPropertyBase propertyBase)
-            => propertyBase.IsIndexedProperty || !propertyBase.IsShadowProperty
+            => !propertyBase.IsShadowProperty
                 ? base.ReadPropertyValue(propertyBase)
                 : _shadowValues[propertyBase.GetShadowIndex()];
 

--- a/src/EFCore/Metadata/Internal/EntityMaterializerSource.cs
+++ b/src/EFCore/Metadata/Internal/EntityMaterializerSource.cs
@@ -112,7 +112,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     .Concat(
                         entityType
                             .GetProperties()
-                            .Where(p => !p.IsShadowProperty || p.IsIndexedProperty)));
+                            .Where(p => !p.IsShadowProperty)));
 
             foreach (var consumedProperty in constructorBinding
                 .ParameterBindings

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -1597,7 +1597,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 ClrType?.GetMembersInHierarchy(name).FirstOrDefault(),
                 configurationSource,
                 typeConfigurationSource,
-                isIndexProperty: false);
+                isIndexedProperty: false);
         }
 
         /// <summary>
@@ -1628,7 +1628,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 memberInfo,
                 configurationSource,
                 configurationSource,
-                isIndexProperty: false);
+                isIndexedProperty: false);
         }
 
 
@@ -1646,13 +1646,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Check.NotNull(name, nameof(name));
             Check.NotNull(propertyType, nameof(propertyType));
 
+            var indexerProperty = this.EFIndexerProperty();
+            if (indexerProperty == null)
+            {
+                throw new InvalidOperationException(CoreStrings.NoIndexer(name, this.DisplayName()));
+            }
+
             return AddProperty(
                 name,
                 propertyType,
-                null,
+                indexerProperty,
                 configurationSource,
                 typeConfigurationSource,
-                isIndexProperty: true);
+                isIndexedProperty: true);
         }
 
         private Property AddProperty(
@@ -1661,7 +1667,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             MemberInfo memberInfo,
             ConfigurationSource configurationSource,
             ConfigurationSource? typeConfigurationSource,
-            bool isIndexProperty)
+            bool isIndexedProperty)
         {
             var conflictingMember = FindMembersInHierarchy(name).FirstOrDefault();
             if (conflictingMember != null)
@@ -1685,6 +1691,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             else
             {
                 if (memberInfo != null
+                    && !isIndexedProperty
                     && propertyType != memberInfo.GetMemberType())
                 {
                     throw new InvalidOperationException(
@@ -1698,7 +1705,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             var property = new Property(
                 name, propertyType, memberInfo as PropertyInfo, memberInfo as FieldInfo, this,
-                configurationSource, typeConfigurationSource, isIndexProperty);
+                configurationSource, typeConfigurationSource);
 
             _properties.Add(property.Name, property);
             PropertyMetadataChanged();

--- a/src/EFCore/Metadata/Internal/IndexedPropertyGetterFactory.cs
+++ b/src/EFCore/Metadata/Internal/IndexedPropertyGetterFactory.cs
@@ -25,10 +25,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         protected override IClrPropertyGetter CreateGeneric<TEntity, TValue, TNonNullableEnumValue>(
             PropertyInfo propertyInfo, IPropertyBase propertyBase)
         {
+            Debug.Assert(propertyInfo != null);
             Debug.Assert(propertyBase != null);
 
-            var indexerPropertyInfo = propertyBase.DeclaringType.EFIndexerProperty();
-            if (indexerPropertyInfo == null)
+            if (!propertyInfo.IsEFIndexerProperty())
             {
                 throw new InvalidOperationException(
                     CoreStrings.NoIndexer(propertyBase.Name, propertyBase.DeclaringType.DisplayName()));
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var entityParameter = Expression.Parameter(typeof(TEntity), "entity");
             var indexerParameterList = new List<Expression>() { Expression.Constant(propertyBase.Name) };
             Expression readExpression = Expression.MakeIndex(
-                entityParameter, indexerPropertyInfo, indexerParameterList);
+                entityParameter, propertyInfo, indexerParameterList);
 
             if (readExpression.Type != typeof(TValue))
             {

--- a/src/EFCore/Metadata/Internal/Property.cs
+++ b/src/EFCore/Metadata/Internal/Property.cs
@@ -45,9 +45,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [CanBeNull] FieldInfo fieldInfo,
             [NotNull] EntityType declaringEntityType,
             ConfigurationSource configurationSource,
-            ConfigurationSource? typeConfigurationSource,
-            bool isIndexProperty = false)
-            : base(name, propertyInfo, fieldInfo, isIndexProperty)
+            ConfigurationSource? typeConfigurationSource)
+            : base(name, propertyInfo, fieldInfo)
         {
             Check.NotNull(clrType, nameof(clrType));
             Check.NotNull(declaringEntityType, nameof(declaringEntityType));

--- a/src/EFCore/Metadata/Internal/PropertyBase.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBase.cs
@@ -18,13 +18,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     {
         private FieldInfo _fieldInfo;
         private ConfigurationSource? _fieldInfoConfigurationSource;
+        private bool _isIndexedProperty;
 
         // Warning: Never access these fields directly as access needs to be thread-safe
         private IClrPropertyGetter _getter;
         private IClrPropertySetter _setter;
         private PropertyAccessors _accessors;
         private PropertyIndexes _indexes;
-        private bool _isIndexedProperty;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -33,15 +33,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         protected PropertyBase(
             [NotNull] string name,
             [CanBeNull] PropertyInfo propertyInfo,
-            [CanBeNull] FieldInfo fieldInfo,
-            bool isIndexProperty = false)
+            [CanBeNull] FieldInfo fieldInfo)
         {
             Check.NotEmpty(name, nameof(name));
 
             Name = name;
             PropertyInfo = propertyInfo;
             _fieldInfo = fieldInfo;
-            _isIndexedProperty = isIndexProperty;
+            _isIndexedProperty = propertyInfo != null
+                && propertyInfo.IsEFIndexerProperty();
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Internal/PropertyExtensions.cs
+++ b/src/EFCore/Metadata/Internal/PropertyExtensions.cs
@@ -244,6 +244,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 builder.Append(" Shadow");
             }
 
+            if (property.IsIndexedProperty)
+            {
+                builder.Append(" Indexed");
+            }
+
             if (!property.IsNullable)
             {
                 builder.Append(" Required");

--- a/src/EFCore/Metadata/Internal/TypeBaseExtensions.cs
+++ b/src/EFCore/Metadata/Internal/TypeBaseExtensions.cs
@@ -52,11 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 : type.ClrType.GetRuntimeProperties();
 
             // find the indexer with single argument of type string which returns an object
-            return (from p in runtimeProperties
-                    where p.PropertyType == typeof(object)
-                    let q = p.GetIndexParameters()
-                    where q.Length == 1 && q[0].ParameterType == typeof(string)
-                    select p).FirstOrDefault();
+            return runtimeProperties.FirstOrDefault(p => p.IsEFIndexerProperty());
         }
     }
 }

--- a/src/Shared/PropertyInfoExtensions.cs
+++ b/src/Shared/PropertyInfoExtensions.cs
@@ -21,6 +21,21 @@ namespace System.Reflection
                && propertyInfo.GetMethod != null && (!publicOnly || propertyInfo.GetMethod.IsPublic)
                && propertyInfo.GetIndexParameters().Length == 0;
 
+        public static bool IsEFIndexerProperty([NotNull] this PropertyInfo propertyInfo)
+        {
+            if (propertyInfo.PropertyType == typeof(object))
+            {
+                var indexParams = propertyInfo.GetIndexParameters();
+                if (indexParams.Length == 1
+                    && indexParams[0].ParameterType == typeof(string))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         public static PropertyInfo FindGetterProperty([NotNull] this PropertyInfo propertyInfo)
             => propertyInfo.DeclaringType
                 .GetPropertiesInHierarchy(propertyInfo.GetSimpleMemberName())


### PR DESCRIPTION
This pull request is not to be checked in. I am getting a weird exception and want to be able to discuss it with people / see if others can repro it.

When I run `GearsOfWarQuerySqlServerTest.Can_query_on_indexed_properties()` I get a `VerificationException` with the message "Operation could destabilize the runtime." and the stack trace below. Note: this is happening when it attempts to create the `OriginalValues` for the `City` entity - which is the entity to which I've added an indexed property.

The changes I've made were just the initial stab at passing in the `PropertyInfo` object for an indexed property and making use of that. Note that before this change an `IndexedProperty` was automatically also a `ShadowProperty` (which is what I'm trying to fix).

```
   at lambda_method(Closure , InternalEntityEntry )
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.InternalEntityEntry.OriginalValues..ctor(InternalEntityEntry entry) in C:\git\aspnet\EntityFramework\src\EFCore\ChangeTracking\Internal\OriginalValues.cs:line 20
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.InternalEntityEntry.EnsureOriginalValues() in C:\git\aspnet\EntityFramework\src\EFCore\ChangeTracking\Internal\InternalEntityEntry.cs:line 750
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.InternalEntityEntrySubscriber.SnapshotAndSubscribe(InternalEntityEntry entry) in C:\git\aspnet\EntityFramework\src\EFCore\ChangeTracking\Internal\InternalEntityEntrySubscriber.cs:line 31
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.StateManager.StartTracking(InternalEntityEntry entry) in C:\git\aspnet\EntityFramework\src\EFCore\ChangeTracking\Internal\StateManager.cs:line 492
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.InternalEntityEntry.SetEntityState(EntityState oldState, EntityState newState, Boolean acceptChanges) in C:\git\aspnet\EntityFramework\src\EFCore\ChangeTracking\Internal\InternalEntityEntry.cs:line 244
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.InternalEntityEntry.SetEntityState(EntityState entityState, Boolean acceptChanges, Nullable`1 forceStateWhenUnknownKey) in C:\git\aspnet\EntityFramework\src\EFCore\ChangeTracking\Internal\InternalEntityEntry.cs:line 90
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.EntityGraphAttacher.PaintAction(EntityEntryGraphNode node, Boolean force) in C:\git\aspnet\EntityFramework\src\EFCore\ChangeTracking\Internal\EntityGraphAttacher.cs:line 71
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.EntityEntryGraphIterator.TraverseGraph[TState](EntityEntryGraphNode node, TState state, Func`3 handleNode) in C:\git\aspnet\EntityFramework\src\EFCore\ChangeTracking\Internal\EntityEntryGraphIterator.cs:line 29
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.EntityEntryGraphIterator.TraverseGraph[TState](EntityEntryGraphNode node, TState state, Func`3 handleNode) in C:\git\aspnet\EntityFramework\src\EFCore\ChangeTracking\Internal\EntityEntryGraphIterator.cs:line 63
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.EntityEntryGraphIterator.TraverseGraph[TState](EntityEntryGraphNode node, TState state, Func`3 handleNode) in C:\git\aspnet\EntityFramework\src\EFCore\ChangeTracking\Internal\EntityEntryGraphIterator.cs:line 52
   at Microsoft.EntityFrameworkCore.ChangeTracking.Internal.EntityGraphAttacher.AttachGraph(InternalEntityEntry rootEntry, EntityState entityState, Boolean forceStateWhenUnknownKey) in C:\git\aspnet\EntityFramework\src\EFCore\ChangeTracking\Internal\EntityGraphAttacher.cs:line 35
   at Microsoft.EntityFrameworkCore.DbContext.SetEntityState(InternalEntityEntry entry, EntityState entityState) in C:\git\aspnet\EntityFramework\src\EFCore\DbContext.cs:line 718
   at Microsoft.EntityFrameworkCore.DbContext.SetEntityStates(IEnumerable`1 entities, EntityState entityState) in C:\git\aspnet\EntityFramework\src\EFCore\DbContext.cs:line 1236
   at Microsoft.EntityFrameworkCore.DbContext.AddRange(IEnumerable`1 entities) in C:\git\aspnet\EntityFramework\src\EFCore\DbContext.cs:line 1250
   at Microsoft.EntityFrameworkCore.Internal.InternalDbSet`1.AddRange(IEnumerable`1 entities) in C:\git\aspnet\EntityFramework\src\EFCore\Internal\InternalDbSet.cs:line 217
   at Microsoft.EntityFrameworkCore.TestModels.GearsOfWarModel.GearsOfWarContext.Seed(GearsOfWarContext context) in C:\git\aspnet\EntityFramework\src\EFCore.Specification.Tests\TestModels\GearsOfWarModel\GearsOfWarContext.cs:line 43
   at Microsoft.EntityFrameworkCore.Query.GearsOfWarQueryFixtureBase.Seed(GearsOfWarContext context) in C:\git\aspnet\EntityFramework\src\EFCore.Specification.Tests\Query\GearsOfWarQueryFixtureBase.cs:line 316
   at Microsoft.EntityFrameworkCore.SharedStoreFixtureBase`1.<.ctor>b__21_2(DbContext c) in C:\git\aspnet\EntityFramework\src\EFCore.Specification.Tests\SharedStoreFixtureBase.cs:line 55
   at Microsoft.EntityFrameworkCore.TestUtilities.SqlServerTestStore.Initialize(Func`1 createContext, Action`1 seed) in C:\git\aspnet\EntityFramework\test\EFCore.SqlServer.FunctionalTests\TestUtilities\SqlServerTestStore.cs:line 91
   at Microsoft.EntityFrameworkCore.TestUtilities.TestStore.<>c__DisplayClass11_0.<Initialize>b__1() in C:\git\aspnet\EntityFramework\src\EFCore.Specification.Tests\TestUtilities\TestStore.cs:line 40
   at Microsoft.EntityFrameworkCore.TestUtilities.TestStoreIndex.CreateShared(String name, Action initializeDatabase) in C:\git\aspnet\EntityFramework\src\EFCore.Specification.Tests\TestUtilities\TestStoreIndex.cs:line 30
   at Microsoft.EntityFrameworkCore.TestUtilities.TestStore.Initialize(IServiceProvider serviceProvider, Func`1 createContext, Action`1 seed) in C:\git\aspnet\EntityFramework\src\EFCore.Specification.Tests\TestUtilities\TestStore.cs:line 40
   at Microsoft.EntityFrameworkCore.TestUtilities.RelationalTestStore.Initialize(IServiceProvider serviceProvider, Func`1 createContext, Action`1 seed) in C:\git\aspnet\EntityFramework\src\EFCore.Relational.Specification.Tests\TestUtilities\RelationalTestStore.cs:line 29
   at Microsoft.EntityFrameworkCore.SharedStoreFixtureBase`1..ctor() in C:\git\aspnet\EntityFramework\src\EFCore.Specification.Tests\SharedStoreFixtureBase.cs:line 55
   at Microsoft.EntityFrameworkCore.Query.GearsOfWarQueryFixtureBase..ctor() in C:\git\aspnet\EntityFramework\src\EFCore.Specification.Tests\Query\GearsOfWarQueryFixtureBase.cs:line 17
   at Microsoft.EntityFrameworkCore.Query.GearsOfWarQueryRelationalFixture..ctor()
   at Microsoft.EntityFrameworkCore.Query.GearsOfWarQuerySqlServerFixture..ctor()
```


