### PR TITLE
Allow cascade delete timing to be configured

### DIFF
--- a/src/EFCore/ChangeTracking/CascadeTiming.cs
+++ b/src/EFCore/ChangeTracking/CascadeTiming.cs
@@ -1,0 +1,29 @@
+// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.EntityFrameworkCore.ChangeTracking
+{
+    /// <summary>
+    ///     Defines different strategies for when cascading actions will be performed.
+    ///     See <see cref="ChangeTracker.CascadeDeleteTiming" /> and <see cref="ChangeTracker.DeleteOrphansTiming" />.
+    /// </summary>
+    public enum CascadeTiming
+    {
+        /// <summary>
+        ///     Cascading actions are made to dependent/child entities as soon as the principal/parent
+        ///     entity changes.
+        /// </summary>
+        Immediate,
+
+        /// <summary>
+        ///     Cascading actions are made to dependent/child entities as part of <see cref="DbContext.SaveChanges()" />.
+        /// </summary>
+        OnSaveChanges,
+
+        /// <summary>
+        ///     Cascading actions are never made automatically to dependent/child entities, but must instead
+        ///     be triggered by an explicit call.
+        /// </summary>
+        Never
+    }
+}

--- a/src/EFCore/ChangeTracking/Internal/IStateManager.cs
+++ b/src/EFCore/ChangeTracking/Internal/IStateManager.cs
@@ -271,6 +271,18 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
+        void CascadeChanges(bool force);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        void CascadeDelete([NotNull] InternalEntityEntry entry, bool force);
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
         IDiagnosticsLogger<DbLoggerCategory.Update> UpdateLogger { get; }
     }
 }

--- a/src/EFCore/DbContext.cs
+++ b/src/EFCore/DbContext.cs
@@ -577,7 +577,9 @@ namespace Microsoft.EntityFrameworkCore
                 _changeTracker?.AutoDetectChangesEnabled,
                 _changeTracker?.QueryTrackingBehavior,
                 _database?.AutoTransactionsEnabled,
-                _changeTracker?.LazyLoadingEnabled);
+                _changeTracker?.LazyLoadingEnabled,
+                _changeTracker?.CascadeDeleteTiming,
+                _changeTracker?.DeleteOrphansTiming);
 
         void IDbContextPoolable.Resurrect(DbContextPoolConfigurationSnapshot configurationSnapshot)
         {
@@ -587,10 +589,14 @@ namespace Microsoft.EntityFrameworkCore
             {
                 Debug.Assert(configurationSnapshot.QueryTrackingBehavior.HasValue);
                 Debug.Assert(configurationSnapshot.LazyLoadingEnabled.HasValue);
+                Debug.Assert(configurationSnapshot.CascadeDeleteTiming.HasValue);
+                Debug.Assert(configurationSnapshot.DeleteOrphansTiming.HasValue);
 
                 ChangeTracker.AutoDetectChangesEnabled = configurationSnapshot.AutoDetectChangesEnabled.Value;
                 ChangeTracker.QueryTrackingBehavior = configurationSnapshot.QueryTrackingBehavior.Value;
                 ChangeTracker.LazyLoadingEnabled = configurationSnapshot.LazyLoadingEnabled.Value;
+                ChangeTracker.CascadeDeleteTiming = configurationSnapshot.CascadeDeleteTiming.Value;
+                ChangeTracker.DeleteOrphansTiming = configurationSnapshot.DeleteOrphansTiming.Value;
             }
             else
             {

--- a/src/EFCore/DeleteBehavior.cs
+++ b/src/EFCore/DeleteBehavior.cs
@@ -50,8 +50,7 @@ namespace Microsoft.EntityFrameworkCore
         ///         For entities being tracked by the <see cref="DbContext" />, the values of foreign key properties in
         ///         dependent entities are not changed. This can result in an inconsistent graph of entities
         ///         where the values of foreign key properties do not match the relationships in the
-        ///         graph. If a property remains in this state when <see cref="DbContext.SaveChanges()" />
-        ///         is called, then an exception will be thrown.
+        ///         graph.
         ///     </para>
         ///     <para>
         ///         If the database has been created from the model using Entity Framework Migrations or the

--- a/src/EFCore/Internal/DbContextPoolConfigurationSnapshot.cs
+++ b/src/EFCore/Internal/DbContextPoolConfigurationSnapshot.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+
 namespace Microsoft.EntityFrameworkCore.Internal
 {
     /// <summary>
@@ -17,12 +19,16 @@ namespace Microsoft.EntityFrameworkCore.Internal
             bool? autoDetectChangesEnabled,
             QueryTrackingBehavior? queryTrackingBehavior,
             bool? autoTransactionsEnabled,
-            bool? lazyLoadingEnabled)
+            bool? lazyLoadingEnabled,
+            CascadeTiming? cascadeDeleteTiming,
+            CascadeTiming? deleteOrphansTiming)
         {
             AutoDetectChangesEnabled = autoDetectChangesEnabled;
             QueryTrackingBehavior = queryTrackingBehavior;
             AutoTransactionsEnabled = autoTransactionsEnabled;
             LazyLoadingEnabled = lazyLoadingEnabled;
+            CascadeDeleteTiming = cascadeDeleteTiming;
+            DeleteOrphansTiming = deleteOrphansTiming;
         }
 
         /// <summary>
@@ -36,6 +42,18 @@ namespace Microsoft.EntityFrameworkCore.Internal
         ///     directly from your code. This API may change or be removed in future releases.
         /// </summary>
         public virtual bool? LazyLoadingEnabled { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual CascadeTiming? CascadeDeleteTiming { get; }
+
+        /// <summary>
+        ///     This API supports the Entity Framework Core infrastructure and is not intended to be used
+        ///     directly from your code. This API may change or be removed in future releases.
+        /// </summary>
+        public virtual CascadeTiming? DeleteOrphansTiming { get; }
 
         /// <summary>
         ///     This API supports the Entity Framework Core infrastructure and is not intended to be used

--- a/test/EFCore.InMemory.FunctionalTests/GraphUpdatesInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/GraphUpdatesInMemoryTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 
@@ -15,158 +16,209 @@ namespace Microsoft.EntityFrameworkCore
         {
         }
 
-        public override DbUpdateException Optional_One_to_one_relationships_are_one_to_one()
+        public override DbUpdateException Optional_One_to_one_relationships_are_one_to_one(
+            CascadeTiming? deleteOrphansTiming)
         {
             // FK uniqueness not enforced in in-memory database
             return null;
         }
 
-        public override DbUpdateException Required_One_to_one_relationships_are_one_to_one()
+        public override DbUpdateException Required_One_to_one_relationships_are_one_to_one(
+            CascadeTiming? deleteOrphansTiming)
         {
             // FK uniqueness not enforced in in-memory database
             return null;
         }
 
-        public override DbUpdateException Optional_One_to_one_with_AK_relationships_are_one_to_one()
+        public override DbUpdateException Optional_One_to_one_with_AK_relationships_are_one_to_one(
+            CascadeTiming? deleteOrphansTiming)
         {
             // FK uniqueness not enforced in in-memory database
             return null;
         }
 
-        public override DbUpdateException Required_One_to_one_with_AK_relationships_are_one_to_one()
+        public override DbUpdateException Required_One_to_one_with_AK_relationships_are_one_to_one(
+            CascadeTiming? deleteOrphansTiming)
         {
             // FK uniqueness not enforced in in-memory database
             return null;
         }
 
         public override void Save_required_one_to_one_changed_by_reference_with_alternate_key(
-            ChangeMechanism changeMechanism, bool useExistingEntities)
+            ChangeMechanism changeMechanism,
+            bool useExistingEntities,
+            CascadeTiming? deleteOrphansTiming)
         {
             // Cascade delete not supported by in-memory database
         }
 
         public override void Save_required_non_PK_one_to_one_changed_by_reference_with_alternate_key(
-            ChangeMechanism changeMechanism, bool useExistingEntities)
+            ChangeMechanism changeMechanism,
+            bool useExistingEntities,
+            CascadeTiming? deleteOrphansTiming)
         {
             // Cascade delete not supported by in-memory database
         }
 
-        public override DbUpdateException Save_required_one_to_one_changed_by_reference(ChangeMechanism changeMechanism)
-        {
-            // Cascade delete not supported by in-memory database
-            return null;
-        }
-
-        public override void Save_removed_required_many_to_one_dependents(ChangeMechanism changeMechanism)
-        {
-            // Cascade delete not supported by in-memory database
-        }
-
-        public override void Save_required_non_PK_one_to_one_changed_by_reference(ChangeMechanism changeMechanism, bool useExistingEntities)
-        {
-            // Cascade delete not supported by in-memory database
-        }
-
-        public override void Sever_required_one_to_one_with_alternate_key(ChangeMechanism changeMechanism)
-        {
-            // Cascade delete not supported by in-memory database
-        }
-
-        public override DbUpdateException Sever_required_one_to_one(ChangeMechanism changeMechanism)
+        public override DbUpdateException Save_required_one_to_one_changed_by_reference(
+            ChangeMechanism changeMechanism,
+            CascadeTiming? deleteOrphansTiming)
         {
             // Cascade delete not supported by in-memory database
             return null;
         }
 
-        public override void Sever_required_non_PK_one_to_one(ChangeMechanism changeMechanism)
+        public override void Save_removed_required_many_to_one_dependents(
+            ChangeMechanism changeMechanism,
+            CascadeTiming? deleteOrphansTiming)
         {
             // Cascade delete not supported by in-memory database
         }
 
-        public override void Sever_required_non_PK_one_to_one_with_alternate_key(ChangeMechanism changeMechanism)
+        public override void Save_required_non_PK_one_to_one_changed_by_reference(
+            ChangeMechanism changeMechanism,
+            bool useExistingEntities,
+            CascadeTiming? deleteOrphansTiming)
         {
             // Cascade delete not supported by in-memory database
         }
 
-        public override DbUpdateException Required_many_to_one_dependents_are_cascade_deleted_in_store()
+        public override void Sever_required_one_to_one_with_alternate_key(
+            ChangeMechanism changeMechanism,
+            CascadeTiming? deleteOrphansTiming)
         {
             // Cascade delete not supported by in-memory database
-            return null;
         }
 
-        public override DbUpdateException Required_one_to_one_are_cascade_deleted_in_store()
-        {
-            // Cascade delete not supported by in-memory database
-            return null;
-        }
-
-        public override DbUpdateException Required_non_PK_one_to_one_are_cascade_deleted_in_store()
-        {
-            // Cascade delete not supported by in-memory database
-            return null;
-        }
-
-        public override DbUpdateException Required_many_to_one_dependents_with_alternate_key_are_cascade_deleted_in_store()
+        public override DbUpdateException Sever_required_one_to_one(
+            ChangeMechanism changeMechanism,
+            CascadeTiming? deleteOrphansTiming)
         {
             // Cascade delete not supported by in-memory database
             return null;
         }
 
-        public override DbUpdateException Required_one_to_one_with_alternate_key_are_cascade_deleted_in_store()
+        public override void Sever_required_non_PK_one_to_one(
+            ChangeMechanism changeMechanism,
+            CascadeTiming? deleteOrphansTiming)
+        {
+            // Cascade delete not supported by in-memory database
+        }
+
+        public override void Sever_required_non_PK_one_to_one_with_alternate_key(
+            ChangeMechanism changeMechanism,
+            CascadeTiming? deleteOrphansTiming)
+        {
+            // Cascade delete not supported by in-memory database
+        }
+
+        public override DbUpdateException Required_many_to_one_dependents_are_cascade_deleted_in_store(
+            CascadeTiming? cascadeDeleteTiming,
+            CascadeTiming? deleteOrphansTiming)
         {
             // Cascade delete not supported by in-memory database
             return null;
         }
 
-        public override DbUpdateException Required_non_PK_one_to_one_with_alternate_key_are_cascade_deleted_in_store()
+        public override DbUpdateException Required_one_to_one_are_cascade_deleted_in_store(
+            CascadeTiming? cascadeDeleteTiming,
+            CascadeTiming? deleteOrphansTiming)
         {
             // Cascade delete not supported by in-memory database
             return null;
         }
 
-        public override DbUpdateException Optional_many_to_one_dependents_are_orphaned_in_store()
+        public override DbUpdateException Required_non_PK_one_to_one_are_cascade_deleted_in_store(
+            CascadeTiming? cascadeDeleteTiming,
+            CascadeTiming? deleteOrphansTiming)
+        {
+            // Cascade delete not supported by in-memory database
+            return null;
+        }
+
+        public override DbUpdateException Required_many_to_one_dependents_with_alternate_key_are_cascade_deleted_in_store(
+            CascadeTiming? cascadeDeleteTiming,
+            CascadeTiming? deleteOrphansTiming)
+        {
+            // Cascade delete not supported by in-memory database
+            return null;
+        }
+
+        public override DbUpdateException Required_one_to_one_with_alternate_key_are_cascade_deleted_in_store(
+            CascadeTiming? cascadeDeleteTiming,
+            CascadeTiming? deleteOrphansTiming)
+        {
+            // Cascade delete not supported by in-memory database
+            return null;
+        }
+
+        public override DbUpdateException Required_non_PK_one_to_one_with_alternate_key_are_cascade_deleted_in_store(
+            CascadeTiming? cascadeDeleteTiming,
+            CascadeTiming? deleteOrphansTiming)
+        {
+            // Cascade delete not supported by in-memory database
+            return null;
+        }
+
+        public override DbUpdateException Optional_many_to_one_dependents_are_orphaned_in_store(
+            CascadeTiming? cascadeDeleteTiming,
+            CascadeTiming? deleteOrphansTiming)
         {
             // Cascade nulls not supported by in-memory database
             return null;
         }
 
-        public override DbUpdateException Optional_one_to_one_are_orphaned_in_store()
+        public override DbUpdateException Optional_one_to_one_are_orphaned_in_store(
+            CascadeTiming? cascadeDeleteTiming,
+            CascadeTiming? deleteOrphansTiming)
         {
             // Cascade nulls not supported by in-memory database
             return null;
         }
 
-        public override DbUpdateException Optional_many_to_one_dependents_with_alternate_key_are_orphaned_in_store()
+        public override DbUpdateException Optional_many_to_one_dependents_with_alternate_key_are_orphaned_in_store(
+            CascadeTiming? cascadeDeleteTiming,
+            CascadeTiming? deleteOrphansTiming)
         {
             // Cascade nulls not supported by in-memory database
             return null;
         }
 
-        public override DbUpdateException Optional_one_to_one_with_alternate_key_are_orphaned_in_store()
+        public override DbUpdateException Optional_one_to_one_with_alternate_key_are_orphaned_in_store(
+            CascadeTiming? cascadeDeleteTiming,
+            CascadeTiming? deleteOrphansTiming)
         {
             // Cascade nulls not supported by in-memory database
             return null;
         }
 
-        public override DbUpdateException Required_non_PK_one_to_one_with_alternate_key_are_cascade_detached_when_Added()
+        public override DbUpdateException Required_non_PK_one_to_one_with_alternate_key_are_cascade_detached_when_Added(
+            CascadeTiming? cascadeDeleteTiming,
+            CascadeTiming? deleteOrphansTiming)
         {
             // Cascade nulls not supported by in-memory database
             return null;
         }
 
-        public override DbUpdateException Required_one_to_one_are_cascade_detached_when_Added()
+        public override DbUpdateException Required_one_to_one_are_cascade_detached_when_Added(
+            CascadeTiming? cascadeDeleteTiming,
+            CascadeTiming? deleteOrphansTiming)
         {
             // Cascade nulls not supported by in-memory database
             return null;
         }
 
-        public override DbUpdateException Required_one_to_one_with_alternate_key_are_cascade_detached_when_Added()
+        public override DbUpdateException Required_one_to_one_with_alternate_key_are_cascade_detached_when_Added(
+            CascadeTiming? cascadeDeleteTiming,
+            CascadeTiming? deleteOrphansTiming)
         {
             // Cascade nulls not supported by in-memory database
             return null;
         }
 
-        public override DbUpdateException Required_non_PK_one_to_one_are_cascade_detached_when_Added()
+        public override DbUpdateException Required_non_PK_one_to_one_are_cascade_detached_when_Added(
+            CascadeTiming? cascadeDeleteTiming,
+            CascadeTiming? deleteOrphansTiming)
         {
             // Cascade nulls not supported by in-memory database
             return null;

--- a/test/EFCore.InMemory.FunctionalTests/ProxyGraphUpdatesInMemoryTest.cs
+++ b/test/EFCore.InMemory.FunctionalTests/ProxyGraphUpdatesInMemoryTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -32,15 +33,21 @@ namespace Microsoft.EntityFrameworkCore
             {
             }
 
-            public override void Optional_many_to_one_dependents_with_alternate_key_are_orphaned_in_store()
+            public override void Optional_many_to_one_dependents_with_alternate_key_are_orphaned_in_store(
+                CascadeTiming cascadeDeleteTiming,
+                CascadeTiming deleteOrphansTiming)
             {
             }
 
-            public override void Optional_many_to_one_dependents_are_orphaned_in_store()
+            public override void Optional_many_to_one_dependents_are_orphaned_in_store(
+                CascadeTiming cascadeDeleteTiming,
+                CascadeTiming deleteOrphansTiming)
             {
             }
 
-            public override void Required_one_to_one_are_cascade_detached_when_Added()
+            public override void Required_one_to_one_are_cascade_detached_when_Added(
+                CascadeTiming cascadeDeleteTiming,
+                CascadeTiming deleteOrphansTiming)
             {
             }
 
@@ -52,27 +59,39 @@ namespace Microsoft.EntityFrameworkCore
             {
             }
 
-            public override void Required_one_to_one_with_alternate_key_are_cascade_detached_when_Added()
+            public override void Required_one_to_one_with_alternate_key_are_cascade_detached_when_Added(
+                CascadeTiming cascadeDeleteTiming,
+                CascadeTiming deleteOrphansTiming)
             {
             }
 
-            public override void Required_one_to_one_with_alternate_key_are_cascade_deleted_in_store()
+            public override void Required_one_to_one_with_alternate_key_are_cascade_deleted_in_store(
+                CascadeTiming cascadeDeleteTiming,
+                CascadeTiming deleteOrphansTiming)
             {
             }
 
-            public override void Required_many_to_one_dependents_are_cascade_deleted_in_store()
+            public override void Required_many_to_one_dependents_are_cascade_deleted_in_store(
+                CascadeTiming cascadeDeleteTiming,
+                CascadeTiming deleteOrphansTiming)
             {
             }
 
-            public override void Required_many_to_one_dependents_with_alternate_key_are_cascade_deleted_in_store()
+            public override void Required_many_to_one_dependents_with_alternate_key_are_cascade_deleted_in_store(
+                CascadeTiming cascadeDeleteTiming,
+                CascadeTiming deleteOrphansTiming)
             {
             }
 
-            public override void Required_non_PK_one_to_one_are_cascade_detached_when_Added()
+            public override void Required_non_PK_one_to_one_are_cascade_detached_when_Added(
+                CascadeTiming cascadeDeleteTiming,
+                CascadeTiming deleteOrphansTiming)
             {
             }
 
-            public override void Required_non_PK_one_to_one_with_alternate_key_are_cascade_detached_when_Added()
+            public override void Required_non_PK_one_to_one_with_alternate_key_are_cascade_detached_when_Added(
+                CascadeTiming cascadeDeleteTiming,
+                CascadeTiming deleteOrphansTiming)
             {
             }
 

--- a/test/EFCore.Specification.Tests/StoreGeneratedFixupTestBase.cs
+++ b/test/EFCore.Specification.Tests/StoreGeneratedFixupTestBase.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.ChangeTracking.Internal;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -4003,6 +4004,8 @@ namespace Microsoft.EntityFrameworkCore
         {
             using (var context = CreateContext())
             {
+                context.ChangeTracker.DeleteOrphansTiming = CascadeTiming.OnSaveChanges;
+
                 var game = new Game { Id = Guid77 };
                 var level = new Level { Game = game };
                 var item = new Item { Level = level };

--- a/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/DbContextPoolingTest.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.EntityFrameworkCore.Query;
 using Microsoft.EntityFrameworkCore.TestUtilities;
@@ -74,6 +75,8 @@ namespace Microsoft.EntityFrameworkCore
                 ChangeTracker.AutoDetectChangesEnabled = false;
                 ChangeTracker.LazyLoadingEnabled = false;
                 Database.AutoTransactionsEnabled = false;
+                ChangeTracker.CascadeDeleteTiming = CascadeTiming.Never;
+                ChangeTracker.DeleteOrphansTiming= CascadeTiming.Never;
             }
 
             protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
@@ -289,6 +292,8 @@ namespace Microsoft.EntityFrameworkCore
             context1.ChangeTracker.AutoDetectChangesEnabled = true;
             context1.ChangeTracker.LazyLoadingEnabled = true;
             context1.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
+            context1.ChangeTracker.CascadeDeleteTiming = CascadeTiming.Immediate;
+            context1.ChangeTracker.DeleteOrphansTiming= CascadeTiming.Immediate;
             context1.Database.AutoTransactionsEnabled = true;
 
             serviceScope.Dispose();
@@ -305,6 +310,8 @@ namespace Microsoft.EntityFrameworkCore
             Assert.False(context2.ChangeTracker.AutoDetectChangesEnabled);
             Assert.False(context2.ChangeTracker.LazyLoadingEnabled);
             Assert.Equal(QueryTrackingBehavior.TrackAll, context2.ChangeTracker.QueryTrackingBehavior);
+            Assert.Equal(CascadeTiming.Never, context2.ChangeTracker.CascadeDeleteTiming);
+            Assert.Equal(CascadeTiming.Never, context2.ChangeTracker.DeleteOrphansTiming);
             Assert.False(context2.Database.AutoTransactionsEnabled);
         }
 
@@ -322,6 +329,8 @@ namespace Microsoft.EntityFrameworkCore
             context1.ChangeTracker.LazyLoadingEnabled = false;
             context1.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
             context1.Database.AutoTransactionsEnabled = false;
+            context1.ChangeTracker.CascadeDeleteTiming = CascadeTiming.Immediate;
+            context1.ChangeTracker.DeleteOrphansTiming= CascadeTiming.Immediate;
 
             serviceScope.Dispose();
 
@@ -335,6 +344,8 @@ namespace Microsoft.EntityFrameworkCore
             Assert.True(context2.ChangeTracker.AutoDetectChangesEnabled);
             Assert.True(context2.ChangeTracker.LazyLoadingEnabled);
             Assert.Equal(QueryTrackingBehavior.TrackAll, context2.ChangeTracker.QueryTrackingBehavior);
+            Assert.Equal(CascadeTiming.Immediate, context2.ChangeTracker.CascadeDeleteTiming);
+            Assert.Equal(CascadeTiming.Immediate, context2.ChangeTracker.DeleteOrphansTiming);
             Assert.True(context2.Database.AutoTransactionsEnabled);
         }
 

--- a/test/EFCore.SqlServer.FunctionalTests/GraphUpdatesSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/GraphUpdatesSqlServerTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Linq;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -56,9 +57,10 @@ namespace Microsoft.EntityFrameworkCore
             {
             }
 
-            public override DbUpdateException Optional_One_to_one_relationships_are_one_to_one()
+            public override DbUpdateException Optional_One_to_one_relationships_are_one_to_one(
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Optional_One_to_one_relationships_are_one_to_one();
+                var updateException = base.Optional_One_to_one_relationships_are_one_to_one(deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("IX_OptionalSingle1_RootId", updateException.InnerException.Message);
@@ -66,9 +68,10 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_One_to_one_relationships_are_one_to_one()
+            public override DbUpdateException Required_One_to_one_relationships_are_one_to_one(
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_One_to_one_relationships_are_one_to_one();
+                var updateException = base.Required_One_to_one_relationships_are_one_to_one(deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("PK_RequiredSingle1", updateException.InnerException.Message);
@@ -76,9 +79,10 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Optional_One_to_one_with_AK_relationships_are_one_to_one()
+            public override DbUpdateException Optional_One_to_one_with_AK_relationships_are_one_to_one(
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Optional_One_to_one_with_AK_relationships_are_one_to_one();
+                var updateException = base.Optional_One_to_one_with_AK_relationships_are_one_to_one(deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("IX_OptionalSingleAk1_RootId", updateException.InnerException.Message);
@@ -86,9 +90,10 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_One_to_one_with_AK_relationships_are_one_to_one()
+            public override DbUpdateException Required_One_to_one_with_AK_relationships_are_one_to_one(
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_One_to_one_with_AK_relationships_are_one_to_one();
+                var updateException = base.Required_One_to_one_with_AK_relationships_are_one_to_one(deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("IX_RequiredSingleAk1_RootId", updateException.InnerException.Message);
@@ -96,9 +101,11 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Save_required_one_to_one_changed_by_reference(ChangeMechanism changeMechanism)
+            public override DbUpdateException Save_required_one_to_one_changed_by_reference(
+                ChangeMechanism changeMechanism,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Save_required_one_to_one_changed_by_reference(changeMechanism);
+                var updateException = base.Save_required_one_to_one_changed_by_reference(changeMechanism, deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredSingle2_RequiredSingle1_Id", updateException.InnerException.Message);
@@ -106,9 +113,11 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Sever_required_one_to_one(ChangeMechanism changeMechanism)
+            public override DbUpdateException Sever_required_one_to_one(
+                ChangeMechanism changeMechanism,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Sever_required_one_to_one(changeMechanism);
+                var updateException = base.Sever_required_one_to_one(changeMechanism, deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredSingle2_RequiredSingle1_Id", updateException.InnerException.Message);
@@ -116,9 +125,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_many_to_one_dependents_are_cascade_deleted()
+            public override DbUpdateException Required_many_to_one_dependents_are_cascade_deleted(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_many_to_one_dependents_are_cascade_deleted();
+                var updateException = base.Required_many_to_one_dependents_are_cascade_deleted(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_Required2_Required1_ParentId", updateException.InnerException.Message);
@@ -126,9 +139,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Optional_many_to_one_dependents_are_orphaned()
+            public override DbUpdateException Optional_many_to_one_dependents_are_orphaned(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Optional_many_to_one_dependents_are_orphaned();
+                var updateException = base.Optional_many_to_one_dependents_are_orphaned(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_Optional2_Optional1_ParentId", updateException.InnerException.Message);
@@ -136,9 +153,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Optional_one_to_one_are_orphaned()
+            public override DbUpdateException Optional_one_to_one_are_orphaned(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Optional_one_to_one_are_orphaned();
+                var updateException = base.Optional_one_to_one_are_orphaned(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_OptionalSingle2_OptionalSingle1_BackId", updateException.InnerException.Message);
@@ -146,9 +167,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_one_to_one_are_cascade_deleted()
+            public override DbUpdateException Required_one_to_one_are_cascade_deleted(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_one_to_one_are_cascade_deleted();
+                var updateException = base.Required_one_to_one_are_cascade_deleted(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredSingle2_RequiredSingle1_Id", updateException.InnerException.Message);
@@ -156,9 +181,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_non_PK_one_to_one_are_cascade_deleted()
+            public override DbUpdateException Required_non_PK_one_to_one_are_cascade_deleted(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_non_PK_one_to_one_are_cascade_deleted();
+                var updateException = base.Required_non_PK_one_to_one_are_cascade_deleted(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredNonPkSingle2_RequiredNonPkSingle1_BackId", updateException.InnerException.Message);
@@ -166,9 +195,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Optional_many_to_one_dependents_with_alternate_key_are_orphaned()
+            public override DbUpdateException Optional_many_to_one_dependents_with_alternate_key_are_orphaned(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Optional_many_to_one_dependents_with_alternate_key_are_orphaned();
+                var updateException = base.Optional_many_to_one_dependents_with_alternate_key_are_orphaned(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_OptionalAk2_OptionalAk1_ParentId", updateException.InnerException.Message);
@@ -176,9 +209,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_many_to_one_dependents_with_alternate_key_are_cascade_deleted()
+            public override DbUpdateException Required_many_to_one_dependents_with_alternate_key_are_cascade_deleted(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_many_to_one_dependents_with_alternate_key_are_cascade_deleted();
+                var updateException = base.Required_many_to_one_dependents_with_alternate_key_are_cascade_deleted(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredAk2_RequiredAk1_ParentId", updateException.InnerException.Message);
@@ -186,9 +223,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Optional_one_to_one_with_alternate_key_are_orphaned()
+            public override DbUpdateException Optional_one_to_one_with_alternate_key_are_orphaned(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Optional_one_to_one_with_alternate_key_are_orphaned();
+                var updateException = base.Optional_one_to_one_with_alternate_key_are_orphaned(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_OptionalSingleAk2_OptionalSingleAk1_BackId", updateException.InnerException.Message);
@@ -196,9 +237,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_one_to_one_with_alternate_key_are_cascade_deleted()
+            public override DbUpdateException Required_one_to_one_with_alternate_key_are_cascade_deleted(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_one_to_one_with_alternate_key_are_cascade_deleted();
+                var updateException = base.Required_one_to_one_with_alternate_key_are_cascade_deleted(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredSingleAk2_RequiredSingleAk1_BackId", updateException.InnerException.Message);
@@ -206,9 +251,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_non_PK_one_to_one_with_alternate_key_are_cascade_deleted()
+            public override DbUpdateException Required_non_PK_one_to_one_with_alternate_key_are_cascade_deleted(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_non_PK_one_to_one_with_alternate_key_are_cascade_deleted();
+                var updateException = base.Required_non_PK_one_to_one_with_alternate_key_are_cascade_deleted(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredNonPkSingleAk2_RequiredNonPkSingleAk1_BackId", updateException.InnerException.Message);
@@ -216,9 +265,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_many_to_one_dependents_are_cascade_deleted_in_store()
+            public override DbUpdateException Required_many_to_one_dependents_are_cascade_deleted_in_store(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_many_to_one_dependents_are_cascade_deleted_in_store();
+                var updateException = base.Required_many_to_one_dependents_are_cascade_deleted_in_store(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_Required2_Required1_ParentId", updateException.InnerException.Message);
@@ -226,9 +279,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_one_to_one_are_cascade_deleted_in_store()
+            public override DbUpdateException Required_one_to_one_are_cascade_deleted_in_store(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_one_to_one_are_cascade_deleted_in_store();
+                var updateException = base.Required_one_to_one_are_cascade_deleted_in_store(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredSingle2_RequiredSingle1_Id", updateException.InnerException.Message);
@@ -236,9 +293,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_non_PK_one_to_one_are_cascade_deleted_in_store()
+            public override DbUpdateException Required_non_PK_one_to_one_are_cascade_deleted_in_store(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_non_PK_one_to_one_are_cascade_deleted_in_store();
+                var updateException = base.Required_non_PK_one_to_one_are_cascade_deleted_in_store(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredNonPkSingle2_RequiredNonPkSingle1_BackId", updateException.InnerException.Message);
@@ -246,9 +307,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_many_to_one_dependents_with_alternate_key_are_cascade_deleted_in_store()
+            public override DbUpdateException Required_many_to_one_dependents_with_alternate_key_are_cascade_deleted_in_store(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_many_to_one_dependents_with_alternate_key_are_cascade_deleted_in_store();
+                var updateException = base.Required_many_to_one_dependents_with_alternate_key_are_cascade_deleted_in_store(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredAk2_RequiredAk1_ParentId", updateException.InnerException.Message);
@@ -256,9 +321,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_one_to_one_with_alternate_key_are_cascade_deleted_in_store()
+            public override DbUpdateException Required_one_to_one_with_alternate_key_are_cascade_deleted_in_store(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_one_to_one_with_alternate_key_are_cascade_deleted_in_store();
+                var updateException = base.Required_one_to_one_with_alternate_key_are_cascade_deleted_in_store(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredSingleAk2_RequiredSingleAk1_BackId", updateException.InnerException.Message);
@@ -266,9 +335,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_non_PK_one_to_one_with_alternate_key_are_cascade_deleted_in_store()
+            public override DbUpdateException Required_non_PK_one_to_one_with_alternate_key_are_cascade_deleted_in_store(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_non_PK_one_to_one_with_alternate_key_are_cascade_deleted_in_store();
+                var updateException = base.Required_non_PK_one_to_one_with_alternate_key_are_cascade_deleted_in_store(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredNonPkSingleAk2_RequiredNonPkSingleAk1_BackId", updateException.InnerException.Message);
@@ -276,9 +349,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Optional_many_to_one_dependents_are_orphaned_in_store()
+            public override DbUpdateException Optional_many_to_one_dependents_are_orphaned_in_store(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Optional_many_to_one_dependents_are_orphaned_in_store();
+                var updateException = base.Optional_many_to_one_dependents_are_orphaned_in_store(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_Optional2_Optional1_ParentId", updateException.InnerException.Message);
@@ -286,9 +363,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Optional_one_to_one_are_orphaned_in_store()
+            public override DbUpdateException Optional_one_to_one_are_orphaned_in_store(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Optional_one_to_one_are_orphaned_in_store();
+                var updateException = base.Optional_one_to_one_are_orphaned_in_store(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_OptionalSingle2_OptionalSingle1_BackId", updateException.InnerException.Message);
@@ -296,9 +377,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Optional_many_to_one_dependents_with_alternate_key_are_orphaned_in_store()
+            public override DbUpdateException Optional_many_to_one_dependents_with_alternate_key_are_orphaned_in_store(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Optional_many_to_one_dependents_with_alternate_key_are_orphaned_in_store();
+                var updateException = base.Optional_many_to_one_dependents_with_alternate_key_are_orphaned_in_store(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_OptionalAk2_OptionalAk1_ParentId", updateException.InnerException.Message);
@@ -306,9 +391,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Optional_one_to_one_with_alternate_key_are_orphaned_in_store()
+            public override DbUpdateException Optional_one_to_one_with_alternate_key_are_orphaned_in_store(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Optional_one_to_one_with_alternate_key_are_orphaned_in_store();
+                var updateException = base.Optional_one_to_one_with_alternate_key_are_orphaned_in_store(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_OptionalSingleAk2_OptionalSingleAk1_BackId", updateException.InnerException.Message);
@@ -316,9 +405,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_many_to_one_dependents_are_cascade_deleted_starting_detached()
+            public override DbUpdateException Required_many_to_one_dependents_are_cascade_deleted_starting_detached(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_many_to_one_dependents_are_cascade_deleted_starting_detached();
+                var updateException = base.Required_many_to_one_dependents_are_cascade_deleted_starting_detached(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_Required2_Required1_ParentId", updateException.InnerException.Message);
@@ -326,9 +419,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Optional_many_to_one_dependents_are_orphaned_starting_detached()
+            public override DbUpdateException Optional_many_to_one_dependents_are_orphaned_starting_detached(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Optional_many_to_one_dependents_are_orphaned_starting_detached();
+                var updateException = base.Optional_many_to_one_dependents_are_orphaned_starting_detached(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_Optional2_Optional1_ParentId", updateException.InnerException.Message);
@@ -336,9 +433,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Optional_one_to_one_are_orphaned_starting_detached()
+            public override DbUpdateException Optional_one_to_one_are_orphaned_starting_detached(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Optional_one_to_one_are_orphaned_starting_detached();
+                var updateException = base.Optional_one_to_one_are_orphaned_starting_detached(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_OptionalSingle2_OptionalSingle1_BackId", updateException.InnerException.Message);
@@ -346,9 +447,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_one_to_one_are_cascade_deleted_starting_detached()
+            public override DbUpdateException Required_one_to_one_are_cascade_deleted_starting_detached(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_one_to_one_are_cascade_deleted_starting_detached();
+                var updateException = base.Required_one_to_one_are_cascade_deleted_starting_detached(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredSingle2_RequiredSingle1_Id", updateException.InnerException.Message);
@@ -356,9 +461,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_non_PK_one_to_one_are_cascade_deleted_starting_detached()
+            public override DbUpdateException Required_non_PK_one_to_one_are_cascade_deleted_starting_detached(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_non_PK_one_to_one_are_cascade_deleted_starting_detached();
+                var updateException = base.Required_non_PK_one_to_one_are_cascade_deleted_starting_detached(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredNonPkSingle2_RequiredNonPkSingle1_BackId", updateException.InnerException.Message);
@@ -366,9 +475,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Optional_many_to_one_dependents_with_alternate_key_are_orphaned_starting_detached()
+            public override DbUpdateException Optional_many_to_one_dependents_with_alternate_key_are_orphaned_starting_detached(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Optional_many_to_one_dependents_with_alternate_key_are_orphaned_starting_detached();
+                var updateException = base.Optional_many_to_one_dependents_with_alternate_key_are_orphaned_starting_detached(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_OptionalAk2_OptionalAk1_ParentId", updateException.InnerException.Message);
@@ -376,9 +489,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_many_to_one_dependents_with_alternate_key_are_cascade_deleted_starting_detached()
+            public override DbUpdateException Required_many_to_one_dependents_with_alternate_key_are_cascade_deleted_starting_detached(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_many_to_one_dependents_with_alternate_key_are_cascade_deleted_starting_detached();
+                var updateException = base.Required_many_to_one_dependents_with_alternate_key_are_cascade_deleted_starting_detached(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredAk2_RequiredAk1_ParentId", updateException.InnerException.Message);
@@ -386,9 +503,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Optional_one_to_one_with_alternate_key_are_orphaned_starting_detached()
+            public override DbUpdateException Optional_one_to_one_with_alternate_key_are_orphaned_starting_detached(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Optional_one_to_one_with_alternate_key_are_orphaned_starting_detached();
+                var updateException = base.Optional_one_to_one_with_alternate_key_are_orphaned_starting_detached(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_OptionalSingleAk2_OptionalSingleAk1_BackId", updateException.InnerException.Message);
@@ -396,9 +517,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_one_to_one_with_alternate_key_are_cascade_deleted_starting_detached()
+            public override DbUpdateException Required_one_to_one_with_alternate_key_are_cascade_deleted_starting_detached(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_one_to_one_with_alternate_key_are_cascade_deleted_starting_detached();
+                var updateException = base.Required_one_to_one_with_alternate_key_are_cascade_deleted_starting_detached(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredSingleAk2_RequiredSingleAk1_BackId", updateException.InnerException.Message);
@@ -406,9 +531,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_non_PK_one_to_one_with_alternate_key_are_cascade_deleted_starting_detached()
+            public override DbUpdateException Required_non_PK_one_to_one_with_alternate_key_are_cascade_deleted_starting_detached(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_non_PK_one_to_one_with_alternate_key_are_cascade_deleted_starting_detached();
+                var updateException = base.Required_non_PK_one_to_one_with_alternate_key_are_cascade_deleted_starting_detached(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredNonPkSingleAk2_RequiredNonPkSingleAk1_BackId", updateException.InnerException.Message);
@@ -416,9 +545,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_many_to_one_dependents_are_cascade_detached_when_Added()
+            public override DbUpdateException Required_many_to_one_dependents_are_cascade_detached_when_Added(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_many_to_one_dependents_are_cascade_detached_when_Added();
+                var updateException = base.Required_many_to_one_dependents_are_cascade_detached_when_Added(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_Required2_Required1_ParentId", updateException.InnerException.Message);
@@ -426,9 +559,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_one_to_one_are_cascade_detached_when_Added()
+            public override DbUpdateException Required_one_to_one_are_cascade_detached_when_Added(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_one_to_one_are_cascade_detached_when_Added();
+                var updateException = base.Required_one_to_one_are_cascade_detached_when_Added(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredSingle2_RequiredSingle1_Id", updateException.InnerException.Message);
@@ -436,9 +573,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_non_PK_one_to_one_are_cascade_detached_when_Added()
+            public override DbUpdateException Required_non_PK_one_to_one_are_cascade_detached_when_Added(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_non_PK_one_to_one_are_cascade_detached_when_Added();
+                var updateException = base.Required_non_PK_one_to_one_are_cascade_detached_when_Added(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredNonPkSingle2_RequiredNonPkSingle1_BackId", updateException.InnerException.Message);
@@ -446,9 +587,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_many_to_one_dependents_with_alternate_key_are_cascade_detached_when_Added()
+            public override DbUpdateException Required_many_to_one_dependents_with_alternate_key_are_cascade_detached_when_Added(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_many_to_one_dependents_with_alternate_key_are_cascade_detached_when_Added();
+                var updateException = base.Required_many_to_one_dependents_with_alternate_key_are_cascade_detached_when_Added(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredAk2_RequiredAk1_ParentId", updateException.InnerException.Message);
@@ -456,9 +601,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_one_to_one_with_alternate_key_are_cascade_detached_when_Added()
+            public override DbUpdateException Required_one_to_one_with_alternate_key_are_cascade_detached_when_Added(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_one_to_one_with_alternate_key_are_cascade_detached_when_Added();
+                var updateException = base.Required_one_to_one_with_alternate_key_are_cascade_detached_when_Added(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredSingleAk2_RequiredSingleAk1_BackId", updateException.InnerException.Message);
@@ -466,9 +615,13 @@ namespace Microsoft.EntityFrameworkCore
                 return updateException;
             }
 
-            public override DbUpdateException Required_non_PK_one_to_one_with_alternate_key_are_cascade_detached_when_Added()
+            public override DbUpdateException Required_non_PK_one_to_one_with_alternate_key_are_cascade_detached_when_Added(
+                CascadeTiming? cascadeDeleteTiming,
+                CascadeTiming? deleteOrphansTiming)
             {
-                var updateException = base.Required_non_PK_one_to_one_with_alternate_key_are_cascade_detached_when_Added();
+                var updateException = base.Required_non_PK_one_to_one_with_alternate_key_are_cascade_detached_when_Added(
+                    cascadeDeleteTiming,
+                    deleteOrphansTiming);
 
                 // Disabled check -- see issue #11031
                 //Assert.Contains("FK_RequiredNonPkSingleAk2_RequiredNonPkSingleAk1_BackId", updateException.InnerException.Message);

--- a/test/EFCore.SqlServer.FunctionalTests/LazyLoadProxySqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/LazyLoadProxySqlServerTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -170,16 +171,16 @@ WHERE [e].[ParentId] = @__p_0",
                 ignoreLineEndingDifferences: true);
         }
 
-        public override void Lazy_load_collection_already_loaded(EntityState state)
+        public override void Lazy_load_collection_already_loaded(EntityState state, CascadeTiming cascadeDeleteTiming)
         {
-            base.Lazy_load_collection_already_loaded(state);
+            base.Lazy_load_collection_already_loaded(state, cascadeDeleteTiming);
 
             Assert.Equal("", Sql);
         }
 
-        public override void Lazy_load_many_to_one_reference_to_principal_already_loaded(EntityState state)
+        public override void Lazy_load_many_to_one_reference_to_principal_already_loaded(EntityState state, CascadeTiming cascadeDeleteTiming)
         {
-            base.Lazy_load_many_to_one_reference_to_principal_already_loaded(state);
+            base.Lazy_load_many_to_one_reference_to_principal_already_loaded(state, cascadeDeleteTiming);
 
             Assert.Equal("", Sql);
         }
@@ -191,9 +192,9 @@ WHERE [e].[ParentId] = @__p_0",
             Assert.Equal("", Sql);
         }
 
-        public override void Lazy_load_one_to_one_reference_to_dependent_already_loaded(EntityState state)
+        public override void Lazy_load_one_to_one_reference_to_dependent_already_loaded(EntityState state, CascadeTiming cascadeDeleteTiming)
         {
-            base.Lazy_load_one_to_one_reference_to_dependent_already_loaded(state);
+            base.Lazy_load_one_to_one_reference_to_dependent_already_loaded(state, cascadeDeleteTiming);
 
             Assert.Equal("", Sql);
         }

--- a/test/EFCore.SqlServer.FunctionalTests/LoadSqlServerTest.cs
+++ b/test/EFCore.SqlServer.FunctionalTests/LoadSqlServerTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.EntityFrameworkCore.TestUtilities;
 using Xunit;
@@ -170,9 +171,9 @@ WHERE [e].[ParentId] = @__p_0",
                 ignoreLineEndingDifferences: true);
         }
 
-        public override void Lazy_load_collection_already_loaded(EntityState state)
+        public override void Lazy_load_collection_already_loaded(EntityState state, CascadeTiming cascadeDeleteTiming)
         {
-            base.Lazy_load_collection_already_loaded(state);
+            base.Lazy_load_collection_already_loaded(state, cascadeDeleteTiming);
 
             Assert.Equal("", Sql);
         }
@@ -191,9 +192,9 @@ WHERE [e].[ParentId] = @__p_0",
             Assert.Equal("", Sql);
         }
 
-        public override void Lazy_load_one_to_one_reference_to_dependent_already_loaded(EntityState state)
+        public override void Lazy_load_one_to_one_reference_to_dependent_already_loaded(EntityState state, CascadeTiming cascadeDeleteTiming)
         {
-            base.Lazy_load_one_to_one_reference_to_dependent_already_loaded(state);
+            base.Lazy_load_one_to_one_reference_to_dependent_already_loaded(state, cascadeDeleteTiming);
 
             Assert.Equal("", Sql);
         }
@@ -802,9 +803,9 @@ WHERE [e].[ParentId] = @__p_0",
             }
         }
 
-        public override async Task Load_collection_already_loaded(EntityState state, bool async)
+        public override async Task Load_collection_already_loaded(EntityState state, bool async, CascadeTiming cascadeDeleteTiming)
         {
-            await base.Load_collection_already_loaded(state, async);
+            await base.Load_collection_already_loaded(state, async, cascadeDeleteTiming);
 
             if (!async)
             {
@@ -822,9 +823,9 @@ WHERE [e].[ParentId] = @__p_0",
             }
         }
 
-        public override async Task Load_one_to_one_reference_to_principal_already_loaded(EntityState state, bool async)
+        public override async Task Load_one_to_one_reference_to_principal_already_loaded(EntityState state, bool async, CascadeTiming cascadeDeleteTiming)
         {
-            await base.Load_one_to_one_reference_to_principal_already_loaded(state, async);
+            await base.Load_one_to_one_reference_to_principal_already_loaded(state, async, cascadeDeleteTiming);
 
             if (!async)
             {
@@ -832,9 +833,9 @@ WHERE [e].[ParentId] = @__p_0",
             }
         }
 
-        public override async Task Load_one_to_one_reference_to_dependent_already_loaded(EntityState state, bool async)
+        public override async Task Load_one_to_one_reference_to_dependent_already_loaded(EntityState state, bool async, CascadeTiming cascadeDeleteTiming)
         {
-            await base.Load_one_to_one_reference_to_dependent_already_loaded(state, async);
+            await base.Load_one_to_one_reference_to_dependent_already_loaded(state, async, cascadeDeleteTiming);
 
             if (!async)
             {
@@ -862,9 +863,9 @@ WHERE [e].[ParentId] = @__p_0",
             }
         }
 
-        public override async Task Load_collection_using_Query_already_loaded(EntityState state, bool async)
+        public override async Task Load_collection_using_Query_already_loaded(EntityState state, bool async, CascadeTiming cascadeDeleteTiming)
         {
-            await base.Load_collection_using_Query_already_loaded(state, async);
+            await base.Load_collection_using_Query_already_loaded(state, async, cascadeDeleteTiming);
 
             if (!async)
             {
@@ -913,9 +914,9 @@ WHERE [e].[Id] = @__p_0",
             }
         }
 
-        public override async Task Load_one_to_one_reference_to_dependent_using_Query_already_loaded(EntityState state, bool async)
+        public override async Task Load_one_to_one_reference_to_dependent_using_Query_already_loaded(EntityState state, bool async, CascadeTiming cascadeDeleteTiming)
         {
-            await base.Load_one_to_one_reference_to_dependent_using_Query_already_loaded(state, async);
+            await base.Load_one_to_one_reference_to_dependent_using_Query_already_loaded(state, async, cascadeDeleteTiming);
 
             if (!async)
             {
@@ -1236,9 +1237,9 @@ WHERE [e].[ParentId] = @__p_0",
             }
         }
 
-        public override async Task Load_collection_already_loaded_untyped(EntityState state, bool async)
+        public override async Task Load_collection_already_loaded_untyped(EntityState state, bool async, CascadeTiming cascadeDeleteTiming)
         {
-            await base.Load_collection_already_loaded_untyped(state, async);
+            await base.Load_collection_already_loaded_untyped(state, async, cascadeDeleteTiming);
 
             if (!async)
             {
@@ -1266,9 +1267,9 @@ WHERE [e].[ParentId] = @__p_0",
             }
         }
 
-        public override async Task Load_one_to_one_reference_to_dependent_already_loaded_untyped(EntityState state, bool async)
+        public override async Task Load_one_to_one_reference_to_dependent_already_loaded_untyped(EntityState state, bool async, CascadeTiming cascadeDeleteTiming)
         {
-            await base.Load_one_to_one_reference_to_dependent_already_loaded_untyped(state, async);
+            await base.Load_one_to_one_reference_to_dependent_already_loaded_untyped(state, async, cascadeDeleteTiming);
 
             if (!async)
             {
@@ -1276,9 +1277,9 @@ WHERE [e].[ParentId] = @__p_0",
             }
         }
 
-        public override async Task Load_collection_using_Query_already_loaded_untyped(EntityState state, bool async)
+        public override async Task Load_collection_using_Query_already_loaded_untyped(EntityState state, bool async, CascadeTiming cascadeDeleteTiming)
         {
-            await base.Load_collection_using_Query_already_loaded_untyped(state, async);
+            await base.Load_collection_using_Query_already_loaded_untyped(state, async, cascadeDeleteTiming);
 
             if (!async)
             {
@@ -1327,9 +1328,9 @@ WHERE [e].[Id] = @__p_0",
             }
         }
 
-        public override async Task Load_one_to_one_reference_to_dependent_using_Query_already_loaded_untyped(EntityState state, bool async)
+        public override async Task Load_one_to_one_reference_to_dependent_using_Query_already_loaded_untyped(EntityState state, bool async, CascadeTiming cascadeDeleteTiming)
         {
-            await base.Load_one_to_one_reference_to_dependent_using_Query_already_loaded_untyped(state, async);
+            await base.Load_one_to_one_reference_to_dependent_using_Query_already_loaded_untyped(state, async, cascadeDeleteTiming);
 
             if (!async)
             {

--- a/test/EFCore.Tests/ChangeTracking/Internal/FixupTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/FixupTest.cs
@@ -2127,6 +2127,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
+                context.ChangeTracker.DeleteOrphansTiming = CascadeTiming.OnSaveChanges;
+
                 var principal = new Parent(77);
                 var oldDependent = new Child(78, principal.Id);
                 oldDependent.SetParent(principal);
@@ -2218,6 +2220,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
+                context.ChangeTracker.DeleteOrphansTiming = CascadeTiming.OnSaveChanges;
+
                 var principal = new ParentPN
                 {
                     Id = 77
@@ -2312,6 +2316,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
+                context.ChangeTracker.DeleteOrphansTiming = CascadeTiming.OnSaveChanges;
+
                 var principal = new ParentDN
                 {
                     Id = 77
@@ -2369,6 +2375,8 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
         {
             using (var context = new FixupContext())
             {
+                context.ChangeTracker.DeleteOrphansTiming = CascadeTiming.OnSaveChanges;
+
                 var principal = new ParentNN
                 {
                     Id = 77

--- a/test/EFCore.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
+++ b/test/EFCore.Tests/ChangeTracking/Internal/NavigationFixerTest.cs
@@ -1445,11 +1445,11 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
 
             principalEntry1.SetEntityState(EntityState.Deleted);
 
-            Assert.Same(principal1, dependent1.AlternateProduct);
+            Assert.Null(dependent1.AlternateProduct);
             Assert.Same(dependent1, principal1.OriginalProduct);
             Assert.Same(principal2, dependent2.AlternateProduct);
             Assert.Same(dependent2, principal2.OriginalProduct);
-            Assert.Equal(dependent1.AlternateProductId, principal1.Id);
+            Assert.Null(dependent1.AlternateProductId);
             Assert.Equal(dependent2.AlternateProductId, principal2.Id);
 
             principalEntry1.SetEntityState(EntityState.Detached);
@@ -1458,7 +1458,7 @@ namespace Microsoft.EntityFrameworkCore.ChangeTracking.Internal
             Assert.Same(dependent1, principal1.OriginalProduct);
             Assert.Same(principal2, dependent2.AlternateProduct);
             Assert.Same(dependent2, principal2.OriginalProduct);
-            Assert.Equal(dependent1.AlternateProductId, principal1.Id);
+            Assert.Null(dependent1.AlternateProductId);
             Assert.Equal(dependent2.AlternateProductId, principal2.Id);
         }
 

--- a/test/EFCore.Tests/DbContextTrackingTest.cs
+++ b/test/EFCore.Tests/DbContextTrackingTest.cs
@@ -98,15 +98,13 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Same(relatedDependent, relatedDependentEntry.Entity);
                 Assert.Same(dependent, dependentEntry.Entity);
 
-                var expectedRelatedState = expectedState == EntityState.Deleted ? EntityState.Unchanged : expectedState;
-
                 Assert.Same(principal, principalEntry.Entity);
                 Assert.Equal(expectedState, principalEntry.State);
                 Assert.Same(relatedPrincipal, relatedPrincipalEntry.Entity);
-                Assert.Equal(expectedRelatedState, relatedPrincipalEntry.State);
+                Assert.Equal(expectedState == EntityState.Deleted ? EntityState.Unchanged : expectedState, relatedPrincipalEntry.State);
 
                 Assert.Same(relatedDependent, relatedDependentEntry.Entity);
-                Assert.Equal(expectedRelatedState, relatedDependentEntry.State);
+                Assert.Equal(expectedState, relatedDependentEntry.State);
                 Assert.Same(dependent, dependentEntry.Entity);
                 Assert.Equal(expectedState, dependentEntry.State);
 
@@ -200,15 +198,13 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Same(relatedDependent, context.Entry(relatedDependent).Entity);
                 Assert.Same(dependent, context.Entry(dependent).Entity);
 
-                var expectedRelatedState = expectedState == EntityState.Deleted ? EntityState.Unchanged : expectedState;
-
                 Assert.Same(principal, context.Entry(principal).Entity);
                 Assert.Equal(expectedState, context.Entry(principal).State);
                 Assert.Same(relatedPrincipal, context.Entry(relatedPrincipal).Entity);
-                Assert.Equal(expectedRelatedState, context.Entry(relatedPrincipal).State);
+                Assert.Equal(expectedState == EntityState.Deleted ? EntityState.Unchanged : expectedState, context.Entry(relatedPrincipal).State);
 
                 Assert.Same(relatedDependent, context.Entry(relatedDependent).Entity);
-                Assert.Equal(expectedRelatedState, context.Entry(relatedDependent).State);
+                Assert.Equal(expectedState, context.Entry(relatedDependent).State);
                 Assert.Same(dependent, context.Entry(dependent).Entity);
                 Assert.Equal(expectedState, context.Entry(dependent).State);
             }
@@ -498,15 +494,13 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Same(relatedDependent, relatedDependentEntry.Entity);
                 Assert.Same(dependent, dependentEntry.Entity);
 
-                var expectedRelatedState = expectedState == EntityState.Deleted ? EntityState.Unchanged : expectedState;
-
                 Assert.Same(principal, principalEntry.Entity);
                 Assert.Equal(expectedState, principalEntry.State);
                 Assert.Same(relatedPrincipal, relatedPrincipalEntry.Entity);
-                Assert.Equal(expectedRelatedState, relatedPrincipalEntry.State);
+                Assert.Equal(expectedState == EntityState.Deleted ? EntityState.Unchanged : expectedState, relatedPrincipalEntry.State);
 
                 Assert.Same(relatedDependent, relatedDependentEntry.Entity);
-                Assert.Equal(expectedRelatedState, relatedDependentEntry.State);
+                Assert.Equal(expectedState, relatedDependentEntry.State);
                 Assert.Same(dependent, dependentEntry.Entity);
                 Assert.Equal(expectedState, dependentEntry.State);
 
@@ -600,15 +594,13 @@ namespace Microsoft.EntityFrameworkCore
                 Assert.Same(relatedDependent, context.Entry(relatedDependent).Entity);
                 Assert.Same(dependent, context.Entry(dependent).Entity);
 
-                var expectedRelatedState = expectedState == EntityState.Deleted ? EntityState.Unchanged : expectedState;
-
                 Assert.Same(principal, context.Entry(principal).Entity);
                 Assert.Equal(expectedState, context.Entry(principal).State);
                 Assert.Same(relatedPrincipal, context.Entry(relatedPrincipal).Entity);
-                Assert.Equal(expectedRelatedState, context.Entry(relatedPrincipal).State);
+                Assert.Equal(expectedState == EntityState.Deleted ? EntityState.Unchanged : expectedState, context.Entry(relatedPrincipal).State);
 
                 Assert.Same(relatedDependent, context.Entry(relatedDependent).Entity);
-                Assert.Equal(expectedRelatedState, context.Entry(relatedDependent).State);
+                Assert.Equal(expectedState, context.Entry(relatedDependent).State);
                 Assert.Same(dependent, context.Entry(dependent).Entity);
                 Assert.Equal(expectedState, context.Entry(dependent).State);
             }

--- a/test/EFCore.Tests/TestUtilities/FakeStateManager.cs
+++ b/test/EFCore.Tests/TestUtilities/FakeStateManager.cs
@@ -114,6 +114,8 @@ namespace Microsoft.EntityFrameworkCore.TestUtilities
         public event EventHandler<EntityStateChangedEventArgs> StateChanged;
         public void OnStateChanged(InternalEntityEntry internalEntityEntry, EntityState oldState) => StateChanged?.Invoke(null, null);
         public bool SensitiveLoggingEnabled { get; }
+        public void CascadeChanges(bool force) => throw new NotImplementedException();
+        public void CascadeDelete(InternalEntityEntry entry, bool force) => throw new NotImplementedException();
         public IDiagnosticsLogger<DbLoggerCategory.Update> UpdateLogger { get; }
     }
 }


### PR DESCRIPTION
Fixes #10114

Allows timing cascade delete (i.e. delete of dependent on principal deletion) and delete orphans (i.e. delete of dependent on severing its relationship to the principal) to be configured as:
* Immediate: Dependents changed to Deleted immediately, or at least at the next DetectChanges
* OnSaveChanges: Dependents are not changed to Deleted until SaveChanges is called
* Never: Cascades don't happen automatically. They can be triggered by a new method: `context.ChangeTracker.CascadeChanges()`

The default for both has been changed to `Immediate` which is a breaking change, but likely a better default because:
* Auditing in overridden SaveChanges will now report anything that will be deleted
* Data binding will reflect the changes immediately

However, deleting orphans can be more difficult. This doesn't appear to be a major problem in EF Core because we don't aggressively graph shred, we don't typically have entities that handle their own fixup, and conceptual nulls still exist to allow transitionary states.

Note that EF6 does not support deleting orphans, which means the behavior here with both set to Immediate is not quite the same as the default behavior of EF6.
