### PR TITLE
[WIP] - Shared-Type Entities Update Pipeline

### DIFF
--- a/src/EFCore/ChangeTracking/Internal/ISharedTypeEntityFinder.cs
+++ b/src/EFCore/ChangeTracking/Internal/ISharedTypeEntityFinder.cs
@@ -1,27 +1,22 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
 
-namespace Microsoft.EntityFrameworkCore.Internal
+namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 {
     /// <summary>
     ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
     ///     directly from your code. This API may change or be removed in future releases.
     /// </summary>
-    public interface IDbSetSource
+    public interface ISharedTypeEntityFinder
     {
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        object Create([NotNull] DbContext context, [NotNull] Type type);
-
-        /// <summary>
-        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
-        ///     directly from your code. This API may change or be removed in future releases.
-        /// </summary>
-        object CreateSharedTypeSet([NotNull] DbContext context, [NotNull] string entityTypeName, [NotNull] Type type);
+        /// <returns> the shared-type EntityType corresponding to this instance if found in the model, or null if not. </returns>
+        IEntityType FindSharedTypeEntityType([NotNull] object entityInstance);
     }
 }

--- a/src/EFCore/ChangeTracking/Internal/SelfDescribingIndexPropertyEntityFinder.cs
+++ b/src/EFCore/ChangeTracking/Internal/SelfDescribingIndexPropertyEntityFinder.cs
@@ -1,0 +1,83 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class SelfDescribingIndexPropertyEntityFinder : ISharedTypeEntityFinder
+    {
+        public const string DefaultEntityTypeNamePropertyName = "__EntityTypeName__";
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public SelfDescribingIndexPropertyEntityFinder([NotNull] IModel model)
+        {
+            Check.NotNull(model, nameof(model));
+
+            Model = model;
+            EntityTypeNamePropertyName = DefaultEntityTypeNamePropertyName;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual string EntityTypeNamePropertyName { get; [NotNull]set; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual IModel Model { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        /// <returns> the shared-type EntityType corresponding to this instance if found in the model, or null if not. </returns>
+        public virtual IEntityType FindSharedTypeEntityType(object entityInstance)
+        {
+            Check.NotNull(entityInstance, nameof(entityInstance));
+
+            var efIndexerPropInfo = entityInstance.GetType()
+                .GetRuntimeProperties().FirstOrDefault(p => p.IsEFIndexerProperty());
+            if (efIndexerPropInfo == null)
+            {
+                return null;
+            }
+
+            string entityTypeName = null;
+            try
+            {
+                entityTypeName = efIndexerPropInfo
+                    .GetValue(entityInstance, new[] { EntityTypeNamePropertyName }) as string;
+            }
+            catch
+            {
+                // exceptions indicate the indexer does not have the
+                // EntityTypeNamePropertyName key etc.
+            }
+
+            var entityType = entityTypeName == null
+                ? null
+                : Model.FindEntityType(entityTypeName);
+
+            return entityType != null && entityType.IsSharedType ? entityType : null;
+        }
+    }
+}

--- a/src/EFCore/ChangeTracking/Internal/StateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManager.cs
@@ -47,6 +47,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         private readonly IModel _model;
         private readonly IDatabase _database;
         private readonly IConcurrencyDetector _concurrencyDetector;
+        private readonly ISharedTypeEntityFinder _sharedTypeEntityFinder;
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
@@ -72,6 +73,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             UpdateLogger = dependencies.UpdateLogger;
             _changeTrackingLogger = dependencies.ChangeTrackingLogger;
+            _sharedTypeEntityFinder = dependencies.SharedTypeEntityFinder;
         }
 
         /// <summary>
@@ -155,7 +157,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             {
                 _trackingQueryMode = TrackingQueryMode.Multiple;
 
-                var entityType = _model.FindRuntimeEntityType(entity.GetType());
+                var entityType = _sharedTypeEntityFinder.FindSharedTypeEntityType(entity)
+                    ?? _model.FindRuntimeEntityType(entity.GetType());
                 if (entityType == null)
                 {
                     if (_model.HasEntityTypeWithDefiningNavigation(entity.GetType()))

--- a/src/EFCore/ChangeTracking/Internal/StateManagerDependencies.cs
+++ b/src/EFCore/ChangeTracking/Internal/StateManagerDependencies.cs
@@ -60,7 +60,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             [NotNull] IEntityMaterializerSource entityMaterializerSource,
             [NotNull] ILoggingOptions loggingOptions,
             [NotNull] IDiagnosticsLogger<DbLoggerCategory.Update> updateLogger,
-            [NotNull] IDiagnosticsLogger<DbLoggerCategory.ChangeTracking> changeTrackingLogger)
+            [NotNull] IDiagnosticsLogger<DbLoggerCategory.ChangeTracking> changeTrackingLogger,
+            [NotNull] ISharedTypeEntityFinder sharedEntityTypeFinder)
         {
             InternalEntityEntryFactory = internalEntityEntryFactory;
             InternalEntityEntrySubscriber = internalEntityEntrySubscriber;
@@ -76,6 +77,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             LoggingOptions = loggingOptions;
             UpdateLogger = updateLogger;
             ChangeTrackingLogger = changeTrackingLogger;
+            SharedTypeEntityFinder = sharedEntityTypeFinder;
         }
 
         /// <summary>
@@ -163,6 +165,12 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         public IDiagnosticsLogger<DbLoggerCategory.ChangeTracking> ChangeTrackingLogger { get; }
 
         /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public ISharedTypeEntityFinder SharedTypeEntityFinder { get; }
+
+        /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
         /// </summary>
         /// <param name="internalEntityEntryFactory"> A replacement for the current dependency of this type. </param>
@@ -182,7 +190,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityMaterializerSource,
                 LoggingOptions,
                 UpdateLogger,
-                ChangeTrackingLogger);
+                ChangeTrackingLogger,
+                SharedTypeEntityFinder);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -204,7 +213,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityMaterializerSource,
                 LoggingOptions,
                 UpdateLogger,
-                ChangeTrackingLogger);
+                ChangeTrackingLogger,
+                SharedTypeEntityFinder);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -226,7 +236,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityMaterializerSource,
                 LoggingOptions,
                 UpdateLogger,
-                ChangeTrackingLogger);
+                ChangeTrackingLogger,
+                SharedTypeEntityFinder);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -248,7 +259,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityMaterializerSource,
                 LoggingOptions,
                 UpdateLogger,
-                ChangeTrackingLogger);
+                ChangeTrackingLogger,
+                SharedTypeEntityFinder);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -270,7 +282,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityMaterializerSource,
                 LoggingOptions,
                 UpdateLogger,
-                ChangeTrackingLogger);
+                ChangeTrackingLogger,
+                SharedTypeEntityFinder);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -292,7 +305,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityMaterializerSource,
                 LoggingOptions,
                 UpdateLogger,
-                ChangeTrackingLogger);
+                ChangeTrackingLogger,
+                SharedTypeEntityFinder);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -314,7 +328,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityMaterializerSource,
                 LoggingOptions,
                 UpdateLogger,
-                ChangeTrackingLogger);
+                ChangeTrackingLogger,
+                SharedTypeEntityFinder);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -336,7 +351,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityMaterializerSource,
                 LoggingOptions,
                 UpdateLogger,
-                ChangeTrackingLogger);
+                ChangeTrackingLogger,
+                SharedTypeEntityFinder);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -358,7 +374,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityMaterializerSource,
                 LoggingOptions,
                 UpdateLogger,
-                ChangeTrackingLogger);
+                ChangeTrackingLogger,
+                SharedTypeEntityFinder);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -380,7 +397,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityMaterializerSource,
                 LoggingOptions,
                 UpdateLogger,
-                ChangeTrackingLogger);
+                ChangeTrackingLogger,
+                SharedTypeEntityFinder);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -402,7 +420,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 entityMaterializerSource,
                 LoggingOptions,
                 UpdateLogger,
-                ChangeTrackingLogger);
+                ChangeTrackingLogger,
+                SharedTypeEntityFinder);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -424,7 +443,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityMaterializerSource,
                 loggingOptions,
                 UpdateLogger,
-                ChangeTrackingLogger);
+                ChangeTrackingLogger,
+                SharedTypeEntityFinder);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -446,7 +466,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityMaterializerSource,
                 LoggingOptions,
                 updateLogger,
-                ChangeTrackingLogger);
+                ChangeTrackingLogger,
+                SharedTypeEntityFinder);
 
         /// <summary>
         ///     Clones this dependency parameter object with one service replaced.
@@ -468,6 +489,31 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
                 EntityMaterializerSource,
                 LoggingOptions,
                 UpdateLogger,
-                changeTrackingLogger);
+                changeTrackingLogger,
+                SharedTypeEntityFinder);
+
+        /// <summary>
+        ///     Clones this dependency parameter object with one service replaced.
+        /// </summary>
+        /// <param name="sharedTypeEntityFinder"> A replacement for the current dependency of this type. </param>
+        /// <returns> A new parameter object with the given service replaced. </returns>
+        public StateManagerDependencies With([NotNull] ISharedTypeEntityFinder sharedTypeEntityFinder)
+            => new StateManagerDependencies(
+                InternalEntityEntryFactory,
+                InternalEntityEntrySubscriber,
+                InternalEntityEntryNotifier,
+                ValueGenerationManager,
+                Model,
+                Database,
+                ConcurrencyDetector,
+                CurrentContext,
+                EntityFinderSource,
+                SetSource,
+                EntityMaterializerSource,
+                LoggingOptions,
+                UpdateLogger,
+                ChangeTrackingLogger,
+                sharedTypeEntityFinder);
+
     }
 }

--- a/src/EFCore/DbSet`.cs
+++ b/src/EFCore/DbSet`.cs
@@ -35,7 +35,7 @@ namespace Microsoft.EntityFrameworkCore
     ///     <para>
     ///         <see cref="DbSet{TEntity}" /> objects are usually obtained from a <see cref="DbSet{TEntity}" />
     ///         property on a derived <see cref="DbContext" /> or from the <see cref="DbContext.Set{TEntity}" />
-    ///         method.
+    ///         or <see cref="DbContext.SharedTypeSet{TEntity}" /> methods.
     ///     </para>
     /// </summary>
     /// <typeparam name="TEntity"> The type of entity being operated on by this set. </typeparam>

--- a/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
+++ b/src/EFCore/Infrastructure/EntityFrameworkServicesBuilder.cs
@@ -106,6 +106,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
                 { typeof(IKeyPropagator), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(INavigationFixer), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(ILocalViewListener), new ServiceCharacteristics(ServiceLifetime.Scoped) },
+                { typeof(ISharedTypeEntityFinder), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IStateManager), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(Func<IStateManager>), new ServiceCharacteristics(ServiceLifetime.Scoped) },
                 { typeof(IConcurrencyDetector), new ServiceCharacteristics(ServiceLifetime.Scoped) },
@@ -232,6 +233,7 @@ namespace Microsoft.EntityFrameworkCore.Infrastructure
             TryAdd<IKeyPropagator, KeyPropagator>();
             TryAdd<INavigationFixer, NavigationFixer>();
             TryAdd<ILocalViewListener, LocalViewListener>();
+            TryAdd<ISharedTypeEntityFinder, SelfDescribingIndexPropertyEntityFinder>();
             TryAdd<IStateManager, StateManager>();
             TryAdd<IConcurrencyDetector, ConcurrencyDetector>();
             TryAdd<IInternalEntityEntryNotifier, InternalEntityEntryNotifier>();

--- a/src/EFCore/Internal/DbSetSource.cs
+++ b/src/EFCore/Internal/DbSetSource.cs
@@ -17,41 +17,56 @@ namespace Microsoft.EntityFrameworkCore.Internal
         private static readonly MethodInfo _genericCreateSet
             = typeof(DbSetSource).GetTypeInfo().GetDeclaredMethod(nameof(CreateSetFactory));
 
+        private static readonly MethodInfo _genericCreateSharedTypeSet
+            = typeof(DbSetSource).GetTypeInfo().GetDeclaredMethod(nameof(CreateSharedTypeSetFactory));
+
         private static readonly MethodInfo _genericCreateQuery
             = typeof(DbSetSource).GetTypeInfo().GetDeclaredMethod(nameof(CreateQueryFactory));
 
-        private readonly ConcurrentDictionary<Type, Func<DbContext, object>> _cache
-            = new ConcurrentDictionary<Type, Func<DbContext, object>>();
+        private readonly ConcurrentDictionary<string, Func<DbContext, string, object>> _cache
+            = new ConcurrentDictionary<string, Func<DbContext, string, object>>();
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual object Create(DbContext context, Type type)
-            => CreateCore(context, type, _genericCreateSet);
+            => CreateCore(context, type.DisplayName(), type, _genericCreateSet);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual object CreateSharedTypeSet(DbContext context, string entityTypeName, Type type)
+            => CreateCore(context, entityTypeName, type, _genericCreateSharedTypeSet);
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual object CreateQuery(DbContext context, Type type)
-            => CreateCore(context, type, _genericCreateQuery);
+            => CreateCore(context, type.DisplayName(), type, _genericCreateQuery);
 
-        private object CreateCore(DbContext context, Type type, MethodInfo createMethod)
+        private object CreateCore(DbContext context, string entityTypeName, Type type, MethodInfo createMethod)
             => _cache.GetOrAdd(
-                type,
-                t => (Func<DbContext, object>)createMethod
-                    .MakeGenericMethod(t)
-                    .Invoke(null, null))(context);
+                entityTypeName,
+                name => (Func<DbContext, string, object>)createMethod
+                    .MakeGenericMethod(type)
+                    .Invoke(null, null))(context, entityTypeName);
 
         [UsedImplicitly]
-        private static Func<DbContext, object> CreateSetFactory<TEntity>()
+        private static Func<DbContext, string, object> CreateSetFactory<TEntity>()
             where TEntity : class
-            => c => new InternalDbSet<TEntity>(c);
+            => (ctx, _) => new InternalDbSet<TEntity>(ctx);
 
         [UsedImplicitly]
-        private static Func<DbContext, DbQuery<TQuery>> CreateQueryFactory<TQuery>()
+        private static Func<DbContext, string, object> CreateSharedTypeSetFactory<TEntity>()
+            where TEntity : class
+            => (ctx, entityTypeName) => new InternalSharedTypeDbSet<TEntity>(ctx, entityTypeName);
+
+        [UsedImplicitly]
+        private static Func<DbContext, string, DbQuery<TQuery>> CreateQueryFactory<TQuery>()
             where TQuery : class
-            => c => new InternalDbQuery<TQuery>(c);
+            => (ctx, _) => new InternalDbQuery<TQuery>(ctx);
     }
 }

--- a/src/EFCore/Internal/EntityFinder.cs
+++ b/src/EFCore/Internal/EntityFinder.cs
@@ -292,7 +292,9 @@ namespace Microsoft.EntityFrameworkCore.Internal
         {
             var definingEntityType = entityType.DefiningEntityType;
             return definingEntityType == null
-                ? (IQueryable)_setCache.GetOrAddSet(_setSource, entityType.ClrType)
+                ? entityType.IsSharedType
+                    ? (IQueryable)_setCache.GetOrAddSharedTypeSet(_setSource, entityType.Name, entityType.ClrType)
+                    : (IQueryable)_setCache.GetOrAddSet(_setSource, entityType.ClrType)
                 : BuildQueryRoot(definingEntityType, entityType);
         }
 

--- a/src/EFCore/Internal/IDbSetCache.cs
+++ b/src/EFCore/Internal/IDbSetCache.cs
@@ -17,5 +17,11 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         object GetOrAddSet([NotNull] IDbSetSource source, [NotNull] Type type);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        object GetOrAddSharedTypeSet([NotNull] IDbSetSource source, [NotNull] string entityTypeName, [NotNull] Type type);
     }
 }

--- a/src/EFCore/Internal/InternalDbSet.cs
+++ b/src/EFCore/Internal/InternalDbSet.cs
@@ -25,8 +25,8 @@ namespace Microsoft.EntityFrameworkCore.Internal
         DbSet<TEntity>, IQueryable<TEntity>, IAsyncEnumerableAccessor<TEntity>, IInfrastructure<IServiceProvider>, IResettableService
         where TEntity : class
     {
-        private readonly DbContext _context;
-        private IEntityType _entityType;
+        protected readonly DbContext _context;
+        protected IEntityType _entityType;
         private EntityQueryable<TEntity> _entityQueryable;
         private LocalView<TEntity> _localView;
 
@@ -43,7 +43,7 @@ namespace Microsoft.EntityFrameworkCore.Internal
             _context = context;
         }
 
-        private IEntityType EntityType
+        protected virtual IEntityType EntityType
         {
             get
             {

--- a/src/EFCore/Internal/InternalSharedTypeDbSet.cs
+++ b/src/EFCore/Internal/InternalSharedTypeDbSet.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Utilities;
+
+namespace Microsoft.EntityFrameworkCore.Internal
+{
+    /// <summary>
+    ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+    ///     directly from your code. This API may change or be removed in future releases.
+    /// </summary>
+    public class InternalSharedTypeDbSet<TEntity> : InternalDbSet<TEntity>
+        where TEntity : class
+    {
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public InternalSharedTypeDbSet([NotNull] DbContext context, [NotNull] string entityTypeName)
+            :base(context)
+        {
+            Check.NotNull(context, nameof(context));
+
+            EntityTypeName = entityTypeName;
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual string EntityTypeName { get; }
+
+        protected override IEntityType EntityType
+        {
+            get
+            {
+                if (_entityType == null)
+                {
+                    _entityType = _context.Model.FindEntityType(EntityTypeName);
+                    if (_entityType == null)
+                    {
+                        throw new InvalidOperationException(CoreStrings.InvalidSharedTypeSet(EntityTypeName));
+                    }
+                }
+
+                return _entityType;
+            }
+        }
+    }
+}

--- a/src/EFCore/Metadata/IEntityType.cs
+++ b/src/EFCore/Metadata/IEntityType.cs
@@ -44,6 +44,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         bool IsQueryType { get; }
 
         /// <summary>
+        ///     Gets whether this entity type can share its ClrType with other entities.
+        /// </summary>
+        /// <returns> true if the entity type can share its ClrType with other entities; otherwise false. </returns>
+        bool IsSharedType { get; }
+
+        /// <summary>
         ///     <para>
         ///         Gets primary key for this entity. Returns null if no primary key is defined.
         ///     </para>

--- a/src/EFCore/Metadata/IMutableEntityType.cs
+++ b/src/EFCore/Metadata/IMutableEntityType.cs
@@ -42,6 +42,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata
         new bool IsQueryType { get; set; }
 
         /// <summary>
+        ///     Gets or sets whether this entity type can share its ClrType with other entities.
+        /// </summary>
+        /// <returns> true if the entity type can share its ClrType with other entities; otherwise false. </returns>
+        new bool IsSharedType { get; set; }
+
+        /// <summary>
         ///     Gets the LINQ query used as the default source for queries of this type.
         /// </summary>
         new LambdaExpression DefiningQuery { get; [param: CanBeNull] set; }

--- a/src/EFCore/Metadata/IMutableModel.cs
+++ b/src/EFCore/Metadata/IMutableModel.cs
@@ -65,6 +65,16 @@ namespace Microsoft.EntityFrameworkCore.Metadata
             [NotNull] IMutableEntityType definingEntityType);
 
         /// <summary>
+        ///     Adds an entity type to the model which has a CLR-type which can be shared with other entity types.
+        /// </summary>
+        /// <param name="name"> The name of the entity to be added. </param>
+        /// <param name="type"> The CLR class that is used to represent instances of this entity type. </param>
+        /// <returns> The new entity type. </returns>
+        IMutableEntityType AddSharedTypeEntityType(
+            [NotNull] string name,
+            [NotNull] Type type);
+
+        /// <summary>
         ///     Gets the entity with the given name. Returns null if no entity type with the given name is found
         ///     or the entity type has a defining navigation.
         /// </summary>

--- a/src/EFCore/Metadata/Internal/EntityType.cs
+++ b/src/EFCore/Metadata/Internal/EntityType.cs
@@ -124,6 +124,20 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        public EntityType([NotNull] string name,
+            [NotNull] Type clrType,
+            [NotNull] Model model,
+            ConfigurationSource configurationSource)
+            : base(name, clrType, model, configurationSource)
+        {
+            _properties = new SortedDictionary<string, Property>(new PropertyComparer(this));
+            Builder = new InternalEntityTypeBuilder(this, model.Builder);
+        }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         public virtual InternalEntityTypeBuilder Builder
         {
             [DebuggerStepThrough]
@@ -173,6 +187,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual bool IsQueryType { get; set; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual bool IsSharedType { get; set; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
+++ b/src/EFCore/Metadata/Internal/EntityTypeExtensions.cs
@@ -33,7 +33,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         [DebuggerStepThrough]
         public static string ShortName([NotNull] this IEntityType type)
         {
-            if (type.ClrType != null)
+            if (!type.IsSharedType && type.ClrType != null)
             {
                 return type.ClrType.ShortDisplayName();
             }

--- a/src/EFCore/Metadata/Internal/PropertyAccessorsFactory.cs
+++ b/src/EFCore/Metadata/Internal/PropertyAccessorsFactory.cs
@@ -62,9 +62,19 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                     Expression.Property(entryParameter, "Entity"),
                     entityClrType);
 
-                currentValueExpression = Expression.MakeMemberAccess(
-                    convertedExpression,
-                    propertyBase.GetMemberInfo(forConstruction: false, forSet: false));
+                if (propertyBase.IsIndexedProperty)
+                {
+                    currentValueExpression = Expression.MakeIndex(
+                        convertedExpression,
+                        propertyBase.PropertyInfo,
+                        new [] { Expression.Constant(propertyBase.Name) });
+                }
+                else
+                {
+                    currentValueExpression = Expression.MakeMemberAccess(
+                        convertedExpression,
+                        propertyBase.GetMemberInfo(forConstruction: false, forSet: false));
+                }
 
                 if (currentValueExpression.Type != typeof(TProperty))
                 {

--- a/src/EFCore/Metadata/Internal/TypeBase.cs
+++ b/src/EFCore/Metadata/Internal/TypeBase.cs
@@ -50,6 +50,22 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             ClrType = clrType;
         }
 
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        protected TypeBase([NotNull] string name, [NotNull] Type clrType,
+            [NotNull] Model model, ConfigurationSource configurationSource)
+            : this(model, configurationSource)
+        {
+            Check.NotEmpty(name, nameof(name));
+            Check.NotNull(clrType, nameof(clrType));
+            Check.NotNull(model, nameof(model));
+
+            Name = name;
+            ClrType = clrType;
+        }
+
         private TypeBase([NotNull] Model model, ConfigurationSource configurationSource)
         {
             Model = model;

--- a/src/EFCore/Metadata/Internal/TypeBaseExtensions.cs
+++ b/src/EFCore/Metadata/Internal/TypeBaseExtensions.cs
@@ -48,11 +48,11 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         public static PropertyInfo EFIndexerProperty([NotNull] this ITypeBase type)
         {
             var runtimeProperties = type is TypeBase typeBase
-                ? typeBase.GetRuntimeProperties().Values // better perf if we've already computed them once
+                ? typeBase.GetRuntimeProperties()?.Values // better perf if we've already computed them once
                 : type.ClrType.GetRuntimeProperties();
 
             // find the indexer with single argument of type string which returns an object
-            return runtimeProperties.FirstOrDefault(p => p.IsEFIndexerProperty());
+            return runtimeProperties?.FirstOrDefault(p => p.IsEFIndexerProperty());
         }
     }
 }

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -2828,6 +2828,22 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 GetString("ConflictingForeignKeyAttributes", nameof(propertyList), nameof(entityType)),
                 propertyList, entityType);
 
+        /// <summary>
+        ///     The shared-type entity type '{entityType}' cannot be added to the model because an entity type with the same name already exists.
+        /// </summary>
+        public static string ClashingSharedTypeEntityType([CanBeNull] object entityType)
+            => string.Format(
+                GetString("ClashingSharedTypeEntityType", nameof(entityType)),
+                entityType);
+
+        /// <summary>
+        ///     Cannot create a shared-type DbSet with name '{entityTypeName}' because no entity type with that name has been included in the model for this context.  Please define a shared-type entity type by calling 'modelBuilder.Model.AddSharedTypeEntityType()' in `OnModelCreating()`.
+        /// </summary>
+        public static string InvalidSharedTypeSet([CanBeNull] object entityTypeName)
+            => string.Format(
+                GetString("InvalidSharedTypeSet", nameof(entityTypeName)),
+                entityTypeName);
+
         private static string GetString(string name, params string[] formatterNames)
         {
             var value = _resourceManager.GetString(name);

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -1138,4 +1138,10 @@
   <data name="ConflictingForeignKeyAttributes" xml:space="preserve">
     <value>There are multiple ForeignKeyAttributes which are pointing to same set of properties - '{propertyList}' on entity type '{entityType}'.</value>
   </data>
+  <data name="ClashingSharedTypeEntityType" xml:space="preserve">
+    <value>The shared-type entity type '{entityType}' cannot be added to the model because an entity type with the same name already exists.</value>
+  </data>
+  <data name="InvalidSharedTypeSet" xml:space="preserve">
+    <value>Cannot create a shared-type DbSet with name '{entityTypeName}' because no entity type with that name has been included in the model for this context.  Please define a shared-type entity type by calling 'modelBuilder.Model.AddSharedTypeEntityType()' in `OnModelCreating()`.</value>
+  </data>
 </root>

--- a/src/EFCore/breakingchanges.netcore.json
+++ b/src/EFCore/breakingchanges.netcore.json
@@ -16,5 +16,25 @@
       "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IPropertyBase : Microsoft.EntityFrameworkCore.Infrastructure.IAnnotatable",
       "MemberId": "System.Boolean get_IsIndexedProperty()",
       "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IEntityType : Microsoft.EntityFrameworkCore.Metadata.ITypeBase",
+      "MemberId": "System.Boolean get_IsSharedType()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType : Microsoft.EntityFrameworkCore.Metadata.IEntityType, Microsoft.EntityFrameworkCore.Metadata.IMutableTypeBase",
+      "MemberId": "System.Boolean get_IsSharedType()",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType : Microsoft.EntityFrameworkCore.Metadata.IEntityType, Microsoft.EntityFrameworkCore.Metadata.IMutableTypeBase",
+      "MemberId": "System.Void set_IsSharedType(System.Boolean value)",
+      "Kind": "Addition"
+    },
+    {
+      "TypeId": "public interface Microsoft.EntityFrameworkCore.Metadata.IMutableModel : Microsoft.EntityFrameworkCore.Metadata.IModel, Microsoft.EntityFrameworkCore.Metadata.IMutableAnnotatable",
+      "MemberId": "Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType AddSharedTypeEntityType(System.String name, System.Type type)",
+      "Kind": "Addition"
     }
   ]

--- a/test/EFCore.Tests/ChangeTracking/Internal/SelfDescribingIndexPropertyEntityFinderTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/SelfDescribingIndexPropertyEntityFinderTest.cs
@@ -1,0 +1,103 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Xunit;
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
+{
+    public class SelfDescribingIndexPropertyEntityFinderTest
+    {
+        [Fact]
+        public void Can_find_EntityType_using_default_EntityTypeNamePropertyName()
+        {
+            var model = new Model();
+            var entityType = model.AddSharedTypeEntityType("TestDictionaryEntityType", typeof(Dictionary<string, object>));
+            var idProperty = entityType.AddIndexedProperty("Id", typeof(int));
+            idProperty.IsNullable = false;
+            var propA = entityType.AddIndexedProperty("PropA", typeof(string));
+
+            var instance = new Dictionary<string, object>()
+            {
+                { "__EntityTypeName__", "TestDictionaryEntityType" },
+                { "Id", 0 },
+                { "PropA", "PropAValue"},
+            };
+
+            var finder = new SelfDescribingIndexPropertyEntityFinder(model);
+
+            Assert.Equal(entityType, finder.FindSharedTypeEntityType(instance));
+        }
+
+        [Fact]
+        public void Can_find_EntityType_using_user_defined_EntityTypeNamePropertyName()
+        {
+            var model = new Model();
+            var entityType = model.AddSharedTypeEntityType("TestDictionaryEntityType", typeof(Dictionary<string, object>));
+            var idProperty = entityType.AddIndexedProperty("Id", typeof(int));
+            idProperty.IsNullable = false;
+            var propA = entityType.AddIndexedProperty("PropA", typeof(string));
+
+            var instance = new Dictionary<string, object>()
+            {
+                { "SelfDescribingProperty", "TestDictionaryEntityType" },
+                { "Id", 0 },
+                { "PropA", "PropAValue"},
+            };
+
+            var finder = new SelfDescribingIndexPropertyEntityFinder(model);
+            finder.EntityTypeNamePropertyName = "SelfDescribingProperty";
+
+            Assert.Equal(entityType, finder.FindSharedTypeEntityType(instance));
+        }
+
+        [Fact]
+        public void Return_null_if_no_matching_EntityType_found()
+        {
+            var model = new Model();
+            var entityType = model.AddSharedTypeEntityType("DifferentlyNamedEntityType", typeof(Dictionary<string, object>));
+            var idProperty = entityType.AddIndexedProperty("Id", typeof(int));
+            idProperty.IsNullable = false;
+            var propA = entityType.AddIndexedProperty("PropA", typeof(string));
+
+            var instance = new Dictionary<string, object>()
+            {
+                { "__EntityTypeName__", "TestDictionaryEntityType" },
+                { "Id", 0 },
+                { "PropA", "PropAValue"},
+            };
+
+            var finder = new SelfDescribingIndexPropertyEntityFinder(model);
+
+            Assert.Null(finder.FindSharedTypeEntityType(instance));
+        }
+        [Fact]
+        public void Return_null_if_find_non_shared_type_EntityType_with_same_name()
+        {
+            var model = new Model();
+            var entityType = model.AddEntityType(typeof(NonSharedTypeEntity));
+            var idProperty = entityType.AddProperty("Id", typeof(int));
+            idProperty.IsNullable = false;
+            var propA = entityType.AddProperty("PropA", typeof(string));
+
+            var instance = new Dictionary<string, object>()
+            {
+                { "__EntityTypeName__", entityType.Name },
+                { "Id", 0 },
+                { "PropA", "PropAValue"},
+            };
+
+            var finder = new SelfDescribingIndexPropertyEntityFinder(model);
+
+            Assert.Null(finder.FindSharedTypeEntityType(instance));
+        }
+
+        private class NonSharedTypeEntity
+        {
+            public int Id { get; set; }
+            public string PropA { get; set; }
+        }
+    }
+}

--- a/test/EFCore.Tests/DbContextTest.cs
+++ b/test/EFCore.Tests/DbContextTest.cs
@@ -862,7 +862,7 @@ namespace Microsoft.EntityFrameworkCore
             await Assert.ThrowsAsync<ObjectDisposedException>(() => context.FindAsync(typeof(Random), 77));
 
             var methodCount = typeof(DbContext).GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly).Count();
-            var expectedMethodCount = 41;
+            var expectedMethodCount = 42;
             Assert.True(
                 methodCount == expectedMethodCount,
                 userMessage: $"Expected {expectedMethodCount} methods on DbContext but found {methodCount}. " +

--- a/test/EFCore.Tests/DbSetSourceTest.cs
+++ b/test/EFCore.Tests/DbSetSourceTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -23,6 +24,19 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [Fact]
+        public void Can_create_new_generic_SharedTypeDbSet()
+        {
+            var context = InMemoryTestHelpers.Instance.CreateContext();
+
+            var factorySource = new DbSetSource();
+
+            var set = factorySource.CreateSharedTypeSet(context, "SharedTypeEntityType", typeof(Dictionary<string, object>));
+
+            Assert.IsType<InternalSharedTypeDbSet<Dictionary<string, object>>>(set);
+        }
+
+
+        [Fact]
         public void Always_creates_a_new_DbSet_instance()
         {
             var context = InMemoryTestHelpers.Instance.CreateContext();
@@ -30,6 +44,18 @@ namespace Microsoft.EntityFrameworkCore
             var factorySource = new DbSetSource();
 
             Assert.NotSame(factorySource.Create(context, typeof(Random)), factorySource.Create(context, typeof(Random)));
+        }
+
+        [Fact]
+        public void Always_creates_a_new_SharedTypeDbSet_instance()
+        {
+            var context = InMemoryTestHelpers.Instance.CreateContext();
+
+            var factorySource = new DbSetSource();
+
+            Assert.NotSame(
+                factorySource.CreateSharedTypeSet(context, "SharedTypeEntityType", typeof(Dictionary<string, object>)),
+                factorySource.CreateSharedTypeSet(context, "SharedTypeEntityType", typeof(Dictionary<string, object>)));
         }
     }
 }

--- a/test/EFCore.Tests/DbSetTest.cs
+++ b/test/EFCore.Tests/DbSetTest.cs
@@ -115,6 +115,15 @@ namespace Microsoft.EntityFrameworkCore
         }
 
         [Fact]
+        public void Direct_use_of_SharedTypeSet_throws_if_context_disposed()
+        {
+            var context = new EarlyLearningCenter();
+            context.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => context.SharedTypeSet<Dictionary<string, object>>("SharedTypeEntityTypeName"));
+        }
+
+        [Fact]
         public void Direct_use_of_Query_throws_if_context_disposed()
         {
             var context = new EarlyLearningCenter();

--- a/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/EntityTypeTest.cs
@@ -102,6 +102,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             public LambdaExpression QueryFilter { get; }
             public LambdaExpression DefiningQuery { get; }
             public bool IsQueryType { get; }
+            public bool IsSharedType { get; }
             public IKey FindPrimaryKey() => throw new NotImplementedException();
             public IKey FindKey(IReadOnlyList<IProperty> properties) => throw new NotImplementedException();
             public IEnumerable<IKey> GetKeys() => throw new NotImplementedException();

--- a/test/EFCore.Tests/Metadata/Internal/PropertyAccessorsFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/PropertyAccessorsFactoryTest.cs
@@ -1,0 +1,88 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.EntityFrameworkCore.TestUtilities;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+// ReSharper disable InconsistentNaming
+namespace Microsoft.EntityFrameworkCore.Metadata.Internal
+{
+    public class PropertyAccessorsFactoryTest
+    {
+        [Fact]
+        public void Can_use_PropertyAccessorsFactory_on_indexed_property()
+        {
+            var model = new Model();
+            var entityType = model.AddEntityType(typeof(IndexedClass));
+            var id = entityType.AddProperty("Id", typeof(int));
+            var propertyA = entityType.AddIndexedProperty("PropertyA", typeof(string));
+
+            var contextServices = InMemoryTestHelpers.Instance.CreateContextServices(model);
+            var stateManager = contextServices.GetRequiredService<IStateManager>();
+            var factory = contextServices.GetRequiredService<IInternalEntityEntryFactory>();
+
+            var entity = new IndexedClass();
+            var entry = factory.Create(stateManager, entityType, entity);
+
+            var propertyAccessors = new PropertyAccessorsFactory().Create(propertyA);
+            Assert.Equal("ValueA", ((Func<InternalEntityEntry, string>)propertyAccessors.CurrentValueGetter)(entry));
+            Assert.Equal("ValueA", ((Func<InternalEntityEntry, string>)propertyAccessors.OriginalValueGetter)(entry));
+            Assert.Equal("ValueA", ((Func<InternalEntityEntry, string>)propertyAccessors.PreStoreGeneratedCurrentValueGetter)(entry));
+            Assert.Equal("ValueA", ((Func<InternalEntityEntry, string>)propertyAccessors.RelationshipSnapshotGetter)(entry));
+
+            var valueBuffer = new ValueBuffer(new object[] { 1, "ValueA" });
+            Assert.Equal("ValueA", ((Func<ValueBuffer, object>)propertyAccessors.ValueBufferGetter)(valueBuffer));
+        }
+
+        [Fact]
+        public void Can_use_PropertyAccessorsFactory_on_non_indexed_property()
+        {
+            var model = new Model();
+            var entityType = model.AddEntityType(typeof(NonIndexedClass));
+            var id = entityType.AddProperty("Id", typeof(int));
+            var propA = entityType.AddProperty("PropA", typeof(string));
+
+            var contextServices = InMemoryTestHelpers.Instance.CreateContextServices(model);
+            var stateManager = contextServices.GetRequiredService<IStateManager>();
+            var factory = contextServices.GetRequiredService<IInternalEntityEntryFactory>();
+
+            var entity = new NonIndexedClass();
+            var entry = factory.Create(stateManager, entityType, entity);
+
+            var propertyAccessors = new PropertyAccessorsFactory().Create(propA);
+            Assert.Equal("ValueA", ((Func<InternalEntityEntry, string>)propertyAccessors.CurrentValueGetter)(entry));
+            Assert.Equal("ValueA", ((Func<InternalEntityEntry, string>)propertyAccessors.OriginalValueGetter)(entry));
+            Assert.Equal("ValueA", ((Func<InternalEntityEntry, string>)propertyAccessors.PreStoreGeneratedCurrentValueGetter)(entry));
+            Assert.Equal("ValueA", ((Func<InternalEntityEntry, string>)propertyAccessors.RelationshipSnapshotGetter)(entry));
+
+            var valueBuffer = new ValueBuffer(new object[] { 1, "ValueA" });
+            Assert.Equal("ValueA", ((Func<ValueBuffer, object>)propertyAccessors.ValueBufferGetter)(valueBuffer));
+        }
+
+        private class IndexedClass
+        {
+            private Dictionary<string, object> _internalValues = new Dictionary<string, object>()
+                {
+                    { "PropertyA", "ValueA" }
+                };
+
+            internal int Id { get; set; }
+
+            public object this[string name]
+            {
+                get => _internalValues[name];
+            }
+        }
+
+        private class NonIndexedClass
+        {
+            internal int Id { get; set; }
+            public string PropA { get; set; } = "ValueA";
+        }
+    }
+}


### PR DESCRIPTION
DO NOT COMMIT THIS - work in progress.

Wanted to get some feedback on the work on Shared-Type Entity Types (#9914). So far I've updated the `Model` to have a new `AddSharedEntityType()` method to be used during `OnModelCreating()`; updated `DbContext` to allow specifying a Shared-Type-DbSet which uses that `EntityType`; and using that you can insert, update and delete those entities (Note: query not implemented yet).

As part of this I created a new service `ISharedTypeEntityFinder`. This is used by the `StateManager`, when given an entity instance, to associate that instance with a Shared-Type-EntityType defined during `OnModelCreating()`. At the moment there is only one implementation of this service - which identifies the instance by expecting it to have a property-indexer (see #13610) which takes a specific (but configurable) argument and which returns the name of the `EntityType` which it represents; however the service is replaceable - so other implementations are possible.

Added and updated some tests. More functional tests will be needed but wanted to get feedback first.