### PR TITLE
Remove workaround for dotnet/arcade#1634

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -2,13 +2,5 @@
   <ItemGroup>
     <!-- Third-party assemblies should be signed with the 3rd party certificate -->
     <FileSignInfo Include="Newtonsoft.Json.dll" CertificateName="3PartySHA2" />
-    
-    <!-- HACK: Work around dotnet/arcade#1634 -->
-    <FileSignInfo Include="EntityFrameworkCore.PowerShell2.psd1" CertificateName="None" />
-    <FileSignInfo Include="EntityFrameworkCore.PowerShell2.psm1" CertificateName="None" />
-    <FileSignInfo Include="EntityFrameworkCore.psd1" CertificateName="None" />
-    <FileSignInfo Include="EntityFrameworkCore.psm1" CertificateName="None" />
-    <FileSignInfo Include="init.ps1" CertificateName="None" />
-    <FileSignInfo Include="install.ps1" CertificateName="None" />
   </ItemGroup>
 </Project>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -9,6 +9,8 @@
     <IncludeSourceRevisionInInformationalVersion>False</IncludeSourceRevisionInInformationalVersion>
     <UsingToolNetFrameworkReferenceAssemblies>True</UsingToolNetFrameworkReferenceAssemblies>
     <UsingToolXliff>False</UsingToolXliff>
+    <!-- HACK: Work around dotnet/arcade#1599 -->
+    <MicrosoftDotNetSignToolVersion>1.0.0-beta.19057.6</MicrosoftDotNetSignToolVersion>
   </PropertyGroup>
   <PropertyGroup Label="Package Versions">
     <CastleCorePackageVersion>4.2.1</CastleCorePackageVersion>


### PR DESCRIPTION
(Manually running on the [internal CI](https://dev.azure.com/dnceng/internal/_build/results?buildId=68596))