### PR TITLE
Allow writing to to readonly fields

### DIFF
--- a/src/EFCore.Specification.Tests/DataAnnotationTestBase.cs
+++ b/src/EFCore.Specification.Tests/DataAnnotationTestBase.cs
@@ -221,9 +221,7 @@ namespace Microsoft.EntityFrameworkCore
 #pragma warning disable 169
             [Key]
             [Column("dsdsd", Order = 1, TypeName = "nvarchar(128)")]
-#pragma warning disable IDE0044 // Add readonly modifier
-            private string _personFirstName;
-#pragma warning restore IDE0044 // Add readonly modifier
+            private readonly string _personFirstName;
 #pragma warning restore 169
         }
 

--- a/src/EFCore.Specification.Tests/LazyLoadProxyTestBase.cs
+++ b/src/EFCore.Specification.Tests/LazyLoadProxyTestBase.cs
@@ -1911,9 +1911,7 @@ namespace Microsoft.EntityFrameworkCore
 
         public class FirstName
         {
-#pragma warning disable IDE0044 // Add readonly modifier
-            private string _value;
-#pragma warning restore IDE0044 // Add readonly modifier
+            private readonly string _value;
 
             protected FirstName()
             {
@@ -1932,9 +1930,7 @@ namespace Microsoft.EntityFrameworkCore
 
         public class LastName
         {
-#pragma warning disable IDE0044 // Add readonly modifier
-            private string _value;
-#pragma warning restore IDE0044 // Add readonly modifier
+            private readonly string _value;
 
             protected LastName()
             {

--- a/src/EFCore.Specification.Tests/WithConstructorsTestBase.cs
+++ b/src/EFCore.Specification.Tests/WithConstructorsTestBase.cs
@@ -818,9 +818,7 @@ namespace Microsoft.EntityFrameworkCore
 
         protected class Blog
         {
-#pragma warning disable IDE0044 // Add readonly modifier
-            private int _blogId;
-#pragma warning restore IDE0044 // Add readonly modifier
+            private readonly int _blogId;
 
             private Blog(
                 int blogId,
@@ -864,9 +862,7 @@ namespace Microsoft.EntityFrameworkCore
 
         protected class Post
         {
-#pragma warning disable IDE0044 // Add readonly modifier
-            private int _id;
-#pragma warning restore IDE0044 // Add readonly modifier
+            private readonly int _id;
 
             private Post(
                 int id,

--- a/src/EFCore/Metadata/Internal/ClrCollectionAccessorFactory.cs
+++ b/src/EFCore/Metadata/Internal/ClrCollectionAccessorFactory.cs
@@ -107,10 +107,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (setterMemberInfo != null)
             {
                 setterDelegate = Expression.Lambda<Action<TEntity, TCollection>>(
-                    Expression.Assign(
-                        Expression.MakeMemberAccess(
-                            entityParameter,
-                            setterMemberInfo),
+                    Expression.MakeMemberAccess(
+                        entityParameter,
+                        setterMemberInfo).Assign(
                         Expression.Convert(
                             valueParameter,
                             setterMemberInfo.GetMemberType())),

--- a/src/EFCore/Metadata/Internal/ClrPropertySetterFactory.cs
+++ b/src/EFCore/Metadata/Internal/ClrPropertySetterFactory.cs
@@ -41,9 +41,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             Expression writeExpression;
             if (memberInfo.DeclaringType.GetTypeInfo().IsAssignableFrom(typeof(TEntity).GetTypeInfo()))
             {
-                writeExpression = Expression.Assign(
-                    Expression.MakeMemberAccess(entityParameter, memberInfo),
-                    convertedParameter);
+                writeExpression = Expression.MakeMemberAccess(entityParameter, memberInfo)
+                    .Assign(convertedParameter);
             }
             else
             {
@@ -59,9 +58,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                             Expression.TypeAs(entityParameter, memberInfo.DeclaringType)),
                         Expression.IfThen(
                             Expression.ReferenceNotEqual(converted, Expression.Constant(null)),
-                            Expression.Assign(
-                                Expression.MakeMemberAccess(converted, memberInfo),
-                                convertedParameter))
+                            Expression.MakeMemberAccess(converted, memberInfo)
+                                .Assign(convertedParameter))
                     });
             }
 

--- a/src/EFCore/Metadata/Internal/PropertyBaseExtensions.cs
+++ b/src/EFCore/Metadata/Internal/PropertyBaseExtensions.cs
@@ -136,29 +136,12 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             if (mode == null
                 || mode == PropertyAccessMode.FieldDuringConstruction)
             {
-                if (forConstruction
-                    && fieldInfo?.IsInitOnly == false)
-                {
-                    memberInfo = fieldInfo;
-                    return true;
-                }
-
                 if (forConstruction)
                 {
                     if (fieldInfo != null)
                     {
-                        if (!fieldInfo.IsInitOnly)
-                        {
-                            memberInfo = fieldInfo;
-                            return true;
-                        }
-
-                        if (mode == PropertyAccessMode.FieldDuringConstruction
-                            && !isCollectionNav)
-                        {
-                            errorMessage = CoreStrings.ReadonlyField(fieldInfo.Name, propertyBase.DeclaringType.DisplayName());
-                            return false;
-                        }
+                        memberInfo = fieldInfo;
+                        return true;
                     }
 
                     if (mode == PropertyAccessMode.FieldDuringConstruction)
@@ -184,17 +167,8 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
                     if (fieldInfo != null)
                     {
-                        if (!fieldInfo.IsInitOnly)
-                        {
-                            memberInfo = fieldInfo;
-                            return true;
-                        }
-
-                        if (!isCollectionNav)
-                        {
-                            errorMessage = CoreStrings.ReadonlyField(fieldInfo.Name, propertyBase.DeclaringType.DisplayName());
-                            return false;
-                        }
+                        memberInfo = fieldInfo;
+                        return true;
                     }
 
                     if (!isCollectionNav)
@@ -231,18 +205,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
                         || !isCollectionNav)
                     {
                         errorMessage = GetNoFieldErrorMessage(propertyBase);
-                        return false;
-                    }
-
-                    return true;
-                }
-
-                if (forSet
-                    && fieldInfo.IsInitOnly)
-                {
-                    if (!isCollectionNav)
-                    {
-                        errorMessage = CoreStrings.ReadonlyField(fieldInfo.Name, propertyBase.DeclaringType.DisplayName());
                         return false;
                     }
 

--- a/src/EFCore/Properties/CoreStrings.Designer.cs
+++ b/src/EFCore/Properties/CoreStrings.Designer.cs
@@ -317,14 +317,6 @@ namespace Microsoft.EntityFrameworkCore.Internal
                 property, entity);
 
         /// <summary>
-        ///     Field '{field}' of entity type '{entity}' is readonly and so cannot be set.
-        /// </summary>
-        public static string ReadonlyField([CanBeNull] object field, [CanBeNull] object entity)
-            => string.Format(
-                GetString("ReadonlyField", nameof(field), nameof(entity)),
-                field, entity);
-
-        /// <summary>
         ///     No property was associated with field '{field}' of entity type '{entity}'. Either configure a property or use a different '{pam}'.
         /// </summary>
         public static string NoProperty([CanBeNull] object field, [CanBeNull] object entity, [CanBeNull] object pam)

--- a/src/EFCore/Properties/CoreStrings.resx
+++ b/src/EFCore/Properties/CoreStrings.resx
@@ -232,9 +232,6 @@
   <data name="NoFieldOrGetter" xml:space="preserve">
     <value>No backing field could be found for property '{property}' of entity type '{entity}' and the property does not have a getter.</value>
   </data>
-  <data name="ReadonlyField" xml:space="preserve">
-    <value>Field '{field}' of entity type '{entity}' is readonly and so cannot be set.</value>
-  </data>
   <data name="NoProperty" xml:space="preserve">
     <value>No property was associated with field '{field}' of entity type '{entity}'. Either configure a property or use a different '{pam}'.</value>
   </data>

--- a/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
+++ b/test/EFCore.Relational.Tests/Migrations/Internal/MigrationsModelDifferTest.cs
@@ -7280,9 +7280,7 @@ namespace Microsoft.EntityFrameworkCore.Migrations.Internal
 
         private class Order
         {
-#pragma warning disable IDE0044 // Add readonly modifier
-            private int _secretId;
-#pragma warning restore IDE0044 // Add readonly modifier
+            private readonly int _secretId;
 
             public Order()
             {

--- a/test/EFCore.Tests/ChangeTracking/Internal/FixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/FixupTest.cs
@@ -2783,9 +2783,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         private class Category
         {
             // ReSharper disable once FieldCanBeMadeReadOnly.Local
-#pragma warning disable IDE0044 // Add readonly modifier
-            private int _id;
-#pragma warning restore IDE0044 // Add readonly modifier
+            private readonly int _id;
             private ICollection<Product> _products;
 
             // ReSharper disable once UnusedMember.Local
@@ -2811,9 +2809,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         private class Product
         {
             // ReSharper disable once FieldCanBeMadeReadOnly.Local
-#pragma warning disable IDE0044 // Add readonly modifier
-            private int _id;
-#pragma warning restore IDE0044 // Add readonly modifier
+            private readonly int _id;
             private int _categoryId;
             private Category _category;
             private ICollection<SpecialOffer> _specialOffers;
@@ -2852,9 +2848,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         private class SpecialOffer
         {
             // ReSharper disable once FieldCanBeMadeReadOnly.Local
-#pragma warning disable IDE0044 // Add readonly modifier
-            private int _id;
-#pragma warning restore IDE0044 // Add readonly modifier
+            private readonly int _id;
             private int _productId;
             private Product _product;
 

--- a/test/EFCore.Tests/Metadata/Internal/ClrCollectionAccessorFactoryTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/ClrCollectionAccessorFactoryTest.cs
@@ -355,21 +355,13 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
         [Fact]
         public void Initialization_for_read_only_auto_prop_navigation()
         {
-            var accessor = new ClrCollectionAccessorFactory().Create(CreateNavigation("ReadOnlyAutoProp"));
-
-            Assert.Equal(
-                CoreStrings.NavigationNoSetter("ReadOnlyAutoProp", typeof(MyEntity).Name),
-                Assert.Throws<InvalidOperationException>(() => accessor.Add(new MyEntity(false), new MyOtherEntity())).Message);
+            AccessorTest("ReadOnlyAutoProp", e => e.ReadOnlyAutoProp, initializeCollections: false);
         }
 
         [Fact]
         public void Initialization_for_read_only_navigation_backed_by_readonly_field()
         {
-            var accessor = new ClrCollectionAccessorFactory().Create(CreateNavigation("ReadOnlyFieldProp"));
-
-            Assert.Equal(
-                CoreStrings.NavigationNoSetter("ReadOnlyFieldProp", typeof(MyEntity).Name),
-                Assert.Throws<InvalidOperationException>(() => accessor.Add(new MyEntity(false), new MyOtherEntity())).Message);
+            AccessorTest("ReadOnlyFieldProp", e => e.ReadOnlyFieldProp, initializeCollections: false);
         }
 
         [Fact]
@@ -420,7 +412,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             return navigation;
         }
 
-#pragma warning disable IDE0044 // Add readonly modifier
         private class MyEntity
         {
             private ICollection<MyOtherEntity> _asICollection;
@@ -429,7 +420,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             private List<MyOtherEntity> _asList;
             private MyCollection _myCollection;
             private readonly ICollection<MyOtherEntity> _withNoBackingFieldFound;
-            private ICollection<MyOtherEntity> _withNoSetter;
+            private readonly ICollection<MyOtherEntity> _withNoSetter;
             private ICollection<MyOtherEntity> _withNoGetter;
             private IEnumerable<MyOtherEntity> _enumerable;
             private IEnumerable<MyOtherEntity> _enumerableNotCollection;
@@ -437,7 +428,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             private MyPrivateCollection _privateCollection;
             private MyInternalCollection _internalCollection;
             private MyUnavailableCollection _unavailableCollection;
-            private IEnumerable<MyOtherEntity> _readOnlyProp;
+            private readonly IEnumerable<MyOtherEntity> _readOnlyProp;
             private readonly IEnumerable<MyOtherEntity> _readOnlyFieldProp;
             private IEnumerable<MyOtherEntity> _writeOnlyProp;
             private IEnumerable<MyOtherEntity> _fullPropNoFieldNotFound;
@@ -635,6 +626,5 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
-#pragma warning restore IDE0044 // Add readonly modifier
     }
 }

--- a/test/EFCore.Tests/Metadata/Internal/PropertyBaseTest.cs
+++ b/test/EFCore.Tests/Metadata/Internal/PropertyBaseTest.cs
@@ -73,9 +73,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var property = CreateProperty<ReadOnlyAutoProp>(field);
             Assert.False(property.IsShadowProperty);
 
-            MemberInfoTest(property, null, ReadonlyField<ReadOnlyAutoProp>(field), ReadonlyField<ReadOnlyAutoProp>(field), Property);
-            MemberInfoTest(property, PropertyAccessMode.Field, ReadonlyField<ReadOnlyAutoProp>(field), ReadonlyField<ReadOnlyAutoProp>(field), field);
-            MemberInfoTest(property, PropertyAccessMode.FieldDuringConstruction, ReadonlyField<ReadOnlyAutoProp>(field), ReadonlyField<ReadOnlyAutoProp>(field), Property);
+            MemberInfoTest(property, null, field, field, Property);
+            MemberInfoTest(property, PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(property, PropertyAccessMode.FieldDuringConstruction, field, field, Property);
             MemberInfoTest(property, PropertyAccessMode.Property, NoSetter<ReadOnlyAutoProp>(), NoSetter<ReadOnlyAutoProp>(), Property);
         }
 
@@ -86,9 +86,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var property = CreateProperty<ReadOnlyFieldProp>(field);
             Assert.False(property.IsShadowProperty);
 
-            MemberInfoTest(property, null, ReadonlyField<ReadOnlyFieldProp>(field), ReadonlyField<ReadOnlyFieldProp>(field), Property);
-            MemberInfoTest(property, PropertyAccessMode.Field, ReadonlyField<ReadOnlyFieldProp>(field), ReadonlyField<ReadOnlyFieldProp>(field), field);
-            MemberInfoTest(property, PropertyAccessMode.FieldDuringConstruction, ReadonlyField<ReadOnlyFieldProp>(field), ReadonlyField<ReadOnlyFieldProp>(field), Property);
+            MemberInfoTest(property, null, field, field, Property);
+            MemberInfoTest(property, PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(property, PropertyAccessMode.FieldDuringConstruction, field, field, Property);
             MemberInfoTest(property, PropertyAccessMode.Property, NoSetter<ReadOnlyFieldProp>(), NoSetter<ReadOnlyFieldProp>(), Property);
         }
 
@@ -138,9 +138,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             var property = CreateProperty<ReadOnlyFieldOnly>(field);
             Assert.False(property.IsShadowProperty);
 
-            MemberInfoTest(property, null, ReadonlyField<ReadOnlyFieldOnly>(field), ReadonlyField<ReadOnlyFieldOnly>(field), field);
-            MemberInfoTest(property, PropertyAccessMode.Field, ReadonlyField<ReadOnlyFieldOnly>(field), ReadonlyField<ReadOnlyFieldOnly>(field), field);
-            MemberInfoTest(property, PropertyAccessMode.FieldDuringConstruction, ReadonlyField<ReadOnlyFieldOnly>(field), ReadonlyField<ReadOnlyFieldOnly>(field), field);
+            MemberInfoTest(property, null, field, field, field);
+            MemberInfoTest(property, PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(property, PropertyAccessMode.FieldDuringConstruction, field, field, field);
             MemberInfoTest(property, PropertyAccessMode.Property, NoProperty<ReadOnlyFieldOnly>(field), NoProperty<ReadOnlyFieldOnly>(field), NoProperty<ReadOnlyFieldOnly>(field));
         }
 
@@ -248,9 +248,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             const string field = "<Reference>k__BackingField";
             var navigation = CreateReferenceNavigation<ReadOnlyAutoProp>(field);
 
-            MemberInfoTest(navigation, null, ReadonlyField<ReadOnlyAutoProp>(field), ReadonlyField<ReadOnlyAutoProp>(field), Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.Field, ReadonlyField<ReadOnlyAutoProp>(field), ReadonlyField<ReadOnlyAutoProp>(field), field);
-            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, ReadonlyField<ReadOnlyAutoProp>(field), ReadonlyField<ReadOnlyAutoProp>(field), Reference);
+            MemberInfoTest(navigation, null, field, field, Reference);
+            MemberInfoTest(navigation, PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, field, field, Reference);
             MemberInfoTest(navigation, PropertyAccessMode.Property, NoSetterRef<ReadOnlyAutoProp>(), NoSetterRef<ReadOnlyAutoProp>(), Reference);
         }
 
@@ -260,9 +260,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             const string field = "_reference";
             var navigation = CreateReferenceNavigation<ReadOnlyFieldProp>(field);
 
-            MemberInfoTest(navigation, null, ReadonlyField<ReadOnlyFieldProp>(field), ReadonlyField<ReadOnlyFieldProp>(field), Reference);
-            MemberInfoTest(navigation, PropertyAccessMode.Field, ReadonlyField<ReadOnlyFieldProp>(field), ReadonlyField<ReadOnlyFieldProp>(field), field);
-            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, ReadonlyField<ReadOnlyFieldProp>(field), ReadonlyField<ReadOnlyFieldProp>(field), Reference);
+            MemberInfoTest(navigation, null, field, field, Reference);
+            MemberInfoTest(navigation, PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, field, field, Reference);
             MemberInfoTest(navigation, PropertyAccessMode.Property, NoSetterRef<ReadOnlyFieldProp>(), NoSetterRef<ReadOnlyFieldProp>(), Reference);
         }
 
@@ -377,9 +377,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             const string field = "<Collection>k__BackingField";
             var navigation = CreateCollectionNavigation<ReadOnlyAutoProp>(field);
 
-            MemberInfoTest(navigation, null, null, null, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.Field, null, null, field);
-            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, null, null, Collection);
+            MemberInfoTest(navigation, null, field, field, Collection);
+            MemberInfoTest(navigation, PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, field, field, Collection);
             MemberInfoTest(navigation, PropertyAccessMode.Property, null, null, Collection);
         }
 
@@ -389,9 +389,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
             const string field = "_collection";
             var navigation = CreateCollectionNavigation<ReadOnlyFieldProp>(field);
 
-            MemberInfoTest(navigation, null, null, null, Collection);
-            MemberInfoTest(navigation, PropertyAccessMode.Field, null, null, field);
-            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, null, null, Collection);
+            MemberInfoTest(navigation, null, field, field, Collection);
+            MemberInfoTest(navigation, PropertyAccessMode.Field, field, field, field);
+            MemberInfoTest(navigation, PropertyAccessMode.FieldDuringConstruction, field, field, Collection);
             MemberInfoTest(navigation, PropertyAccessMode.Property, null, null, Collection);
         }
 
@@ -481,9 +481,6 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         private static string NoGetter<TEntity>()
             => CoreStrings.NoGetter(Property, typeof(TEntity).Name, nameof(PropertyAccessMode));
-
-        private static string ReadonlyField<TEntity>(string fieldName)
-            => CoreStrings.ReadonlyField(fieldName, typeof(TEntity).Name);
 
         private static string NoFieldRef<TEntity>()
             => CoreStrings.NoBackingField(Reference, typeof(TEntity).Name, nameof(PropertyAccessMode));
@@ -753,11 +750,9 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         private class ReadOnlyProp
         {
-#pragma warning disable IDE0044 // Add readonly modifier
-            private int _foo;
-            private ReadOnlyProp _reference;
-            private IEnumerable<ReadOnlyProp> _collection;
-#pragma warning restore IDE0044 // Add readonly modifier
+            private readonly int _foo;
+            private readonly ReadOnlyProp _reference;
+            private readonly IEnumerable<ReadOnlyProp> _collection;
 
             public int Id { get; set; }
 
@@ -833,9 +828,7 @@ namespace Microsoft.EntityFrameworkCore.Metadata.Internal
 
         private class FieldOnly
         {
-#pragma warning disable IDE0044 // Add readonly modifier
-            private int _foo;
-#pragma warning restore IDE0044 // Add readonly modifier
+            private readonly int _foo;
 
             public FieldOnly(int id)
             {

--- a/test/EFCore.Tests/ModelBuilding/ModelBuilder.Other.cs
+++ b/test/EFCore.Tests/ModelBuilding/ModelBuilder.Other.cs
@@ -118,9 +118,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         protected class User13300
         {
             public Guid Id { get; set; }
-#pragma warning disable IDE0044 // Add readonly modifier
-            private string _email = string.Empty;
-#pragma warning restore IDE0044 // Add readonly modifier
+            private readonly string _email = string.Empty;
             private readonly List<Profile13300> _profiles = new List<Profile13300>();
         }
 
@@ -163,9 +161,7 @@ namespace Microsoft.EntityFrameworkCore.ModelBuilding
         protected class User13694
         {
             public Guid Id { get; set; }
-#pragma warning disable IDE0044 // Add readonly modifier
-            private string _email = string.Empty;
-#pragma warning restore IDE0044 // Add readonly modifier
+            private readonly string _email = string.Empty;
             private readonly List<Profile13694> _profiles = new List<Profile13694>();
         }
 


### PR DESCRIPTION
Fixes #13237

On both .NET Core and .NET Framework, the expression builder APIs do not allow assignment to IsInitOnly fields. However, on .NET Core, if this check is bypassed, then the compiler will happily compile the expression tree, which results in performant code for setting readonly fields. We should decide if we're comfortable doing this.

On .NET Framework, the compiler will not compile the expression tree, so if not running on Core, we drop down to calling FieldInfo.SetValue, which both boxes and is on the order of 1000 times slower, but has always worked and so should be safe to do.