### PR TITLE
[backport] Change prerelease label to 'servicing' for 2.1.x nightly builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ pr:
     include:
     - '*'
 
-name: $(Date:yyMMdd)-$(Rev:rr)
+name: $(Date:yyyyMMdd)-$(Rev:rr)
 
 jobs:
 - template: build/templates/default-build.yml
@@ -24,6 +24,7 @@ jobs:
     configuration: Release
     artifacts:
       publish: true
+      name: packages
       path: 'artifacts/build/'
 
 - template: build/templates/default-build.yml

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -7,7 +7,7 @@
   <PropertyGroup Label="Package Versions: Auto">
     <CastleCorePackageVersion>4.2.1</CastleCorePackageVersion>
     <FunctionalTests_PackageVersion>0.0.0</FunctionalTests_PackageVersion>
-    <InternalAspNetCoreSdkPackageVersion>2.1.3-rtm-15847</InternalAspNetCoreSdkPackageVersion>
+    <InternalAspNetCoreSdkPackageVersion>2.1.7-build-20190110.2</InternalAspNetCoreSdkPackageVersion>
     <MicrosoftAzureDocumentDBCorePackageVersion>1.7.1</MicrosoftAzureDocumentDBCorePackageVersion>
     <MicrosoftCodeAnalysisCSharpPackageVersion>2.8.0</MicrosoftCodeAnalysisCSharpPackageVersion>
     <MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>2.8.0</MicrosoftCodeAnalysisCSharpWorkspacesPackageVersion>
@@ -15,7 +15,7 @@
     <MicrosoftExtensionsDependencyModelPackageVersion>2.1.0</MicrosoftExtensionsDependencyModelPackageVersion>
     <MicrosoftNETCoreApp11PackageVersion>1.1.8</MicrosoftNETCoreApp11PackageVersion>
     <MicrosoftNETCoreApp20PackageVersion>2.0.9</MicrosoftNETCoreApp20PackageVersion>
-    <MicrosoftNETCoreApp21PackageVersion>2.1.5</MicrosoftNETCoreApp21PackageVersion>
+    <MicrosoftNETCoreApp21PackageVersion>2.1.7</MicrosoftNETCoreApp21PackageVersion>
     <MicrosoftNETTestSdkPackageVersion>15.6.1</MicrosoftNETTestSdkPackageVersion>
     <NETStandardLibrary20PackageVersion>2.0.3</NETStandardLibrary20PackageVersion>
     <NewtonsoftJsonPackageVersion>11.0.2</NewtonsoftJsonPackageVersion>

--- a/korebuild-lock.txt
+++ b/korebuild-lock.txt
@@ -1,2 +1,2 @@
-version:2.1.3-rtm-15847
-commithash:08641cb93aa5a9d52dc56c7516828b73aa448690
+version:2.1.7-build-20190110.2
+commithash:00aefcfd284db33352f35bfa2c74c65f8580e372

--- a/version.props
+++ b/version.props
@@ -1,18 +1,60 @@
 ﻿<Project>
   <PropertyGroup>
-    <VersionPrefix>2.1.8</VersionPrefix>
-    <VersionSuffix>rtm</VersionSuffix>
-    <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' == 'rtm' ">$(VersionPrefix)</PackageVersion>
-    <PackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(VersionSuffix)' != 'rtm' ">$(VersionPrefix)-$(VersionSuffix)-final</PackageVersion>
-    <BuildNumber Condition="'$(BuildNumber)' == ''">t000</BuildNumber>
-    <FeatureBranchVersionPrefix Condition="'$(FeatureBranchVersionPrefix)' == ''">a-</FeatureBranchVersionPrefix>
-    <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(FeatureBranchVersionSuffix)' != ''">$(FeatureBranchVersionPrefix)$(VersionSuffix)-$([System.Text.RegularExpressions.Regex]::Replace('$(FeatureBranchVersionSuffix)', '[^\w-]', '-'))</VersionSuffix>
-    <VersionSuffix Condition="'$(VersionSuffix)' != '' And '$(BuildNumber)' != ''">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
-
-    <ExperimentalVersionPrefix>0.1.8</ExperimentalVersionPrefix>
-    <ExperimentalVersionSuffix>rtm</ExperimentalVersionSuffix>
-    <ExperimentalPackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(ExperimentalVersionSuffix)' == 'rtm' ">$(ExperimentalVersionPrefix)</ExperimentalPackageVersion>
-    <ExperimentalPackageVersion Condition="'$(IsFinalBuild)' == 'true' AND '$(ExperimentalVersionSuffix)' != 'rtm' ">$(ExperimentalVersionPrefix)-$(ExperimentalVersionSuffix)-final</ExperimentalPackageVersion>
-    <ExperimentalVersionSuffix Condition="'$(ExperimentalVersionSuffix)' != '' And '$(BuildNumber)' != ''">$(ExperimentalVersionSuffix)-$(BuildNumber)</ExperimentalVersionSuffix>
+    <MajorVersion>2</MajorVersion>
+    <MinorVersion>1</MinorVersion>
+    <PatchVersion>8</PatchVersion>
+    <PreReleaseLabel>servicing</PreReleaseLabel>
+    <OfficialBuildId Condition="'$(OfficialBuildId)' == ''">$(BUILD_BUILDNUMBER)</OfficialBuildId>
   </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(OfficialBuildId)' != '' ">
+    <!-- This implements core versioning. Spec: https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md -->
+    <_BuildNumber>$(OfficialBuildId)</_BuildNumber>
+
+    <!-- _BuildNumber from CI is assumed to have format "yyyyMMdd.r". -->
+    <_BuildNumberYY>$(_BuildNumber.Substring(2, 2))</_BuildNumberYY>
+    <_BuildNumberMM>$(_BuildNumber.Substring(4, 2))</_BuildNumberMM>
+    <_BuildNumberDD>$(_BuildNumber.Substring(6, 2))</_BuildNumberDD>
+    <_BuildNumberR>$(_BuildNumber.Substring(9))</_BuildNumberR>
+
+    <!-- yy * 1000 + mm * 50 + dd -->
+    <_BuildNumberShortDate>$([MSBuild]::Add($([MSBuild]::Add($([MSBuild]::Multiply($(_BuildNumberYY), 1000)), $([MSBuild]::Multiply($(_BuildNumberMM), 50)))), $(_BuildNumberDD)))</_BuildNumberShortDate>
+
+     <VersionSuffixBuildOfTheDay>$([System.Convert]::ToInt32($(_BuildNumberR)))</VersionSuffixBuildOfTheDay>
+
+     <_BuildNumberSuffix>$(_BuildNumberShortDate).$(VersionSuffixBuildOfTheDay)</_BuildNumberSuffix>
+  </PropertyGroup>
+
+  <!-- This is temporary until we finish https://github.com/aspnet/AspNetCore-Internal/issues/1338  -->
+  <PropertyGroup Condition=" '$(TEAMCITY_VERSION)' != '' ">
+    <_BuildNumberSuffix>$(BuildNumber)</_BuildNumberSuffix>
+    <VersionSuffix>$(PreReleaseLabel)-$(_BuildNumberSuffix)</VersionSuffix>
+  </PropertyGroup>
+
+   <PropertyGroup>
+    <_BuildNumberSuffix Condition=" '$(_BuildNumberSuffix)' == '' ">0</_BuildNumberSuffix>
+    <VersionPrefix>$(MajorVersion).$(MinorVersion).$(PatchVersion)</VersionPrefix>
+    <VersionSuffix Condition=" '$(VersionSuffix)' == '' ">$(PreReleaseLabel)-$(_BuildNumberSuffix)</VersionSuffix>
+
+    <!-- Run the build with /p:IsFinalBuild=true to produce the product with 'final' branding and versioning -->
+    <IsFinalBuild Condition=" '$(IsFinalBuild)' == '' ">false</IsFinalBuild>
+    <IncludePreReleaseLabelInPackageVersion>true</IncludePreReleaseLabelInPackageVersion>
+    <IncludePreReleaseLabelInPackageVersion Condition=" '$(IsFinalBuild)' == 'true' AND ('$(PreReleaseLabel)' == 'servicing' OR '$(PreReleaseLabel)' == 'rtm')">false</IncludePreReleaseLabelInPackageVersion>
+
+    <!-- The version in files -->
+    <PackageVersion>$(VersionPrefix)</PackageVersion>
+    <PackageVersion Condition=" '$(IncludePreReleaseLabelInPackageVersion)' == 'true' ">$(VersionPrefix)-$(VersionSuffix)</PackageVersion>
+
+    <ExperimentalVersionPrefix>0.1.$(PatchVersion)</ExperimentalVersionPrefix>
+    <ExperimentalPackageVersion>$(ExperimentalVersionPrefix)</ExperimentalPackageVersion>
+    <ExperimentalPackageVersion Condition=" '$(IncludePreReleaseLabelInPackageVersion)' == 'true' ">$(ExperimentalVersionPrefix)-$(VersionSuffix)</ExperimentalPackageVersion>
+  </PropertyGroup>
+
+  <!-- Run 'dotnet msbuild version.props' to test changes to this file. -->
+  <Target Name="InspectVersionNumbers">
+    <Message Importance="High" Text="PackageVersion   = '$(PackageVersion)'" />
+    <Message Importance="High" Text="VersionPrefix    = '$(VersionPrefix)'" />
+    <Message Importance="High" Text="VersionSuffix    = '$(VersionSuffix)'" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
This backports a change made in 2.2 to build servicing builds as `2.1.8-servicing-123` instead of `2.1.8-rtm-123`