### PR TITLE
[WIP] - Include skip(0) to subqueries with order by to avoid client eval

### DIFF
--- a/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
+++ b/src/EFCore.Relational/Query/RelationalQueryModelVisitor.cs
@@ -866,13 +866,17 @@ namespace Microsoft.EntityFrameworkCore.Query
             {
                 var subSelectExpression = subQueryModelVisitor.Queries.First();
 
-                if ((subSelectExpression.OrderBy.Count == 0
-                     || subSelectExpression.Limit != null
-                     || subSelectExpression.Offset != null)
-                    && (QueryCompilationContext.IsLateralJoinSupported
-                        || !subSelectExpression.IsCorrelated()
-                        || !(querySource is AdditionalFromClause)))
+                if (QueryCompilationContext.IsLateralJoinSupported
+                    || !subSelectExpression.IsCorrelated()
+                    || !(querySource is AdditionalFromClause))
                 {
+                    if (subSelectExpression.OrderBy.Count > 0
+                        && subSelectExpression.Limit == null
+                        && subSelectExpression.Offset == null)
+                    {
+                        subSelectExpression.Offset = Expression.Constant(0);
+                    }
+
                     var groupByNotRequiringPushdown = subSelectExpression.GroupBy.Count > 0
                                                       && subQueryModel.ResultOperators.LastOrDefault() is GroupResultOperator;
 

--- a/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/GearsOfWarQueryTestBase.cs
@@ -1971,6 +1971,19 @@ namespace Microsoft.EntityFrameworkCore.Query
                     },
                 elementSorter: e => e.FullName);
         }
+        
+        [ConditionalTheory]
+        [MemberData(nameof(IsAsyncData))]
+        public virtual Task Join_with_order_by_without_skip_or_take(bool isAsync)
+        {
+            return AssertQuery<Gear, Weapon>(
+                isAsync,
+                (gs, ws) =>
+                    from g in gs
+                    join w in ws.OrderBy(ww => ww.Name) on g.FullName equals w.OwnerFullName
+                    select new { w.Name, g.FullName },
+                elementSorter: w => w.Name);
+        }
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
@@ -3357,7 +3370,7 @@ namespace Microsoft.EntityFrameworkCore.Query
 
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
-        public virtual Task Subquery_is_not_lifted_from_additional_from_clause(bool isAsync)
+        public virtual Task Subquery_is_lifted_from_additional_from_clause(bool isAsync)
         {
             return AssertQuery<Gear>(
                 isAsync,

--- a/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
+++ b/src/EFCore.Specification.Tests/Query/SimpleQueryTestBase.cs
@@ -631,7 +631,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                     /* non-deterministic */
                 });
         }
-        
+
         [ConditionalTheory]
         [MemberData(nameof(IsAsyncData))]
         public virtual Task Skip_orderby_const(bool isAsync)
@@ -2957,7 +2957,7 @@ namespace Microsoft.EntityFrameworkCore.Query
                         c.CustomerID,
                         o.OrderID
                     },
-                assertOrder: true);
+                assertOrder: false);
         }
 
         [ConditionalTheory]

--- a/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.JoinGroupJoin.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/Query/SimpleQuerySqlServerTest.JoinGroupJoin.cs
@@ -93,12 +93,15 @@ INNER JOIN [Orders] AS [o] ON [c].[CustomerID] = [o].[CustomerID]");
             await base.Join_customers_orders_with_subquery(isAsync);
 
             AssertContainsSql(
-                @"SELECT [o20].[CustomerID], [o20].[OrderID]
-FROM [Orders] AS [o20]
-ORDER BY [o20].[OrderID]",
-                //
-                @"SELECT [c].[CustomerID], [c].[ContactName]
-FROM [Customers] AS [c]");
+                @"SELECT [c].[ContactName], [t].[OrderID]
+FROM [Customers] AS [c]
+INNER JOIN (
+    SELECT [o2].*
+    FROM [Orders] AS [o2]
+    ORDER BY [o2].[OrderID]
+    OFFSET 0 ROWS
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
+WHERE [t].[CustomerID] = N'ALFKI'");
         }
 
         public override async Task Join_customers_orders_with_subquery_with_take(bool isAsync)
@@ -123,12 +126,16 @@ WHERE [t].[CustomerID] = N'ALFKI'");
             await base.Join_customers_orders_with_subquery_anonymous_property_method(isAsync);
 
             AssertContainsSql(
-                @"SELECT [o20].[OrderID], [o20].[CustomerID], [o20].[EmployeeID], [o20].[OrderDate]
-FROM [Orders] AS [o20]
-ORDER BY [o20].[OrderID]",
-                //
                 @"SELECT [c].[CustomerID]
-FROM [Customers] AS [c]");
+FROM [Customers] AS [c]",
+                //
+                @"SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
+FROM (
+    SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
+    FROM [Orders] AS [o2]
+    ORDER BY [o2].[OrderID]
+    OFFSET 0 ROWS
+) AS [t]");
         }
 
         public override async Task Join_customers_orders_with_subquery_anonymous_property_method_with_take(bool isAsync)
@@ -154,13 +161,16 @@ FROM [Customers] AS [c]");
             await base.Join_customers_orders_with_subquery_predicate(isAsync);
 
             AssertContainsSql(
-                @"SELECT [o20].[CustomerID], [o20].[OrderID]
-FROM [Orders] AS [o20]
-WHERE [o20].[OrderID] > 0
-ORDER BY [o20].[OrderID]",
-                //
-                @"SELECT [c].[CustomerID], [c].[ContactName]
-FROM [Customers] AS [c]");
+                @"SELECT [c].[ContactName], [t].[OrderID]
+FROM [Customers] AS [c]
+INNER JOIN (
+    SELECT [o2].*
+    FROM [Orders] AS [o2]
+    WHERE [o2].[OrderID] > 0
+    ORDER BY [o2].[OrderID]
+    OFFSET 0 ROWS
+) AS [t] ON [c].[CustomerID] = [t].[CustomerID]
+WHERE [t].[CustomerID] = N'ALFKI'");
         }
 
         public override async Task Join_customers_orders_with_subquery_predicate_with_take(bool isAsync)


### PR DESCRIPTION
DO NOT COMMIT THIS - work in progress.

I've taken a stab at solving #10102. Wanted to get some feedback on the change and some help resolving the last few unit tests failures it introduced.

I updated the subQueryModelVisitor to add a Skip(0) into the subquery if an order by is present. This works a treat for the simple examples. It all gets a bit fruity on the _Join_customers_orders_with_subquery_anonymous_property_method_ unit test.  Which now produces the following two sql statements which to me look wrong:

```
SELECT [t].[OrderID], [t].[CustomerID], [t].[EmployeeID], [t].[OrderDate]
FROM (
    SELECT [o2].[OrderID], [o2].[CustomerID], [o2].[EmployeeID], [o2].[OrderDate]
    FROM [Orders] AS [o2]
    ORDER BY [o2].[OrderID]
    OFFSET 0 ROWS
) AS [t]
```

```
SELECT [c].[CustomerID]
FROM [Customers] AS [c]
```
The other issue I can't get my head around is SimpleQuerySqlServerTest.OrderBy_Join tests fail with what seems like the order of Customers being correct but the suborder of the Orders are reversed every other customer.

PS, ignore my branch name, seems I was looking at the wrong issue when I created it.