### PR TITLE
[2.2.x] Don't change FK requiredness when only some of the contained properties change nullability.

### DIFF
--- a/src/EFCore/Metadata/Internal/Property.cs
+++ b/src/EFCore/Metadata/Internal/Property.cs
@@ -194,7 +194,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             foreach (var affectedForeignKey in affectedForeignKeys)
             {
                 if (!nullable
-                    && affectedForeignKey.Properties.Any(p => p.IsNullable))
+                    && affectedForeignKey.Properties.Any(p => p.IsNullable)
+                    && (!AppContext.TryGetSwitch("Microsoft.EntityFrameworkCore.Issue14157", out var isEnabled)
+                    || !isEnabled))
                 {
                     continue;
                 }


### PR DESCRIPTION
Fixes #14157