### PR TITLE
Add build tags automatically and cleanup dead code from the build job template

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Documentation on using EF Core is available at <https://docs.microsoft.com/ef/core/>.
 
+[![Build Status](https://dnceng.visualstudio.com/public/_apis/build/status/aspnet/EntityFrameworkCore/EntityFrameworkCore-ci)](https://dnceng.visualstudio.com/public/_build/latest?definitionId=51)
+
 ## EF Core here, EF6 elsewhere
 
 This project is for Entity Framework Core. Entity Framework 6 is still under active development at https://github.com/aspnet/EntityFramework6.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,6 +24,7 @@ jobs:
     configuration: Release
     artifacts:
       publish: true
+      name: packages
       path: 'artifacts/build/'
 
 - template: build/templates/default-build.yml

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -1,10 +1,16 @@
-﻿<Project>
+﻿<Project InitialTargets="TagCiBuilds">
+
+  <Target Name="TagCiBuilds" Condition=" '$(CI)' == 'true' ">
+    <!-- These tags can be used in Azure Pipelines to alter the behavior of release triggers. -->
+    <Message Importance="high" Text="##vso[build.addbuildtag]daily-build" Condition=" '$(IsFinalBuild)' != 'true' " />
+    <Message Importance="high" Text="##vso[build.addbuildtag]release-candidate" Condition=" '$(IsFinalBuild)' == 'true' " />
+  </Target>
 
   <Target Name="_FilterTestProjects" BeforeTargets="GetTestAssemblies">
     <PropertyGroup Condition="'$(TestFilter)' == '' And '$(FunctionalTests_PackageVersion)' != '0.0.0'">
       <TestFilter>FunctionalTests</TestFilter>
     </PropertyGroup>
-  
+
     <ItemGroup Condition="'$(TestFilter)' != ''">
       <ProjectsToTest Remove="@(ProjectsToTest)"/>
       <ProjectsToTest Include="$(RepositoryRoot)test\*$(TestFilter)*\*.csproj" Exclude="@(ExcludeFromTest)" />

--- a/build/repo.targets
+++ b/build/repo.targets
@@ -1,6 +1,6 @@
 ﻿<Project InitialTargets="TagCiBuilds">
 
-  <Target Name="TagCiBuilds" Condition=" '$(CI)' == 'true' ">
+  <Target Name="TagCiBuilds" Condition=" '$(CI)' == 'true' AND '$(BUILD_REASON)' != 'PullRequest' ">
     <!-- These tags can be used in Azure Pipelines to alter the behavior of release triggers. -->
     <Message Importance="high" Text="##vso[build.addbuildtag]daily-build" Condition=" '$(IsFinalBuild)' != 'true' " />
     <Message Importance="high" Text="##vso[build.addbuildtag]release-candidate" Condition=" '$(IsFinalBuild)' == 'true' " />

--- a/build/templates/default-build.yml
+++ b/build/templates/default-build.yml
@@ -1,22 +1,15 @@
 # default-build.yml
 #
 # Description: Defines a build phase for invoking build.sh/cmd
+#
 # Parameters:
-#   jobName: string
-#       The name of the job. Defaults to the name of the OS. No spaces allowed
-#   jobDisplayName: string
-#       The friendly job name to display in the UI. Defaults to the name of the OS.
-#   poolName: string
-#       The name of the VSTS agent queue to use.
 #   agentOs: string
 #       Used in templates to define variables which are OS specific. Typically from the set { Windows, Linux, macOS }
+#   configuration: string
+#       Debug or Release
 #   buildArgs: string
 #       Additional arguments to pass to the build.sh/cmd script.
 #       Note: -ci is always passed
-#   beforeBuild: [steps]
-#       Additional steps to run before build.sh/cmd
-#   afterBuild: [steps]
-#       Additional steps to run after build.sh/cmd
 #   artifacts:
 #      publish: boolean
 #           Should artifacts be published
@@ -24,50 +17,25 @@
 #           The file path to artifacts output
 #      name: string
 #           The name of the artifact container
-#   variables: { string: string }
-#     A map of custom variables
-#   matrix: { string: { string: string } }
-#     A map of matrix configurations and variables. https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema?view=vsts#matrix
-#   demands: string | [ string ]
-#     A list of agent demands. https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema?view=vsts#demands
-#   dependsOn: string | [ string ]
-#     For fan-out/fan-in. https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema?view=vsts#phase
 #   codeSign: boolean
 #       This build definition is enabled for code signing. (Only applies to Windows)
 
 parameters:
   agentOs: 'Windows'
-  poolName: ''
   buildArgs: ''
   configuration: 'Release'
-  demands: []
-  beforeBuild: []
-  afterBuild: []
   codeSign: false
-  variables: {}
-  dependsOn: ''
   artifacts:
     publish: false
     path: 'artifacts/'
-  # buildSteps: [] - don't define an empty object default because there is no way in template expression yet to check "if isEmpty(parameters.buildSteps)"
-  # jobName: '' - use agentOs by default.
-  # jobDisplayName: '' - use agentOs by default.
-  # matrix: {} - don't define an empty object default because there is no way in template expression yet to check "if isEmpty(parameters.matrix)"
 
 jobs:
-- job: ${{ coalesce(parameters.jobName, parameters.agentOs) }}
-  displayName: ${{ coalesce(parameters.jobDisplayName, parameters.agentOs) }}
-  dependsOn: ${{ parameters.dependsOn }}
+- job: ${{ parameters.agentOs }}
   workspace:
     clean: all
-  strategy:
-    ${{ if ne(parameters.matrix, '') }}:
-      maxParallel: 8
-      matrix: ${{ parameters.matrix }}
   # Map friendly OS names to the right queue
+  # See https://github.com/dotnet/arcade/blob/master/Documentation/ChoosingAMachinePool.md
   pool:
-    ${{ if ne(parameters.poolName, '') }}:
-      name: ${{ parameters.poolName }}
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'macOS')) }}:
       name: Hosted macOS
       vmImage: macOS-10.13
@@ -75,9 +43,8 @@ jobs:
       name: Hosted Ubuntu 1604
       vmImage: ubuntu-16.04
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'Windows')) }}:
-      # These Windows pools are temporary while the .NET Core engineering team does more infrastructure work
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        name: DotNetCore-Windows
+        name: dotnet-internal-temp
       ${{ if ne(variables['System.TeamProject'], 'internal') }}:
         name: dotnet-external-temp
   variables:
@@ -85,13 +52,11 @@ jobs:
     DOTNET_HOME: $(Agent.WorkFolder)/.dotnet
     BuildScriptArgs: ${{ parameters.buildArgs }}
     BuildConfiguration: ${{ parameters.configuration }}
-    VSTS_OVERWRITE_TEMP: false # Workaround for https://github.com/dotnet/core-eng/issues/2812
     ${{ if or(ne(parameters.codeSign, 'true'), ne(variables['System.TeamProject'], 'internal')) }}:
       _SignType:
     ${{ if and(eq(parameters.codeSign, 'true'), eq(variables['System.TeamProject'], 'internal')) }}:
       TeamName: AspNetCore
       _SignType: real
-    ${{ insert }}: ${{ parameters.variables }}
   steps:
   - checkout: self
     clean: true
@@ -102,16 +67,13 @@ jobs:
       inputs:
         signType: $(_SignType)
         zipSources: false
-  - ${{ parameters.beforeBuild }}
-  - ${{ if eq(parameters.buildSteps, '') }}:
-    - ${{ if eq(parameters.agentOs, 'Windows') }}:
-      - script: .\build.cmd -ci /p:SignType=$(_SignType) /p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
-        displayName: Run build.cmd
-    - ${{ if ne(parameters.agentOs, 'Windows') }}:
-      - script: ./build.sh -ci -p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
-        displayName: Run build.sh
-  - ${{ if ne(parameters.buildSteps, '') }}:
-    - ${{ parameters.buildSteps }}
+        feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+  - ${{ if eq(parameters.agentOs, 'Windows') }}:
+    - script: .\build.cmd -ci /p:SignType=$(_SignType) /p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
+      displayName: Run build.cmd
+  - ${{ if ne(parameters.agentOs, 'Windows') }}:
+    - script: ./build.sh -ci -p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
+      displayName: Run build.sh
   - task: PublishTestResults@2
     displayName: Publish test results
     condition: always()
@@ -132,7 +94,6 @@ jobs:
           artifactName: ${{ parameters.artifacts.name }}
         artifactType: Container
         parallel: true
-  - ${{ parameters.afterBuild }}
   - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.agentOs, 'Windows')) }}:
     - task: MicroBuildCleanup@1
       displayName: Cleanup MicroBuild tasks


### PR DESCRIPTION
Changes:
* Add tags to builds based on whether or not "IsFinalBuild" is true. These can be used in the release pipeline to change build deployment triggers.
* Remove unused variables from the build template
* Switch the internal build queue to "dotnet-internal-temp".
* Add a README build badge