### PR TITLE
UseRowNumberForPaging returns SqlServerDbContextOptionsBuilder

### DIFF
--- a/src/EFCore.SqlServer/Infrastructure/SqlServerDbContextOptionsBuilder.cs
+++ b/src/EFCore.SqlServer/Infrastructure/SqlServerDbContextOptionsBuilder.cs
@@ -35,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
         /// <summary>
         ///     Use a ROW_NUMBER() in queries instead of OFFSET/FETCH. This method is backwards-compatible to SQL Server 2005.
         /// </summary>
-        public virtual void UseRowNumberForPaging(bool useRowNumberForPaging = true)
+        public virtual SqlServerDbContextOptionsBuilder UseRowNumberForPaging(bool useRowNumberForPaging = true)
             => WithOption(e => e.WithRowNumberPaging(useRowNumberForPaging));
 
         /// <summary>

--- a/test/EFCore.Tests/ApiConsistencyTestBase.cs
+++ b/test/EFCore.Tests/ApiConsistencyTestBase.cs
@@ -37,7 +37,6 @@ namespace Microsoft.EntityFrameworkCore
                    from method in type.GetMethods(PublicInstance | BindingFlags.Static)
                    where method.ReturnType == typeof(void)
                    select type.Name + "." + method.Name)
-                .Except(new[] { "SqlServerDbContextOptionsBuilder.UseRowNumberForPaging" }) // TODO: #10808
                 .ToList();
 
             Assert.False(


### PR DESCRIPTION
Summary of the changes
 - Updated UseRowNumberForPaging to return SqlServerDbContextOptionsBuilder
 - Updated Fluent_api_methods_should_not_return_void to not needing this exclusion

Breaking change planned for 3.0.

Fixes #10808