### PR TITLE
Make specification tests run with SQL Server Compact

### DIFF
--- a/src/EFCore.Specification.Tests/GraphUpdatesFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/GraphUpdatesFixtureBase.cs
@@ -2758,6 +2758,8 @@ namespace Microsoft.EntityFrameworkCore
             private int? _childAsAParentId;
             private ChildAsAParent _childAsAParent;
 
+            public bool Filler { get; set; }
+
             [DatabaseGenerated(DatabaseGeneratedOption.None)]
             public int Id
             {
@@ -2782,6 +2784,8 @@ namespace Microsoft.EntityFrameworkCore
         {
             private int _id;
             private ParentAsAChild _parentAsAChild;
+
+            public bool Filler { get; set; }
 
             public int Id
             {


### PR DESCRIPTION
Added additional property to specification test classes to make INSERTs work (SQL Compact does not allow INSERTs into a table with only an Identity column)

fixes #14184
