### PR TITLE
Omit Order By (Select 1) when no skip/take present

### DIFF
--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -631,6 +631,20 @@ namespace Microsoft.EntityFrameworkCore.Query
                     /* non-deterministic */
                 });
         }
+        
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Skip_orderby_const(bool isAsync)
+        {
+            return AssertQuery<Customer>(
+                isAsync,
+                cs => cs.OrderBy(c => true).Skip(5),
+                entryCount: 86,
+                elementAsserter: (_, __) =>
+                {
+                    /* non-deterministic */
+                });
+        }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -6499,8 +6499,7 @@ LEFT JOIN (
     SELECT [g].*
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
-) AS [t0] ON @_outer_FullName1 = [t0].[FullName]
-ORDER BY (SELECT 1)",
+) AS [t0] ON @_outer_FullName1 = [t0].[FullName]",
                 //
                 @"@_outer_FullName1='Marcus Fenix' (Size = 450)
 
@@ -6510,8 +6509,7 @@ LEFT JOIN (
     SELECT [g].*
     FROM [Gears] AS [g]
     WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
-) AS [t0] ON @_outer_FullName1 = [t0].[FullName]
-ORDER BY (SELECT 1)");
+) AS [t0] ON @_outer_FullName1 = [t0].[FullName]");
         }
 
         public override async Task Outer_parameter_in_group_join_with_DefaultIfEmpty(bool isAsync)
@@ -7036,7 +7034,7 @@ WHERE ([g].[Discriminator] IN (N'Officer', N'Gear') AND ([g].[HasSoulPatch] = 1)
             AssertSql(
                 @"SELECT [s].[Id], [s].[InternalNumber], [s].[Name]
 FROM [Squads] AS [s]
-ORDER BY (SELECT 1), [s].[Id]",
+ORDER BY [s].[Id]",
                 //
                 @"SELECT [s.Members].[Nickname], [s.Members].[SquadId], [s.Members].[AssignedCityName], [s.Members].[CityOrBirthName], [s.Members].[Discriminator], [s.Members].[FullName], [s.Members].[HasSoulPatch], [s.Members].[LeaderNickname], [s.Members].[LeaderSquadId], [s.Members].[Rank]
 FROM [Gears] AS [s.Members]
@@ -7055,7 +7053,7 @@ ORDER BY [t].[c], [t].[Id]");
             AssertSql(
                 @"SELECT [s].[Id], [s].[InternalNumber], [s].[Name]
 FROM [Squads] AS [s]
-ORDER BY (SELECT 1), [s].[Id]",
+ORDER BY [s].[Id]",
                 //
                 @"SELECT [s.Members].[Nickname], [s.Members].[SquadId], [s.Members].[AssignedCityName], [s.Members].[CityOrBirthName], [s.Members].[Discriminator], [s.Members].[FullName], [s.Members].[HasSoulPatch], [s.Members].[LeaderNickname], [s.Members].[LeaderSquadId], [s.Members].[Rank]
 FROM [Gears] AS [s.Members]
@@ -7075,7 +7073,7 @@ ORDER BY [t].[c], [t].[Id]");
                 @"SELECT [s].[Nickname], [s].[FullName]
 FROM [Gears] AS [s]
 WHERE [s].[Discriminator] IN (N'Officer', N'Gear')
-ORDER BY (SELECT 1) DESC, [s].[Nickname], [s].[SquadId], [s].[FullName]",
+ORDER BY [s].[Nickname], [s].[SquadId], [s].[FullName]",
                 //
                 @"SELECT [t].[c], [t].[Nickname], [t].[SquadId], [t].[FullName], [s.Weapons].[Name], [s.Weapons].[OwnerFullName]
 FROM [Weapons] AS [s.Weapons]
@@ -7193,7 +7191,7 @@ WHERE @_outer_FullName = [w].[OwnerFullName]");
                 @"SELECT [o].[Nickname], [o].[SquadId], [o].[AssignedCityName], [o].[CityOrBirthName], [o].[Discriminator], [o].[FullName], [o].[HasSoulPatch], [o].[LeaderNickname], [o].[LeaderSquadId], [o].[Rank]
 FROM [Gears] AS [o]
 WHERE [o].[Discriminator] IN (N'Officer', N'Gear')
-ORDER BY [o].[Rank], (SELECT 1), [o].[Nickname], [o].[FullName]",
+ORDER BY [o].[Rank], [o].[Nickname], [o].[FullName]",
                 //
                 @"SELECT [o.Weapons].[Id], [o.Weapons].[AmmunitionType], [o.Weapons].[IsAutomatic], [o.Weapons].[Name], [o.Weapons].[OwnerFullName], [o.Weapons].[SynergyWithId]
 FROM [Weapons] AS [o.Weapons]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/GearsOfWarQuerySqlServerTest.cs
@@ -7699,7 +7699,7 @@ ORDER BY [t].[Name], [c.StationedGears].[Nickname] DESC");
                 @"SELECT [g].[Nickname], [g].[FullName]
 FROM [Gears] AS [g]
 WHERE [g].[Discriminator] IN (N'Officer', N'Gear')
-ORDER BY (SELECT 1) DESC, [g].[Nickname], [g].[SquadId], [g].[FullName]",
+ORDER BY [g].[Nickname], [g].[SquadId], [g].[FullName]",
                 //
                 @"SELECT [t].[c], [t].[Nickname], [t].[SquadId], [t].[FullName], [g.Weapons].[Name], [g.Weapons].[OwnerFullName]
 FROM [Weapons] AS [g.Weapons]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.Select.cs
@@ -136,8 +136,7 @@ FROM [Customers] AS [c]");
                 @"@__boolean_0='False'
 
 SELECT @__boolean_0
-FROM [Customers] AS [c]
-ORDER BY (SELECT 1)");
+FROM [Customers] AS [c]");
         }
 
         public override async Task Select_scalar(bool isAsync)

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -4633,8 +4633,7 @@ FROM (
 
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-ORDER BY (SELECT 1)");
+FROM [Customers] AS [c]");
         }
 
         public override async Task OrderBy_empty_list_does_not_contains(bool isAsync)
@@ -4643,8 +4642,7 @@ ORDER BY (SELECT 1)");
 
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-ORDER BY (SELECT 1)");
+FROM [Customers] AS [c]");
         }
 
         public override void Manual_expression_tree_typed_null_equality()

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.cs
@@ -881,6 +881,20 @@ FROM [Customers] AS [c]
 ORDER BY (SELECT 1)
 OFFSET @__p_0 ROWS");
         }
+        
+        [SqlServerCondition(SqlServerCondition.SupportsOffset)]
+        public override async Task Skip_orderby_const(bool isAsync)
+        {
+            await base.Skip_orderby_const(isAsync);
+
+            AssertSql(
+                @"@__p_0='5'
+
+SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
+FROM [Customers] AS [c]
+ORDER BY (SELECT 1)
+OFFSET @__p_0 ROWS");
+        }
 
         [SqlServerCondition(SqlServerCondition.SupportsOffset)]
         public override async Task Skip_Take(bool isAsync)
@@ -2076,8 +2090,7 @@ ORDER BY [c].[CustomerID]");
 
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-ORDER BY (SELECT 1)");
+FROM [Customers] AS [c]");
         }
 
         public override async Task OrderBy_integer(bool isAsync)
@@ -2086,8 +2099,7 @@ ORDER BY (SELECT 1)");
 
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-ORDER BY (SELECT 1)");
+FROM [Customers] AS [c]");
         }
 
         public override async Task OrderBy_parameter(bool isAsync)
@@ -2096,8 +2108,7 @@ ORDER BY (SELECT 1)");
 
             AssertSql(
                 @"SELECT [c].[CustomerID], [c].[Address], [c].[City], [c].[CompanyName], [c].[ContactName], [c].[ContactTitle], [c].[Country], [c].[Fax], [c].[Phone], [c].[PostalCode], [c].[Region]
-FROM [Customers] AS [c]
-ORDER BY (SELECT 1)");
+FROM [Customers] AS [c]");
         }
 
         public override async Task OrderBy_anon(bool isAsync)


### PR DESCRIPTION
Summary of the changes
 - Added check for constant and parameter expressions when no take or skip is present and filters the order by list
 - Fixed up unit tests to omit ORDER BY (SELECT 1) when there is no skip/take.
 - Fixed processedExperssion typo

Fixes #10410