### PR TITLE
Use shortdate in package versions

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,13 +8,14 @@ trigger:
     include:
     - 'master'
     - 'release/*'
+    - 'internal/release/*'
 # Run PR validation on all branches
 pr:
   branches:
     include:
     - '*'
 
-name: $(Date:yyMMdd)-$(Rev:rr)
+name: $(Date:yyyyMMdd).$(Rev:rr)
 
 jobs:
 - template: build/templates/default-build.yml

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -5,7 +5,7 @@
   <PropertyGroup Label="Package Versions">
     <CastleCorePackageVersion>4.2.1</CastleCorePackageVersion>
     <FunctionalTests_PackageVersion>0.0.0</FunctionalTests_PackageVersion>
-    <InternalAspNetCoreSdkPackageVersion>3.0.0-alpha1-20181108.5</InternalAspNetCoreSdkPackageVersion>
+    <InternalAspNetCoreSdkPackageVersion>3.0.0-build-20181114.5</InternalAspNetCoreSdkPackageVersion>
     <InternalWebHostBuilderFactorySourcesPackageVersion>3.0.0-alpha1-10717</InternalWebHostBuilderFactorySourcesPackageVersion>
     <MicrosoftAzureDocumentDBCorePackageVersion>1.7.1</MicrosoftAzureDocumentDBCorePackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>2.8.0</MicrosoftCodeAnalysisCSharpPackageVersion>

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:3.0.0-alpha1-20181108.5
-commithash:dae1d0c39ad86505e53f3629665714313bfd0d7d
+version:3.0.0-build-20181114.5
+commithash:880e9a204d4ee4a18dfd83c9fb05a192a28bca60

--- a/src/ef/ef.csproj
+++ b/src/ef/ef.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <Target Name="BuildX86" AfterTargets="Build" Condition=" '$(TargetFramework)' == 'net461' And '$(Platform)' != 'x86' ">
-    <MSBuild Projects="$(MSBuildProjectFullPath)" Properties="TargetFramework=$(TargetFramework);Platform=x86;Configuration=$(Configuration);BuildNumber=$(BuildNumber)" Targets="Build" />
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Properties="TargetFramework=$(TargetFramework);Platform=x86;Configuration=$(Configuration)" Targets="Build" />
   </Target>
 
 </Project>

--- a/version.props
+++ b/version.props
@@ -4,10 +4,31 @@
     <MinorVersion>0</MinorVersion>
     <PatchVersion>0</PatchVersion>
     <PreReleaseLabel>preview</PreReleaseLabel>
-    <BuildNumber Condition="'$(BuildNumber)' == ''">t000</BuildNumber>
+    <OfficialBuildId Condition="'$(OfficialBuildId)' == ''">$(BUILD_BUILDNUMBER)</OfficialBuildId>
+  </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(OfficialBuildId)' != '' ">
+    <!-- This implements core versioning. Spec: https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md -->
+    <_BuildNumber>$(OfficialBuildId)</_BuildNumber>
+
+    <!-- _BuildNumber from CI is assumed to have format "yyyyMMdd.r". -->
+    <_BuildNumberYY>$(_BuildNumber.Substring(2, 2))</_BuildNumberYY>
+    <_BuildNumberMM>$(_BuildNumber.Substring(4, 2))</_BuildNumberMM>
+    <_BuildNumberDD>$(_BuildNumber.Substring(6, 2))</_BuildNumberDD>
+    <_BuildNumberR>$(_BuildNumber.Substring(9))</_BuildNumberR>
+
+    <!-- yy * 1000 + mm * 50 + dd -->
+    <_BuildNumberShortDate>$([MSBuild]::Add($([MSBuild]::Add($([MSBuild]::Multiply($(_BuildNumberYY), 1000)), $([MSBuild]::Multiply($(_BuildNumberMM), 50)))), $(_BuildNumberDD)))</_BuildNumberShortDate>
+
+     <VersionSuffixBuildOfTheDay>$([System.Convert]::ToInt32($(_BuildNumberR)))</VersionSuffixBuildOfTheDay>
+
+     <_BuildNumberSuffix>$(_BuildNumberShortDate).$(VersionSuffixBuildOfTheDay)</_BuildNumberSuffix>
+  </PropertyGroup>
+
+   <PropertyGroup>
+    <_BuildNumberSuffix Condition=" '$(_BuildNumberSuffix)' == '' ">0</_BuildNumberSuffix>
     <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
-    <VersionSuffix>$(PreReleaseLabel)-$(BuildNumber)</VersionSuffix>
+    <VersionSuffix>$(PreReleaseLabel).$(_BuildNumberSuffix)</VersionSuffix>
 
     <!-- Run the build with /p:IsFinalBuild=true to produce the product with 'final' branding and versioning -->
     <IsFinalBuild Condition=" '$(IsFinalBuild)' == '' ">false</IsFinalBuild>


### PR DESCRIPTION
This implements the shared versioning spec for .NET Core 3.0. See https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md for details.

For example, today's build would be `3.0.0-preview.18565.1`

Notably: this uses SemVer 2.0