### PR TITLE
Prepare the release/2.2 branch for servicing updates

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,8 +1,7 @@
 ﻿<Project>
-  <PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetLatestDotNetRuntime)' != 'false' ">
     <!-- Assign these values at the end of the project after TargetFramework has been assigned. TargetFramework is not assigned yet in Directory.Build.props. -->
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">$(MicrosoftNETCoreApp20PackageVersion)</RuntimeFrameworkVersion>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">$(MicrosoftNETCoreApp22PackageVersion)</RuntimeFrameworkVersion>
-    <NETStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard2.0' ">$(NETStandardLibrary20PackageVersion)</NETStandardImplicitPackageVersion>
+    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.2' ">$(MicrosoftNETCoreAppPackageVersion)</RuntimeFrameworkVersion>
   </PropertyGroup>
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,13 +8,14 @@ trigger:
     include:
     - 'master'
     - 'release/*'
+    - 'internal/release/*'
 # Run PR validation on all branches
 pr:
   branches:
     include:
     - '*'
 
-name: $(Date:yyMMdd)-$(Rev:rr)
+name: $(Date:yyyyMMdd).$(Rev:rr)
 
 jobs:
 - template: build/templates/default-build.yml
@@ -24,6 +25,7 @@ jobs:
     configuration: Release
     artifacts:
       publish: true
+      name: packages
       path: 'artifacts/build/'
 
 - template: build/templates/default-build.yml

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -8,7 +8,7 @@
     They are used to automatically flow new dependencies in a ProdCon build.
   -->
   <PropertyGroup Label="Package Versions">
-    <InternalAspNetCoreSdkPackageVersion>2.2.0-preview2-20181105.3</InternalAspNetCoreSdkPackageVersion>
+    <InternalAspNetCoreSdkPackageVersion>2.2.1-build-20181130.1</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftNETCoreAppPackageVersion>2.2.0</MicrosoftNETCoreAppPackageVersion>
     <MicrosoftCSharpPackageVersion>4.5.0</MicrosoftCSharpPackageVersion>
     <SystemCollectionsImmutablePackageVersion>1.5.0</SystemCollectionsImmutablePackageVersion>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -2,29 +2,48 @@
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
+
+  <!--
+    These versions may be overriden by automation.
+    They are used to automatically flow new dependencies in a ProdCon build.
+  -->
   <PropertyGroup Label="Package Versions">
+    <InternalAspNetCoreSdkPackageVersion>2.2.0-preview2-20181105.3</InternalAspNetCoreSdkPackageVersion>
+    <MicrosoftNETCoreAppPackageVersion>2.2.0</MicrosoftNETCoreAppPackageVersion>
+    <MicrosoftCSharpPackageVersion>4.5.0</MicrosoftCSharpPackageVersion>
+    <SystemCollectionsImmutablePackageVersion>1.5.0</SystemCollectionsImmutablePackageVersion>
+    <SystemComponentModelAnnotationsPackageVersion>4.5.0</SystemComponentModelAnnotationsPackageVersion>
+    <SystemDataSqlClientPackageVersion>4.6.0</SystemDataSqlClientPackageVersion>
+    <SystemDiagnosticsDiagnosticSourcePackageVersion>4.5.0</SystemDiagnosticsDiagnosticSourcePackageVersion>
+  </PropertyGroup>
+
+  <Import Project="$(DotNetPackageVersionPropsPath)" Condition=" '$(DotNetPackageVersionPropsPath)' != '' " />
+
+  <!-- These versions should not be overriden by automation. -->
+  <PropertyGroup Label="Package Versions: Pinned">
+    <!--
+      These are pinned to ensure EF 2.2.x remains compatible with most installations of .NET Core.
+      They should be updated if there is an essential update to these packages which EF must have to function correctly.
+    -->
+    <InternalWebHostBuilderFactorySourcesPackageVersion>2.2.0</InternalWebHostBuilderFactorySourcesPackageVersion>
+    <MicrosoftExtensionsCachingMemoryPackageVersion>2.2.0</MicrosoftExtensionsCachingMemoryPackageVersion>
+    <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>2.2.0</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
+    <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>2.2.0</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
+    <MicrosoftExtensionsConfigurationJsonPackageVersion>2.2.0</MicrosoftExtensionsConfigurationJsonPackageVersion>
+    <MicrosoftExtensionsConfigurationPackageVersion>2.2.0</MicrosoftExtensionsConfigurationPackageVersion>
+    <MicrosoftExtensionsDependencyInjectionPackageVersion>2.2.0</MicrosoftExtensionsDependencyInjectionPackageVersion>
+    <MicrosoftExtensionsDependencyModelPackageVersion>2.1.0</MicrosoftExtensionsDependencyModelPackageVersion>
+    <MicrosoftExtensionsLoggingPackageVersion>2.2.0</MicrosoftExtensionsLoggingPackageVersion>
+
+    <!-- These dependencies are not automatically flowed via ProdCon. If updates are required, they must be made manually. -->
     <CastleCorePackageVersion>4.2.1</CastleCorePackageVersion>
     <FunctionalTests_PackageVersion>0.0.0</FunctionalTests_PackageVersion>
-    <InternalAspNetCoreSdkPackageVersion>2.2.0-preview2-20181105.3</InternalAspNetCoreSdkPackageVersion>
-    <InternalWebHostBuilderFactorySourcesPackageVersion>2.2.0-rtm-35661</InternalWebHostBuilderFactorySourcesPackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>2.8.0</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>2.8.0</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
-    <MicrosoftCSharpPackageVersion>4.5.0</MicrosoftCSharpPackageVersion>
-    <MicrosoftDataSqliteCorePackageVersion>2.2.0-rtm-35661</MicrosoftDataSqliteCorePackageVersion>
-    <MicrosoftExtensionsCachingMemoryPackageVersion>2.2.0-rtm-181106-13</MicrosoftExtensionsCachingMemoryPackageVersion>
-    <MicrosoftExtensionsConfigurationAbstractionsPackageVersion>2.2.0-rtm-181106-13</MicrosoftExtensionsConfigurationAbstractionsPackageVersion>
-    <MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>2.2.0-rtm-181106-13</MicrosoftExtensionsConfigurationEnvironmentVariablesPackageVersion>
-    <MicrosoftExtensionsConfigurationJsonPackageVersion>2.2.0-rtm-181106-13</MicrosoftExtensionsConfigurationJsonPackageVersion>
-    <MicrosoftExtensionsConfigurationPackageVersion>2.2.0-rtm-181106-13</MicrosoftExtensionsConfigurationPackageVersion>
-    <MicrosoftExtensionsDependencyInjectionPackageVersion>2.2.0-rtm-181106-13</MicrosoftExtensionsDependencyInjectionPackageVersion>
-    <MicrosoftExtensionsDependencyModelPackageVersion>2.1.0</MicrosoftExtensionsDependencyModelPackageVersion>
-    <MicrosoftExtensionsLoggingPackageVersion>2.2.0-rtm-181106-13</MicrosoftExtensionsLoggingPackageVersion>
     <MicrosoftNETCoreApp11PackageVersion>1.1.9</MicrosoftNETCoreApp11PackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.9</MicrosoftNETCoreApp20PackageVersion>
-    <MicrosoftNETCoreApp22PackageVersion>2.2.0-rtm-27105-02</MicrosoftNETCoreApp22PackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.6.1</MicrosoftNETTestSdkPackageVersion>
     <mod_spatialitePackageVersion>4.3.0.1</mod_spatialitePackageVersion>
-    <NETStandardLibrary20PackageVersion>2.0.3</NETStandardLibrary20PackageVersion>
     <NetTopologySuiteCorePackageVersion>1.15.1</NetTopologySuiteCorePackageVersion>
     <NetTopologySuiteIOSpatiaLitePackageVersion>1.15.0</NetTopologySuiteIOSpatiaLitePackageVersion>
     <NetTopologySuiteIOSqlServerBytesPackageVersion>1.15.0</NetTopologySuiteIOSqlServerBytesPackageVersion>
@@ -35,10 +54,7 @@
     <SQLitePCLRawBundleSqlcipherPackageVersion>1.1.11</SQLitePCLRawBundleSqlcipherPackageVersion>
     <SQLitePCLRawCorePackageVersion>1.1.11</SQLitePCLRawCorePackageVersion>
     <StyleCopAnalyzersPackageVersion>1.0.0</StyleCopAnalyzersPackageVersion>
-    <SystemCollectionsImmutablePackageVersion>1.5.0</SystemCollectionsImmutablePackageVersion>
-    <SystemComponentModelAnnotationsPackageVersion>4.5.0</SystemComponentModelAnnotationsPackageVersion>
-    <SystemDataSqlClientPackageVersion>4.6.0-rtm-27105-02</SystemDataSqlClientPackageVersion>
-    <SystemDiagnosticsDiagnosticSourcePackageVersion>4.5.0</SystemDiagnosticsDiagnosticSourcePackageVersion>
+    <!-- This package is System.*, but it's not from corefx. -->
     <SystemInteractiveAsyncPackageVersion>3.2.0</SystemInteractiveAsyncPackageVersion>
     <XunitAnalyzersPackageVersion>0.10.0</XunitAnalyzersPackageVersion>
     <XunitAssertPackageVersion>2.3.1</XunitAssertPackageVersion>
@@ -47,6 +63,4 @@
     <XunitPackageVersion>2.3.1</XunitPackageVersion>
     <XunitRunnerVisualStudioPackageVersion>2.4.0</XunitRunnerVisualStudioPackageVersion>
   </PropertyGroup>
-  <Import Project="$(DotNetPackageVersionPropsPath)" Condition=" '$(DotNetPackageVersionPropsPath)' != '' " />
-  <PropertyGroup Label="Package Versions: Pinned" />
 </Project>

--- a/build/repo.props
+++ b/build/repo.props
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp20PackageVersion)" />
-    <DotNetCoreRuntime Include="$(MicrosoftNETCoreApp22PackageVersion)" />
+    <DotNetCoreRuntime Include="$(MicrosoftNETCoreAppPackageVersion)" />
 
     <ExcludeFromTest Include="$(RepositoryRoot)samples\OracleProvider\test\OracleProvider.FunctionalTests\*.csproj" />
     <ExcludeFromTest Include="$(RepositoryRoot)test\EFCore.SqlServer.FunctionalTests\*.csproj" Condition="'$(OS)' != 'Windows_NT' AND '$(Test__SqlServer__DefaultConnection)' == ''"/>
@@ -15,11 +15,5 @@
     <ExcludeSolutions Include="$(RepositoryRoot)EFCore.Cosmos.sln" />
     <ExcludeSolutions Include="$(RepositoryRoot)Microsoft.Data.Sqlite.sln" />
   </ItemGroup>
-  <PropertyGroup>
-    <!-- These properties are use by the automation that updates dependencies.props -->
-    <LineupPackageId>Internal.AspNetCore.Universe.Lineup</LineupPackageId>
-    <LineupPackageVersion>2.2.0-*</LineupPackageVersion>
-    <LineupPackageRestoreSource>https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json</LineupPackageRestoreSource>
-  </PropertyGroup>
 
 </Project>

--- a/build/templates/default-build.yml
+++ b/build/templates/default-build.yml
@@ -1,22 +1,15 @@
 # default-build.yml
 #
 # Description: Defines a build phase for invoking build.sh/cmd
+#
 # Parameters:
-#   jobName: string
-#       The name of the job. Defaults to the name of the OS. No spaces allowed
-#   jobDisplayName: string
-#       The friendly job name to display in the UI. Defaults to the name of the OS.
-#   poolName: string
-#       The name of the VSTS agent queue to use.
 #   agentOs: string
 #       Used in templates to define variables which are OS specific. Typically from the set { Windows, Linux, macOS }
+#   configuration: string
+#       Debug or Release
 #   buildArgs: string
 #       Additional arguments to pass to the build.sh/cmd script.
 #       Note: -ci is always passed
-#   beforeBuild: [steps]
-#       Additional steps to run before build.sh/cmd
-#   afterBuild: [steps]
-#       Additional steps to run after build.sh/cmd
 #   artifacts:
 #      publish: boolean
 #           Should artifacts be published
@@ -24,50 +17,25 @@
 #           The file path to artifacts output
 #      name: string
 #           The name of the artifact container
-#   variables: { string: string }
-#     A map of custom variables
-#   matrix: { string: { string: string } }
-#     A map of matrix configurations and variables. https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema?view=vsts#matrix
-#   demands: string | [ string ]
-#     A list of agent demands. https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema?view=vsts#demands
-#   dependsOn: string | [ string ]
-#     For fan-out/fan-in. https://docs.microsoft.com/en-us/vsts/pipelines/yaml-schema?view=vsts#phase
 #   codeSign: boolean
 #       This build definition is enabled for code signing. (Only applies to Windows)
 
 parameters:
   agentOs: 'Windows'
-  poolName: ''
   buildArgs: ''
   configuration: 'Release'
-  demands: []
-  beforeBuild: []
-  afterBuild: []
   codeSign: false
-  variables: {}
-  dependsOn: ''
   artifacts:
     publish: false
     path: 'artifacts/'
-  # buildSteps: [] - don't define an empty object default because there is no way in template expression yet to check "if isEmpty(parameters.buildSteps)"
-  # jobName: '' - use agentOs by default.
-  # jobDisplayName: '' - use agentOs by default.
-  # matrix: {} - don't define an empty object default because there is no way in template expression yet to check "if isEmpty(parameters.matrix)"
 
 jobs:
-- job: ${{ coalesce(parameters.jobName, parameters.agentOs) }}
-  displayName: ${{ coalesce(parameters.jobDisplayName, parameters.agentOs) }}
-  dependsOn: ${{ parameters.dependsOn }}
+- job: ${{ parameters.agentOs }}
   workspace:
     clean: all
-  strategy:
-    ${{ if ne(parameters.matrix, '') }}:
-      maxParallel: 8
-      matrix: ${{ parameters.matrix }}
   # Map friendly OS names to the right queue
+  # See https://github.com/dotnet/arcade/blob/master/Documentation/ChoosingAMachinePool.md
   pool:
-    ${{ if ne(parameters.poolName, '') }}:
-      name: ${{ parameters.poolName }}
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'macOS')) }}:
       name: Hosted macOS
       vmImage: macOS-10.13
@@ -75,9 +43,8 @@ jobs:
       name: Hosted Ubuntu 1604
       vmImage: ubuntu-16.04
     ${{ if and(eq(parameters.poolName, ''), eq(parameters.agentOs, 'Windows')) }}:
-      # These Windows pools are temporary while the .NET Core engineering team does more infrastructure work
       ${{ if eq(variables['System.TeamProject'], 'internal') }}:
-        name: DotNetCore-Windows
+        name: dotnet-internal-temp
       ${{ if ne(variables['System.TeamProject'], 'internal') }}:
         name: dotnet-external-temp
   variables:
@@ -85,13 +52,11 @@ jobs:
     DOTNET_HOME: $(Agent.WorkFolder)/.dotnet
     BuildScriptArgs: ${{ parameters.buildArgs }}
     BuildConfiguration: ${{ parameters.configuration }}
-    VSTS_OVERWRITE_TEMP: false # Workaround for https://github.com/dotnet/core-eng/issues/2812
     ${{ if or(ne(parameters.codeSign, 'true'), ne(variables['System.TeamProject'], 'internal')) }}:
       _SignType:
     ${{ if and(eq(parameters.codeSign, 'true'), eq(variables['System.TeamProject'], 'internal')) }}:
       TeamName: AspNetCore
       _SignType: real
-    ${{ insert }}: ${{ parameters.variables }}
   steps:
   - checkout: self
     clean: true
@@ -102,16 +67,13 @@ jobs:
       inputs:
         signType: $(_SignType)
         zipSources: false
-  - ${{ parameters.beforeBuild }}
-  - ${{ if eq(parameters.buildSteps, '') }}:
-    - ${{ if eq(parameters.agentOs, 'Windows') }}:
-      - script: .\build.cmd -ci /p:SignType=$(_SignType) /p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
-        displayName: Run build.cmd
-    - ${{ if ne(parameters.agentOs, 'Windows') }}:
-      - script: ./build.sh -ci -p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
-        displayName: Run build.sh
-  - ${{ if ne(parameters.buildSteps, '') }}:
-    - ${{ parameters.buildSteps }}
+        feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+  - ${{ if eq(parameters.agentOs, 'Windows') }}:
+    - script: .\build.cmd -ci /p:SignType=$(_SignType) /p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
+      displayName: Run build.cmd
+  - ${{ if ne(parameters.agentOs, 'Windows') }}:
+    - script: ./build.sh -ci -p:Configuration=$(BuildConfiguration) $(BuildScriptArgs)
+      displayName: Run build.sh
   - task: PublishTestResults@2
     displayName: Publish test results
     condition: always()
@@ -132,7 +94,6 @@ jobs:
           artifactName: ${{ parameters.artifacts.name }}
         artifactType: Container
         parallel: true
-  - ${{ parameters.afterBuild }}
   - ${{ if and(eq(variables['System.TeamProject'], 'internal'), eq(parameters.agentOs, 'Windows')) }}:
     - task: MicroBuildCleanup@1
       displayName: Cleanup MicroBuild tasks

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.2.0-preview2-20181105.3
-commithash:2f561e9983bce0f39e64fdb262635da897b32d8c
+version:2.2.1-build-20181130.1
+commithash:e7f77e1fda60bc39e8239ea51d94a9b4cdb889bc

--- a/src/dotnet-ef/dotnet-ef.csproj
+++ b/src/dotnet-ef/dotnet-ef.csproj
@@ -23,6 +23,11 @@ dotnet ef database update
     <CodeAnalysisRuleSet>..\..\EFCore.ruleset</CodeAnalysisRuleSet>
     <EnableApiCheck>false</EnableApiCheck>
     <NuspecFile>$(MSBuildProjectName).nuspec</NuspecFile>
+    <!--
+      This keeps ef.exe targeting the default version of .NET Core for netcoreapp2.0,
+      which maximizes the machines on which this tool will be compatible.
+    -->
+    <TargetLatestDotNetRuntime>false</TargetLatestDotNetRuntime>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ef/ef.csproj
+++ b/src/ef/ef.csproj
@@ -7,6 +7,11 @@
     <IsPackable>false</IsPackable>
     <RootNamespace>Microsoft.EntityFrameworkCore.Tools</RootNamespace>
     <CodeAnalysisRuleSet>..\..\EFCore.ruleset</CodeAnalysisRuleSet>
+    <!--
+      This keeps ef.exe targeting the default version of .NET Core for netcoreapp2.0,
+      which maximizes the machines on which this tool will be compatible.
+    -->
+    <TargetLatestDotNetRuntime>false</TargetLatestDotNetRuntime>
   </PropertyGroup>
 
   <ItemGroup>

--- a/version.props
+++ b/version.props
@@ -1,18 +1,56 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>2.2.0</VersionPrefix>
-    <VersionSuffix>rtm</VersionSuffix>
-    <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' == 'rtm' ">$(VersionPrefix)</PackageVersion>
-    <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' != 'rtm' ">$(VersionPrefix)-$(VersionSuffix)-final</PackageVersion>
-    <BuildNumber Condition="'$(BuildNumber)' == ''">t000</BuildNumber>
-    <FeatureBranchVersionPrefix Condition="'$(FeatureBranchVersionPrefix)' == ''">a-</FeatureBranchVersionPrefix>
-    <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(FeatureBranchVersionSuffix)' != ''">$(FeatureBranchVersionPrefix)$(VersionSuffix)-$([System.Text.RegularExpressions.Regex]::Replace('$(FeatureBranchVersionSuffix)', '[^\w-]', '-'))</VersionSuffix>
-    <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
-
-    <ExperimentalVersionPrefix>0.2.0</ExperimentalVersionPrefix>
-    <ExperimentalVersionSuffix>rtm</ExperimentalVersionSuffix>
-    <ExperimentalPackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(ExperimentalVersionSuffix)' == 'rtm' ">$(ExperimentalVersionPrefix)</ExperimentalPackageVersion>
-    <ExperimentalPackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(ExperimentalVersionSuffix)' != 'rtm' ">$(ExperimentalVersionPrefix)-$(ExperimentalVersionSuffix)-final</ExperimentalPackageVersion>
-    <ExperimentalVersionSuffix Condition="'$(ExperimentalVersionSuffix)' != '' And '$(BuildNumber)' != ''">$(ExperimentalVersionSuffix)-$(BuildNumber)</ExperimentalVersionSuffix>
+    <MajorVersion>2</MajorVersion>
+    <MinorVersion>2</MinorVersion>
+    <PatchVersion>1</PatchVersion>
+    <PreReleaseLabel>servicing</PreReleaseLabel>
+    <OfficialBuildId Condition="'$(OfficialBuildId)' == ''">$(BUILD_BUILDNUMBER)</OfficialBuildId>
   </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(OfficialBuildId)' != '' ">
+    <!-- This implements core versioning. Spec: https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md -->
+    <_BuildNumber>$(OfficialBuildId)</_BuildNumber>
+
+    <!-- _BuildNumber from CI is assumed to have format "yyyyMMdd.r". -->
+    <_BuildNumberYY>$(_BuildNumber.Substring(2, 2))</_BuildNumberYY>
+    <_BuildNumberMM>$(_BuildNumber.Substring(4, 2))</_BuildNumberMM>
+    <_BuildNumberDD>$(_BuildNumber.Substring(6, 2))</_BuildNumberDD>
+    <_BuildNumberR>$(_BuildNumber.Substring(9))</_BuildNumberR>
+
+    <!-- yy * 1000 + mm * 50 + dd -->
+    <_BuildNumberShortDate>$([MSBuild]::Add($([MSBuild]::Add($([MSBuild]::Multiply($(_BuildNumberYY), 1000)), $([MSBuild]::Multiply($(_BuildNumberMM), 50)))), $(_BuildNumberDD)))</_BuildNumberShortDate>
+
+     <VersionSuffixBuildOfTheDay>$([System.Convert]::ToInt32($(_BuildNumberR)))</VersionSuffixBuildOfTheDay>
+
+     <_BuildNumberSuffix>$(_BuildNumberShortDate).$(VersionSuffixBuildOfTheDay)</_BuildNumberSuffix>
+  </PropertyGroup>
+
+  <!-- This is temporary until we finish https://github.com/aspnet/AspNetCore-Internal/issues/1338  -->
+  <PropertyGroup Condition=" '$(TEAMCITY_VERSION)' != '' ">
+    <_BuildNumberSuffix>$(BuildNumber)</_BuildNumberSuffix>
+    <VersionSuffix>$(PreReleaseLabel)-$(_BuildNumberSuffix)</VersionSuffix>
+  </PropertyGroup>
+
+   <PropertyGroup>
+    <_BuildNumberSuffix Condition=" '$(_BuildNumberSuffix)' == '' ">0</_BuildNumberSuffix>
+    <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
+    <VersionSuffix Condition=" '$(VersionSuffix)' == '' ">$(PreReleaseLabel).$(_BuildNumberSuffix)</VersionSuffix>
+
+    <!-- Run the build with /p:IsFinalBuild=true to produce the product with 'final' branding and versioning -->
+    <IsFinalBuild Condition=" '$(IsFinalBuild)' == '' ">false</IsFinalBuild>
+    <IncludePreReleaseLabelInPackageVersion>true</IncludePreReleaseLabelInPackageVersion>
+    <IncludePreReleaseLabelInPackageVersion Condition=" '$(IsFinalBuild)' == 'true' AND ('$(PreReleaseLabel)' == 'servicing' OR '$(PreReleaseLabel)' == 'rtm')">false</IncludePreReleaseLabelInPackageVersion>
+
+    <!-- The version in files -->
+    <PackageVersion>$(VersionPrefix)</PackageVersion>
+    <PackageVersion Condition=" '$(IncludePreReleaseLabelInPackageVersion)' == 'true' ">$(VersionPrefix)-$(VersionSuffix)</PackageVersion>
+  </PropertyGroup>
+
+  <!-- Run 'dotnet msbuild version.props' to test changes to this file. -->
+  <Target Name="InspectVersionNumbers">
+    <Message Importance="High" Text="PackageVersion   = '$(PackageVersion)'" />
+    <Message Importance="High" Text="VersionPrefix    = '$(VersionPrefix)'" />
+    <Message Importance="High" Text="VersionSuffix    = '$(VersionSuffix)'" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
This updates targets and property files to build a 2.2.1 version of EF Core.

cc @AndriySvyryd @bricelam @roji 