### PR TITLE
Fix SequenceHiLo to use the sequence from the correct database

### DIFF
--- a/src/EFCore.SqlServer/ValueGeneration/Internal/ISqlServerValueGeneratorCache.cs
+++ b/src/EFCore.SqlServer/ValueGeneration/Internal/ISqlServerValueGeneratorCache.cs
@@ -3,6 +3,7 @@
 
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 
 namespace Microsoft.EntityFrameworkCore.SqlServer.ValueGeneration.Internal
@@ -17,6 +18,8 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.ValueGeneration.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        SqlServerSequenceValueGeneratorState GetOrAddSequenceState([NotNull] IProperty property);
+        SqlServerSequenceValueGeneratorState GetOrAddSequenceState(
+            [NotNull] IProperty property,
+            [NotNull] IRelationalConnection connection);
     }
 }

--- a/src/EFCore.SqlServer/ValueGeneration/Internal/SqlServerValueGeneratorCache.cs
+++ b/src/EFCore.SqlServer/ValueGeneration/Internal/SqlServerValueGeneratorCache.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using JetBrains.Annotations;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.EntityFrameworkCore.Utilities;
 using Microsoft.EntityFrameworkCore.ValueGeneration;
 
@@ -32,20 +33,28 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.ValueGeneration.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
-        public virtual SqlServerSequenceValueGeneratorState GetOrAddSequenceState(IProperty property)
+        public virtual SqlServerSequenceValueGeneratorState GetOrAddSequenceState(
+            IProperty property,
+            IRelationalConnection connection)
         {
-            Check.NotNull(property, nameof(property));
-
             var sequence = property.SqlServer().FindHiLoSequence();
 
             Debug.Assert(sequence != null);
 
             return _sequenceGeneratorCache.GetOrAdd(
-                GetSequenceName(sequence),
+                GetSequenceName(sequence, connection),
                 sequenceName => new SqlServerSequenceValueGeneratorState(sequence));
         }
 
-        private static string GetSequenceName(ISequence sequence)
-            => (sequence.Schema == null ? "" : sequence.Schema + ".") + sequence.Name;
+        private static string GetSequenceName(ISequence sequence, IRelationalConnection connection)
+        {
+            var dbConnection = connection.DbConnection;
+
+            return dbConnection.Database.ToUpperInvariant()
+                   + "::"
+                   + dbConnection.DataSource?.ToUpperInvariant()
+                   + "::"
+                   + (sequence.Schema == null ? "" : sequence.Schema + ".") + sequence.Name;
+        }
     }
 }

--- a/src/EFCore.SqlServer/ValueGeneration/Internal/SqlServerValueGeneratorSelector.cs
+++ b/src/EFCore.SqlServer/ValueGeneration/Internal/SqlServerValueGeneratorSelector.cs
@@ -54,7 +54,7 @@ namespace Microsoft.EntityFrameworkCore.SqlServer.ValueGeneration.Internal
 
             return property.GetValueGeneratorFactory() == null
                    && property.SqlServer().ValueGenerationStrategy == SqlServerValueGenerationStrategy.SequenceHiLo
-                ? _sequenceFactory.Create(property, Cache.GetOrAddSequenceState(property), _connection)
+                ? _sequenceFactory.Create(property, Cache.GetOrAddSequenceState(property, _connection), _connection)
                 : base.Select(property, entityType);
         }
 

--- a/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
+++ b/test/EFCore.Relational.Tests/TestUtilities/FakeProvider/FakeRelationalConnection.cs
@@ -18,10 +18,10 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
 
         private readonly List<FakeDbConnection> _dbConnections = new List<FakeDbConnection>();
 
-        public FakeRelationalConnection(IDbContextOptions options)
+        public FakeRelationalConnection(IDbContextOptions options = null)
             : base(
                 new RelationalConnectionDependencies(
-                    options,
+                    options ?? CreateOptions(),
                     new DiagnosticsLogger<DbLoggerCategory.Database.Transaction>(
                         new LoggerFactory(),
                         new LoggingOptions(),
@@ -30,9 +30,19 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities.FakeProvider
                         new LoggerFactory(),
                         new LoggingOptions(),
                         new DiagnosticListener("FakeDiagnosticListener")),
-                    new NamedConnectionStringResolver(options),
+                    new NamedConnectionStringResolver(options ?? CreateOptions()),
                     new RelationalTransactionFactory(new RelationalTransactionFactoryDependencies())))
         {
+        }
+
+        private static IDbContextOptions CreateOptions()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder();
+
+            ((IDbContextOptionsBuilderInfrastructure)optionsBuilder)
+                .AddOrUpdateExtension(new FakeRelationalOptionsExtension().WithConnectionString("Database=Dummy"));
+
+            return optionsBuilder.Options;
         }
 
         public void UseConnection(DbConnection connection) => _connection = connection;


### PR DESCRIPTION
Fixes #11451

Fix is to add database name and server name to the sequence state cache key.
