### PR TITLE
Make Indexed Properties no longer Shadow Properties

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalEntityEntry.cs
@@ -589,7 +589,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         /// </summary>
         protected virtual object ReadPropertyValue([NotNull] IPropertyBase propertyBase)
         {
-            Debug.Assert(propertyBase.IsIndexedProperty || !propertyBase.IsShadowProperty);
+            Debug.Assert(!propertyBase.IsShadowProperty);
 
             return ((PropertyBase)propertyBase).Getter.GetClrValue(Entity);
         }

--- a/src/EFCore/ChangeTracking/Internal/InternalMixedEntityEntry.cs
+++ b/src/EFCore/ChangeTracking/Internal/InternalMixedEntityEntry.cs
@@ -68,7 +68,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         protected override object ReadPropertyValue(IPropertyBase propertyBase)
-            => propertyBase.IsIndexedProperty || !propertyBase.IsShadowProperty
+            => !propertyBase.IsShadowProperty
                 ? base.ReadPropertyValue(propertyBase)
                 : _shadowValues[propertyBase.GetShadowIndex()];
 

--- a/src/EFCore/ChangeTracking/Internal/SnapshotFactoryFactory.cs
+++ b/src/EFCore/ChangeTracking/Internal/SnapshotFactoryFactory.cs
@@ -114,6 +114,21 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                         CreateReadShadowValueExpression(parameter, propertyBase),
                         propertyBase);
                 }
+                else if (propertyBase.IsIndexedProperty)
+                {
+                    var indexerAccessExpression = (Expression)Expression.MakeIndex(
+                        entityVariable,
+                        propertyBase.PropertyInfo,
+                        new List<Expression>() { Expression.Constant(propertyBase.Name) });
+                    if (propertyBase.PropertyInfo.PropertyType != propertyBase.ClrType)
+                    {
+                        indexerAccessExpression =
+                            Expression.Convert(indexerAccessExpression, propertyBase.ClrType);
+                    }
+
+                    arguments[i] =
+                        CreateSnapshotValueExpression(indexerAccessExpression, propertyBase);
+                }
                 else
                 {
                     var memberAccess = (Expression)Expression.MakeMemberAccess(

--- a/src/EFCore/Metadata/Internal/ClrAccessorFactory.cs
+++ b/src/EFCore/Metadata/Internal/ClrAccessorFactory.cs
@@ -23,7 +23,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual TAccessor Create([NotNull] IPropertyBase property)
-            => property as TAccessor ?? Create(null, property);
+            => property as TAccessor ?? Create(property.PropertyInfo, property);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/Internal/EntityMaterializerSource.cs
+++ b/src/EFCore/Metadata/Internal/EntityMaterializerSource.cs
@@ -112,7 +112,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     .Concat(
                         entityType
                             .GetProperties()
-                            .Where(p => !p.IsShadowProperty || p.IsIndexedProperty)));
+                            .Where(p => !p.IsShadowProperty)));
 
             foreach (var consumedProperty in constructorBinding
                 .ParameterBindings

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -1597,7 +1597,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 ClrType?.GetMembersInHierarchy(name).FirstOrDefault(),
                 configurationSource,
                 typeConfigurationSource,
-                isIndexProperty: false);
+                isIndexedProperty: false);
         }
 
         /// <summary>
@@ -1628,7 +1628,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 memberInfo,
                 configurationSource,
                 configurationSource,
-                isIndexProperty: false);
+                isIndexedProperty: false);
         }
 
 
@@ -1646,13 +1646,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Check.NotNull(name, nameof(name));
             Check.NotNull(propertyType, nameof(propertyType));
 
+            var indexerProperty = this.EFIndexerProperty();
+            if (indexerProperty == null)
+            {
+                throw new InvalidOperationException(CoreStrings.NoIndexer(name, this.DisplayName()));
+            }
+
             return AddProperty(
                 name,
                 propertyType,
-                null,
+                indexerProperty,
                 configurationSource,
                 typeConfigurationSource,
-                isIndexProperty: true);
+                isIndexedProperty: true);
         }
 
         private Property AddProperty(
@@ -1661,7 +1667,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             MemberInfo memberInfo,
             ConfigurationSource configurationSource,
             ConfigurationSource? typeConfigurationSource,
-            bool isIndexProperty)
+            bool isIndexedProperty)
         {
             var conflictingMember = FindMembersInHierarchy(name).FirstOrDefault();
             if (conflictingMember != null)
@@ -1685,6 +1691,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             else
             {
                 if (memberInfo != null
+                    && !isIndexedProperty
                     && propertyType != memberInfo.GetMemberType())
                 {
                     throw new InvalidOperationException(
@@ -1698,7 +1705,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             var property = new Property(
                 name, propertyType, memberInfo as PropertyInfo, memberInfo as FieldInfo, this,
-                configurationSource, typeConfigurationSource, isIndexProperty);
+                configurationSource, typeConfigurationSource);
 
             _properties.Add(property.Name, property);
             PropertyMetadataChanged();

--- a/src/EFCore/Metadata/Internal/IndexedPropertyGetterFactory.cs
+++ b/src/EFCore/Metadata/Internal/IndexedPropertyGetterFactory.cs
@@ -25,10 +25,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         protected override IClrPropertyGetter CreateGeneric<TEntity, TValue, TNonNullableEnumValue>(
             PropertyInfo propertyInfo, IPropertyBase propertyBase)
         {
+            Debug.Assert(propertyInfo != null);
             Debug.Assert(propertyBase != null);
 
-            var indexerPropertyInfo = propertyBase.DeclaringType.EFIndexerProperty();
-            if (indexerPropertyInfo == null)
+            if (!propertyInfo.IsEFIndexerProperty())
             {
                 throw new InvalidOperationException(
                     CoreStrings.NoIndexer(propertyBase.Name, propertyBase.DeclaringType.DisplayName()));
@@ -37,7 +37,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var entityParameter = Expression.Parameter(typeof(TEntity), "entity");
             var indexerParameterList = new List<Expression>() { Expression.Constant(propertyBase.Name) };
             Expression readExpression = Expression.MakeIndex(
-                entityParameter, indexerPropertyInfo, indexerParameterList);
+                entityParameter, propertyInfo, indexerParameterList);
 
             if (readExpression.Type != typeof(TValue))
             {

--- a/src/EFCore/Metadata/Internal/Property.cs
+++ b/src/EFCore/Metadata/Internal/Property.cs
@@ -45,9 +45,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             [CanBeNull] FieldInfo fieldInfo,
             [NotNull] EntityType declaringEntityType,
             ConfigurationSource configurationSource,
-            ConfigurationSource? typeConfigurationSource,
-            bool isIndexProperty = false)
-            : base(name, propertyInfo, fieldInfo, isIndexProperty)
+            ConfigurationSource? typeConfigurationSource)
+            : base(name, propertyInfo, fieldInfo)
         {
             Check.NotNull(clrType, nameof(clrType));
             Check.NotNull(declaringEntityType, nameof(declaringEntityType));

--- a/src/EFCore/Metadata/Internal/PropertyBase.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBase.cs
@@ -18,13 +18,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
     {
         private FieldInfo _fieldInfo;
         private ConfigurationSource? _fieldInfoConfigurationSource;
+        private bool _isIndexedProperty;
 
         // Warning: Never access these fields directly as access needs to be thread-safe
         private IClrPropertyGetter _getter;
         private IClrPropertySetter _setter;
         private PropertyAccessors _accessors;
         private PropertyIndexes _indexes;
-        private bool _isIndexedProperty;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -33,15 +33,15 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         protected PropertyBase(
             [NotNull] string name,
             [CanBeNull] PropertyInfo propertyInfo,
-            [CanBeNull] FieldInfo fieldInfo,
-            bool isIndexProperty = false)
+            [CanBeNull] FieldInfo fieldInfo)
         {
             Check.NotEmpty(name, nameof(name));
 
             Name = name;
             PropertyInfo = propertyInfo;
             _fieldInfo = fieldInfo;
-            _isIndexedProperty = isIndexProperty;
+            _isIndexedProperty = propertyInfo != null
+                && propertyInfo.IsEFIndexerProperty();
         }
 
         /// <summary>

--- a/src/EFCore/Metadata/Internal/PropertyExtensions.cs
+++ b/src/EFCore/Metadata/Internal/PropertyExtensions.cs
@@ -244,6 +244,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 builder.Append(" Shadow");
             }
 
+            if (property.IsIndexedProperty)
+            {
+                builder.Append(" Indexed");
+            }
+
             if (!property.IsNullable)
             {
                 builder.Append(" Required");

--- a/src/EFCore/Metadata/Internal/TypeBaseExtensions.cs
+++ b/src/EFCore/Metadata/Internal/TypeBaseExtensions.cs
@@ -52,11 +52,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 : type.ClrType.GetRuntimeProperties();
 
             // find the indexer with single argument of type string which returns an object
-            return (from p in runtimeProperties
-                    where p.PropertyType == typeof(object)
-                    let q = p.GetIndexParameters()
-                    where q.Length == 1 && q[0].ParameterType == typeof(string)
-                    select p).FirstOrDefault();
+            return runtimeProperties.FirstOrDefault(p => p.IsEFIndexerProperty());
         }
     }
 }

--- a/src/Shared/PropertyInfoExtensions.cs
+++ b/src/Shared/PropertyInfoExtensions.cs
@@ -21,6 +21,21 @@ namespace System.Reflection
                && propertyInfo.GetMethod != null && (!publicOnly || propertyInfo.GetMethod.IsPublic)
                && propertyInfo.GetIndexParameters().Length == 0;
 
+        public static bool IsEFIndexerProperty([NotNull] this PropertyInfo propertyInfo)
+        {
+            if (propertyInfo.PropertyType == typeof(object))
+            {
+                var indexParams = propertyInfo.GetIndexParameters();
+                if (indexParams.Length == 1
+                    && indexParams[0].ParameterType == typeof(string))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         public static PropertyInfo FindGetterProperty([NotNull] this PropertyInfo propertyInfo)
             => propertyInfo.DeclaringType
                 .GetPropertiesInHierarchy(propertyInfo.GetSimpleMemberName())

--- a/test/EFCore.Tests/Metadata/Internal/IndexedPropertyGetterFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/IndexedPropertyGetterFactoryTest.cs
@@ -30,14 +30,10 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         {
             var entityType = new Model().AddEntityType(typeof(NonIndexedClass));
             var idProperty = entityType.AddProperty("Id", typeof(int));
-            var propertyA = entityType.AddIndexedProperty("PropertyA", typeof(string));
-            var propertyB = entityType.AddIndexedProperty("PropertyB", typeof(int));
-
-            var nonIndexedClass = new NonIndexedClass();
             Assert.Throws<InvalidOperationException>(
-                () => new IndexedPropertyGetterFactory().Create(propertyA).GetClrValue(nonIndexedClass));
+                () => entityType.AddIndexedProperty("PropA", typeof(string)));
             Assert.Throws<InvalidOperationException>(
-                () => new IndexedPropertyGetterFactory().Create(propertyB).GetClrValue(nonIndexedClass));
+                () => entityType.AddIndexedProperty("PropB", typeof(int)));
         }
 
         private class IndexedClass

--- a/test/EFCore.Tests/Metadata/Internal/IndexedPropertySetterFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/IndexedPropertySetterFactoryTest.cs
@@ -1,7 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
 using Xunit;
 
@@ -29,27 +28,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Assert.Equal(456, indexedClass["PropertyB"]);
         }
 
-        [Fact]
-        public void Exception_is_returned_when_setting_indexed_property_without_indexer()
-        {
-            var entityType = new Model().AddEntityType(typeof(NonIndexedClass));
-            var idProperty = entityType.AddProperty("Id", typeof(int));
-            var propertyA = entityType.AddIndexedProperty("PropertyA", typeof(string));
-            var propertyB = entityType.AddIndexedProperty("PropertyB", typeof(int));
-
-            var indexedClass = new NonIndexedClass
-            {
-                Id = 1,
-                PropA = "PropAValue",
-                PropB = 123
-            };
-
-            Assert.Throws<InvalidOperationException>(
-                () => new IndexedPropertySetterFactory().Create(propertyA).SetClrValue(indexedClass, "UpdatedValueA"));
-            Assert.Throws<InvalidOperationException>(
-                () => new IndexedPropertySetterFactory().Create(propertyB).SetClrValue(indexedClass, 456));
-        }
-
         private class IndexedClass
         {
             private Dictionary<string, object> _internalValues = new Dictionary<string, object>()
@@ -65,13 +43,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 get => _internalValues[name];
                 set => _internalValues[name] = value;
             }
-        }
-
-        private class NonIndexedClass
-        {
-            internal int Id { get; set; }
-            public string PropA { get; set; }
-            public int PropB { get; set; }
         }
     }
 }


### PR DESCRIPTION
When an indexed property is created pass in the `PropertyInfo` associated with the indexer which will be used for this property. This has the desired effect of making indexed properties no longer shadow properties and allows the code to reference that `PropertyInfo` directly. This addresses part of #13610.
