### PR TITLE
Support |DataDirectory| for SQLite provider

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -19,7 +19,8 @@ namespace Microsoft.Data.Sqlite
     public partial class SqliteConnection : DbConnection
     {
         internal const string MainDatabaseName = "main";
-        internal const string DataDirectoryToken = "|DataDirectory|";
+
+        private const string DataDirectoryMacro = "|DataDirectory|";
 
         private readonly IList<WeakReference<SqliteCommand>> _commands = new List<WeakReference<SqliteCommand>>();
 
@@ -218,9 +219,9 @@ namespace Microsoft.Data.Sqlite
                 && (flags & raw.SQLITE_OPEN_URI) == 0
                 && !filename.Equals(":memory:", StringComparison.OrdinalIgnoreCase))
             {
-                if (filename.StartsWith(DataDirectoryToken, StringComparison.InvariantCultureIgnoreCase))
+                if (filename.StartsWith(DataDirectoryMacro, StringComparison.InvariantCultureIgnoreCase))
                 {
-                    filename = Path.Combine(dataDirectory, filename.Substring(DataDirectoryToken.Length));
+                    filename = Path.Combine(dataDirectory, filename.Substring(DataDirectoryMacro.Length));
                 }
                 else if (!Path.IsPathRooted(filename))
                 {

--- a/test/EFCore.Sqlite.FunctionalTests/SqliteDatabaseCreatorTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/SqliteDatabaseCreatorTest.cs
@@ -58,40 +58,7 @@ namespace Microsoft.EntityFrameworkCore
                 }
             }
         }
-
-        [ConditionalTheory]
-        [InlineData(false, false)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(true, true)]
-        public async Task Create_database_with_custom_DataDirectory_path(bool async, bool useCanConnect)
-        {
-            string testDirectory = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
-            string dataSubDirectory = Path.Combine(testDirectory, "DataFolder");
-
-            if (!Directory.Exists(dataSubDirectory))
-                Directory.CreateDirectory(dataSubDirectory);
-
-            AppDomain.CurrentDomain.SetData("DataDirectory", dataSubDirectory);
-
-            using (var testStore = SqliteTestStore.GetOrCreateInitialized("|DataDirectory|Empty"))
-            {
-                var context = CreateContext(testStore.ConnectionString);
-
-                if (useCanConnect)
-                {
-                    Assert.True(async ? await context.Database.CanConnectAsync() : context.Database.CanConnect());
-                }
-                else
-                {
-                    var creator = context.GetService<IRelationalDatabaseCreator>();
-                    Assert.True(async ? await creator.ExistsAsync() : creator.Exists());
-                }
-            }
-
-            Assert.True(File.Exists(Path.Combine(dataSubDirectory, "Empty.db")));
-        }
-
+        
         private DbContext CreateContext(string connectionString)
             => new DbContext(
                     new DbContextOptionsBuilder()

--- a/test/EFCore.Sqlite.FunctionalTests/SqliteDatabaseCreatorTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/SqliteDatabaseCreatorTest.cs
@@ -1,8 +1,6 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.IO;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -58,7 +56,7 @@ namespace Microsoft.EntityFrameworkCore
                 }
             }
         }
-        
+
         private DbContext CreateContext(string connectionString)
             => new DbContext(
                     new DbContextOptionsBuilder()

--- a/test/EFCore.Sqlite.FunctionalTests/SqliteDatabaseCreatorTest.cs
+++ b/test/EFCore.Sqlite.FunctionalTests/SqliteDatabaseCreatorTest.cs
@@ -1,6 +1,8 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.IO;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -55,6 +57,39 @@ namespace Microsoft.EntityFrameworkCore
                     Assert.True(async ? await creator.ExistsAsync() : creator.Exists());
                 }
             }
+        }
+
+        [ConditionalTheory]
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(true, true)]
+        public async Task Create_database_with_custom_DataDirectory_path(bool async, bool useCanConnect)
+        {
+            string testDirectory = Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location);
+            string dataSubDirectory = Path.Combine(testDirectory, "DataFolder");
+
+            if (!Directory.Exists(dataSubDirectory))
+                Directory.CreateDirectory(dataSubDirectory);
+
+            AppDomain.CurrentDomain.SetData("DataDirectory", dataSubDirectory);
+
+            using (var testStore = SqliteTestStore.GetOrCreateInitialized("|DataDirectory|Empty"))
+            {
+                var context = CreateContext(testStore.ConnectionString);
+
+                if (useCanConnect)
+                {
+                    Assert.True(async ? await context.Database.CanConnectAsync() : context.Database.CanConnect());
+                }
+                else
+                {
+                    var creator = context.GetService<IRelationalDatabaseCreator>();
+                    Assert.True(async ? await creator.ExistsAsync() : creator.Exists());
+                }
+            }
+
+            Assert.True(File.Exists(Path.Combine(dataSubDirectory, "Empty.db")));
         }
 
         private DbContext CreateContext(string connectionString)

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionTest.cs
@@ -155,9 +155,6 @@ namespace Microsoft.Data.Sqlite
         [Fact]
         public void Open_adjusts_relative_path()
         {
-            // Ensure there isn't a data directory context that can affect the pathing
-            AppDomain.CurrentDomain.SetData("DataDirectory", null);
-
             using (var connection = new SqliteConnection("Data Source=local.db"))
             {
                 connection.Open();

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionTest.cs
@@ -128,6 +128,24 @@ namespace Microsoft.Data.Sqlite
         }
 
         [Fact]
+        public void Open_adjusts_data_directory_path()
+        {
+            string dataSubDirectory = Path.Combine(AppContext.BaseDirectory, "DataFolder");
+
+            if (!Directory.Exists(dataSubDirectory))
+                Directory.CreateDirectory(dataSubDirectory);
+
+            AppDomain.CurrentDomain.SetData("DataDirectory", dataSubDirectory);
+
+            using (var connection = new SqliteConnection("Data Source=|DataDirectory|local.db"))
+            {
+                connection.Open();
+
+                Assert.Equal(Path.Combine(dataSubDirectory, "local.db"), connection.DataSource);
+            }
+        }
+
+        [Fact]
         public void Open_adjusts_relative_path()
         {
             using (var connection = new SqliteConnection("Data Source=local.db"))

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteConnectionTest.cs
@@ -137,17 +137,27 @@ namespace Microsoft.Data.Sqlite
 
             AppDomain.CurrentDomain.SetData("DataDirectory", dataSubDirectory);
 
-            using (var connection = new SqliteConnection("Data Source=|DataDirectory|local.db"))
-            {
-                connection.Open();
+            try
+            { 
+                using (var connection = new SqliteConnection("Data Source=|DataDirectory|local.db"))
+                {
+                    connection.Open();
 
-                Assert.Equal(Path.Combine(dataSubDirectory, "local.db"), connection.DataSource);
+                    Assert.Equal(Path.Combine(dataSubDirectory, "local.db"), connection.DataSource);
+                }
+            }
+            finally
+            {
+                AppDomain.CurrentDomain.SetData("DataDirectory", null);
             }
         }
 
         [Fact]
         public void Open_adjusts_relative_path()
         {
+            // Ensure there isn't a data directory context that can affect the pathing
+            AppDomain.CurrentDomain.SetData("DataDirectory", null);
+
             using (var connection = new SqliteConnection("Data Source=local.db"))
             {
                 connection.Open();


### PR DESCRIPTION
Summary of the changes
 - Added |DataDirectory| checks in SqliteConnection connection string path
 - Created unit test for checking |DataDirectory| support

Fixes #13840