### PR TITLE
Use a retrying execution strategy when initializing Northwind

### DIFF
--- a/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.EntityFrameworkCore.TestUtilities.Xunit;
 using Microsoft.Extensions.DependencyInjection;
@@ -20,7 +21,7 @@ using Xunit.Abstractions;
 // ReSharper disable VirtualMemberCallInConstructor
 namespace Microsoft.EntityFrameworkCore
 {
-    public class DbContextPoolingTest
+    public class DbContextPoolingTest : IClassFixture<NorthwindQuerySqlServerFixture<NoopModelCustomizer>>
     {
         private static IServiceProvider BuildServiceProvider<TContextService, TContext>(int poolSize = 32)
             where TContextService : class
@@ -654,7 +655,7 @@ namespace Microsoft.EntityFrameworkCore
         private readonly ITestOutputHelper _testOutputHelper = null;
 
         // ReSharper disable once UnusedParameter.Local
-        public DbContextPoolingTest(ITestOutputHelper testOutputHelper)
+        public DbContextPoolingTest(NorthwindQuerySqlServerFixture<NoopModelCustomizer> fixture, ITestOutputHelper testOutputHelper)
         {
             //_testOutputHelper = testOutputHelper;
         }

--- a/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/TestUtilities/SqlServerTestStore.cs
@@ -316,8 +316,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         private static T Execute<T>(
             DbConnection connection, Func<DbCommand, T> execute, string sql,
             bool useTransaction = false, object[] parameters = null)
-            => TestEnvironment.IsSqlAzure
-                ? new TestSqlServerRetryingExecutionStrategy().Execute(
+            => new TestSqlServerRetryingExecutionStrategy().Execute(
                     new
                     {
                         connection,
@@ -326,8 +325,7 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
                         useTransaction,
                         parameters
                     },
-                    state => ExecuteCommand(state.connection, state.execute, state.sql, state.useTransaction, state.parameters))
-                : ExecuteCommand(connection, execute, sql, useTransaction, parameters);
+                    state => ExecuteCommand(state.connection, state.execute, state.sql, state.useTransaction, state.parameters));
 
         private static T ExecuteCommand<T>(
             DbConnection connection, Func<DbCommand, T> execute, string sql, bool useTransaction, object[] parameters)


### PR DESCRIPTION
Use a fixture in DbContextPoolingTest to ensure Northwind is initialized

Fixes #14434