### PR TITLE
Add key discovery convention for owned collections

### DIFF
--- a/src/EFCore.Specification.Tests/GraphUpdatesFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/GraphUpdatesFixtureBase.cs
@@ -351,6 +351,8 @@ namespace Microsoft.EntityFrameworkCore
                 modelBuilder.Entity<RequiredComposite1>(
                     eb =>
                     {
+                        eb.Property(e => e.Id).ValueGeneratedNever();
+
                         eb.HasKey(
                             e => new
                             {
@@ -377,6 +379,8 @@ namespace Microsoft.EntityFrameworkCore
                 modelBuilder.Entity<OptionalOverlaping2>(
                     eb =>
                     {
+                        eb.Property(e => e.Id).ValueGeneratedNever();
+
                         eb.HasKey(
                             e => new
                             {

--- a/src/EFCore.Specification.Tests/ProxyGraphUpdatesFixtureBase.cs
+++ b/src/EFCore.Specification.Tests/ProxyGraphUpdatesFixtureBase.cs
@@ -346,6 +346,8 @@ namespace Microsoft.EntityFrameworkCore
                 modelBuilder.Entity<RequiredComposite1>(
                     eb =>
                     {
+                        eb.Property(e => e.Id).ValueGeneratedNever();
+
                         eb.HasKey(
                             e => new
                             {
@@ -372,6 +374,8 @@ namespace Microsoft.EntityFrameworkCore
                 modelBuilder.Entity<OptionalOverlaping2>(
                     eb =>
                     {
+                        eb.Property(e => e.Id).ValueGeneratedNever();
+
                         eb.HasKey(
                             e => new
                             {

--- a/src/EFCore.Specification.Tests/StoreGeneratedFixupTestBase.cs
+++ b/src/EFCore.Specification.Tests/StoreGeneratedFixupTestBase.cs
@@ -4326,7 +4326,11 @@ namespace Microsoft.EntityFrameworkCore
 
                 modelBuilder.Entity<Product>(b => b.HasKey(e => new { e.Id1, e.Id2 }));
 
-                modelBuilder.Entity<Level>(eb => eb.HasKey(l => new { l.GameId, l.Id }));
+                modelBuilder.Entity<Level>(eb =>
+                {
+                    eb.Property(g => g.Id).ValueGeneratedNever();
+                    eb.HasKey(l => new { l.GameId, l.Id });
+                });
 
                 modelBuilder.Entity<GameEntity>();
 

--- a/src/EFCore/Metadata/Conventions/Internal/KeyDiscoveryConvention.cs
+++ b/src/EFCore/Metadata/Conventions/Internal/KeyDiscoveryConvention.cs
@@ -56,21 +56,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 return entityTypeBuilder;
             }
 
-            IReadOnlyList<Property> keyProperties = null;
+            List<Property> keyProperties = null;
             var definingFk = entityType.FindDefiningNavigation()?.ForeignKey
                              ?? entityType.FindOwnership();
-
-            if (definingFk?.IsUnique == false
-                && definingFk.DeclaringEntityType == entityType)
-            {
-                entityTypeBuilder.PrimaryKey((IReadOnlyList<string>)null, ConfigurationSource.Convention);
-                return entityTypeBuilder;
-            }
 
             if (definingFk?.IsUnique == true
                 && definingFk.DeclaringEntityType == entityType)
             {
-                keyProperties = definingFk.Properties;
+                keyProperties = definingFk.Properties.ToList();
             }
 
             if (keyProperties == null)
@@ -78,12 +71,36 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Conventions.Internal
                 var candidateProperties = entityType.GetProperties().Where(
                     p => !p.IsShadowProperty
                          || !ConfigurationSource.Convention.Overrides(p.GetConfigurationSource())).ToList();
-                keyProperties = (IReadOnlyList<Property>)DiscoverKeyProperties(entityType, candidateProperties);
+                keyProperties = (List<Property>)DiscoverKeyProperties(entityType, candidateProperties);
                 if (keyProperties.Count > 1)
                 {
                     _logger?.MultiplePrimaryKeyCandidates(keyProperties[0], keyProperties[1]);
                     return entityTypeBuilder;
                 }
+            }
+
+            if (definingFk?.IsUnique == false
+                && definingFk.DeclaringEntityType == entityType)
+            {
+                if (keyProperties.Count == 0
+                    || definingFk.Properties.Contains(keyProperties.First()))
+                {
+                    var shadowProperty = entityType.FindPrimaryKey()?.Properties.Last();
+                    if (shadowProperty == null
+                        || entityType.FindPrimaryKey().Properties.Count == 1
+                        || definingFk.Properties.Contains(shadowProperty))
+                    {
+                        shadowProperty = entityTypeBuilder.CreateUniqueProperty("Id", typeof(int), isRequired: true);
+                    }
+
+                    keyProperties.Clear();
+                    keyProperties.Add(shadowProperty);
+                }
+
+                var extraProperty = keyProperties[0];
+                keyProperties.RemoveAt(0);
+                keyProperties.AddRange(definingFk.Properties);
+                keyProperties.Add(extraProperty);
             }
 
             if (keyProperties.Count > 0)

--- a/src/EFCore/Metadata/Internal/Property.cs
+++ b/src/EFCore/Metadata/Internal/Property.cs
@@ -272,7 +272,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 _beforeSaveBehavior = beforeSaveBehavior;
             }
 
-            UpdateBeforeSaveBehaviorConfigurationSource(configurationSource);
+            if (beforeSaveBehavior == null)
+            {
+                _beforeSaveBehaviorConfigurationSource = null;
+            }
+            else
+            {
+                UpdateBeforeSaveBehaviorConfigurationSource(configurationSource);
+            }
         }
 
         private PropertySaveBehavior DefaultBeforeSaveBehavior
@@ -321,7 +328,14 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                 _afterSaveBehavior = afterSaveBehavior;
             }
 
-            UpdateAfterSaveBehaviorConfigurationSource(configurationSource);
+            if (afterSaveBehavior == null)
+            {
+                _afterSaveBehaviorConfigurationSource = null;
+            }
+            else
+            {
+                UpdateAfterSaveBehaviorConfigurationSource(configurationSource);
+            }
         }
 
         private PropertySaveBehavior DefaultAfterSaveBehavior

--- a/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/SqlServerEndToEndTest.cs
@@ -918,6 +918,9 @@ namespace Microsoft.EntityFrameworkCore
                 modelBuilder.Entity<Level>(
                     eb =>
                     {
+                        eb.Property(g => g.Id)
+                            .ValueGeneratedNever();
+
                         eb.HasKey(
                             l => new
                             {
@@ -929,12 +932,16 @@ namespace Microsoft.EntityFrameworkCore
                 modelBuilder.Entity<Actor>(
                     eb =>
                     {
+                        eb.Property(g => g.Id)
+                            .ValueGeneratedNever();
+
                         eb.HasKey(
                             a => new
                             {
                                 a.GameId,
                                 a.Id
                             });
+
                         eb.HasOne(a => a.Level)
                             .WithMany(l => l.Actors)
                             .HasForeignKey(nameof(Actor.GameId), "LevelId")
@@ -956,6 +963,9 @@ namespace Microsoft.EntityFrameworkCore
                 modelBuilder.Entity<Item>(
                     eb =>
                     {
+                        eb.Property(g => g.Id)
+                            .ValueGeneratedNever();
+
                         eb.HasKey(
                             l => new
                             {


### PR DESCRIPTION
  * Find a candidate property using the normal convention or create a shadow int property if none found
  * Configure the PK to be composed of the FK property(ies) and the found property
  * The non-FK property is configured as ValueGeneratedOnAdd

HasKey and KeyAttribute work the same as on other entity types

Fixes #13295 