### PR TITLE
Microsoft.Data.Sqlite: Improve SqliteDataReader.GetFieldType() when NULL

### DIFF
--- a/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
+++ b/src/Microsoft.Data.Sqlite.Core/SqliteDataReader.cs
@@ -659,7 +659,8 @@ namespace Microsoft.Data.Sqlite
                 var tableName = sqlite3_column_table_name(_record.Handle, i).utf8_to_string();
                 schemaRow[BaseTableName] = tableName;
                 schemaRow[DataType] = GetFieldType(i);
-                schemaRow[DataTypeName] = GetDataTypeName(i);
+                var dataTypeName = GetDataTypeName(i);
+                schemaRow[DataTypeName] = dataTypeName;
                 schemaRow[IsAliased] = columnName != GetName(i);
                 schemaRow[IsExpression] = columnName == null;
                 schemaRow[IsLong] = DBNull.Value;
@@ -691,7 +692,11 @@ namespace Microsoft.Data.Sqlite
                             .AppendLine("LIMIT 1;").ToString();
 
                         var type = (string)command.ExecuteScalar();
-                        schemaRow[DataType] = SqliteDataRecord.GetFieldType(type);
+                        schemaRow[DataType] =
+                            (type != null)
+                            ? SqliteDataRecord.GetFieldType(type)
+                            : SqliteDataRecord.GetFieldTypeFromSqliteType(
+                            SqliteDataRecord.Sqlite3AffinityType(dataTypeName));
                     }
 
                     if (!string.IsNullOrEmpty(databaseName))


### PR DESCRIPTION
In case a column value is NULL, SqliteDataReader.GetFieldType() now tries to return the field type based on the column affinity. 
SQLite does not provide the affinity via its API, therefore the corresponding C function sqlite3AffinityType was ported to C#. The affinity NUMERIC has no corresponding data type, so here the data type TEXT is returned (as suggested as default in #13831). 
A special case is a column where no type is specified, here the explicit rule was used, that such a column is of affinity BLOB (see [Determination Of Column Affinity](https://www.sqlite.org/datatype3.html#determination_of_column_affinity)).
The corresponding changes were also introduced for the SqliteDataReader.GetSchemaTable() DataType column.

Fixes #13831 and fixes #13839