### PR TITLE
Update buildtools to 2.1.3-rtm-15847

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -7,7 +7,7 @@
   <PropertyGroup Label="Package Versions: Auto">
     <CastleCorePackageVersion>4.2.1</CastleCorePackageVersion>
     <FunctionalTests_PackageVersion>0.0.0</FunctionalTests_PackageVersion>
-    <InternalAspNetCoreSdkPackageVersion>2.1.3-rtm-15839</InternalAspNetCoreSdkPackageVersion>
+    <InternalAspNetCoreSdkPackageVersion>2.1.3-rtm-15847</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftAzureDocumentDBCorePackageVersion>1.7.1</MicrosoftAzureDocumentDBCorePackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>2.8.0</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>2.8.0</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>

--- a/build/repo.props
+++ b/build/repo.props
@@ -15,11 +15,5 @@
     <ExcludeSolutions Include="$(RepositoryRoot)EFCore.Runtime.sln" />
     <ExcludeSolutions Include="$(RepositoryRoot)Microsoft.Data.Sqlite.sln" />
   </ItemGroup>
-  <PropertyGroup>
-    <!-- These properties are use by the automation that updates dependencies.props -->
-    <LineupPackageId>Internal.AspNetCore.Universe.Lineup</LineupPackageId>
-    <LineupPackageVersion>2.1.6-*</LineupPackageVersion>
-    <LineupPackageRestoreSource>https://dotnet.myget.org/F/aspnetcore-dev/api/v3/index.json</LineupPackageRestoreSource>
-  </PropertyGroup>
 
 </Project>

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.3-rtm-15839
-commithash:ee0ad5bd4ede948c6954704b621acc0c83445e5d
+version:2.1.3-rtm-15847
+commithash:08641cb93aa5a9d52dc56c7516828b73aa448690


### PR DESCRIPTION
Changes 
* Includes updates to to fix bugs in code-signing tools
* Remove a reference to Internal.AspNetCore.Universe.Lineup, which isn't used in servicing branches anymore