### PR TITLE
Microsoft.Data.Sqlite: Fix memory leak after disposing SqliteCommand

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteCommand.cs
@@ -202,6 +202,7 @@ namespace Microsoft.Data.Sqlite
         protected override void Dispose(bool disposing)
         {
             DisposePreparedStatements(disposing);
+            _connection?.RemoveCommand(this);
 
             base.Dispose(disposing);
         }

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -76,8 +76,6 @@ namespace Microsoft.Data.Sqlite
 
         internal SqliteConnectionStringBuilder ConnectionStringBuilder { get; set; }
 
-        internal int CommandsCount => _commands.Count;
-
         /// <summary>
         ///     Gets the name of the current database. Always 'main'.
         /// </summary>
@@ -261,7 +259,7 @@ namespace Microsoft.Data.Sqlite
                 }
             }
 
-            _commands.Clear();
+            Debug.Assert(_commands.Count == 0);
 
             _db.Dispose2();
             _db = null;

--- a/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteConnection.cs
@@ -76,6 +76,8 @@ namespace Microsoft.Data.Sqlite
 
         internal SqliteConnectionStringBuilder ConnectionStringBuilder { get; set; }
 
+        internal int CommandsCount => _commands.Count;
+
         /// <summary>
         ///     Gets the name of the current database. Always 'main'.
         /// </summary>
@@ -249,8 +251,10 @@ namespace Microsoft.Data.Sqlite
 
             Transaction?.Dispose();
 
-            foreach (var reference in _commands)
+            // command.Dispose() removes itself from _commands
+            for (var i = _commands.Count - 1; i >= 0; i--)
             {
+                var reference = _commands[i];
                 if (reference.TryGetTarget(out var command))
                 {
                     command.Dispose();

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteCommandTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteCommandTest.cs
@@ -879,19 +879,5 @@ namespace Microsoft.Data.Sqlite
                 Assert.NotNull(result);
             }
         }
-
-        [Fact]
-        public void Commands_are_disposed_with_cleanup_of_connection()
-        {
-            using (var connection = new SqliteConnection("Data Source=:memory:"))
-            {
-                connection.Open();
-                using (var cmd = new SqliteCommand("SELECT 1", connection))
-                {
-                }
-
-                Assert.Equal(0, connection.CommandsCount);
-            }
-        }
     }
 }

--- a/test/Microsoft.Data.Sqlite.Tests/SqliteCommandTest.cs
+++ b/test/Microsoft.Data.Sqlite.Tests/SqliteCommandTest.cs
@@ -879,5 +879,19 @@ namespace Microsoft.Data.Sqlite
                 Assert.NotNull(result);
             }
         }
+
+        [Fact]
+        public void Commands_are_disposed_with_cleanup_of_connection()
+        {
+            using (var connection = new SqliteConnection("Data Source=:memory:"))
+            {
+                connection.Open();
+                using (var cmd = new SqliteCommand("SELECT 1", connection))
+                {
+                }
+
+                Assert.Equal(0, connection.CommandsCount);
+            }
+        }
     }
 }


### PR DESCRIPTION
Command removes itself from connection when disposing itself.

Fixes #13898 
