### PR TITLE
Fix NetTopologySuite.IO.SqlServerBytes Version

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -26,7 +26,7 @@
     <NETStandardLibrary20PackageVersion>2.0.3</NETStandardLibrary20PackageVersion>
     <NetTopologySuiteCorePackageVersion>1.15.1</NetTopologySuiteCorePackageVersion>
     <NetTopologySuiteIOSpatiaLitePackageVersion>1.15.0</NetTopologySuiteIOSpatiaLitePackageVersion>
-    <NetTopologySuiteIOSqlServerBytesPackageVersion>1.15.0-pre001</NetTopologySuiteIOSqlServerBytesPackageVersion>
+    <NetTopologySuiteIOSqlServerBytesPackageVersion>1.15.0</NetTopologySuiteIOSqlServerBytesPackageVersion>
     <NewtonsoftJsonPackageVersion>11.0.2</NewtonsoftJsonPackageVersion>
     <OracleManagedDataAccessPackageVersion>12.2.1100</OracleManagedDataAccessPackageVersion>
     <RemotionLinqPackageVersion>2.2.0</RemotionLinqPackageVersion>


### PR DESCRIPTION
Somehow, this got missed. Probably while resolving a 2.2 to 3.0 merge conflict.